### PR TITLE
Add --all --yes to cleanup commands for automation

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -359,13 +359,13 @@ YAML
               sudo sed -i "/[[:space:]]${escaped_domain}$/d" /etc/hosts; }
             echo "Removed $domain from /etc/hosts"
         fi
+        # Remove compose file before worktrees so worktree.sh doesn't see them as env-bound.
+        rm -f "$compose_file"
         # Remove worktrees that were mounted by this environment.
         for wt in "${worktree_entries[@]}"; do
             IFS='/' read -r wt_repo wt_branch <<< "$wt"
             "$NABSPATH/bin/worktree.sh" remove --yes "$wt_repo" "$wt_branch"
         done
-        # Remove compose file last so earlier steps can be retried on failure.
-        rm -f "$compose_file"
         echo "Destroyed environment '$env_name'"
         ;;
     list)
@@ -383,6 +383,16 @@ YAML
         done
         ;;
     cleanup)
+        shift
+        cleanup_all=false
+        cleanup_yes=false
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --all) cleanup_all=true; shift ;;
+                --yes) cleanup_yes=true; shift ;;
+                *) echo "Usage: n env cleanup [--all --yes]"; exit 1 ;;
+            esac
+        done
         envs=()
         for f in "$NABSPATH"/docker-compose.env-*.yml; do
             [[ -f "$f" ]] || continue
@@ -393,54 +403,62 @@ YAML
             echo "No environments to clean up."
             exit 0
         fi
