### PR TITLE
feat: assorted tweaks to envs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ n sh <name>                    # Shell into environment container
 ### How It Works
 - Each env binds to a unique loopback IP (127.0.0.2+) on ports 80/443 with HTTPS via mkcert
 - Domain defaults to the loopback IP, overridable with `--domain`
-- `n start` pre-creates loopback aliases (127.0.0.2–10) so agents can create envs without sudo. If `newspack-manage-host` is installed (via `./bin/setup-networking.sh`), networking is set up without password prompts -- otherwise `sudo` is required
+- `n start` pre-creates loopback aliases (127.0.0.2–100) so agents can create envs without sudo. If `newspack-manage-host` is installed (via `./bin/setup-networking.sh`), networking is set up without password prompts -- otherwise `sudo` is required
 - Each env mounts `envs/<name>/html/` as `/var/www/html` (isolated from `./html/`)
 - Each env gets its own database (`wordpress_<name>`) in the shared MariaDB server
 - Each env gets a unique `WP_CACHE_KEY_SALT` to prevent memcached key collisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,9 +230,11 @@ n env create <name> [options]  # Create environment config
   --domain <domain>            #   Custom domain (default: <name>.local)
   --up                         #   Start the environment immediately after creation
 n env up <name> [--build]      # Start environment (creates DB, installs WP, sets up SSL)
+n env up --all [--build]       # Start all existing environments at once
 n env down <name>              # Stop environment
 n env destroy <name>           # Remove environment, DB, worktrees, and files
