### PR TITLE
fix(env): use newspack-manage-host for hosts entry in env create/up

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -162,7 +162,10 @@ YAML
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if [ -t 0 ] && [ -t 1 ]; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
+                # Passwordless via the locked-down wrapper — works without a TTY.
+                sudo newspack-manage-host host-add "$ip" "$domain"
+            elif [ -t 0 ] && [ -t 1 ]; then
                 read -p "Add $domain to /etc/hosts? (Y/n): " choice
                 choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
                 if [[ "$choice" != "n" ]]; then
@@ -278,7 +281,11 @@ MIGRATE
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ -n "$domain" && "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if [ -t 0 ] && [ -t 1 ]; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
+                # Passwordless via the locked-down wrapper — works without a TTY.
+                sudo newspack-manage-host host-add "$ip" "$domain"
+                echo "Added $domain to /etc/hosts"
+            elif [ -t 0 ] && [ -t 1 ]; then
                 echo "Adding $domain to /etc/hosts (requires sudo)..."
                 echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
                 echo "Added $domain to /etc/hosts"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #67. That PR wired the passwordless `newspack-manage-host` wrapper into `alias-add` everywhere, `host-add` in the combined `n env create --up` path (`n:137`), and `host-remove` in the destroy path — but **missed `host-add` in `bin/env.sh`'s standalone `create` and `up` paths.**

In those two paths the loopback *alias* is registered via the wrapper, but the `/etc/hosts` *entry* is added only through a TTY-gated raw `sudo tee` (or, when non-interactive, just a printed `sudo sh -c 'echo … >> /etc/hosts'` warning). The wrapper's `host-add` is never invoked. So a non-interactive caller (AI agent, piped stdin) running `n env create` then `n env up` as separate commands gets the warning and **no hosts entry**, even though the passwordless wrapper is installed and is exactly what's needed.

This makes the env reachable by its `.local` domain only after a manual `sudo`, which defeats the point of #67 for the standalone flow.

#### Fix

When `newspack-manage-host` is installed and the domain is `*.local`, register the entry with `sudo newspack-manage-host host-add "$ip" "$domain"` (passwordless, no TTY required), mirroring the combined `n` path and the destroy path. Falls back to the previous interactive prompt / raw-sudo warning when the wrapper is absent or the domain isn't `.local` (the wrapper only accepts `.local` anyway).

### How to test the changes in this Pull Request:

1. Ensure the wrapper is installed (`./bin/setup-networking.sh`).
2. From a **non-interactive** shell (pipe stdin from /dev/null), run `n env create test-host </dev/null` then `n env up test-host </dev/null`.
3. Confirm `grep test-host.local /etc/hosts` shows the entry — with no sudo prompt and no "add hosts entry" warning.
4. `n env destroy test-host` cleans the entry up (unchanged behavior).
5. Remove the wrapper (`sudo rm /usr/local/bin/newspack-manage-host`) and confirm the create/up paths fall back to the interactive prompt / warning as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally? (`bash -n bin/env.sh` passes; verified the wrapper path resolves the missing-entry case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)