### PR TITLE
docs: add instructions for connecting isolated envs to Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,25 @@ That's it!
 
 Now visit `manager.com/wp-admin`, go to Newspack Manager, and add the URL for you other site there.
 
+### Connecting isolated environments to Manager
+
+Isolated environments (created with `n env create`) bind to loopback IPs like `127.0.0.2`. These IPs are accessible from the host machine but **not from inside other Docker containers**, because each container has its own loopback interface.
+
+When you add an isolated environment's URL (e.g. `https://127.0.0.2`) to the Manager UI, the manager container tries to reach `127.0.0.2` and fails -- the request never leaves the container. The error in the manager debug log will show `rest_no_route` / 404, which is misleading.
+
+To fix this, add a hosts entry inside the manager container that maps the loopback IP to the isolated environment's Docker-internal IP:
+
+```BASH
+# Find the environment container's Docker IP
+docker inspect newspack_env_<name> --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
+# e.g. 172.19.0.5
+
+# Add the mapping inside the manager container
+docker exec newspack_dev bash -c "echo '172.19.0.5 127.0.0.2' >> /etc/hosts"
+```
+
+This entry is lost when the manager container restarts, so you'll need to re-add it after `n stop`/`n start`.
+
 ### Note about the site domain when running CLI commands
 
 By default, the docker environment provides a dynamic site url, so you can access the site either via localhost or a tunneled domain, required for some actions. This is useful because it allows you to run your site without the tunnel when you don't need it.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds documentation for connecting isolated environments to the Manager site. Isolated envs bind to loopback IPs that aren't reachable from inside other Docker containers, so the Manager container can't communicate with them by default. The new section explains the issue and provides a workaround using Docker inspect and a hosts entry.

### How to test the changes in this Pull Request:

1. Review the new "Connecting isolated environments to Manager" section in the README.
2. Verify the instructions are accurate by creating an isolated environment (`n env create test-env`) and following the documented steps to connect it to the Manager site.
3. Confirm the `docker inspect` command correctly retrieves the environment container's internal IP.
4. Confirm adding the hosts entry inside the manager container allows the Manager to reach the isolated environment's URL.
5. Verify that after restarting containers (`n stop` / `n start`), the hosts entry is indeed lost, matching the documented caveat.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?