### PR TITLE
fix(migration): install pnpm + node in the legacy sync workflow

### DIFF
--- a/.github/workflows/sync-legacy.yml
+++ b/.github/workflows/sync-legacy.yml
@@ -50,6 +50,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git-filter-repo
+      # pnpm + node so the sync script can refresh pnpm-lock.yaml after merges
+      # that change plugin/theme package.json files.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: integration/.nvmrc
       - name: Configure git
         working-directory: integration
         run: |


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress / VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #93. That PR ported `restore_workspace_deps` / `regenerate_lockfile` to main, but a manual `workflow_dispatch` run of the sync revealed `regenerate_lockfile` never actually runs:

```
==> pnpm not found, skipping lockfile refresh
```

The nightly sync executes **main's** copy of `sync-legacy.yml`, which sets up `git-filter-repo` but **not pnpm or node**. `regenerate_lockfile` guards on `command -v pnpm`, so it silently skips on every run, leaving `pnpm-lock.yaml` stale whenever a synced commit changes a plugin/theme manifest — which is exactly the `ERR_PNPM_OUTDATED_LOCKFILE` failure mode the function was meant to prevent.

This adds the two setup steps (already present on `monorepo-integration`) before the sync step:

```yaml
      - uses: pnpm/action-setup@v4
        with:
          version: 10.33.0
      - uses: actions/setup-node@v4
        with:
          node-version-file: integration/.nvmrc
```

`node-version-file: integration/.nvmrc` resolves against the `integration` checkout (monorepo-integration, `path: integration`), which carries `.nvmrc` — main itself doesn't need one.

Closes # .

### How to test the changes in this Pull Request:

1. After merge, dispatch the workflow (`Actions → Sync legacy repos → Run workflow`).
2. In the `Run sync` step logs, confirm it no longer prints `pnpm not found, skipping lockfile refresh`. When a synced commit changes a manifest, expect `==> Refreshing pnpm-lock.yaml` and a `chore(sync): refresh pnpm-lock.yaml after legacy merges` commit on monorepo-integration.

### Other information:

Found via a real `workflow_dispatch` run (#26160779234): the run integrated newspack-newsletters (+3 commits) and pushed to monorepo-integration, but skipped the lockfile refresh. CI stayed green only because those commits changed a version field and a `repository` field, not dependency specifiers.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?