### PR TITLE
fix(env): anchor loopback alias check to avoid substring match

### DIFF
--- a/n
+++ b/n
@@ -111,7 +111,7 @@ start() {
         lo0_addrs=$(ifconfig lo0 2>/dev/null)
         for octet in $(seq 2 100); do
             ip="127.0.0.$octet"
-            if ! echo "$lo0_addrs" | grep -q "$ip"; then
+            if ! echo "$lo0_addrs" | grep -qE "inet $ip( |$)"; then
                 missing_aliases+=("$ip")
             fi
         done


### PR DESCRIPTION
## Summary
- `start()` pre-allocates `127.0.0.2`–`127.0.0.100` loopback aliases by greping `ifconfig lo0` output for each IP. The grep is unanchored, so checking `127.0.0.2` matches `127.0.0.26`, `127.0.0.3` matches `127.0.0.36`, etc. – the script then thinks those low-octet aliases already exist and silently skips creating them.
- Anchor the match to `inet <ip> ` so each address is matched exactly.

## How to reproduce
1. Reboot (loopback aliases reset).
2. `n env up <env-using-127.0.0.5-or-higher>` – this creates `.5`+ first.
3. `n env up <env-using-127.0.0.2>` – fails with `bind: can't assign requested address` because `.2` was skipped on the previous run.

## Test plan
- [ ] After reboot, `n env up` on any env with a low-octet (`.2`, `.3`) IP works on the first try.
- [ ] `ifconfig lo0 | grep -E 'inet 127.0.0.[2-9] '` lists 2–9 after `n` runs.