### PR TITLE
chore(migration): restore workspace:* deps and refresh lockfile during sync

### DIFF
--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -119,7 +119,7 @@ normalize_package_repos() {
         changed.push(pj);
       }
     }
-    process.stdout.write(changed.join("\0"));
+    for (const f of changed) process.stdout.write(f + "\0");
   ' | while IFS= read -r -d "" f; do
     git add -- "$f"
   done
@@ -162,7 +162,7 @@ restore_workspace_deps() {
         changed.push(pj);
       }
     }
-    process.stdout.write(changed.join("\0"));
+    for (const f of changed) process.stdout.write(f + "\0");
   ' | while IFS= read -r -d "" f; do
     git add -- "$f"
   done

--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -69,8 +69,8 @@ gh_pr_create() {
 # that touches them upstream), per-plugin LICENSE/LICENSE.md (the monorepo
 # carries a single root LICENSE under GPL-2.0-or-later, with each plugin
 # header declaring the same; per-plugin copies were folded out at cutover),
-# and commitlint.config.js (root package.json declares commitlint config
-# workspace-wide).
+# and per-plugin commitlint.config.js (root package.json declares commitlint
+# config workspace-wide).
 # Also restore workspace:* in any conflicting plugin/theme package.json —
 # the legacy repo bumps newspack-{scripts,components,colors,icons} to concrete
 # versions, which would break the pnpm workspace if landed.
@@ -123,6 +123,71 @@ normalize_package_repos() {
   ' | while IFS= read -r -d "" f; do
     git add -- "$f"
   done
+}
+
+# Restore workspace:* for any dependency on a workspace-published package
+# (newspack-scripts/components/colors/icons) in any plugin/theme package.json.
+# Legacy commits bump these against published semver (e.g. "^5.9.7"); a clean
+# merge into the monorepo brings that bump in unchallenged, which breaks
+# pnpm's frozen-lockfile install because pnpm-lock.yaml expects workspace:*.
+# Idempotent — safe to call after every merge.
+restore_workspace_deps() {
+  node -e '
+    const fs = require("fs"), path = require("path");
+    const WS_PACKAGES = ["newspack-scripts", "newspack-components", "newspack-colors", "newspack-icons"];
+    const roots = ["plugins", "themes"];
+    const changed = [];
+    for (const r of roots) {
+      if (!fs.existsSync(r)) continue;
+      for (const name of fs.readdirSync(r)) {
+        const pj = path.join(r, name, "package.json");
+        if (!fs.existsSync(pj)) continue;
+        const src = fs.readFileSync(pj, "utf8");
+        const indentMatch = src.match(/\n(\t+|[ ]+)"/);
+        const indent = indentMatch ? indentMatch[1] : "  ";
+        const trail = src.endsWith("\n") ? "\n" : "";
+        const j = JSON.parse(src);
+        let dirty = false;
+        for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+          if (!j[section]) continue;
+          for (const pkg of WS_PACKAGES) {
+            if (j[section][pkg] && j[section][pkg] !== "workspace:*") {
+              j[section][pkg] = "workspace:*";
+              dirty = true;
+            }
+          }
+        }
+        if (!dirty) continue;
+        fs.writeFileSync(pj, JSON.stringify(j, null, indent) + trail);
+        changed.push(pj);
+      }
+    }
+    process.stdout.write(changed.join("\0"));
+  ' | while IFS= read -r -d "" f; do
+    git add -- "$f"
+  done
+}
+
+# Refresh pnpm-lock.yaml when plugin/theme package.json files have changed
+# during the integration run. Without this, a legacy commit that adds/removes
+# a dependency cleanly merges into the monorepo but leaves the lockfile out
+# of sync, and CI's `pnpm install --frozen-lockfile` fails on the next PR.
+# Silently no-ops when pnpm isn't available (e.g. local DRY_RUN on a machine
+# without it) — only commits a change if the lockfile actually moved.
+regenerate_lockfile() {
+  command -v pnpm > /dev/null 2>&1 || { echo "==> pnpm not found, skipping lockfile refresh"; return; }
+  echo "==> Refreshing pnpm-lock.yaml"
+  pnpm install --lockfile-only > /dev/null 2>&1 || {
+    echo "    WARN: pnpm install --lockfile-only failed; leaving lockfile untouched"
+    return
+  }
+  if [ -n "$(git status --porcelain pnpm-lock.yaml)" ]; then
+    git add pnpm-lock.yaml
+    git commit -m "chore(sync): refresh pnpm-lock.yaml after legacy merges" > /dev/null
+    echo "    lockfile updated"
+  else
+    echo "    lockfile already in sync"
+  fi
 }
 
 # For newspack-plugin: redirect any path under

--- a/bin/migration/sync-legacy.sh
+++ b/bin/migration/sync-legacy.sh
@@ -235,6 +235,7 @@ integrate_all() {
     fi
 
     normalize_package_repos
+    restore_workspace_deps
 
     if [ -z "$(git diff --name-only --diff-filter=U)" ]; then
       git commit --no-edit > /dev/null
@@ -250,6 +251,7 @@ integrate_all() {
   done
 
   if [ "$(git rev-parse HEAD)" != "$START" ]; then
+    regenerate_lockfile
     echo "==> Pushing $(git rev-list --count "$START..HEAD") new commits to monorepo-integration"
     git_push origin HEAD:monorepo-integration
   else


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the WordPress / VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

The nightly legacy sync workflow (`.github/workflows/sync-legacy.yml`) checks out **`main`** into `scripts-src` and runs **main's** copy of `bin/migration/sync-legacy.sh`. Two post-merge guards currently live only on the `monorepo-integration` branch and were never on `main`, so the running sync doesn't execute them:

- `restore_workspace_deps()` – after each `-Xtheirs` merge, rewrites `newspack-{scripts,components,colors,icons}` back to `workspace:*`. Legacy repos (and their Dependabot PRs) pin these to published semver (e.g. `^5.9.8`); landing that unchallenged breaks the pnpm workspace.
- `regenerate_lockfile()` – refreshes `pnpm-lock.yaml` after manifests change during a run.

Without these, the sync drifts manifests to published semver and leaves `pnpm-lock.yaml` stale, so the next PR's `pnpm install --frozen-lockfile` fails (`ERR_PNPM_OUTDATED_LOCKFILE`). This PR ports both functions and their call sites from `monorepo-integration` to `main`, where the workflow actually reads from.

This is a straight port – the functions are already proven on `monorepo-integration`. Node and pnpm are both set up in the sync workflow, so they will run.

Closes # .

### How to test the changes in this Pull Request:

1. `git diff origin/main HEAD -- bin/migration/` shows only the two added functions in `lib.sh` and the two call sites (`restore_workspace_deps` after `normalize_package_repos`, `regenerate_lockfile` before the push) in `sync-legacy.sh`.
2. `bash -n bin/migration/lib.sh && bash -n bin/migration/sync-legacy.sh` – both parse cleanly.
3. After merge, the next scheduled `Sync legacy repos` run should commit a `chore(sync): refresh pnpm-lock.yaml after legacy merges` when manifests move, and leave `newspack-scripts` et al. at `workspace:*`.

### Other information:

Note: these guards do **not** cover third-party direct deps (e.g. `clsx`, `lodash`, `prop-types`) that legacy manifests omit and that pnpm's strict layout won't hoist. That is a separate, known gap; this PR only stops the `workspace:*` / lockfile drift.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?