### PR TITLE
feat(env): passwordless networking for non-interactive terminals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,8 +262,8 @@ n sh <name>                    # Shell into environment container
 
 ### How It Works
 - Each env binds to a unique loopback IP (127.0.0.2+) on ports 80/443 with HTTPS via mkcert
-- Domain defaults to `<name>.local`, overridable with `--domain`
-- `n start` pre-creates loopback aliases and the shared `newspack_envs` Docker network
+- Domain defaults to the loopback IP, overridable with `--domain`
+- `n start` pre-creates loopback aliases (127.0.0.2–10) so agents can create envs without sudo. If `newspack-manage-host` is installed (via `./bin/setup-networking.sh`), networking is set up without password prompts -- otherwise `sudo` is required
 - Each env mounts `envs/<name>/html/` as `/var/www/html` (isolated from `./html/`)
 - Each env gets its own database (`wordpress_<name>`) in the shared MariaDB server
 - Each env gets a unique `WP_CACHE_KEY_SALT` to prevent memcached key collisions

--- a/README.md
+++ b/README.md
@@ -312,6 +312,20 @@ n env destroy my-feature
 n worktree remove newspack-plugin fix/my-feature
 ```
 
+### Passwordless networking setup (macOS)
+
+Isolated environments need loopback IP aliases and `/etc/hosts` entries, both of which require `sudo`. This is a problem for non-interactive processes (e.g. AI agents) that can't enter a password.
+
+Run the one-time setup script to allow these specific operations without a password:
+
+```BASH
+./bin/setup-networking.sh
+```
+
+This installs a locked-down wrapper script (`newspack-manage-host`) that only allows adding/removing `127.0.0.*` loopback aliases and `*.local` hosts entries, and creates a sudoers rule so your user can run it without a password. After this, `n start`, `n env create`, `n env up`, and `n env destroy` will manage networking automatically -- no password prompts, even from non-interactive terminals.
+
+To undo: `sudo rm /etc/sudoers.d/newspack-manage-host /usr/local/bin/newspack-manage-host`
+
 ## Newspack Manager
 
 This Docker environment will launch two sites by default. One is the site you will be working on to develop all plugins, and the other is the one that will run the Newspack Manager Client.

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -154,11 +154,18 @@ YAML
         echo "Created $compose_file (db: $db_name, domain: $domain, ip: $ip)"
         # Check networking prerequisites (macOS only — Linux routes all 127.x.x.x by default).
         if [[ "$(uname)" == "Darwin" ]] && ! ifconfig lo0 2>/dev/null | grep -q "$ip"; then
-            echo "Note: loopback alias for $ip is missing. Run 'n start' or: sudo ifconfig lo0 alias $ip"
+            if command -v newspack-manage-host >/dev/null 2>&1; then
+                sudo newspack-manage-host alias-add "$ip"
+            else
+                echo "Note: loopback alias for $ip is missing. Run 'n start' or: sudo ifconfig lo0 alias $ip"
+            fi
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if [ -t 0 ] && [ -t 1 ]; then
+            if command -v newspack-manage-host >/dev/null 2>&1; then
+                sudo newspack-manage-host host-add "$ip" "$domain"
+                echo "Added $domain to /etc/hosts"
+            elif [ -t 0 ] && [ -t 1 ]; then
                 read -p "Add $domain to /etc/hosts? (Y/n): " choice
                 choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
                 if [[ "$choice" != "n" ]]; then
@@ -239,13 +246,20 @@ MIGRATE
         domain=$(domain_for_env "$compose_file")
         # Ensure loopback alias exists (macOS only — Linux routes all 127.x.x.x by default).
         if [[ "$(uname)" == "Darwin" && -n "$ip" && "$ip" != "127.0.0.1" ]] && ! ifconfig lo0 | grep -q "$ip"; then
-            echo "Error: loopback alias for $ip is not set up."
-            echo "Run 'n start' to set up networking, or manually: sudo ifconfig lo0 alias $ip"
-            exit 1
+            if command -v newspack-manage-host >/dev/null 2>&1; then
+                sudo newspack-manage-host alias-add "$ip"
+            else
+                echo "Error: loopback alias for $ip is not set up."
+                echo "Run 'n start' to set up networking, or manually: sudo ifconfig lo0 alias $ip"
+                exit 1
+            fi
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ -n "$domain" && "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if [ -t 0 ] && [ -t 1 ]; then
+            if command -v newspack-manage-host >/dev/null 2>&1; then
+                sudo newspack-manage-host host-add "$ip" "$domain"
+                echo "Added $domain to /etc/hosts"
+            elif [ -t 0 ] && [ -t 1 ]; then
                 echo "Adding $domain to /etc/hosts (requires sudo)..."
                 echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
                 echo "Added $domain to /etc/hosts"
@@ -400,9 +414,13 @@ MIGRATE
         fi
         # Remove /etc/hosts entry (only for custom domains, not IP-based).
         if [[ -n "$domain" && "$domain" != "$ip" ]] && grep -q "$domain" /etc/hosts 2>/dev/null; then
-            escaped_domain="${domain//./\\.}"
-            { sudo sed -i '' "/[[:space:]]${escaped_domain}$/d" /etc/hosts 2>/dev/null || \
-              sudo sed -i "/[[:space:]]${escaped_domain}$/d" /etc/hosts; }
+            if command -v newspack-manage-host >/dev/null 2>&1; then
+                sudo newspack-manage-host host-remove "$domain"
+            else
+                escaped_domain="${domain//./\\.}"
+                { sudo sed -i '' "/[[:space:]]${escaped_domain}$/d" /etc/hosts 2>/dev/null || \
+                  sudo sed -i "/[[:space:]]${escaped_domain}$/d" /etc/hosts; }
+            fi
             echo "Removed $domain from /etc/hosts"
         fi
         # Remove compose file before worktrees so worktree.sh doesn't see them as env-bound.

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -162,7 +162,7 @@ YAML
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
                 sudo newspack-manage-host host-add "$ip" "$domain"
                 echo "Added $domain to /etc/hosts"
             elif [ -t 0 ] && [ -t 1 ]; then
@@ -256,7 +256,7 @@ MIGRATE
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ -n "$domain" && "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
                 sudo newspack-manage-host host-add "$ip" "$domain"
                 echo "Added $domain to /etc/hosts"
             elif [ -t 0 ] && [ -t 1 ]; then
@@ -414,7 +414,7 @@ MIGRATE
         fi
         # Remove /etc/hosts entry (only for custom domains, not IP-based).
         if [[ -n "$domain" && "$domain" != "$ip" ]] && grep -q "$domain" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
                 sudo newspack-manage-host host-remove "$domain"
             else
                 escaped_domain="${domain//./\\.}"

--- a/bin/newspack-manage-host
+++ b/bin/newspack-manage-host
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Wrapper script for managing loopback aliases and /etc/hosts entries.
+# Intended to be granted passwordless sudo via a sudoers drop-in,
+# so that non-interactive processes (e.g. AI agents) can set up
+# networking for isolated environments without a password prompt.
+#
+# Only allows:
+#   - Adding/removing loopback aliases on lo0 (127.0.0.*)
+#   - Adding /etc/hosts entries for 127.0.0.* -> *.local domains
+#   - Removing /etc/hosts entries for *.local domains
+
+set -euo pipefail
+
+usage() {
+    echo "Usage:"
+    echo "  $0 alias-add <127.0.0.X>"
+    echo "  $0 alias-remove <127.0.0.X>"
+    echo "  $0 host-add <127.0.0.X> <domain.local>"
+    echo "  $0 host-remove <domain.local>"
+    exit 1
+}
+
+validate_loopback_ip() {
+    if [[ ! "$1" =~ ^127\.0\.0\.[0-9]+$ ]]; then
+        echo "Error: invalid loopback IP '$1' (must be 127.0.0.X)" >&2
+        exit 1
+    fi
+}
+
+validate_local_domain() {
+    if [[ ! "$1" =~ ^[a-zA-Z0-9._-]+\.local$ ]]; then
+        echo "Error: invalid domain '$1' (must end in .local)" >&2
+        exit 1
+    fi
+}
+
+[[ $# -lt 2 ]] && usage
+
+case "$1" in
+    alias-add)
+        validate_loopback_ip "$2"
+        ifconfig lo0 alias "$2"
+        ;;
+    alias-remove)
+        validate_loopback_ip "$2"
+        ifconfig lo0 -alias "$2"
+        ;;
+    host-add)
+        [[ $# -lt 3 ]] && usage
+        validate_loopback_ip "$2"
+        validate_local_domain "$3"
+        # Don't add if already present.
+        if ! grep -q "[[:space:]]${3}$" /etc/hosts 2>/dev/null; then
+            echo "$2 $3" >> /etc/hosts
+        fi
+        ;;
+    host-remove)
+        validate_local_domain "$2"
+        escaped="${2//./\\.}"
+        # BSD sed first, fall back to GNU sed.
+        sed -i '' "/[[:space:]]${escaped}$/d" /etc/hosts 2>/dev/null || \
+            sed -i "/[[:space:]]${escaped}$/d" /etc/hosts
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/bin/setup-networking.sh
+++ b/bin/setup-networking.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# One-time setup for passwordless networking management on macOS.
+#
+# Installs the newspack-manage-host wrapper to /usr/local/bin and creates
+# a sudoers drop-in that allows the current user to run it without a password.
+# After this, `n start` and `n env create` can set up loopback aliases and
+# /etc/hosts entries without interactive sudo prompts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER_SRC="$SCRIPT_DIR/newspack-manage-host"
+WRAPPER_DEST="/usr/local/bin/newspack-manage-host"
+SUDOERS_FILE="/etc/sudoers.d/newspack-manage-host"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "This setup is only needed on macOS. Linux routes all 127.x.x.x by default."
+    exit 0
+fi
+
+if [[ ! -f "$WRAPPER_SRC" ]]; then
+    echo "Error: wrapper script not found at $WRAPPER_SRC" >&2
+    exit 1
+fi
+
+echo "This will:"
+echo "  1. Copy newspack-manage-host to $WRAPPER_DEST (owned by root)"
+echo "  2. Create $SUDOERS_FILE so '$(whoami)' can run it without a password"
+echo ""
+echo "After this, 'n start' and 'n env create' will manage networking automatically."
+echo ""
+read -p "Continue? (Y/n): " choice
+choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
+if [[ "$choice" == "n" ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+echo "Installing wrapper script (requires sudo)..."
+sudo cp "$WRAPPER_SRC" "$WRAPPER_DEST"
+sudo chown root:wheel "$WRAPPER_DEST"
+sudo chmod 755 "$WRAPPER_DEST"
+
+echo "Creating sudoers rule..."
+CURRENT_USER="$(whoami)"
+sudo tee "$SUDOERS_FILE" > /dev/null <<EOF
+# Allow $CURRENT_USER to manage loopback aliases and /etc/hosts for Newspack Docker.
+$CURRENT_USER ALL=(root) NOPASSWD: $WRAPPER_DEST *
+EOF
+sudo chmod 440 "$SUDOERS_FILE"
+
+# Validate the sudoers file.
+if sudo visudo -cf "$SUDOERS_FILE"; then
+    echo ""
+    echo "Done! Networking setup will now work without password prompts."
+    echo "To undo, run: sudo rm $SUDOERS_FILE $WRAPPER_DEST"
+else
+    echo "Error: sudoers file is invalid. Removing it." >&2
+    sudo rm -f "$SUDOERS_FILE"
+    exit 1
+fi

--- a/n
+++ b/n
@@ -132,7 +132,11 @@ start() {
                 done
                 for entry in "${missing_hosts[@]}"; do
                     read -r ip domain <<< "$entry"
-                    sudo newspack-manage-host host-add "$ip" "$domain"
+                    if [[ "$domain" == *.local ]]; then
+                        sudo newspack-manage-host host-add "$ip" "$domain"
+                    else
+                        echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
+                    fi
                 done
             else
                 echo ""

--- a/n
+++ b/n
@@ -125,14 +125,25 @@ start() {
             fi
         done
         if [[ ${#missing_aliases[@]} -gt 0 || ${#missing_hosts[@]} -gt 0 ]]; then
-            echo ""
-            echo "Setting up networking for isolated environments (requires sudo)..."
-            for ip in "${missing_aliases[@]}"; do
-                sudo ifconfig lo0 alias "$ip"
-            done
-            for entry in "${missing_hosts[@]}"; do
-                echo "$entry" | sudo tee -a /etc/hosts > /dev/null
-            done
+            # Use the wrapper script if installed (passwordless sudo), otherwise fall back to raw sudo.
+            if command -v newspack-manage-host >/dev/null 2>&1; then
+                for ip in "${missing_aliases[@]}"; do
+                    sudo newspack-manage-host alias-add "$ip"
+                done
+                for entry in "${missing_hosts[@]}"; do
+                    read -r ip domain <<< "$entry"
+                    sudo newspack-manage-host host-add "$ip" "$domain"
+                done
+            else
+                echo ""
+                echo "Setting up networking for isolated environments (requires sudo)..."
+                for ip in "${missing_aliases[@]}"; do
+                    sudo ifconfig lo0 alias "$ip"
+                done
+                for entry in "${missing_hosts[@]}"; do
+                    echo "$entry" | sudo tee -a /etc/hosts > /dev/null
+                done
+            fi
             echo "Ready: loopback aliases 127.0.0.2–10, $(( ${#missing_hosts[@]} )) hosts entries."
         fi
     fi


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a locked-down wrapper script (`newspack-manage-host`) and a one-time setup script (`setup-networking.sh`) so that `n start`, `n env create`, `n env up`, and `n env destroy` can manage loopback aliases and `/etc/hosts` entries without interactive `sudo` prompts. This unblocks AI agents (and any non-interactive process) from creating and managing isolated environments autonomously.

The wrapper only accepts `127.0.0.*` loopback IPs and `*.local` domains, so it can't be used to redirect arbitrary domains.

### How to test the changes in this Pull Request:

1. Undo existing setup if present: `sudo rm -f /etc/sudoers.d/newspack-manage-host /usr/local/bin/newspack-manage-host`
2. Run `./bin/setup-networking.sh` and confirm the prompts. Verify it completes successfully.
3. Verify the wrapper rejects bad input:
   - `sudo newspack-manage-host alias-add 10.0.0.1` should fail with "invalid loopback IP"
   - `sudo newspack-manage-host host-add 127.0.0.5 evil.com` should fail with "invalid domain"
4. Verify the wrapper works for valid input:
   - `sudo newspack-manage-host alias-add 127.0.0.99` should succeed
   - `ifconfig lo0 | grep 127.0.0.99` should show the alias
   - `sudo newspack-manage-host alias-remove 127.0.0.99` should remove it
5. Test end-to-end: `n env create test-pw-networking --up` from a non-interactive terminal (e.g. pipe stdin from /dev/null). Verify the env starts without sudo prompts.
6. `n env destroy test-pw-networking` should clean up the hosts entry without prompts.
7. Verify fallback: remove the wrapper (`sudo rm /usr/local/bin/newspack-manage-host`) and confirm the scripts fall back to raw `sudo` with the original behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?