### PR TITLE
chore(migration): drop legacy LICENSE/LICENSE.md on sync

### DIFF
--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -66,15 +66,19 @@ gh_pr_create() {
 # Drop legacy per-plugin .github/ (CI runs at the monorepo root),
 # package-lock.json (the monorepo uses pnpm-lock.yaml at the root; per-plugin
 # lockfiles are vestigial and would otherwise be re-added on every sync run
-# that touches them upstream), and commitlint.config.js (root package.json
-# declares commitlint config workspace-wide). Also restore workspace:* in any
-# conflicting plugin/theme package.json — the legacy repo bumps
-# newspack-{scripts,components,colors,icons} to concrete versions, which
-# would break the pnpm workspace if landed.
+# that touches them upstream), per-plugin LICENSE/LICENSE.md (the monorepo
+# carries a single root LICENSE under GPL-2.0-or-later, with each plugin
+# header declaring the same; per-plugin copies were folded out at cutover),
+# and commitlint.config.js (root package.json declares commitlint config
+# workspace-wide).
+# Also restore workspace:* in any conflicting plugin/theme package.json —
+# the legacy repo bumps newspack-{scripts,components,colors,icons} to concrete
+# versions, which would break the pnpm workspace if landed.
 apply_structural_overrides() {
   local target=$1
   git rm -rf --ignore-unmatch \
     "$target/.github" "$target/package-lock.json" \
+    "$target/LICENSE" "$target/LICENSE.md" \
     "$target/commitlint.config.js" \
     > /dev/null 2>&1 || true
   while IFS= read -r f; do


### PR DESCRIPTION
## Summary

Follow-up to #90. The legacy `apply_structural_overrides` in `bin/migration/lib.sh` already had the LICENSE drops on `monorepo-integration`, but they were missed when porting to `main`. Since the daily sync workflow checks the script out from `main`, the override never fired in CI.

The monorepo carries a single root `LICENSE` under GPL-2.0-or-later (each plugin header declares the same), so per-plugin `LICENSE` / `LICENSE.md` files were folded out at cutover. This change keeps the daily legacy sync from reintroducing them.

## Test plan

- [ ] Next sync workflow run cleanly drops `LICENSE` / `LICENSE.md` from every legacy merge
- [ ] No `plugins/*/LICENSE*` or `themes/*/LICENSE*` reappear on `monorepo-integration`