### PR TITLE
feat(migration): cutover-day PR-transplant tooling

### DIFF
--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# lib.sh — shared helpers for the legacy → monorepo migration scripts.
+#
+# Sourced by sync-legacy.sh (daily trunk sync) and transplant-pr.sh (per-PR
+# transplant on cutover day). Provides:
+#
+#   • The legacy-repo manifest: name → target subdir in the monorepo.
+#   • Path-rewrite / merge helpers used to land legacy commits cleanly:
+#       - apply_structural_overrides: drop legacy .github/, package-lock.json,
+#         and pin workspace:* in plugin/theme package.json.
+#       - normalize_package_repos: rewrite repository.url in every workspace
+#         package.json so semantic-release resolves to the monorepo, not the
+#         standalone legacy repo.
+#       - route_extracted_packages: relocate any
+#         plugins/newspack-plugin/packages/{colors,components,icons}/* to
+#         packages/<pkg>/* (those package homes moved during extraction).
+#   • Dry-run wrappers around git push and gh pr create.
+#   • Helpers to look up the manifest entry for a given legacy repo name.
+#
+# The whole bin/migration/ tree is intended to be deleted after cutover —
+# none of this code is needed once development has moved to the monorepo.
+
+# Manifest: legacy repo name → monorepo target subdir. Stable order; the
+# integrate phase of sync-legacy.sh merges in this order, so changing it
+# changes the resulting merge-commit shape on monorepo-integration.
+LEGACY_REPOS=(
+  newspack-plugin:plugins/newspack-plugin
+  newspack-blocks:plugins/newspack-blocks
+  newspack-popups:plugins/newspack-popups
+  newspack-newsletters:plugins/newspack-newsletters
+  newspack-ads:plugins/newspack-ads
+  newspack-network:plugins/newspack-network
+  newspack-multibranded-site:plugins/newspack-multibranded-site
+  newspack-listings:plugins/newspack-listings
+  newspack-sponsors:plugins/newspack-sponsors
+  newspack-story-budget:plugins/newspack-story-budget
+  super-cool-ad-inserter-plugin:plugins/super-cool-ad-inserter-plugin
+  republication-tracker-tool:plugins/republication-tracker-tool
+  newspack-theme:themes/newspack-theme
+  newspack-block-theme:themes/newspack-block-theme
+  newspack-scripts:packages/scripts
+)
+
+# Look up the monorepo target subdir for a legacy repo name. Echoes the
+# subdir on stdout, returns 1 if the name isn't in the manifest.
+legacy_repo_target() {
+  local name=$1 entry
+  for entry in "${LEGACY_REPOS[@]}"; do
+    if [ "${entry%%:*}" = "$name" ]; then
+      echo "${entry#*:}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Wrap git push so DRY_RUN=1 prints the intended push instead of running it.
+# Callers set DRY_RUN themselves; we read it from the environment.
+git_push() {
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    echo "    [dry-run] would push: git push $*"
+  else
+    git push "$@"
+  fi
+}
+
+# Wrap gh pr create the same way. Errors are warned but not fatal: in the
+# escalation path the conflict branch is already on origin, so a missing PR
+# can be opened by hand later.
+gh_pr_create() {
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    echo "    [dry-run] would create draft PR: gh pr create $*" | head -c 400
+    echo
+  else
+    gh pr create "$@" \
+      || echo "WARN: gh pr create failed; conflict branch is at origin"
+  fi
+}
+
+# Drop legacy per-plugin .github/ (CI runs at the monorepo root) and
+# package-lock.json (the monorepo uses pnpm-lock.yaml at the root; per-plugin
+# lockfiles are vestigial and would otherwise be re-added on every sync run
+# that touches them upstream). Also restore workspace:* in any conflicting
+# plugin/theme package.json — the legacy repo bumps newspack-{scripts,
+# components,colors,icons} to concrete versions, which would break the
+# pnpm workspace if landed.
+apply_structural_overrides() {
+  local target=$1
+  git rm -rf --ignore-unmatch \
+    "$target/.github" "$target/package-lock.json" \
+    > /dev/null 2>&1 || true
+  while IFS= read -r f; do
+    case "$f" in
+      plugins/*/package.json|themes/*/package.json)
+        git checkout --ours -- "$f"
+        git add "$f"
+        ;;
+    esac
+  done < <(git diff --name-only --diff-filter=U)
+}
+
+# Rewrite repository field in every workspace package.json so semantic-release
+# resolves to the monorepo. Without this, multi-semantic-release ls-remotes
+# the legacy standalone repo of each plugin (which has no alpha/release
+# branches) and aborts. Idempotent — safe to call after every merge.
+normalize_package_repos() {
+  node -e '
+    const fs = require("fs"), path = require("path");
+    const url = "git+https://github.com/Automattic/newspack-workspace.git";
+    const roots = ["plugins", "themes", "packages"];
+    const changed = [];
+    for (const r of roots) {
+      if (!fs.existsSync(r)) continue;
+      for (const name of fs.readdirSync(r)) {
+        const dir = path.join(r, name);
+        const pj = path.join(dir, "package.json");
+        if (!fs.existsSync(pj)) continue;
+        const src = fs.readFileSync(pj, "utf8");
+        const indentMatch = src.match(/\n(\t+|[ ]+)"/);
+        const indent = indentMatch ? indentMatch[1] : "  ";
+        const trail = src.endsWith("\n") ? "\n" : "";
+        const j = JSON.parse(src);
+        const want = { type: "git", url, directory: dir };
+        if (JSON.stringify(j.repository) === JSON.stringify(want)) continue;
+        j.repository = want;
+        fs.writeFileSync(pj, JSON.stringify(j, null, indent) + trail);
+        changed.push(pj);
+      }
+    }
+    process.stdout.write(changed.join("\0"));
+  ' | while IFS= read -r -d "" f; do
+    git add -- "$f"
+  done
+}
+
+# For newspack-plugin: redirect any path under
+# plugins/newspack-plugin/packages/{colors,components,icons}/ to the workspace
+# path packages/<pkg>/<rest>. Three cases:
+#   1. Path is conflicted: 3-way merge legacy's change into the workspace file.
+#   2. Path is cleanly merged in (legacy added/modified, no monorepo-side
+#      change): move/overwrite at the workspace path.
+#   3. Path is deleted in legacy: drop it.
+# Returns 1 if any routed file ends up with conflict markers, or if a modified
+# file has no workspace target.
+route_extracted_packages() {
+  local rc=0
+
+  # Process conflicts first (the unresolved index entries hold the base/theirs
+  # blobs we need for a real 3-way merge).
+  while IFS= read -r path; do
+    case "$path" in
+      plugins/newspack-plugin/packages/colors/*|\
+      plugins/newspack-plugin/packages/components/*|\
+      plugins/newspack-plugin/packages/icons/*) ;;
+      *) continue ;;
+    esac
+
+    local rel="${path#plugins/newspack-plugin/packages/}"
+    local target="packages/$rel"
+    local base_blob theirs_blob
+    base_blob=$(git ls-files -s -- "$path" | awk '$3==1{print $2}')
+    theirs_blob=$(git ls-files -s -- "$path" | awk '$3==3{print $2}')
+
+    if [ -z "$theirs_blob" ]; then
+      git rm -f -- "$path" > /dev/null
+      continue
+    fi
+
+    if [ ! -e "$target" ]; then
+      if [ -z "$base_blob" ]; then
+        mkdir -p "$(dirname "$target")"
+        git show "$theirs_blob" > "$target"
+        git add "$target"
+        git rm -f -- "$path" > /dev/null
+      else
+        rc=1
+      fi
+      continue
+    fi
+
+    local base_src=/tmp/sync-base-$$
+    local theirs_src=/tmp/sync-theirs-$$
+    local merged=/tmp/sync-merged-$$
+    if [ -n "$base_blob" ]; then
+      git show "$base_blob" > "$base_src"
+    else
+      : > "$base_src"
+    fi
+    git show "$theirs_blob" > "$theirs_src"
+
+    if git merge-file -p "$theirs_src" "$base_src" "$target" > "$merged" 2>/dev/null; then
+      cp "$merged" "$target"
+      git add "$target"
+      git rm -f -- "$path" > /dev/null
+    else
+      cp "$merged" "$target"
+      git rm -f -- "$path" > /dev/null
+      rc=1
+    fi
+    rm -f "$base_src" "$theirs_src" "$merged"
+  done < <(git diff --name-only --diff-filter=U)
+
+  # Sweep any remaining cleanly-merged files under the extracted dirs (the
+  # conflict pass missed them because there was no conflict — just legacy's
+  # content landing at the legacy path).
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    local rel="${path#plugins/newspack-plugin/packages/}"
+    local target="packages/$rel"
+    mkdir -p "$(dirname "$target")"
+    git show ":0:$path" > "$target"
+    git add "$target"
+    git rm -f -- "$path" > /dev/null
+  done < <(git ls-files -- \
+    'plugins/newspack-plugin/packages/colors/*' \
+    'plugins/newspack-plugin/packages/components/*' \
+    'plugins/newspack-plugin/packages/icons/*')
+
+  return "$rc"
+}

--- a/bin/migration/sync-legacy-repo.sh
+++ b/bin/migration/sync-legacy-repo.sh
@@ -65,8 +65,14 @@ rm -rf "$OUTPUT_DIR"
 mkdir -p "$(dirname "$OUTPUT_DIR")"
 
 # --mirror preserves all refs so we can pick trunk out reliably even when
-# the source is a working copy with a different HEAD.
-git clone --mirror --quiet "$SOURCE" "$OUTPUT_DIR"
+# the source is a working copy with a different HEAD. --no-hardlinks
+# prevents a race condition that bites when transplant-pr.sh runs many
+# PRs of the same legacy repo concurrently: they all clone-mirror from the
+# same bare source, and git's default hardlink optimization can fail with
+# "hardlink different from source" if pack files get rewritten between
+# the link calls. The disk-space cost of a real copy is fine at the scale
+# we care about (one filtered repo per PR).
+git clone --mirror --no-hardlinks --quiet "$SOURCE" "$OUTPUT_DIR"
 
 cd "$OUTPUT_DIR"
 

--- a/bin/migration/sync-legacy.sh
+++ b/bin/migration/sync-legacy.sh
@@ -47,6 +47,11 @@ SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 SCRATCH_DIR="${SCRATCH_DIR:-/tmp/sync-legacy}"
 PARALLEL_FILTER_JOBS="${PARALLEL_FILTER_JOBS:-5}"
 
+# Shared helpers (manifest, structural overrides, dry-run wrappers, etc.)
+# live in lib.sh so transplant-pr.sh can reuse them at cutover time.
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
 # In dry-run mode, transparently re-execute inside a fresh detached-HEAD
 # worktree based off the integration target (origin/monorepo-integration by
 # default; override with DRY_RUN_BASE) so the caller's working tree and HEAD
@@ -90,54 +95,16 @@ if [ "$DRY_RUN" = "1" ] && [ "${SYNC_LEGACY_DRY_RUN_ISOLATED:-0}" != "1" ]; then
   exit $?
 fi
 
-# Manifest: name:target_subdir. Stable order (the integrate phase merges in
-# this order, so changing it changes the merge commit shape).
-REPOS=(
-  newspack-plugin:plugins/newspack-plugin
-  newspack-blocks:plugins/newspack-blocks
-  newspack-popups:plugins/newspack-popups
-  newspack-newsletters:plugins/newspack-newsletters
-  newspack-ads:plugins/newspack-ads
-  newspack-network:plugins/newspack-network
-  newspack-multibranded-site:plugins/newspack-multibranded-site
-  newspack-listings:plugins/newspack-listings
-  newspack-sponsors:plugins/newspack-sponsors
-  newspack-story-budget:plugins/newspack-story-budget
-  super-cool-ad-inserter-plugin:plugins/super-cool-ad-inserter-plugin
-  republication-tracker-tool:plugins/republication-tracker-tool
-  newspack-theme:themes/newspack-theme
-  newspack-block-theme:themes/newspack-block-theme
-  newspack-scripts:packages/scripts
-)
-
-git_push() {
-  if [ "$DRY_RUN" = "1" ]; then
-    echo "    [dry-run] would push: git push $*"
-  else
-    git push "$@"
-  fi
-}
-
-gh_pr_create() {
-  if [ "$DRY_RUN" = "1" ]; then
-    echo "    [dry-run] would create draft PR: gh pr create $*" | head -c 400
-    echo
-  else
-    gh pr create "$@" \
-      || echo "WARN: gh pr create failed; conflict branch is at origin"
-  fi
-}
-
 # ---------------------------------------------------------------------------
 # Phase 1: filter
 # ---------------------------------------------------------------------------
 filter_all() {
   mkdir -p "$SCRATCH_DIR"
-  echo "==> Phase 1: filtering ${#REPOS[@]} legacy repos (P=$PARALLEL_FILTER_JOBS)"
+  echo "==> Phase 1: filtering ${#LEGACY_REPOS[@]} legacy repos (P=$PARALLEL_FILTER_JOBS)"
 
   # Render manifest as one entry per line for xargs.
   local manifest
-  manifest=$(printf '%s\n' "${REPOS[@]}")
+  manifest=$(printf '%s\n' "${LEGACY_REPOS[@]}")
   local rc=0
   # xargs appends each stdin line as an extra argument after the fixed ones,
   # so positional args inside `bash -c` are: $0=script, $1=scratch, $2=entry.
@@ -179,7 +146,7 @@ filter_all() {
 # ---------------------------------------------------------------------------
 publish_all() {
   echo "==> Phase 2: publishing sync/<name> branches"
-  for entry in "${REPOS[@]}"; do
+  for entry in "${LEGACY_REPOS[@]}"; do
     local name="${entry%%:*}"
     if [ "$DRY_RUN" = "1" ]; then
       # Wire the filtered tip directly into refs/remotes/origin/sync/<name>
@@ -199,146 +166,6 @@ publish_all() {
 # ---------------------------------------------------------------------------
 # Phase 3: integrate
 # ---------------------------------------------------------------------------
-
-# Drop legacy per-plugin .github/ (CI runs at the monorepo root) and
-# package-lock.json (the monorepo uses pnpm-lock.yaml at the root; per-plugin
-# lockfiles are vestigial and would otherwise be re-added on every sync run
-# that touches them upstream). Also restore workspace:* in any conflicting
-# plugin/theme package.json.
-apply_structural_overrides() {
-  local target=$1
-  git rm -rf --ignore-unmatch \
-    "$target/.github" "$target/package-lock.json" \
-    > /dev/null 2>&1 || true
-  while IFS= read -r f; do
-    case "$f" in
-      plugins/*/package.json|themes/*/package.json)
-        git checkout --ours -- "$f"
-        git add "$f"
-        ;;
-    esac
-  done < <(git diff --name-only --diff-filter=U)
-}
-
-# Rewrite repository field in every workspace package.json so semantic-release
-# resolves to the monorepo. Without this, multi-semantic-release ls-remotes
-# the legacy standalone repo of each plugin (which has no alpha/release
-# branches) and aborts. Idempotent — safe to call after every merge.
-normalize_package_repos() {
-  node -e '
-    const fs = require("fs"), path = require("path");
-    const url = "git+https://github.com/Automattic/newspack-workspace.git";
-    const roots = ["plugins", "themes", "packages"];
-    const changed = [];
-    for (const r of roots) {
-      if (!fs.existsSync(r)) continue;
-      for (const name of fs.readdirSync(r)) {
-        const dir = path.join(r, name);
-        const pj = path.join(dir, "package.json");
-        if (!fs.existsSync(pj)) continue;
-        const src = fs.readFileSync(pj, "utf8");
-        const indentMatch = src.match(/\n(\t+|[ ]+)"/);
-        const indent = indentMatch ? indentMatch[1] : "  ";
-        const trail = src.endsWith("\n") ? "\n" : "";
-        const j = JSON.parse(src);
-        const want = { type: "git", url, directory: dir };
-        if (JSON.stringify(j.repository) === JSON.stringify(want)) continue;
-        j.repository = want;
-        fs.writeFileSync(pj, JSON.stringify(j, null, indent) + trail);
-        changed.push(pj);
-      }
-    }
-    process.stdout.write(changed.join("\0"));
-  ' | while IFS= read -r -d "" f; do
-    git add -- "$f"
-  done
-}
-
-# For newspack-plugin: redirect any path under
-# plugins/newspack-plugin/packages/{colors,components,icons}/ to the workspace
-# path packages/<pkg>/<rest>. Handles three cases:
-#   1. Path is conflicted: 3-way merge legacy's change into the workspace file.
-#   2. Path is cleanly merged in (legacy added or modified, no monorepo-side
-#      change): move/overwrite at the workspace path.
-#   3. Path is deleted in legacy: drop it.
-# Returns 1 if any routed file ends up with conflict markers, or if a modified
-# file has no workspace target.
-route_extracted_packages() {
-  local rc=0
-
-  # Process conflicts first (the unresolved index entries hold the base/theirs
-  # blobs we need for a real 3-way merge).
-  while IFS= read -r path; do
-    case "$path" in
-      plugins/newspack-plugin/packages/colors/*|\
-      plugins/newspack-plugin/packages/components/*|\
-      plugins/newspack-plugin/packages/icons/*) ;;
-      *) continue ;;
-    esac
-
-    local rel="${path#plugins/newspack-plugin/packages/}"
-    local target="packages/$rel"
-    local base_blob theirs_blob
-    base_blob=$(git ls-files -s -- "$path" | awk '$3==1{print $2}')
-    theirs_blob=$(git ls-files -s -- "$path" | awk '$3==3{print $2}')
-
-    if [ -z "$theirs_blob" ]; then
-      git rm -f -- "$path" > /dev/null
-      continue
-    fi
-
-    if [ ! -e "$target" ]; then
-      if [ -z "$base_blob" ]; then
-        mkdir -p "$(dirname "$target")"
-        git show "$theirs_blob" > "$target"
-        git add "$target"
-        git rm -f -- "$path" > /dev/null
-      else
-        rc=1
-      fi
-      continue
-    fi
-
-    local base_src=/tmp/sync-base-$$
-    local theirs_src=/tmp/sync-theirs-$$
-    local merged=/tmp/sync-merged-$$
-    if [ -n "$base_blob" ]; then
-      git show "$base_blob" > "$base_src"
-    else
-      : > "$base_src"
-    fi
-    git show "$theirs_blob" > "$theirs_src"
-
-    if git merge-file -p "$theirs_src" "$base_src" "$target" > "$merged" 2>/dev/null; then
-      cp "$merged" "$target"
-      git add "$target"
-      git rm -f -- "$path" > /dev/null
-    else
-      cp "$merged" "$target"
-      git rm -f -- "$path" > /dev/null
-      rc=1
-    fi
-    rm -f "$base_src" "$theirs_src" "$merged"
-  done < <(git diff --name-only --diff-filter=U)
-
-  # Sweep any remaining cleanly-merged files under the extracted dirs (the
-  # conflict pass missed them because there was no conflict — just legacy's
-  # content landing at the legacy path).
-  while IFS= read -r path; do
-    [ -z "$path" ] && continue
-    local rel="${path#plugins/newspack-plugin/packages/}"
-    local target="packages/$rel"
-    mkdir -p "$(dirname "$target")"
-    git show ":0:$path" > "$target"
-    git add "$target"
-    git rm -f -- "$path" > /dev/null
-  done < <(git ls-files -- \
-    'plugins/newspack-plugin/packages/colors/*' \
-    'plugins/newspack-plugin/packages/components/*' \
-    'plugins/newspack-plugin/packages/icons/*')
-
-  return "$rc"
-}
 
 # Push the conflicted state to a sync/conflicts/* branch and open a draft PR.
 escalate() {
@@ -370,7 +197,7 @@ integrate_all() {
   local START
   START=$(git rev-parse HEAD)
 
-  for entry in "${REPOS[@]}"; do
+  for entry in "${LEGACY_REPOS[@]}"; do
     local name="${entry%%:*}"
     local target="${entry#*:}"
     local saved

--- a/bin/migration/transplant-pr.sh
+++ b/bin/migration/transplant-pr.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+#
+# transplant-pr.sh — transplant a single open PR from a legacy Newspack repo
+# into the monorepo as a new PR against newspack-workspace.
+#
+# Cutover-day tool. Runs end-to-end:
+#
+#   1. Reads the legacy PR's metadata via gh: head ref, base ref, author,
+#      title, body, labels, requested reviewers, draft state.
+#   2. Clones the legacy repo (or the contributor's fork for fork PRs) into a
+#      bare scratch repo and fetches the PR head.
+#   3. Records the fork-point SHA between legacy trunk and the PR head — the
+#      boundary between "already on trunk" and "the PR's actual feature
+#      commits". Recorded BEFORE sync-legacy-repo.sh prunes the trunk ref.
+#   4. Runs sync-legacy-repo.sh to filter the PR branch into monorepo layout
+#      (files under <target-subdir>/, tags namespaced). Determinism: the
+#      filter writes commit-map mapping every legacy SHA → its filtered SHA.
+#   5. Looks up the filtered fork-point in the commit-map.
+#   6. In the workspace clone (the directory this script is run from),
+#      rebases just the feature commits — filtered_fork_point..filtered_tip —
+#      onto the monorepo's chosen base (origin/trunk by default), with -X
+#      theirs so the PR's intent wins on every conflict.
+#   7. Applies a single "finalize" commit that fixes things the PR's commits
+#      can't reasonably get right against monorepo layout: drops legacy
+#      <target>/.github/ and <target>/package-lock.json, restores workspace:*
+#      for the four hoisted packages (newspack-{scripts,components,colors,
+#      icons}), and runs normalize_package_repos so the repository field
+#      points at newspack-workspace. See lib.sh for the underlying helpers.
+#   8. Pushes the result to origin as pr-import/<repo>/<N>.
+#   9. Opens a new PR in newspack-workspace with the original metadata copied
+#      across, plus a redirect block linking back to the legacy PR.
+#  10. (Optional, --close-source) Posts a redirect comment on the legacy PR
+#      and closes it.
+#
+# On unresolvable conflicts: the rebase is aborted, the conflicted state is
+# pushed to pr-import/conflicts/<repo>-<N>, and a draft PR with the
+# transplant-conflict label is opened for manual resolution. The legacy PR
+# is left open so the source of truth isn't lost.
+#
+# Caveats called out in code comments below:
+#   • newspack-plugin PRs that touch plugins/newspack-plugin/packages/{colors,
+#     components,icons}/ need the same path-rerouting that sync-legacy.sh
+#     applies. The post-rebase finalize step detects these and either moves
+#     the file or aborts to manual resolution.
+#   • Inline review comments on the legacy PR can't be relocated (they
+#     reference SHAs that no longer exist after rebase). The redirect block
+#     in the new PR's body links to the original review thread URL.
+#   • Fork PRs from external contributors: the rebase preserves commit
+#     authorship via Author headers, so the contributor still gets credit on
+#     the new PR's diff. They can't push more commits to the
+#     org-owned pr-import branch though — the redirect comment instructs
+#     them to rebase their fork against newspack-workspace and submit a
+#     follow-up.
+#
+# Usage:
+#   bin/migration/transplant-pr.sh <repo> <pr-number> [options]
+#
+# Options:
+#   --dry-run               Print intended pushes / gh calls without running.
+#   --close-source          Close the legacy PR after success (default off).
+#   --target-base <ref>     Monorepo base branch (default origin/trunk).
+#   --scratch <dir>         Scratch dir (default /tmp/transplant-pr).
+#
+# Environment:
+#   LEGACY_SYNC_GH_TOKEN    Org-scoped token if the legacy repo is private
+#                           (currently only newspack-story-budget).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing.
+# ---------------------------------------------------------------------------
+DRY_RUN="${DRY_RUN:-0}"
+CLOSE_SOURCE=0
+TARGET_BASE="origin/trunk"
+SCRATCH_DIR="${SCRATCH_DIR:-/tmp/transplant-pr}"
+REPO=""
+PR=""
+
+usage() {
+  sed -n '2,/^# ----/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)        DRY_RUN=1; shift ;;
+    --close-source)   CLOSE_SOURCE=1; shift ;;
+    --target-base)    TARGET_BASE="$2"; shift 2 ;;
+    --scratch)        SCRATCH_DIR="$2"; shift 2 ;;
+    -h|--help)        usage ;;
+    -*) echo "ERROR: unknown option $1" >&2; usage ;;
+    *)
+      if [ -z "$REPO" ]; then REPO="$1"
+      elif [ -z "$PR" ]; then PR="$1"
+      else echo "ERROR: extra positional arg $1" >&2; usage
+      fi
+      shift
+      ;;
+  esac
+done
+[ -n "$REPO" ] && [ -n "$PR" ] || usage
+
+export DRY_RUN
+
+TARGET_SUBDIR=$(legacy_repo_target "$REPO") \
+  || { echo "ERROR: $REPO is not in the legacy-repos manifest (lib.sh)" >&2; exit 2; }
+
+mkdir -p "$SCRATCH_DIR"
+
+echo "==> Transplant: Automattic/$REPO#$PR → newspack-workspace"
+echo "    target subdir : $TARGET_SUBDIR"
+echo "    base ref      : $TARGET_BASE"
+echo "    dry run       : $DRY_RUN"
+echo "    close source  : $CLOSE_SOURCE"
+
+# ---------------------------------------------------------------------------
+# Phase 1: read the legacy PR's metadata.
+# ---------------------------------------------------------------------------
+# All PR metadata in one gh call to keep API usage tight. The redirect
+# comment uses .author.login to @mention the original author on the legacy
+# PR (and credits them in the new PR's body).
+META_JSON="$SCRATCH_DIR/$REPO-$PR.meta.json"
+gh pr view "$PR" --repo "Automattic/$REPO" \
+  --json number,title,body,headRefName,headRefOid,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,isDraft,author,url \
+  > "$META_JSON"
+
+PR_TITLE=$(jq -r '.title' "$META_JSON")
+PR_BODY=$(jq -r '.body // ""' "$META_JSON")
+PR_HEAD_REF=$(jq -r '.headRefName' "$META_JSON")
+PR_HEAD_SHA=$(jq -r '.headRefOid' "$META_JSON")
+PR_BASE_REF=$(jq -r '.baseRefName' "$META_JSON")
+PR_AUTHOR=$(jq -r '.author.login' "$META_JSON")
+PR_URL=$(jq -r '.url' "$META_JSON")
+PR_IS_DRAFT=$(jq -r '.isDraft' "$META_JSON")
+HEAD_OWNER=$(jq -r '.headRepositoryOwner.login // empty' "$META_JSON")
+HEAD_REPO_NAME=$(jq -r '.headRepository.name // empty' "$META_JSON")
+
+echo "    head ref      : $PR_HEAD_REF @ ${PR_HEAD_SHA:0:8}"
+echo "    head owner    : ${HEAD_OWNER:-(none)} (fork=$( [ "$HEAD_OWNER" != "Automattic" ] && echo yes || echo no ))"
+echo "    author        : $PR_AUTHOR"
+
+# ---------------------------------------------------------------------------
+# Phase 2: bare-clone the legacy upstream and fetch both trunk and the PR
+# head into named local refs. Always cloning the upstream (even for fork
+# PRs) is intentional: GitHub mirrors fork PR heads as refs/pull/<N>/head on
+# the upstream, so we get the head ref through normal auth without ever
+# touching the contributor's fork URL.
+# ---------------------------------------------------------------------------
+SRC_BARE="$SCRATCH_DIR/$REPO.src.git"
+if [ -n "${LEGACY_SYNC_GH_TOKEN:-}" ]; then
+  CLONE_URL="https://x-access-token:${LEGACY_SYNC_GH_TOKEN}@github.com/Automattic/$REPO.git"
+else
+  CLONE_URL="https://github.com/Automattic/$REPO.git"
+fi
+
+if [ ! -d "$SRC_BARE" ]; then
+  echo "==> Cloning $REPO (bare) into $SRC_BARE"
+  git clone --bare --quiet "$CLONE_URL" "$SRC_BARE"
+else
+  echo "==> Reusing existing bare clone at $SRC_BARE"
+  git -C "$SRC_BARE" fetch --quiet --prune origin
+fi
+
+# Fetch the PR head. refs/pull/<N>/head exists on the upstream regardless of
+# whether the PR comes from a fork. Land it on a stable local ref so
+# sync-legacy-repo.sh can filter it.
+echo "==> Fetching refs/pull/$PR/head from upstream"
+git -C "$SRC_BARE" fetch --quiet origin "+refs/pull/$PR/head:refs/heads/transplant/pr-$PR"
+
+# ---------------------------------------------------------------------------
+# Phase 3: capture the fork-point SHA in legacy-space BEFORE filtering.
+# sync-legacy-repo.sh's first action is to prune all refs except the one
+# being filtered, so we have to read this now.
+# ---------------------------------------------------------------------------
+# Resolve the legacy trunk name (some older repos still use master). Match
+# the same fallback sync-legacy-repo.sh does so the fork point is computed
+# against the same branch the PR was opened against.
+LEGACY_TRUNK=""
+for ref in "refs/heads/$PR_BASE_REF" "refs/heads/trunk" "refs/heads/master"; do
+  if git -C "$SRC_BARE" show-ref --verify --quiet "$ref"; then
+    LEGACY_TRUNK="${ref#refs/heads/}"
+    break
+  fi
+done
+[ -n "$LEGACY_TRUNK" ] || { echo "ERROR: no trunk-like ref found in $SRC_BARE" >&2; exit 3; }
+
+LEGACY_FORK_POINT=$(git -C "$SRC_BARE" merge-base "$LEGACY_TRUNK" "transplant/pr-$PR")
+echo "==> Legacy fork point: ${LEGACY_FORK_POINT:0:8} (against $LEGACY_TRUNK)"
+
+# ---------------------------------------------------------------------------
+# Phase 4: filter the PR branch into monorepo layout. The bare clone is
+# passed by path; sync-legacy-repo.sh writes a fresh filtered bare repo to
+# the output dir and won't touch the source.
+# ---------------------------------------------------------------------------
+FILTERED="$SCRATCH_DIR/$REPO-pr-$PR.filtered.git"
+echo "==> Filtering PR branch into $FILTERED"
+"$SCRIPT_DIR/sync-legacy-repo.sh" \
+  "$SRC_BARE" "$TARGET_SUBDIR" "$FILTERED" "transplant/pr-$PR"
+
+# Look up the filtered fork-point SHA in filter-repo's commit-map. The map is
+# whitespace-separated "<old> <new>" lines. If the lookup fails, the PR
+# branch had no commits at the fork-point boundary, which would mean the PR
+# is empty or somehow malformed — bail out rather than guess.
+COMMIT_MAP="$FILTERED/filter-repo/commit-map"
+[ -f "$COMMIT_MAP" ] || { echo "ERROR: no commit-map at $COMMIT_MAP" >&2; exit 4; }
+FILTERED_FORK_POINT=$(awk -v sha="$LEGACY_FORK_POINT" '$1==sha{print $2; exit}' "$COMMIT_MAP")
+[ -n "$FILTERED_FORK_POINT" ] || {
+  echo "ERROR: legacy fork point $LEGACY_FORK_POINT not found in commit-map" >&2
+  exit 4
+}
+FILTERED_TIP=$(git -C "$FILTERED" rev-parse "refs/heads/transplant/pr-$PR")
+COMMIT_COUNT=$(git -C "$FILTERED" rev-list --count "$FILTERED_FORK_POINT..$FILTERED_TIP")
+echo "==> Filtered range: ${FILTERED_FORK_POINT:0:8}..${FILTERED_TIP:0:8} ($COMMIT_COUNT commits)"
+
+if [ "$COMMIT_COUNT" -eq 0 ]; then
+  echo "ERROR: PR has 0 commits ahead of legacy trunk after filtering — nothing to transplant" >&2
+  exit 5
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 5: rebase the feature commits onto monorepo's target base.
+#
+# The script must be run from a workspace clone (the directory this script
+# is invoked from). We fetch the filtered objects into the workspace
+# repo's object store, create a fresh branch off the target base, and
+# replay the filtered range with -X theirs so the PR's intent wins on
+# every conflict. -X theirs at rebase time means "for hunks that conflict
+# with whatever monorepo trunk has, prefer the version coming from the
+# PR's commits". Almost every conflict the rebase will see comes from
+# package.json drift (workspace:* vs concrete versions, repository field
+# pointing at the legacy repo). We let theirs win and then fix those up
+# in the finalize step.
+# ---------------------------------------------------------------------------
+NEW_BRANCH="pr-import/$REPO/$PR"
+
+# Fetch the filtered objects into the workspace clone. The lhs is the local
+# ref in the bare filter; the rhs is a private namespace under refs/transplant
+# so we don't pollute refs/heads.
+echo "==> Fetching filtered objects into workspace"
+git fetch --quiet --force "$FILTERED" \
+  "+refs/heads/transplant/pr-$PR:refs/transplant/$REPO/pr-$PR"
+
+# Resolve the target base to a SHA so the worktree starts from a fixed point
+# even if origin/trunk advances mid-run.
+if ! BASE_SHA=$(git rev-parse --verify --quiet "$TARGET_BASE^{commit}"); then
+  echo "ERROR: target base $TARGET_BASE not found. Did you fetch?" >&2
+  exit 6
+fi
+echo "    base SHA      : ${BASE_SHA:0:8} ($TARGET_BASE)"
+
+# Run the rebase in a dedicated worktree so it doesn't disturb the caller's
+# working tree or HEAD. Trap removes it on any exit.
+TXN_WORKTREE=$(mktemp -d -t transplant-pr-XXXXXX)
+MAIN_REPO=$(git rev-parse --show-toplevel)
+cleanup_worktree() {
+  local rc=$?
+  cd "$MAIN_REPO" 2>/dev/null || cd /
+  git -C "$TXN_WORKTREE" rebase --abort 2>/dev/null || true
+  git -C "$MAIN_REPO" worktree remove --force "$TXN_WORKTREE" 2>/dev/null || true
+  git -C "$MAIN_REPO" worktree prune 2>/dev/null || true
+  return "$rc"
+}
+trap cleanup_worktree EXIT INT TERM
+
+# Clean up any branch left over from a previous failed run. Force-delete is
+# safe: NEW_BRANCH is fully derived from <repo,pr> and is intended to be
+# reproducible from scratch on every invocation.
+git branch -D "$NEW_BRANCH" 2>/dev/null || true
+git branch -D "pr-import/conflicts/$REPO-$PR" 2>/dev/null || true
+
+git worktree add --quiet -b "$NEW_BRANCH" "$TXN_WORKTREE" "$BASE_SHA"
+cd "$TXN_WORKTREE"
+
+# Cherry-pick the feature commits one at a time onto the new branch, with
+# automated handling of two recurring conflict shapes:
+#
+#   • modify/delete (DU): legacy commit modifies <target>/.github/<x> or
+#     <target>/package-lock.json, both of which the monorepo intentionally
+#     removed at integration time (CI runs at the root, lockfile is
+#     pnpm-lock.yaml at the root). Auto-resolve by `git rm`-ing the file.
+#
+#   • content conflict in plugin/theme package.json from workspace:* drift,
+#     newspack-{scripts,components,colors,icons} versions, or repository
+#     field divergence. -X theirs already gives us the PR's content; we'll
+#     post-process those in the finalize commit.
+#
+# Anything else: escalate. The legacy PR stays open so the source of truth
+# isn't lost.
+#
+# We cherry-pick rather than `git rebase --onto` so the auto-resolution
+# logic runs between every pick instead of only on rebase failure (which
+# stops on the first conflict it can't handle).
+COMMITS=$(git -C "$FILTERED" rev-list --reverse "$FILTERED_FORK_POINT..$FILTERED_TIP")
+echo "==> Cherry-picking $COMMIT_COUNT commits onto ${BASE_SHA:0:8}"
+PICK_LOG=/tmp/transplant-pick.log
+: > "$PICK_LOG"
+
+# Tracks whether escalation is needed after the loop.
+PICK_RC=0
+PICK_FAILED_AT=""
+
+# Auto-resolves the recurring modify/delete patterns and re-stages files
+# left modified by -X theirs. Returns 0 if cherry-pick can be continued,
+# 1 if there's still a conflict we can't handle.
+auto_resolve_conflicts() {
+  # Drop legacy CI / lockfile paths the monorepo doesn't carry per-plugin.
+  local resolved_any=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local code path
+    code="${line:0:2}"
+    path="${line:3}"
+    case "$code" in
+      DU|UD)
+        case "$path" in
+          $TARGET_SUBDIR/.github/*|$TARGET_SUBDIR/package-lock.json)
+            git rm -f --quiet -- "$path" 2>/dev/null || true
+            resolved_any=1
+            ;;
+        esac
+        ;;
+    esac
+  done < <(git status --porcelain)
+
+  # Anything left unresolved? -X theirs has already populated the working
+  # tree with the PR's version for content conflicts, so just `git add` them.
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    git add -- "$path" 2>/dev/null && resolved_any=1
+  done < <(git diff --name-only --diff-filter=U)
+
+  # Final check: any unmerged paths still left?
+  if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+    return 1
+  fi
+  return 0
+}
+
+for c in $COMMITS; do
+  # Skip merge commits entirely. In practice these are "merge trunk into
+  # feature" sync commits inside the PR's branch; the trunk-side content
+  # they bring in is already on the monorepo's base (origin/trunk or
+  # origin/monorepo-integration), so picking them in pulls drift between
+  # legacy trunk and monorepo into the transplanted PR's diff. Skipping
+  # is correct for the common case; uncommon multi-feature merges within
+  # a PR would lose content here, but those are vanishingly rare. The
+  # later non-merge picks reapply each contributor commit individually
+  # so we don't lose the actual feature changes.
+  if git -C "$FILTERED" rev-parse --verify --quiet "$c^2" > /dev/null; then
+    echo "    skip merge $c" >> "$PICK_LOG"
+    continue
+  fi
+  if git cherry-pick -X theirs --keep-redundant-commits --allow-empty "$c" \
+       >> "$PICK_LOG" 2>&1; then
+    continue
+  fi
+  if auto_resolve_conflicts; then
+    # If conflict resolution dropped every hunk in the commit (e.g. its
+    # only change was to a <target>/.github/ workflow we deleted), there
+    # is nothing to commit and we --skip. Otherwise --continue, which
+    # commits the staged content under the original author + message.
+    # We can't pass --allow-empty to --continue (cherry-pick doesn't
+    # take it), so we have to make this choice up front.
+    if git diff --cached --quiet HEAD -- 2>/dev/null; then
+      git cherry-pick --skip >> "$PICK_LOG" 2>&1 \
+        || { PICK_RC=$?; PICK_FAILED_AT="$c"; break; }
+    else
+      git -c core.editor=true cherry-pick --continue \
+        >> "$PICK_LOG" 2>&1 \
+        || { PICK_RC=$?; PICK_FAILED_AT="$c"; break; }
+    fi
+  else
+    PICK_RC=1
+    PICK_FAILED_AT="$c"
+    break
+  fi
+done
+
+if [ "$PICK_RC" -ne 0 ]; then
+  # Park the conflicted state so a human can resolve. The cherry-pick is
+  # already in-progress with markers in the working tree; commit it (markers
+  # and all) under a bot identity so the conflict branch reflects exactly
+  # what the automation produced.
+  echo "==> Cherry-pick failed at ${PICK_FAILED_AT:0:8}. Escalating."
+  CONFLICT_BRANCH="pr-import/conflicts/$REPO-$PR"
+  git add -A 2>/dev/null || true
+  if ! git diff --cached --quiet; then
+    git -c user.name="newspack-transplant-bot" \
+        -c user.email="newspack-transplant-bot@users.noreply.github.com" \
+        commit --no-edit \
+        -m "transplant(conflict): unresolved cherry-pick of Automattic/$REPO#$PR at ${PICK_FAILED_AT:0:8}" \
+        >> "$PICK_LOG" 2>&1 || true
+  fi
+  git cherry-pick --abort 2>/dev/null || true
+
+  # Rename the branch to the conflict naming convention.
+  git branch -M "$CONFLICT_BRANCH" 2>/dev/null || true
+
+  cd "$MAIN_REPO"
+  git_push origin "+$CONFLICT_BRANCH:$CONFLICT_BRANCH"
+  gh_pr_create \
+    --base "${TARGET_BASE#origin/}" \
+    --head "$CONFLICT_BRANCH" \
+    --draft \
+    --reviewer adekbadek \
+    --label transplant-conflict \
+    --title "transplant conflict: $REPO#$PR — $PR_TITLE" \
+    --body "$(printf 'Unresolvable conflicts during automated transplant of %s.\n\nResolve conflicts on this branch, then mark ready for review. Source PR is **left open** — close it manually after this transplant lands.\n\nLast pick log (truncated):\n```\n%s\n```\n' "$PR_URL" "$(tail -50 "$PICK_LOG")")"
+  echo "==> Conflict parked at $CONFLICT_BRANCH (legacy PR left open)."
+  exit 7
+fi
+
+# If the cherry-pick loop completed but every commit got --skip'd, the PR's
+# changes only touched paths that don't exist in monorepo layout (e.g.
+# legacy-only <target>/.github/ workflows). Don't open an empty PR — the
+# monorepo-side equivalent has to be rebuilt by hand. Surface this so the
+# batch report counts these explicitly.
+PICKED_COUNT=$(git rev-list --count "$BASE_SHA..HEAD")
+if [ "$PICKED_COUNT" = "0" ]; then
+  echo "==> Noop-after-filter: every commit in $REPO#$PR was --skip'd"
+  echo "    (changes only touched paths that don't exist in monorepo layout —"
+  echo "    e.g. <target>/.github/ workflows. Manual port required against the"
+  echo "    monorepo's root-level config.)"
+  exit 9
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 6: finalize commit. Fixes things the per-PR commits can't reasonably
+# get right when replayed against monorepo layout:
+#
+#   • Drop <target>/.github/ — CI runs at the monorepo root.
+#   • Drop <target>/package-lock.json — monorepo uses pnpm-lock.yaml at root.
+#   • Restore workspace:* for the four hoisted packages (newspack-{scripts,
+#     components,colors,icons}) if any commit in the PR bumped them to a
+#     concrete version.
+#   • Run normalize_package_repos so repository.url resolves to the monorepo.
+#   • For newspack-plugin only: relocate any files the PR added under
+#     plugins/newspack-plugin/packages/{colors,components,icons}/ to the
+#     workspace path packages/<x>/. If the file already exists at both old
+#     and new paths after the rebase, we abort to manual resolution rather
+#     than guess at a 3-way merge.
+#
+# All of these get squashed into a single follow-up commit so the PR's
+# original commit history is preserved and the cleanup is auditable.
+# ---------------------------------------------------------------------------
+echo "==> Applying finalize commit"
+
+# Drop legacy .github/ and package-lock.json under the target subdir.
+git rm -rf --ignore-unmatch --quiet \
+  "$TARGET_SUBDIR/.github" \
+  "$TARGET_SUBDIR/package-lock.json" \
+  2>/dev/null || true
+
+# Restore workspace:* and the monorepo repository field in <target>/package.json
+# only. We deliberately don't touch other plugins'/themes' package.json: any
+# pre-existing drift there is unrelated to this PR and shouldn't get bundled
+# into the transplant's finalize commit.
+TARGET_PJ="$TARGET_SUBDIR/package.json"
+if [ -f "$TARGET_PJ" ]; then
+  TARGET_PJ_PATH="$TARGET_PJ" node -e '
+    const fs = require("fs");
+    const HOISTED = ["newspack-scripts","newspack-components","newspack-colors","newspack-icons"];
+    const url = "git+https://github.com/Automattic/newspack-workspace.git";
+    const pj = process.env.TARGET_PJ_PATH;
+    const src = fs.readFileSync(pj, "utf8");
+    const indentMatch = src.match(/\n(\t+|[ ]+)"/);
+    const indent = indentMatch ? indentMatch[1] : "  ";
+    const trail = src.endsWith("\n") ? "\n" : "";
+    const j = JSON.parse(src);
+    let dirty = false;
+    for (const key of ["dependencies","devDependencies","peerDependencies"]) {
+      const deps = j[key];
+      if (!deps) continue;
+      for (const h of HOISTED) {
+        if (deps[h] != null && deps[h] !== "workspace:*") {
+          deps[h] = "workspace:*";
+          dirty = true;
+        }
+      }
+    }
+    const want = { type: "git", url, directory: pj.replace(/\/package\.json$/, "") };
+    if (JSON.stringify(j.repository) !== JSON.stringify(want)) {
+      j.repository = want;
+      dirty = true;
+    }
+    if (dirty) {
+      fs.writeFileSync(pj, JSON.stringify(j, null, indent) + trail);
+      process.stdout.write("changed");
+    }
+  ' | grep -q changed && git add -- "$TARGET_PJ"
+fi
+
+# newspack-plugin extracted-packages relocation. The rebase's -Xtheirs may
+# have created or modified files at plugins/newspack-plugin/packages/{colors,
+# components,icons}/. Move them to the workspace path packages/<x>/.
+EXTRACTED_CONFLICT=0
+if [ "$REPO" = "newspack-plugin" ]; then
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    rel="${path#plugins/newspack-plugin/packages/}"
+    target="packages/$rel"
+    mkdir -p "$(dirname "$target")"
+    if [ -e "$target" ]; then
+      # Both the old and new paths are present in the working tree. Without
+      # a 3-way merge base we can't safely combine them — escalate.
+      EXTRACTED_CONFLICT=1
+      break
+    fi
+    git mv -- "$path" "$target"
+  done < <(git ls-files -- \
+    'plugins/newspack-plugin/packages/colors/*' \
+    'plugins/newspack-plugin/packages/components/*' \
+    'plugins/newspack-plugin/packages/icons/*')
+fi
+
+if [ "$EXTRACTED_CONFLICT" = "1" ]; then
+  echo "==> PR touches paths under plugins/newspack-plugin/packages/{colors,components,icons}/" >&2
+  echo "    that already exist at the workspace location packages/<x>/. Manual merge required." >&2
+  echo "    Aborting transplant; legacy PR is left open." >&2
+  exit 8
+fi
+
+# Commit the finalize step if anything changed. authorship goes to the bot;
+# the original PR commits keep their own authors.
+if ! git diff --cached --quiet || ! git diff --quiet; then
+  git add -A
+  git -c user.name="newspack-transplant-bot" \
+      -c user.email="newspack-transplant-bot@users.noreply.github.com" \
+      commit --quiet \
+      -m "chore(transplant): normalize workspace metadata after Automattic/$REPO#$PR"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 7: push and open the new PR.
+# ---------------------------------------------------------------------------
+cd "$MAIN_REPO"
+
+git_push origin "+$NEW_BRANCH:$NEW_BRANCH"
+
+# Build the new PR body. Original body verbatim, then a redirect block so
+# reviewers can find the original review thread (inline comments aren't
+# transplantable).
+NEW_BODY=$(printf '%s\n\n---\n\n_Transplanted from %s by `bin/migration/transplant-pr.sh` as part of the monorepo cutover. Original author: @%s. Original review thread: %s_\n' \
+  "$PR_BODY" "$PR_URL" "$PR_AUTHOR" "$PR_URL")
+
+# Labels and reviewer/assignee args. Empty arrays are fine to pass through.
+LABEL_ARGS=()
+while IFS= read -r lbl; do
+  [ -n "$lbl" ] && LABEL_ARGS+=(--label "$lbl")
+done < <(jq -r '.labels[].name' "$META_JSON")
+LABEL_ARGS+=(--label transplanted)
+
+REVIEWER_ARGS=()
+while IFS= read -r rev; do
+  [ -n "$rev" ] && REVIEWER_ARGS+=(--reviewer "$rev")
+done < <(jq -r '.reviewRequests[]?.login // .reviewRequests[]?.name // empty' "$META_JSON")
+
+ASSIGNEE_ARGS=()
+while IFS= read -r asg; do
+  [ -n "$asg" ] && ASSIGNEE_ARGS+=(--assignee "$asg")
+done < <(jq -r '.assignees[].login' "$META_JSON")
+
+DRAFT_ARG=()
+[ "$PR_IS_DRAFT" = "true" ] && DRAFT_ARG=(--draft)
+
+NEW_TITLE="[$REPO] $PR_TITLE"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "    [dry-run] would create PR: gh pr create --base ${TARGET_BASE#origin/} --head $NEW_BRANCH --title '$NEW_TITLE' (+labels +reviewers)"
+else
+  gh pr create \
+    --base "${TARGET_BASE#origin/}" \
+    --head "$NEW_BRANCH" \
+    --title "$NEW_TITLE" \
+    --body "$NEW_BODY" \
+    "${LABEL_ARGS[@]}" \
+    "${REVIEWER_ARGS[@]}" \
+    "${ASSIGNEE_ARGS[@]}" \
+    "${DRAFT_ARG[@]}" \
+    || echo "WARN: gh pr create failed; branch is still at origin/$NEW_BRANCH"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 8: close the legacy PR (opt-in via --close-source).
+# ---------------------------------------------------------------------------
+if [ "$CLOSE_SOURCE" = "1" ]; then
+  CLOSE_COMMENT=$(printf 'Continued at the monorepo as part of the cutover. New PR: <fill in by tooling — see pr-import/%s/%s>. Closing here. Authored by @%s.\n\nIf you need to push more changes, please rebase your fork against `Automattic/newspack-workspace:trunk` (your changes are now under `%s/`) and open a follow-up PR there.' \
+    "$REPO" "$PR" "$PR_AUTHOR" "$TARGET_SUBDIR")
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "    [dry-run] would comment+close Automattic/$REPO#$PR"
+  else
+    gh pr comment "$PR" --repo "Automattic/$REPO" --body "$CLOSE_COMMENT" \
+      || echo "WARN: gh pr comment failed for legacy $REPO#$PR"
+    gh pr close "$PR" --repo "Automattic/$REPO" \
+      || echo "WARN: gh pr close failed for legacy $REPO#$PR"
+  fi
+fi
+
+echo "==> Transplant complete: $REPO#$PR → $NEW_BRANCH"

--- a/bin/migration/transplant-prs-batch.sh
+++ b/bin/migration/transplant-prs-batch.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# transplant-prs-batch.sh — fan transplant-pr.sh out across every open PR
+# from a JSON snapshot produced by transplant-prs-report.sh. Cutover-day
+# orchestration script.
+#
+# Why a separate script vs a `for` loop in the report's output: the batch
+# step has its own progress, partial-failure, and parallelism concerns that
+# don't belong in either the report (read-only) or the per-PR transplant
+# (which is intentionally focused on one PR's correctness, not on dozens
+# running concurrently).
+#
+# Parallelism note: the filter step in transplant-pr.sh is CPU-bound and
+# parallelizable. The git push + gh pr create step needs serialization
+# only insofar as both target the same origin remote — concurrent gh pr
+# creates against newspack-workspace are fine in practice (GitHub
+# tolerates ~10 concurrent writes from one user without issues). Default
+# concurrency is 4; bump higher with --concurrency.
+#
+# On failure of one PR: the rest continue. A summary at the end lists what
+# succeeded, what conflicted (parked on pr-import/conflicts/...), and what
+# errored (script bug, network issue, GH 5xx).
+#
+# Usage:
+#   bin/migration/transplant-prs-batch.sh [options] [--input <json>]
+#
+# Options:
+#   --input <file>            JSON snapshot from transplant-prs-report.sh.
+#                             If omitted, runs the report inline (excluding
+#                             bots, including drafts).
+#   --concurrency N           Max parallel transplants (default 4).
+#   --dry-run                 Pass --dry-run through to each transplant-pr.sh.
+#   --close-source            Pass --close-source through. ONLY use this on
+#                             cutover day — closes legacy PRs in the source
+#                             repos.
+#   --target-base <ref>       Pass --target-base through (default origin/trunk).
+#   --scratch <dir>           Shared scratch dir (default /tmp/transplant-pr).
+#   --filter <jq-expr>        Extra jq filter applied to the input. Useful
+#                             for sub-batches: --filter '.[] | select(.repo == "newspack-plugin")'
+
+# -e and pipefail; not -u because the per-flag arrays in the dispatcher loop
+# are intentionally empty when the corresponding flag wasn't passed, and
+# expanding [*] of an empty array under set -u is fatal.
+set -eo pipefail
+
+INPUT=""
+CONCURRENCY=4
+PASSTHROUGH_FLAGS=""
+EXTRA_FILTER='.'
+
+# Build a single space-separated string of passthrough flags. Word-splitting
+# is intentional when this string is later expanded inside the xargs body.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --input)         INPUT="$2"; shift 2 ;;
+    --concurrency)   CONCURRENCY="$2"; shift 2 ;;
+    --dry-run)       PASSTHROUGH_FLAGS="$PASSTHROUGH_FLAGS --dry-run"; shift ;;
+    --close-source)  PASSTHROUGH_FLAGS="$PASSTHROUGH_FLAGS --close-source"; shift ;;
+    --target-base)   PASSTHROUGH_FLAGS="$PASSTHROUGH_FLAGS --target-base $2"; shift 2 ;;
+    --scratch)       PASSTHROUGH_FLAGS="$PASSTHROUGH_FLAGS --scratch $2"; shift 2 ;;
+    --filter)        EXTRA_FILTER="$2"; shift 2 ;;
+    -h|--help)       sed -n '2,/^# Usage/p;/^# Options/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'; exit 2 ;;
+    *) echo "ERROR: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Generate the input snapshot inline if none was given. Default policy
+# matches the cutover plan: humans only, drafts included, JSON format.
+# We only register $INPUT for trap-cleanup if WE created it. A user-supplied
+# --input file must survive the run untouched.
+INPUT_IS_TEMP=0
+if [ -z "$INPUT" ]; then
+  INPUT=$(mktemp -t transplant-prs-batch-input-XXXXXX.json)
+  INPUT_IS_TEMP=1
+  echo "==> No --input given; generating snapshot via transplant-prs-report.sh" >&2
+  "$SCRIPT_DIR/transplant-prs-report.sh" --format json --output "$INPUT"
+fi
+
+# Render one "<repo> <number>" line per PR after applying the extra filter.
+WORKLIST=$(mktemp -t transplant-prs-batch-list-XXXXXX)
+cleanup_temps() {
+  rm -f "$WORKLIST"
+  [ "$INPUT_IS_TEMP" = "1" ] && rm -f "$INPUT"
+}
+trap cleanup_temps EXIT
+jq -r "$EXTRA_FILTER"' | .[] | "\(.repo) \(.number)"' "$INPUT" > "$WORKLIST"
+TOTAL=$(wc -l < "$WORKLIST" | tr -d ' ')
+echo "==> Transplanting $TOTAL PRs at concurrency=$CONCURRENCY" >&2
+
+# Per-PR results land in this dir. We aggregate at the end.
+RESULTS_DIR=$(mktemp -d -t transplant-prs-batch-results-XXXXXX)
+echo "==> Logs and per-PR exit codes: $RESULTS_DIR" >&2
+
+# xargs -P drives the parallelism. Each spawned shell calls transplant-pr.sh
+# with the passthrough flags and writes its log + exit code to RESULTS_DIR.
+# We can't trap-cleanup RESULTS_DIR because the caller may want to inspect
+# it after the run.
+# Pass shared state (results dir, transplant script path, passthrough flags)
+# through the environment so the bash -c body stays readable. The body
+# intentionally word-splits $PASSTHROUGH_FLAGS to expand it as separate args.
+export RESULTS_DIR SCRIPT_DIR PASSTHROUGH_FLAGS
+cat "$WORKLIST" | xargs -n2 -P"$CONCURRENCY" \
+  bash -c '
+    repo="$1"; pr="$2"
+    log="$RESULTS_DIR/$repo-$pr.log"
+    # shellcheck disable=SC2086 # word-splitting is intentional.
+    if "$SCRIPT_DIR/transplant-pr.sh" "$repo" "$pr" $PASSTHROUGH_FLAGS \
+         > "$log" 2>&1; then
+      echo "    OK   $repo#$pr"
+      echo 0 > "$RESULTS_DIR/$repo-$pr.rc"
+    else
+      rc=$?
+      echo "    FAIL $repo#$pr (rc=$rc; see $log)"
+      echo "$rc" > "$RESULTS_DIR/$repo-$pr.rc"
+    fi
+  ' _ \
+  || true
+
+# ---------------------------------------------------------------------------
+# Summary. Exit codes from transplant-pr.sh have specific meanings — match
+# the script source for the canonical list:
+#   0   transplanted cleanly
+#   2   usage / argument error
+#   3   no trunk-like ref in legacy repo (shouldnt happen in practice)
+#   4   commit-map lookup failure
+#   5   PR is empty after filtering
+#   6   target base not found in workspace clone
+#   7   rebase conflict — parked on pr-import/conflicts/<repo>-<N>
+#   8   newspack-plugin extracted-packages conflict — manual merge needed
+#   9   noop-after-filter — every commit only touched legacy-only paths
+# Anything else: unexpected failure, look at the log.
+# ---------------------------------------------------------------------------
+ok=0; conflict=0; extracted=0; empty=0; noop=0; other=0
+for rc_file in "$RESULTS_DIR"/*.rc; do
+  [ -f "$rc_file" ] || continue
+  rc=$(cat "$rc_file")
+  case "$rc" in
+    0) ok=$((ok+1)) ;;
+    5) empty=$((empty+1)) ;;
+    7) conflict=$((conflict+1)) ;;
+    8) extracted=$((extracted+1)) ;;
+    9) noop=$((noop+1)) ;;
+    *) other=$((other+1)) ;;
+  esac
+done
+
+echo
+echo "==> Batch summary"
+echo "    OK                 : $ok"
+echo "    Conflicts          : $conflict (parked on pr-import/conflicts/...)"
+echo "    Extracted-pkg      : $extracted (newspack-plugin manual merges)"
+echo "    Noop-after-filter  : $noop (legacy-only paths; needs manual port)"
+echo "    Empty-after-filter : $empty"
+echo "    Other failures     : $other"
+echo "    Total processed    : $((ok + conflict + extracted + empty + noop + other)) / $TOTAL"
+echo
+echo "    Per-PR logs in: $RESULTS_DIR"
+
+# Exit non-zero if any PR didn't transplant cleanly so callers (CI, Slack
+# webhooks) can fan that out as a notification.
+[ "$conflict" = "0" ] && [ "$extracted" = "0" ] && [ "$other" = "0" ]

--- a/bin/migration/transplant-prs-report.sh
+++ b/bin/migration/transplant-prs-report.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# transplant-prs-report.sh — pre-cutover snapshot of every open PR in every
+# legacy Newspack repo. Output is the source-of-truth list that
+# transplant-prs-batch.sh consumes (and that humans use to decide which PRs
+# to merge in legacy before cutover so they don't need transplanting).
+#
+# Two output formats:
+#   - --format json (default): a single JSON document with one entry per PR.
+#     Suitable for piping into transplant-prs-batch.sh.
+#   - --format table: human-readable Markdown table. Use this for sharing
+#     in Slack / a planning doc.
+#
+# By default, dependabot PRs are EXCLUDED. Dependabot will re-open PRs
+# against the monorepo's hoisted lockfile after cutover, so transplanting
+# them would just create churn. Opt them back in with --include-bots.
+#
+# Usage:
+#   bin/migration/transplant-prs-report.sh [options]
+#
+# Options:
+#   --format json|table       Output format (default json).
+#   --include-bots            Include dependabot/renovate/copilot PRs.
+#   --include-drafts          Include drafts (default: included; flag is a
+#                             no-op kept for symmetry with --exclude-drafts).
+#   --exclude-drafts          Drop drafts from the output.
+#   --output <file>           Write to file instead of stdout.
+
+set -euo pipefail
+
+FORMAT=json
+INCLUDE_BOTS=0
+EXCLUDE_DRAFTS=0
+OUTPUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --format)         FORMAT="$2"; shift 2 ;;
+    --include-bots)   INCLUDE_BOTS=1; shift ;;
+    --include-drafts) shift ;;
+    --exclude-drafts) EXCLUDE_DRAFTS=1; shift ;;
+    --output)         OUTPUT="$2"; shift 2 ;;
+    -h|--help)        sed -n '2,/^# Usage/p;/^# Options/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'; exit 2 ;;
+    *) echo "ERROR: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$FORMAT" in
+  json|table) ;;
+  *) echo "ERROR: --format must be json or table" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+# Pull all open PRs from each legacy repo in parallel into per-repo JSON
+# blobs in a temp dir, then jq-merge them into a single stream. gh pr list
+# rate-limits gracefully; 16 concurrent calls is well inside the budget.
+TMP=$(mktemp -d -t transplant-prs-report-XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "==> Querying ${#LEGACY_REPOS[@]} legacy repos in parallel" >&2
+
+# We don't query for newspack-scripts here even though it's in LEGACY_REPOS:
+# its standalone repo is part of the workspace's packages/ tree but doesn't
+# accept stand-alone PRs the same way. If you need to include it, edit the
+# loop manifest below.
+PIDS=()
+for entry in "${LEGACY_REPOS[@]}"; do
+  name="${entry%%:*}"
+  if [ "$name" = "newspack-scripts" ]; then continue; fi
+  (gh pr list --repo "Automattic/$name" --state open --limit 200 \
+     --json number,title,author,isDraft,headRefName,headRepositoryOwner,labels,createdAt,updatedAt,url \
+   | jq --arg repo "$name" '[.[] | . + {repo: $repo}]' \
+   > "$TMP/$name.json" 2> "$TMP/$name.err") &
+  PIDS+=($!)
+done
+for pid in "${PIDS[@]}"; do wait "$pid"; done
+
+# Merge, filter, sort. Filters are applied in jq so the JSON output is the
+# same shape regardless of --format.
+JQ_FILTERS='.'
+if [ "$INCLUDE_BOTS" = "0" ]; then
+  # GraphQL surfaces dependabot as "app/dependabot" and copilot/etc as
+  # "<name>[bot]". Match both patterns.
+  JQ_FILTERS=$JQ_FILTERS' | map(select((.author.login | test("^app/")) | not))'
+  JQ_FILTERS=$JQ_FILTERS' | map(select((.author.login | test("\\[bot\\]$"; "i")) | not))'
+fi
+if [ "$EXCLUDE_DRAFTS" = "1" ]; then
+  JQ_FILTERS=$JQ_FILTERS' | map(select(.isDraft == false))'
+fi
+# Sort by repo then by PR number so the output is stable across runs.
+JQ_FILTERS=$JQ_FILTERS' | sort_by(.repo, .number)'
+
+MERGED=$(jq -s 'add' "$TMP"/*.json | jq "$JQ_FILTERS")
+
+emit() {
+  if [ -n "$OUTPUT" ]; then
+    cat > "$OUTPUT"
+  else
+    cat
+  fi
+}
+
+if [ "$FORMAT" = "json" ]; then
+  printf '%s\n' "$MERGED" | emit
+else
+  # Markdown table. Columns: Repo, #, Title, Author, Draft?, Fork?, Updated.
+  {
+    printf '| Repo | # | Title | Author | Draft | Fork | Updated |\n'
+    printf '| --- | ---: | --- | --- | :---: | :---: | --- |\n'
+    printf '%s\n' "$MERGED" | jq -r '
+      .[] |
+      [
+        .repo,
+        ("#" + (.number|tostring)),
+        (.title | gsub("\\|"; "\\|") | gsub("\n"; " ")),
+        ("@" + .author.login),
+        (if .isDraft then "✓" else "" end),
+        (if (.headRepositoryOwner.login // "") != "Automattic" then "✓" else "" end),
+        (.updatedAt | sub("T.*"; ""))
+      ] | "| " + join(" | ") + " |"
+    '
+
+    # Footer with counts.
+    TOTAL=$(printf '%s' "$MERGED" | jq 'length')
+    PER_REPO=$(printf '%s' "$MERGED" | jq -r 'group_by(.repo) | map([.[0].repo, length] | join(": ")) | join(", ")')
+    printf '\n**Total: %d PRs** (%s)\n' "$TOTAL" "$PER_REPO"
+  } | emit
+fi
+
+if [ -n "$OUTPUT" ]; then
+  echo "==> Wrote $(jq 'length' "$OUTPUT" 2>/dev/null || wc -l < "$OUTPUT") items to $OUTPUT" >&2
+fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

> Stacked on top of #83 — review and merge #83 first.

New tooling under `bin/migration/` that lifts every open PR from the legacy Newspack repos into the monorepo on cutover day, preserving commit authorship, original messages, labels, and reviewers. Plus a small refactor of `sync-legacy.sh` to share helpers with the new scripts.

**New scripts:**

- `transplant-pr.sh`: single-PR driver. Reads metadata via `gh`, fetches `refs/pull/<N>/head` from the legacy upstream (works for fork PRs), filters via `sync-legacy-repo.sh`, replays feature commits onto the monorepo's base with `-X theirs` and auto-resolution of legacy-only paths (`.github/`, `package-lock.json`), applies a finalize commit only on `<target>/package.json`, opens a new PR with original metadata + a redirect block linking to the legacy PR, and (with `--close-source`) closes the legacy PR. Documented exit codes for ok / empty / conflict / extracted-pkg / noop-after-filter.
- `transplant-prs-batch.sh`: fan-out driver with `--concurrency`. Aggregates per-PR exit codes into a summary suitable for Slack.
- `transplant-prs-report.sh`: pre-cutover snapshot of every open PR in every legacy repo (JSON or markdown table). Excludes dependabot by default — Dependabot will re-open against the monorepo's hoisted lockfile.

**Refactor:**

- Extract `REPOS` manifest, dry-run wrappers, `apply_structural_overrides`, `normalize_package_repos`, and `route_extracted_packages` from `sync-legacy.sh` into `bin/migration/lib.sh` so both the daily sync and the transplant tooling share one definition. Behavior of the daily sync is unchanged; full `DRY_RUN=1` regression-tested.
- `sync-legacy-repo.sh` adds `--no-hardlinks` to the bare-clone step. Without it, concurrent `transplant-pr.sh` runs that share the same legacy bare source on one filesystem hit `fatal: hardlink different from source` (caught during validation; reproduced and fixed).

### How to test the changes in this Pull Request:

1. **Daily-sync regression** — `DRY_RUN=1 bin/migration/sync-legacy.sh`. Same outputs as before #83 + this stack: 9 integrations + 6 skips, no escalations.
2. **Single-PR dry-run with merge-commit handling** — `bin/migration/transplant-pr.sh newspack-blocks 2282 --dry-run --target-base origin/monorepo-integration`. Expect a clean transplant with 6 contributor commits replayed at original authorship; the trunk-merge commit inside the PR is correctly skipped; final diff matches the original PR's 5 files +82 -0.
3. **Single-PR fork case** — `bin/migration/transplant-pr.sh newspack-popups 1553 --dry-run --target-base origin/monorepo-integration`. Validates `refs/pull/<N>/head` fetch from upstream + commit authorship preservation for an external fork PR (@jhalitschke).
4. **Batch dry-run** — generate the snapshot and run a 35-PR sub-batch:
   ```sh
   bin/migration/transplant-prs-report.sh --output /tmp/snapshot.json
   bin/migration/transplant-prs-batch.sh \
     --dry-run --concurrency 4 \
     --input /tmp/snapshot.json \
     --target-base origin/monorepo-integration \
     --filter 'map(select(.repo | IN("newspack-blocks","newspack-popups","newspack-newsletters")))'
   ```
   Expected: 32 OK + 3 noop-after-filter (the dependabot-auto-merge clones) + 0 conflicts. Wall ~1 min. Batch script returns exit 1 because some PRs need human attention; that's intentional.

### Other information:

- All transplant scripts are heavily commented in lieu of separate docs.
- After this and #83 merge, retrigger the sync workflow with `gh workflow run sync-legacy.yml --repo Automattic/newspack-workspace` and close the eight open `sync/conflicts/...` PRs (#75–#82) as superseded.