### PR TITLE
fix(story-budget): pin react-router-dom to v5; bring RTT build config from main

### DIFF
--- a/plugins/newspack-story-budget/CHANGELOG.md
+++ b/plugins/newspack-story-budget/CHANGELOG.md
@@ -1,0 +1,6 @@
+## newspack-story-budget [1.0.1-hotfix-story-budget-router.1](https://github.com/Automattic/newspack-workspace/compare/newspack-story-budget@1.0.0...newspack-story-budget@1.0.1-hotfix-story-budget-router.1) (2026-05-28)
+
+
+### Bug Fixes
+
+* **story-budget:** pin react-router-dom to v5 to match source API usage ([c5a67d9](https://github.com/Automattic/newspack-workspace/commit/c5a67d9b5732425ae4e806a2af118346955c12bc))

--- a/plugins/newspack-story-budget/newspack-story-budget.php
+++ b/plugins/newspack-story-budget/newspack-story-budget.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Story Budget
  * Description: Story budgeting by Newspack.
- * Version: 1.0.0
+ * Version: 1.0.1-hotfix-story-budget-router.1
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_STORY_BUDGET_VERSION', '1.0.0' );
+define( 'NEWSPACK_STORY_BUDGET_VERSION', '1.0.1-hotfix-story-budget-router.1' );
 
 // Define NEWSPACK_STORY_BUDGET_PLUGIN_DIR.
 if ( ! defined( 'NEWSPACK_STORY_BUDGET_PLUGIN_DIR' ) ) {

--- a/plugins/newspack-story-budget/package.json
+++ b/plugins/newspack-story-budget/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-story-budget",
-	"version": "1.0.0",
+	"version": "1.0.1-hotfix-story-budget-router.1",
 	"description": "Story budgeting by Newspack. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-story-budget/issues"
@@ -41,8 +41,8 @@
 		"classnames": "^2.5.0",
 		"clsx": "^2.1.0",
 		"lodash": "^4.17.0",
-		"newspack-components": "workspace:*",
-		"newspack-scripts": "workspace:*",
+		"newspack-components": "4.3.0",
+		"newspack-scripts": "5.9.8",
 		"react-dom": "^18.0.0",
 		"react-router-dom": "^5.3.4",
 		"redux": "^5.0.0"

--- a/plugins/newspack-story-budget/package.json
+++ b/plugins/newspack-story-budget/package.json
@@ -41,8 +41,8 @@
 		"classnames": "^2.5.0",
 		"clsx": "^2.1.0",
 		"lodash": "^4.17.0",
-		"newspack-components": "4.3.0",
-		"newspack-scripts": "5.9.8",
+		"newspack-components": "workspace:*",
+		"newspack-scripts": "workspace:*",
 		"react-dom": "^18.0.0",
 		"react-router-dom": "^5.3.4",
 		"redux": "^5.0.0"

--- a/plugins/newspack-story-budget/package.json
+++ b/plugins/newspack-story-budget/package.json
@@ -44,7 +44,7 @@
 		"newspack-components": "workspace:*",
 		"newspack-scripts": "workspace:*",
 		"react-dom": "^18.0.0",
-		"react-router-dom": "^6.0.0",
+		"react-router-dom": "^5.3.4",
 		"redux": "^5.0.0"
 	},
 	"repository": {

--- a/plugins/republication-tracker-tool/.distignore
+++ b/plugins/republication-tracker-tool/.distignore
@@ -35,3 +35,4 @@ contributing.md
 docs
 release.sh
 release
+src

--- a/plugins/republication-tracker-tool/.gitignore
+++ b/plugins/republication-tracker-tool/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 *.sql
 *.tar.gz
 *.zip
+dist/
 release/
 vendor
 .phpunit.result.cache

--- a/plugins/republication-tracker-tool/src/index.js
+++ b/plugins/republication-tracker-tool/src/index.js
@@ -1,0 +1,131 @@
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { ToggleControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+const META_KEY = 'republication-tracker-tool-hide-widget';
+
+const RepublicationTrackerPanel = () => {
+	const { postType, meta, filterHides, shareData } = useSelect(
+		( select ) => {
+			const editor = select( 'core/editor' );
+			return {
+				postType: editor.getCurrentPostType(),
+				meta: editor.getEditedPostAttribute( 'meta' ),
+				filterHides: editor.getEditedPostAttribute(
+					'republication_tracker_tool_filter_hides'
+				),
+				shareData: editor.getEditedPostAttribute(
+					'republication_tracker_tool_share_data'
+				),
+			};
+		},
+		[]
+	);
+
+	const { editPost } = useDispatch( 'core/editor' );
+
+	if ( 'post' !== postType ) {
+		return null;
+	}
+
+	const hideWidget = !! meta?.[ META_KEY ];
+	const total = shareData?.total ?? 0;
+	const entries = shareData?.entries ?? [];
+
+	return (
+		<PluginDocumentSettingPanel
+			name="republication-tracker-tool"
+			title={ __(
+				'Republication Widget Settings',
+				'republication-tracker-tool'
+			) }
+		>
+			<ToggleControl
+				label={ __(
+					'Hide Republication widget',
+					'republication-tracker-tool'
+				) }
+				checked={ filterHides ? true : hideWidget }
+				disabled={ filterHides }
+				onChange={ ( value ) =>
+					editPost( {
+						meta: { ...( meta ?? {} ), [ META_KEY ]: value },
+					} )
+				}
+				help={
+					filterHides
+						? createInterpolateElement(
+								// translators: <a> and </a> tags represent a link to the Republication Tracker README file on GitHub.
+								__(
+									'The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a>Read more about this filter</a>.',
+									'republication-tracker-tool'
+								),
+								{
+									code: <code />,
+									a: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/removing-republish-button-from-categories.md"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								}
+						  )
+						: undefined
+				}
+			/>
+			<p style={ { marginTop: '16px' } }>
+				{ __( 'Total number of views:', 'republication-tracker-tool' ) }{ ' ' }
+				{ total }
+			</p>
+			{ entries.length > 0 ? (
+				<table className="widefat striped">
+					<thead>
+						<tr>
+							<th>
+								{ __(
+									'Republished URL',
+									'republication-tracker-tool'
+								) }
+							</th>
+							<th>
+								{ __( 'Views', 'republication-tracker-tool' ) }
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ entries.map( ( entry ) => (
+							<tr key={ entry.url }>
+								<td>
+									<a
+										href={ entry.url }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ entry.url }
+									</a>
+								</td>
+								<td>{ entry.count }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			) : (
+				<p>
+					{ __(
+						'There are no shares to display.',
+						'republication-tracker-tool'
+					) }
+				</p>
+			) }
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'republication-tracker-tool', {
+	render: RepublicationTrackerPanel,
+} );

--- a/plugins/republication-tracker-tool/webpack.config.js
+++ b/plugins/republication-tracker-tool/webpack.config.js
@@ -1,0 +1,3 @@
+// Placeholder so the build script doesn't fail on the release branch,
+// which has no src/ entry points yet. The real config lives on main.
+module.exports = { entry: {} };

--- a/plugins/republication-tracker-tool/webpack.config.js
+++ b/plugins/republication-tracker-tool/webpack.config.js
@@ -1,3 +1,8 @@
-// Placeholder so the build script doesn't fail on the release branch,
-// which has no src/ entry points yet. The real config lives on main.
-module.exports = { entry: {} };
+const path = require( 'path' );
+const getBaseWebpackConfig = require( 'newspack-scripts/config/getWebpackConfig' );
+
+const entry = {
+	index: path.join( __dirname, 'src', 'index.js' ),
+};
+
+module.exports = getBaseWebpackConfig( { entry } );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,8 +515,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: ^6.0.0
-        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^5.3.4
+        version: 5.3.4(react@18.3.1)
       redux:
         specifier: ^5.0.0
         version: 5.0.1


### PR DESCRIPTION
## Summary

**Story Budget fix:** The monorepo migration declared `react-router-dom@^6.0.0` in story-budget's `package.json`, but the source code uses v5-only APIs (`Switch`, `Redirect`, `Route` with `component` prop). These named exports don't exist in v6, causing the app to crash with `React.jsx: type is invalid — got undefined` at runtime. Editors on sites using the release ZIP (e.g. Ledger and Recorder) see a blank Story Budget page.

- Pins `react-router-dom` to `^5.3.4` (matches what `newspack-components` already resolves)

**RTT build config:** The release branch predates RTT's block editor sidebar panel (added on main). Without `webpack.config.js` + `src/index.js`, the build step fails and blocks all releases. Cherry-picked from main so the post-release merge to main resolves cleanly. This is a `chore` commit — no RTT release triggered.

## How it happened

The legacy story-budget repo never declared `react-router-dom` directly — it resolved v5 via hoisting from `newspack-components`. During the monorepo dep-alignment pass (`6c20f5de4e`), the dependency was made explicit but pinned to `^6.0.0` instead of `^5.3.4`.

## Merge strategy

**Do NOT squash merge.** Use a merge commit (`gh pr merge --merge`). A squash would collapse the `chore` RTT commits and the `fix` story-budget commit into a single `fix` commit touching both packages — multi-semantic-release scopes by file path and would trigger a drive-by RTT release.

## Test plan

- [x] Prerelease `newspack-story-budget@1.0.1-hotfix-story-budget-router.1` created and tested
- [x] Installed release ZIP in isolated env — Story Budget page loads with 0 console errors
- [x] No drive-by releases (only story-budget released)
- [ ] Merge commit (not squash) to `release` → stable `1.0.1` → post-release syncs alpha + main