### PR TITLE
ci(sync): retarget legacy sync to main via auto-merging PR

### DIFF
--- a/.github/workflows/sync-legacy.yml
+++ b/.github/workflows/sync-legacy.yml
@@ -4,9 +4,16 @@ name: Sync legacy repos
 #
 # bin/migration/sync-legacy.sh runs end-to-end: filters each legacy repo's
 # trunk into the monorepo layout, publishes per-repo sync/<name> branches,
-# and merges them into monorepo-integration with auto-resolution and per-repo
-# escalation (draft PR with @adekbadek as reviewer) for any repo that
-# can't be merged automatically. See that script for the policy.
+# and integrates them onto main. Clean merges are pushed to the
+# sync/legacy-incoming branch and landed via an auto-merging PR (merge commit,
+# never squash, so per-commit types survive for release versioning); repos that
+# can't be merged automatically escalate to a draft PR (@adekbadek reviewer).
+# See that script for the policy.
+#
+# Post-cutover there is no monorepo-integration branch (it was merged into main
+# and deleted). main is the integration target; the sync lands legacy commits
+# that merged on the now-frozen legacy trunks (new legacy PRs are blocked, but
+# already-open ones still merge upstream and must keep flowing in).
 #
 # The same script runs locally — DRY_RUN=1 bin/migration/sync-legacy.sh from
 # any worktree skips git push and gh pr create.
@@ -32,23 +39,24 @@ jobs:
     name: Filter, publish, and integrate
     runs-on: ubuntu-latest
     steps:
-      # Sync scripts live on main; the working tree the script merges into
-      # is monorepo-integration. Two checkouts keep them separate.
+      # Sync scripts and the working tree are both main now. Two checkouts keep
+      # the read-only script copy (scripts-src) separate from the working tree
+      # the script integrates into and pushes from (integration).
       - name: Check out main (sync scripts)
         uses: actions/checkout@v4
         with:
           ref: main
           path: scripts-src
-      - name: Check out monorepo-integration (working tree)
+      - name: Check out main (working tree)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use a PAT (not GITHUB_TOKEN) so the sync's pushes to
-          # monorepo-integration trigger CI. Commits pushed with GITHUB_TOKEN
-          # do not start new workflow runs, which would leave synced changes
-          # (and PR #70's checks) silently un-validated.
+          # Use the matticbot PAT (not GITHUB_TOKEN) so the sync's push to
+          # sync/legacy-incoming triggers CI (GITHUB_TOKEN pushes don't start
+          # workflow runs) and so the auto-merge runs as matticbot — the
+          # identity allowed to bypass main's required review.
           token: ${{ secrets.GH_TOKEN }}
-          ref: monorepo-integration
+          ref: main
           path: integration
       - name: Install git-filter-repo
         run: |
@@ -70,7 +78,10 @@ jobs:
       - name: Run sync
         working-directory: integration
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # matticbot PAT: it opens and auto-merges the PR to main (it is the
+          # bypass-allowed identity for main's required review) and its branch
+          # push triggers CI.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           # Org-scoped token for cloning private legacy repos (currently
           # only newspack-story-budget). The default GITHUB_TOKEN is scoped
           # to this repo and can't read other private Automattic repos.

--- a/bin/migration/sync-legacy.sh
+++ b/bin/migration/sync-legacy.sh
@@ -32,11 +32,11 @@
 #   bin/sync-legacy.sh                # full run (CI default)
 #   DRY_RUN=1 bin/sync-legacy.sh      # local: no git push, no gh pr create
 #
-# Run from any worktree whose HEAD is the integration target. CI uses
-# monorepo-integration; locally you can test against any tip.
+# Run from any worktree whose HEAD is the integration target. CI uses main;
+# locally you can test against any tip.
 #
-# Required tools: git, git-filter-repo, gh (only when DRY_RUN!=1 and a
-# conflict triggers escalation).
+# Required tools: git, git-filter-repo, gh (gh is used on a real run to open
+# and auto-merge the PR to main, and to escalate conflicts).
 
 set -euo pipefail
 
@@ -53,17 +53,17 @@ PARALLEL_FILTER_JOBS="${PARALLEL_FILTER_JOBS:-5}"
 . "$SCRIPT_DIR/lib.sh"
 
 # In dry-run mode, transparently re-execute inside a fresh detached-HEAD
-# worktree based off the integration target (origin/monorepo-integration by
-# default; override with DRY_RUN_BASE) so the caller's working tree and HEAD
-# are left untouched, and so dry-runs reproduce CI semantics regardless of
-# the branch the user happens to be on.
+# worktree based off the integration target (origin/main by default; override
+# with DRY_RUN_BASE) so the caller's working tree and HEAD are left untouched,
+# and so dry-runs reproduce CI semantics regardless of the branch the user
+# happens to be on.
 #
 # Trap cleans up the worktree and scratch dir on any exit, including SIGINT.
 if [ "$DRY_RUN" = "1" ] && [ "${SYNC_LEGACY_DRY_RUN_ISOLATED:-0}" != "1" ]; then
-  DRY_RUN_BASE="${DRY_RUN_BASE:-origin/monorepo-integration}"
+  DRY_RUN_BASE="${DRY_RUN_BASE:-origin/main}"
   if ! git rev-parse --verify --quiet "$DRY_RUN_BASE" > /dev/null; then
     echo "ERROR: DRY_RUN_BASE '$DRY_RUN_BASE' not found." >&2
-    echo "       Either fetch it (git fetch origin monorepo-integration) or" >&2
+    echo "       Either fetch it (git fetch origin main) or" >&2
     echo "       override: DRY_RUN_BASE=<ref> DRY_RUN=1 bin/sync-legacy.sh" >&2
     exit 2
   fi
