### PR TITLE
chore(env): migrate generated dev domains from .local to .test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ The main container is `newspack_dev`. For isolated environments, the container n
 
 ### Multi-Site
 ```bash
-n sites-add <name>            # Create additional site at name.local
+n sites-add <name>            # Create additional site at name.test
 n sites-list                  # List additional sites
 n sites-drop <name>           # Remove site
 ```
@@ -220,14 +220,14 @@ Each isolated environment gets its own Docker container, WordPress installation,
 n env create myenv --worktree newspack-plugin:mybranch
 n env up myenv
 n setup --env myenv --yes     # fully configured Newspack site
-# → https://myenv.local/  (override with --domain)
+# → https://myenv.test/  (override with --domain)
 ```
 
 ### Environment Commands
 ```bash
 n env create <name> [options]  # Create environment config
   --worktree <repo>:<branch>   #   Mount a worktree (repeatable for multiple repos)
-  --domain <domain>            #   Custom domain (default: <name>.local)
+  --domain <domain>            #   Custom domain (default: <name>.test)
   --up                         #   Start the environment immediately after creation
 n env up <name> [--build]      # Start environment (creates DB, installs WP, sets up SSL)
 n env up --all [--build]       # Start all existing environments at once

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Run the one-time setup script to allow these specific operations without a passw
 ./bin/setup-networking.sh
 ```
 
-This installs a locked-down wrapper script (`newspack-manage-host`) that only allows adding/removing `127.0.0.*` loopback aliases and `*.test` hosts entries, and creates a sudoers rule so your user can run it without a password. After this, `n start`, `n env create`, `n env up`, and `n env destroy` will manage networking automatically -- no password prompts, even from non-interactive terminals.
+This installs a locked-down wrapper script (`newspack-manage-host`) that only allows adding/removing `127.0.0.*` loopback aliases and `*.test` (and legacy `*.local`) hosts entries, and creates a sudoers rule so your user can run it without a password. After this, `n start`, `n env create`, `n env up`, and `n env destroy` will manage networking automatically -- no password prompts, even from non-interactive terminals.
 
 > **Already ran this before the `.test` migration?** Re-run `./bin/setup-networking.sh` to install the updated wrapper -- the previous version only accepts `.local` domains and will reject newly-created `.test` environments.
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,9 @@ Run the one-time setup script to allow these specific operations without a passw
 ./bin/setup-networking.sh
 ```
 
-This installs a locked-down wrapper script (`newspack-manage-host`) that only allows adding/removing `127.0.0.*` loopback aliases and `*.local` hosts entries, and creates a sudoers rule so your user can run it without a password. After this, `n start`, `n env create`, `n env up`, and `n env destroy` will manage networking automatically -- no password prompts, even from non-interactive terminals.
+This installs a locked-down wrapper script (`newspack-manage-host`) that only allows adding/removing `127.0.0.*` loopback aliases and `*.test` hosts entries, and creates a sudoers rule so your user can run it without a password. After this, `n start`, `n env create`, `n env up`, and `n env destroy` will manage networking automatically -- no password prompts, even from non-interactive terminals.
+
+> **Already ran this before the `.test` migration?** Re-run `./bin/setup-networking.sh` to install the updated wrapper -- the previous version only accepts `.local` domains and will reject newly-created `.test` environments.
 
 To undo: `sudo rm /etc/sudoers.d/newspack-manage-host /usr/local/bin/newspack-manage-host`
 
@@ -348,7 +350,7 @@ It's safe to re-run: an existing environment is reused, and only worktrees missi
 # Options:
 n env e2e-setup <name> \
   --branch <branch>   # branch to check out per plugin (default: release)
