### PR TITLE
fix(ci): split sync-legacy checkout so scripts come from main

### DIFF
--- a/.github/workflows/sync-legacy.yml
+++ b/.github/workflows/sync-legacy.yml
@@ -32,20 +32,31 @@ jobs:
     name: Filter, publish, and integrate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Sync scripts live on main; the working tree the script merges into
+      # is monorepo-integration. Two checkouts keep them separate.
+      - name: Check out main (sync scripts)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: scripts-src
+      - name: Check out monorepo-integration (working tree)
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: monorepo-integration
+          path: integration
       - name: Install git-filter-repo
         run: |
           sudo apt-get update
           sudo apt-get install -y git-filter-repo
       - name: Configure git
+        working-directory: integration
         run: |
           git config user.name  "Adam Cassis"
           git config user.email "adam.cassis@automattic.com"
       - name: Run sync
+        working-directory: integration
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bin/sync-legacy.sh
+        run: ../scripts-src/bin/sync-legacy.sh


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the sync-legacy workflow's first run, which errored out with `bin/sync-legacy.sh: No such file or directory` ([run](https://github.com/Automattic/newspack-workspace/actions/runs/25048337061)).

The workflow checks out `monorepo-integration` because that's the branch the script merges into and pushes back to. But the sync scripts only live on `main` (they were intentionally not synced into `monorepo-integration`), so the script wasn't there to run.

This PR splits the checkout in two:

- `scripts-src/` — `main`, just for `bin/sync-legacy.sh` and `bin/sync-legacy-repo.sh`.
- `integration/` — `monorepo-integration` with full history, used as the working tree.

The script is invoked as `../scripts-src/bin/sync-legacy.sh` with `working-directory: integration`. `SCRIPT_DIR` resolves to `scripts-src/bin/` (so it still finds its sibling `sync-legacy-repo.sh`), and all `git` calls operate on the integration checkout via CWD. No script changes needed.

### How to test the changes in this Pull Request:

1. Merge.
2. Trigger the workflow manually via Actions → "Sync legacy repos" → "Run workflow".
3. Confirm the run reaches the filter/integrate phase instead of failing at the first `bin/sync-legacy.sh` call.