### PR TITLE
ci(github): add PR review labels workflow and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Automattic/newspack-product

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,45 @@
+on:
+  pull_request_review:
+    types: [submitted]
+name: Label pull requests on review
+jobs:
+  labelOnReview:
+    name: Label on review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Update review labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const APPROVED = '[Status] Approved';
+            const NEEDS_REVIEW = '[Status] Needs Review';
+            const NEEDS_CHANGES = '[Status] Needs Changes or Feedback';
+
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+            const state = context.payload.review.state;
+
+            const add = [];
+            const remove = [];
+
+            if (state === 'approved') {
+              add.push(APPROVED);
+              remove.push(NEEDS_REVIEW, NEEDS_CHANGES);
+            } else if (state === 'changes_requested') {
+              add.push(NEEDS_CHANGES);
+              remove.push(APPROVED, NEEDS_REVIEW);
+            }
+
+            if (add.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: add });
+            }
+            for (const name of remove) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add GitHub Actions workflow for automatic PR label management and CODEOWNERS file, matching the pattern used across all other Newspack repositories.

- When a review approves a PR, adds `[Status] Approved` and removes `[Status] Needs Review` / `[Status] Needs Changes or Feedback`.
- When a review requests changes, adds `[Status] Needs Changes or Feedback` and removes `[Status] Approved` / `[Status] Needs Review`.
- CODEOWNERS assigns `@Automattic/newspack-product` as the default reviewer for all files.

Also created the corresponding GitHub labels (`[Status] Approved` and `[Status] Needs Changes or Feedback`) on the repository. `[Status] Needs Review` already existed.

### How to test the changes in this Pull Request:

1. Merge this PR and create a test PR on the repository.
2. Submit an approving review on the test PR.
3. Verify that the `[Status] Approved` label is added and `[Status] Needs Review` is removed.
4. Submit a "request changes" review on the test PR.
5. Verify that `[Status] Needs Changes or Feedback` is added and `[Status] Approved` is removed.
6. Verify that the CODEOWNERS file triggers a review request to `Newspack Product` team on new PRs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?