-  --domain <domain>   # site domain (default: <name>.local)
+  --domain <domain>   # site domain (default: <name>.test)
   --e2e-repo <path>   # path to the newspack-e2e-tests checkout
                       #   (default: a sibling of this workspace)
 ```
@@ -427,7 +429,7 @@ define( 'NEWSPACK_DOCKER_SITE_URL_CLI_OVERRIDE', 'https://my-domain.my-tunnel.co
 
 If you need to run a couple of additional sites, we got you covered.
 
-You can have a number of additional sites running under `you-name-it.local`. They will live in their own local domain, such as `site1.local` and `another-site.local`.
+You can have a number of additional sites running under `you-name-it.test`. They will live in their own local domain, such as `site1.test` and `another-site.test`.
 
 `n sites-add $site_name` will launch a new site. The site will come with Newpack already initialized and all the plugins linked. Your secrets will also be copied. It's basically the same result as running `n reset-site` for your main site.
 

--- a/bin/additional-sites-index.php
+++ b/bin/additional-sites-index.php
@@ -6,9 +6,9 @@ $dirHandle = opendir('.');
         ?>
         <h2><?php echo $file; ?></h2>
         <p>
-            <a href="http://additional-sites.local/<?php echo $file; ?>">Site</a>
+            <a href="http://additional-sites.test/<?php echo $file; ?>">Site</a>
             |
-            <a href="http://additional-sites.local/<?php echo $file; ?>/wp-admin">WP Admin</a>
+            <a href="http://additional-sites.test/<?php echo $file; ?>/wp-admin">WP Admin</a>
             
         </p>
         <?php

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -104,7 +104,7 @@ case $1 in
         done
         ip=$(next_loopback_ip)
         if [[ -z "$domain" ]]; then
-            domain="${env_name}.local"
+            domain="${env_name}.test"
         fi
         compose_file="$NABSPATH/docker-compose.env-${env_name}.yml"
         container_name=$(echo "newspack_env_${env_name}" | tr '-' '_')
@@ -162,7 +162,7 @@ YAML
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.test || "$domain" == *.local ]]; then
                 # Passwordless via the locked-down wrapper — works without a TTY.
                 sudo newspack-manage-host host-add "$ip" "$domain"
             elif [ -t 0 ] && [ -t 1 ]; then
@@ -241,9 +241,9 @@ YAML
         ip=$(ip_for_env "$compose_file")
         # --- Migration: add shared network + domain if missing ---
         if ! grep -q 'newspack_envs' "$compose_file"; then
-            # Assign a .local domain if the env is IP-based.
+            # Assign a .test domain if the env is IP-based.
             if [[ "$domain" == "$ip" || -z "$domain" ]]; then
-                domain="${env_name}.local"
+                domain="${env_name}.test"
                 # Update WP_DOMAIN in the compose file.
                 sed -i '' "s|WP_DOMAIN=${ip}|WP_DOMAIN=${domain}|" "$compose_file" 2>/dev/null || \
                     sed -i "s|WP_DOMAIN=${ip}|WP_DOMAIN=${domain}|" "$compose_file"
@@ -281,7 +281,7 @@ MIGRATE
         fi
         # Custom domains (not IP-based) need a /etc/hosts entry.
         if [[ -n "$domain" && "$domain" != "$ip" ]] && ! grep -q "[[:space:]]${domain}" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.test || "$domain" == *.local ]]; then
                 # Passwordless via the locked-down wrapper — works without a TTY.
                 sudo newspack-manage-host host-add "$ip" "$domain"
                 echo "Added $domain to /etc/hosts"
@@ -338,7 +338,7 @@ MIGRATE
                 # Check if core tables exist (wp core is-installed returns true even without them).
                 if docker exec "$container_name" wp --allow-root db query "SELECT 1 FROM wp_options LIMIT 1" 2>/dev/null | grep -q 1; then
                     echo "WordPress already installed."
-                    # Update site URL if domain changed (e.g., migration from IP to .local).
+                    # Update site URL if domain changed (e.g., migration from IP to .test).
                     current_url=$(docker exec "$container_name" wp --allow-root option get siteurl 2>/dev/null)
                     if [[ -n "$current_url" && "$current_url" != "https://${domain}" ]]; then
                         docker exec "$container_name" wp --allow-root search-replace "$current_url" "https://${domain}" --skip-columns=guid --quiet 2>/dev/null
@@ -453,7 +453,7 @@ MIGRATE
         fi
         # Remove /etc/hosts entry (only for custom domains, not IP-based).
         if [[ -n "$domain" && "$domain" != "$ip" ]] && grep -q "$domain" /etc/hosts 2>/dev/null; then
-            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.local ]]; then
+            if command -v newspack-manage-host >/dev/null 2>&1 && [[ "$domain" == *.test || "$domain" == *.local ]]; then
                 sudo newspack-manage-host host-remove "$domain"
             else
                 escaped_domain="${domain//./\\.}"

--- a/bin/init-additional-site.sh
+++ b/bin/init-additional-site.sh
@@ -53,19 +53,19 @@ cp /var/scripts/newspack-docker-mu.php "/var/www/additional-sites-html/$SITE_NAM
 /var/scripts/link-repos.sh "/var/www/additional-sites-html/$SITE_NAME/wp-content"
 
 # SSL
-sudo /usr/local/bin/ssl "${SITE_NAME}.local"
+sudo /usr/local/bin/ssl "${SITE_NAME}.test"
 
 # check if a VirtualHost block for the site already exists
-if ! grep -q "ServerName ${SITE_NAME}.local:443" /etc/apache2/sites-available/002-additional.conf; then
+if ! grep -q "ServerName ${SITE_NAME}.test:443" /etc/apache2/sites-available/002-additional.conf; then
 echo "Adding SSL VirtualHost block to the apache config file for ${SITE_NAME}…"
 # https://stackoverflow.com/questions/41979785/how-to-configure-multiple-ssl-certs-on-apache-virtual-host-with-aliases
 sudo cat <<EOF >> /etc/apache2/sites-available/002-additional.conf
 <VirtualHost *:443>
-	ServerName ${SITE_NAME}.local:443
+	ServerName ${SITE_NAME}.test:443
 	DocumentRoot /var/www/additional-sites-html/${SITE_NAME}
 	SSLEngine on
-	SSLCertificateFile /etc/ssl/certs/${SITE_NAME}.local.pem
-	SSLCertificateKeyFile /etc/ssl/certs/${SITE_NAME}.local-key.pem
+	SSLCertificateFile /etc/ssl/certs/${SITE_NAME}.test.pem
+	SSLCertificateKeyFile /etc/ssl/certs/${SITE_NAME}.test-key.pem
 	<Directory /var/www/additional-sites-html/${SITE_NAME}>
         AllowOverride All
         Require all granted

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -6,7 +6,7 @@ SITE_TITLE=$WP_TITLE
 
 if [[ "$WP_PATH" == *"additional-sites-html"* ]]; then
     SITE_TITLE=$(echo $WP_PATH | sed -e 's/.*additional-sites-html\///' | cut -d'/' -f1)
-    DOMAIN_TO_INSTALL="$SITE_TITLE.local"
+    DOMAIN_TO_INSTALL="$SITE_TITLE.test"
 fi
 
 if wp --allow-root --path=$WP_PATH core is-installed; then

--- a/bin/newspack-manage-host
+++ b/bin/newspack-manage-host
@@ -6,8 +6,8 @@
 #
 # Only allows:
 #   - Adding/removing loopback aliases on lo0 (127.0.0.*)
-#   - Adding /etc/hosts entries for 127.0.0.* -> *.local domains
-#   - Removing /etc/hosts entries for *.local domains
+#   - Adding /etc/hosts entries for 127.0.0.* -> *.test / *.local domains
+#   - Removing /etc/hosts entries for *.test / *.local domains
 
 set -euo pipefail
 
@@ -15,8 +15,8 @@ usage() {
     echo "Usage:"
     echo "  $0 alias-add <127.0.0.X>"
     echo "  $0 alias-remove <127.0.0.X>"
-    echo "  $0 host-add <127.0.0.X> <domain.local>"
-    echo "  $0 host-remove <domain.local>"
+    echo "  $0 host-add <127.0.0.X> <domain.test>"
+    echo "  $0 host-remove <domain.test>"
     exit 1
 }
 
@@ -28,8 +28,8 @@ validate_loopback_ip() {
 }
 
 validate_local_domain() {
-    if [[ ! "$1" =~ ^[a-zA-Z0-9._-]+\.local$ ]]; then
-        echo "Error: invalid domain '$1' (must end in .local)" >&2
+    if [[ ! "$1" =~ ^[a-zA-Z0-9._-]+\.(test|local)$ ]]; then
+        echo "Error: invalid domain '$1' (must end in .test or .local)" >&2
         exit 1
     fi
 }

--- a/bin/newspack-network/connect-distributor.php
+++ b/bin/newspack-network/connect-distributor.php
@@ -27,7 +27,7 @@ $auth = [
     'base64_encoded' => base64_encode( $wp_user . ':' . $app_pass ),
 ];
 
-$site_url = 'http://' . $site_name . '.local/wp-json/';
+$site_url = 'http://' . $site_name . '.test/wp-json/';
 
 echo "Connecting Distributor in site $this_site to $site_url\n";
 

--- a/bin/newspack-network/create-nodes.php
+++ b/bin/newspack-network/create-nodes.php
@@ -9,7 +9,7 @@ foreach( $nodes as $node ) {
     if ( empty( $node ) ) {
         continue;
     }
-    $domain = $node . '.local';
+    $domain = $node . '.test';
     $existing_node = Newspack_Network\Hub\Nodes::get_node_by_url( 'http://' . $domain );
     if ( $existing_node ) {
         echo "Node $domain already exists.\n";

--- a/bin/setup-local-e2e.sh
+++ b/bin/setup-local-e2e.sh
@@ -11,7 +11,7 @@
 #
 # Options:
 #   --branch <branch>     Branch to check out for each plugin (default: release).
-#   --domain <domain>     Site domain (default: <name>.local).
+#   --domain <domain>     Site domain (default: <name>.test).
 #   --e2e-repo <path>     Path to the newspack-e2e-tests checkout
 #                         (default: a sibling of this workspace).
 #   -h, --help            Show this help.
@@ -84,7 +84,7 @@ fi
 validate_env_name "$env_name"
 validate_name "$branch" "branch"
 [[ -n "$domain" ]] && validate_domain "$domain"
-[[ -z "$domain" ]] && domain="${env_name}.local"
+[[ -z "$domain" ]] && domain="${env_name}.test"
 
 # Resolve the e2e-tests repo and the two files we pull from it.
 e2e_plugin_src="$e2e_repo/e2e-plugin.php"
@@ -141,7 +141,7 @@ log_info "Starting environment (this installs WordPress and seeds assets)..."
 # Ensure the domain resolves so Playwright (running on the host) can reach it.
 # `n env up` only adds /etc/hosts entries interactively; the e2e suite is usually
 # driven non-interactively, so add it here via the passwordless helper if present.
-if [[ "$domain" == *.local ]] && ! grep -q "[[:space:]]${domain}$" /etc/hosts 2>/dev/null; then
+if [[ "$domain" == *.test || "$domain" == *.local ]] && ! grep -q "[[:space:]]${domain}$" /etc/hosts 2>/dev/null; then
     ip=$(grep -o '127\.0\.0\.[0-9]*' "$compose_file" | head -1)
     if command -v newspack-manage-host >/dev/null 2>&1; then
         sudo newspack-manage-host host-add "$ip" "$domain" \

--- a/bin/setup-newspack-network.sh
+++ b/bin/setup-newspack-network.sh
@@ -41,11 +41,11 @@ for site in $(ls -d /var/www/additional-sites-html/*/); do
     NODES="$NODES,$site_name"
     # Create the service account
     if ! wp --allow-root user application-password exists 1 $APP_NAME --path=$site; then
-        echo "Creating service account for $site_name.local"
+        echo "Creating service account for $site_name.test"
         PASSWORD=$(wp --allow-root user application-password create 1 $APP_NAME --porcelain --path=$site)
         echo "$site_name:$PASSWORD" >> $SERVICE_ACCOUNTS_FILE
     else
-        echo "Service account for $site_name.local already exists"
+        echo "Service account for $site_name.test already exists"
     fi
 done
 

--- a/bin/sites-add.sh
+++ b/bin/sites-add.sh
@@ -15,7 +15,7 @@ if [ ! -d "/var/www/additional-sites-html/$name" ]; then
     sudo -E -u $user /var/scripts/reset-site.sh /var/www/additional-sites-html/$name
 
     echo
-    echo "Site $name created!. Open https://${name}.local"
+    echo "Site $name created!. Open https://${name}.test"
     echo
 else
     echo

--- a/bin/sites-list.sh
+++ b/bin/sites-list.sh
@@ -5,6 +5,6 @@ parent_folder="/var/www/additional-sites-html"
 for folder in "$parent_folder"/*; do
     if [ -d "$folder" ]; then
         folder_name=$(basename "$folder")
-        echo "- http://$folder_name.local/"
+        echo "- http://$folder_name.test/"
     fi
 done

--- a/config/apache_additional_sites
+++ b/config/apache_additional_sites
@@ -1,6 +1,6 @@
 <VirtualHost *:80>
 	UseCanonicalName Off
-    ServerAlias *.local
+    ServerAlias *.test *.local
 	VirtualDocumentRoot /var/www/additional-sites-html/%1
 
 	ServerAdmin webmaster@localhost

--- a/n
+++ b/n
@@ -318,7 +318,7 @@ case $1 in
         ;;
     sites-add)
         docker exec $DOCKER_IT $TARGET_CONTAINER sh -c "/var/scripts/sites-add.sh $2"
-        if ! grep -q "\s$2.test" /etc/hosts; then
+        if ! grep -q "[[:space:]]$2\.test" /etc/hosts; then
             read -p "Do you want to add this domain to your local hosts file? (Y/n): " choice
             choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
             if [[ "$choice" != "n" ]]; then

--- a/n
+++ b/n
@@ -133,7 +133,7 @@ start() {
                 done
                 for entry in "${missing_hosts[@]}"; do
                     read -r ip domain <<< "$entry"
-                    if [[ "$domain" == *.local ]]; then
+                    if [[ "$domain" == *.test || "$domain" == *.local ]]; then
                         sudo newspack-manage-host host-add "$ip" "$domain"
                     else
                         echo "$ip $domain" | sudo tee -a /etc/hosts > /dev/null
@@ -318,11 +318,11 @@ case $1 in
         ;;
     sites-add)
         docker exec $DOCKER_IT $TARGET_CONTAINER sh -c "/var/scripts/sites-add.sh $2"
-        if ! grep -q "\s$2.local" /etc/hosts; then
+        if ! grep -q "\s$2.test" /etc/hosts; then
             read -p "Do you want to add this domain to your local hosts file? (Y/n): " choice
             choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
             if [[ "$choice" != "n" ]]; then
-              echo "127.0.0.1 $2.local" | sudo tee -a /etc/hosts
+              echo "127.0.0.1 $2.test" | sudo tee -a /etc/hosts
             fi
         fi
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `.local` TLD is discouraged for local development because it collides with mDNS/Bonjour resolution. This switches the domains generated for isolated environments (`n env create`) and additional sites (`n sites-add`) to `.test` — the TLD reserved by RFC 6761 specifically for testing.

`.localhost` was considered but rejected: browsers and macOS hard-code `*.localhost` to `127.0.0.1` and ignore `/etc/hosts`, which would break the per-environment loopback-IP isolation (each env binds Apache to its own `127.0.0.x:443`). `.test` is not special-cased, so it respects `/etc/hosts` and per-env IPs — a true drop-in replacement.

Highlights:

- New isolated environments and additional sites get `.test` domains.
- The main site is unchanged (it already uses `localhost`).
- Backward compatible: the `newspack-manage-host` sudo wrapper and the additional-sites Apache wildcard vhost accept **both** `.test` and `.local`, so pre-existing `.local` environments keep working and still tear down cleanly via `n env destroy`.
- Existing `.local` environments are not migrated — they continue to run from their persisted compose files.

> [!IMPORTANT]
> Anyone who previously ran `./bin/setup-networking.sh` must re-run it to install the updated `newspack-manage-host` wrapper — the old version only accepts `.local` domains and will reject newly-created `.test` environments. The `config/apache_additional_sites` change also requires a Docker image rebuild to take effect for additional sites.

### How to test the changes in this Pull Request:

1. Re-run `./bin/setup-networking.sh` to install the updated `newspack-manage-host` wrapper.
2. Run `n env create test-tld --up`, then confirm `https://test-tld.test/` resolves and loads, and that `grep test-tld.test /etc/hosts` shows a per-env loopback IP (`127.0.0.x`, not `127.0.0.1`).
3. Run `n env destroy test-tld` and confirm the container, DB, and the `test-tld.test` `/etc/hosts` entry are all removed.
4. Confirm a pre-existing `.local` environment still appears in `n env list` and still tears down cleanly via `n env destroy <name>` (verifies the wrapper still accepts `.local`).
5. Rebuild the Docker image, then run `n sites-add demo` and confirm `https://demo.test/` and `http://demo.test/` both route to the additional site.
6. Run `n env e2e-setup <name>` and confirm the e2e environment is created with a `.test` domain.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (No automated test harness exists for these shell/PHP scripts; verified with `bash -n` and `php -l`.)
* [x] Have you successfully ran tests with your changes locally?