-        # Track which indices to keep.
-        keep_flags=()
-        for i in "${!envs[@]}"; do keep_flags[$i]=false; done
-        while true; do
-            echo ""
-            echo "Environments (marked for REMOVAL unless toggled):"
-            for i in "${!envs[@]}"; do
-                name="${envs[$i]}"
-                container_name=$(echo "newspack_env_${name}" | tr '-' '_')
-                domain=$(domain_for_env "$NABSPATH/docker-compose.env-${name}.yml")
-                status="stopped"
-                docker inspect -f '{{.State.Status}}' "$container_name" >/dev/null 2>&1 && \
-                    status=$(docker inspect -f '{{.State.Status}}' "$container_name" 2>/dev/null)
-                if [[ "${keep_flags[$i]}" == true ]]; then
-                    echo "  $((i+1)). [KEEP]    $name ($status) https://${domain}/"
-                else
-                    echo "  $((i+1)). [REMOVE]  $name ($status) https://${domain}/"
+        # --all: skip interactive selection (select all for removal).
+        # --yes: skip final confirmation prompt.
+        if [[ "$cleanup_all" != true ]]; then
+            # Interactive toggle loop.
+            keep_flags=()
+            for i in "${!envs[@]}"; do keep_flags[$i]=false; done
+            while true; do
+                echo ""
+                echo "Environments (marked for REMOVAL unless toggled):"
+                for i in "${!envs[@]}"; do
+                    name="${envs[$i]}"
+                    container_name=$(echo "newspack_env_${name}" | tr '-' '_')
+                    domain=$(domain_for_env "$NABSPATH/docker-compose.env-${name}.yml")
+                    status="stopped"
+                    docker inspect -f '{{.State.Status}}' "$container_name" >/dev/null 2>&1 && \
+                        status=$(docker inspect -f '{{.State.Status}}' "$container_name" 2>/dev/null)
+                    if [[ "${keep_flags[$i]}" == true ]]; then
+                        echo "  $((i+1)). [KEEP]    $name ($status) https://${domain}/"
+                    else
+                        echo "  $((i+1)). [REMOVE]  $name ($status) https://${domain}/"
+                    fi
+                done
+                echo ""
+                echo "Enter a number to toggle, 'a' to select all for removal, or 'delete' to proceed:"
+                read -p "> " choice
+                if [[ "$choice" == "delete" ]]; then
+                    break
+                elif [[ "$choice" == "a" ]]; then
+                    for i in "${!envs[@]}"; do keep_flags[$i]=false; done
+                elif [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 && "$choice" -le ${#envs[@]} ]]; then
+                    idx=$((choice-1))
+                    if [[ "${keep_flags[$idx]}" == true ]]; then
+                        keep_flags[$idx]=false
+                    else
+                        keep_flags[$idx]=true
+                    fi
                 fi
             done
-            echo ""
-            echo "Enter a number to toggle, 'a' to select all for removal, or 'delete' to proceed:"
-            read -p "> " choice
-            if [[ "$choice" == "delete" ]]; then
-                break
-            elif [[ "$choice" == "a" ]]; then
-                for i in "${!envs[@]}"; do keep_flags[$i]=false; done
-            elif [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 && "$choice" -le ${#envs[@]} ]]; then
-                idx=$((choice-1))
-                if [[ "${keep_flags[$idx]}" == true ]]; then
-                    keep_flags[$idx]=false
-                else
-                    keep_flags[$idx]=true
-                fi
-            fi
-        done
-        to_remove=()
-        for i in "${!envs[@]}"; do
-            [[ "${keep_flags[$i]}" != true ]] && to_remove+=("${envs[$i]}")
-        done
+            to_remove=()
+            for i in "${!envs[@]}"; do
+                [[ "${keep_flags[$i]}" != true ]] && to_remove+=("${envs[$i]}")
+            done
+        else
+            to_remove=("${envs[@]}")
+        fi
         if [[ ${#to_remove[@]} -eq 0 ]]; then
             echo "Nothing to remove."
             exit 0
         fi
         echo "Will destroy: ${to_remove[*]}"
-        read -p "Confirm? (y/N): " confirm
-        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
-            echo "Aborted."
-            exit 0
+        if [[ "$cleanup_yes" != true ]]; then
+            read -p "Confirm? (y/N): " confirm
+            if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                echo "Aborted."
+                exit 0
+            fi
         fi
         for name in "${to_remove[@]}"; do
             echo ""
@@ -450,5 +468,6 @@ YAML
         ;;
     *)
         echo "Usage: n env <create|up|down|destroy|list|cleanup>"
+        echo "  cleanup [--all --yes]  Remove environments (interactive, or destroy all non-interactively)"
         ;;
 esac

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -390,7 +390,7 @@ YAML
             case $1 in
                 --all) cleanup_all=true; shift ;;
                 --yes) cleanup_yes=true; shift ;;
-                *) echo "Usage: n env cleanup [--all --yes]"; exit 1 ;;
+                *) echo "Usage: n env cleanup [--all] [--yes]"; exit 1 ;;
             esac
         done
         envs=()
@@ -406,6 +406,10 @@ YAML
         # --all: skip interactive selection (select all for removal).
         # --yes: skip final confirmation prompt.
         if [[ "$cleanup_all" != true ]]; then
+            if ! [ -t 0 ] || ! [ -t 1 ]; then
+                echo "Interactive mode requires a terminal. Use --all --yes for non-interactive cleanup."
+                exit 1
+            fi
             # Interactive toggle loop.
             keep_flags=()
             for i in "${!envs[@]}"; do keep_flags[$i]=false; done
@@ -468,6 +472,6 @@ YAML
         ;;
     *)
         echo "Usage: n env <create|up|down|destroy|list|cleanup>"
-        echo "  cleanup [--all --yes]  Remove environments (interactive, or destroy all non-interactively)"
+        echo "  cleanup [--all] [--yes]  Remove environments (--all selects everything, --yes skips confirmation)"
         ;;
 esac

--- a/bin/worktree.sh
+++ b/bin/worktree.sh
@@ -146,7 +146,7 @@ case $1 in
             case $1 in
                 --all) cleanup_all=true; shift ;;
                 --yes) cleanup_yes=true; shift ;;
-                *) echo "Usage: n worktree cleanup [--all --yes]"; exit 1 ;;
+                *) echo "Usage: n worktree cleanup [--all] [--yes]"; exit 1 ;;
             esac
         done
         # Collect all worktrees across repos.
