### PR TITLE
fix(agents): remove legacy project scope plugin copies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,11 @@
 {
+  "enabledPlugins": {
+    "newspack@newspack-devkit": true,
+    "superpowers@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "linear@claude-plugins-official": true,
+    "figma@claude-plugins-official": true
+  },
   "extraKnownMarketplaces": {
     "newspack-devkit": {
       "source": {
@@ -6,12 +13,5 @@
         "repo": "Automattic/newspack-devkit"
       }
     }
-  },
-  "enabledPlugins": {
-    "newspack@newspack-devkit": true,
-    "superpowers@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
-    "linear@claude-plugins-official": true,
-    "figma@claude-plugins-official": true
   }
 }

--- a/bin/setup-agents.sh
+++ b/bin/setup-agents.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 #
-# Set up AI agent tooling for Newspack development.
-# Reads marketplace and plugin configuration from .claude/settings.json
-# and installs everything at user scope.
+# Bootstrap AI agent tooling for Newspack contributors.
+#
+# For Claude Code: reads `extraKnownMarketplaces` and `enabledPlugins`
+# from .claude/settings.json and:
+#
+#   1. Registers each declared marketplace.
+#   2. Removes any project scope copy of each plugin so older versions
+#      pinned to this workspace stop shadowing the user scope ones.
+#   3. Installs each plugin at user scope so it loads in every Claude
+#      Code session, not just inside this workspace.
+#
+# Safe to re-run: existing installs are skipped; new entries in
+# .claude/settings.json are picked up on the next run.
 #
 # Usage: n setup-agents
 
@@ -46,16 +56,29 @@ jq -r '.extraKnownMarketplaces // {} | to_entries[] | select(.value.source.sourc
   claude plugin marketplace add "$m" 2>/dev/null || true
 done
 
-# Install plugins from enabledPlugins
+# Detect legacy project-scope copies. Abort on query failure so we don't silently skip cleanup.
+if ! plugin_list_json=$(claude plugin list --json); then
+  echo "==> Could not query installed plugins. See error above." >&2
+  exit 1
+fi
+needs_cleanup=$(jq -r --arg path "$ROOT_DIR" '[.[] | select(.scope == "project" and .projectPath == $path)] | length' <<< "$plugin_list_json")
+
+# Project-scope uninstall also strips entries from `enabledPlugins`, our source
+# of truth, so snapshot the file and let the trap restore it on any exit.
+if [[ "${needs_cleanup:-0}" -gt 0 ]]; then
+  settings_backup="$(mktemp "${SETTINGS_FILE}.bak.XXXXXX")"
+  cp "$SETTINGS_FILE" "$settings_backup"
+  trap 'mv -f "$settings_backup" "$SETTINGS_FILE"' EXIT; trap 'exit 130' INT; trap 'exit 143' TERM HUP
+fi
+
 echo ""
 echo -e "${cyan}🔌 Installing plugins...${reset}"
 jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true) | .key' "$SETTINGS_FILE" | while read -r p; do
   echo -e "   ${dim}${p}${reset}"
-  if claude plugin install "$p" --scope user 2>/dev/null; then
-    echo -e "   ${green}✓${reset} ${p}"
-  else
-    echo -e "   ${yellow}⚠${reset} ${p} ${dim}(may already be installed)${reset}"
+  if [[ "${needs_cleanup:-0}" -gt 0 ]]; then
+    claude plugin uninstall "$p" --scope project -y >/dev/null 2>&1 || true
   fi
+  claude plugin install "$p" --scope user
 done
 
 echo ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Earlier versions of `bin/setup-agents.sh` installed Claude Code plugins at project scope. Project scope copies live alongside user scope copies in `~/.claude/plugins/installed_plugins.json` and show up in `claude plugin list` until they are removed.

This PR teaches `setup-agents` to clean up that legacy state on the next run:

* Detect any project scope plugin records pinned to this workspace via `claude plugin list --json`.
* If found, snapshot the workspace's `.claude/settings.json` and call `claude plugin uninstall <p> --scope project` to remove the stale records. The uninstall has a documented side effect of stripping the entry from `enabledPlugins`, so the script restores the file from the snapshot on exit.
* Install each plugin at user scope as before.

If no legacy state exists (the common case for fresh checkouts and anyone who set up after this lands), the cleanup machinery is skipped entirely and the script behaves identically to before.

### How to test the changes in this Pull Request:

1. **Common case (no legacy state).** From a fresh state, run `n setup-agents`. The script should register marketplaces, install plugins at user scope, and leave `.claude/settings.json` untouched. No backup file should appear in `.claude/`.
2. **Legacy state recovery.** Simulate a stale install: from inside the workspace run `claude plugin install context7@claude-plugins-official --scope project`. Confirm with `claude plugin list --json | jq '.[] | select(.scope == "project") | .id'` that context7 is listed. Then run `n setup-agents`. After it completes, the same query should return nothing, and `.claude/settings.json` should be unchanged from what it was right before the run.
3. **Failure handling.** Temporarily edit the script to call `claude plugin list-bogus --json` (a command that does not exist) and run `n setup-agents`. The script should print the CLI error, surface its own context line ("Could not query installed plugins. See error above."), and exit 1 instead of silently skipping cleanup.
4. **Settings.json preservation.** Add a temporary entry to `enabledPlugins`, run the script, and confirm your edit survives.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?