### PR TITLE
feat(env): one-shot local e2e setup + fix env permalinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,42 @@ This installs a locked-down wrapper script (`newspack-manage-host`) that only al
 
 To undo: `sudo rm /etc/sudoers.d/newspack-manage-host /usr/local/bin/newspack-manage-host`
 
+### Running the e2e test suite locally
+
+The [newspack-e2e-tests](https://github.com/Automattic/newspack-e2e-tests) Playwright suite normally runs in CI against staging. You can run it against a local isolated environment instead, to reproduce and fix failures without a CI round-trip:
+
+```BASH
+n env e2e-setup <name>
+```
+
+This one command does everything needed to go from nothing to a runnable e2e site:
+
+1. Creates worktrees on `release` for the plugins the suite needs (`newspack-plugin`, `newspack-blocks`, `newspack-popups`, `newspack-newsletters`, `newspack-ads`, `newspack-theme`) and an isolated environment that mounts them.
+2. Starts the environment, installs WordPress, and writes working permalink rewrite rules.
+3. Builds any worktree that's missing compiled assets (it doesn't assume `repos/` is built).
+4. Installs the e2e helper plugin and runs `e2e-reset.sh` (Newspack setup, sample content, snapshots, WooCommerce) — both pulled from the e2e-tests checkout, not vendored here.
+5. Points the e2e repo's `.env` at the new site (`SITE_URL`, admin credentials), preserving any other keys.
+
+It's safe to re-run: an existing environment is reused, and only worktrees missing assets are rebuilt.
+
+```BASH
+# Options:
+n env e2e-setup <name> \
+  --branch <branch>   # branch to check out per plugin (default: release)
+  --domain <domain>   # site domain (default: <name>.local)
+  --e2e-repo <path>   # path to the newspack-e2e-tests checkout
+                      #   (default: a sibling of this workspace)
+```
+
+When it finishes, run the suite against the new environment:
+
+```BASH
+cd ../newspack-e2e-tests
+npx playwright test --project="Vanilla in Desktop Chrome"
+```
+
+By default the suite expects the e2e-tests checkout to sit alongside this workspace (`../newspack-e2e-tests`); pass `--e2e-repo` if yours lives elsewhere.
+
 ## Newspack Manager
 
 This Docker environment will launch two sites by default. One is the site you will be working on to develop all plugins, and the other is the one that will run the Newspack Manager Client.

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -30,3 +30,15 @@ validate_port() {
         exit 1
     fi
 }
+
+# Logging helpers — mirror the colored output used by bin/site-setup.sh.
+NP_RED='\033[0;31m'
+NP_GREEN='\033[0;32m'
+NP_YELLOW='\033[1;33m'
+NP_BLUE='\033[0;34m'
+NP_NC='\033[0m'
+
+log_info() { echo -e "${NP_BLUE}[INFO]${NP_NC} ${1}"; }
+log_success() { echo -e "${NP_GREEN}[SUCCESS]${NP_NC} ${1}"; }
+log_warning() { echo -e "${NP_YELLOW}[WARNING]${NP_NC} ${1}"; }
+log_error() { echo -e "${NP_RED}[ERROR]${NP_NC} ${1}"; }

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -355,6 +355,19 @@ MIGRATE
         done
         if ! docker exec "$container_name" wp --allow-root core is-installed 2>/dev/null; then
             echo "Warning: WordPress may not be fully installed. Run 'n env up $env_name' to retry."
+        elif docker exec "$container_name" test -f /var/www/html/wp-config.php 2>/dev/null; then
+            # Ensure pretty permalinks work. A fresh isolated env installs with WP's
+            # default (plain) permalink structure, so the .htaccess rewrite block stays
+            # empty — and a later `wp rewrite flush --hard` with an empty structure
+            # rewrites .htaccess down to a bare "# BEGIN/END WordPress" marker, 404-ing
+            # every pretty permalink. Set a structure and flush --hard so the rewrite
+            # rules are written out, then hand the file back to the Apache user so WP can
+            # keep it updated. The main-site path does this via site-setup.sh; envs skip
+            # that and install WordPress directly, so it has to happen here too.
+            run_user="${USE_CUSTOM_APACHE_USER:-www-data}"
+            docker exec "$container_name" wp --allow-root rewrite structure '/%year%/%monthnum%/%day%/%postname%/' --hard >/dev/null 2>&1
+            docker exec "$container_name" wp --allow-root rewrite flush --hard >/dev/null 2>&1
+            docker exec "$container_name" chown "$run_user":"$run_user" /var/www/html/.htaccess 2>/dev/null || true
         fi
         # Reload Apache to pick up SSL config (it's running by now).
         docker exec "$container_name" apachectl graceful 2>/dev/null