@@ -174,6 +174,10 @@ case $1 in
         # --all: skip interactive selection (select all for removal).
         # --yes: skip final confirmation prompt.
         if [[ "$cleanup_all" != true ]]; then
+            if ! [ -t 0 ] || ! [ -t 1 ]; then
+                echo "Interactive mode requires a terminal. Use --all --yes for non-interactive cleanup."
+                exit 1
+            fi
             # Interactive toggle loop.
             keep_flags=()
             for i in "${!worktrees[@]}"; do keep_flags[$i]=false; done
@@ -250,6 +254,6 @@ case $1 in
         ;;
     *)
         echo "Usage: n worktree <add|list|remove|cleanup> [repo] [branch]"
-        echo "  cleanup [--all --yes]  Remove worktrees (interactive, or remove all non-interactively)"
+        echo "  cleanup [--all] [--yes]  Remove worktrees (--all selects everything, --yes skips confirmation)"
         ;;
 esac

--- a/bin/worktree.sh
+++ b/bin/worktree.sh
@@ -139,6 +139,16 @@ case $1 in
         exit 0
         ;;
     cleanup)
+        shift
+        cleanup_all=false
+        cleanup_yes=false
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --all) cleanup_all=true; shift ;;
+                --yes) cleanup_yes=true; shift ;;
+                *) echo "Usage: n worktree cleanup [--all --yes]"; exit 1 ;;
+            esac
+        done
         # Collect all worktrees across repos.
         worktrees=()
         worktree_repos=()
@@ -161,66 +171,76 @@ case $1 in
             echo "No worktrees to clean up."
             exit 0
         fi
-        # Track which indices to keep (use index-based array to avoid key issues).
-        keep_flags=()
-        for i in "${!worktrees[@]}"; do keep_flags[$i]=false; done
-        while true; do
-            echo ""
-            echo "Worktrees (marked for REMOVAL unless toggled):"
-            for i in "${!worktrees[@]}"; do
-                repo="${worktree_repos[$i]}"
-                branch="${worktree_branches[$i]}"
-                # Check if an env uses this worktree.
-                env_label=""
-                for f in "$NABSPATH"/docker-compose.env-*.yml; do
-                    [[ -f "$f" ]] || continue
-                    if grep -q "worktrees/$repo/$branch" "$f" 2>/dev/null; then
-                        env_name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
-                        env_label=" (env: $env_name)"
-                        break
+        # --all: skip interactive selection (select all for removal).
+        # --yes: skip final confirmation prompt.
+        if [[ "$cleanup_all" != true ]]; then
+            # Interactive toggle loop.
+            keep_flags=()
+            for i in "${!worktrees[@]}"; do keep_flags[$i]=false; done
+            while true; do
+                echo ""
+                echo "Worktrees (marked for REMOVAL unless toggled):"
+                for i in "${!worktrees[@]}"; do
+                    repo="${worktree_repos[$i]}"
+                    branch="${worktree_branches[$i]}"
+                    # Check if an env uses this worktree.
+                    env_label=""
+                    for f in "$NABSPATH"/docker-compose.env-*.yml; do
+                        [[ -f "$f" ]] || continue
+                        if grep -q "worktrees/$repo/$branch" "$f" 2>/dev/null; then
+                            env_name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
+                            env_label=" (env: $env_name)"
+                            break
+                        fi
+                    done
+                    if [[ "${keep_flags[$i]}" == true ]]; then
+                        echo "  $((i+1)). [KEEP]    ${worktrees[$i]}$env_label"
+                    else
+                        echo "  $((i+1)). [REMOVE]  ${worktrees[$i]}$env_label"
                     fi
                 done
