### PR TITLE
Assorted improvements to site setup

### DIFF
--- a/bin/link-repos.sh
+++ b/bin/link-repos.sh
@@ -27,7 +27,7 @@ do :
 		echo "$dir already symlinked"
 	else
 		echo "Symlinking $dir"
-		ln -s "$CODE_PATH/$dir" "$link"
+		ln -s "$CODE_PATH/$dir" "$link" || true
 	fi
 done
 

--- a/bin/link-repos.sh
+++ b/bin/link-repos.sh
@@ -38,7 +38,7 @@ do :
 		echo "$dir already symlinked"
 	else
 		echo "Symlinking $dir"
-		ln -s "$CODE_PATH/newspack-theme/$dir" "$link"
+		ln -s "$CODE_PATH/newspack-theme/$dir" "$link" || true
 	fi
 done
 
@@ -49,14 +49,14 @@ do :
 		echo "$dir already symlinked"
 	else
 		echo "Symlinking $dir"
-		ln -s "$CODE_PATH/$dir" "$link"
+		ln -s "$CODE_PATH/$dir" "$link" || true
 	fi
 done
 
-link="/var/www/manager-html/wp-content/plugins/newspack-manager-client"
+link="/var/www/manager-html/wp-content/plugins/newspack-manager-admin"
 if [ -L "${link}" ]; then
-	echo "newspack-manager-client already symlinked"
+	echo "newspack-manager-admin already symlinked"
 else
-	echo "Symlinking newspack-manager-client"
-	ln -s "$CODE_PATH/newspack-manager-client" "$link"
+	echo "Symlinking newspack-manager-admin"
+	ln -s "$CODE_PATH/newspack-manager-admin" "$link"
 fi