-n env list                     # List environments with status and URLs
+n env list                     # List environments with status, URLs, and worktrees
+n env list --porcelain         # Machine-readable tab-separated output (name, status, url, worktrees)
 n env cleanup                  # Interactive bulk cleanup of environments
 ```
 

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -194,7 +194,32 @@ YAML
         env_name="$2"
         if [[ -z "$env_name" ]]; then
             echo "Usage: n env up <name> [--build]"
+            echo "       n env up --all [--build]"
             exit 1
+        fi
+        # --all: start all existing environments.
+        if [[ "$env_name" == "--all" ]]; then
+            shift 2
+            pass_args=()
+            while [[ $# -gt 0 ]]; do
+                pass_args+=("$1"); shift
+            done
+            started=0
+            failed=0
+            for f in "$NABSPATH"/docker-compose.env-*.yml; do
+                [[ -f "$f" ]] || continue
+                name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
+                echo ""
+                echo "=== Starting $name ==="
+                if "$NABSPATH/bin/env.sh" up "$name" "${pass_args[@]}"; then
+                    started=$((started + 1))
+                else
+                    failed=$((failed + 1))
+                fi
+            done
+            echo ""
+            echo "Done: $started started, $failed failed."
+            exit 0
         fi
         validate_env_name "$env_name"
         shift 2
@@ -536,6 +561,8 @@ MIGRATE
         ;;
     *)
         echo "Usage: n env <create|up|down|destroy|list|cleanup>"
+        echo "  up <name> [--build]      Start an environment"
+        echo "  up --all [--build]       Start all environments"
         echo "  cleanup [--all] [--yes]  Remove environments (--all selects everything, --yes skips confirmation)"
         ;;
 esac

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -469,6 +469,12 @@ MIGRATE
             else
                 echo "  $name (stopped) https://${domain}/"
             fi
+            # Show worktrees mounted by this environment.
+            grep 'worktrees/' "$f" 2>/dev/null | sed 's|.*/newspack-repos/||' | while read -r repo; do
+                wt_path=$(grep "newspack-repos/$repo" "$f" | sed 's/^ *- //' | cut -d: -f1)
+                branch=$(echo "$wt_path" | sed "s|.*worktrees/${repo}/||")
+                echo "    └ $repo ($branch)"
+            done
         done
         ;;
     cleanup)

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -170,6 +170,7 @@ YAML
                 choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
                 if [[ "$choice" != "n" ]]; then
                     echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
+                    echo "Added $domain to /etc/hosts"
                 fi
             else
                 echo "Note: add hosts entry before browser access: sudo sh -c 'echo \"$ip $domain\" >> /etc/hosts'"

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -162,15 +162,11 @@ YAML
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
-                sudo newspack-manage-host host-add "$ip" "$domain"
-                echo "Added $domain to /etc/hosts"
-            elif [ -t 0 ] && [ -t 1 ]; then
+            if [ -t 0 ] && [ -t 1 ]; then
                 read -p "Add $domain to /etc/hosts? (Y/n): " choice
                 choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
                 if [[ "$choice" != "n" ]]; then
                     echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
-                    echo "Added $domain to /etc/hosts"
                 fi
             else
                 echo "Note: add hosts entry before browser access: sudo sh -c 'echo \"$ip $domain\" >> /etc/hosts'"
@@ -282,10 +278,7 @@ MIGRATE
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ -n "$domain" && "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
-                sudo newspack-manage-host host-add "$ip" "$domain"
-                echo "Added $domain to /etc/hosts"
-            elif [ -t 0 ] && [ -t 1 ]; then
+            if [ -t 0 ] && [ -t 1 ]; then
                 echo "Adding $domain to /etc/hosts (requires sudo)..."
                 echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
                 echo "Added $domain to /etc/hosts"

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -458,23 +458,40 @@ MIGRATE
         echo "Destroyed environment '$env_name'"
         ;;
     list)
-        echo "Environments:"
+        porcelain=false
+        if [[ "$2" == "--porcelain" ]]; then
+            porcelain=true
+        fi
+        [[ "$porcelain" == false ]] && echo "Environments:"
         for f in "$NABSPATH"/docker-compose.env-*.yml; do
             [[ -f "$f" ]] || continue
             name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
             container_name=$(echo "newspack_env_${name}" | tr '-' '_')
             domain=$(domain_for_env "$f")
             if status=$(docker inspect -f '{{.State.Status}}' "$container_name" 2>/dev/null); then
-                echo "  $name ($status) https://${domain}/"
+                :
             else
-                echo "  $name (stopped) https://${domain}/"
+                status="stopped"
             fi
-            # Show worktrees mounted by this environment.
-            grep 'worktrees/' "$f" 2>/dev/null | sed 's|.*/newspack-repos/||' | while read -r repo; do
+            # Collect worktrees as repo:branch pairs.
+            worktrees=""
+            while read -r repo; do
                 wt_path=$(grep "newspack-repos/$repo" "$f" | sed 's/^ *- //' | cut -d: -f1)
                 branch=$(echo "$wt_path" | sed "s|.*worktrees/${repo}/||")
-                echo "    └ $repo ($branch)"
-            done
+                [[ -n "$worktrees" ]] && worktrees="$worktrees,"
+                worktrees="${worktrees}${repo}:${branch}"
+            done < <(grep 'worktrees/' "$f" 2>/dev/null | sed 's|.*/newspack-repos/||')
+            if [[ "$porcelain" == true ]]; then
+                printf '%s\t%s\thttps://%s/\t%s\n' "$name" "$status" "$domain" "$worktrees"
+            else
+                echo "  $name ($status) https://${domain}/"
+                # Show worktrees mounted by this environment.
+                grep 'worktrees/' "$f" 2>/dev/null | sed 's|.*/newspack-repos/||' | while read -r repo; do
+                    wt_path=$(grep "newspack-repos/$repo" "$f" | sed 's/^ *- //' | cut -d: -f1)
+                    branch=$(echo "$wt_path" | sed "s|.*worktrees/${repo}/||")
+                    echo "    └ $repo ($branch)"
+                done
+            fi
         done
         ;;
     cleanup)

--- a/n
+++ b/n
@@ -104,11 +104,11 @@ start() {
     fi
 
     # macOS: set up loopback aliases for isolated environments.
-    # Pre-allocate 127.0.0.2–10 so agents can create envs without sudo later.
+    # Pre-allocate 127.0.0.2–100 so agents can create envs without sudo later.
     # These don't survive reboots, so this runs on every start.
     if [[ "$(uname)" == "Darwin" ]]; then
         missing_aliases=()
-        for octet in $(seq 2 10); do
+        for octet in $(seq 2 100); do
             ip="127.0.0.$octet"
             if ! ifconfig lo0 2>/dev/null | grep -q "$ip"; then
                 missing_aliases+=("$ip")
@@ -148,7 +148,7 @@ start() {
                     echo "$entry" | sudo tee -a /etc/hosts > /dev/null
                 done
             fi
-            echo "Ready: loopback aliases 127.0.0.2–10, $(( ${#missing_hosts[@]} )) hosts entries."
+            echo "Ready: loopback aliases 127.0.0.2–100, $(( ${#missing_hosts[@]} )) hosts entries."
         fi
     fi
 }

--- a/n
+++ b/n
@@ -108,9 +108,10 @@ start() {
     # These don't survive reboots, so this runs on every start.
     if [[ "$(uname)" == "Darwin" ]]; then
         missing_aliases=()
+        lo0_addrs=$(ifconfig lo0 2>/dev/null)
         for octet in $(seq 2 100); do
             ip="127.0.0.$octet"
-            if ! ifconfig lo0 2>/dev/null | grep -q "$ip"; then
+            if ! echo "$lo0_addrs" | grep -q "$ip"; then
                 missing_aliases+=("$ip")
             fi
         done


### PR DESCRIPTION
## Summary
- Adds `n env up --all` to start all existing isolated environments at once, useful after a Docker restart when all envs show as "exited"
- Shows worktrees under each environment in `n env list` output
- Adds `--porcelain` flag to `n env list` for machine-readable tab-separated output
- Bumps pre-allocated loopback aliases from 127.0.0.2–10 to 127.0.0.2–100

## Test plan
- [ ] `n env up --all` starts all existing environments
- [ ] `n env up --all --build` starts all and copies built assets
- [ ] Individual `n env up <name>` still works as before
- [ ] `n env list` shows worktrees under each environment
- [ ] `n env list --porcelain` outputs tab-separated: name, status, url, worktrees
- [ ] `n start` creates loopback aliases up to 127.0.0.100

🤖 Generated with [Claude Code](https://claude.com/claude-code)