-                if [[ "${keep_flags[$i]}" == true ]]; then
-                    echo "  $((i+1)). [KEEP]    ${worktrees[$i]}$env_label"
-                else
-                    echo "  $((i+1)). [REMOVE]  ${worktrees[$i]}$env_label"
+                echo ""
+                echo "Enter a number to toggle, 'a' to select all for removal, or 'delete' to proceed:"
+                read -p "> " choice
+                if [[ "$choice" == "delete" ]]; then
+                    break
+                elif [[ "$choice" == "a" ]]; then
+                    for i in "${!worktrees[@]}"; do keep_flags[$i]=false; done
+                elif [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 && "$choice" -le ${#worktrees[@]} ]]; then
+                    idx=$((choice-1))
+                    if [[ "${keep_flags[$idx]}" == true ]]; then
+                        keep_flags[$idx]=false
+                    else
+                        keep_flags[$idx]=true
+                    fi
                 fi
             done
-            echo ""
-            echo "Enter a number to toggle, 'a' to select all for removal, or 'delete' to proceed:"
-            read -p "> " choice
-            if [[ "$choice" == "delete" ]]; then
-                break
-            elif [[ "$choice" == "a" ]]; then
-                for i in "${!worktrees[@]}"; do keep_flags[$i]=false; done
-            elif [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 && "$choice" -le ${#worktrees[@]} ]]; then
-                idx=$((choice-1))
-                if [[ "${keep_flags[$idx]}" == true ]]; then
-                    keep_flags[$idx]=false
-                else
-                    keep_flags[$idx]=true
+            to_remove=()
+            to_remove_repos=()
+            to_remove_branches=()
+            for i in "${!worktrees[@]}"; do
+                if [[ "${keep_flags[$i]}" != true ]]; then
+                    to_remove+=("${worktrees[$i]}")
+                    to_remove_repos+=("${worktree_repos[$i]}")
+                    to_remove_branches+=("${worktree_branches[$i]}")
                 fi
-            fi
-        done
-        to_remove=()
-        to_remove_repos=()
-        to_remove_branches=()
-        for i in "${!worktrees[@]}"; do
-            if [[ "${keep_flags[$i]}" != true ]]; then
-                to_remove+=("${worktrees[$i]}")
-                to_remove_repos+=("${worktree_repos[$i]}")
-                to_remove_branches+=("${worktree_branches[$i]}")
-            fi
-        done
+            done
+        else
+            to_remove=("${worktrees[@]}")
+            to_remove_repos=("${worktree_repos[@]}")
+            to_remove_branches=("${worktree_branches[@]}")
+        fi
         if [[ ${#to_remove[@]} -eq 0 ]]; then
             echo "Nothing to remove."
             exit 0
         fi
         echo "Will remove: ${to_remove[*]}"
-        read -p "Confirm? (y/N): " confirm
-        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
-            echo "Aborted."
-            exit 0
+        if [[ "$cleanup_yes" != true ]]; then
+            read -p "Confirm? (y/N): " confirm
+            if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                echo "Aborted."
+                exit 0
+            fi
         fi
         for i in "${!to_remove[@]}"; do
             echo ""
@@ -230,5 +250,6 @@ case $1 in
         ;;
     *)
         echo "Usage: n worktree <add|list|remove|cleanup> [repo] [branch]"
+        echo "  cleanup [--all --yes]  Remove worktrees (interactive, or remove all non-interactively)"
         ;;
 esac


### PR DESCRIPTION
## Summary
- `n env cleanup` and `n worktree cleanup` are fully interactive with no non-interactive path, which means skills/agents can hang when calling them
- Adds `--all --yes` flags to both commands so they can be used non-interactively (both flags required together to prevent accidental mass-deletion)
- Default interactive behavior is unchanged

```bash
# Non-interactive usage
n env cleanup --all --yes
n worktree cleanup --all --yes
```

## Test plan
- [ ] `n env cleanup` still works interactively (unchanged)
- [ ] `n worktree cleanup` still works interactively (unchanged)
- [ ] `n env cleanup --all --yes` destroys all envs without prompts
- [ ] `n worktree cleanup --all --yes` removes all worktrees without prompts
- [ ] `n env cleanup --all` (without --yes) still enters interactive mode
- [ ] `n env cleanup --badflag` shows usage and exits