### PR TITLE
chore: upgrade MariaDB from 10.8.2 to 11.8.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ n release                     # Switch all repos to release
 
 ### Docker Services
 - `wordpress` (container: `newspack_dev`) - Apache + PHP + WordPress
-- `db` - MariaDB 10.8.2
+- `db` - MariaDB 11.8.6
 - `mailhog` - Email capture at http://localhost:8025
 - `adminer` - Database UI at http://localhost:8088
 

--- a/bin/docker-db-start-and-autoupgrade.sh
+++ b/bin/docker-db-start-and-autoupgrade.sh
@@ -13,7 +13,7 @@ find /var/log/mysql \! -user mysql -exec chown mysql '{}' +
 	sleep 1
 
 	# Wait until server is up
-	while ! mysql $CREDENTIALS_PARAMS ${MYSQL_DATABASE} -e 'quit' > /dev/null 2>&1
+	while ! mariadb $CREDENTIALS_PARAMS ${MYSQL_DATABASE} -e 'quit' > /dev/null 2>&1
 	do
 		# Let's wait a bit before retrying
 		echo "Auto-updater waiting for DB to be up..."
@@ -22,7 +22,7 @@ find /var/log/mysql \! -user mysql -exec chown mysql '{}' +
 
 	echo "Trying to upgrade database..."
 
-	mysql_upgrade $CREDENTIALS_PARAMS
+	mariadb-upgrade $CREDENTIALS_PARAMS
 ) &
 
 # Start the actual database

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -296,7 +296,7 @@ MIGRATE
         docker compose -f "$NABSPATH/docker-compose.yml" up -d db
         echo "Creating database $db_name..."
         docker compose -f "$NABSPATH/docker-compose.yml" exec -T db \
-            mysql -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
+            mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
             -e "CREATE DATABASE IF NOT EXISTS \`${db_name}\`; GRANT ALL PRIVILEGES ON \`${db_name}\`.* TO '${MYSQL_USER}'@'%'; FLUSH PRIVILEGES;" 2>/dev/null
         # Start the env container.
         if ! docker compose -f "$NABSPATH/docker-compose.yml" -f "$compose_file" up -d "env-${env_name}"; then
@@ -418,7 +418,7 @@ MIGRATE
         set +a
         docker compose -f "$NABSPATH/docker-compose.yml" up -d db 2>/dev/null
         docker compose -f "$NABSPATH/docker-compose.yml" exec -T db \
-            mysql -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
+            mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
             -e "DROP DATABASE IF EXISTS \`${db_name}\`" 2>/dev/null
         echo "Dropped database $db_name"
         # Remove env html and certs directories.

--- a/docker-compose-82.yml
+++ b/docker-compose-82.yml
@@ -9,7 +9,7 @@ services:
   ## We map a local directory (data/mysql) so we can have the mysql data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
-    image: mariadb:10.8.2
+    image: mariadb:11.8.6
     volumes:
       - ./data/newspack-dev_mysql:/var/lib/mysql
       - ./logs/newspack-dev/mysql:/var/log/mysql
@@ -19,7 +19,7 @@ services:
       - default.env
       - .env
     entrypoint: [ '/bin/bash', '/var/scripts/docker-db-start-and-autoupgrade.sh' ]
-    command: [ 'mysqld' ]
+    command: [ 'mariadbd' ]
 
   ## - The container wordpress is a very basic but custom container with WordPress and all of the tools we need
   ##   for development.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   ## We map a local directory (data/mysql) so we can have the mysql data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
-    image: mariadb:10.8.2
+    image: mariadb:11.8.6
     volumes:
       - ./data/newspack-dev_mysql:/var/lib/mysql
       - ./logs/newspack-dev/mysql:/var/log/mysql
@@ -19,7 +19,7 @@ services:
       - default.env
       - .env
     entrypoint: ["/bin/bash", "/var/scripts/docker-db-start-and-autoupgrade.sh"]
-    command: ["mysqld"]
+    command: ["mariadbd"]
 
   ## - The container wordpress is a very basic but custom container with WordPress and all of the tools we need
   ##   for development.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Upgrades the local dev MariaDB from `10.8.2` (RC released [2022-02-14](https://mariadb.com/docs/release-notes/community-server/old-releases/10.8/10.8.2), 10.8 series EOL since May 2023) to `11.8.6` LTS (released [2026-02-04](https://mariadb.com/docs/release-notes/community-server/11.8/11.8.6)). This brings us to a supported release with ongoing security patches, matching the version running on production servers.

The official `mariadb:11.8` Docker image no longer ships the legacy `mysqld` and `mysql` binary symlinks (MariaDB has been deprecating them since 10.5 in favor of `mariadbd` and `mariadb`). The db container command and the autoupgrade entrypoint are updated accordingly. Anyone with local scripts that reference the old binary names will need to update them.

**Disclaimer:** Existing data directories are migrated automatically via the autoupgrade entry point on first start, so no manual intervention is required. That said, any major version jump carries a small chance of an unexpected hiccup, so please back up your database (if you care about it) before pulling to keep rollback trivial.

### How to test the changes in this Pull Request:

1. **Back up your main site database before pulling.** Replace `/path/to/backup/` below with the path where you want to store the backup. From inside `newspack-workspace` with the current stack running on 10.8.2:

   ```
   docker exec newspack_dev sh -c "wp db export - --allow-root" > /path/to/backup/newspack-pre-11.8.6-$(date +%Y%m%d-%H%M%S).sql
   ```
   If you run additional sites (`n sites-add`) or isolated envs (`n env create`), back those up too.

2. Optional extra safety net: snapshot the MariaDB data directory for a full rollback target:
   ```
   n stop
   cp -a data/newspack-dev_mysql data/newspack-dev_mysql.pre-11.8.bak
   ```

3. Pull this branch and bring the stack up:

   ```
   n start
   ```

4. Watch the db container logs and confirm the autoupgrade runs cleanly. Every table should report `OK`:
   ```
   docker logs -f newspack-docker-db-1
   ```

5. Verify the server version:
   ```
   n db
   mysql> SELECT VERSION();
   ```
   Expected: `11.8.6-MariaDB-ubu2404-log`.

6. Verify data is intact, and the site loads and works as expected.

7. Verify the `wp_tests` schema also migrated by running a plugin test suite from inside any `repos/<plugin>/`:
   ```
   n test-php
   ```

8. Verify the fresh init code path with a throwaway isolated env:
   ```
   n env create mariadb-test --worktree newspack-plugin:trunk
   n env up mariadb-test
   ```
   Browse to the URL it prints. Cleanup after: `n env destroy mariadb-test`.

9. **Rollback if anything looks wrong.** Switch back to `main`, drop the upgraded data directory, and reload the SQL backup:
   ```
   n stop
   git switch main
   trash data/newspack-dev_mysql
   n start
   docker exec -i newspack_dev sh -c "wp db import - --allow-root" \
       < /path/to/backup/newspack-pre-11.8.6-*.sql
   ```
   Or, if you took the data directory snapshot in step 2, restore from that instead of re importing:
   ```
   n stop
   git switch main
   trash data/newspack-dev_mysql
   mv data/newspack-dev_mysql.pre-11.8.bak data/newspack-dev_mysql
   n start
   ```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
