### PR TITLE
fix(setup): activate and configure Stripe gateway during WooCommerce setup

### DIFF
--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -34,4 +34,5 @@ woocommerce_plugins=(
 	"woocommerce-subscriptions"
 	"woocommerce-memberships"
 	"woocommerce-name-your-price"
+	"woocommerce-gateway-stripe"
 )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add `woocommerce-gateway-stripe` to the WooCommerce plugins activated during `n setup --woocommerce`, and auto-configure it in test mode when Stripe API keys are provided via environment variables (`STRIPE_TEST_PUBLISHABLE_KEY`, `STRIPE_TEST_SECRET_KEY`).

Without this, bootstrapped sites have no payment gateway configured, making it impossible to test donation/subscription flows end-to-end.

### How to test the changes in this Pull Request:

1. Add Stripe test keys to your `.env` file:
   ```
   STRIPE_TEST_PUBLISHABLE_KEY=pk_test_...
   STRIPE_TEST_SECRET_KEY=sk_test_...
   ```
2. Run `n setup --woocommerce --yes`.
3. Verify `woocommerce-gateway-stripe` is activated: `n wp plugin list | grep stripe`.
4. Verify Stripe is configured in test mode: `n wp option get woocommerce_stripe_settings --format=json`.
5. Confirm the gateway appears in WooCommerce > Settings > Payments.
6. Test without env vars set – Stripe plugin should still activate but skip configuration, logging a message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?