### PR TITLE
feat(site-setup): configure newsletters ESPs from env vars

### DIFF
--- a/bin/copy-secrets.php
+++ b/bin/copy-secrets.php
@@ -65,3 +65,35 @@ foreach ( $secrets->constants as $constant_name => $constant_value ) {
 		$wpconfig->update( 'constant', $constant_name, $constant_value, [ 'raw' => ! is_string( $constant_value ) ] );
     }
 }
+
+// If any ESP credentials were imported, activate newspack-newsletters and
+// default the service provider to the first ESP with a complete credential set.
+$esp_providers = [
+    'active_campaign'  => [ 'newspack_newsletters_active_campaign_key', 'newspack_newsletters_active_campaign_url' ],
+    'mailchimp'        => [ 'newspack_mailchimp_api_key' ],
+    'constant_contact' => [ 'newspack_newsletters_constant_contact_api_key', 'newspack_newsletters_constant_contact_api_secret' ],
+    'campaign_monitor' => [ 'newspack_newsletters_campaign_monitor_api_key', 'newspack_newsletters_campaign_monitor_client_id' ],
+];
+$configured_esps = [];
+foreach ( $esp_providers as $slug => $required_options ) {
+    $complete = true;
+    foreach ( $required_options as $option ) {
+        if ( empty( get_option( $option ) ) ) {
+            $complete = false;
+            break;
+        }
+    }
+    if ( $complete ) {
+        $configured_esps[] = $slug;
+    }
+}
+if ( ! empty( $configured_esps ) ) {
+    if ( ! is_plugin_active( 'newspack-newsletters/newspack-newsletters.php' ) ) {
+        activate_plugin( 'newspack-newsletters/newspack-newsletters.php' );
+        echo "Activated newspack-newsletters\n";
+    }
+    if ( empty( get_option( 'newspack_newsletters_service_provider' ) ) ) {
+        update_option( 'newspack_newsletters_service_provider', $configured_esps[0] );
+        echo "Service provider set to " . $configured_esps[0] . "\n";
+    }
+}

--- a/bin/site-setup.sh
+++ b/bin/site-setup.sh
@@ -241,41 +241,58 @@ log_info "Enabling Reader Activation..."
 $WP option update newspack_reader_activation_enabled 1
 log_success "Reader Activation enabled"
 
-# Configure newspack-newsletters ESPs (if env vars provided).
-HAS_AC=false
-HAS_MC=false
-[ -n "${ACTIVECAMPAIGN_API_URL:-}" ] && [ -n "${ACTIVECAMPAIGN_API_KEY:-}" ] && HAS_AC=true
-[ -n "${MAILCHIMP_API_KEY:-}" ] && HAS_MC=true
+# Import secrets (API keys, options, constants) from secrets.json, if present.
+if [ -f /var/scripts/secrets.json ]; then
+    log_info "Importing secrets from secrets.json..."
+    /var/scripts/import-secrets.sh "$WP_PATH" || {
+        log_warning "Failed to import secrets"
+    }
 
