### PR TITLE
fix(ci): restore workspace:* deps in post-release branch maintenance

### DIFF
--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -5,13 +5,16 @@
 # After a release on the `release` branch:
 #   - reset the single-serving `alpha` branch onto `release` (when the release
 #     came from an alpha merge), or merge `release` into `alpha` otherwise;
+#   - restore `workspace:*` for any internal workspace dep that the release
+#     concretized (see restore_workspace_deps below);
 #   - merge `release` back into the repository's default branch so they stay in
-#     sync, notifying Slack on conflict.
+#     sync (then restore workspace:* there too), notifying Slack on conflict.
 #
 # This lives in the monorepo (not packages/scripts, which mirrors the legacy
 # newspack-scripts repo and is overwritten by the daily sync) and targets the
 # repo's actual default branch rather than the hard-coded `trunk` the legacy
-# script used. Pure git — no package manager required.
+# script used. Uses node only for the small workspace-deps rewrite (preinstalled
+# on ubuntu-latest runners); otherwise pure git.
 
 set -euo pipefail
 
@@ -24,6 +27,67 @@ DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
 # carries the merge info used to decide whether the release came from alpha.
 SECOND_TO_LAST_COMMIT_MSG=$(git log -n 1 --skip 1 --pretty=format:"%s")
 LATEST_VERSION_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "release")
