### PR TITLE
chore(docker): bump Composer to 2.9.8 for GHSA-f9f8-rm49-7jv2

### DIFF
--- a/build-image-82.sh
+++ b/build-image-82.sh
@@ -10,7 +10,7 @@ docker build \
     --platform linux/arm64 \
     -t newspack-dev-82 \
     --build-arg PHP_VERSION=8.2 \
-    --build-arg COMPOSER_VERSION=2.2.6 \
+    --build-arg COMPOSER_VERSION=2.9.8 \
     --build-arg NODE_VERSION=20.16.0 \
     --build-arg APACHE_RUN_USER="$APACHE_USER" \
     --build-arg PHPUNIT_VERSION=9.5.10 \

--- a/build-image.sh
+++ b/build-image.sh
@@ -10,7 +10,7 @@ docker build \
     --platform linux/arm64 \
     -t newspack-dev \
     --build-arg PHP_VERSION=8.3 \
-    --build-arg COMPOSER_VERSION=2.2.6 \
+    --build-arg COMPOSER_VERSION=2.9.8 \
     --build-arg NODE_VERSION=20.16.0 \
     --build-arg APACHE_RUN_USER="$APACHE_USER" \
     --build-arg PHPUNIT_VERSION=9.5.10 \


### PR DESCRIPTION
## Summary

Bumps the Composer version pinned in the local dev Docker image from `2.2.6` to `2.9.8` (the patched release for [GHSA-f9f8-rm49-7jv2](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2)).

`2.2.6` falls in the affected `>=2.0.0,<2.2.28` range. The vulnerability leaks GitHub OAuth tokens to stderr when validation of a hyphen-containing token fails. Practical exposure for our local dev image is low (Composer steps don't typically receive tokens), but there's no reason to keep a vulnerable pin.

## Scope

- Local dev Docker image only (`build-image.sh`, `build-image-82.sh`).
- CI is unaffected: `newspack-scripts` workflows use `tools: composer` via `shivammathur/setup-php@v2`, which already tracks the latest stable (2.9.8).
- No workflow forwards a GitHub OAuth token to a `composer install/update` step, so historical pre-patch CI runs had no exposure path either.

## Test plan

- [ ] `./build-image.sh` builds successfully
- [ ] `./build-image-82.sh` builds successfully
- [ ] `n start` boots the container and `docker exec newspack_dev composer --version` reports 2.9.8
- [ ] `n ci-build newspack-plugin` (or equivalent) completes without Composer regressions