### PR TITLE
fix(newspack-plugin): catch up post-migration legacy trunk delta on main

### DIFF
--- a/packages/components/src/card-feature/README.md
+++ b/packages/components/src/card-feature/README.md
@@ -11,7 +11,7 @@ A card component for presenting a named feature or setting with a predictable, s
 
 | State | Condition | Button | Dropdown | Badge |
 |---|---|---|---|---|
-| **Unmet requirements** | `requirements` is set | "Enable" — disabled | Hidden | Error badge with `requirements` text |
+| **Unmet requirements** | `requirements` is set | "Enable" — disabled (clickable if `requirementsActionable`) | Hidden | Error badge with `requirements` text |
 | **Disabled** | `!enabled`, no requirements | "Enable" | Hidden | None |
 | **Enabled** | `enabled`, no requirements | "Configure" | Shown if `moreControls` provided | Success badge ("Enabled") |
 
@@ -155,6 +155,7 @@ import { __ } from '@wordpress/i18n';
 | `icon` | `CardFeatureIcon` | — | Icon displayed on the right. See `CardFeatureIcon` below. |
 | `enabled` | `boolean` | `false` | Whether the feature is currently enabled |
 | `requirements` | `string` | — | When set, enters the unmet-requirements state; value is used as the error badge text |