-if [ "$HAS_AC" = true ] || [ "$HAS_MC" = true ]; then
-    log_info "Configuring newspack-newsletters ESPs..."
-    if $WP plugin is-installed newspack-newsletters &>/dev/null; then
-        $WP plugin activate newspack-newsletters || {
-            log_warning "Failed to activate newspack-newsletters"
+    # If any ESP credentials landed in options, activate newspack-newsletters
+    # and default the service provider to the first ESP with credentials.
+    $WP eval '
+        $providers = [
+            "active_campaign"  => [ "newspack_newsletters_active_campaign_key", "newspack_newsletters_active_campaign_url" ],
+            "mailchimp"        => [ "newspack_mailchimp_api_key" ],
+            "constant_contact" => [ "newspack_newsletters_constant_contact_api_key", "newspack_newsletters_constant_contact_api_secret" ],
+            "campaign_monitor" => [ "newspack_newsletters_campaign_monitor_api_key", "newspack_newsletters_campaign_monitor_client_id" ],
+        ];
+        $configured = [];
+        foreach ( $providers as $slug => $required_options ) {
+            $complete = true;
+            foreach ( $required_options as $option ) {
+                if ( empty( get_option( $option ) ) ) {
+                    $complete = false;
+                    break;
+                }
+            }
+            if ( $complete ) {
+                $configured[] = $slug;
+            }
         }
-
-        if [ "$HAS_AC" = true ]; then
-            $WP option update newspack_newsletters_active_campaign_url "$ACTIVECAMPAIGN_API_URL"
-            $WP option update newspack_newsletters_active_campaign_key "$ACTIVECAMPAIGN_API_KEY"
-            log_success "ActiveCampaign credentials configured"
-        fi
-
-        if [ "$HAS_MC" = true ]; then
-            $WP option update newspack_mailchimp_api_key "$MAILCHIMP_API_KEY"
-            log_success "Mailchimp credentials configured"
-        fi
-
-        # Prefer ActiveCampaign if both are present; user can change later.
-        if [ "$HAS_AC" = true ]; then
-            $WP option update newspack_newsletters_service_provider active_campaign
-            log_success "Service provider set to ActiveCampaign"
-        else
-            $WP option update newspack_newsletters_service_provider mailchimp
-            log_success "Service provider set to Mailchimp"
-        fi
-    else
-        log_warning "newspack-newsletters not installed, skipping ESP setup"
-    fi
+        if ( empty( $configured ) ) {
+            echo "No ESP credentials found in options\n";
+            return;
+        }
+        // Activate the plugin now that credentials are in place.
+        if ( ! is_plugin_active( "newspack-newsletters/newspack-newsletters.php" ) ) {
+            activate_plugin( "newspack-newsletters/newspack-newsletters.php" );
+            echo "Activated newspack-newsletters\n";
+        }
+        // Default the service provider to the first configured ESP if not already set.
+        $current = get_option( "newspack_newsletters_service_provider" );
+        if ( empty( $current ) ) {
+            update_option( "newspack_newsletters_service_provider", $configured[0] );
+            echo "Service provider set to " . $configured[0] . "\n";
+        } else {
+            echo "Service provider already set to " . $current . "\n";
+        }
+    ' || {
+        log_warning "Failed to finalize newsletters ESP setup"
+    }
+    log_success "Secrets imported"
+else
+    log_info "No secrets.json found, skipping secrets import"
 fi
 
 # Remove default Sample Page

--- a/bin/site-setup.sh
+++ b/bin/site-setup.sh
@@ -241,6 +241,43 @@ log_info "Enabling Reader Activation..."
 $WP option update newspack_reader_activation_enabled 1
 log_success "Reader Activation enabled"
 
+# Configure newspack-newsletters ESPs (if env vars provided).
+HAS_AC=false
+HAS_MC=false
+[ -n "${ACTIVECAMPAIGN_API_URL:-}" ] && [ -n "${ACTIVECAMPAIGN_API_KEY:-}" ] && HAS_AC=true
+[ -n "${MAILCHIMP_API_KEY:-}" ] && HAS_MC=true
+
+if [ "$HAS_AC" = true ] || [ "$HAS_MC" = true ]; then
+    log_info "Configuring newspack-newsletters ESPs..."
+    if $WP plugin is-installed newspack-newsletters &>/dev/null; then
+        $WP plugin activate newspack-newsletters || {
+            log_warning "Failed to activate newspack-newsletters"
+        }
+
+        if [ "$HAS_AC" = true ]; then
+            $WP option update newspack_newsletters_active_campaign_url "$ACTIVECAMPAIGN_API_URL"
+            $WP option update newspack_newsletters_active_campaign_key "$ACTIVECAMPAIGN_API_KEY"
+            log_success "ActiveCampaign credentials configured"
+        fi
+
+        if [ "$HAS_MC" = true ]; then
+            $WP option update newspack_mailchimp_api_key "$MAILCHIMP_API_KEY"
+            log_success "Mailchimp credentials configured"
+        fi
+
+        # Prefer ActiveCampaign if both are present; user can change later.
+        if [ "$HAS_AC" = true ]; then
+            $WP option update newspack_newsletters_service_provider active_campaign
+            log_success "Service provider set to ActiveCampaign"
+        else
+            $WP option update newspack_newsletters_service_provider mailchimp
+            log_success "Service provider set to Mailchimp"
+        fi
+    else
+        log_warning "newspack-newsletters not installed, skipping ESP setup"
+    fi
+fi
+
 # Remove default Sample Page
 log_info "Removing default Sample Page..."
 $WP post delete $($WP post list --post_type=page --name=sample-page --field=ID --format=ids 2>/dev/null) --force 2>/dev/null || true

--- a/bin/site-setup.sh
+++ b/bin/site-setup.sh
@@ -247,49 +247,6 @@ if [ -f /var/scripts/secrets.json ]; then
     /var/scripts/import-secrets.sh "$WP_PATH" || {
         log_warning "Failed to import secrets"
     }
