### PR TITLE
test(ci): probe change-detection logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
           fi
 
           # pnpm's change filter already handles transitive dependency graphs.
-          CHANGED=$(pnpm --silent --filter "...[$BASE_REF]" exec node -e 'console.log(process.env.npm_package_name)' 2>/dev/null | sort -u || true)
+          # PNPM_PACKAGE_NAME (uppercase) is what pnpm exposes to pnpm exec;
+          # npm_package_name is only set when pnpm runs a package script, not
+          # bare exec. Using the wrong one prints "undefined" for every package,
+          # which produces a matrix of {package: "undefined"} that silently
+          # matches nothing downstream — CI then appears green without running.
+          CHANGED=$(pnpm --silent --filter "...[$BASE_REF]" exec node -e 'console.log(process.env.PNPM_PACKAGE_NAME)' 2>/dev/null | sort -u || true)
 
           if [ -z "$CHANGED" ]; then
             echo "js-matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,10 @@ jobs:
           # bare exec. Using the wrong one prints "undefined" for every package,
           # which produces a matrix of {package: "undefined"} that silently
           # matches nothing downstream — CI then appears green without running.
-          CHANGED=$(pnpm --silent --filter "...[$BASE_REF]" exec node -e 'console.log(process.env.PNPM_PACKAGE_NAME)' 2>/dev/null | sort -u || true)
+          # Exclude the root workspace package — it has no plugin-shaped
+          # lint/build/test scripts, and changes to .github/ or root configs
+          # otherwise spawn a job that just fails.
+          CHANGED=$(pnpm --silent --filter "...[$BASE_REF]" exec node -e 'console.log(process.env.PNPM_PACKAGE_NAME)' 2>/dev/null | grep -v '^newspack-workspace$' | sort -u || true)
 
           if [ -z "$CHANGED" ]; then
             echo "js-matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -270,3 +270,4 @@ Note that before the first time updating you'll need to set the API key for Circ
 ### `@wordpress/*` packages
 
 This project lists [`@wordpress/*` packages](https://github.com/WordPress/gutenberg/tree/trunk/packages) as dependencies in order to provide them to consumers. In a project using `@wordpress/scripts` (e.g. a consumer of `newspack-scripts`), the `@wordpress/*` packages are sourced from WP Core, not `node_modules`. The packages should be included in `node_modules`, though, to be available in other environments – notably when running tests. See [Dependency Extraction Webpack Plugin](https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin) for more information.
+// ci-test transitive marker 1778666562

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -1579,3 +1579,4 @@ class Newspack_Blocks {
 	}
 }
 Newspack_Blocks::init();
+// ci-test marker 1778666012


### PR DESCRIPTION
Throwaway PR to validate CI change-detection logic on PR #70's content.

Two-phase probe:
1. Narrow change (1 file in `plugins/newspack-blocks/`) — matrix should contain `newspack-blocks` only.
2. Follow-up commit will touch `packages/scripts/` — matrix should fan out to every plugin/theme that depends on `newspack-scripts`.

Will close after both runs are observed.