--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -15,6 +15,12 @@ add_filter(
 );
 
 /**
+ * Prevent WooCommerce from assuming that this is a duplicate site.
+ * On "duplicate sites", all subscriptions will be treated as manual, to prevent automatic renewals.
+ */
+add_filter('woocommerce_subscriptions_is_duplicate_site', '__return_false');
+
+/**
  * Disable SSL for local WP development
  *
  * Plugin Name: Disable SSL for local WP development

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -36,4 +36,5 @@ woocommerce_plugins=(
 	"woocommerce-subscriptions"
 	"woocommerce-memberships"
 	"woocommerce-name-your-price"
+	"woocommerce-gateway-stripe"
 )

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -8,12 +8,13 @@ newspack_plugins=(
 	"newspack-plugin"
 	"newspack-popups"
 	"newspack-manager"
-	"newspack-manager-client"
+	"newspack-manager-admin"
 	"newspack-sponsors"
 	"republication-tracker-tool"
 	"super-cool-ad-inserter-plugin"
 	"newspack-multibranded-site"
 	"newspack-network"
+	"newspack-subscription-migrations"
 )
 
 newspack_themes=(
@@ -31,6 +32,7 @@ newspack_block_theme=(
 
 woocommerce_plugins=(
 	"woocommerce"
+	"woocommerce-gateway-stripe"
 	"woocommerce-subscriptions"
 	"woocommerce-memberships"
 	"woocommerce-name-your-price"

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -36,5 +36,4 @@ woocommerce_plugins=(
 	"woocommerce-subscriptions"
 	"woocommerce-memberships"
 	"woocommerce-name-your-price"
-	"woocommerce-gateway-stripe"
 )

--- a/bin/setup-manager.sh
+++ b/bin/setup-manager.sh
@@ -15,7 +15,7 @@ wp --allow-root plugin activate newspack-manager
 
 cd /var/www/manager-html
 wp --allow-root config set NEWSPACK_MANAGER_API_PRIVATE_KEY "$(cat /var/scripts/manager.private.key)"
-wp --allow-root plugin activate newspack-manager-client
+wp --allow-root plugin activate newspack-manager-admin
 
 # For some reason, permalinks are not pretty by default. Because of this, the REST API wouldn't work.
 wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root

--- a/bin/site-setup.sh
+++ b/bin/site-setup.sh
@@ -387,6 +387,20 @@ if [ "$WOOCOMMERCE_ENABLED" = true ]; then
         echo "WooCommerce setup completed\n";
     '
 
+    # Setup Stripe gateway (if keys are provided via env vars)
+    if [ -n "${STRIPE_TEST_PUBLISHABLE_KEY:-}" ] && [ -n "${STRIPE_TEST_SECRET_KEY:-}" ]; then
+        log_info "Configuring Stripe gateway (test mode)..."
+        if $WP plugin is-installed woocommerce-gateway-stripe &>/dev/null; then
+            $WP plugin activate woocommerce-gateway-stripe 2>/dev/null || true
+            $WP option update woocommerce_stripe_settings \
+                "{\"enabled\":\"yes\",\"testmode\":\"yes\",\"test_publishable_key\":\"$STRIPE_TEST_PUBLISHABLE_KEY\",\"test_secret_key\":\"$STRIPE_TEST_SECRET_KEY\",\"upe_checkout_experience_enabled\":\"yes\",\"upe_checkout_experience_accepted_payments\":[\"card\"],\"capture\":\"yes\",\"saved_cards\":\"yes\",\"logging\":\"no\"}" \
+                --format=json
+            log_success "Stripe gateway configured (test mode)"
+        else
+            log_warning "woocommerce-gateway-stripe not installed, skipping Stripe setup"
+        fi
+    fi
+
     # Setup Newspack Donations
     log_info "Setting up Newspack Donations..."
     $WP eval '

--- a/bin/site-setup.sh
+++ b/bin/site-setup.sh
@@ -196,6 +196,7 @@ log_success "Database reset completed"
 
 # Reinstall WordPress
 log_info "Reinstalling WordPress..."
+$WP cache flush 2>/dev/null || true
 $WP core install \
     --url="$SITE_URL" \
     --title="Newspack Site" \
@@ -392,8 +393,10 @@ if [ "$WOOCOMMERCE_ENABLED" = true ]; then
         log_info "Configuring Stripe gateway (test mode)..."
         if $WP plugin is-installed woocommerce-gateway-stripe &>/dev/null; then
             $WP plugin activate woocommerce-gateway-stripe 2>/dev/null || true
-            $WP option update woocommerce_stripe_settings \
-                "{\"enabled\":\"yes\",\"testmode\":\"yes\",\"test_publishable_key\":\"$STRIPE_TEST_PUBLISHABLE_KEY\",\"test_secret_key\":\"$STRIPE_TEST_SECRET_KEY\",\"upe_checkout_experience_enabled\":\"yes\",\"upe_checkout_experience_accepted_payments\":[\"card\"],\"capture\":\"yes\",\"saved_cards\":\"yes\",\"logging\":\"no\"}" \
+            $WP option update woocommerce_stripe_settings "$(jq -n \
+                --arg pk "$STRIPE_TEST_PUBLISHABLE_KEY" \
+                --arg sk "$STRIPE_TEST_SECRET_KEY" \
+                '{enabled:"yes",testmode:"yes",test_publishable_key:$pk,test_secret_key:$sk,upe_checkout_experience_enabled:"yes",upe_checkout_experience_accepted_payments:["card"],capture:"yes",saved_cards:"yes",logging:"no"}')" \
                 --format=json
             log_success "Stripe gateway configured (test mode)"
         else

--- a/bin/site-setup.sh
+++ b/bin/site-setup.sh
@@ -186,6 +186,8 @@ fi
 
 # Step 1: Reset the database
 log_info "Step 1: Resetting the database..."
+# Deactivate all plugins first to prevent bootstrap queries against missing tables.
+$WP plugin deactivate --all 2>/dev/null || true
 $WP db reset --yes || {
     log_error "Failed to reset database"
     exit 1
@@ -194,7 +196,6 @@ log_success "Database reset completed"
 
 # Reinstall WordPress
 log_info "Reinstalling WordPress..."
-$WP cache flush 2>/dev/null || true
 $WP core install \
     --url="$SITE_URL" \
     --title="Newspack Site" \

--- a/default.env
+++ b/default.env
@@ -31,6 +31,11 @@ WP_ADMIN_EMAIL=wordpress@example.com
 WP_ADMIN_PASSWORD=wordpress
 WP_TITLE=HelloWord
 
+# Stripe (test mode) - Set these to auto-configure the Stripe gateway during setup
+# Get keys from https://dashboard.stripe.com/test/apikeys
+#STRIPE_TEST_PUBLISHABLE_KEY=pk_test_...
+#STRIPE_TEST_SECRET_KEY=sk_test_...
+
 # Database - No changes necessary
 MYSQL_HOST=db:3306
 MYSQL_DATABASE=wordpress


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Fix DB error spam during `n setup` caused by WooCommerce/Action Scheduler querying tables after `db reset` but before `core install` recreates them. Plugins are now deactivated before the reset.
- Add `woocommerce-gateway-stripe` to the WooCommerce plugins list so it is activated during `--woocommerce` setup.
- Auto-configure Stripe gateway in test mode during `--woocommerce` setup when `STRIPE_TEST_PUBLISHABLE_KEY` and `STRIPE_TEST_SECRET_KEY` env vars are set.
- Update repo list: rename `newspack-manager-client` to `newspack-manager-admin`, add `newspack-subscription-migrations`.
- Prevent WooCommerce Subscriptions from treating the local dev site as a duplicate (which forces all subscriptions to manual renewal).
- Make theme symlink failures non-fatal in `link-repos.sh`.

### How to test the changes in this Pull Request:

1. Start a fresh environment: `n start`.
2. Run `n setup --yes` and verify the output has **no** `wpdberror` HTML in the console.
3. Run `n setup --yes --woocommerce` and verify:
   - No DB errors in the output.
   - `woocommerce-gateway-stripe` is listed as active: `n wp plugin list | grep stripe`.
   - WooCommerce Subscriptions does not show "duplicate site" notice in WP admin.
4. To test Stripe auto-config: add `STRIPE_TEST_PUBLISHABLE_KEY=pk_test_xxx` and `STRIPE_TEST_SECRET_KEY=sk_test_xxx` to `.env`, then run `n setup --yes --woocommerce`. Verify Stripe settings are configured: `n wp option get woocommerce_stripe_settings --format=json`.
5. Verify `newspack-manager-admin` and `newspack-subscription-migrations` are symlinked: `n wp plugin list | grep -E 'manager-admin|subscription-migrations'`.
6. Remove one of the theme directories temporarily and re-run `n start` – `link-repos.sh` should not abort on the missing symlink.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?