### PR TITLE
Add a plugins folder symlinking plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 repos
+contributed-plugins
 logs
 html
 data

--- a/bin/link-contributed-plugins.sh
+++ b/bin/link-contributed-plugins.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+WP_PATH=$1
+echo "Linking contributed plugins to $WP_PATH"
+
+# if WP_PATH is empty, use default
+if [ -z "$WP_PATH" ]; then
+	WP_PATH="/var/www/html/wp-content"
+else
+  WP_PATH="/var/www/additional-sites-html/$WP_PATH/wp-content"
+fi
+
+if [ ! -d "${WP_PATH}" ]; then
+	echo "$WP_PATH directory does not exist"
+	exit 1
+fi
+
+SOURCE_DIR="/contributed-plugins"
+TARGET_DIR="$WP_PATH/plugins";
+
+find "$SOURCE_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | while IFS= read -r -d '' dir; do
+    # Extract the base directory name
+    dirname=$(basename "$dir")
+
+    symlink_path="$TARGET_DIR/$dirname"
+
+    # Check if the symlink already exists and if not – create it
+    if [ ! -e "$symlink_path" ]; then
+        ln -s "$dir" "$symlink_path"
+        echo "Symlinked: $symlink_path -> $dir"
+    fi
+done

--- a/docker-compose-74.yml
+++ b/docker-compose-74.yml
@@ -43,6 +43,7 @@ services:
       - ./logs/newspack-dev/php:/var/log/php
       - ./bin:/var/scripts
       - ./repos:/newspack-repos
+      - ./contributed-plugins:/contributed-plugins
       - ./html:/var/www/html
       - ./manager-html:/var/www/manager-html
       - ./additional-sites-html:/var/www/additional-sites-html

--- a/docker-compose-80.yml
+++ b/docker-compose-80.yml
@@ -42,6 +42,7 @@ services:
       - ./logs/newspack-dev/php:/var/log/php
       - ./bin:/var/scripts
       - ./repos:/newspack-repos
+      - ./contributed-plugins:/contributed-plugins
       - ./html:/var/www/html
       - ./manager-html:/var/www/manager-html
       - ./additional-sites-html:/var/www/additional-sites-html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - ./logs/newspack-dev/php:/var/log/php
       - ./bin:/var/scripts
       - ./repos:/newspack-repos
+      - ./contributed-plugins:/contributed-plugins
       - ./html:/var/www/html
       - ./manager-html:/var/www/manager-html
       - ./additional-sites-html:/var/www/additional-sites-html

--- a/n
+++ b/n
@@ -237,6 +237,9 @@ case $1 in
     setup-newspack-network)
         docker exec -it $USER_COMMAND newspack_dev sh -c "/var/scripts/setup-newspack-network.sh"
         ;;
+    symlink-contributed-plugins)
+        docker exec -it $USER_COMMAND newspack_dev sh -c "/var/scripts/link-contributed-plugins.sh $2"
+    ;;
     *)
         echo Unknown command
         ;;


### PR DESCRIPTION
This adds a shared folder with a not so great name: `/contributed-plugins`. I'd love to find a better name that conveys that it is plugins not written by us, but downloaded stuff.

The idea is that one can download plugins to that folder and then symlink them to the main site and all additional sites. There is a command n symlink-contributed-plugins that does that.

Note that this is pretty basic. We are not hooking into wp plugin install to download plugins to another location or anything, so the symlinks can be overwritten at any time. The script also respects that if there is a plugin already installed it will not create the symlinks. So – the PR is a little bit useful, but we could add on more to make it more useful. Ideas welcome!

I had some commit mess on the branch in #32 so this is the cleaner replacement for that PR.