@@ -174,7 +174,7 @@ escalate() {
 
   git add -A
   git commit --no-edit \
-    -m "sync(conflict): unresolved merge of ${name} into monorepo-integration"
+    -m "sync(conflict): unresolved merge of ${name} into main"
 
   local marker_files
   marker_files=$(git grep -lE '^<<<<<<< |^>>>>>>> ' HEAD -- 2>/dev/null | head -50 || true)
@@ -182,12 +182,12 @@ escalate() {
   git_push origin "HEAD:refs/heads/$branch"
 
   gh_pr_create \
-    --base monorepo-integration \
+    --base main \
     --head "$branch" \
     --draft \
     --reviewer adekbadek \
     --title "sync conflict: $name" \
-    --body "$(printf 'Daily legacy-sync job hit unresolvable conflicts merging \`%s\` into \`monorepo-integration\`.\n\n**To resolve:**\n\n```\ngh pr checkout %s\ngit grep -lE %s | xargs -r $EDITOR   # fix conflict markers\ngit add -A\ngit commit --amend --no-edit\ngit push --force-with-lease\n```\n\nThen mark this PR ready for review and merge.\n\nFiles with conflict markers:\n\n```\n%s\n```\n' "$name" "$branch" "'^<<<<<<< |^>>>>>>> '" "${marker_files:-(none — only structural conflicts)}")"
+    --body "$(printf 'Daily legacy-sync job hit unresolvable conflicts merging \`%s\` into \`main\`.\n\n**To resolve:**\n\n```\ngh pr checkout %s\ngit grep -lE %s | xargs -r $EDITOR   # fix conflict markers\ngit add -A\ngit commit --amend --no-edit\ngit push --force-with-lease\n```\n\nThen mark this PR ready for review and merge.\n\nFiles with conflict markers:\n\n```\n%s\n```\n' "$name" "$branch" "'^<<<<<<< |^>>>>>>> '" "${marker_files:-(none — only structural conflicts)}")"
 
   git reset --hard "$saved"
 }
@@ -252,11 +252,43 @@ integrate_all() {
 
   if [ "$(git rev-parse HEAD)" != "$START" ]; then
     regenerate_lockfile
-    echo "==> Pushing $(git rev-list --count "$START..HEAD") new commits to monorepo-integration"
-    git_push origin HEAD:monorepo-integration
+    land_on_main "$START"
   else
-    echo "==> No clean merges this run; nothing to push to monorepo-integration"
+    echo "==> No clean merges this run; nothing to land on main"
   fi
+}
+
+# Land the integrated commits on main via an auto-merging PR. main is protected
+# (no direct pushes), so the sync force-updates the standing sync/legacy-incoming
+# branch, ensures a PR to main is open, and enables auto-merge with a MERGE
+# commit. Squash is never used: it would collapse the per-plugin merge commits
+# (and the individual legacy commits they carry), and semantic-release would then
+# mis-compute version bumps. Auto-merge clears main's required review because the
+# matticbot identity (whose token runs gh here) is on main's bypass list; it
+# completes once the required CI check passes.
+INCOMING_BRANCH="${INCOMING_BRANCH:-sync/legacy-incoming}"
+land_on_main() {
+  local start=$1
+  local n
+  n=$(git rev-list --count "$start..HEAD")
+  echo "==> Landing $n new commits on main via PR (branch: $INCOMING_BRANCH)"
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "    [dry-run] would force-push HEAD:$INCOMING_BRANCH, open/refresh a PR to main, and enable --auto --merge"
+    return 0
+  fi
+  git_push origin --force "HEAD:refs/heads/$INCOMING_BRANCH"
+  # Open the PR if one isn't already open for the branch (the force-push above
+  # updates an existing one in place).
+  if ! gh pr view "$INCOMING_BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+    gh pr create \
+      --base main \
+      --head "$INCOMING_BRANCH" \
+      --title "sync: land legacy trunk commits" \
+      --body "$(printf 'Automated daily sync of commits that merged on the (frozen) legacy trunks into the monorepo.\n\n**Merge with a merge commit, never squash** — squashing collapses the per-plugin commits and breaks semantic-release version computation. Auto-merge (merge) is enabled; it lands once CI passes.')" \
+      || echo "WARN: gh pr create failed; branch is on origin for manual handling"
+  fi
+  gh pr merge "$INCOMING_BRANCH" --auto --merge \
+    || echo "WARN: could not enable auto-merge; PR is open on origin for manual merge"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`monorepo-integration` was auto-deleted when PR #70 merged, so the daily `sync-legacy.yml` job has been failing at checkout. Post-cutover, `main` is the integration target.

The sync now checks out `main`, pushes the integrated result to a standing `sync/legacy-incoming` branch, opens/refreshes a PR to `main`, and enables auto-merge with a **merge commit** (never squash — preserves per-commit types for release versioning). Unresolvable conflicts still escalate to a draft PR against `main`. The Run-sync step uses the `matticbot` PAT (`secrets.GH_TOKEN`) so its branch push triggers CI and the auto-merge runs as the bypass-allowed identity.

### Activation (separate, not in this PR)

Requires (real repo): enable repo-level auto-merge + add `matticbot` to `main`s PR-review bypass allowance. If auto-merge cannot engage, the PR stays open for manual merge (graceful degradation).

### How to test

DRY_RUN=1 validated locally: isolates off `origin/main`, integrates all 15 repos cleanly (newspack-plugin up-to-date, others auto-resolve, no escalations), and reaches the land step. First real run lands the ~58-commit post-baseline legacy backlog (all chore/ci/translation — no release impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)