+| `requirementsActionable` | `boolean` | `false` | When `requirements` is set, keep the primary button clickable so it can remediate the unmet requirement |
 | `enableLabel` | `string` | `"Enable"` | Primary button label when not enabled |
 | `configureLabel` | `string` | `"Configure"` | Primary button label when enabled |
 | `onEnable` | `() => void` | — | Called when the primary button is clicked and the feature is not enabled |

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -49,10 +49,17 @@ type CardFeatureProps = {
 	/** Whether the feature is currently enabled. */
 	enabled?: boolean;
 	/**
-	 * When set, the card enters the "unmet requirements" state: the primary
-	 * button is disabled and an error badge displays this string.
+	 * When set, the card enters the "unmet requirements" state: an error
+	 * badge displays this string and the title/description are muted. By
+	 * default the primary button is disabled — set `requirementsActionable`
+	 * if the primary button is the remediation for the unmet requirement.
 	 */
 	requirements?: string;
+	/**
+	 * When `requirements` is set, keep the primary button clickable so the
+	 * user can remediate the unmet requirement from this card.
+	 */
+	requirementsActionable?: boolean;
 	/** Primary button label when not enabled. Default: "Enable". */
 	enableLabel?: string;
 	/** Primary button label when enabled. Default: "Configure". */
@@ -83,6 +90,7 @@ const CardFeature = ( {
 	icon,
 	enabled = false,
 	requirements,
+	requirementsActionable = false,
 	enableLabel,
 	configureLabel,
 	onEnable,
@@ -149,7 +157,12 @@ const CardFeature = ( {
 						</HStack>
 						<HStack alignment="edge">
 							<HStack expanded={ false } spacing="8px">
-								<Button variant="secondary" disabled={ isMuted } onClick={ handleButtonClick }>
+								<Button
+									variant={ isConfigureState ? 'tertiary' : 'secondary' }
+									disabled={ isMuted && ! requirementsActionable }
+									onClick={ handleButtonClick }
+									size="compact"
+								>
 									{ buttonLabel }
 								</Button>
 								{ enabled && ! requirements && !! moreControls?.length && (

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [6.41.3](https://github.com/Automattic/newspack-plugin/compare/v6.41.2...v6.41.3) (2026-05-25)
+
+
+### Bug Fixes
+
+* **editor:** exclude Customizer Additional CSS from iframed editor ([#4750](https://github.com/Automattic/newspack-plugin/issues/4750)) ([3aaf8f6](https://github.com/Automattic/newspack-plugin/commit/3aaf8f627974a282b7c74ef29d65b94af005d1e2))
+
 ## [6.41.2](https://github.com/Automattic/newspack-plugin/compare/v6.41.1...v6.41.2) (2026-05-21)
 
 

--- a/plugins/newspack-plugin/includes/class-newspack-ui.php
+++ b/plugins/newspack-plugin/includes/class-newspack-ui.php
@@ -1182,14 +1182,18 @@ class Newspack_UI {
 								<input type="hidden" name="reader-activation-newsletters-signup" value="1" />
 								<input type="hidden" name="email_address" value="<?php echo esc_attr( $demo_email_address ); ?>" />
 
-								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container" data-list-default-size="<?php echo esc_attr( $demo_default_list_size ); ?>">
+								<?php $demo_has_overflow = count( $demo_newsletters_lists ) > (int) $demo_default_list_size; ?>
+								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container">
 								<?php
 								foreach ( $demo_newsletters_lists as $list ) {
-									$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
-									$is_hidden   = $loop_index <= $demo_default_list_size ? '' : 'hidden';
+									$checkbox_id   = sprintf( 'newspack-plugin-list-%s', $list['id'] );
+									$is_peek       = $loop_index === (int) $demo_default_list_size;
+									$is_hidden     = $loop_index > (int) $demo_default_list_size;
+									$label_classes = 'newspack-ui__input-card' . ( $is_hidden ? ' hidden' : '' );
+									$label_inert   = ( $is_peek || $is_hidden ) ? ' inert' : '';
 									$loop_index++;
 									?>
-									<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo esc_attr( $checkbox_id ); ?>">
+									<label class="<?php echo esc_attr( $label_classes ); ?>" for="<?php echo esc_attr( $checkbox_id ); ?>"<?php echo esc_attr( $label_inert ); ?>>
 										<input
 											type="checkbox"
 											name="lists[]"
@@ -1207,17 +1211,15 @@ class Newspack_UI {
 										<?php endif; ?>
 									</label>
 									<?php
-									if ( $loop_index === (int) $demo_default_list_size && count( $demo_newsletters_lists ) > $demo_default_list_size ) :
-										?>
-										<div class="newspack-ui__gradient-divider"></div>
-										<?php
-									endif;
 								}
 								?>
+								<?php if ( $demo_has_overflow ) : ?>
+									<div class="newspack-ui__gradient-divider"></div>
+								<?php endif; ?>
 								</div>
 
 								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 newspack-ui__spacing-top--5">
-									<?php if ( count( $demo_newsletters_lists ) > $demo_default_list_size ) : ?>
+									<?php if ( $demo_has_overflow ) : ?>
 										<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary see-all-button" aria-label="<?php esc_attr_e( 'See all newsletters', 'newspack-plugin' ); ?>">
 											<span aria-hidden="true"><?php esc_html_e( 'See all', 'newspack-plugin' ); ?></span>
 											<?php Newspack_UI_Icons::print_svg( 'chevronDownSmall' ); ?>
@@ -1229,43 +1231,43 @@ class Newspack_UI {
 						</div>
 						<script>
 							( function() {
-								const container = document.querySelector( '.newspack-newsletters-signup' );
-								if ( ! container ) {
-									return;
-								}
-								const seeAllButton = container.querySelector( '.see-all-button' );
-								const newsletterContainer = container.querySelector( '.newsletter-list-container' );
-								if ( seeAllButton && newsletterContainer ) {
+								const setupReveal = function( container ) {
+									const seeAllButton = container.querySelector( '.see-all-button' );
+									const newsletterContainer = container.querySelector( '.newsletter-list-container' );
+									if ( ! seeAllButton || ! newsletterContainer ) {
+										return;
+									}
 									const divider = newsletterContainer.querySelector( '.newspack-ui__gradient-divider' );
+									const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
+
 									seeAllButton.addEventListener( 'click', function() {
-										newsletterContainer.querySelectorAll( '.hidden' ).forEach( function( item ) {
+										const firstRevealed = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]' );
+										newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( function( item ) {
 											item.classList.remove( 'hidden' );
+											item.removeAttribute( 'inert' );
 										} );
 										newsletterContainer.style.maxHeight = 'none';
 										if ( divider ) {
 											divider.classList.add( 'hidden' );
 										}
 										seeAllButton.classList.add( 'hidden' );
+										if ( firstRevealed ) {
+											const firstInput = firstRevealed.querySelector( 'input' );
+											if ( firstInput ) {
+												firstInput.focus();
+											}
+										}
 									} );
 
-									// Set the initial height to show partially visible.
-									const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );
-									const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
-
-									if ( newsletterItems.length > listDefaultSize ) {
-										const gap = 12;
-										const extraSpace = 32;
-
-										let totalHeight = 0;
-										newsletterItems.forEach( function( item, index ) {
-											if ( index < listDefaultSize ) {
-												totalHeight += item.offsetHeight;
-											}
-										} );
-
-										const maxHeight = totalHeight + listDefaultSize * gap + extraSpace;
-										newsletterContainer.style.maxHeight = maxHeight + 'px';
+									if ( peekItem ) {
+										const peekAmount = ( divider && divider.offsetHeight ) || 32;
+										newsletterContainer.style.maxHeight = ( peekItem.offsetTop + peekAmount ) + 'px';
 									}
+								};
+
+								const container = document.querySelector( '.newspack-newsletters-signup' );
+								if ( container ) {
+									setupReveal( container );
 								}
 							} )();
 						</script>

--- a/plugins/newspack-plugin/includes/class-patches.php
+++ b/plugins/newspack-plugin/includes/class-patches.php
@@ -44,6 +44,11 @@ class Patches {
 
 		// Fix an issue when running The Events Calendar where all posts block items have same date.
 		add_action( 'tribe_events_views_v2_after_make_view', [ __CLASS__, 'remove_tec_extra_excerpt_filtering' ], 1 );
+
+		// Prevent Customizer "Additional CSS" from leaking into the iframed block editor in WP 7.0+.
+		if ( version_compare( get_bloginfo( 'version' ), '7.0', '>=' ) ) {
+			add_filter( 'block_editor_settings_all', [ __CLASS__, 'strip_customizer_css_from_editor' ], 999 );
+		}
 	}
 
 	/**
@@ -517,6 +522,50 @@ class Patches {
 	 */
 	public static function remove_tec_extra_excerpt_filtering() {
 		remove_all_actions( 'tribe_events_views_v2_after_make_view' );
+	}
+
+	/**
+	 * Remove the Customizer "Additional CSS" entry from the block editor styles array.
+	 *
+	 * WP core injects `wp_get_custom_css()` into the editor's styles array as
+	 * `[ '__unstableType' => 'user', 'isGlobalStyles' => false ]`. Since WP 7.0
+	 * iframes the post editor when all blocks use Block API v3+, any front-end
+	 * `body { ... }` rule in Customizer → Additional CSS now lands on the
+	 * editor canvas. The front-end is unaffected — that copy is printed by
+	 * `wp_custom_css_cb()` on `wp_head`.
+	 *
+	 * @param array $settings Block editor settings.
+	 * @return array
+	 */
+	public static function strip_customizer_css_from_editor( $settings ) {
+		if ( empty( $settings['styles'] ) || ! is_array( $settings['styles'] ) ) {
+			return $settings;
+		}
+
+		/**
+		 * Filters whether to strip Customizer Additional CSS from the editor iframe.
+		 *
+		 * @param bool $strip Default true.
+		 */
+		if ( ! apply_filters( 'newspack_strip_customizer_css_in_editor', true ) ) {
+			return $settings;
+		}
+
+		// Note: `__unstableType` is a private WP core key. Re-verify on WP upgrades.
+		$settings['styles'] = array_values(
+			array_filter(
+				$settings['styles'],
+				function ( $entry ) {
+					return ! (
+						isset( $entry['__unstableType'] )
+						&& 'user' === $entry['__unstableType']
+						&& empty( $entry['isGlobalStyles'] )
+					);
+				}
+			)
+		);
+
+		return $settings;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/class-plugin-manager.php
+++ b/plugins/newspack-plugin/includes/class-plugin-manager.php
@@ -32,6 +32,19 @@ class Plugin_Manager {
 	];
 
 	/**
+	 * Per-request memoization for get_managed_plugin_status(), keyed by slug.
+	 *
+	 * The underlying get_installed_plugins() calls wp_get_themes() which rescans
+	 * /themes on every call (get_plugins() is cached intra-request, themes are
+	 * not). With multiple integrations declaring the same required plugin, that
+	 * scan ran once per lookup. The cache is per-request, so plugin state changes
+	 * between requests are picked up on the next call.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $managed_plugin_status_cache = [];
+
+	/**
 	 * Get info about all the managed plugins and their status.
 	 *
 	 * @todo Define what the structure of this looks like better and load it up from a config or something.
@@ -393,6 +406,9 @@ class Plugin_Manager {
 		if ( Newspack::is_debug_mode() ) {
 			return 'active';
 		}
+		if ( isset( self::$managed_plugin_status_cache[ $plugin_slug ] ) ) {
+			return self::$managed_plugin_status_cache[ $plugin_slug ];
+		}
 		$status            = 'uninstalled';
 		$installed_plugins = self::get_installed_plugins();
 
@@ -430,7 +446,18 @@ class Plugin_Manager {
 			}
 		}
 
+		self::$managed_plugin_status_cache[ $plugin_slug ] = $status;
 		return $status;
+	}
+
+	/**
+	 * Reset the per-request memoization of get_managed_plugin_status().
+	 *
+	 * Tests that mutate plugin install/active state mid-test must call this so
+	 * subsequent get_managed_plugin_status() calls re-derive the status.
+	 */
+	public static function reset_managed_plugin_status_cache() {
+		self::$managed_plugin_status_cache = [];
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
@@ -424,20 +424,27 @@ class Integrations {
 				continue;
 			}
 			$result[ $id ] = [
-				'id'          => $id,
-				'name'        => $integration->get_name(),
-				'description' => $integration->get_description(),
-				'enabled'     => self::is_enabled( $id ),
-				'is_set_up'   => $integration->is_set_up(),
-				'setup_url'   => $integration->get_setup_url(),
-				'settings'    => $integration->get_settings_config(),
+				'id'               => $id,
+				'name'             => $integration->get_name(),
+				'description'      => $integration->get_description(),
+				'enabled'          => self::is_enabled( $id ),
+				'is_set_up'        => $integration->is_set_up(),
+				'setup_url'        => $integration->get_setup_url(),
+				'settings'         => $integration->get_settings_config(),
+				'required_plugins' => $integration->get_required_plugins(),
 			];
 		}
 		return $result;
 	}
 
 	/**
-	 * Update settings for a specific integration.
+	 * Update settings for a specific integration from an admin REST request.
+	 *
+	 * Skips fields whose type is managed server-side (see
+	 * Integration::MANAGED_FIELD_TYPES — e.g., 'oauth', 'hidden') so admin
+	 * clients can't overwrite tokens or other programmatically-managed values
+	 * by POSTing them in the settings payload. Server-side writers continue
+	 * to use Integration::update_settings_field_value() directly.
 	 *
 	 * @param string $integration_id The integration ID.
 	 * @param array  $settings       Key-value pairs of settings to update.
@@ -449,6 +456,9 @@ class Integrations {
 			return null;
 		}
 		foreach ( $settings as $key => $value ) {
+			if ( $integration->is_managed_settings_field( $key ) ) {
+				continue;
+			}
 			$integration->update_settings_field_value( $key, $value );
 		}
 		return true;

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -1727,14 +1727,18 @@ final class Reader_Activation {
 					<input type="hidden" name="<?php echo \esc_attr( self::NEWSLETTERS_SIGNUP_FORM_ACTION ); ?>" value="1" />
 					<input type="hidden" name="email_address" value="<?php echo esc_attr( $email_address ); ?>" />
 
-					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container" data-list-default-size="<?php echo esc_attr( $default_list_size ); ?>">
+					<?php $has_overflow = count( $newsletters_lists ) > (int) $default_list_size; ?>
+					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container">
 					<?php
 					foreach ( $newsletters_lists as $list ) {
-						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
-						$is_hidden   = $loop_index <= $default_list_size ? '' : 'hidden';
+						$checkbox_id   = sprintf( 'newspack-plugin-list-%s', $list['id'] );
+						$is_peek       = $loop_index === (int) $default_list_size;
+						$is_hidden     = $loop_index > (int) $default_list_size;
+						$label_classes = 'newspack-ui__input-card' . ( $is_hidden ? ' hidden' : '' );
+						$label_inert   = ( $is_peek || $is_hidden ) ? ' inert' : '';
 						$loop_index++;
 						?>
-						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>">
+						<label class="<?php echo esc_attr( $label_classes ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo esc_attr( $label_inert ); ?>>
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -1752,17 +1756,15 @@ final class Reader_Activation {
 							<?php endif; ?>
 						</label>
 						<?php
-						if ( $loop_index === (int) $default_list_size && count( $newsletters_lists ) > $default_list_size ) :
-							?>
-							<div class="newspack-ui__gradient-divider"></div>
-							<?php
-						endif;
 					}
 					?>
+					<?php if ( $has_overflow ) : ?>
+						<div class="newspack-ui__gradient-divider"></div>
+					<?php endif; ?>
 					</div>
 
 					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 newspack-ui__spacing-top--5">
-						<?php if ( count( $newsletters_lists ) > $default_list_size ) : ?>
+						<?php if ( $has_overflow ) : ?>
 							<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary see-all-button" aria-label="<?php esc_attr_e( 'See all newsletters', 'newspack-plugin' ); ?>">
 								<span aria-hidden="true"><?php esc_html_e( 'See all', 'newspack-plugin' ); ?></span>
 								<?php Newspack_UI_Icons::print_svg( 'chevronDownSmall' ); ?>

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-esp.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-esp.php
@@ -65,6 +65,23 @@ class ESP extends Integration {
 	}
 
 	/**
+	 * Get the plugins this integration depends on, with their install/active status.
+	 *
+	 * @return array List of associative arrays with keys `slug`, `name`, `is_active`, `is_installed`.
+	 */
+	public function get_required_plugins() {
+		$status = \Newspack\Plugin_Manager::get_managed_plugin_status( 'newspack-newsletters' );
+		return [
+			[
+				'slug'         => 'newspack-newsletters',
+				'name'         => __( 'Newspack Newsletters', 'newspack-plugin' ),
+				'is_active'    => 'active' === $status,
+				'is_installed' => 'uninstalled' !== $status,
+			],
+		];
+	}
+
+	/**
 	 * Register the settings fields declared by this integration.
 	 *
 	 * Returns ALL possible ESP fields unconditionally as static

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
@@ -152,6 +152,23 @@ abstract class Integration {
 	}
 
 	/**
+	 * Get the plugins this integration depends on, with their active status.
+	 *
+	 * Child classes should override this to declare any plugins that must be
+	 * active for the integration to function. The integrations UI uses this
+	 * to surface a "requirements" affordance on the integration card.
+	 *
+	 * Each entry must include all of `slug`, `name`, `is_active`, and `is_installed` —
+	 * the integrations UI treats a missing `is_installed` as uninstalled and renders
+	 * a disabled "Requires …" card instead of the Activate action.
+	 *
+	 * @return array List of associative arrays with keys `slug`, `name`, `is_active`, `is_installed`.
+	 */
+	public function get_required_plugins() {
+		return [];
+	}
+
+	/**
 	 * Whether this integration supports frontend reader registration.
 	 *
 	 * Integrations that return true will have their key output to the page
@@ -603,7 +620,7 @@ abstract class Integration {
 			$fields_to_store[ $key ] = $raw_data;
 		}
 
-		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields_to_store );
+		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields_to_store, false );
 	}
 
 	/**
@@ -615,7 +632,7 @@ abstract class Integration {
 	public function update_enabled_outgoing_fields( $fields ) {
 		// Only allow fields that are in the metadata keys map.
 		$fields = array_intersect( Sync\Metadata::get_default_fields(), $fields );
-		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( $fields ) );
+		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( $fields ), false );
 	}
 
 	/**
@@ -698,7 +715,7 @@ abstract class Integration {
 		$legacy_value = \get_option( Sync\Metadata::PREFIX_OPTION, null );
 		if ( null !== $legacy_value && ! empty( $legacy_value ) ) {
 			// update option directly to avoid infinite loop.
-			\update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $legacy_value );
+			\update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $legacy_value, false );
 			return $legacy_value;
 		}
 		return 'NP_';
@@ -760,7 +777,7 @@ abstract class Integration {
 		if ( empty( $prefix ) ) {
 			$prefix = 'NP_';
 		}
-		return \update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, \sanitize_text_field( $prefix ) );
+		return \update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, \sanitize_text_field( $prefix ), false );
 	}
 
 	/**
@@ -773,6 +790,29 @@ abstract class Integration {
 			$this->settings_fields,
 			$this->get_metadata_fields()
 		);
+	}
+
+	/**
+	 * Settings field types that are managed by server-side code (e.g., OAuth
+	 * callbacks) and must not be writable from the admin settings REST endpoint.
+	 *
+	 * @var string[]
+	 */
+	const MANAGED_FIELD_TYPES = [ 'oauth', 'hidden' ];
+
+	/**
+	 * Whether a settings field is managed by server-side code and therefore
+	 * read-only on the REST settings save path.
+	 *
+	 * @param string $key The field key.
+	 * @return bool True if the field is a managed type, false otherwise.
+	 */
+	public function is_managed_settings_field( $key ) {
+		$field = $this->get_settings_field_by_key( $key );
+		if ( ! $field ) {
+			return false;
+		}
+		return in_array( $field['type'] ?? 'text', self::MANAGED_FIELD_TYPES, true );
 	}
 
 	/**
@@ -814,7 +854,7 @@ abstract class Integration {
 			$legacy_value = \get_option( self::$legacy_option_map[ $key ], null );
 			if ( null !== $legacy_value ) {
 				// update option directly to avoid infinite loop.
-				\update_option( $option_name, $legacy_value );
+				\update_option( $option_name, $legacy_value, false );
 				return $legacy_value;
 			}
 		}
@@ -847,7 +887,7 @@ abstract class Integration {
 		}
 
 		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
-		return \update_option( $option_name, $sanitized );
+		return \update_option( $option_name, $sanitized, false );
 	}
 
 	/**
@@ -912,6 +952,19 @@ abstract class Integration {
 	protected function sanitize_settings_field_value( $field, $value ) {
 		$type = $field['type'] ?? 'text';
 		switch ( $type ) {
+			case 'hidden':
+			case 'oauth':
+				// Server-managed types. Admin POSTs to the settings REST endpoint
+				// are filtered out upstream in Integrations::update_integration_settings(),
+				// so values land here only via trusted PHP writers (e.g., an OAuth
+				// callback). Assumes a single-line, tag-free scalar — sanitize_text_field
+				// will strip tags and collapse whitespace, which is fine for opaque
+				// tokens but would silently corrupt a multiline secret. Non-scalar
+				// payloads fall back to the declared default.
+				if ( ! is_scalar( $value ) ) {
+					return $field['default'] ?? '';
+				}
+				return \sanitize_text_field( (string) $value );
 			case 'checkbox':
 				return (bool) $value;
 			case 'number':

--- a/plugins/newspack-plugin/languages/newspack-plugin.pot
+++ b/plugins/newspack-plugin/languages/newspack-plugin.pot
@@ -2,21 +2,21 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 6.41.0\n"
+"Project-Id-Version: Newspack 6.41.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/newspack-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-21T16:06:08+00:00\n"
+"POT-Creation-Date: 2026-05-26T10:14:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
 
 #. Plugin Name of the plugin
 #: newspack.php
-#: includes/class-plugin-manager.php:166
+#: includes/class-plugin-manager.php:179
 msgid "Newspack"
 msgstr ""
 
@@ -27,17 +27,17 @@ msgstr ""
 
 #. Author of the plugin
 #: newspack.php
-#: includes/class-plugin-manager.php:46
-#: includes/class-plugin-manager.php:82
-#: includes/class-plugin-manager.php:91
-#: includes/class-plugin-manager.php:99
-#: includes/class-plugin-manager.php:107
-#: includes/class-plugin-manager.php:116
-#: includes/class-plugin-manager.php:125
-#: includes/class-plugin-manager.php:134
-#: includes/class-plugin-manager.php:142
-#: includes/class-plugin-manager.php:150
-#: includes/class-plugin-manager.php:158
+#: includes/class-plugin-manager.php:59
+#: includes/class-plugin-manager.php:95
+#: includes/class-plugin-manager.php:104
+#: includes/class-plugin-manager.php:112
+#: includes/class-plugin-manager.php:120
+#: includes/class-plugin-manager.php:129
+#: includes/class-plugin-manager.php:138
+#: includes/class-plugin-manager.php:147
+#: includes/class-plugin-manager.php:155
+#: includes/class-plugin-manager.php:163
+#: includes/class-plugin-manager.php:171
 msgid "Automattic"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 #: includes/class-magic-link.php:417
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:506
 #: includes/reader-activation/class-reader-activation.php:1323
-#: includes/reader-activation/class-reader-activation.php:2290
+#: includes/reader-activation/class-reader-activation.php:2292
 msgid "Invalid user."
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 #: includes/class-magic-link.php:1103
 #: includes/cli/class-ras.php:74
 #: includes/plugins/co-authors-plus/class-nicename-change-ui.php:138
-#: includes/reader-activation/integrations/class-esp.php:375
+#: includes/reader-activation/integrations/class-esp.php:392
 #: includes/reader-activation/sync/class-contact-sync-admin.php:180
 #: includes/reader-activation/sync/class-contact-sync.php:542
 msgid "User not found."
@@ -238,7 +238,7 @@ msgstr ""
 #: includes/class-magic-link.php:1091
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:573
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:593
-#: includes/reader-activation/class-reader-activation.php:2117
+#: includes/reader-activation/class-reader-activation.php:2119
 #: includes/reader-activation/sync/class-contact-sync-admin.php:168
 msgid "Invalid request."
 msgstr ""
@@ -264,12 +264,12 @@ msgid "Authentication links support is currently %1$s for %2$s."
 msgstr ""
 
 #: includes/class-magic-link.php:1162
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:67
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:79
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:82
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:104
 #: dist/blocks.js:4
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:22
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:42
@@ -278,12 +278,12 @@ msgid "disabled"
 msgstr ""
 
 #: includes/class-magic-link.php:1162
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:67
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:79
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:82
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:104
 #: dist/blocks.js:4
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:22
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:42
@@ -319,17 +319,17 @@ msgstr ""
 #: includes/class-newspack-ui.php:1050
 #: includes/class-newspack-ui.php:1082
 #: includes/class-newspack-ui.php:1130
-#: includes/class-newspack-ui.php:1282
-#: includes/class-newspack-ui.php:1336
+#: includes/class-newspack-ui.php:1284
+#: includes/class-newspack-ui.php:1338
 #: includes/content-gate/content-gifting/class-content-gifting.php:592
 #: includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php:721
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:294
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:340
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:364
 #: includes/reader-activation/class-reader-activation.php:1679
-#: includes/reader-activation/class-reader-activation.php:1802
+#: includes/reader-activation/class-reader-activation.php:1804
 #: src/blocks/overlay-menu/panel/class-overlay-menu-panel-block.php:111
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: dist/blocks.js:6
 #: src/blocks/overlay-menu/panel/edit.js:216
 #: src/wizards/audience/components/prompt-action-card/index.js:139
@@ -364,467 +364,468 @@ msgstr ""
 msgid "Open Menu"
 msgstr ""
 
-#: includes/class-newspack-ui.php:1221
-#: includes/reader-activation/class-reader-activation.php:1766
+#: includes/class-newspack-ui.php:1223
+#: includes/reader-activation/class-reader-activation.php:1768
 msgid "See all newsletters"
 msgstr ""
 
-#: includes/class-newspack-ui.php:1222
-#: includes/reader-activation/class-reader-activation.php:1767
+#: includes/class-newspack-ui.php:1224
+#: includes/reader-activation/class-reader-activation.php:1769
 msgid "See all"
 msgstr ""
 
-#: includes/class-newspack-ui.php:1226
+#: includes/class-newspack-ui.php:1228
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:431
 #: includes/reader-activation/class-reader-activation.php:286
 #: includes/reader-activation/class-reader-activation.php:314
 #: src/blocks/reader-registration/index.php:253
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: dist/blocks.js:4
 #: src/blocks/reader-registration/edit.js:315
 #: src/wizards/audience/views/setup/campaign.js:86
 msgid "Continue"
 msgstr ""
 
-#: includes/class-patches.php:122
+#: includes/class-patches.php:127
 msgid "Pattern Categories"
 msgstr ""
 
-#: includes/class-patches.php:199
+#: includes/class-patches.php:204
 msgid "Filter by Pattern Category"
 msgstr ""
 
-#: includes/class-patches.php:201
+#: includes/class-patches.php:206
 msgid "All Pattern Categories"
 msgstr ""
 
-#: includes/class-patches.php:373
+#: includes/class-patches.php:378
 msgid "Please choose a new homepage before attempting to unpublish this page."
 msgstr ""
 
-#: includes/class-patches.php:530
+#: includes/class-patches.php:579
 msgid "Patterns Count"
 msgstr ""
 
-#: includes/class-plugin-manager.php:44
+#: includes/class-plugin-manager.php:57
 msgid "Akismet Anti-Spam"
 msgstr ""
 
-#: includes/class-plugin-manager.php:45
+#: includes/class-plugin-manager.php:58
 msgid "Used by millions, Akismet is quite possibly the best way in the world to protect your blog from spam. It keeps your site protected even while you sleep."
 msgstr ""
 
-#: includes/class-plugin-manager.php:52
+#: includes/class-plugin-manager.php:65
 msgid "Co-Authors Plus"
 msgstr ""
 
-#: includes/class-plugin-manager.php:53
+#: includes/class-plugin-manager.php:66
 msgid "Allows multiple authors and guest authors to be assigned to a post."
 msgstr ""
 
-#: includes/class-plugin-manager.php:54
+#: includes/class-plugin-manager.php:67
 msgid "Mohammad Jangda, Daniel Bachhuber, Automattic, Weston Ruter"
 msgstr ""
 
-#: includes/class-plugin-manager.php:60
+#: includes/class-plugin-manager.php:73
 #: includes/wizards/newspack/class-newspack-dashboard.php:295
 msgid "Google Site Kit"
 msgstr ""
 
-#: includes/class-plugin-manager.php:61
+#: includes/class-plugin-manager.php:74
 msgid "Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web."
 msgstr ""
 
-#: includes/class-plugin-manager.php:62
+#: includes/class-plugin-manager.php:75
 #: dist/commons.js:15
 #: dist/newspack-wizards.e386313f64136198a71d.js:5
 msgid "Google"
 msgstr ""
 
-#: includes/class-plugin-manager.php:73
+#: includes/class-plugin-manager.php:86
 msgid "Gravity Forms"
 msgstr ""
 
-#: includes/class-plugin-manager.php:74
+#: includes/class-plugin-manager.php:87
 msgid "Create custom web forms to capture leads, collect payments, automate your workflows, and build your business online."
 msgstr ""
 
-#: includes/class-plugin-manager.php:75
+#: includes/class-plugin-manager.php:88
 msgid "Rocketgenius"
 msgstr ""
 
-#: includes/class-plugin-manager.php:80
+#: includes/class-plugin-manager.php:93
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
 msgid "Jetpack"
 msgstr ""
 
-#: includes/class-plugin-manager.php:81
+#: includes/class-plugin-manager.php:94
 msgid "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users."
 msgstr ""
 
-#: includes/class-plugin-manager.php:89
+#: includes/class-plugin-manager.php:102
 #: includes/wizards/newspack/class-newspack-dashboard.php:284
 msgid "Newspack Ads"
 msgstr ""
 
-#: includes/class-plugin-manager.php:90
+#: includes/class-plugin-manager.php:103
 msgid "Ads integration."
 msgstr ""
 
-#: includes/class-plugin-manager.php:97
+#: includes/class-plugin-manager.php:110
 msgid "Newspack Blocks"
 msgstr ""
 
-#: includes/class-plugin-manager.php:98
+#: includes/class-plugin-manager.php:111
 msgid "A collection of blocks for news publishers."
 msgstr ""
 
-#: includes/class-plugin-manager.php:105
+#: includes/class-plugin-manager.php:118
 msgid "Newspack Content Converter"
 msgstr ""
 
-#: includes/class-plugin-manager.php:106
+#: includes/class-plugin-manager.php:119
 msgid "Batch conversion of Classic->Gutenberg post conversion."
 msgstr ""
 
-#: includes/class-plugin-manager.php:114
+#: includes/class-plugin-manager.php:127
 msgid "Newspack Multibranded Site"
 msgstr ""
 
-#: includes/class-plugin-manager.php:115
+#: includes/class-plugin-manager.php:128
 msgid "Brand different content and sections of your site with unique colors and navigation."
 msgstr ""
 
-#: includes/class-plugin-manager.php:123
+#: includes/class-plugin-manager.php:136
 msgid "Newspack Network"
 msgstr ""
 
-#: includes/class-plugin-manager.php:124
+#: includes/class-plugin-manager.php:137
 msgid "Distribute content across a network of Newspack sites."
 msgstr ""
 
-#: includes/class-plugin-manager.php:132
+#: includes/class-plugin-manager.php:145
+#: includes/reader-activation/integrations/class-esp.php:77
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
 msgid "Newspack Newsletters"
 msgstr ""
 
-#: includes/class-plugin-manager.php:133
+#: includes/class-plugin-manager.php:146
 msgid "Newsletter authoring using the Gutenberg editor."
 msgstr ""
 
-#: includes/class-plugin-manager.php:140
+#: includes/class-plugin-manager.php:153
 msgid "Newspack Campaigns"
 msgstr ""
 
-#: includes/class-plugin-manager.php:141
+#: includes/class-plugin-manager.php:154
 msgid "Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header."
 msgstr ""
 
-#: includes/class-plugin-manager.php:148
+#: includes/class-plugin-manager.php:161
 msgid "Newspack Sponsors"
 msgstr ""
 
-#: includes/class-plugin-manager.php:149
+#: includes/class-plugin-manager.php:162
 msgid "Sponsored and underwritten content for Newspack sites."
 msgstr ""
 
-#: includes/class-plugin-manager.php:156
+#: includes/class-plugin-manager.php:169
 #: includes/wizards/class-listings-wizard.php:122
 msgid "Newspack Listings"
 msgstr ""
 
-#: includes/class-plugin-manager.php:157
+#: includes/class-plugin-manager.php:170
 msgid "Create reusable content in list form using the Gutenberg editor."
 msgstr ""
 
-#: includes/class-plugin-manager.php:164
+#: includes/class-plugin-manager.php:177
 msgid "Newspack Theme"
 msgstr ""
 
-#: includes/class-plugin-manager.php:165
+#: includes/class-plugin-manager.php:178
 msgid "The Newspack theme."
 msgstr ""
 
-#: includes/class-plugin-manager.php:169
+#: includes/class-plugin-manager.php:182
 msgid "Parse.ly"
 msgstr ""
 
-#: includes/class-plugin-manager.php:170
+#: includes/class-plugin-manager.php:183
 msgid "This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog."
 msgstr ""
 
-#: includes/class-plugin-manager.php:171
+#: includes/class-plugin-manager.php:184
 msgid "Mike Sukmanowsky ( mike@parsely.com )"
 msgstr ""
 
-#: includes/class-plugin-manager.php:177
+#: includes/class-plugin-manager.php:190
 msgid "Password Protected"
 msgstr ""
 
-#: includes/class-plugin-manager.php:178
+#: includes/class-plugin-manager.php:191
 msgid "A very simple way to quickly password protect your WordPress site with a single password. Please note: This plugin does not restrict access to uploaded files and images and does not work with some caching setups."
 msgstr ""
 
-#: includes/class-plugin-manager.php:179
+#: includes/class-plugin-manager.php:192
 msgid "Ben Huson"
 msgstr ""
 
-#: includes/class-plugin-manager.php:186
+#: includes/class-plugin-manager.php:199
 msgid "Perfmatters"
 msgstr ""
 
-#: includes/class-plugin-manager.php:187
+#: includes/class-plugin-manager.php:200
 msgid "Perfmatters is a lightweight performance plugin developed to speed up your WordPress site."
 msgstr ""
 
-#: includes/class-plugin-manager.php:188
+#: includes/class-plugin-manager.php:201
 msgid "forgemedia"
 msgstr ""
 
-#: includes/class-plugin-manager.php:193
+#: includes/class-plugin-manager.php:206
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
 msgid "Publish to Apple News"
 msgstr ""
 
-#: includes/class-plugin-manager.php:194
+#: includes/class-plugin-manager.php:207
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
 msgid "Export and synchronize posts to Apple format."
 msgstr ""
 
-#: includes/class-plugin-manager.php:195
+#: includes/class-plugin-manager.php:208
 msgid "Alley Interactive"
 msgstr ""
 
-#: includes/class-plugin-manager.php:206
+#: includes/class-plugin-manager.php:219
 msgid "PWA"
 msgstr ""
 
-#: includes/class-plugin-manager.php:207
+#: includes/class-plugin-manager.php:220
 msgid "Feature plugin to bring Progressive Web App (PWA) capabilities to Core."
 msgstr ""
 
-#: includes/class-plugin-manager.php:208
+#: includes/class-plugin-manager.php:221
 msgid "PWA Plugin Contributors"
 msgstr ""
 
-#: includes/class-plugin-manager.php:214
+#: includes/class-plugin-manager.php:227
 msgid "Redirection"
 msgstr ""
 
-#: includes/class-plugin-manager.php:215
+#: includes/class-plugin-manager.php:228
 msgid "Manage all your 301 redirects and monitor 404 errors."
 msgstr ""
 
-#: includes/class-plugin-manager.php:216
+#: includes/class-plugin-manager.php:229
 msgid "John Godley"
 msgstr ""
 
-#: includes/class-plugin-manager.php:222
-#: includes/class-plugin-manager.php:233
-#: includes/class-plugin-manager.php:242
-#: includes/class-plugin-manager.php:251
-#: includes/class-plugin-manager.php:267
+#: includes/class-plugin-manager.php:235
+#: includes/class-plugin-manager.php:246
+#: includes/class-plugin-manager.php:255
+#: includes/class-plugin-manager.php:264
+#: includes/class-plugin-manager.php:280
 msgid "WooCommerce"
 msgstr ""
 
-#: includes/class-plugin-manager.php:223
+#: includes/class-plugin-manager.php:236
 msgid "An eCommerce toolkit that helps you sell anything. Beautifully."
 msgstr ""
 
-#: includes/class-plugin-manager.php:224
+#: includes/class-plugin-manager.php:237
 msgid "WordPress.com VIP, XWP, Google, and contributors"
 msgstr ""
 
-#: includes/class-plugin-manager.php:231
+#: includes/class-plugin-manager.php:244
 msgid "WooCommerce Stripe Gateway"
 msgstr ""
 
-#: includes/class-plugin-manager.php:232
+#: includes/class-plugin-manager.php:245
 msgid "Take credit card payments on your store using Stripe."
 msgstr ""
 
-#: includes/class-plugin-manager.php:240
+#: includes/class-plugin-manager.php:253
 msgid "WooPayments"
 msgstr ""
 
-#: includes/class-plugin-manager.php:241
+#: includes/class-plugin-manager.php:254
 msgid "Accept payments via credit card. Manage transactions within WordPress."
 msgstr ""
 
-#: includes/class-plugin-manager.php:249
+#: includes/class-plugin-manager.php:262
 msgid "WooCommerce PayPal Payments"
 msgstr ""
 
-#: includes/class-plugin-manager.php:250
+#: includes/class-plugin-manager.php:263
 msgid "PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage."
 msgstr ""
 
-#: includes/class-plugin-manager.php:258
+#: includes/class-plugin-manager.php:271
 msgid "WooCommerce Name Your Price"
 msgstr ""
 
-#: includes/class-plugin-manager.php:259
+#: includes/class-plugin-manager.php:272
 msgid "WooCommerce Name Your Price allows customers to set their own price for products or donations."
 msgstr ""
 
-#: includes/class-plugin-manager.php:260
+#: includes/class-plugin-manager.php:273
 msgid "Kathy Darling"
 msgstr ""
 
-#: includes/class-plugin-manager.php:265
+#: includes/class-plugin-manager.php:278
 msgid "WooCommerce Subscriptions"
 msgstr ""
 
-#: includes/class-plugin-manager.php:266
+#: includes/class-plugin-manager.php:279
 msgid "Sell products and services with recurring payments in your WooCommerce Store."
 msgstr ""
 
-#: includes/class-plugin-manager.php:272
+#: includes/class-plugin-manager.php:285
 msgid "Yoast SEO"
 msgstr ""
 
-#: includes/class-plugin-manager.php:273
+#: includes/class-plugin-manager.php:286
 msgid "The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more."
 msgstr ""
 
-#: includes/class-plugin-manager.php:274
+#: includes/class-plugin-manager.php:287
 msgid "Team Yoast"
 msgstr ""
 
-#: includes/class-plugin-manager.php:280
+#: includes/class-plugin-manager.php:293
 msgid "Complianz - GDPR/CCPA Cookie Consent"
 msgstr ""
 
-#: includes/class-plugin-manager.php:281
+#: includes/class-plugin-manager.php:294
 msgid "Complianz is a GDPR/CCPA Cookie Consent plugin that supports GDPR, ePrivacy, DSGVO, TTDSG, LGPD, POPIA, APA, RGPD, CCPA/CPRA and PIPEDA with a conditional Cookie Notice and customized Cookie Policy based on the results of the built-in Cookie Scan."
 msgstr ""
 
-#: includes/class-plugin-manager.php:282
+#: includes/class-plugin-manager.php:295
 msgid "Really Simple Plugins"
 msgstr ""
 
-#: includes/class-plugin-manager.php:288
+#: includes/class-plugin-manager.php:301
 msgid "Simple Local Avatars"
 msgstr ""
 
-#: includes/class-plugin-manager.php:289
+#: includes/class-plugin-manager.php:302
 msgid "Adds an avatar upload field to user profiles if the current user has media permissions. Generates requested sizes on demand just like Gravatar! Simple and lightweight."
 msgstr ""
 
-#: includes/class-plugin-manager.php:290
+#: includes/class-plugin-manager.php:303
 msgid "Jake Goldman, 10up"
 msgstr ""
 
-#: includes/class-plugin-manager.php:296
+#: includes/class-plugin-manager.php:309
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
 msgid "Distributor"
 msgstr ""
 
-#: includes/class-plugin-manager.php:297
+#: includes/class-plugin-manager.php:310
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
 msgid "Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web."
 msgstr ""
 
-#: includes/class-plugin-manager.php:304
+#: includes/class-plugin-manager.php:317
 msgid "Super Cool Ad Inserter Plugin"
 msgstr ""
 
-#: includes/class-plugin-manager.php:305
+#: includes/class-plugin-manager.php:318
 msgid "Display ads within your article content."
 msgstr ""
 
-#: includes/class-plugin-manager.php:306
+#: includes/class-plugin-manager.php:319
 msgid "INN Labs, Automattic"
 msgstr ""
 
-#: includes/class-plugin-manager.php:312
+#: includes/class-plugin-manager.php:325
 #: dist/billboard.js:15
 #: src/wizards/advertising/components/ad-refresh-control/index.js:129
 msgid "Ad Refresh Control"
 msgstr ""
 
-#: includes/class-plugin-manager.php:313
+#: includes/class-plugin-manager.php:326
 #: dist/billboard.js:15
 #: src/wizards/advertising/components/ad-refresh-control/index.js:130
 msgid "Enable Active View refresh for Google Ad Manager ads without needing to modify any code."
 msgstr ""
 
-#: includes/class-plugin-manager.php:314
+#: includes/class-plugin-manager.php:327
 msgid "Gary Thayer, David Green, 10up"
 msgstr ""
 
-#: includes/class-plugin-manager.php:320
+#: includes/class-plugin-manager.php:333
 msgid "Ads.txt Manager"
 msgstr ""
 
-#: includes/class-plugin-manager.php:321
+#: includes/class-plugin-manager.php:334
 msgid "Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, just like any other content asset."
 msgstr ""
 
-#: includes/class-plugin-manager.php:322
+#: includes/class-plugin-manager.php:335
 msgid "10up"
 msgstr ""
 
-#: includes/class-plugin-manager.php:329
+#: includes/class-plugin-manager.php:342
 msgid "Broadstreet"
 msgstr ""
 
-#: includes/class-plugin-manager.php:330
+#: includes/class-plugin-manager.php:343
 msgid "Integrate Broadstreet’s business directory and ad-serving features into your site."
 msgstr ""
 
-#: includes/class-plugin-manager.php:337
+#: includes/class-plugin-manager.php:350
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
 msgid "Everlit"
 msgstr ""
 
-#: includes/class-plugin-manager.php:338
+#: includes/class-plugin-manager.php:351
 msgid "Using a new generation of ultra realistic, AI-driven speech synthesis, we are bringing a backlog of human interest stories, fiction, and knowledge to the present day."
 msgstr ""
 
-#: includes/class-plugin-manager.php:537
+#: includes/class-plugin-manager.php:564
 msgid "Invalid plugin."
 msgstr ""
 
-#: includes/class-plugin-manager.php:586
-#: includes/class-plugin-manager.php:710
+#: includes/class-plugin-manager.php:613
+#: includes/class-plugin-manager.php:737
 msgid "The plugin is not installed."
 msgstr ""
 
-#: includes/class-plugin-manager.php:596
+#: includes/class-plugin-manager.php:623
 msgid "The plugin is not active."
 msgstr ""
 
-#: includes/class-plugin-manager.php:601
+#: includes/class-plugin-manager.php:628
 msgid "Failed to deactivate plugin."
 msgstr ""
 
-#: includes/class-plugin-manager.php:680
+#: includes/class-plugin-manager.php:707
 msgid "Plugins cannot be installed."
 msgstr ""
 
-#: includes/class-plugin-manager.php:698
+#: includes/class-plugin-manager.php:725
 msgid "Plugins cannot be uninstalled."
 msgstr ""
 
-#: includes/class-plugin-manager.php:734
+#: includes/class-plugin-manager.php:761
 msgid "The plugin could not be uninstalled."
 msgstr ""
 
-#: includes/class-plugin-manager.php:747
+#: includes/class-plugin-manager.php:774
 msgid "The plugin directory already exists."
 msgstr ""
 
-#: includes/class-plugin-manager.php:754
+#: includes/class-plugin-manager.php:781
 msgid "Plugin not found."
 msgstr ""
 
-#: includes/class-plugin-manager.php:760
+#: includes/class-plugin-manager.php:787
 msgid "Newspack cannot install this plugin. You will need to get it from the plugin's site and install it manually."
 msgstr ""
 
 #. translators: %s: plugin URL
-#: includes/class-plugin-manager.php:763
+#: includes/class-plugin-manager.php:790
 #, php-format
 msgid "Newspack cannot install this plugin. You will need to get it from <a href=\"%s\">the plugin's site</a> and install it manually."
 msgstr ""
@@ -1134,13 +1135,13 @@ msgid "Use global setting"
 msgstr ""
 
 #: includes/collections/class-collection-meta.php:123
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:134
 msgid "Show"
 msgstr ""
 
 #: includes/collections/class-collection-meta.php:127
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:134
 msgid "Hide"
 msgstr ""
@@ -1483,9 +1484,9 @@ msgstr ""
 #: includes/content-gate/block-patterns/pay-wall-two-tiers.php:24
 #: includes/content-gate/block-patterns/pay-wall-two-tiers.php:94
 #: includes/content-gate/block-patterns/registration-wall.php:11
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/components/prompt-action-card/index.js:153
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:164
 msgid "Title"
@@ -1510,9 +1511,9 @@ msgstr ""
 #: includes/content-gate/content-gifting/class-content-gifting-cta.php:240
 #: includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php:691
 #: includes/reader-activation/class-reader-activation.php:292
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:174
 #: src/wizards/audience/views/setup/countdown-banner.js:113
 msgid "Sign in to an existing account"
@@ -1533,7 +1534,7 @@ msgstr ""
 #: includes/content-gate/block-patterns/pay-wall-two-tiers.php:21
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:264
 #: includes/plugins/woocommerce/my-account/templates/v1/subscription-totals-table.php:38
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Subscription"
 msgid_plural "Subscriptions"
 msgstr[0] ""
@@ -1564,10 +1565,10 @@ msgstr ""
 #: includes/content-gate/block-patterns/pay-wall-two-tiers.php:88
 #: includes/content-gate/block-patterns/registration-banner.php:16
 #: includes/content-gate/block-patterns/registration-wall.php:17
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:67
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:97
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:101
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:104
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:22
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:39
@@ -1757,7 +1758,7 @@ msgstr ""
 #: includes/content-gate/block-patterns/pay-wall-two-tiers.php:58
 #: includes/content-gate/block-patterns/pay-wall-two-tiers.php:115
 #: includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php:543
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:56
 msgid "Frequency"
 msgstr ""
@@ -1839,7 +1840,7 @@ msgstr ""
 
 #: includes/content-gate/block-patterns/registration-banner.php:13
 #: includes/content-gate/block-patterns/registration-wall.php:9
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:194
 msgid "Registration"
 msgstr ""
@@ -1881,7 +1882,7 @@ msgid "example.com,another.com"
 msgstr ""
 
 #: includes/content-gate/class-access-rules.php:109
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Reader data"
 msgstr ""
 
@@ -1972,7 +1973,7 @@ msgstr ""
 
 #: includes/content-gate/class-content-gate.php:359
 #: includes/plugins/wc-memberships/class-memberships.php:149
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:73
 msgid "Content Gate"
 msgstr ""
@@ -2081,8 +2082,8 @@ msgid "Newsletter subscription lists."
 msgstr ""
 
 #: includes/content-gate/class-institution.php:77
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Institutions"
 msgstr ""
 
@@ -2172,8 +2173,8 @@ msgid "An error occurred. Please try again."
 msgstr ""
 
 #: includes/content-gate/class-metering-countdown.php:43
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
 #: dist/commons.js:15
 #: src/blocks/content-gate/countdown-box/edit.jsx:112
 #: src/wizards/audience/views/setup/countdown-banner.js:112
@@ -2182,9 +2183,9 @@ msgstr ""
 
 #: includes/content-gate/class-metering-countdown.php:44
 #: includes/content-gate/content-gifting/class-content-gifting-cta.php:137
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:187
 #: src/wizards/audience/views/setup/countdown-banner.js:125
 msgid "Subscribe now"
@@ -2211,8 +2212,8 @@ msgstr ""
 #: includes/reader-activation/class-reader-activation.php:281
 #: includes/reader-activation/class-reader-activation.php:291
 #: includes/reader-activation/class-reader-activation.php:297
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:172
 msgid "Create an account"
 msgstr ""
@@ -2250,8 +2251,8 @@ msgid "or"
 msgstr ""
 
 #: includes/content-gate/content-gifting/class-content-gifting-cta.php:48
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:166
 msgid "This article has been gifted to you by someone who values great journalism."
 msgstr ""
@@ -2267,8 +2268,8 @@ msgid "Must be one of the following: day, week, month."
 msgstr ""
 
 #: includes/content-gate/content-gifting/class-content-gifting.php:273
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/content-gate-editor-metering.js:1
 #: src/content-gate/editor/metering-settings.js:54
 #: src/wizards/audience/views/setup/content-gifting.js:57
@@ -2276,8 +2277,8 @@ msgid "Day"
 msgstr ""
 
 #: includes/content-gate/content-gifting/class-content-gifting.php:274
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/content-gate-editor-metering.js:1
 #: src/content-gate/editor/metering-settings.js:55
 #: src/wizards/audience/views/setup/content-gifting.js:58
@@ -2285,8 +2286,8 @@ msgid "Week"
 msgstr ""
 
 #: includes/content-gate/content-gifting/class-content-gifting.php:275
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/content-gate-editor-metering.js:1
 #: src/content-gate/editor/metering-settings.js:56
 #: src/wizards/audience/views/setup/content-gifting.js:59
@@ -2322,15 +2323,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: includes/content-gate/content-gifting/class-content-gifting.php:382
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:80
 msgid "Hours"
 msgstr ""
 
 #: includes/content-gate/content-gifting/class-content-gifting.php:383
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:81
 msgid "Days"
 msgstr ""
@@ -2860,8 +2861,8 @@ msgstr ""
 #: includes/wizards/newspack/class-newspack-dashboard.php:166
 #: includes/wizards/newspack/class-newspack-dashboard.php:202
 #: includes/wizards/newspack/class-newspack-settings.php:186
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/billboard.js:15
 #: dist/blocks.js:4
 #: dist/blocks.js:6
@@ -3151,15 +3152,16 @@ msgstr ""
 
 #: includes/optional-modules/class-media-partners.php:477
 #: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:229
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:43
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:108
 #: dist/billboard.js:1
 #: dist/billboard.js:15
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
@@ -3842,11 +3844,11 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:325
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:351
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:375
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/billboard.js:1
 #: dist/billboard.js:9
 #: dist/billboard.js:15
@@ -3872,7 +3874,7 @@ msgid "Cancel"
 msgstr ""
 
 #: includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php:204
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Weekly"
 msgstr ""
@@ -3880,7 +3882,7 @@ msgstr ""
 #: includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php:205
 #: includes/plugins/woocommerce/class-woocommerce-connection.php:517
 #: includes/plugins/woocommerce/class-woocommerce-connection.php:611
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Monthly"
 msgstr ""
@@ -4026,7 +4028,7 @@ msgstr ""
 
 #: includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php:379
 #: includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php:860
-#: includes/reader-activation/class-reader-activation.php:1842
+#: includes/reader-activation/class-reader-activation.php:1844
 msgid "Invalid email address."
 msgstr ""
 
@@ -4132,7 +4134,7 @@ msgstr ""
 #: includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php:111
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1107
 #: includes/reader-activation/class-reader-activation.php:275
-#: includes/reader-activation/class-reader-activation.php:2327
+#: includes/reader-activation/class-reader-activation.php:2329
 msgid "Please enter a valid email address."
 msgstr ""
 
@@ -4189,7 +4191,7 @@ msgid "Changing these settings will override settings inherited from %s."
 msgstr ""
 
 #: includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php:372
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 msgid "the product"
 msgstr ""
 
@@ -4209,7 +4211,7 @@ msgstr ""
 
 #: includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php:439
 #: includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php:441
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: dist/commons.js:13
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
 #: dist/other-scripts/nextdoor.js:1
@@ -4277,7 +4279,7 @@ msgid "Transaction fee (%s)"
 msgstr ""
 
 #: includes/plugins/woocommerce/class-woocommerce-connection.php:247
-#: includes/reader-activation/class-reader-activation.php:2666
+#: includes/reader-activation/class-reader-activation.php:2668
 msgid "Please wait a moment before trying again."
 msgstr ""
 
@@ -4458,10 +4460,10 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:470
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:621
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1221
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: dist/newsletters.js:1
 #: dist/newsletters.js:4
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
@@ -4561,9 +4563,9 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:327
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:459
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:555
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Are you sure?"
@@ -4600,7 +4602,7 @@ msgstr ""
 
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:365
 #: includes/wizards/newspack/class-newspack-dashboard.php:81
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: dist/componentsDemo.js:1
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:208
 #: src/wizards/componentsDemo/index.js:990
@@ -4997,7 +4999,7 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:164
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:189
 #: includes/reader-activation/class-comment-display-name.php:113
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/billboard.js:15
 #: dist/newspack-wizards.e386313f64136198a71d.js:1
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
@@ -5048,7 +5050,7 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php:55
 #: includes/plugins/woocommerce/my-account/templates/v1/related-orders.php:30
 #: includes/plugins/woocommerce/my-account/templates/v1/related-orders.php:59
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:141
 msgid "Status"
 msgstr ""
@@ -5063,9 +5065,9 @@ msgid "Expired"
 msgstr ""
 
 #: includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php:247
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:25
 #: src/wizards/audience/views/integrations/logs-view.js:150
 msgid "Pending"
@@ -5119,9 +5121,9 @@ msgstr ""
 
 #: includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php:26
 #: includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php:41
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:130
 #: src/wizards/audience/views/setup/countdown-banner.js:70
 msgid "Product"
@@ -5247,13 +5249,13 @@ msgstr ""
 
 #: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:218
 #: includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php:104
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:94
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:102
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:98
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:106
 #: dist/billboard.js:9
 #: dist/billboard.js:15
 #: dist/componentsDemo.js:1
@@ -5447,14 +5449,14 @@ msgid "Please choose a display name that is not derived from your email address.
 msgstr ""
 
 #: includes/reader-activation/class-promoted-fields.php:161
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
 msgid "Yes"
 msgstr ""
 
 #: includes/reader-activation/class-promoted-fields.php:165
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
 msgid "No"
@@ -5819,7 +5821,7 @@ msgid "Enable reCAPTCHA and enter your account credentials."
 msgstr ""
 
 #: includes/reader-activation/class-reader-activation.php:980
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:222
 msgid "Reader Revenue"
 msgstr ""
@@ -5870,94 +5872,94 @@ msgstr ""
 msgid "Sign in by entering the code we sent to %s, or clicking the magic link in the email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1812
+#: includes/reader-activation/class-reader-activation.php:1814
 msgid "Sending to: "
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1847
+#: includes/reader-activation/class-reader-activation.php:1849
 msgid "No lists selected."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2024
+#: includes/reader-activation/class-reader-activation.php:2026
 #: dist/blocks.js:4
 #: src/blocks/reader-registration/edit.js:304
 msgid "Continue with Google"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2027
+#: includes/reader-activation/class-reader-activation.php:2029
 #: dist/blocks.js:4
 #: src/blocks/reader-registration/edit.js:306
 msgid "Or"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2121
+#: includes/reader-activation/class-reader-activation.php:2123
 #: src/blocks/reader-registration/index.php:540
 msgid "You must enter a valid email address."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2128
-#: includes/reader-activation/class-reader-activation.php:2132
+#: includes/reader-activation/class-reader-activation.php:2130
+#: includes/reader-activation/class-reader-activation.php:2134
 msgid "Account not found. <a data-set-action=\"register\" href=\"#register_modal\">Create an account</a> instead?"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2132
-#: includes/reader-activation/class-reader-activation.php:2204
+#: includes/reader-activation/class-reader-activation.php:2134
+#: includes/reader-activation/class-reader-activation.php:2206
 msgid "An account was already registered with this email. Please check your inbox for an authentication link."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2155
-#: includes/reader-activation/class-reader-activation.php:2182
+#: includes/reader-activation/class-reader-activation.php:2157
+#: includes/reader-activation/class-reader-activation.php:2184
 msgid "We encountered an error sending an authentication link. Please try again."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2165
-#: includes/reader-activation/class-reader-activation.php:2169
+#: includes/reader-activation/class-reader-activation.php:2167
+#: includes/reader-activation/class-reader-activation.php:2171
 msgid "Password not recognized, try again."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2204
+#: includes/reader-activation/class-reader-activation.php:2206
 msgid "An account was already registered with this email. Please sign in to continue."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2209
+#: includes/reader-activation/class-reader-activation.php:2211
 msgid "Unable to register your account. Try a different email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2317
+#: includes/reader-activation/class-reader-activation.php:2319
 msgid "Registration is disabled."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2321
+#: includes/reader-activation/class-reader-activation.php:2323
 msgid "Cannot register while logged in."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2700
+#: includes/reader-activation/class-reader-activation.php:2702
 msgid "Please wait before requesting another verification email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2923
+#: includes/reader-activation/class-reader-activation.php:2925
 msgid "Your personal data will be used to process your order and create an account if one doesn't exist. This information will also support your experience throughout this website, and be used for other purposes described in our privacy policy."
 msgstr ""
 
 #. Translators: %s is the name of the site.
-#: includes/reader-activation/class-reader-activation.php:2940
+#: includes/reader-activation/class-reader-activation.php:2942
 #, php-format
 msgid "Thank you for supporting %s. Your transaction was completed successfully."
 msgstr ""
 
 #. Translators: %s is the name of the site.
-#: includes/reader-activation/class-reader-activation.php:2959
+#: includes/reader-activation/class-reader-activation.php:2961
 #, php-format
 msgid "Thank you for supporting %s. Your account has been created, and your transaction was completed successfully."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2985
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: includes/reader-activation/class-reader-activation.php:2987
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "I understand this is a recurring subscription and that I can cancel anytime through the My Account Page."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:3009
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: includes/reader-activation/class-reader-activation.php:3011
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "I have read and accept the {{Terms & Conditions}}."
 msgstr ""
 
@@ -6015,105 +6017,105 @@ msgstr ""
 msgid "Syncs reader data with your Newspack Newsletters email service provider."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:82
+#: includes/reader-activation/integrations/class-esp.php:99
 msgid "Mailchimp Audience"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:83
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: includes/reader-activation/integrations/class-esp.php:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #: src/wizards/audience/components/mailchimp.js:47
 #: src/wizards/audience/components/settings.js:37
 msgid "Choose an audience to receive reader activity data."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:89
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:49
+#: includes/reader-activation/integrations/class-esp.php:106
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:52
 #: src/wizards/audience/components/mailchimp.js:58
 #: src/wizards/audience/components/settings.js:74
 msgid "Default reader status"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:90
+#: includes/reader-activation/integrations/class-esp.php:107
 msgid "Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:93
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: includes/reader-activation/integrations/class-esp.php:110
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/mailchimp.js:69
 #: src/wizards/audience/components/settings.js:89
 msgid "Transactional/Non-Subscribed"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:97
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: includes/reader-activation/integrations/class-esp.php:114
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/mailchimp.js:71
 #: src/wizards/audience/components/settings.js:91
 msgid "Subscribed"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:106
+#: includes/reader-activation/integrations/class-esp.php:123
 msgid "ActiveCampaign Master List"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:107
-#: includes/reader-activation/integrations/class-esp.php:114
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: includes/reader-activation/integrations/class-esp.php:124
+#: includes/reader-activation/integrations/class-esp.php:131
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #: src/wizards/audience/components/settings.js:38
 msgid "Choose a master list to which all registered readers will be added."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:113
+#: includes/reader-activation/integrations/class-esp.php:130
 msgid "Constant Contact Master List"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:120
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: includes/reader-activation/integrations/class-esp.php:137
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:241
 #: src/wizards/audience/views/setup/setup.js:248
 msgid "Sync user account deletion"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:121
+#: includes/reader-activation/integrations/class-esp.php:138
 msgid "When a reader account is deleted, also remove the contact from the ESP."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:221
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:49
+#: includes/reader-activation/integrations/class-esp.php:238
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:52
 #: src/wizards/audience/components/active-campaign.js:52
 #: src/wizards/audience/components/mailchimp.js:52
 #: src/wizards/audience/components/settings.js:68
 msgid "None"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:312
-#: includes/reader-activation/integrations/class-esp.php:415
+#: includes/reader-activation/integrations/class-esp.php:329
+#: includes/reader-activation/integrations/class-esp.php:432
 msgid "Newspack Newsletters is not available."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:319
+#: includes/reader-activation/integrations/class-esp.php:336
 msgid "ESP sync is not enabled."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-esp.php:325
-#: includes/reader-activation/integrations/class-esp.php:424
+#: includes/reader-activation/integrations/class-esp.php:342
+#: includes/reader-activation/integrations/class-esp.php:441
 msgid "ESP master list ID is not set."
 msgstr ""
 
-#: includes/reader-activation/integrations/class-integration.php:668
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: includes/reader-activation/integrations/class-integration.php:685
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/metadata-fields.js:20
 msgid "Metadata field prefix"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-integration.php:669
+#: includes/reader-activation/integrations/class-integration.php:686
 msgid "A string to prefix metadata fields synced to the integration. Required to ensure that metadata field names are unique. Default: NP_"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-integration.php:675
+#: includes/reader-activation/integrations/class-integration.php:692
 msgid "Outgoing metadata fields"
 msgstr ""
 
-#: includes/reader-activation/integrations/class-integration.php:681
+#: includes/reader-activation/integrations/class-integration.php:698
 msgid "Incoming metadata fields"
 msgstr ""
 
@@ -6179,7 +6181,7 @@ msgstr ""
 msgid "Synced"
 msgstr ""
 
-#: includes/reader-activation/sync/class-metadata.php:327
+#: includes/reader-activation/sync/class-metadata.php:328
 msgid "Additional"
 msgstr ""
 
@@ -6201,6 +6203,10 @@ msgstr ""
 
 #: includes/reader-activation/sync/class-sync.php:145
 msgid "No active integrations found."
+msgstr ""
+
+#: includes/reader-activation/sync/contact-metadata/class-content-gate.php:55
+msgid "Content Access"
 msgstr ""
 
 #: includes/reader-revenue/class-reader-revenue-emails.php:60
@@ -6924,15 +6930,15 @@ msgid "Sponsors"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-campaigns.php:50
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: src/wizards/audience/views/campaigns/index.js:30
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: src/wizards/audience/views/campaigns/index.js:31
 msgid "Audience Management / Campaigns"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-campaigns.php:112
 #: includes/wizards/newspack/class-newspack-dashboard.php:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/settings-modal/index.js:31
 #: src/wizards/audience/components/settings-modal/index.js:41
 #: src/wizards/audience/views/campaigns/campaigns/index.js:171
@@ -6941,15 +6947,15 @@ msgid "Campaigns"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-content-gates.php:77
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: src/wizards/audience/views/content-gates/consts.js:4
 msgid "Audience Management / Access control"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-content-gates.php:131
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/content-gate-block-visibility.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: dist/wizards.js:115
@@ -6971,7 +6977,7 @@ msgid "Invalid gate type."
 msgstr ""
 
 #: includes/wizards/audience/class-audience-donations.php:46
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/views/donations/index.js:34
 msgid "Audience Management / Donations"
 msgstr ""
@@ -6992,16 +6998,16 @@ msgid "Reset failed: unable to reset email template."
 msgstr ""
 
 #: includes/wizards/audience/class-audience-integrations.php:60
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: src/wizards/audience/views/integrations/index.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
+#: src/wizards/audience/views/integrations/index.js:154
 msgid "Audience Management / Integrations"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-integrations.php:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:255
-#: src/wizards/audience/views/integrations/settings-section.js:41
+#: src/wizards/audience/views/integrations/settings-section.js:43
 msgid "Integrations"
 msgstr ""
 
@@ -7016,7 +7022,7 @@ msgid "Integration not found."
 msgstr ""
 
 #: includes/wizards/audience/class-audience-subscriptions.php:44
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Audience Management / Subscriptions"
 msgstr ""
 
@@ -7035,17 +7041,17 @@ msgstr ""
 
 #: includes/wizards/audience/class-audience-wizard.php:150
 #: includes/wizards/newspack/class-newspack-dashboard.php:52
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:19
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:19
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/donations/index.js:26
 #: src/wizards/audience/views/setup/index.js:101
 msgid "Configuration"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-wizard.php:151
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/index.js:101
 msgid "Setup"
 msgstr ""
@@ -7212,8 +7218,8 @@ msgstr ""
 
 #: includes/wizards/newspack/class-newspack-dashboard.php:47
 #: includes/wizards/newspack/class-newspack-dashboard.php:260
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/index.js:136
 #: src/wizards/audience/views/setup/setup.js:81
 msgid "Audience Management"
@@ -7558,12 +7564,12 @@ msgid "Menu"
 msgstr ""
 
 #: src/blocks/reader-registration/index.php:40
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: dist/content-gate-editor.js:25
 #: src/content-gate/editor/editor.js:23
 #: src/wizards/audience/components/segment-group/index.js:171
-#: src/wizards/audience/views/campaigns/utils.js:62
+#: src/wizards/audience/views/campaigns/utils.js:63
 msgid "Inline"
 msgstr ""
 
@@ -7602,49 +7608,49 @@ msgid "Please visit %s to verify and manage your account."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:4
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:4
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:4
 #, js-format
 msgid "Get started with %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:4
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:4
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:4
 msgid "premium newsletters"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:4
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:4
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:4
 msgid "access control"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:4
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:4
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:4
 msgid "Set up premium newsletters to manage which lists readers can sign up for. Start by selecting which lists to restrict, then configure access through registered and/or paid options."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:4
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:4
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:4
 msgid "Set up gates to manage what content readers can access across your site. Start by selecting which content to restrict, then configure access through registered and/or paid options (including metered rules)."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:7
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:128
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:7
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:132
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:7
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:70
 #, js-format
 msgid "Restrict all %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:7
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:10
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:125
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:128
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:131
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:134
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:137
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:7
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:10
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:129
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:132
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:135
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:138
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:141
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:7
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:10
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:67
@@ -7655,11 +7661,11 @@ msgstr ""
 msgid "lists"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:7
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:10
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:125
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:128
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:131
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:7
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:10
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:129
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:132
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:135
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:7
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:10
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:67
@@ -7668,167 +7674,167 @@ msgstr ""
 msgid "posts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:7
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:7
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:7
 msgid "All lists on your site will require access."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:7
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:7
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:7
 msgid "All posts on your site will require access."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:10
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:134
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:10
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:138
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:10
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:76
 #, js-format
 msgid "Choose specific %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:10
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:10
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:10
 msgid "Select which lists to restrict using custom rules."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:10
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:10
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:10
 msgid "Select which content to restrict using custom rules."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:10
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:10
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:10
 msgid "(no name)"
 msgstr ""
 
 #. translators: 1: rule name, 2: includes or excludes
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:13
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:13
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 #, js-format
 msgid "%1$s %2$s:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:13
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:13
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 msgid "exclude"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:13
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:13
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 msgid "include"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:13
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:13
 msgid "Click to select, type to search"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 msgid "All lists"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/blocks.js:6
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 #: src/blocks/collections/components/InspectorPanel.jsx:65
 msgid "Mode"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 msgid "Include"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
 msgid "Exclude"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/setup.js:1
 msgid "Suggested Donations"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/setup.js:1
 msgid "Set suggested donation amounts. These will be the default settings for the Donate block."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/setup.js:1
 msgid "Donation Type"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/setup.js:1
 msgid "Tiered"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:16
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:16
 #: dist/setup.js:1
 msgid "Untiered"
 msgstr ""
 
 #. Translators: %1$s is a link to the trashed products. %2$s is a comma-separated list of trashed product names.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:19
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:19
 #: dist/setup.js:4
 #, js-format
 msgid "One or more donation products is in trash. Please <a href=\"%1$s\">restore the product(s)</a> to continue using donation features: %2$s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:19
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:19
 #: dist/setup.js:4
 msgid "Warning: suggested donations should be at least the minimum donation amount."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:19
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:19
 #: dist/setup.js:4
 msgid "Minimum donation"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:19
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:19
 #: dist/setup.js:4
 msgid "Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:19
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:19
 msgid "Some donation products are invalid. Please correct the following issues:"
 msgstr ""
 
 #. translators: %d: Product ID.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #, js-format
 msgid "Product ID %d"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 msgid "edit"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 msgid "Donations Landing Page"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 msgid "Your donations landing page is published."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 msgid "Your donations landing page is not yet published."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: dist/billboard.js:15
 #: dist/newsletters.js:1
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
@@ -7844,7 +7850,7 @@ msgstr ""
 msgid "Save Settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: dist/billboard.js:15
 #: dist/newspack-wizards.e386313f64136198a71d.js:1
 #: src/wizards/advertising/views/ad-units/options-popover.js:34
@@ -7853,19 +7859,19 @@ msgstr ""
 msgid "Close Popover"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/components/campaign-management-popover/index.js:43
 msgid "Activate all prompts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/components/campaign-management-popover/index.js:54
 msgid "Deactivate all prompts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/campaign-management-popover/index.js:64
 #: src/wizards/audience/components/prompt-action-card/index.js:177
 #: src/wizards/audience/components/prompt-popovers/primary.js:67
@@ -7874,34 +7880,34 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:108
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:46
 #: src/wizards/audience/components/campaign-management-popover/index.js:73
 #: src/wizards/audience/views/campaigns/campaigns/index.js:48
 msgid "Rename"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: dist/billboard.js:15
 #: src/wizards/advertising/views/ad-units/options-popover.js:40
 #: src/wizards/audience/components/campaign-management-popover/index.js:83
 msgid "Archive"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/components/campaign-management-popover/index.js:94
 msgid "Unarchive"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:108
 #: dist/billboard.js:15
 #: dist/componentsDemo.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:16
@@ -7920,20 +7926,20 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/components/prompt-popovers/primary.js:46
 msgid "Restore"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/components/prompt-popovers/primary.js:49
 msgid "Delete permanently"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/commons.js:13
 #: dist/componentsDemo.js:1
 #: packages/components/src/web-preview/index.js:224
@@ -7944,297 +7950,306 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:108
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:46
 #: src/wizards/audience/components/prompt-popovers/primary.js:76
 msgid "Deactivate"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:108
 #: dist/commons.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:46
 #: packages/components/src/plugin-installer/index.js:169
 #: packages/components/src/plugin-installer/index.js:214
 #: src/wizards/audience/components/prompt-popovers/primary.js:76
+#: src/wizards/audience/views/integrations/settings-section.js:84
 msgid "Activate"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
 #: src/wizards/audience/components/prompt-popovers/primary.js:84
 msgid "ID:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:137
-#: src/wizards/audience/views/campaigns/utils.js:53
+#: src/wizards/audience/views/campaigns/utils.js:54
 msgid "Top Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:54
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:55
 msgid "Top Left Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:56
 msgid "Top Right Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:120
-#: src/wizards/audience/views/campaigns/utils.js:56
+#: src/wizards/audience/views/campaigns/utils.js:57
 msgid "Center Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:57
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:58
 msgid "Center Left Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:59
 msgid "Center Right Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:154
-#: src/wizards/audience/views/campaigns/utils.js:59
+#: src/wizards/audience/views/campaigns/utils.js:60
 msgid "Bottom Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:60
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:61
 msgid "Bottom Left Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:62
 msgid "Bottom Right Overlay"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:63
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:64
 msgid "In archive pages"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: dist/componentsDemo.js:1
 #: src/wizards/audience/components/segment-group/index.js:188
-#: src/wizards/audience/views/campaigns/utils.js:64
+#: src/wizards/audience/views/campaigns/utils.js:65
 #: src/wizards/componentsDemo/index.js:1014
 msgid "Above Header"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:239
-#: src/wizards/audience/views/campaigns/utils.js:65
+#: src/wizards/audience/views/campaigns/utils.js:66
 msgid "Manual Only"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:205
-#: src/wizards/audience/views/campaigns/utils.js:71
+#: src/wizards/audience/views/campaigns/utils.js:72
 msgid "Custom Placement"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:96
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:97
 msgid "Once a month"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:97
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:98
 msgid "Once a week"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:98
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:99
 msgid "Once a day"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:99
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:100
 msgid "Every pageview"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:101
 msgid "Custom frequency (edit prompt to manage)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:124
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:125
 msgid "Campaign: "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:124
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:125
 msgid "Campaigns: "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:128
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:129
 msgid "Categories: "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:131
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:132
 msgid "Tags: "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:134
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:135
 msgid "Pending review"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:137
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:138
 msgid "Scheduled"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:139
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:140
 msgid "Frequency: "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:148
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:149
 msgid "Segment disabled"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:219
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:220
 msgid "Favorite Categories:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:279
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:280
 msgid "Subscribed to:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:279
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:280
 msgid "Not subscribed to:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:310
-#: src/wizards/audience/views/campaigns/utils.js:283
+#: src/wizards/audience/views/campaigns/utils.js:284
 msgid "Deleted list"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:300
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:301
 msgid "Has active subscription(s):"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:301
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:302
 msgid "Does not have active subscription(s):"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:328
-#: src/wizards/audience/views/campaigns/utils.js:305
+#: src/wizards/audience/views/campaigns/utils.js:306
 msgid "Deleted subscription"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:321
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:322
 msgid "Has active membership(s):"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:322
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:323
 msgid "Does not have active membership(s):"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:22
-#: src/wizards/audience/views/campaigns/utils.js:326
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:22
+#: src/wizards/audience/views/campaigns/utils.js:327
 msgid "Deleted membership"
 msgstr ""
 
 #. Translators: %s is prompt type (above-header or overlay).
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:25
-#: src/wizards/audience/views/campaigns/utils.js:347
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:25
+#: src/wizards/audience/views/campaigns/utils.js:348
 #, js-format
 msgid "If multiple %s are rendered on the same pageview, only the most recent one will be displayed."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:25
-#: src/wizards/audience/views/campaigns/utils.js:348
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:25
+#: src/wizards/audience/views/campaigns/utils.js:349
 msgid "above-header prompts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:25
-#: src/wizards/audience/views/campaigns/utils.js:348
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:25
+#: src/wizards/audience/views/campaigns/utils.js:349
 msgid "overlays"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:25
-#: src/wizards/audience/views/campaigns/utils.js:353
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:25
+#: src/wizards/audience/views/campaigns/utils.js:354
 msgid "If multiple prompts are rendered in the same custom placement, only the most recent one will be displayed."
 msgstr ""
 
 #. Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
-#: src/wizards/audience/views/campaigns/utils.js:389
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:28
+#: src/wizards/audience/views/campaigns/utils.js:390
 #, js-format
 msgid "%s detected:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
-#: src/wizards/audience/views/campaigns/utils.js:390
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:28
+#: src/wizards/audience/views/campaigns/utils.js:391
 msgid "Conflicts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
-#: src/wizards/audience/views/campaigns/utils.js:390
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:28
+#: src/wizards/audience/views/campaigns/utils.js:391
 msgid "Conflict"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#. Translators: %s: title of the conflicting prompt.
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
+#: src/wizards/audience/views/campaigns/utils.js:401
+#, js-format
+msgid "%s:"
+msgstr ""
+
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:27
 msgid "Close Modal"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:32
 msgid "Assign a prompt to one or more campaigns for easier management"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:49
 msgid "When and how should the prompt be displayed"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: dist/content-gate-editor.js:25
 #: src/content-gate/editor/editor.js:100
 #: src/wizards/audience/components/settings-modal/index.js:65
 msgid "Position"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:65
 msgid "Placement"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: dist/billboard.js:15
 #: dist/blocks.js:6
 #: dist/content-gate-editor.js:25
@@ -8246,79 +8261,79 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:87
 msgid "Targeting"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:90
 msgid "Under which conditions should the prompt be displayed"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:92
 msgid "If multiple conditions are set, all will have to be satisfied in order to display the prompt"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:108
 msgid "Segments"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:112
 msgid "Post categories"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:117
 msgid "Prompt will only appear on posts with the specified categories."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:120
 msgid "Post tags"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:28
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:31
 #: src/wizards/audience/components/settings-modal/index.js:126
 msgid "Prompt will only appear on posts with the specified tags."
 msgstr ""
 
 #. translators: %s: whether to show or hide advanced settings fields.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:133
 #, js-format
 msgid "%s Advanced Settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:141
 msgid "Category Exclusions"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:152
 msgid "Prompt will not appear on posts with the specified categories."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:155
 msgid "Tag Exclusions"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/settings-modal/index.js:167
 msgid "Prompt will not appear on posts with the specified tags."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/prompt-action-card/index.js:49
 msgid " copy"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: dist/commons.js:4
 #: dist/commons.js:13
 #: packages/components/src/autocomplete-with-latest-posts/index.js:138
@@ -8328,12 +8343,12 @@ msgstr ""
 msgid "(no title)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: src/wizards/audience/components/prompt-action-card/index.js:73
 msgid "Prompt settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:31
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:34
 #: dist/billboard.js:15
 #: dist/commons.js:13
 #: dist/newspack-wizards.e386313f64136198a71d.js:1
@@ -8344,344 +8359,344 @@ msgid "More options"
 msgstr ""
 
 #. Translators: %s: The title of the item.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:34
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:37
 #: src/wizards/audience/components/prompt-action-card/index.js:109
 #, js-format
 msgid "Duplicate “%s”"
 msgstr ""
 
 #. Translators: %s: The title of the item.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/prompt-action-card/index.js:123
 #, js-format
 msgid "Duplicate of “%s” created as a draft."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/prompt-action-card/index.js:128
 msgid "This prompt is currently not assigned to any campaign."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/prompt-action-card/index.js:149
 msgid "This prompt will not be assigned to any campaign."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/segment-group/index.js:46
 msgid "No unassigned prompts in this segment."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/segment-group/index.js:48
 msgid "No prompts in this segment for"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/segment-group/index.js:50
 msgid "No active prompts in this segment."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:37
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:40
 #: src/wizards/audience/components/segment-group/index.js:65
 msgid "Edit Segment"
 msgstr ""
 
 #. translators: %s: segment label
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:38
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:41
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:72
 #: src/wizards/audience/components/segment-group/index.js:95
 #, js-format
 msgid "Segment: %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:38
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:41
 #: src/wizards/audience/components/segment-group/index.js:80
 msgid "All readers, regardless of segment"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:38
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:41
 #: src/wizards/audience/components/segment-group/index.js:90
 msgid "Preview Segment"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:101
 #: src/wizards/audience/components/segment-group/index.js:105
 msgid "Add New Prompt"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:121
 msgid "Fixed at the center of the screen"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:138
 msgid "Fixed at the top of the screen"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:155
 msgid "Fixed at the bottom of the screen"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:172
 msgid "Embedded in content"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:189
 msgid "Embedded at the very top of the page"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:206
 msgid "Only appears when placed in content"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:222
 msgid "In Archive Pages"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:223
 msgid "Embedded once or many times in archive pages"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/components/segment-group/index.js:241
 msgid "Only appears where Single Prompt block is inserted"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:39
 msgid "Rename Campaign"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:41
 msgid "Duplicate Campaign"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:43
 #: src/wizards/audience/views/campaigns/campaigns/index.js:259
 msgid "Add New Campaign"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: dist/other-scripts/corrections-modal.js:4
 #: src/other-scripts/corrections-modal/index.js:353
 #: src/wizards/audience/views/campaigns/campaigns/index.js:52
 msgid "Add"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:90
 msgid "Everyone"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:149
 msgid "Active Prompts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:153
 msgid "All Prompts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:157
 msgid "Trash"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:163
 msgid "Unassigned Prompts"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:185
 msgid "Archived Campaigns"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:192
 msgid "(archived)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: dist/newspack-wizards.e386313f64136198a71d.js:26
 #: src/wizards/audience/views/campaigns/campaigns/index.js:221
 msgid "Actions"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:270
 #: src/wizards/audience/views/campaigns/campaigns/index.js:272
 msgid "Campaign Name"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:18
 msgid "Add New Segment"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:135
 msgid "Audience segments"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:98
 msgid "There was an error sorting segments. Please try again."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:143
 msgid "You have no saved audience segments."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:146
 msgid "Create audience segments to target visitors by engagement, activity, and more."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:306
 msgid "Start typing to search for lists…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:324
 msgid "Start typing to search for products…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:342
 msgid "Start typing to search for membership plans…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:346
 msgid "Deleted plan"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:50
 msgid "There are unsaved changes to this segment. Discard changes?"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:161
 msgid "Untitled Segment"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:169
 msgid "Segment Status"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:170
 msgid "If not enabled, the segment will be ignored for reader segmentation."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:174
 msgid "Segment enabled"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:181
 msgid "Reader Engagement"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:182
 msgid "Target readers based on their browsing behavior."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:195
 msgid "Target readers based on their user account registration status."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:209
 msgid "Target readers based on their newsletter subscription status."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:223
 msgid "Target readers based on their revenue activity."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:236
 msgid "Referrer Sources"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:237
 msgid "Target readers based on where they’re coming from."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:238
 msgid "Segments using these options will apply only to the first page visited after coming from an external source."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:256
 msgid "Target readers based on data from connected integrations."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: src/wizards/audience/views/campaigns/index.js:174
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: src/wizards/audience/views/campaigns/index.js:175
 msgid "Error duplicating prompt. Please try again later."
 msgstr ""
 
 #. translators: %s: prompt title
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: src/wizards/audience/views/campaigns/index.js:220
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: src/wizards/audience/views/campaigns/index.js:223
 #, js-format
 msgid "Prompt: %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
 msgid "Ready"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 msgid "Skipped"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:39
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:42
 msgid "Unavailable"
 msgstr ""
 
 #. translators: %s: Prerequisite status
 #. translators: %s: status of the prompt.
 #. Translators: %s: Plugin status
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:40
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:43
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
 #, js-format
 msgid "Status: %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:40
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:43
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/newspack-wizards.e386313f64136198a71d.js:14
 #: src/wizards/audience/components/payment-methods/index.js:39
 #: src/wizards/audience/components/payment-methods/index.js:54
@@ -8695,9 +8710,9 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:40
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:43
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: dist/newspack-wizards.e386313f64136198a71d.js:31
 #: dist/other-scripts/corrections-modal.js:7
 #: src/other-scripts/corrections-modal/index.js:391
@@ -8706,15 +8721,15 @@ msgstr ""
 
 #. translators: %s: save or update settings.
 #. Translators: %s is the email service provider title
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:43
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #: src/wizards/audience/components/settings.js:44
 #, js-format
 msgid "%s settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:43
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: dist/billboard.js:13
 #: dist/bylines.js:1
 #: dist/componentsDemo.js:1
@@ -8727,290 +8742,290 @@ msgid "Update"
 msgstr ""
 
 #. translators: %1$s: specific instructions for satisfying the prerequisite. %2$s: opening <a> tag for the link to the Audience Configuration page. %3$s: closing </a> tag.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #, js-format
 msgid "%1$s%2$sReturn to the Audience Configuration page to complete the settings and activate%3$s."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 msgid "Update "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 msgid "Save "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 msgid "Configure "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/campaign.js:83
 #: src/wizards/audience/views/setup/index.js:70
 msgid "Skip"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #: src/wizards/audience/components/mailchimp.js:46
 #: src/wizards/audience/components/settings.js:35
 msgid "Audience ID"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #: src/wizards/audience/components/active-campaign.js:46
 #: src/wizards/audience/components/settings.js:35
 msgid "Master List"
 msgstr ""
 
 #. Translators: %s is the email service provider title
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:46
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:49
 #: src/wizards/audience/components/settings.js:46
 #, js-format
 msgid "Settings for the %s integration."
 msgstr ""
 
 #. Translators: 1 is the term used to refer to lists for a given email service provider and 2 is the email service provider title
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:49
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:52
 #: src/wizards/audience/components/settings.js:54
 #, js-format
 msgid "No %1$s selected. You will not be able to send reader activity data to %2$s."
 msgstr ""
 
 #. Translators: %s is the email service provider title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/settings.js:77
 #, js-format
 msgid "Choose which %s status readers should have by default if they are not subscribed to any newsletters"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/metadata-fields.js:16
 msgid "Metadata field settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/metadata-fields.js:17
 msgid "Select which data to sync for each contact."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/metadata-fields.js:21
 msgid "A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: packages/components/src/sortable-newsletter-list-control/index.js:42
 msgid "Checked by default"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: packages/components/src/sortable-newsletter-list-control/index.js:106
 msgid "Add more lists:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: packages/components/src/sortable-newsletter-list-control/index.js:108
 msgid "Select lists:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:74
 msgid "We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:143
 msgid "Salesforce Settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:149
 msgid "Your site is connected to Salesforce."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:152
 msgid "Establish a connection to sync WooCommerce order data to Salesforce. To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the full URL for this page ("
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:163
 msgid "copied to clipboard!"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:163
 msgid "copy to clipboard"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:166
 msgid ") into the “Callback URL” field in the Connected App’s settings. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/components/salesforce/index.js:169
 msgid "Learn how to create a Connected App"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:84
 msgid "Newspack's Audience Management system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:95
 msgid "The following plugins are required."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:97
 msgid "Complete these settings to enable Audience Management."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:100
 msgid "Audience Management is enabled."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:105
 msgid "Fetching status…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:130
 msgid "Present newsletter signup after checkout and registration"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:131
 msgid "Ask readers to sign up for newsletters after creating an account or completing a purchase."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:151
 msgid "Initial list size"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:152
 msgid "Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a \"See all\" button."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:164
 msgid "Use My Account login screen for OAuth clients"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:165
 msgid "Allow OAuth clients to redirect to the My Account login screen instead of the default WordPress login screen. Might require additional configuration."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:177
 msgid "Email Service Provider (ESP) Advanced Settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:178
 msgid "Settings for Newspack Newsletters integration."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:181
 msgid "Newsletter subscription text on registration"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:182
 msgid "The text to display while subscribing to newsletters from the sign-in modal."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:186
 msgid "Configure options for syncing reader data to the connected ESP."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:189
 msgid "Sync contacts to ESP"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:242
 msgid "If enabled, the contact will be deleted from the ESP when a user account is deleted. If disabled, the contact will be unsubscribed from all lists, but not deleted."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:268
 msgid "Please select a Mailchimp Audience ID."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:273
 msgid "Please select an ActiveCampaign Master List."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
 #: src/wizards/audience/views/setup/setup.js:278
 msgid "Please select a Constant Contact Master List."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:52
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "You have unsaved changes that will be lost. Discard changes?"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
 msgid "Unsaved changes"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
 msgid "Select file"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:55
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:58
 msgid "Prompt saved."
 msgstr ""
 
 #. translators: %s: save or update settings.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #, js-format
 msgid "%s prompt settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 msgid "Preview prompt"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 msgid "We recommend"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/campaign.js:54
 msgid "Set Up Audience Management Campaign"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/campaign.js:55
 msgid "Preview and customize the prompts, or use our suggested defaults."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/campaign.js:61
 msgid "Retrieving prompts…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: dist/billboard.js:15
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
 #: dist/newspack-wizards.e386313f64136198a71d.js:37
@@ -9020,302 +9035,302 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:19
 msgid "Your <strong>current segments and prompts</strong> will be deactivated and archived."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:23
 msgid "<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:29
 msgid "The <strong>Audience Management campaign</strong> will be activated with default segments and settings."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:35
 msgid "Setting up new segments…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:36
 msgid "Activating reader registration…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:37
 msgid "Activating Audience Management Campaign…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:100
 msgid "Done!"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:133
 #: src/wizards/audience/views/setup/complete.js:169
 msgid "Enable Audience Management"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:136
 msgid "An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:158
 msgid "You're all set to enable Audience Management!"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/complete.js:159
 msgid "This is what will happen next:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/countdown-banner.js:21
 msgid "Metered Countdown"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/countdown-banner.js:23
 msgid "Show a countdown banner before content is restricted by a metered content gate."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:94
 #: src/wizards/audience/views/setup/countdown-banner.js:34
 msgid "Message"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
 #: src/wizards/audience/views/setup/countdown-banner.js:35
 msgid "Text displayed in the countdown banner."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:101
 #: src/wizards/audience/views/setup/countdown-banner.js:41
 msgid "Subscribe button label"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:102
 #: src/wizards/audience/views/setup/countdown-banner.js:42
 msgid "Text displayed on the subscribe button in the banner."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:110
 #: src/wizards/audience/views/setup/countdown-banner.js:50
 msgid "Style"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:116
 #: src/wizards/audience/views/setup/countdown-banner.js:56
 msgid "Light"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:117
 #: src/wizards/audience/views/setup/countdown-banner.js:57
 msgid "Dark"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:120
 #: src/wizards/audience/views/setup/countdown-banner.js:60
 msgid "Subscribe button action"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:121
 #: src/wizards/audience/views/setup/countdown-banner.js:61
 msgid "Whether the subscribe button should start a product checkout or redirect to a landing page."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:131
 #: src/wizards/audience/views/setup/countdown-banner.js:71
 msgid "Landing page"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:135
 #: src/wizards/audience/views/setup/countdown-banner.js:75
 msgid "Subscribe button product"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:136
 #: src/wizards/audience/views/setup/countdown-banner.js:76
 msgid "Product linked to the subscribe button."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:137
 #: src/wizards/audience/views/setup/countdown-banner.js:77
 msgid "Select a product"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:148
 #: src/wizards/audience/views/setup/countdown-banner.js:88
 msgid "Subscribe button URL"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:149
 #: src/wizards/audience/views/setup/countdown-banner.js:89
 msgid "URL for the landing page to redirect to."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
 #: src/wizards/audience/views/setup/countdown-banner.js:108
 msgid "1/10 free articles this month"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gifting.js:26
 msgid "Content Gifting"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gifting.js:28
 msgid "Allow members to gift articles up to the configured limit."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: dist/commons.js:13
 #: packages/components/src/plugin-settings/index.js:201
 #: src/wizards/audience/views/setup/content-gifting.js:40
 msgid "General Settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:43
 msgid "Gifting limit"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:44
 msgid "Maximum number of articles that can be gifted per user for the configured interval."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:52
 msgid "Gifting limit interval"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:53
 msgid "Interval at which the gifting limit is reset."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:64
 msgid "Article link expiration time"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:65
 msgid "Time after which the article link expires."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:73
 msgid "Article link expiration time unit"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:74
 msgid "Unit of time for the article link expiration time."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gifting.js:91
 msgid "Recipient Banner"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/setup/content-gifting.js:95
 msgid "Text displayed in the banner shown to recipients of gifted articles."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/content-gating.js:61
 #: src/wizards/audience/views/setup/index.js:106
 msgid "Content Gating"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:64
 msgid "WooCommerce Memberships integration to improve the reader experience with content gating. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:50
 msgid "Configure the gate rendered on content with restricted access."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:52
 msgid "The gate is currently published."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:54
 msgid "The gate is currently a draft."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/billboard.js:1
 #: dist/commons.js:13
 #: dist/componentsDemo.js:1
@@ -9328,7 +9343,7 @@ msgstr ""
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:85
 #: src/wizards/audience/components/payment-methods/stripe.js:93
 #: src/wizards/audience/components/payment-methods/woopayments.js:85
-#: src/wizards/audience/views/integrations/settings-section.js:71
+#: src/wizards/audience/views/integrations/settings-section.js:97
 #: src/wizards/audience/views/setup/content-gating.js:77
 #: src/wizards/componentsDemo/index.js:379
 #: src/wizards/componentsDemo/index.js:389
@@ -9338,41 +9353,41 @@ msgstr ""
 msgid "Configure"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:83
 msgid "Require membership in all plans"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:84
 msgid "When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:95
 msgid "Display memberships on the subscriptions tab"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/views/setup/content-gating.js:96
 msgid "Display memberships that don't have active subscriptions on the My Account Subscriptions tab, so readers can see information like expiration dates."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: dist/componentsDemo.js:1
 #: src/wizards/audience/components/payment-methods/stripe.js:69
 #: src/wizards/componentsDemo/index.js:977
 msgid "Stripe"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/components/payment-methods/stripe.js:72
 msgid "Enable the Stripe payment gateway for WooCommerce. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/commons.js:13
 #: dist/commons.js:15
 #: dist/newspack-wizards.e386313f64136198a71d.js:5
@@ -9389,20 +9404,20 @@ msgstr ""
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:39
 #: src/wizards/audience/components/payment-methods/stripe.js:40
 #: src/wizards/audience/components/payment-methods/woopayments.js:39
-#: src/wizards/audience/views/integrations/settings-section.js:48
+#: src/wizards/audience/views/integrations/settings-section.js:50
 msgid "Loading…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:45
 #: src/wizards/audience/components/payment-methods/stripe.js:49
 #: src/wizards/audience/components/payment-methods/woopayments.js:45
 msgid "Connected - test mode"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: dist/newspack-wizards.e386313f64136198a71d.js:1
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
@@ -9412,13 +9427,13 @@ msgstr ""
 msgid "Connected"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
 #: src/wizards/audience/components/payment-methods/stripe.js:46
 msgid "Needs attention"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: dist/commons.js:18
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
@@ -9428,9 +9443,9 @@ msgstr ""
 msgid "Not connected"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:58
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/commons.js:18
 #: dist/componentsDemo.js:1
 #: dist/newspack-wizards.e386313f64136198a71d.js:8
@@ -9438,252 +9453,253 @@ msgstr ""
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:89
 #: src/wizards/audience/components/payment-methods/stripe.js:102
 #: src/wizards/audience/components/payment-methods/woopayments.js:89
-#: src/wizards/audience/views/integrations/settings-section.js:70
+#: src/wizards/audience/views/integrations/settings-field.js:57
+#: src/wizards/audience/views/integrations/settings-section.js:81
 #: src/wizards/componentsDemo/index.js:962
 msgid "Connect"
 msgstr ""
 
 #. Translators: %s is the payment gateway name.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:67
 #: src/wizards/audience/components/payment-methods/woopayments.js:67
 #, js-format
 msgid "Enable %s. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/payment-methods/index.js:31
 msgid "Payment Gateways"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/payment-methods/index.js:34
 msgid "Configure Newspack-supported payment gateways for WooCommerce. Payment gateways allow you to accept various payment methods from your readers. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/payment-methods/index.js:50
 msgid "Missing or invalid SSL configuration detected. To collect payments, the site must be secured with SSL. "
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:44
 msgid "News Revenue Hub Settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:45
 msgid "Configure your site’s connection to News Revenue Hub."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:50
 msgid "Organization ID"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:56
 msgid "Custom domain (optional)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:63
 msgid "Salesforce Campaign ID (optional)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:72
 msgid "Donor Landing Page"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:80
 msgid "Search for a New Donor Landing Page"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:92
 msgid "page"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/nrh-settings/index.js:93
 msgid "pages"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Billing Fields"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Configure the billing fields shown in the modal checkout form. Fields marked with (*) are required if shown. Note that for shippable products, address fields will always be shown."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Checkout Configuration"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Require sign in or create account before checkout"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Prompt users who are not logged in to sign in or register a new account before proceeding to checkout. When disabled, an account will automatically be created with the email address used at checkout."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Post-checkout success message"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "The success message to display to readers after completing checkout."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Post-checkout registration success message"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "The success message to display to new readers that have an account automatically created after completing checkout."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Checkout privacy policy text"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "The privacy policy text to display at time of checkout for existing users. This will not show up unless a privacy page is set."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:37
 #: src/wizards/audience/components/cover-fees-settings/index.js:45
 msgid "Collect transaction fees"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:38
 msgid "Allow readers to optionally cover transaction fees imposed by payment processors when making donations or subscribing."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:58
 msgid "Fee multiplier"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:66
 msgid "Fee static portion"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:72
 msgid "Custom message"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:73
 msgid "A message to explain the transaction fee option (optional)."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:80
 msgid "Cover fees by default"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:83
 msgid "If enabled, the option to cover the transaction fee will be checked by default."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:87
 msgid "Donations only"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/components/cover-fees-settings/index.js:90
 msgid "If enabled, the option to cover the transaction fee will only be available for donations."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Manage the settings for subscription transparency and compliance."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Enable subscription confirmation checkbox"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: dist/collections-admin.js:1
 #: src/collections/admin/collection-meta-ctas-field.js:206
 msgid "Label"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Enable Terms & Conditions confirmation checkbox"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Text wrapped in {{ }} will be linked to the page set in the URL field."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: dist/collections-admin.js:1
 #: dist/newspack-wizards.e386313f64136198a71d.js:26
 #: src/collections/admin/collection-meta-ctas-field.js:225
 msgid "URL"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 msgid "Please provide a URL for the Terms & Conditions page."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/index.js:110
 #: src/wizards/audience/views/setup/payment.js:25
 msgid "Checkout & Payment"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/payment.js:26
 msgid "Reader revenue configuration for donations and subscriptions."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:61
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:64
 #: src/wizards/audience/views/setup/index.js:69
 msgid "Are you sure you want to skip this step? You can always come back later."
 msgstr ""
 
 #. translators: %s is the gate title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:64
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:67
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:19
 #, js-format
 msgid "This will <strong>permanently delete</strong> “%s” and cannot be undone."
 msgstr ""
 
 #. translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:67
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:104
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:22
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:42
 #, js-format
 msgid "%1$s gate %2$s."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:67
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:79
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:100
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:82
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:104
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:22
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:42
@@ -9691,110 +9707,110 @@ msgid "Undo"
 msgstr ""
 
 #. translators: %s is the gate title, or "Content" if we can't determine the deleted gate title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #, js-format
 msgid "%s gate deleted."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 msgid "Edit registered access layout"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 msgid "Edit paid access layout"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 msgid "Content rules"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:73
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:28
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "N/A"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:143
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:147
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:85
 msgid "Registered access"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 msgid "Require verification:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:70
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:73
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:76
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:25
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:28
 msgid "Metered:"
 msgstr ""
 
 #. translators: 1: metering count, 2: metering period
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:73
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:28
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #, js-format
 msgid "%1$d free views per %2$s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:73
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:146
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:150
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:28
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:88
 msgid "Paid access"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 msgid "Gate priority updated."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 msgid "Gate priority"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 msgid "Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Settings updated."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Advanced settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 msgid "Restrict content in feeds"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 msgid "Truncate restricted content in RSS feeds."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/billboard.js:15
 #: dist/componentsDemo.js:1
 #: dist/newspack-wizards.e386313f64136198a71d.js:39
 #: src/wizards/advertising/views/placements/index.js:329
-#: src/wizards/audience/views/integrations/settings-section.js:82
+#: src/wizards/audience/views/integrations/settings-section.js:108
 #: src/wizards/componentsDemo/index.js:917
 #: src/wizards/componentsDemo/index.js:932
 #: src/wizards/componentsDemo/index.js:953
@@ -9803,27 +9819,27 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:76
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:79
 msgid "Add new content gate"
 msgstr ""
 
 #. translators: %s is the status of the countdown banner.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:79
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:82
 #, js-format
 msgid "Metered countdown %s."
 msgstr ""
 
 #. translators: %s is the status of the content gifting.
 #. translators: %s is the status of content gifting.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #, js-format
 msgid "Content gifting %s."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/componentsDemo.js:1
 #: src/wizards/audience/views/content-gates/index.js:62
 #: src/wizards/componentsDemo/index.js:899
@@ -9832,20 +9848,20 @@ msgstr ""
 msgid "Metered countdown"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/content-gates/index.js:63
 msgid "Show a countdown banner letting readers know how many free views they have left before content is restricted."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
 #: dist/componentsDemo.js:1
 #: src/wizards/componentsDemo/index.js:904
 msgid "Requires metering"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/componentsDemo.js:1
 #: src/wizards/audience/views/content-gates/index.js:74
 #: src/wizards/componentsDemo/index.js:939
@@ -9853,28 +9869,28 @@ msgstr ""
 msgid "Content gifting"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/content-gates/index.js:75
 msgid "Let members gift articles to non-subscribers. Recipients can read the full content without needing to subscribe."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Discard changes"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
 msgid "Metered countdown settings updated."
 msgstr ""
 
 #. translators: %s: placement name.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:82
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/billboard.js:9
 #: dist/billboard.js:13
 #: dist/commons.js:13
@@ -9882,7 +9898,7 @@ msgstr ""
 #: dist/newspack-wizards.e386313f64136198a71d.js:32
 #: src/wizards/advertising/views/placements/index.js:227
 #: src/wizards/advertising/views/placements/index.js:308
-#: src/wizards/audience/views/integrations/settings-section.js:70
+#: src/wizards/audience/views/integrations/settings-section.js:81
 #: src/wizards/componentsDemo/index.js:1036
 #: src/wizards/componentsDemo/index.js:1046
 #: src/wizards/componentsDemo/index.js:1055
@@ -9890,54 +9906,54 @@ msgid "Enable"
 msgstr ""
 
 #. translators: %s is the status of the countdown banner.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
 #, js-format
 msgid "Countdown banner %s."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
 msgid "Countdown banner"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:85
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:88
 msgid "Content gifting settings updated."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "General settings"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Recipient banner"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Get started with institutions"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Create institutions to manage access to your content by email domain, IP range, or reader data."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/content-gates/index.js:94
 msgid "Add new institution"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Back to Access control"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Failed to load institutions. Please refresh the page."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/newspack-wizards.e386313f64136198a71d.js:1
 msgid "Logo"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/other-scripts/corrections-modal.js:1
 #: dist/other-scripts/corrections-modal.js:4
 #: src/other-scripts/corrections-modal/index.js:292
@@ -9945,88 +9961,88 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Email domain"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "IP range"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Copy access page URL"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "URL copied to clipboard."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Failed to copy URL. Please copy it manually."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "This will permanently delete this institution. This action cannot be undone."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Failed to delete institution. Please try again."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Failed to save institution. Please try again."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Add institution"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: src/wizards/audience/views/content-gates/index.js:102
 msgid "Edit institution"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Name and description"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Identify this institution. The name and image are shown on the access verification page."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Access rules"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Define how readers from this institution are identified. Rules use OR logic — matching any rule grants access."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Match readers by verified email domain"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Domains (comma-separated)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Match visitors by IP address or CIDR block"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "IPs / CIDR blocks (comma-separated)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Match readers by custom metadata"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 msgid "Key=value pairs (semicolon-delimited)"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/componentsDemo.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: src/wizards/componentsDemo/index.js:364
@@ -10034,272 +10050,295 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Inactive"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: src/wizards/audience/views/integrations/settings-section.js:42
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: src/wizards/audience/views/integrations/settings-section.js:44
 msgid "Manage how Newspack syncs reader data with your tools. Connect an integration to start syncing reader activity across your stack."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
-#: src/wizards/audience/views/integrations/settings-section.js:51
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:91
+#: src/wizards/audience/views/integrations/settings-section.js:53
 msgid "No integrations with configurable settings are registered."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#. translators: %s: comma-separated list of required plugin names.
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
+#: src/wizards/audience/views/integrations/settings-section.js:72
+#, js-format
+msgid "Requires %s"
+msgstr ""
+
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
+#: src/wizards/audience/views/integrations/settings-section.js:84
+msgid "Activating…"
+msgstr ""
+
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:68
-#: src/wizards/audience/views/integrations/settings-section.js:78
+#: src/wizards/audience/views/integrations/settings-section.js:104
 msgid "Logs"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
+#: dist/commons.js:18
+#: dist/componentsDemo.js:1
+#: dist/newspack-wizards.e386313f64136198a71d.js:8
+#: dist/newspack-wizards.e386313f64136198a71d.js:30
+#: src/wizards/audience/views/integrations/settings-field.js:51
+#: src/wizards/componentsDemo/index.js:426
+#: src/wizards/componentsDemo/index.js:968
+msgid "Disconnect"
+msgstr ""
+
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/configure-view.js:97
 msgid "Integration not found"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/configure-view.js:98
 msgid "The requested integration could not be found."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/configure-view.js:145
 msgid "Inbound"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/configure-view.js:175
 msgid "Outbound"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:23
 #: src/wizards/audience/views/integrations/logs-view.js:148
 msgid "Success"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:24
 #: src/wizards/audience/views/integrations/logs-view.js:149
 msgid "Failed"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:26
 #: src/wizards/audience/views/integrations/logs-view.js:151
 msgid "Canceled"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:72
 msgid "Back to Integrations"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:110
 msgid "Failed to load activity logs. Please try again."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:129
 msgid "Timestamp"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: src/wizards/audience/views/integrations/logs-view.js:135
 msgid "Event"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/commons.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: dist/newspack-wizards.e386313f64136198a71d.js:5
 msgid "Invalid Mailchimp API Key."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/commons.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: dist/newspack-wizards.e386313f64136198a71d.js:5
 msgid "Missing Google refresh token. Please re-authenticate site."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/commons.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: dist/newspack-wizards.e386313f64136198a71d.js:5
 msgid "Popup blocked by browser. Disable any popup blocking settings and try again."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 #: dist/commons.js:13
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: dist/newspack-wizards.e386313f64136198a71d.js:5
 msgid "URL is invalid. Please try again or contact support if the issue persists."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Subscription Upgrade Link"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Share the following URL to trigger the subscription upgrade:"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Primary Subscription Product"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Select a grouped or variable subscription product to allow readers to change their active subscriptions amongst all of its linked products and variations."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Select a product…"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:88
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:92
 msgid "Reset primary product"
 msgstr ""
 
 #. translators: %s: product title
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #, js-format
 msgid "Edit %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 msgid "Manage Subscriptions settings in Woo Memberships"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 msgid "You can manage the details of your subscription offerings in the Woo Memberships plugin."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 msgid "Manage Subscriptions"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/content-gate-editor-metering.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 #: src/content-gate/editor/metering-settings.js:19
 msgid "Metering"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Allow limited free views before access conditions apply."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Metering is enabled but the number of views is set to 0. Content will be gated for all readers."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Free views"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Free views before the gate appears."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Reset period"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "How often free views reset."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Allow limited free views before requiring login."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/content-gate-block-visibility.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Require verification"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/content-gate-block-visibility.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Readers must verify their account to access."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Failed to load options. The list may be outdated."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:89
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:93
 #: dist/content-gate-block-visibility.js:1
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:31
 msgid "Separate with commas."
 msgstr ""
 
 #. translators: %s is the gate title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:92
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:96
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:34
 #, js-format
 msgid "This will <strong>permanently delete</strong> \"%s\" and cannot be undone."
 msgstr ""
 
 #. translators: %s is the gate title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:94
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:98
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:36
 #, js-format
 msgid "\"%s\" gate created."
 msgstr ""
 
 #. translators: %s is the gate title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:97
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:101
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:39
 #, js-format
 msgid "%s gate updated."
 msgstr ""
 
 #. translators: %s is the gate title.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:102
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:106
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:44
 #, js-format
 msgid "“%s” gate deleted."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:102
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:106
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:44
 msgid "Add new"
 msgstr ""
 
 #. translators: %d is the content gate ID.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:104
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:108
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:46
 #, js-format
 msgid "Content gate %d not found. Create a new gate?"
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:107
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:111
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:49
 #, js-format
 msgid "Add new %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:107
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:110
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:113
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:116
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:119
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:111
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:114
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:117
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:120
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:123
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:49
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:52
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:55
@@ -10308,11 +10347,11 @@ msgstr ""
 msgid "premium newsletter"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:107
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:110
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:113
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:116
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:119
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:111
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:114
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:117
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:120
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:123
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:49
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:52
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:55
@@ -10322,67 +10361,67 @@ msgid "gate"
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:110
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:114
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:52
 #, js-format
 msgid "Untitled %s"
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:113
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:117
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:55
 #, js-format
 msgid "What should we call this %s?"
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:116
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:120
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:58
 #, js-format
 msgid "Choose a name to help you find this %s later. It won’t be shown to readers."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:119
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:123
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:61
 #, js-format
 msgid "%s name"
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:122
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:126
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:64
 #, js-format
 msgid "e.g. %s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:122
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:126
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:64
 msgid "Premium Lists"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:122
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:126
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:64
 msgid "Premium Articles"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:122
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:126
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:64
 msgid "What would you like to restrict?"
 msgstr ""
 
 #. translators: 1: the type of content to restrict, 2: content or "lists".
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:125
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:129
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:67
 #, js-format
 msgid "Choose whether to restrict all %1$s or select specific %2$s."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:125
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:134
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:137
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:140
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:143
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:129
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:138
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:141
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:144
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:147
 #: dist/blocks.js:6
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:67
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:76
@@ -10394,68 +10433,68 @@ msgid "content"
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:131
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:135
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:73
 #, js-format
 msgid "All %s on your site will require access."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:137
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:141
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:79
 #, js-format
 msgid "Select which %s to restrict using custom rules."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:140
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:144
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:82
 #, js-format
 msgid "What’s required to access this %s?"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:140
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:143
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:144
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:147
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:82
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:85
 msgid "list"
 msgstr ""
 
 #. translators: 1: the type of content to restrict, 2: the metering description.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:143
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:147
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:85
 #, js-format
 msgid "Choose how readers can unlock this %1$s. Enable registered access, paid access, or both. %2$s"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:143
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:147
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:85
 msgid "Each option can include metering to give readers limited free access before the restriction applies."
 msgstr ""
 
 #. translators: %s is the type of content to restrict.
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:146
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:150
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:88
 #, js-format
 msgid "Readers must log in to view %s."
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:146
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:150
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:88
 msgid "these lists"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:146
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:150
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:88
 msgid "this content"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:146
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:150
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:88
 msgid "Edit layout"
 msgstr ""
 
-#: dist/audience-wizards.0d31cfa203d9dcf58d76.js:146
+#: dist/audience-wizards.755c65c184bf8bac00ac.js:150
 #: dist/newsletters-wizards.e4f94b5f30b2b1b16ab3.js:88
 msgid "Readers must meet at least one condition to gain access."
 msgstr ""
@@ -12368,15 +12407,6 @@ msgstr ""
 #: dist/newspack-wizards.e386313f64136198a71d.js:30
 #, js-format
 msgid "Connected as %s"
-msgstr ""
-
-#: dist/commons.js:18
-#: dist/componentsDemo.js:1
-#: dist/newspack-wizards.e386313f64136198a71d.js:8
-#: dist/newspack-wizards.e386313f64136198a71d.js:30
-#: src/wizards/componentsDemo/index.js:426
-#: src/wizards/componentsDemo/index.js:968
-msgid "Disconnect"
 msgstr ""
 
 #: dist/commons.js:18

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.41.2
+ * Version: 6.41.3
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.41.2' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.41.3' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.41.2",
+	"version": "6.41.3",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/src/newspack-ui/scss/elements/_stack.scss
+++ b/plugins/newspack-plugin/src/newspack-ui/scss/elements/_stack.scss
@@ -38,18 +38,18 @@ $stack-gaps: (
 		&--horizontal {
 			flex-direction: row;
 
-			> :where(:not([class*="newspack-ui__spacing-"])) {
-				margin-left: 0;
-				margin-right: 0;
+			> :not([class*="newspack-ui__spacing-"]) {
+				margin-left: 0 !important;
+				margin-right: 0 !important;
 			}
 		}
 
 		&--vertical {
 			flex-direction: column;
 
-			> :where(:not([class*="newspack-ui__spacing-"])) {
-				margin-bottom: 0;
-				margin-top: 0;
+			> :not([class*="newspack-ui__spacing-"]) {
+				margin-bottom: 0 !important;
+				margin-top: 0 !important;
 			}
 		}
 

--- a/plugins/newspack-plugin/src/reader-activation-newsletters/newsletters-form.js
+++ b/plugins/newspack-plugin/src/reader-activation-newsletters/newsletters-form.js
@@ -15,50 +15,42 @@ window.newspackRAS.push( function ( readerActivation ) {
 			return;
 		}
 
+		const setupReveal = container => {
+			const seeAllButton = container.querySelector( '.see-all-button' );
+			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
+			if ( ! seeAllButton || ! newsletterContainer ) {
+				return;
+			}
+			const divider = newsletterContainer.querySelector( '.newspack-ui__gradient-divider' );
+			const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
+
+			seeAllButton.addEventListener( 'click', () => {
+				const firstRevealed = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]' );
+				newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( item => {
+					item.classList.remove( 'hidden' );
+					item.removeAttribute( 'inert' );
+				} );
+				newsletterContainer.style.maxHeight = 'none';
+				if ( divider ) {
+					divider.classList.add( 'hidden' );
+				}
+				seeAllButton.classList.add( 'hidden' );
+				firstRevealed?.querySelector( 'input' )?.focus();
+			} );
+
+			if ( peekItem ) {
+				const peekAmount = divider?.offsetHeight || 32;
+				newsletterContainer.style.maxHeight = `${ peekItem.offsetTop + peekAmount }px`;
+			}
+		};
+
 		containers.forEach( container => {
 			let form = container.querySelector( 'form' );
 			if ( ! form ) {
 				return;
 			}
 
-			// Handle "See all" button logic.
-			const seeAllButton = container.querySelector( '.see-all-button' );
-			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
-			const divider = newsletterContainer?.querySelector( '.newspack-ui__gradient-divider' );
-
-			if ( seeAllButton && newsletterContainer ) {
-				// Remove the "hidden" class from all newsletter items.
-				seeAllButton.addEventListener( 'click', () => {
-					newsletterContainer.querySelectorAll( '.hidden' ).forEach( item => {
-						item.classList.remove( 'hidden' );
-					} );
-					newsletterContainer.style.maxHeight = 'none';
-					if ( divider ) {
-						divider.classList.add( 'hidden' );
-					}
-					seeAllButton.classList.add( 'hidden' );
-				} );
-
-				// Set the initial height to show partially visible.
-				const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );
-				const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
-
-				if ( newsletterItems.length > listDefaultSize ) {
-					const gap = 12;
-					const extraSpace = 32; // Additional space for partial visibility.
-
-					let totalHeight = 0;
-					newsletterItems.forEach( ( item, index ) => {
-						if ( index < listDefaultSize ) {
-							totalHeight += item.offsetHeight;
-						}
-					} );
-
-					const maxHeight = totalHeight + listDefaultSize * gap + extraSpace;
-
-					newsletterContainer.style.maxHeight = `${ maxHeight }px`;
-				}
-			}
+			setupReveal( container );
 
 			const handleSubmit = ev => {
 				ev.preventDefault();
@@ -122,6 +114,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				// Make sure we aren't adding multiple event listeners to the form.
 				form.removeEventListener( 'submit', handleSubmit );
 				form.addEventListener( 'submit', handleSubmit );
+				setupReveal( container );
 			} );
 		} );
 	} );

--- a/plugins/newspack-plugin/src/reader-activation-newsletters/style.scss
+++ b/plugins/newspack-plugin/src/reader-activation-newsletters/style.scss
@@ -6,10 +6,14 @@
 
 	.newspack-newsletters-signup {
 		margin-top: var(--newspack-ui-spacer-5);
+	}
+}
 
-		.newsletter-list-container {
-			transition: max-height 250ms ease-in-out;
-		}
+.newspack-newsletters-signup .newsletter-list-container {
+	transition: max-height 250ms ease-in-out;
+
+	.newspack-ui__input-card.hidden {
+		display: none !important;
 	}
 }
 

--- a/plugins/newspack-plugin/src/reader-activation/store.js
+++ b/plugins/newspack-plugin/src/reader-activation/store.js
@@ -39,10 +39,18 @@ const mergeStrategies = new Map();
  */
 function rehydrateItem( key, serverValue ) {
 	const merge = mergeStrategies.get( key );
-	if ( merge ) {
-		const clientValue = _get( key );
-		_set( key, merge( serverValue, clientValue ) );
-	} else {
+	try {
+		if ( merge ) {
+			const clientValue = _get( key );
+			_set( key, merge( serverValue, clientValue ) );
+		} else {
+			_set( key, serverValue );
+		}
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.warn( `Unable to rehydrate ${ key }`, err );
+		// Fall back to overwriting with the server value so a failing merge
+		// strategy can't leave the store in an inconsistent/missing state.
 		_set( key, serverValue );
 	}
 }

--- a/plugins/newspack-plugin/src/reader-activation/store.test.js
+++ b/plugins/newspack-plugin/src/reader-activation/store.test.js
@@ -99,6 +99,24 @@ describe( 'Store', () => {
 		store.rehydrate();
 		expect( store.get( 'foo' ) ).toEqual( 'bar' );
 	} );
+	it( 'should fall back to the server value when a merge strategy throws', () => {
+		window.newspack_reader_data = {
+			items: {
+				flaky: '"server"',
+			},
+		};
+		const store = Store();
+		store.register( 'flaky', {
+			merge: () => {
+				throw new Error( 'boom' );
+			},
+		} );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+		expect( () => store.rehydrate() ).not.toThrow();
+		expect( store.get( 'flaky' ) ).toEqual( 'server' );
+		expect( warn ).toHaveBeenCalledWith( expect.stringContaining( 'Unable to rehydrate flaky' ), expect.any( Error ) );
+		warn.mockRestore();
+	} );
 	describe( 'getAll', () => {
 		beforeEach( () => {
 			window.newspack_reader_data = {};

--- a/plugins/newspack-plugin/src/wizards/audience/components/segment-group/SegmentGroup.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/segment-group/SegmentGroup.test.js
@@ -326,6 +326,26 @@ describe( 'A segment with conflicting prompts', () => {
 		expect( notice2.textContent ).toEqual( `${ PROMPTS.overlaysUncategorized[ 0 ].title }: ${ noticeText }` );
 	} );
 
+	it( 'decodes HTML entities in conflicting prompt titles', async () => {
+		SEGMENT.prompts = [
+			{ ...PROMPTS.overlaysUncategorized[ 0 ], id: 13, title: 'Donate &amp; Subscribe' },
+			{ ...PROMPTS.overlaysUncategorized[ 1 ], id: 14, title: 'Tom &amp; Jerry' },
+		];
+
+		// Expected warning text.
+		const noticeText = 'If multiple overlays are rendered on the same pageview, only the most recent one will be displayed.';
+		const props = {
+			campaignData: CAMPAIGN.campaignData,
+			campaign: CAMPAIGN.campaignId,
+			segment: SEGMENT,
+		};
+		const { getByTestId } = render( <SegmentGroup { ...props } /> );
+
+		// Each notice lists the *other* prompt's title, decoded.
+		expect( getByTestId( 'conflict-warning-13' ).textContent ).toEqual( `Tom & Jerry: ${ noticeText }` );
+		expect( getByTestId( 'conflict-warning-14' ).textContent ).toEqual( `Donate & Subscribe: ${ noticeText }` );
+	} );
+
 	it( 'renders a conflict notice for multiple above-header prompts in the same segment', async () => {
 		SEGMENT.prompts = PROMPTS.aboveHeadersUncategorized;
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/index.js
@@ -11,6 +11,7 @@ import '../../../../shared/js/public-path';
 import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * External dependencies.
@@ -217,7 +218,11 @@ class AudienceCampaigns extends Component {
 		return (
 			<WebPreview
 				url={ previewUrl }
-				title={ previewTitle ? /* translators: %s: prompt title */ sprintf( __( 'Prompt: %s', 'newspack-plugin' ), previewTitle ) : null }
+				title={
+					previewTitle
+						? /* translators: %s: prompt title */ sprintf( __( 'Prompt: %s', 'newspack-plugin' ), decodeEntities( previewTitle ) )
+						: null
+				}
 				onClose={ () => this.setState( { previewUrl: null, previewTitle: null } ) }
 				renderButton={ ( { showPreview } ) => {
 					const sharedProps = {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { useEffect, useState, Fragment } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * External dependencies.
@@ -394,7 +395,13 @@ export const warningForPopup = ( prompts, prompt ) => {
 						{ filteredConflictingPrompts.map( conflictingPrompt => (
 							<li key={ conflictingPrompt.id }>
 								<p data-testid={ `conflict-warning-${ prompt.id }` }>
-									<strong>{ sprintf( '%s: ', conflictingPrompt.title ) }</strong>
+									<strong>
+										{ sprintf(
+											// Translators: %s: title of the conflicting prompt.
+											__( '%s:', 'newspack-plugin' ),
+											decodeEntities( conflictingPrompt.title )
+										) }{ ' ' }
+									</strong>
 									<span>{ buildWarning( prompt, promptCategories ) }</span>
 								</p>
 							</li>

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -20,6 +20,7 @@ const AudienceIntegrations = ( props, ref ) => {
 	const [ pendingChanges, setPendingChanges ] = useState( {} );
 	const [ saving, setSaving ] = useState( {} );
 	const [ toggling, setToggling ] = useState( {} );
+	const [ activating, setActivating ] = useState( {} );
 	const [ loading, setLoading ] = useState( true );
 
 	const fetchSettings = useCallback( () => {
@@ -88,15 +89,64 @@ const AudienceIntegrations = ( props, ref ) => {
 			} );
 	}, [] );
 
+	const handleActivatePlugin = useCallback(
+		pluginSlugs => {
+			const slugs = ( Array.isArray( pluginSlugs ) ? pluginSlugs : [ pluginSlugs ] ).filter( Boolean );
+			if ( ! slugs.length ) {
+				return;
+			}
+			// Set-as-guard: filter out slugs already in flight, then dispatch the
+			// activation only for the newly-claimed ones. Using the state setter
+			// callback gives us an atomic check-and-claim against concurrent clicks.
+			setActivating( prev => {
+				const claimed = slugs.filter( slug => ! prev[ slug ] );
+				if ( ! claimed.length ) {
+					return prev;
+				}
+				Promise.all(
+					claimed.map( slug =>
+						apiFetch( {
+							path: `/newspack/v1/plugins/${ slug }/activate`,
+							method: 'POST',
+						} )
+					)
+				)
+					.then( () => fetchSettings() )
+					.catch( () => {
+						// Surface nothing here; failures leave the integration in its
+						// previous state and the user can retry. apiFetch already logs
+						// the underlying error to the console.
+					} )
+					.finally( () => {
+						setActivating( current => {
+							const next = { ...current };
+							claimed.forEach( slug => {
+								delete next[ slug ];
+							} );
+							return next;
+						} );
+					} );
+				const next = { ...prev };
+				claimed.forEach( slug => {
+					next[ slug ] = true;
+				} );
+				return next;
+			} );
+		},
+		[ fetchSettings ]
+	);
+
 	const sharedProps = {
 		integrations,
 		pendingChanges,
 		saving,
 		toggling,
+		activating,
 		loading,
 		onFieldChange: handleFieldChange,
 		onSave: handleSave,
 		onToggleEnabled: handleToggleEnabled,
+		onActivatePlugin: handleActivatePlugin,
 	};
 
 	return (

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.js
@@ -7,7 +7,7 @@ import { CheckboxControl, ExternalLink, TextareaControl } from '@wordpress/compo
 /**
  * Internal dependencies.
  */
-import { Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
+import { Button, Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
 
 /**
  * Render a single settings field.
@@ -32,6 +32,34 @@ export const SettingsField = ( { field, value, onChange } ) => {
 	);
 
 	switch ( type ) {
+		case 'hidden':
+			return null;
+		case 'oauth': {
+			const isConnected = !! value;
+			const oauthUrl = field.oauth_url || '';
+			return (
+				<div key={ key } className="newspack-oauth-field">
+					<p>
+						<strong>{ label }</strong>
+					</p>
+					{ ( description || helpUrl ) && <p>{ help }</p> }
+					{ isConnected ? (
+						<>
+							<p>{ value }</p>
+							{ field.disconnect_url && (
+								<Button variant="secondary" isDestructive href={ field.disconnect_url }>
+									{ __( 'Disconnect', 'newspack-plugin' ) }
+								</Button>
+							) }
+						</>
+					) : (
+						<Button variant="primary" href={ oauthUrl || undefined } disabled={ ! oauthUrl }>
+							{ __( 'Connect', 'newspack-plugin' ) }
+						</Button>
+					) }
+				</div>
+			);
+		}
 		case 'metadata': {
 			const selectedFields = Array.isArray( value ) ? value : [];
 			const normalizedOptions = ( options || [] ).map( option =>

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, envelope } from '@wordpress/icons';
 
 /**
@@ -32,7 +32,9 @@ const DEFAULT_ICON = {
 	backgroundColor: colors[ 'neutral-100' ],
 };
 
-export const SettingsSection = ( { integrations, loading, onToggleEnabled, history } ) => {
+const getMissingPlugins = integration => ( integration.required_plugins || [] ).filter( plugin => ! plugin.is_active );
+
+export const SettingsSection = ( { integrations, loading, activating = {}, onToggleEnabled, onActivatePlugin, history } ) => {
 	const integrationIds = Object.keys( integrations );
 
 	return (
@@ -54,12 +56,34 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, histo
 				{ ! loading && integrationIds.length > 0 && (
 					<Grid columns={ 2 } gutter={ 16 }>
 						{ integrationIds.map( id => {
-							const { enabled, is_set_up: isSetUp, setup_url, name, description } = integrations[ id ];
+							const integration = integrations[ id ];
+							const { enabled, is_set_up: isSetUp, setup_url, name, description } = integration;
+							const missingPlugins = getMissingPlugins( integration );
+							const requiresInstallPlugins = missingPlugins.filter( plugin => ! plugin.is_installed );
+							// Only offer Activate when every missing plugin is at least installed;
+							// otherwise the card stays in the disabled "Requires …" state until the
+							// uninstalled plugin is installed first.
+							const activatablePlugins = requiresInstallPlugins.length === 0 ? missingPlugins : [];
+							const canActivate = activatablePlugins.length > 0;
+							const isActivating = canActivate && activatablePlugins.some( plugin => activating[ plugin.slug ] );
+							const requirements = missingPlugins.length
+								? sprintf(
+										/* translators: %s: comma-separated list of required plugin names. */
+										__( 'Requires %s', 'newspack-plugin' ),
+										missingPlugins.map( plugin => plugin.name ).join( ', ' )
+								  )
+								: undefined;
 							const isEnabled = enabled;
 							const needsSetup = ! isSetUp && !! setup_url;
 							const goToSetup = () => {
 								window.location.href = setup_url;
 							};
+							let enableLabel = isSetUp ? __( 'Enable', 'newspack-plugin' ) : __( 'Connect', 'newspack-plugin' );
+							let onEnable = needsSetup ? goToSetup : () => onToggleEnabled( id, true );
+							if ( canActivate ) {
+								enableLabel = isActivating ? __( 'Activating…', 'newspack-plugin' ) : __( 'Activate', 'newspack-plugin' );
+								onEnable = () => onActivatePlugin( activatablePlugins.map( plugin => plugin.slug ) );
+							}
 							return (
 								<CardFeature
 									key={ id }
@@ -67,9 +91,11 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, histo
 									description={ description }
 									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
 									enabled={ isEnabled }
-									enableLabel={ isSetUp ? __( 'Enable', 'newspack-plugin' ) : __( 'Connect', 'newspack-plugin' ) }
+									requirements={ requirements }
+									requirementsActionable={ canActivate }
+									enableLabel={ enableLabel }
 									configureLabel={ needsSetup ? __( 'Configure', 'newspack-plugin' ) : undefined }
-									onEnable={ needsSetup ? goToSetup : () => onToggleEnabled( id, true ) }
+									onEnable={ onEnable }
 									onConfigure={ needsSetup ? goToSetup : () => history?.push( `/settings/${ id }` ) }
 									moreControls={
 										isEnabled

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-sample-integration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-sample-integration.php
@@ -33,11 +33,18 @@ class Sample_Integration extends Integration {
 	public $my_account_render_calls = [];
 
 	/**
+	 * Settings fields to return from register_settings_fields(). Tests that
+	 * need declared fields set this before constructing the integration.
+	 *
+	 * @var array
+	 */
+	public static $declared_settings_fields = [];
+
+	/**
 	 * Register settings fields (test implementation).
 	 */
 	public function register_settings_fields() {
-		// No settings fields for this test implementation.
-		return [];
+		return self::$declared_settings_fields;
 	}
 
 	/**
@@ -84,6 +91,17 @@ class Sample_Integration extends Integration {
 	}
 
 	/**
+	 * Sanitize a settings field value (public wrapper for testing).
+	 *
+	 * @param array $field The field declaration.
+	 * @param mixed $value The value to sanitize.
+	 * @return mixed
+	 */
+	public function test_sanitize_settings_field_value( $field, $value ) {
+		return $this->sanitize_settings_field_value( $field, $value );
+	}
+
+	/**
 	 * Sample handler method for data events.
 	 *
 	 * @param int    $timestamp Timestamp.
@@ -102,7 +120,8 @@ class Sample_Integration extends Integration {
 	 * Reset captured state between tests.
 	 */
 	public static function reset() {
-		self::$handler_args = null;
+		self::$handler_args            = null;
+		self::$declared_settings_fields = [];
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-esp.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-esp.php
@@ -20,6 +20,22 @@ require_once dirname( __DIR__, 2 ) . '/mocks/newsletters-mocks.php';
 class Test_ESP extends \WP_UnitTestCase {
 
 	/**
+	 * Whether a test mutated the cached get_plugins() result. tear_down deletes
+	 * the cache when set, so the next caller rescans the real plugin directory.
+	 *
+	 * @var bool
+	 */
+	private $plugins_cache_dirty = false;
+
+	/**
+	 * Snapshot of the `active_plugins` option taken before a test mutates it,
+	 * so tear_down can restore the original value.
+	 *
+	 * @var array|null
+	 */
+	private $original_active_plugins = null;
+
+	/**
 	 * Cleanup state set up by individual tests so failures don't leak across cases.
 	 */
 	public function tear_down() {
@@ -27,7 +43,53 @@ class Test_ESP extends \WP_UnitTestCase {
 		remove_all_filters( 'newspack_ras_metadata_keys' );
 		remove_all_filters( 'newspack_ras_metadata_prefix' );
 		\delete_option( 'newspack_integration_incoming_fields_esp' );
+		if ( $this->plugins_cache_dirty ) {
+			\wp_cache_delete( 'plugins', 'plugins' );
+			$this->plugins_cache_dirty = false;
+		}
+		if ( null !== $this->original_active_plugins ) {
+			\update_option( 'active_plugins', $this->original_active_plugins );
+			$this->original_active_plugins = null;
+		}
+		\Newspack\Plugin_Manager::reset_managed_plugin_status_cache();
 		parent::tear_down();
+	}
+
+	/**
+	 * Stub Plugin_Manager::get_managed_plugin_status() for the newspack-newsletters
+	 * slug by pre-populating the cached get_plugins() result and the active_plugins option.
+	 *
+	 * Core's get_plugins() short-circuits on its `plugins` cache key in the `plugins`
+	 * group, so writing into that cache bypasses the real filesystem scan. The
+	 * all_plugins filter does NOT cover this path — it only fires from the admin
+	 * plugins list table.
+	 *
+	 * @param string $status One of 'active', 'inactive', 'uninstalled'.
+	 */
+	private function stub_newsletters_status( $status ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_file                   = 'newspack-newsletters/newspack-newsletters.php';
+		$this->original_active_plugins = \get_option( 'active_plugins', [] );
+
+		$plugins = \get_plugins();
+		if ( 'uninstalled' === $status ) {
+			unset( $plugins[ $plugin_file ] );
+		} else {
+			$plugins[ $plugin_file ] = [
+				'Name'    => 'Newspack Newsletters',
+				'Version' => '1.0.0',
+			];
+		}
+		\wp_cache_set( 'plugins', [ '' => $plugins ], 'plugins' );
+		$this->plugins_cache_dirty = true;
+
+		\update_option(
+			'active_plugins',
+			'active' === $status ? [ $plugin_file ] : []
+		);
 	}
 
 	/**
@@ -407,5 +469,49 @@ class Test_ESP extends \WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'good', $result[0]->get_key() );
+	}
+
+	/**
+	 * Active newspack-newsletters maps to is_active=true, is_installed=true so the
+	 * integrations UI shows the normal Enable/Connect action, not the requirements badge.
+	 */
+	public function test_get_required_plugins_reports_active_state() {
+		$this->stub_newsletters_status( 'active' );
+
+		$required = ( new ESP() )->get_required_plugins();
+
+		$this->assertCount( 1, $required );
+		$this->assertSame( 'newspack-newsletters', $required[0]['slug'] );
+		$this->assertSame( 'Newspack Newsletters', $required[0]['name'] );
+		$this->assertTrue( $required[0]['is_active'] );
+		$this->assertTrue( $required[0]['is_installed'] );
+	}
+
+	/**
+	 * Installed-but-inactive newspack-newsletters maps to is_active=false, is_installed=true
+	 * so the integrations UI shows the Activate remediation button.
+	 */
+	public function test_get_required_plugins_reports_inactive_state() {
+		$this->stub_newsletters_status( 'inactive' );
+
+		$required = ( new ESP() )->get_required_plugins();
+
+		$this->assertCount( 1, $required );
+		$this->assertFalse( $required[0]['is_active'] );
+		$this->assertTrue( $required[0]['is_installed'] );
+	}
+
+	/**
+	 * Absent newspack-newsletters maps to is_active=false, is_installed=false so the
+	 * integrations UI falls back to a disabled "Requires …" affordance.
+	 */
+	public function test_get_required_plugins_reports_uninstalled_state() {
+		$this->stub_newsletters_status( 'uninstalled' );
+
+		$required = ( new ESP() )->get_required_plugins();
+
+		$this->assertCount( 1, $required );
+		$this->assertFalse( $required[0]['is_active'] );
+		$this->assertFalse( $required[0]['is_installed'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -1199,4 +1199,254 @@ class Test_Integrations extends \WP_UnitTestCase {
 		Integrations::register_my_account_endpoints();
 		$this->assertSame( [ 'two-page' ], get_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION ) );
 	}
+
+	/**
+	 * OAuth settings field value: scalar strings are sanitized through sanitize_text_field.
+	 */
+	public function test_sanitize_settings_field_value_oauth_scalar() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		$field       = [
+			'key'  => 'token',
+			'type' => 'oauth',
+		];
+
+		$this->assertSame(
+			'abc123',
+			$integration->test_sanitize_settings_field_value( $field, 'abc123' )
+		);
+		// Tags stripped by sanitize_text_field.
+		$this->assertSame(
+			'token',
+			$integration->test_sanitize_settings_field_value( $field, '<b>token</b>' )
+		);
+		// Non-string scalars are coerced to a string then sanitized.
+		$this->assertSame(
+			'42',
+			$integration->test_sanitize_settings_field_value( $field, 42 )
+		);
+	}
+
+	/**
+	 * OAuth settings field value: non-scalar payloads are rejected and the default is returned.
+	 */
+	public function test_sanitize_settings_field_value_oauth_non_scalar_returns_default() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+
+		// No default declared: falls back to empty string.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'  => 'token',
+					'type' => 'oauth',
+				],
+				[ 'unexpected' => 'array' ]
+			)
+		);
+		// Explicit default is honored.
+		$this->assertSame(
+			'fallback',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'     => 'token',
+					'type'    => 'oauth',
+					'default' => 'fallback',
+				],
+				(object) [ 'unexpected' => 'object' ]
+			)
+		);
+	}
+
+	/**
+	 * Hidden settings field value: scalar strings are sanitized, non-scalars return the default.
+	 */
+	public function test_sanitize_settings_field_value_hidden() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		$field       = [
+			'key'  => 'secret',
+			'type' => 'hidden',
+		];
+
+		$this->assertSame(
+			'opaque-id',
+			$integration->test_sanitize_settings_field_value( $field, 'opaque-id' )
+		);
+		// Non-scalar rejected.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value( $field, [ 'nope' ] )
+		);
+		// Explicit default honored on non-scalar payload.
+		$this->assertSame(
+			'kept',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'     => 'secret',
+					'type'    => 'hidden',
+					'default' => 'kept',
+				],
+				[ 'nope' ]
+			)
+		);
+	}
+
+	/**
+	 * The REST settings save entry point (update_integration_settings) drops
+	 * oauth/hidden keys so admin clients can't overwrite server-managed values
+	 * such as OAuth tokens. Other field types pass through.
+	 */
+	public function test_update_integration_settings_skips_managed_field_types() {
+		Sample_Integration::$declared_settings_fields = [
+			[
+				'key'     => 'api_label',
+				'type'    => 'text',
+				'default' => '',
+			],
+			[
+				'key'     => 'access_token',
+				'type'    => 'hidden',
+				'default' => '',
+			],
+			[
+				'key'     => 'connection',
+				'type'    => 'oauth',
+				'default' => '',
+			],
+		];
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		Integrations::register( $integration );
+
+		// Pre-seed the managed fields as if a server-side OAuth callback had
+		// written them. The REST endpoint must not overwrite these.
+		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_access_token', 'server-managed-token' );
+		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection', 'connected' );
+
+		$result = Integrations::update_integration_settings(
+			'test-id',
+			[
+				'api_label'    => 'My Label',
+				'access_token' => 'attempted-override',
+				'connection'   => 'attempted-override',
+			]
+		);
+
+		$this->assertTrue( $result );
+
+		// The non-managed field was written through.
+		$this->assertSame(
+			'My Label',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_api_label' )
+		);
+
+		// The managed fields kept their server-managed values.
+		$this->assertSame(
+			'server-managed-token',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_access_token' )
+		);
+		$this->assertSame(
+			'connected',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection' )
+		);
+	}
+
+	/**
+	 * Server-side writers (e.g., an OAuth callback) calling
+	 * update_settings_field_value() directly bypass the REST-path filter and
+	 * can still write oauth/hidden values.
+	 */
+	public function test_update_settings_field_value_writes_managed_field_types_directly() {
+		Sample_Integration::$declared_settings_fields = [
+			[
+				'key'     => 'access_token',
+				'type'    => 'hidden',
+				'default' => '',
+			],
+			[
+				'key'     => 'connection',
+				'type'    => 'oauth',
+				'default' => '',
+			],
+		];
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+
+		$integration->update_settings_field_value( 'access_token', 'fresh-token' );
+		$integration->update_settings_field_value( 'connection', 'connected' );
+
+		$this->assertSame(
+			'fresh-token',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_access_token' )
+		);
+		$this->assertSame(
+			'connected',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection' )
+		);
+	}
+
+	/**
+	 * Integrations that don't override get_required_plugins() report an empty
+	 * required_plugins array in the settings payload, so the audience UI renders
+	 * them without a requirements badge.
+	 */
+	public function test_get_all_integration_settings_defaults_required_plugins_to_empty_array() {
+		$integration = new Sample_Integration( 'no-overrides', 'No Overrides' );
+		Integrations::register( $integration );
+
+		$settings = Integrations::get_all_integration_settings();
+
+		$this->assertArrayHasKey( 'no-overrides', $settings );
+		$this->assertArrayHasKey( 'required_plugins', $settings['no-overrides'] );
+		$this->assertSame( [], $settings['no-overrides']['required_plugins'] );
+	}
+
+	/**
+	 * A child integration overriding get_required_plugins() has its declaration
+	 * surfaced verbatim in the settings payload that drives the audience UI card.
+	 */
+	public function test_get_all_integration_settings_surfaces_required_plugins_override() {
+		$declared    = [
+			[
+				'slug'         => 'some-dependency',
+				'name'         => 'Some Dependency',
+				'is_active'    => false,
+				'is_installed' => true,
+			],
+		];
+		$integration = new class( 'with-deps', 'With Deps', $declared ) extends Sample_Integration {
+			/**
+			 * Declared required-plugins payload returned by the override.
+			 *
+			 * @var array
+			 */
+			private $declared;
+
+			/**
+			 * Capture the declaration the test wants returned, then defer
+			 * construction to the parent.
+			 *
+			 * @param string $id       Integration id.
+			 * @param string $name     Integration name.
+			 * @param array  $declared Required-plugins payload to return.
+			 */
+			public function __construct( $id, $name, $declared ) {
+				$this->declared = $declared;
+				parent::__construct( $id, $name );
+			}
+
+			/**
+			 * Return the test-supplied required-plugins payload.
+			 *
+			 * @return array
+			 */
+			public function get_required_plugins() {
+				return $this->declared;
+			}
+		};
+
+		Integrations::register( $integration );
+
+		$settings = Integrations::get_all_integration_settings();
+
+		$this->assertArrayHasKey( 'with-deps', $settings );
+		$this->assertSame( $declared, $settings['with-deps']['required_plugins'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The monorepo baseline (PR #70) snapshotted newspack-plugin at legacy **6.41.2**. Four commits that landed on legacy `trunk` afterward never crossed over, because the daily sync escalated on newspack-plugin every run (the recurring `route_extracted_packages` conflict, fixed in #126) and `monorepo-integration` was auto-deleted when #70 merged. Since development is now on the monorepo, this lands that delta **directly on `main`**:

- #4711, #4721 (card-feature: inactive plugin state), #4744
- **#4750** (editor: exclude Customizer Additional CSS from iframed editor) — the 6.41.3 fix the published `newspack-plugin.zip` already shipped (the release asset was reused from the legacy release) but the monorepo tree lacked.

Produced by the fixed `bin/migration` integrate logic against `main`: extracted-package files route to `packages/<pkg>/`, and the in-plugin `packages/{colors,components,icons}` symlink shims are preserved.

### How to test the changes in this Pull Request:

1. `grep strip_customizer_css_from_editor plugins/newspack-plugin/includes/class-patches.php` — present.
2. `packages/components/src/card-feature/index.tsx` carries the `isConfigureState`/`requirementsActionable` version.
3. `plugins/newspack-plugin/packages/{colors,components,icons}` remain symlinks; the workspace `packages/components/*` holds the routed source.

### Other information:

Follow-ups (separate): retire the obsolete `sync-legacy.yml` workflow (it targets the deleted `monorepo-integration`), then repoint `alpha`/`release` and reconcile the `newspack@6.41.3` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)