### PR TITLE
feat(env): shared Docker network for inter-container communication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ n setup --env myenv --yes     # fully configured Newspack site
 ```bash
 n env create <name> [options]  # Create environment config
   --worktree <repo>:<branch>   #   Mount a worktree (repeatable for multiple repos)
-  --domain <domain>            #   Custom domain (default: loopback IP)
+  --domain <domain>            #   Custom domain (default: <name>.local)
   --up                         #   Start the environment immediately after creation
 n env up <name> [--build]      # Start environment (creates DB, installs WP, sets up SSL)
 n env down <name>              # Stop environment
@@ -263,11 +263,12 @@ n sh <name>                    # Shell into environment container
 ### How It Works
 - Each env binds to a unique loopback IP (127.0.0.2+) on ports 80/443 with HTTPS via mkcert
 - Domain defaults to the loopback IP, overridable with `--domain`
-- `n start` pre-creates loopback aliases (127.0.0.2–10) so agents can create envs without sudo
+- `n start` pre-creates loopback aliases and the shared `newspack_envs` Docker network
 - Each env mounts `envs/<name>/html/` as `/var/www/html` (isolated from `./html/`)
 - Each env gets its own database (`wordpress_<name>`) in the shared MariaDB server
 - Each env gets a unique `WP_CACHE_KEY_SALT` to prevent memcached key collisions
 - Worktrees override specific repos (e.g., `newspack-plugin`) while sharing the rest from `./repos/`
+- All env containers join a shared `newspack_envs` Docker bridge network with their domain as a DNS alias, enabling inter-container communication (e.g., hub/node setups)
 - `n env destroy` cleans up everything: container, DB, html dir, hosts entry, and worktrees
 
 ### Claude Code Plugin Skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ Each isolated environment gets its own Docker container, WordPress installation,
 n env create myenv --worktree newspack-plugin:mybranch
 n env up myenv
 n setup --env myenv --yes     # fully configured Newspack site
-# → https://<ip>/  (use --domain myenv.local for a custom domain)
+# → https://myenv.local/  (override with --domain)
 ```
 
 ### Environment Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,7 @@ n sh <name>                    # Shell into environment container
 
 ### How It Works
 - Each env binds to a unique loopback IP (127.0.0.2+) on ports 80/443 with HTTPS via mkcert
-- Domain defaults to the loopback IP, overridable with `--domain`
+- Domain defaults to `<name>.local`, overridable with `--domain`
 - `n start` pre-creates loopback aliases and the shared `newspack_envs` Docker network
 - Each env mounts `envs/<name>/html/` as `/var/www/html` (isolated from `./html/`)
 - Each env gets its own database (`wordpress_<name>`) in the shared MariaDB server

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -207,6 +207,35 @@ YAML
         db_name=$(db_name_for_env "$env_name")
         domain=$(domain_for_env "$compose_file")
         ip=$(ip_for_env "$compose_file")
+        # --- Migration: add shared network + domain if missing ---
+        if ! grep -q 'newspack_envs' "$compose_file"; then
+            # Assign a .local domain if the env is IP-based.
+            if [[ "$domain" == "$ip" || -z "$domain" ]]; then
+                domain="${env_name}.local"
+                # Update WP_DOMAIN in the compose file.
+                sed -i '' "s|WP_DOMAIN=${ip}|WP_DOMAIN=${domain}|" "$compose_file" 2>/dev/null || \
+                    sed -i "s|WP_DOMAIN=${ip}|WP_DOMAIN=${domain}|" "$compose_file"
+            fi
+            # Replace the old networks block. All existing env compose files end with:
+            #     networks:
+            #       - default
+            # Remove those two trailing lines, then append the new config.
+            # Use a temp file to avoid BSD/GNU sed -i differences with trailing newlines.
+            head -n -2 "$compose_file" > "${compose_file}.tmp" && mv "${compose_file}.tmp" "$compose_file"
+            cat >> "$compose_file" <<MIGRATE
+    networks:
+      default: {}
+      newspack_envs:
+        aliases:
+          - ${domain}
+networks:
+  newspack_envs:
+    external: true
+MIGRATE
+            echo "Migrated $env_name: added shared network (domain: $domain)"
+        fi
+        # Re-read domain after potential migration.
+        domain=$(domain_for_env "$compose_file")
         # Ensure loopback alias exists (macOS only — Linux routes all 127.x.x.x by default).
         if [[ "$(uname)" == "Darwin" && -n "$ip" && "$ip" != "127.0.0.1" ]] && ! ifconfig lo0 | grep -q "$ip"; then
             echo "Error: loopback alias for $ip is not set up."
@@ -268,6 +297,13 @@ YAML
                 # Check if core tables exist (wp core is-installed returns true even without them).
                 if docker exec "$container_name" wp --allow-root db query "SELECT 1 FROM wp_options LIMIT 1" 2>/dev/null | grep -q 1; then
                     echo "WordPress already installed."