@@ -576,10 +589,15 @@ MIGRATE
             "$NABSPATH/bin/env.sh" destroy "$name"
         done
         ;;
+    e2e-setup)
+        shift
+        exec "$NABSPATH/bin/setup-local-e2e.sh" "$@"
+        ;;
     *)
-        echo "Usage: n env <create|up|down|destroy|list|cleanup>"
+        echo "Usage: n env <create|up|down|destroy|list|cleanup|e2e-setup>"
         echo "  up <name> [--build]      Start an environment"
         echo "  up --all [--build]       Start all environments"
         echo "  cleanup [--all] [--yes]  Remove environments (--all selects everything, --yes skips confirmation)"
+        echo "  e2e-setup <name> [opts]  Build a ready-to-run local e2e-tests environment (see --help)"
         ;;
 esac

--- a/bin/setup-local-e2e.sh
+++ b/bin/setup-local-e2e.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+# Build a ready-to-run local environment for the newspack-e2e-tests Playwright
+# suite, end to end. This is the one-shot equivalent of the manual dance of
+# creating worktrees, spinning up an isolated env, building any unbuilt assets,
+# installing the e2e helper plugin, running the e2e reset script, and pointing
+# the e2e repo's .env at the new site.
+#
+# Usage:
+#   n env e2e-setup <name> [options]
+#
+# Options:
+#   --branch <branch>     Branch to check out for each plugin (default: release).
+#   --domain <domain>     Site domain (default: <name>.local).
+#   --e2e-repo <path>     Path to the newspack-e2e-tests checkout
+#                         (default: a sibling of this workspace).
+#   -h, --help            Show this help.
+#
+# Safe to re-run: an existing environment is reused, and only worktrees missing
+# built assets are (re)built.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+# Plugins the e2e suite needs, checked out on the target branch as worktrees.
+E2E_PLUGINS=(
+    newspack-plugin
+    newspack-blocks
+    newspack-popups
+    newspack-newsletters
+    newspack-ads
+    newspack-theme
+)
+
+# A path (relative to the repo root) whose presence means the worktree is built.
+# Missing marker => the worktree's assets need compiling before WordPress can
+# load it (e.g. newspack-plugin's editor bundle, newspack-theme's compiled JS).
+build_marker_for() {
+    case "$1" in
+        newspack-plugin) echo "dist/editor.asset.php" ;;
+        # newspack-theme is a meta-repo; the active classic theme lives in a nested
+        # newspack-theme/ subdir, and that's where its JS build output lands.
+        newspack-theme)  echo "newspack-theme/js/dist" ;;
+        *)               echo "dist" ;;
+    esac
+}
+
+usage() {
+    # Print the leading comment block (the lines after the shebang), stripped of '#'.
+    awk 'NR>2 { if ($0 ~ /^#/) { sub(/^# ?/, ""); print } else { exit } }' "${BASH_SOURCE[0]}"
+}
+
+env_name=""
+branch="release"
+domain=""
+e2e_repo="$(cd "$NABSPATH/.." 2>/dev/null && pwd)/newspack-e2e-tests"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --branch)
+            [[ -z "$2" || "$2" == --* ]] && { log_error "--branch requires a value"; exit 1; }
+            branch="$2"; shift 2 ;;
+        --domain)
+            [[ -z "$2" || "$2" == --* ]] && { log_error "--domain requires a value"; exit 1; }
+            domain="$2"; shift 2 ;;
+        --e2e-repo)
+            [[ -z "$2" || "$2" == --* ]] && { log_error "--e2e-repo requires a value"; exit 1; }
+            e2e_repo="$2"; shift 2 ;;
+        --*) log_error "Unknown option: $1"; usage; exit 1 ;;
+        *)
+            if [[ -z "$env_name" ]]; then
+                env_name="$1"; shift
+            else
+                log_error "Unexpected argument: $1"; exit 1
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$env_name" ]]; then
+    usage
+    exit 1
+fi
+validate_env_name "$env_name"
+validate_name "$branch" "branch"
+[[ -n "$domain" ]] && validate_domain "$domain"
+[[ -z "$domain" ]] && domain="${env_name}.local"
+
+# Resolve the e2e-tests repo and the two files we pull from it.
+e2e_plugin_src="$e2e_repo/e2e-plugin.php"
+e2e_reset_src="$e2e_repo/e2e-reset.sh"
+if [[ ! -f "$e2e_plugin_src" || ! -f "$e2e_reset_src" ]]; then
+    log_error "Could not find e2e-plugin.php / e2e-reset.sh in: $e2e_repo"
+    log_error "Pass the e2e-tests checkout with --e2e-repo <path>."
+    exit 1
+fi
+
+container_name=$(echo "newspack_env_${env_name}" | tr '-' '_')
+compose_file="$NABSPATH/docker-compose.env-${env_name}.yml"
+
+log_info "Setting up local e2e environment '$env_name' (branch: $branch, domain: $domain)"
+
+# The isolated-env compose files reference an external Docker network; create it
+# if 'n start' hasn't already (env up assumes it exists).
+if ! docker network inspect newspack_envs >/dev/null 2>&1; then
+    log_info "Creating shared Docker network 'newspack_envs'..."
+    docker network create newspack_envs >/dev/null || { log_error "Failed to create network"; exit 1; }
+fi
+
+# 1. Create the environment (worktrees on the target branch), reusing it if present.
+if [[ -f "$compose_file" ]]; then
+    log_info "Environment '$env_name' already exists — reusing it."
+else
+    worktree_args=()
+    for repo in "${E2E_PLUGINS[@]}"; do
+        worktree_args+=(--worktree "${repo}:${branch}")
+    done
+    log_info "Creating environment with worktrees: ${E2E_PLUGINS[*]} @ $branch"
+    # Drive create non-interactively (no "start now?" prompt); we start it below.
+    "$NABSPATH/bin/env.sh" create "$env_name" "${worktree_args[@]}" --domain "$domain" < /dev/null \
+        || { log_error "Failed to create environment"; exit 1; }
+fi
+
+# 2. Start it. --build seeds each worktree with built assets from the matching
+#    repos/<plugin> checkout, and the up flow installs WP + writes permalinks.
+log_info "Starting environment (this installs WordPress and seeds assets)..."
+"$NABSPATH/bin/env.sh" up "$env_name" --build || { log_error "Failed to start environment"; exit 1; }
+
+# Ensure the domain resolves so Playwright (running on the host) can reach it.
+# `n env up` only adds /etc/hosts entries interactively; the e2e suite is usually
+# driven non-interactively, so add it here via the passwordless helper if present.
+if [[ "$domain" == *.local ]] && ! grep -q "[[:space:]]${domain}$" /etc/hosts 2>/dev/null; then
+    ip=$(grep -o '127\.0\.0\.[0-9]*' "$compose_file" | head -1)
+    if command -v newspack-manage-host >/dev/null 2>&1; then
+        sudo newspack-manage-host host-add "$ip" "$domain" \
+            && log_info "Added $domain -> $ip to /etc/hosts"
+    else
+        log_warning "$domain is not in /etc/hosts. Add it before running tests:"
+        log_warning "  sudo sh -c 'echo \"$ip $domain\" >> /etc/hosts'"
+    fi
+fi
+
+# 3. Build any worktree that still lacks compiled assets. --build only copies
+#    from repos/<plugin>, so a worktree whose source repo was never built has
+#    nothing to copy — compile it directly inside the container (it mounts the
+#    worktree at /newspack-repos/<repo>).
+for repo in "${E2E_PLUGINS[@]}"; do
+    marker=$(build_marker_for "$repo")
+    if docker exec "$container_name" test -e "/newspack-repos/${repo}/${marker}" 2>/dev/null; then
+        log_info "$repo already has built assets — skipping build."
+    else
+        log_info "Building $repo (missing $marker)..."
+        docker exec "$container_name" bash -c "/var/scripts/build-repos.sh ${repo} ci" \
+            || { log_error "Failed to build $repo"; exit 1; }
+    fi
+done
+
+# 4. Install the e2e helper plugin and run the e2e reset script, both pulled from
+#    the e2e-tests repo (not vendored here). e2e-reset.sh resolves the WordPress
+#    install from its working directory, so it runs from the web root.
+log_info "Installing the e2e helper plugin..."
+docker cp "$e2e_plugin_src" "${container_name}:/var/www/html/wp-content/plugins/e2e-plugin.php"
+
+log_info "Running e2e-reset.sh (Newspack setup, sample content, snapshots, Woo)..."
+docker cp "$e2e_reset_src" "${container_name}:/var/www/html/e2e-reset.sh"
+# Copy the e2e repo's .env too, so optional Stripe keys are picked up; removed after.
+copied_env=false
+if [[ -f "$e2e_repo/.env" ]]; then
+    docker cp "$e2e_repo/.env" "${container_name}:/var/www/html/.env"
+    copied_env=true
+fi
+# e2e-reset.sh has no `set -e`; snapshot/manager/premium-Woo steps can fail
+# harmlessly on a local env, so don't let a non-zero exit abort this script.
+docker exec "$container_name" bash -c "cd /var/www/html && bash e2e-reset.sh" \
+    || log_warning "e2e-reset.sh reported errors (often snapshot/manager/premium-Woo steps); continuing."
+# Clean up the transient files from the web root (keep the activated plugin).
+docker exec "$container_name" rm -f /var/www/html/e2e-reset.sh
+[[ "$copied_env" == true ]] && docker exec "$container_name" rm -f /var/www/html/.env
+
+# 5. Re-assert pretty permalinks. `wp newspack setup` (run by e2e-reset) can flush
+#    rewrite rules, so write them out once more and hand .htaccess back to Apache.
+log_info "Ensuring permalink rewrite rules are in place..."
+run_user="${USE_CUSTOM_APACHE_USER:-www-data}"
+docker exec "$container_name" wp --allow-root rewrite structure '/%year%/%monthnum%/%day%/%postname%/' --hard >/dev/null 2>&1
+docker exec "$container_name" wp --allow-root rewrite flush --hard >/dev/null 2>&1
+docker exec "$container_name" chown "$run_user":"$run_user" /var/www/html/.htaccess 2>/dev/null || true
+docker exec "$container_name" wp --allow-root cache flush >/dev/null 2>&1 || true
+
+# 6. Point the e2e repo's .env at this environment, preserving any other keys
+#    (e.g. Stripe credentials) already present.
+log_info "Configuring $e2e_repo/.env..."
+upsert_env_var() {
+    local key="$1" value="$2" file="$3"
+    if [[ -f "$file" ]] && grep -q "^${key}=" "$file"; then
+        # In-place replace; handle both BSD and GNU sed.
+        sed -i '' "s|^${key}=.*|${key}=\"${value}\"|" "$file" 2>/dev/null \
+            || sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$file"
+    else
+        echo "${key}=\"${value}\"" >> "$file"
+    fi
+}
+touch "$e2e_repo/.env"
+upsert_env_var "SITE_URL" "https://${domain}" "$e2e_repo/.env"
+upsert_env_var "ADMIN_USER" "admin" "$e2e_repo/.env"
+upsert_env_var "ADMIN_PASSWORD" "password" "$e2e_repo/.env"
+
+echo ""
+log_success "Local e2e environment '$env_name' is ready at https://${domain}/"
+log_success "$e2e_repo/.env is configured (SITE_URL=https://${domain})."
+echo ""
+echo "Run the suite against it:"
+echo "  cd $e2e_repo"
+echo "  npx playwright test --project=\"Vanilla in Desktop Chrome\""