+
+# Restore workspace:* for any internal monorepo dep
+# (newspack-{scripts,components,colors,icons}) in every plugin/theme
+# package.json, then commit if anything changed.
+#
+# Why: @semantic-release/npm's prepare step rewrites "workspace:*" to a concrete
+# version in package.json before publishing to npm (npm can't consume
+# workspace:*), and @semantic-release/git then commits that change to the
+# `release` branch as part of the release commit. Resetting alpha onto release
+# (and merging release into the default branch) carries those concrete versions
+# forward, but pnpm-lock.yaml at the workspace root is keyed to workspace:* —
+# the next `pnpm install --frozen-lockfile` then fails with
+# ERR_PNPM_OUTDATED_LOCKFILE. Restoring workspace:* here keeps both branches
+# consistent with the lockfile and lets the next trunk→alpha promotion merge
+# cleanly without any manual restoration dance.
+#
+# The commit (when needed) carries [skip ci] so it doesn't re-trigger
+# release.yml — the alpha branch tip is then a chore[skip ci], same as today,
+# and the team's normal promotion merge commit later (without [skip ci]) is
+# what fires release.yml.
+restore_workspace_deps_and_commit() {
+  local branch="$1"
+  node -e '
+    const fs = require("fs"), path = require("path");
+    const WS_PACKAGES = ["newspack-scripts", "newspack-components", "newspack-colors", "newspack-icons"];
+    const roots = ["plugins", "themes"];
+    const changed = [];
+    for (const r of roots) {
+      if (!fs.existsSync(r)) continue;
+      for (const name of fs.readdirSync(r)) {
+        const pj = path.join(r, name, "package.json");
+        if (!fs.existsSync(pj)) continue;
+        const src = fs.readFileSync(pj, "utf8");
+        const indentMatch = src.match(/\n(\t+|[ ]+)"/);
+        const indent = indentMatch ? indentMatch[1] : "  ";
+        const trail = src.endsWith("\n") ? "\n" : "";
+        const j = JSON.parse(src);
+        let dirty = false;
+        for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+          if (!j[section]) continue;
+          for (const pkg of WS_PACKAGES) {
+            if (j[section][pkg] && j[section][pkg] !== "workspace:*") {
+              j[section][pkg] = "workspace:*";
+              dirty = true;
+            }
+          }
+        }
+        if (!dirty) continue;
+        fs.writeFileSync(pj, JSON.stringify(j, null, indent) + trail);
+        changed.push(pj);
+      }
+    }
+    for (const f of changed) process.stdout.write(f + "\0");
+  ' | while IFS= read -r -d "" f; do
+    git add -- "$f"
+  done
+  if [ -n "$(git status --porcelain)" ]; then
+    git commit -m "chore(release): restore workspace:* deps after release [skip ci]"
+    echo "[post-release] Restored workspace:* deps on $branch."
+  fi
+}
 
 # Notify Slack about a failed post-release merge into $1, if Slack is configured.
 notify_slack() {
@@ -48,10 +112,12 @@ if echo "$SECOND_TO_LAST_COMMIT_MSG" | grep -q '^Merge .*alpha'; then
   echo "[post-release] Release came from the alpha branch. Resetting alpha onto release."
   # The alpha branch is single-serving; discard its history after a release.
   git reset --hard release --
+  restore_workspace_deps_and_commit alpha
   git push --force origin alpha
 else
   echo "[post-release] Release came from a non-alpha branch (e.g. a hotfix). Merging release into alpha."
   if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then
+    restore_workspace_deps_and_commit alpha
     git push origin alpha
   else
     git merge --abort
@@ -63,6 +129,7 @@ fi
 echo "[post-release] Merging release into $DEFAULT_BRANCH."
 git checkout "$DEFAULT_BRANCH"
 if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then
+  restore_workspace_deps_and_commit "$DEFAULT_BRANCH"
   git push origin "$DEFAULT_BRANCH"
 else
   git merge --abort


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After each release, `.github/scripts/post-release.sh` now restores `workspace:*` for the internal monorepo deps (`newspack-scripts`/`components`/`colors`/`icons`) on both the `alpha` and the default branch, immediately after the existing reset/merge ops. Without this, every trunk → alpha promotion needs a manual `restore_workspace_deps` + `git commit --amend` dance.

**Why it's needed.** `@semantic-release/npm`'s prepare step rewrites `workspace:*` to a concrete version in `package.json` before npm publish (npm can't consume `workspace:*`); `@semantic-release/git` commits that to the `release` branch. `post-release.sh` then propagates those concrete versions onto `alpha` (via `reset --hard release`) and the default branch (via `merge release`). But `pnpm-lock.yaml` is workspace-keyed (`workspace:*`), so the next `pnpm install --frozen-lockfile` on either branch fails with `ERR_PNPM_OUTDATED_LOCKFILE`.

**How it works.** A small inline node script (logic mirrors `restore_workspace_deps` in `bin/migration/lib.sh`, but inlined so `post-release.sh` doesn't depend on the migration tree) walks `plugins/*/package.json` and `themes/*/package.json`, rewrites any of the 4 internal deps back to `workspace:*`, and the bash wrapper commits + pushes if anything changed. The commit carries `[skip ci]` so the alpha push still does not re-fire `release.yml`; the team's normal `trunk → alpha` merge commit (no `[skip ci]`) is what triggers the next-alpha run.

**Node availability.** Preinstalled on `ubuntu-latest` runners; no `setup-node` needed in the post-release job.

**Idempotency.** Only commits when something actually changed (no-op if already `workspace:*`).

Surfaced during the NPPM-2752 sandbox rehearsal (cycle 3, `main → alpha` promotion): the lockfile/package.json mismatch caused `ERR_PNPM_OUTDATED_LOCKFILE` until `restore_workspace_deps` was applied and amended into the merge commit. This fix moves that handling upstream into `post-release.sh` so future promotions are clean merges.

Closes #.

### How to test the changes in this Pull Request:

Local smoke test (run against a fixture):

```sh
mkdir -p /tmp/test/plugins/foo
cat > /tmp/test/plugins/foo/package.json <<JSON
{ "name": "foo", "dependencies": { "newspack-colors": "1.1.0", "newspack-icons": "1.0.8", "qs": "^6.15.2" } }
JSON
cd /tmp/test && node -e '<paste the embedded node block from post-release.sh>'
grep newspack /tmp/test/plugins/foo/package.json
# Expect: "newspack-colors": "workspace:*", "newspack-icons": "workspace:*"
# qs untouched.
```

End-to-end this lands at the next `release` push (June 1). The next `trunk → alpha` promotion (June 4) will then be a vanilla `git merge --no-ff main` with no special restoration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)