### PR TITLE
fix(docker): add proxy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,9 @@ A certificate will be generated, so HTTPS is available immediately. However, the
 - `$ docker exec newspack_dev bash -c 'eval cat $(mkcert -CAROOT)/rootCA.pem' > rootCA.pem` to copy the CA certificate from the Docker machine
 - `$ sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" ./rootCA.pem` to trust this CA certificate (import to KeyChain). Alternatively, double-click on the .pem file.
 - remove the `rootCA.pem`, it's no longer needed
+
+## Proxy
+
+Docker is configured to use a socks5 host machine proxy at port 8080. If you
+don't wish to use the proxy, comment out the line with `ALL_PROXY` from the
+docker-compose file you're using.

--- a/docker-compose-74.yml
+++ b/docker-compose-74.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 volumes:
   ## Kludge for not having the ./docker directory bound recursively
   dockerdirectory:
@@ -57,6 +55,8 @@ services:
       - HOST_PORT=${PORT_WORDPRESS:-80}
      # - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
+      # Ensure network requests run via host machine proxy.
+      - ALL_PROXY=socks5h://host.docker.internal:8080
     extra_hosts:
       - "host.docker.internal:host-gateway"
   mailhog:

--- a/docker-compose-80.yml
+++ b/docker-compose-80.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 volumes:
   ## Kludge for not having the ./docker directory bound recursively
   dockerdirectory:
@@ -56,6 +54,8 @@ services:
       - HOST_PORT=${PORT_WORDPRESS:-80}
      # - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
+      # Ensure network requests run via host machine proxy.
+      - ALL_PROXY=socks5h://host.docker.internal:8080
     extra_hosts:
       - "host.docker.internal:host-gateway"
   mailhog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 volumes:
   ## Kludge for not having the ./docker directory bound recursively
   dockerdirectory:
@@ -56,6 +54,8 @@ services:
       - HOST_PORT=${PORT_WORDPRESS:-80}
      # - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
+      # Ensure network requests run via host machine proxy.
+      - ALL_PROXY=socks5h://host.docker.internal:8080
     extra_hosts:
       - "host.docker.internal:host-gateway"
   mailhog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
       # Ensure network requests run via host machine proxy.
       - ALL_PROXY=socks5h://host.docker.internal:8080
+      # Escept for these:
+      - NO_PROXY=.local,manager.com,.ngrok.io
     extra_hosts:
       - "host.docker.internal:host-gateway"
   mailhog:


### PR DESCRIPTION
1. removes the `version` key from the compose file – [it's obsolete now](https://dev.to/ajeetraina/do-we-still-use-version-in-compose-3inp) 
2. adds a network config which will make the docker container use the host machine proxy

Not sure if it's reproducible, but here are testing steps if you also see the issue:

1. on `main`, run `docker exec newspack_dev bash -c 'curl -I https://<site-which-uses-proxy>'`
2. observe it fails
3. switch to this branch, restart the container, observe the command works