### PR DESCRIPTION
## What

Makes running the [newspack-e2e-tests](https://github.com/Automattic/newspack-e2e-tests) Playwright suite against a **local isolated env** painless, by closing the two gaps that previously required ~10 manual steps.

### Ask A — fix empty `.htaccess` → permalinks 404

A freshly-created isolated env installed WordPress directly (`wp core install`) but never set a permalink structure, unlike the main-site path (which goes through `site-setup.sh`). The default *plain* structure means a later `wp rewrite flush --hard` rewrites `.htaccess` down to a bare `# BEGIN/END WordPress` marker, 404-ing every pretty permalink.

`bin/env.sh` `up` now sets a permalink structure and flushes `--hard` after install, then hands `.htaccess` back to the Apache user.

### Ask B — `n env e2e-setup <name>`

One command from nothing to a runnable e2e site (`bin/setup-local-e2e.sh`, dispatched via `n env e2e-setup`):

1. Worktrees on `release` for the suite's plugins + an isolated env mounting them.
2. `env up` (installs WP, writes permalinks).
3. Builds any worktree missing compiled assets (doesn't assume `repos/` is built).
4. Installs the e2e helper plugin and runs `e2e-reset.sh`, both pulled from the e2e-tests checkout (not vendored).
5. Points the e2e repo's `.env` at the new site, preserving other keys.

Idempotent: an existing env is reused; only worktrees missing assets are rebuilt. Shared log helpers were added to `bin/_common.sh`.

## How to test

```bash
n env e2e-setup myenv
cd ../newspack-e2e-tests
npx playwright test --project="Vanilla in Desktop Chrome" homepage-admin.spec.ts campaigns.spec.ts
```

## Verification done

| Item | Status | Evidence |
|---|---|---|
| Fresh env serves post permalinks (200, not 404) | DONE | `curl` of `/2020/03/15/...` → `HTTP 200`; `.htaccess` populated, owned by `www-data` |
| Block editor loads without PHP fatals (assets built) | DONE | all 6 worktrees built; theme JS at nested `newspack-theme/js/dist`; editor specs pass |
| `homepage-admin` + `campaigns` specs pass against local env | DONE | `2 passed (25.8s)` against `https://e2e-local.local/` |
| Command is idempotent | DONE | re-run reused env and skipped all 6 builds |
| Documented in README | DONE | new "Running the e2e test suite locally" section |

🤖 Generated with [Claude Code](https://claude.com/claude-code)