+                    # Update site URL if domain changed (e.g., migration from IP to .local).
+                    current_url=$(docker exec "$container_name" wp --allow-root option get siteurl 2>/dev/null)
+                    if [[ -n "$current_url" && "$current_url" != "https://${domain}" ]]; then
+                        docker exec "$container_name" wp --allow-root search-replace "$current_url" "https://${domain}" --skip-columns=guid --quiet 2>/dev/null
+                        docker exec "$container_name" wp --allow-root cache flush 2>/dev/null
+                        echo "Updated site URL: $current_url -> https://${domain}"
+                    fi
                     break
                 fi
                 echo "Installing WordPress..."

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -104,7 +104,7 @@ case $1 in
         done
         ip=$(next_loopback_ip)
         if [[ -z "$domain" ]]; then
-            domain="$ip"
+            domain="${env_name}.local"
         fi
         compose_file="$NABSPATH/docker-compose.env-${env_name}.yml"
         container_name=$(echo "newspack_env_${env_name}" | tr '-' '_')
@@ -143,7 +143,13 @@ ${worktree_volumes}      - ./envs/${env_name}/html:/var/www/html
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
-      - default
+      default: {}
+      newspack_envs:
+        aliases:
+          - ${domain}
+networks:
+  newspack_envs:
+    external: true
 YAML
         echo "Created $compose_file (db: $db_name, domain: $domain, ip: $ip)"
         # Check networking prerequisites (macOS only — Linux routes all 127.x.x.x by default).

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -220,8 +220,9 @@ YAML
             #     networks:
             #       - default
             # Remove those two trailing lines, then append the new config.
-            # Use a temp file to avoid BSD/GNU sed -i differences with trailing newlines.
-            head -n -2 "$compose_file" > "${compose_file}.tmp" && mv "${compose_file}.tmp" "$compose_file"
+            # BSD head doesn't support -n -2, so use wc + awk.
+            total=$(wc -l < "$compose_file")
+            awk -v n="$((total - 2))" 'NR <= n' "$compose_file" > "${compose_file}.tmp" && mv "${compose_file}.tmp" "$compose_file"
             cat >> "$compose_file" <<MIGRATE
     networks:
       default: {}

--- a/n
+++ b/n
@@ -92,6 +92,14 @@ start() {
         fi
         docker compose -f $file up -d
 
+    # Create shared network for inter-container communication.
+    # Env containers join this network with their domain as an alias,
+    # so they can reach each other by domain name via Docker DNS.
+    if ! docker network inspect newspack_envs >/dev/null 2>&1; then
+        docker network create newspack_envs >/dev/null
+        echo "Created shared network: newspack_envs"
+    fi
+
     # macOS: set up loopback aliases for isolated environments.
     # Pre-allocate 127.0.0.2–10 so agents can create envs without sudo later.
     # These don't survive reboots, so this runs on every start.

--- a/n
+++ b/n
@@ -96,7 +96,10 @@ start() {
     # Env containers join this network with their domain as an alias,
     # so they can reach each other by domain name via Docker DNS.
     if ! docker network inspect newspack_envs >/dev/null 2>&1; then
-        docker network create newspack_envs >/dev/null
+        if ! docker network create newspack_envs >/dev/null; then
+            echo "Error: failed to create Docker network 'newspack_envs'. Is Docker running?" >&2
+            exit 1
+        fi
         echo "Created shared network: newspack_envs"
     fi
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Isolated environment containers (created via `n env create`) can now reach each other by domain name through a shared Docker bridge network. This enables hub/node testing workflows where one WordPress container needs to make HTTP requests to another.

Key changes:
- `n start` creates a `newspack_envs` Docker bridge network
- New envs join this network with their domain as a DNS alias
- Default domain changed from loopback IP to `<name>.local`
- Existing IP-based envs are auto-migrated to `.local` domains on `n env up`

### How to test the changes in this Pull Request:

1. Run `n start` and verify the `newspack_envs` network is created: `docker network inspect newspack_envs`
2. Create a new env: `n env create test-a --up` – verify it gets domain `test-a.local` and joins the shared network
3. Create a second env: `n env create test-b --up` – verify it gets domain `test-b.local`
4. From inside test-b, verify DNS resolution to test-a: `docker exec newspack_env_test_b bash -c 'getent hosts test-a.local'` – should return test-a's IP on the bridge network
5. Test migration: create an env with the old format (manually edit a compose file to use `WP_DOMAIN=127.0.0.x` and the old `networks: [default]` block), then run `n env up <name>` and verify it gets migrated to a `.local` domain and joins the shared network
6. Test idempotency: run `n env up <name>` again on an already-migrated env and verify no "Migrated" message appears
7. Clean up: `n env destroy test-a && n env destroy test-b`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?