-
-    # If any ESP credentials landed in options, activate newspack-newsletters
-    # and default the service provider to the first ESP with credentials.
-    $WP eval '
-        $providers = [
-            "active_campaign"  => [ "newspack_newsletters_active_campaign_key", "newspack_newsletters_active_campaign_url" ],
-            "mailchimp"        => [ "newspack_mailchimp_api_key" ],
-            "constant_contact" => [ "newspack_newsletters_constant_contact_api_key", "newspack_newsletters_constant_contact_api_secret" ],
-            "campaign_monitor" => [ "newspack_newsletters_campaign_monitor_api_key", "newspack_newsletters_campaign_monitor_client_id" ],
-        ];
-        $configured = [];
-        foreach ( $providers as $slug => $required_options ) {
-            $complete = true;
-            foreach ( $required_options as $option ) {
-                if ( empty( get_option( $option ) ) ) {
-                    $complete = false;
-                    break;
-                }
-            }
-            if ( $complete ) {
-                $configured[] = $slug;
-            }
-        }
-        if ( empty( $configured ) ) {
-            echo "No ESP credentials found in options\n";
-            return;
-        }
-        // Activate the plugin now that credentials are in place.
-        if ( ! is_plugin_active( "newspack-newsletters/newspack-newsletters.php" ) ) {
-            activate_plugin( "newspack-newsletters/newspack-newsletters.php" );
-            echo "Activated newspack-newsletters\n";
-        }
-        // Default the service provider to the first configured ESP if not already set.
-        $current = get_option( "newspack_newsletters_service_provider" );
-        if ( empty( $current ) ) {
-            update_option( "newspack_newsletters_service_provider", $configured[0] );
-            echo "Service provider set to " . $configured[0] . "\n";
-        } else {
-            echo "Service provider already set to " . $current . "\n";
-        }
-    ' || {
-        log_warning "Failed to finalize newsletters ESP setup"
-    }
     log_success "Secrets imported"
 else
     log_info "No secrets.json found, skipping secrets import"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Makes `n setup` pre-configure ESP credentials (and any other secrets) from the existing `bin/secrets.json` file instead of requiring a separate `n secrets-import` run after each fresh setup. This builds on the existing `copy-secrets.php` mechanism – no new env vars, no new file format.

When `bin/secrets.json` is present, `site-setup.sh` now:

1. Runs `/var/scripts/import-secrets.sh`, which applies all options, WP constants, and the Stripe config already defined in `secrets.json`.
2. Checks which ESP credentials landed in options (ActiveCampaign, Mailchimp, Constant Contact, or Campaign Monitor).
3. If any ESP has a complete credential set, activates `newspack-newsletters` and defaults `newspack_newsletters_service_provider` to the first configured ESP (unless one is already set in `secrets.json`).

If `secrets.json` is absent, the step is skipped and setup behaves exactly as before.

### How to test the changes in this Pull Request:

1. Without a `bin/secrets.json` file, run `n setup --yes`. Confirm the log shows `No secrets.json found, skipping secrets import` and setup completes normally. `wp plugin is-active newspack-newsletters` should return a non-zero exit (plugin inactive).
2. Copy `bin/secrets.json.sample` to `bin/secrets.json` and fill in only the Mailchimp field (`newspack_mailchimp_api_key`). Leave `newspack_newsletters_service_provider` empty. Run `n setup --yes`. Confirm the log shows the secrets being imported, `newspack-newsletters` being activated, and service provider defaulting to `mailchimp`. Verify with `wp option get newspack_mailchimp_api_key` and `wp option get newspack_newsletters_service_provider`.
3. In `secrets.json`, fill in ActiveCampaign (`newspack_newsletters_active_campaign_key` and `_url`) in addition to Mailchimp. Run `n setup --yes`. Confirm both credentials are present in options and service provider defaults to `active_campaign` (first in the priority order).
4. In `secrets.json`, explicitly set `newspack_newsletters_service_provider` to `mailchimp` while having both ESP credentials configured. Run `n setup --yes`. Confirm the log shows `Service provider already set to mailchimp` and the option matches.
5. Fill out the `stripe` and `constants` blocks in `secrets.json` too. Run `n setup --yes`. Confirm the Stripe settings and `wp-config.php` constants are applied as they are today via `n secrets-import`.
6. With `secrets.json` present but containing no ESP credentials (e.g. only `stripe` populated), run `n setup --yes`. Confirm the log shows `No ESP credentials found in options` and `newspack-newsletters` is not activated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?