### PR TITLE
ci: ignore plugins/*/languages/** in CI push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,16 @@ on:
       - trunk
       - alpha
       - release
-    # Translation-only pushes (the i18n bot commits these to per-plugin
-    # languages/ dirs) used to be skipped via a [skip ci] marker in the
-    # commit subject. That marker leaks into release-merge commit bodies
-    # via GitHub's auto-populated bullet list when a custom merge title
-    # is used, which kills the Release workflow. Filter by path instead.
+    # Translation-only pushes (the i18n bot commits these to languages/
+    # dirs under plugins and themes) used to be skipped via a [skip ci]
+    # marker in the commit subject. That marker leaks into release-merge
+    # commit bodies via GitHub's auto-populated bullet list when a custom
+    # merge title is used, which kills the Release workflow. Filter by
+    # path instead. The pattern matches any languages/ dir at any depth,
+    # covering plugins/*/languages/**, themes/*/languages/**, and the
+    # quirky themes/newspack-theme/newspack-theme/languages/** layout.
     paths-ignore:
-      - 'plugins/*/languages/**'
+      - '**/languages/**'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
       - trunk
       - alpha
       - release
+    # Translation-only pushes (the i18n bot commits these to per-plugin
+    # languages/ dirs) used to be skipped via a [skip ci] marker in the
+    # commit subject. That marker leaks into release-merge commit bodies
+    # via GitHub's auto-populated bullet list when a custom merge title
+    # is used, which kills the Release workflow. Filter by path instead.
+    paths-ignore:
+      - 'plugins/*/languages/**'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds `paths-ignore: ['plugins/*/languages/**']` to the `push` trigger in `.github/workflows/ci.yml`.

**Why:** the i18n bot commits translation updates with `chore: update translation files [skip ci]`. The `[skip ci]` is there so those commits don't re-trigger CI. But when trunk is merged into release with a custom merge commit title, GitHub auto-populates the merge body with a bulleted list of the constituent commits — including the verbatim `[skip ci]` subjects from the bot — and GitHub Actions then skips the entire push, **including the Release workflow**.

This just bit us on `newspack-manager-admin` PR #441 — zero workflow runs on the release-merge commit, no release. Empty commit on `release` was needed to recover.

Path-filtering the trigger here closes the leak vector pre-emptively in the monorepo: translation-only pushes still skip CI (by path, not by commit-message marker), but the marker can no longer kill releases.

Companion change for the legacy repo: Automattic/newspack-manager-admin#442. A separate org-wide fix to drop the `[skip ci]` marker from the bot's commit message will follow on `newspack-scripts`.

Notes:
- `release.yml` is intentionally not path-filtered; it must run on every push to `release`.
- The change-detection logic inside `ci.yml` already short-circuits when no packages are affected, but that runs after the workflow is triggered. `paths-ignore` skips the workflow entirely, which is what's needed to be immune to merge-body `[skip ci]` leaks.

### How to test the changes in this Pull Request:

1. CI on this PR uses `pull_request` (not `push`), so the change doesn't affect this PR's own checks — verify CI runs here normally.
2. After merge, a hypothetical push that only modifies `plugins/<some-plugin>/languages/*.po` should NOT trigger CI.
3. A push that modifies both `plugins/<some-plugin>/languages/*.po` and code should still trigger CI.
4. A push to `release` (release-merge) always contains non-`languages/**` changes, so the Release workflow continues to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)