### PR TITLE
feat(emails): surface WooCommerce emails in unified UI — chip filtering, toggle, first-run (NPPD-1527, slice 2a)

### DIFF
--- a/plugins/newspack-plugin/includes/emails/class-emails.php
+++ b/plugins/newspack-plugin/includes/emails/class-emails.php
@@ -17,6 +17,25 @@ class Emails {
 	const EMAIL_CONFIG_NAME_META = 'newspack_email_type'; // "type" for legacy reasons.
 
 	/**
+	 * Request-scoped cache for `get_email_configs()`. Null = uncached.
+	 *
+	 * @var array|null
+	 */
+	private static $email_configs_cache = null;
+
+	/**
+	 * Reset the `get_email_configs()` request-scoped cache. Call after
+	 * mutating the `newspack_email_configs` filter mid-request (rare in
+	 * production; tests use it to assert per-filter-callback behavior
+	 * without bleeding state across assertions).
+	 *
+	 * @return void
+	 */
+	public static function reset_email_configs_cache(): void {
+		self::$email_configs_cache = null;
+	}
+
+	/**
 	 * Initialize.
 	 *
 	 * @codeCoverageIgnore
@@ -802,9 +821,21 @@ class Emails {
 	 *    may be absent.
 	 */
 	public static function get_email_configs() {
+		// Request-scoped memoization. This method is called repeatedly per
+		// request — directly by the wizard's response builder, and
+		// transitively by serialize_email/get_email_config_by_type once
+		// per email row. Each call would otherwise re-run apply_filters
+		// across every registered provider plus apply_config_defaults on
+		// every entry. Tests that mutate filter callbacks mid-test can
+		// invalidate the cache via reset_email_configs_cache().
+		if ( null !== self::$email_configs_cache ) {
+			return self::$email_configs_cache;
+		}
+
 		$configs = apply_filters( 'newspack_email_configs', [] );
 		if ( ! is_array( $configs ) ) {
-			return [];
+			self::$email_configs_cache = [];
+			return self::$email_configs_cache;
 		}
 		foreach ( $configs as $type => $config ) {
 			// Defensive: a third-party filter callback can return a non-array
@@ -818,7 +849,8 @@ class Emails {
 			}
 			$configs[ $type ] = self::apply_config_defaults( $config );
 		}
-		return $configs;
+		self::$email_configs_cache = $configs;
+		return self::$email_configs_cache;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/emails/class-emails.php
+++ b/plugins/newspack-plugin/includes/emails/class-emails.php
@@ -17,6 +17,25 @@ class Emails {
 	const EMAIL_CONFIG_NAME_META = 'newspack_email_type'; // "type" for legacy reasons.
 
 	/**
+	 * Request-scoped cache for `get_email_configs()`. Null = uncached.
+	 *
+	 * @var array|null
+	 */
+	private static $email_configs_cache = null;
+
+	/**
+	 * Reset the `get_email_configs()` request-scoped cache. Call after
+	 * mutating the `newspack_email_configs` filter mid-request (rare in
+	 * production; tests use it to assert per-filter-callback behavior
+	 * without bleeding state across assertions).
+	 *
+	 * @return void
+	 */
+	public static function reset_email_configs_cache(): void {
+		self::$email_configs_cache = null;
+	}
+
+	/**
 	 * Initialize.
 	 *
 	 * @codeCoverageIgnore
@@ -439,9 +458,21 @@ class Emails {
 	 *    may be absent.
 	 */
 	public static function get_email_configs() {
+		// Request-scoped memoization. This method is called repeatedly per
+		// request — directly by the wizard's response builder, and
+		// transitively by serialize_email/get_email_config_by_type once
+		// per email row. Each call would otherwise re-run apply_filters
+		// across every registered provider plus apply_config_defaults on
+		// every entry. Tests that mutate filter callbacks mid-test can
+		// invalidate the cache via reset_email_configs_cache().
+		if ( null !== self::$email_configs_cache ) {
+			return self::$email_configs_cache;
+		}
+
 		$configs = apply_filters( 'newspack_email_configs', [] );
 		if ( ! is_array( $configs ) ) {
-			return [];
+			self::$email_configs_cache = [];
+			return self::$email_configs_cache;
 		}
 		foreach ( $configs as $type => $config ) {
 			// Defensive: a third-party filter callback can return a non-array
@@ -455,7 +486,8 @@ class Emails {
 			}
 			$configs[ $type ] = self::apply_config_defaults( $config );
 		}
-		return $configs;
+		self::$email_configs_cache = $configs;
+		return self::$email_configs_cache;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -35,6 +35,321 @@ class WooCommerce_Emails {
 	public static function init() {
 		add_filter( 'option_woocommerce_feature_block_email_editor_enabled', [ __CLASS__, 'override_woocommerce_email_editor_option' ], 10, 2 );
 		add_action( 'admin_init', [ __CLASS__, 'update_woocommerce_emails_to_latest' ] );
+		add_filter( 'newspack_email_configs', [ __CLASS__, 'get_email_configs' ] );
+	}
+
+	/**
+	 * Curated allowlist of WooCommerce-source emails surfaced in the
+	 * unified emails wizard, keyed by `WC_Email::$id`. Wrapped in a
+	 * function so `__()` runs at filter time, not class-load time.
+	 *
+	 * The `class` field carries the WC_Email subclass name as a scalar
+	 * string. Storing the class name (not a live instance) keeps the
+	 * `newspack_email_configs` schema JSON-serializable and avoids
+	 * re-instantiating WC_Email objects across requests — the live
+	 * mailer-owned instance is resolved on demand via
+	 * {@see get_wc_email_by_id()}.
+	 *
+	 * @return array<string, array{
+	 *     class: string,
+	 *     chip: 'auth-account'|'reader-revenue',
+	 *     recipient: 'reader'|'admin',
+	 *     recommended: bool,
+	 *     plugin_dependency: ?string,
+	 *     label: string,
+	 *     trigger_description: string,
+	 * }>
+	 */
+	private static function surfaced_wc_emails(): array {
+		return [
+			'customer_notification_auto_renewal' => [
+				'class'               => 'WCS_Email_Customer_Notification_Auto_Renewal',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Renewal reminder', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent before automatic renewal (timing depends on WooCommerce Subscriptions settings).', 'newspack-plugin' ),
+			],
+			'customer_payment_retry'             => [
+				'class'               => 'WCS_Email_Customer_Payment_Retry',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Failed order retry', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a renewal payment fails, before the retry attempt.', 'newspack-plugin' ),
+			],
+			'expired_subscription'               => [
+				'class'               => 'WCS_Email_Expired_Subscription',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Subscription expired', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a subscription reaches its expiration date.', 'newspack-plugin' ),
+			],
+			'customer_completed_switch_order'    => [
+				'class'               => 'WCS_Email_Completed_Switch_Order',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Subscription switch complete', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a reader switches their subscription.', 'newspack-plugin' ),
+			],
+			'WCSG_Email_Customer_New_Account'    => [
+				'class'               => 'WCSG_Email_Customer_New_Account',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'New giftee account', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the giftee when a gift subscription creates their account.', 'newspack-plugin' ),
+			],
+			'recipient_completed_order'          => [
+				// Note: the id is `recipient_completed_order` but the WCSG
+				// class name is `Recipient_New_Initial_Order`. Class and id
+				// don't follow the same naming pattern here — the entry is
+				// keyed by id (the mailer-emitted slug) and `class` carries
+				// the actual subclass name.
+				'class'               => 'WCSG_Email_Recipient_New_Initial_Order',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'New gift order', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the giftee to notify them of a gift subscription.', 'newspack-plugin' ),
+			],
+			'customer_new_account'               => [
+				'class'               => 'WC_Email_Customer_New_Account',
+				'chip'                => 'auth-account',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => null,
+				'label'               => __( 'New account', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a customer creates a new account.', 'newspack-plugin' ),
+			],
+			'customer_refunded_order'            => [
+				'class'               => 'WC_Email_Customer_Refunded_Order',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => false,
+				'plugin_dependency'   => null,
+				'label'               => __( 'Order refund', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when an order is refunded.', 'newspack-plugin' ),
+			],
+			'new_order'                          => [
+				'class'               => 'WC_Email_New_Order',
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'admin',
+				'recommended'         => false,
+				'plugin_dependency'   => null,
+				'label'               => __( 'New order', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the admin when a new order is placed.', 'newspack-plugin' ),
+			],
+		];
+	}
+
+	/**
+	 * Inject WooCommerce-source email configs into the unified
+	 * `newspack_email_configs` filter set.
+	 *
+	 * Iterates the curated allowlist (see {@see surfaced_wc_emails()})
+	 * directly — no `WC()->mailer()->get_emails()` call from the filter
+	 * callback. The mailer is consulted on-demand from
+	 * {@see get_wc_email_by_id()} when the toggle endpoint, first-run
+	 * auto-enable, or serialization actually needs the live instance.
+	 *
+	 * Each entry carries `wc_email_class` (the WC_Email subclass name as
+	 * a scalar string), NOT a live `WC_Email` instance — the schema
+	 * stays JSON-serializable, and no WC objects get re-instantiated
+	 * per call.
+	 *
+	 * @param array $configs Existing email configs from upstream providers.
+	 * @return array Configs with surfaced WC emails added.
+	 */
+	public static function get_email_configs( $configs ) {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
+			return $configs;
+		}
+
+		// Force WC's mailer to bootstrap before iterating surfaced emails.
+		// Without this, depending on whether WC's block-based-emails
+		// alpha feature is enabled, `WC_Email` may not be loaded yet at
+		// the point this filter callback runs (e.g. via
+		// `maybe_first_run_enable_wc_emails` on admin_init). With the
+		// alpha off, the WCS autoloader pulling in a subclass that
+		// extends `WC_Email` would fatal (`Class "WC_Email" not found`).
+		// `WC()->mailer()` is a singleton — it loads `WC_Email` and all
+		// registered email classes (including WCS) idempotently. Cheap
+		// on subsequent calls, safe to call early.
+		if ( method_exists( WC(), 'mailer' ) ) {
+			WC()->mailer();
+		}
+
+		foreach ( self::surfaced_wc_emails() as $id => $meta ) {
+			// Gate on whether the WC_Email subclass is loaded rather than
+			// looking up the plugin file in `active_plugins` — the latter
+			// misses network-activated plugins on multisite, where the
+			// `plugin_dependency` plugin (e.g. WooCommerce Subscriptions)
+			// is listed in `active_sitewide_plugins` instead. The class
+			// presence check works regardless of activation scope.
+			//
+			// `$autoload = false` is defensive: we've already forced the
+			// mailer to bootstrap above, but if any future caller invokes
+			// this method before WC is fully loaded, the autoload-off
+			// check fails closed (skip) instead of fatal (autoload pulls
+			// a `WC_Email` subclass before its parent is available).
+			if ( ! class_exists( $meta['class'], false ) ) {
+				continue;
+			}
+			$configs[ $id ] = [
+				'name'                => $id,
+				'category'            => 'woocommerce',
+				'source'              => 'woocommerce',
+				'label'               => $meta['label'],
+				'description'         => $meta['trigger_description'],
+				'trigger_description' => $meta['trigger_description'],
+				'recipient'           => $meta['recipient'],
+				'recommended'         => $meta['recommended'],
+				'chip'                => $meta['chip'],
+				'woo_email_id'        => $id,
+				'plugin_dependency'   => $meta['plugin_dependency'],
+				'wc_email_class'      => $meta['class'],
+			];
+		}
+		return $configs;
+	}
+
+	/**
+	 * Memoized lookup of the mailer-owned `WC_Email` instance for a
+	 * surfaced email id.
+	 *
+	 * Calls `WC()->mailer()->get_emails()` once per request and caches
+	 * the by-id map for subsequent lookups. Returns `null` for ids that
+	 * the mailer doesn't have (WC not active, plugin not loaded, etc.) —
+	 * callers handle that gracefully (toggle/first-run skip; serialize
+	 * returns null for the row).
+	 *
+	 * The returned instance is the mailer-owned singleton — same object
+	 * across calls, no fresh instantiation. Tests can prime the cache
+	 * via {@see set_wc_email_by_id_for_test()} when real WC isn't
+	 * loaded in the test env.
+	 *
+	 * @param string $id The WC_Email id (e.g. `customer_payment_retry`).
+	 * @return \WC_Email|null The mailer-owned instance, or null.
+	 */
+	public static function get_wc_email_by_id( string $id ) {
+		if ( null === self::$by_id_cache ) {
+			self::$by_id_cache = [];
+			// Existence guards on WC() + WC_Emails are sufficient — if the
+			// mailer itself throws after those are loaded, that's a real
+			// WC-side bug worth surfacing rather than silently swallowing.
+			if ( function_exists( 'WC' ) && class_exists( 'WC_Emails' ) ) {
+				foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+					self::$by_id_cache[ $wc_email->id ] = $wc_email;
+				}
+			}
+		}
+		return self::$by_id_cache[ $id ] ?? null;
+	}
+
+	/**
+	 * Write the enabled state for a WC email — single source of truth for
+	 * the dual-write (in-memory $wc_email->enabled + the
+	 * `woocommerce_*_settings` option). Both the toggle endpoint and the
+	 * first-run auto-enable call this so the write order and rollback
+	 * semantics stay consistent across paths.
+	 *
+	 * Order: in-memory first (keeps the cached mailer instance's `enabled`
+	 * property in sync for any downstream code in the same request that
+	 * reads it directly), then the option (authoritative source — WP busts
+	 * the alloptions cache on update_option so subsequent get_option calls
+	 * see the new value in the same request).
+	 *
+	 * If the option write fails (returns false from a real change — i.e.
+	 * a `pre_update_option_*` filter rejected it), the in-memory write is
+	 * rolled back and this returns false so the caller can surface the
+	 * failure to the client.
+	 *
+	 * @param string $id      The WC_Email id.
+	 * @param bool   $enabled Target enabled state.
+	 * @return bool True on success, false if the email isn't resolvable
+	 *              or the option write was rejected.
+	 */
+	public static function set_wc_email_enabled_state( string $id, bool $enabled ): bool {
+		$wc_email = self::get_wc_email_by_id( $id );
+		if ( ! $wc_email ) {
+			return false;
+		}
+
+		$option_key      = $wc_email->get_option_key();
+		$options         = (array) get_option( $option_key, [] );
+		$previous_in_mem = $wc_email->enabled;
+		$new_value       = $enabled ? 'yes' : 'no';
+
+		// Same-value short-circuit: update_option returns false for
+		// unchanged values, which is indistinguishable from a real
+		// failure. Treat no-op as success.
+		if ( isset( $options['enabled'] ) && $options['enabled'] === $new_value ) {
+			$wc_email->enabled = $new_value;
+			return true;
+		}
+
+		$wc_email->enabled  = $new_value;
+		$options['enabled'] = $new_value;
+
+		if ( ! update_option( $option_key, $options ) ) {
+			// Roll back the in-memory write so the cached mailer
+			// instance doesn't carry a state the DB never recorded.
+			$wc_email->enabled = $previous_in_mem;
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Memoization cache for `get_wc_email_by_id()`. Null until first
+	 * lookup; populated lazily from `WC()->mailer()->get_emails()`.
+	 *
+	 * @var array<string, \WC_Email>|null
+	 */
+	private static $by_id_cache = null;
+
+	/**
+	 * Prime the by-id cache with a stub WC_Email instance.
+	 *
+	 * Test-only — lets PHPUnit suites that don't load real WC inject a
+	 * `WC_Email`-shaped stub for `get_wc_email_by_id()` to return. Tests
+	 * should pair this with `reset_wc_email_cache_for_test()` in
+	 * tear_down so cache state doesn't leak across tests.
+	 *
+	 * @internal
+	 *
+	 * @param string $id       WC_Email id (e.g. `customer_payment_retry`).
+	 * @param mixed  $instance The stub instance to return for this id.
+	 */
+	public static function set_wc_email_by_id_for_test( string $id, $instance ): void {
+		if ( null === self::$by_id_cache ) {
+			self::$by_id_cache = [];
+		}
+		self::$by_id_cache[ $id ] = $instance;
+	}
+
+	/**
+	 * Reset the by-id cache so the next `get_wc_email_by_id()` call
+	 * re-populates from the live mailer.
+	 *
+	 * Test-only — used in `tear_down` to prevent cross-test state leak.
+	 * Also useful in production if WC's mailer registrations change
+	 * within a single request, though that's a rare case.
+	 *
+	 * @internal
+	 */
+	public static function reset_wc_email_cache_for_test(): void {
+		self::$by_id_cache = null;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -40,10 +40,18 @@ class WooCommerce_Emails {
 
 	/**
 	 * Curated allowlist of WooCommerce-source emails surfaced in the
-	 * unified emails wizard, keyed by WC_Email::$id. Wrapped in a
-	 * function so __() runs at filter time, not class-load time.
+	 * unified emails wizard, keyed by `WC_Email::$id`. Wrapped in a
+	 * function so `__()` runs at filter time, not class-load time.
+	 *
+	 * The `class` field carries the WC_Email subclass name as a scalar
+	 * string. Storing the class name (not a live instance) keeps the
+	 * `newspack_email_configs` schema JSON-serializable and avoids
+	 * re-instantiating WC_Email objects across requests — the live
+	 * mailer-owned instance is resolved on demand via
+	 * {@see get_wc_email_by_id()}.
 	 *
 	 * @return array<string, array{
+	 *     class: string,
 	 *     chip: 'auth-account'|'reader-revenue',
 	 *     recipient: 'reader'|'admin',
 	 *     recommended: bool,
@@ -55,6 +63,7 @@ class WooCommerce_Emails {
 	private static function surfaced_wc_emails(): array {
 		return [
 			'customer_notification_auto_renewal' => [
+				'class'               => 'WCS_Email_Customer_Notification_Auto_Renewal',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -63,6 +72,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent before automatic renewal (timing depends on WooCommerce Subscriptions settings).', 'newspack-plugin' ),
 			],
 			'customer_payment_retry'             => [
+				'class'               => 'WCS_Email_Customer_Payment_Retry',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -71,6 +81,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent when a renewal payment fails, before the retry attempt.', 'newspack-plugin' ),
 			],
 			'expired_subscription'               => [
+				'class'               => 'WCS_Email_Expired_Subscription',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -79,6 +90,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent when a subscription reaches its expiration date.', 'newspack-plugin' ),
 			],
 			'customer_completed_switch_order'    => [
+				'class'               => 'WCS_Email_Completed_Switch_Order',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -87,6 +99,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent when a reader switches their subscription.', 'newspack-plugin' ),
 			],
 			'WCSG_Email_Customer_New_Account'    => [
+				'class'               => 'WCSG_Email_Customer_New_Account',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -95,6 +108,12 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent to the giftee when a gift subscription creates their account.', 'newspack-plugin' ),
 			],
 			'recipient_completed_order'          => [
+				// Note: the id is `recipient_completed_order` but the WCSG
+				// class name is `Recipient_New_Initial_Order`. Class and id
+				// don't follow the same naming pattern here — the entry is
+				// keyed by id (the mailer-emitted slug) and `class` carries
+				// the actual subclass name.
+				'class'               => 'WCSG_Email_Recipient_New_Initial_Order',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -103,6 +122,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent to the giftee to notify them of a gift subscription.', 'newspack-plugin' ),
 			],
 			'customer_new_account'               => [
+				'class'               => 'WC_Email_Customer_New_Account',
 				'chip'                => 'auth-account',
 				'recipient'           => 'reader',
 				'recommended'         => true,
@@ -111,6 +131,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent when a customer creates a new account.', 'newspack-plugin' ),
 			],
 			'customer_refunded_order'            => [
+				'class'               => 'WC_Email_Customer_Refunded_Order',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'reader',
 				'recommended'         => false,
@@ -119,6 +140,7 @@ class WooCommerce_Emails {
 				'trigger_description' => __( 'Sent when an order is refunded.', 'newspack-plugin' ),
 			],
 			'new_order'                          => [
+				'class'               => 'WC_Email_New_Order',
 				'chip'                => 'reader-revenue',
 				'recipient'           => 'admin',
 				'recommended'         => false,
@@ -133,12 +155,16 @@ class WooCommerce_Emails {
 	 * Inject WooCommerce-source email configs into the unified
 	 * `newspack_email_configs` filter set.
 	 *
-	 * Discovery-based: iterates `WC()->mailer()->get_emails()` and only
-	 * surfaces IDs in the curated allowlist (see surfaced_wc_emails()).
-	 * Unrecognized IDs are silently skipped. Each surfaced entry carries
-	 * the live `WC_Email` instance as `wc_email_instance` so downstream
-	 * code (toggle endpoint, first-run auto-enable) can invoke instance
-	 * methods directly instead of re-resolving via the mailer.
+	 * Iterates the curated allowlist (see {@see surfaced_wc_emails()})
+	 * directly — no `WC()->mailer()->get_emails()` call from the filter
+	 * callback. The mailer is consulted on-demand from
+	 * {@see get_wc_email_by_id()} when the toggle endpoint, first-run
+	 * auto-enable, or serialization actually needs the live instance.
+	 *
+	 * Each entry carries `wc_email_class` (the WC_Email subclass name as
+	 * a scalar string), NOT a live `WC_Email` instance — the schema
+	 * stays JSON-serializable, and no WC objects get re-instantiated
+	 * per call.
 	 *
 	 * @param array $configs Existing email configs from upstream providers.
 	 * @return array Configs with surfaced WC emails added.
@@ -147,20 +173,7 @@ class WooCommerce_Emails {
 		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
 			return $configs;
 		}
-		// Iterate the curated allowlist (not `WC()->mailer()->get_emails()`)
-		// so registration order — and thus display order in the wizard —
-		// follows our intentional grouping rather than WC's internal
-		// dispatch order. The mailer is indexed for O(1) instance lookup.
-		$surfaced = self::surfaced_wc_emails();
-		$by_id    = [];
-		foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
-			$by_id[ $wc_email->id ] = $wc_email;
-		}
-		foreach ( $surfaced as $id => $meta ) {
-			if ( ! isset( $by_id[ $id ] ) ) {
-				continue;
-			}
-			$wc_email = $by_id[ $id ];
+		foreach ( self::surfaced_wc_emails() as $id => $meta ) {
 			if ( ! empty( $meta['plugin_dependency'] ) ) {
 				$plugin_file = $meta['plugin_dependency'] . '/' . $meta['plugin_dependency'] . '.php';
 				if ( ! \Newspack\is_plugin_active( $plugin_file ) ) {
@@ -179,10 +192,88 @@ class WooCommerce_Emails {
 				'chip'                => $meta['chip'],
 				'woo_email_id'        => $id,
 				'plugin_dependency'   => $meta['plugin_dependency'],
-				'wc_email_instance'   => $wc_email,
+				'wc_email_class'      => $meta['class'],
 			];
 		}
 		return $configs;
+	}
+
+	/**
+	 * Memoized lookup of the mailer-owned `WC_Email` instance for a
+	 * surfaced email id.
+	 *
+	 * Calls `WC()->mailer()->get_emails()` once per request and caches
+	 * the by-id map for subsequent lookups. Returns `null` for ids that
+	 * the mailer doesn't have (WC not active, plugin not loaded, etc.) —
+	 * callers handle that gracefully (toggle/first-run skip; serialize
+	 * returns null for the row).
+	 *
+	 * The returned instance is the mailer-owned singleton — same object
+	 * across calls, no fresh instantiation. Tests can prime the cache
+	 * via {@see set_wc_email_by_id_for_test()} when real WC isn't
+	 * loaded in the test env.
+	 *
+	 * @param string $id The WC_Email id (e.g. `customer_payment_retry`).
+	 * @return \WC_Email|null The mailer-owned instance, or null.
+	 */
+	public static function get_wc_email_by_id( string $id ) {
+		if ( null === self::$by_id_cache ) {
+			self::$by_id_cache = [];
+			if ( function_exists( 'WC' ) && class_exists( 'WC_Emails' ) ) {
+				try {
+					foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+						self::$by_id_cache[ $wc_email->id ] = $wc_email;
+					}
+				} catch ( \Throwable $e ) {
+					// Mailer not available — leave cache empty so callers
+					// fall through their null-handling paths.
+					unset( $e );
+				}
+			}
+		}
+		return self::$by_id_cache[ $id ] ?? null;
+	}
+
+	/**
+	 * Memoization cache for `get_wc_email_by_id()`. Null until first
+	 * lookup; populated lazily from `WC()->mailer()->get_emails()`.
+	 *
+	 * @var array<string, \WC_Email>|null
+	 */
+	private static $by_id_cache = null;
+
+	/**
+	 * Prime the by-id cache with a stub WC_Email instance.
+	 *
+	 * Test-only — lets PHPUnit suites that don't load real WC inject a
+	 * `WC_Email`-shaped stub for `get_wc_email_by_id()` to return. Tests
+	 * should pair this with `reset_wc_email_cache_for_test()` in
+	 * tear_down so cache state doesn't leak across tests.
+	 *
+	 * @internal
+	 *
+	 * @param string $id       WC_Email id (e.g. `customer_payment_retry`).
+	 * @param mixed  $instance The stub instance to return for this id.
+	 */
+	public static function set_wc_email_by_id_for_test( string $id, $instance ): void {
+		if ( null === self::$by_id_cache ) {
+			self::$by_id_cache = [];
+		}
+		self::$by_id_cache[ $id ] = $instance;
+	}
+
+	/**
+	 * Reset the by-id cache so the next `get_wc_email_by_id()` call
+	 * re-populates from the live mailer.
+	 *
+	 * Test-only — used in `tear_down` to prevent cross-test state leak.
+	 * Also useful in production if WC's mailer registrations change
+	 * within a single request, though that's a rare case.
+	 *
+	 * @internal
+	 */
+	public static function reset_wc_email_cache_for_test(): void {
+		self::$by_id_cache = null;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -222,20 +222,12 @@ class WooCommerce_Emails {
 	public static function get_wc_email_by_id( string $id ) {
 		if ( null === self::$by_id_cache ) {
 			self::$by_id_cache = [];
+			// Existence guards on WC() + WC_Emails are sufficient — if the
+			// mailer itself throws after those are loaded, that's a real
+			// WC-side bug worth surfacing rather than silently swallowing.
 			if ( function_exists( 'WC' ) && class_exists( 'WC_Emails' ) ) {
-				try {
-					foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
-						self::$by_id_cache[ $wc_email->id ] = $wc_email;
-					}
-				} catch ( \Throwable $e ) {
-					// Mailer init failed. Log so this surfaces in newspack-log
-					// instead of being a silent empty-list — callers fall
-					// through their null-handling paths regardless.
-					Logger::log(
-						'WC mailer init failed in get_wc_email_by_id: ' . $e->getMessage(),
-						'NEWSPACK-WC-EMAILS',
-						'error'
-					);
+				foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+					self::$by_id_cache[ $wc_email->id ] = $wc_email;
 				}
 			}
 		}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -35,6 +35,147 @@ class WooCommerce_Emails {
 	public static function init() {
 		add_filter( 'option_woocommerce_feature_block_email_editor_enabled', [ __CLASS__, 'override_woocommerce_email_editor_option' ], 10, 2 );
 		add_action( 'admin_init', [ __CLASS__, 'update_woocommerce_emails_to_latest' ] );
+		add_filter( 'newspack_email_configs', [ __CLASS__, 'get_email_configs' ] );
+	}
+
+	/**
+	 * Curated allowlist of WooCommerce-source emails surfaced in the
+	 * unified emails wizard, keyed by WC_Email::$id. Wrapped in a
+	 * function so __() runs at filter time, not class-load time.
+	 *
+	 * @return array<string, array{
+	 *     chip: 'auth-account'|'reader-revenue',
+	 *     recipient: 'reader'|'admin',
+	 *     recommended: bool,
+	 *     plugin_dependency: ?string,
+	 *     label: string,
+	 *     trigger_description: string,
+	 * }>
+	 */
+	private static function surfaced_wc_emails(): array {
+		return [
+			'customer_notification_auto_renewal' => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Renewal reminder', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent before automatic renewal (timing depends on WooCommerce Subscriptions settings).', 'newspack-plugin' ),
+			],
+			'customer_payment_retry'             => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Failed order retry', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a renewal payment fails, before the retry attempt.', 'newspack-plugin' ),
+			],
+			'expired_subscription'               => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Subscription expired', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a subscription reaches its expiration date.', 'newspack-plugin' ),
+			],
+			'customer_completed_switch_order'    => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'Subscription switch complete', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a reader switches their subscription.', 'newspack-plugin' ),
+			],
+			'WCSG_Email_Customer_New_Account'    => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'New giftee account', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the giftee when a gift subscription creates their account.', 'newspack-plugin' ),
+			],
+			'recipient_completed_order'          => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'label'               => __( 'New gift order', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the giftee to notify them of a gift subscription.', 'newspack-plugin' ),
+			],
+			'customer_new_account'               => [
+				'chip'                => 'auth-account',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'plugin_dependency'   => null,
+				'label'               => __( 'New account', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a customer creates a new account.', 'newspack-plugin' ),
+			],
+			'customer_refunded_order'            => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'reader',
+				'recommended'         => false,
+				'plugin_dependency'   => null,
+				'label'               => __( 'Order refund', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when an order is refunded.', 'newspack-plugin' ),
+			],
+			'new_order'                          => [
+				'chip'                => 'reader-revenue',
+				'recipient'           => 'admin',
+				'recommended'         => false,
+				'plugin_dependency'   => null,
+				'label'               => __( 'New order', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the admin when a new order is placed.', 'newspack-plugin' ),
+			],
+		];
+	}
+
+	/**
+	 * Inject WooCommerce-source email configs into the unified
+	 * `newspack_email_configs` filter set.
+	 *
+	 * Discovery-based: iterates `WC()->mailer()->get_emails()` and only
+	 * surfaces IDs in the curated allowlist (see surfaced_wc_emails()).
+	 * Unrecognized IDs are silently skipped. Each surfaced entry carries
+	 * the live `WC_Email` instance as `wc_email_instance` so downstream
+	 * code (toggle endpoint, first-run auto-enable) can invoke instance
+	 * methods directly instead of re-resolving via the mailer.
+	 *
+	 * @param array $configs Existing email configs from upstream providers.
+	 * @return array Configs with surfaced WC emails added.
+	 */
+	public static function get_email_configs( $configs ) {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
+			return $configs;
+		}
+		$surfaced  = self::surfaced_wc_emails();
+		$wc_emails = \WC()->mailer()->get_emails();
+		foreach ( $wc_emails as $wc_email ) {
+			if ( ! isset( $surfaced[ $wc_email->id ] ) ) {
+				continue;
+			}
+			$meta = $surfaced[ $wc_email->id ];
+			if ( ! empty( $meta['plugin_dependency'] ) ) {
+				$plugin_file = $meta['plugin_dependency'] . '/' . $meta['plugin_dependency'] . '.php';
+				if ( ! \Newspack\is_plugin_active( $plugin_file ) ) {
+					continue;
+				}
+			}
+			$configs[ $wc_email->id ] = [
+				'name'                => $wc_email->id,
+				'category'            => 'woocommerce',
+				'source'              => 'woocommerce',
+				'label'               => $meta['label'],
+				'description'         => $meta['trigger_description'],
+				'trigger_description' => $meta['trigger_description'],
+				'recipient'           => $meta['recipient'],
+				'recommended'         => $meta['recommended'],
+				'chip'                => $meta['chip'],
+				'woo_email_id'        => $wc_email->id,
+				'plugin_dependency'   => $meta['plugin_dependency'],
+				'wc_email_instance'   => $wc_email,
+			];
+		}
+		return $configs;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -147,21 +147,28 @@ class WooCommerce_Emails {
 		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
 			return $configs;
 		}
-		$surfaced  = self::surfaced_wc_emails();
-		$wc_emails = \WC()->mailer()->get_emails();
-		foreach ( $wc_emails as $wc_email ) {
-			if ( ! isset( $surfaced[ $wc_email->id ] ) ) {
+		// Iterate the curated allowlist (not `WC()->mailer()->get_emails()`)
+		// so registration order — and thus display order in the wizard —
+		// follows our intentional grouping rather than WC's internal
+		// dispatch order. The mailer is indexed for O(1) instance lookup.
+		$surfaced = self::surfaced_wc_emails();
+		$by_id    = [];
+		foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+			$by_id[ $wc_email->id ] = $wc_email;
+		}
+		foreach ( $surfaced as $id => $meta ) {
+			if ( ! isset( $by_id[ $id ] ) ) {
 				continue;
 			}
-			$meta = $surfaced[ $wc_email->id ];
+			$wc_email = $by_id[ $id ];
 			if ( ! empty( $meta['plugin_dependency'] ) ) {
 				$plugin_file = $meta['plugin_dependency'] . '/' . $meta['plugin_dependency'] . '.php';
 				if ( ! \Newspack\is_plugin_active( $plugin_file ) ) {
 					continue;
 				}
 			}
-			$configs[ $wc_email->id ] = [
-				'name'                => $wc_email->id,
+			$configs[ $id ] = [
+				'name'                => $id,
 				'category'            => 'woocommerce',
 				'source'              => 'woocommerce',
 				'label'               => $meta['label'],
@@ -170,7 +177,7 @@ class WooCommerce_Emails {
 				'recipient'           => $meta['recipient'],
 				'recommended'         => $meta['recommended'],
 				'chip'                => $meta['chip'],
-				'woo_email_id'        => $wc_email->id,
+				'woo_email_id'        => $id,
 				'plugin_dependency'   => $meta['plugin_dependency'],
 				'wc_email_instance'   => $wc_email,
 			];

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -174,11 +174,14 @@ class WooCommerce_Emails {
 			return $configs;
 		}
 		foreach ( self::surfaced_wc_emails() as $id => $meta ) {
-			if ( ! empty( $meta['plugin_dependency'] ) ) {
-				$plugin_file = $meta['plugin_dependency'] . '/' . $meta['plugin_dependency'] . '.php';
-				if ( ! \Newspack\is_plugin_active( $plugin_file ) ) {
-					continue;
-				}
+			// Gate on whether the WC_Email subclass is loaded rather than
+			// looking up the plugin file in `active_plugins` — the latter
+			// misses network-activated plugins on multisite, where the
+			// `plugin_dependency` plugin (e.g. WooCommerce Subscriptions)
+			// is listed in `active_sitewide_plugins` instead. The class
+			// presence check works regardless of activation scope.
+			if ( ! class_exists( $meta['class'] ) ) {
+				continue;
 			}
 			$configs[ $id ] = [
 				'name'                => $id,

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -173,6 +173,21 @@ class WooCommerce_Emails {
 		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
 			return $configs;
 		}
+
+		// Force WC's mailer to bootstrap before iterating surfaced emails.
+		// Without this, depending on whether WC's block-based-emails
+		// alpha feature is enabled, `WC_Email` may not be loaded yet at
+		// the point this filter callback runs (e.g. via
+		// `maybe_first_run_enable_wc_emails` on admin_init). With the
+		// alpha off, the WCS autoloader pulling in a subclass that
+		// extends `WC_Email` would fatal (`Class "WC_Email" not found`).
+		// `WC()->mailer()` is a singleton — it loads `WC_Email` and all
+		// registered email classes (including WCS) idempotently. Cheap
+		// on subsequent calls, safe to call early.
+		if ( method_exists( WC(), 'mailer' ) ) {
+			WC()->mailer();
+		}
+
 		foreach ( self::surfaced_wc_emails() as $id => $meta ) {
 			// Gate on whether the WC_Email subclass is loaded rather than
 			// looking up the plugin file in `active_plugins` — the latter
@@ -180,7 +195,13 @@ class WooCommerce_Emails {
 			// `plugin_dependency` plugin (e.g. WooCommerce Subscriptions)
 			// is listed in `active_sitewide_plugins` instead. The class
 			// presence check works regardless of activation scope.
-			if ( ! class_exists( $meta['class'] ) ) {
+			//
+			// `$autoload = false` is defensive: we've already forced the
+			// mailer to bootstrap above, but if any future caller invokes
+			// this method before WC is fully loaded, the autoload-off
+			// check fails closed (skip) instead of fatal (autoload pulls
+			// a `WC_Email` subclass before its parent is available).
+			if ( ! class_exists( $meta['class'], false ) ) {
 				continue;
 			}
 			$configs[ $id ] = [

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -228,13 +228,73 @@ class WooCommerce_Emails {
 						self::$by_id_cache[ $wc_email->id ] = $wc_email;
 					}
 				} catch ( \Throwable $e ) {
-					// Mailer not available — leave cache empty so callers
-					// fall through their null-handling paths.
-					unset( $e );
+					// Mailer init failed. Log so this surfaces in newspack-log
+					// instead of being a silent empty-list — callers fall
+					// through their null-handling paths regardless.
+					Logger::log(
+						'WC mailer init failed in get_wc_email_by_id: ' . $e->getMessage(),
+						'NEWSPACK-WC-EMAILS',
+						'error'
+					);
 				}
 			}
 		}
 		return self::$by_id_cache[ $id ] ?? null;
+	}
+
+	/**
+	 * Write the enabled state for a WC email — single source of truth for
+	 * the dual-write (in-memory $wc_email->enabled + the
+	 * `woocommerce_*_settings` option). Both the toggle endpoint and the
+	 * first-run auto-enable call this so the write order and rollback
+	 * semantics stay consistent across paths.
+	 *
+	 * Order: in-memory first (keeps the cached mailer instance's `enabled`
+	 * property in sync for any downstream code in the same request that
+	 * reads it directly), then the option (authoritative source — WP busts
+	 * the alloptions cache on update_option so subsequent get_option calls
+	 * see the new value in the same request).
+	 *
+	 * If the option write fails (returns false from a real change — i.e.
+	 * a `pre_update_option_*` filter rejected it), the in-memory write is
+	 * rolled back and this returns false so the caller can surface the
+	 * failure to the client.
+	 *
+	 * @param string $id      The WC_Email id.
+	 * @param bool   $enabled Target enabled state.
+	 * @return bool True on success, false if the email isn't resolvable
+	 *              or the option write was rejected.
+	 */
+	public static function set_wc_email_enabled_state( string $id, bool $enabled ): bool {
+		$wc_email = self::get_wc_email_by_id( $id );
+		if ( ! $wc_email ) {
+			return false;
+		}
+
+		$option_key      = $wc_email->get_option_key();
+		$options         = (array) get_option( $option_key, [] );
+		$previous_in_mem = $wc_email->enabled;
+		$new_value       = $enabled ? 'yes' : 'no';
+
+		// Same-value short-circuit: update_option returns false for
+		// unchanged values, which is indistinguishable from a real
+		// failure. Treat no-op as success.
+		if ( isset( $options['enabled'] ) && $options['enabled'] === $new_value ) {
+			$wc_email->enabled = $new_value;
+			return true;
+		}
+
+		$wc_email->enabled  = $new_value;
+		$options['enabled'] = $new_value;
+
+		if ( ! update_option( $option_key, $options ) ) {
+			// Roll back the in-memory write so the cached mailer
+			// instance doesn't carry a state the DB never recorded.
+			$wc_email->enabled = $previous_in_mem;
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -11,6 +11,7 @@ use Newspack\Emails;
 use Newspack\Reader_Activation;
 use Newspack\Reader_Revenue_Emails;
 use Newspack\Wizards\Wizard_Section;
+use Newspack\WooCommerce_Emails;
 use WP_REST_Server;
 
 defined( 'ABSPATH' ) || exit;
@@ -31,6 +32,42 @@ class Emails_Section extends Wizard_Section {
 	protected $wizard_slug = 'newspack-settings';
 
 	/**
+	 * Constructor — extends Wizard_Section's REST-route hookup with an
+	 * admin_init handler for the WC first-run auto-enable. Decoupling
+	 * first-run from api_get_email_settings keeps the GET endpoint
+	 * idempotent (probes / crawlers can no longer trigger silent
+	 * WC option writes).
+	 *
+	 * @param array $args Section arguments.
+	 */
+	public function __construct( $args = [] ) {
+		parent::__construct( $args );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_first_run_enable_wc_emails' ] );
+	}
+
+	/**
+	 * Whether WooCommerce is active.
+	 *
+	 * Mockable in tests via the `newspack_woocommerce_active` filter. The
+	 * filter exists because a bare `class_exists( 'WooCommerce' )` check
+	 * couples test isolation to whether some sibling test file declared a
+	 * global `class WooCommerce {}` shim — i.e., suite-order-dependent.
+	 * Tests `add_filter( 'newspack_woocommerce_active', '__return_true' )`
+	 * in their setUp; production code paths see the unfiltered default.
+	 *
+	 * @return bool
+	 */
+	private static function is_woocommerce_active(): bool {
+		/**
+		 * Filters whether WooCommerce is considered active for the
+		 * unified emails wizard. Default is `class_exists( 'WooCommerce' )`.
+		 *
+		 * @param bool $active Whether WC is active.
+		 */
+		return (bool) apply_filters( 'newspack_woocommerce_active', class_exists( 'WooCommerce' ) );
+	}
+
+	/**
 	 * Register the endpoints needed for the wizard screens.
 	 */
 	public function register_rest_routes() {
@@ -43,6 +80,89 @@ class Emails_Section extends Wizard_Section {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+
+		// Toggle endpoint for WooCommerce-source emails. Only registered
+		// when WC is loaded; without WC there are no WC configs to toggle.
+		if ( self::is_woocommerce_active() ) {
+			register_rest_route(
+				NEWSPACK_API_NAMESPACE,
+				'wizard/' . $this->wizard_slug . '/emails/(?P<id>[A-Za-z0-9_]+)/toggle',
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ __CLASS__, 'api_toggle_wc_email' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+					'args'                => [
+						'id'      => [
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'enabled' => [
+							'type'              => 'boolean',
+							'required'          => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Toggle a WooCommerce email's enabled state.
+	 *
+	 * Validates the email ID against the unified config set — only
+	 * WC-source configs registered by `WooCommerce_Emails::get_email_configs()`
+	 * are toggleable. Writes both the in-memory `WC_Email::$enabled`
+	 * property AND the underlying WC option, in that order:
+	 *
+	 *   1. `$wc_email->enabled = ...`  — in-memory state, defensive in
+	 *      case downstream code reads the cached mailer instance.
+	 *   2. `update_option( $wc_email->get_option_key(), ... )` — the
+	 *      authoritative source of truth. WP busts the options cache on
+	 *      update_option, so the subsequent `get_option()` call inside
+	 *      api_get_email_settings() (via serialize_wc_email_row) reads
+	 *      the new value in the same request.
+	 *
+	 * The response is a refreshed wizard payload — the toggled email's
+	 * status field reflects the new state.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error Refreshed settings payload or error.
+	 */
+	public static function api_toggle_wc_email( $request ) {
+		$wc_email_id = $request->get_param( 'id' );
+		$enabled     = (bool) $request->get_param( 'enabled' );
+
+		if ( ! self::is_woocommerce_active() ) {
+			return new \WP_Error(
+				'newspack_wc_not_active',
+				__( 'WooCommerce is not active.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// Validate the id is one of the surfaced WC configs before
+		// touching the mailer — defense against arbitrary id input.
+		$configs   = Emails::get_email_configs();
+		$wc_config = $configs[ $wc_email_id ] ?? null;
+		if ( ! $wc_config || 'woocommerce' !== ( $wc_config['source'] ?? 'newspack' ) ) {
+			return new \WP_Error(
+				'newspack_wc_email_not_allowed',
+				__( 'WooCommerce email is not in the surfaced allowlist.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( ! WooCommerce_Emails::set_wc_email_enabled_state( $wc_email_id, $enabled ) ) {
+			return new \WP_Error(
+				'newspack_wc_email_write_failed',
+				__( 'Could not update the WooCommerce email state.', 'newspack-plugin' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return rest_ensure_response( self::api_get_email_settings() );
 	}
 
 	/**
@@ -50,8 +170,11 @@ class Emails_Section extends Wizard_Section {
 	 *
 	 * Builds the unified emails list directly from the
 	 * `newspack_email_configs` schema — no parallel registry, no join.
-	 * WooCommerce-source rows are filtered out at this layer; slice 2
-	 * removes that filter when the WC surface lands.
+	 * Newspack-source configs resolve to WP posts via Emails::get_emails();
+	 * WooCommerce-source configs build rows by resolving the live WC_Email
+	 * instance on-demand via WooCommerce_Emails::get_wc_email_by_id()
+	 * (the schema itself only carries `wc_email_class` — a scalar
+	 * string — so it stays JSON-serializable).
 	 *
 	 * @return array{
 	 *     newspack_emails: array<int, array{
@@ -59,7 +182,7 @@ class Emails_Section extends Wizard_Section {
 	 *         category:            string,
 	 *         label:               string,
 	 *         description:         string,
-	 *         post_id:             int,
+	 *         post_id:             int|string,
 	 *         edit_link:           string,
 	 *         subject:             string,
 	 *         from_name:           string,
@@ -72,45 +195,55 @@ class Emails_Section extends Wizard_Section {
 	 *         recommended:         bool,
 	 *         chip:                'auth-account'|'reader-revenue',
 	 *         source:              'newspack'|'woocommerce',
+	 *         preview_post_id?:    ?int,
 	 *     }>,
 	 *     post_type: string,
 	 * }
 	 */
 	public static function api_get_email_settings(): array {
+		// First-run runs on admin_init (constructor-hooked), not here —
+		// keeps the GET endpoint idempotent so probes / crawlers / SSR
+		// bootstrap reads can't trigger WC option writes as a side effect.
 		$configs = Emails::get_email_configs();
 
-		// Slice 1 surfaces only Newspack-source emails. Slice 2 lifts this.
-		$configs = array_filter(
+		// Split by source — Newspack configs go through Emails::get_emails()
+		// for post resolution; WC configs build rows by resolving the
+		// live WC_Email instance via WooCommerce_Emails::get_wc_email_by_id().
+		$newspack_configs = array_filter(
 			$configs,
 			fn( $config ) => ( $config['source'] ?? 'newspack' ) !== 'woocommerce'
 		);
+		$wc_configs       = array_filter(
+			$configs,
+			fn( $config ) => ( $config['source'] ?? 'newspack' ) === 'woocommerce'
+		);
 
-		// Without Reader Activation, the auth/account flows are unused —
-		// scope the visible set to reader-revenue configs only. Mirrors the
-		// legacy slice 1 behavior.
-		$configs = self::filter_configs_by_ra_state( Reader_Activation::is_enabled(), $configs );
+		// RA gating applies only to Newspack-source configs (the auth/account
+		// flows have no use without RA). WC configs are gated by their own
+		// plugin_dependency at registration time and surface regardless of
+		// RA state.
+		$newspack_configs = self::filter_configs_by_ra_state( Reader_Activation::is_enabled(), $newspack_configs );
 
 		// Resolve each newspack-source config to a Newspack post + serialized
-		// payload via the existing Emails::get_emails() pipeline. The
-		// serialized output now carries the four new schema fields per the
-		// commit 1 patch to Emails::serialize_email().
-		$types = array_keys( $configs );
-
+		// payload via the existing Emails::get_emails() pipeline.
 		// Guard against the empty-types case: Emails::get_emails() treats
 		// an empty $config_names as "no filter" and returns every registered
 		// email, which would bypass the WC-source and RA-state filters
-		// above. Return an empty list explicitly when there's nothing to
-		// resolve.
-		if ( empty( $types ) ) {
-			return [
-				'newspack_emails' => [],
-				'post_type'       => Emails::POST_TYPE,
-			];
-		}
-
-		$emails = Emails::get_emails( $types, false );
+		// above. Skip the resolve path when there are no Newspack configs;
+		// any WC rows are still appended below.
+		$newspack_types = array_keys( $newspack_configs );
+		$emails         = empty( $newspack_types ) ? [] : Emails::get_emails( $newspack_types, false );
 
 		$newspack_emails = array_values( $emails );
+
+		// Build a row per WC config — serialize_wc_email_row resolves
+		// the live WC_Email instance via WooCommerce_Emails::get_wc_email_by_id().
+		foreach ( $wc_configs as $type => $config ) {
+			$wc_row = self::serialize_wc_email_row( $type, $config );
+			if ( null !== $wc_row ) {
+				$newspack_emails[] = $wc_row;
+			}
+		}
 
 		// Single category-only sort: reader-revenue → reader-activation → other.
 		$category_order = [
@@ -118,17 +251,27 @@ class Emails_Section extends Wizard_Section {
 			'reader-activation' => 1,
 		];
 		// `usort` is not stable in PHP — same-category rows can reorder
-		// across requests without a tiebreaker. Use the config type as a
-		// deterministic secondary key so the API output is consistent.
+		// across requests without a tiebreaker. Use the config's
+		// registration order in `$configs` as the secondary key:
+		// providers register in deliberate order (WC: gift emails
+		// adjacent in `WooCommerce_Emails::surfaced_wc_emails()`;
+		// Newspack: receipt → welcome → cancellation in
+		// `Reader_Revenue_Emails`, verification → magic-link → ...
+		// in `Reader_Activation_Emails`), so registration order
+		// equals intended display order. This mirrors the legacy
+		// `array_flip(array_keys($registry))` pattern.
+		$type_order = array_flip( array_keys( $configs ) );
 		usort(
 			$newspack_emails,
-			function ( $a, $b ) use ( $category_order ) {
+			function ( $a, $b ) use ( $category_order, $type_order ) {
 				$order_a = $category_order[ $a['category'] ?? '' ] ?? 2;
 				$order_b = $category_order[ $b['category'] ?? '' ] ?? 2;
 				if ( $order_a !== $order_b ) {
 					return $order_a - $order_b;
 				}
-				return strcmp( (string) ( $a['type'] ?? '' ), (string) ( $b['type'] ?? '' ) );
+				$idx_a = $type_order[ $a['type'] ?? '' ] ?? PHP_INT_MAX;
+				$idx_b = $type_order[ $b['type'] ?? '' ] ?? PHP_INT_MAX;
+				return $idx_a - $idx_b;
 			}
 		);
 
@@ -167,6 +310,292 @@ class Emails_Section extends Wizard_Section {
 		return array_filter(
 			$configs,
 			fn( $config ) => 'reader-revenue' === ( $config['chip'] ?? '' )
+		);
+	}
+
+	/**
+	 * Option name tracking which recommended WC email configs have been
+	 * processed by the first-run auto-enable. Storing processed keys (not
+	 * a single "ran once" boolean) keeps the logic idempotent across new
+	 * config additions: a future config that lands later still gets a
+	 * first-run pass on its first appearance, while previously-processed
+	 * configs are skipped — even if the user has manually disabled them
+	 * since.
+	 *
+	 * @var string
+	 */
+	const FIRST_RUN_OPTION = 'newspack_unified_emails_wc_first_run';
+
+	/**
+	 * WC Subscriptions site-wide master switch option key. When this is
+	 * unset, the renewal-reminder email never fires regardless of its
+	 * own enabled flag — first-run mirrors the email's auto-enable into
+	 * this switch ONLY when we're also enabling the email itself (see
+	 * `maybe_first_run_enable_wc_emails`).
+	 *
+	 * @var string
+	 */
+	const WCS_MASTER_SWITCH_OPTION = 'woocommerce_subscriptions_customer_notifications_enabled';
+
+	/**
+	 * On first encounter of a recommended WC email, enable it — but only
+	 * if the publisher hasn't already recorded an explicit decision for
+	 * that email. Idempotent per config key — once a key is in the
+	 * FIRST_RUN_OPTION list, this method never reconsiders it. The slug
+	 * is added to FIRST_RUN_OPTION regardless of whether we wrote, so
+	 * the "considered once" semantics hold whether or not the publisher
+	 * already had a decision in place.
+	 *
+	 * The gate is `! isset( $options['enabled'] )` — we only auto-enable
+	 * when the email's WC settings option doesn't carry an `enabled` key
+	 * at all (publisher has never saved that email's WC settings form).
+	 * An explicit `'no'` is a deliberate publisher decision; preserve it.
+	 *
+	 * Hooked on `admin_init` rather than called from `api_get_email_settings()`
+	 * so the GET endpoint stays idempotent — a probe, schema crawler, or
+	 * sibling-admin pageload that hits the wizard route doesn't trigger
+	 * silent WC option writes. The endpoint just reads; this method
+	 * does the writing exactly once per slug, gated by an authenticated
+	 * admin pageload.
+	 *
+	 * Auth/account-chipped WC configs (e.g. customer_new_account) are
+	 * skipped when Reader Activation is disabled — that matches the
+	 * filter the wizard surface applies via filter_configs_by_ra_state
+	 * for visibility, and prevents an auth-only WC email from auto-firing
+	 * on a store-only site that never opted into RA. Crucially they are
+	 * NOT added to the processed list while skipped, so enabling RA later
+	 * still gives them a real first-run pass.
+	 *
+	 * Write failures are not marked processed either: if
+	 * `set_wc_email_enabled_state()` fails to land the enable, the slug is
+	 * left out of the processed list so a later run retries it, and the
+	 * WCS master switch is not flipped on the back of a write that didn't
+	 * take.
+	 *
+	 * Special case: `customer_notification_auto_renewal` requires the WC
+	 * Subscriptions master switch
+	 * (`woocommerce_subscriptions_customer_notifications_enabled`) to
+	 * also be on — otherwise the email never fires regardless of its own
+	 * flag. The master-switch write is nested INSIDE the `! isset` guard
+	 * so it only fires when we're actually auto-enabling the email. A
+	 * publisher who toggled the auto_renewal email OFF before first-run
+	 * ran (`isset($options['enabled'])` already true) doesn't get the
+	 * site-wide WCS master switch silently flipped on as a side effect.
+	 */
+	public static function maybe_first_run_enable_wc_emails(): void {
+		if ( ! self::is_woocommerce_active() ) {
+			return;
+		}
+
+		$ra_enabled = Reader_Activation::is_enabled();
+		$processed  = (array) get_option( self::FIRST_RUN_OPTION, [] );
+		$configs    = Emails::get_email_configs();
+		$changed    = false;
+
+		foreach ( $configs as $type => $config ) {
+			if ( ( $config['source'] ?? 'newspack' ) !== 'woocommerce' ) {
+				continue;
+			}
+			if ( empty( $config['recommended'] ) ) {
+				continue;
+			}
+			// Already processed — don't touch even if currently disabled.
+			// This is the user-disabled-after-first-run protection.
+			if ( in_array( $type, $processed, true ) ) {
+				continue;
+			}
+			// Don't auto-enable auth-account WC emails on sites that
+			// haven't opted into Reader Activation. The wizard's read
+			// path already hides them via filter_configs_by_ra_state;
+			// mirror that here so the write path doesn't fire unrelated
+			// WC emails on store-only sites.
+			//
+			// Skip WITHOUT marking processed: the config is only hidden
+			// because RA is off, so it never got a real first-run pass. If
+			// the publisher enables RA later, we want this recommended row
+			// reconsidered then. Burning it into the processed list here
+			// would permanently deny it the auto-enable it was due once it
+			// became eligible. Re-evaluation each admin pageload while RA is
+			// off is just the cheap chip check above.
+			if ( ! $ra_enabled && 'reader-revenue' !== ( $config['chip'] ?? '' ) ) {
+				continue;
+			}
+
+			$wc_email = WooCommerce_Emails::get_wc_email_by_id( $type );
+			if ( ! $wc_email ) {
+				continue;
+			}
+
+			$option_key = $wc_email->get_option_key();
+			$options    = (array) get_option( $option_key, [] );
+
+			// Only write when the publisher hasn't recorded a decision
+			// yet. An explicit 'no' is preserved. The WCS master-switch
+			// write is nested inside the same guard so a publisher who
+			// already disabled the email doesn't get the site-wide
+			// master switch silently flipped on.
+			if ( ! isset( $options['enabled'] ) ) {
+				if ( ! WooCommerce_Emails::set_wc_email_enabled_state( $type, true ) ) {
+					// Write failed (mailer unresolvable, option write
+					// rejected). Leave the slug UNPROCESSED so a later
+					// admin pageload retries it, and don't flip the
+					// site-wide WCS master switch off the back of an
+					// enable that never landed.
+					continue;
+				}
+
+				// WCS master switch: enable only when not present in the
+				// DB, and only now that the email enable actually
+				// succeeded. `get_option(..., false)` returns the default
+				// `false` only when the option row doesn't exist — an
+				// explicit `'no'` returns `'no'` and is preserved.
+				if (
+					'customer_notification_auto_renewal' === $type
+					&& false === get_option( self::WCS_MASTER_SWITCH_OPTION, false )
+				) {
+					update_option( self::WCS_MASTER_SWITCH_OPTION, 'yes' );
+				}
+			}
+
+			// Mark as processed. Reached either because the publisher
+			// already had a decision (isset above) or because the enable
+			// write just succeeded — both are "considered, don't revisit".
+			// A failed write took the `continue` above and is left
+			// unprocessed so it can retry.
+			$processed[] = $type;
+			$changed     = true;
+		}
+
+		if ( $changed ) {
+			// autoload=false: read once per admin pageload, not on every page load.
+			update_option( self::FIRST_RUN_OPTION, $processed, false );
+		}
+	}
+
+	/**
+	 * Build a wizard response row for a WooCommerce-source config entry.
+	 *
+	 * Resolves the live `WC_Email` instance on-demand from
+	 * {@see WooCommerce_Emails::get_wc_email_by_id()} (memoized; one
+	 * mailer init per request). Returns null when the mailer doesn't
+	 * have the id — caller skips the row.
+	 *
+	 * Read the enabled state from the option rather than the in-memory
+	 * `WC_Email::$enabled` property — same-request writes to the option
+	 * (toggle endpoint, first-run auto-enable) may not be reflected on
+	 * the cached instance returned by WC()->mailer()->get_emails().
+	 * Falls back to `WC_Email::is_enabled()` (which reads the property
+	 * and runs the per-id `woocommerce_email_enabled_*` filter) when
+	 * the option key hasn't been written yet.
+	 *
+	 * The class name for the edit link is read from the config's
+	 * `wc_email_class` field — same value as `get_class($wc_email)`,
+	 * but avoids a runtime reflection call.
+	 *
+	 * @param string $type   Config key (equals WC_Email->id).
+	 * @param array  $config Unified config entry from newspack_email_configs.
+	 * @return ?array Wizard response row, or null if the mailer doesn't know the id.
+	 */
+	private static function serialize_wc_email_row( string $type, array $config ): ?array {
+		$wc_email = WooCommerce_Emails::get_wc_email_by_id( $type );
+		if ( ! $wc_email ) {
+			return null;
+		}
+
+		$option_key = $wc_email->get_option_key();
+		$wc_options = (array) get_option( $option_key, [] );
+		$is_enabled = isset( $wc_options['enabled'] )
+			? 'yes' === $wc_options['enabled']
+			: $wc_email->is_enabled();
+
+		// Resolve once, pass to the edit-link helper — both fields use
+		// the same lookup (option read + class_exists + WC posts-manager
+		// DB query), so doing it twice per row would be wasteful.
+		$template_post_id = self::get_wc_email_template_post_id( $type );
+
+		return [
+			'type'                => $type,
+			'category'            => 'woocommerce',
+			'label'               => $config['label'] ?? '',
+			'description'         => $config['description'] ?? ( $config['trigger_description'] ?? '' ),
+			'post_id'             => 'wc:' . $type,
+			'edit_link'           => self::get_wc_email_edit_link( $template_post_id, $config['wc_email_class'] ?? get_class( $wc_email ) ),
+			'subject'             => '',
+			'from_name'           => '',
+			'from_email'          => '',
+			'reply_to_email'      => '',
+			'status'              => $is_enabled ? 'publish' : 'draft',
+			'html_payload'        => '',
+			'trigger_description' => $config['trigger_description'] ?? '',
+			'recipient'           => $config['recipient'] ?? 'reader',
+			'recommended'         => $config['recommended'] ?? false,
+			'chip'                => $config['chip'] ?? 'auth-account',
+			'source'              => 'woocommerce',
+			'preview_post_id'     => $template_post_id,
+		];
+	}
+
+	/**
+	 * Resolve the block-editor template post ID for a WooCommerce email.
+	 *
+	 * Returns null when the WC block email editor is disabled, when the
+	 * WC posts-manager class isn't loaded, or when no template post
+	 * exists for this email ID. Self-contained — depends only on WC core
+	 * (the option and the posts-manager class). No Email_Preview machinery
+	 * involved; that ships with slice 2b.
+	 *
+	 * @param string $wc_email_id The WC_Email instance ID.
+	 * @return ?int Template post ID, or null.
+	 */
+	private static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
+		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
+			return null;
+		}
+
+		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		if ( ! class_exists( $posts_manager_class ) ) {
+			return null;
+		}
+
+		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
+		if ( empty( $template_post_id ) ) {
+			return null;
+		}
+
+		return (int) $template_post_id;
+	}
+
+	/**
+	 * Build the admin edit link for a WooCommerce email.
+	 *
+	 * Routes to the block editor template post when one exists (the caller
+	 * resolves the template_post_id from get_wc_email_template_post_id —
+	 * passed in here so a single resolution serves both this and the
+	 * `preview_post_id` field on the row), otherwise falls back to the
+	 * classic WC settings page filtered to the email's section.
+	 *
+	 * @param int|null $template_post_id Block-editor template post ID, or null.
+	 * @param string   $wc_email_class   Fully-qualified WC_Email subclass name.
+	 * @return string Admin URL.
+	 */
+	private static function get_wc_email_edit_link( ?int $template_post_id, string $wc_email_class ): string {
+		if ( $template_post_id ) {
+			return add_query_arg(
+				[
+					'post'   => $template_post_id,
+					'action' => 'edit',
+				],
+				admin_url( 'post.php' )
+			);
+		}
+
+		return add_query_arg(
+			[
+				'page'    => 'wc-settings',
+				'tab'     => 'email',
+				'section' => strtolower( $wc_email_class ),
+			],
+			admin_url( 'admin.php' )
 		);
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -50,8 +50,10 @@ class Emails_Section extends Wizard_Section {
 	 *
 	 * Builds the unified emails list directly from the
 	 * `newspack_email_configs` schema — no parallel registry, no join.
-	 * WooCommerce-source rows are filtered out at this layer; slice 2
-	 * removes that filter when the WC surface lands.
+	 * Newspack-source configs resolve to WP posts via Emails::get_emails();
+	 * WooCommerce-source configs build rows from the live WC_Email
+	 * instance attached as `wc_email_instance` (see
+	 * WooCommerce_Emails::get_email_configs()).
 	 *
 	 * @return array{
 	 *     newspack_emails: array<int, array{
@@ -59,7 +61,7 @@ class Emails_Section extends Wizard_Section {
 	 *         category:            string,
 	 *         label:               string,
 	 *         description:         string,
-	 *         post_id:             int,
+	 *         post_id:             int|string,
 	 *         edit_link:           string,
 	 *         subject:             string,
 	 *         from_name:           string,
@@ -72,6 +74,7 @@ class Emails_Section extends Wizard_Section {
 	 *         recommended:         bool,
 	 *         chip:                'auth-account'|'reader-revenue',
 	 *         source:              'newspack'|'woocommerce',
+	 *         preview_post_id?:    ?int,
 	 *     }>,
 	 *     post_type: string,
 	 * }
@@ -79,38 +82,43 @@ class Emails_Section extends Wizard_Section {
 	public static function api_get_email_settings(): array {
 		$configs = Emails::get_email_configs();
 
-		// Slice 1 surfaces only Newspack-source emails. Slice 2 lifts this.
-		$configs = array_filter(
+		// Split by source — Newspack configs go through Emails::get_emails()
+		// for post resolution; WC configs build rows directly from their
+		// attached wc_email_instance.
+		$newspack_configs = array_filter(
 			$configs,
 			fn( $config ) => ( $config['source'] ?? 'newspack' ) !== 'woocommerce'
 		);
+		$wc_configs       = array_filter(
+			$configs,
+			fn( $config ) => ( $config['source'] ?? 'newspack' ) === 'woocommerce'
+		);
 
-		// Without Reader Activation, the auth/account flows are unused —
-		// scope the visible set to reader-revenue configs only. Mirrors the
-		// legacy slice 1 behavior.
-		$configs = self::filter_configs_by_ra_state( Reader_Activation::is_enabled(), $configs );
+		// RA gating applies only to Newspack-source configs (the auth/account
+		// flows have no use without RA). WC configs are gated by their own
+		// plugin_dependency at registration time and surface regardless of
+		// RA state.
+		$newspack_configs = self::filter_configs_by_ra_state( Reader_Activation::is_enabled(), $newspack_configs );
 
 		// Resolve each newspack-source config to a Newspack post + serialized
-		// payload via the existing Emails::get_emails() pipeline. The
-		// serialized output now carries the four new schema fields per the
-		// commit 1 patch to Emails::serialize_email().
-		$types = array_keys( $configs );
-
+		// payload via the existing Emails::get_emails() pipeline.
 		// Guard against the empty-types case: Emails::get_emails() treats
 		// an empty $config_names as "no filter" and returns every registered
 		// email, which would bypass the WC-source and RA-state filters
-		// above. Return an empty list explicitly when there's nothing to
-		// resolve.
-		if ( empty( $types ) ) {
-			return [
-				'newspack_emails' => [],
-				'post_type'       => Emails::POST_TYPE,
-			];
-		}
-
-		$emails = Emails::get_emails( $types, false );
+		// above. Skip the resolve path when there are no Newspack configs;
+		// any WC rows are still appended below.
+		$newspack_types = array_keys( $newspack_configs );
+		$emails         = empty( $newspack_types ) ? [] : Emails::get_emails( $newspack_types, false );
 
 		$newspack_emails = array_values( $emails );
+
+		// Build a row per WC config from its wc_email_instance.
+		foreach ( $wc_configs as $type => $config ) {
+			$wc_row = self::serialize_wc_email_row( $type, $config );
+			if ( null !== $wc_row ) {
+				$newspack_emails[] = $wc_row;
+			}
+		}
 
 		// Single category-only sort: reader-revenue → reader-activation → other.
 		$category_order = [
@@ -167,6 +175,120 @@ class Emails_Section extends Wizard_Section {
 		return array_filter(
 			$configs,
 			fn( $config ) => 'reader-revenue' === ( $config['chip'] ?? '' )
+		);
+	}
+
+	/**
+	 * Build a wizard response row for a WooCommerce-source config entry.
+	 *
+	 * Returns null if the config is missing its `wc_email_instance`.
+	 *
+	 * Read the enabled state from the option rather than the in-memory
+	 * `WC_Email::$enabled` property — same-request writes to the option
+	 * (toggle endpoint, first-run auto-enable) may not be reflected on
+	 * the cached instance returned by WC()->mailer()->get_emails().
+	 *
+	 * @param string $type   Config key (equals WC_Email->id).
+	 * @param array  $config Unified config entry from newspack_email_configs.
+	 * @return ?array Wizard response row, or null if wc_email_instance is missing.
+	 */
+	private static function serialize_wc_email_row( string $type, array $config ): ?array {
+		$wc_email = isset( $config['wc_email_instance'] ) ? $config['wc_email_instance'] : null;
+		if ( ! $wc_email ) {
+			return null;
+		}
+
+		$option_key = $wc_email->get_option_key();
+		$wc_options = (array) get_option( $option_key, [] );
+		$is_enabled = isset( $wc_options['enabled'] )
+			? 'yes' === $wc_options['enabled']
+			: 'yes' === $wc_email->enabled;
+
+		return [
+			'type'                => $type,
+			'category'            => 'woocommerce',
+			'label'               => $config['label'] ?? '',
+			'description'         => $config['description'] ?? ( $config['trigger_description'] ?? '' ),
+			'post_id'             => 'wc:' . $type,
+			'edit_link'           => self::get_wc_email_edit_link( $type, get_class( $wc_email ) ),
+			'subject'             => '',
+			'from_name'           => '',
+			'from_email'          => '',
+			'reply_to_email'      => '',
+			'status'              => $is_enabled ? 'publish' : 'draft',
+			'html_payload'        => '',
+			'trigger_description' => $config['trigger_description'] ?? '',
+			'recipient'           => $config['recipient'] ?? 'reader',
+			'recommended'         => $config['recommended'] ?? false,
+			'chip'                => $config['chip'] ?? 'auth-account',
+			'source'              => 'woocommerce',
+			'registry_slug'       => $type,
+			'preview_post_id'     => self::get_wc_email_template_post_id( $type ),
+		];
+	}
+
+	/**
+	 * Resolve the block-editor template post ID for a WooCommerce email.
+	 *
+	 * Returns null when the WC block email editor is disabled, when the
+	 * WC posts-manager class isn't loaded, or when no template post
+	 * exists for this email ID. Self-contained — depends only on WC core
+	 * (the option and the posts-manager class). No Email_Preview machinery
+	 * involved; that ships with slice 2b.
+	 *
+	 * @param string $wc_email_id The WC_Email instance ID.
+	 * @return ?int Template post ID, or null.
+	 */
+	private static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
+		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
+			return null;
+		}
+
+		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		if ( ! class_exists( $posts_manager_class ) ) {
+			return null;
+		}
+
+		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
+		if ( empty( $template_post_id ) ) {
+			return null;
+		}
+
+		return (int) $template_post_id;
+	}
+
+	/**
+	 * Build the admin edit link for a WooCommerce email.
+	 *
+	 * Routes to the block editor template post when one exists (and the
+	 * WC block email editor is enabled), otherwise falls back to the
+	 * classic WC settings page filtered to the email's section.
+	 *
+	 * @param string $wc_email_id    The WC_Email instance ID.
+	 * @param string $wc_email_class Fully-qualified WC_Email subclass name.
+	 * @return string Admin URL.
+	 */
+	private static function get_wc_email_edit_link( string $wc_email_id, string $wc_email_class ): string {
+		$classic_url = add_query_arg(
+			[
+				'page'    => 'wc-settings',
+				'tab'     => 'email',
+				'section' => strtolower( $wc_email_class ),
+			],
+			admin_url( 'admin.php' )
+		);
+
+		$template_post_id = self::get_wc_email_template_post_id( $wc_email_id );
+		if ( ! $template_post_id ) {
+			return $classic_url;
+		}
+
+		return add_query_arg(
+			[
+				'post'   => $template_post_id,
+				'action' => 'edit',
+			],
+			admin_url( 'post.php' )
 		);
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -43,6 +43,99 @@ class Emails_Section extends Wizard_Section {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+
+		// Toggle endpoint for WooCommerce-source emails. Only registered
+		// when WC is loaded; without WC there are no WC configs to toggle.
+		if ( class_exists( 'WooCommerce' ) ) {
+			register_rest_route(
+				NEWSPACK_API_NAMESPACE,
+				'wizard/' . $this->wizard_slug . '/emails/(?P<id>[A-Za-z0-9_]+)/toggle',
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ __CLASS__, 'api_toggle_wc_email' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+					'args'                => [
+						'id'      => [
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'enabled' => [
+							'type'              => 'boolean',
+							'required'          => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Toggle a WooCommerce email's enabled state.
+	 *
+	 * Validates the email ID against the unified config set — only
+	 * WC-source configs registered by `WooCommerce_Emails::get_email_configs()`
+	 * are toggleable. Writes both the in-memory `WC_Email::$enabled`
+	 * property AND the underlying WC option, in that order:
+	 *
+	 *   1. `$wc_email->enabled = ...`  — in-memory state, defensive in
+	 *      case downstream code reads the cached mailer instance.
+	 *   2. `update_option( $wc_email->get_option_key(), ... )` — the
+	 *      authoritative source of truth. WP busts the options cache on
+	 *      update_option, so the subsequent `get_option()` call inside
+	 *      api_get_email_settings() (via serialize_wc_email_row) reads
+	 *      the new value in the same request.
+	 *
+	 * The response is a refreshed wizard payload — the toggled email's
+	 * status field reflects the new state.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error Refreshed settings payload or error.
+	 */
+	public static function api_toggle_wc_email( $request ) {
+		$wc_email_id = $request->get_param( 'id' );
+		$enabled     = (bool) $request->get_param( 'enabled' );
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return new \WP_Error(
+				'newspack_wc_not_active',
+				__( 'WooCommerce is not active.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$configs   = Emails::get_email_configs();
+		$wc_config = $configs[ $wc_email_id ] ?? null;
+		if (
+			! $wc_config
+			|| ( $wc_config['source'] ?? 'newspack' ) !== 'woocommerce'
+			|| empty( $wc_config['wc_email_instance'] )
+		) {
+			return new \WP_Error(
+				'newspack_wc_email_not_allowed',
+				__( 'WooCommerce email is not in the surfaced allowlist.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$wc_email = $wc_config['wc_email_instance'];
+
+		// In-memory write first — keeps the cached mailer instance's
+		// $enabled property in sync for any downstream code in the same
+		// request that reads it directly rather than going through the
+		// option.
+		$wc_email->enabled = $enabled ? 'yes' : 'no';
+
+		// Option write — authoritative source. serialize_wc_email_row()
+		// reads from this option, so the refreshed api_get_email_settings()
+		// response below reflects the toggled state.
+		$option_key         = $wc_email->get_option_key();
+		$options            = (array) get_option( $option_key, [] );
+		$options['enabled'] = $enabled ? 'yes' : 'no';
+		update_option( $option_key, $options );
+
+		return rest_ensure_response( self::api_get_email_settings() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -32,6 +32,28 @@ class Emails_Section extends Wizard_Section {
 	protected $wizard_slug = 'newspack-settings';
 
 	/**
+	 * Whether WooCommerce is active.
+	 *
+	 * Mockable in tests via the `newspack_woocommerce_active` filter. The
+	 * filter exists because a bare `class_exists( 'WooCommerce' )` check
+	 * couples test isolation to whether some sibling test file declared a
+	 * global `class WooCommerce {}` shim — i.e., suite-order-dependent.
+	 * Tests `add_filter( 'newspack_woocommerce_active', '__return_true' )`
+	 * in their setUp; production code paths see the unfiltered default.
+	 *
+	 * @return bool
+	 */
+	private static function is_woocommerce_active(): bool {
+		/**
+		 * Filters whether WooCommerce is considered active for the
+		 * unified emails wizard. Default is `class_exists( 'WooCommerce' )`.
+		 *
+		 * @param bool $active Whether WC is active.
+		 */
+		return (bool) apply_filters( 'newspack_woocommerce_active', class_exists( 'WooCommerce' ) );
+	}
+
+	/**
 	 * Register the endpoints needed for the wizard screens.
 	 */
 	public function register_rest_routes() {
@@ -47,7 +69,7 @@ class Emails_Section extends Wizard_Section {
 
 		// Toggle endpoint for WooCommerce-source emails. Only registered
 		// when WC is loaded; without WC there are no WC configs to toggle.
-		if ( class_exists( 'WooCommerce' ) ) {
+		if ( self::is_woocommerce_active() ) {
 			register_rest_route(
 				NEWSPACK_API_NAMESPACE,
 				'wizard/' . $this->wizard_slug . '/emails/(?P<id>[A-Za-z0-9_]+)/toggle',
@@ -98,7 +120,7 @@ class Emails_Section extends Wizard_Section {
 		$wc_email_id = $request->get_param( 'id' );
 		$enabled     = (bool) $request->get_param( 'enabled' );
 
-		if ( ! class_exists( 'WooCommerce' ) ) {
+		if ( ! self::is_woocommerce_active() ) {
 			return new \WP_Error(
 				'newspack_wc_not_active',
 				__( 'WooCommerce is not active.', 'newspack-plugin' ),
@@ -303,25 +325,31 @@ class Emails_Section extends Wizard_Section {
 	const FIRST_RUN_OPTION = 'newspack_unified_emails_wc_first_run';
 
 	/**
-	 * On first encounter of a recommended WC email, enable it. Idempotent
-	 * per config key — once a key is in the FIRST_RUN_OPTION list, this
-	 * method never touches that email again. Critically, this means if
-	 * the user manually disables an auto-enabled email after first-run,
-	 * subsequent wizard loads do NOT re-enable it.
+	 * On first encounter of a recommended WC email, enable it — but only
+	 * if the publisher hasn't already recorded an explicit decision for
+	 * that email. Idempotent per config key — once a key is in the
+	 * FIRST_RUN_OPTION list, this method never reconsiders it. The slug
+	 * is added to FIRST_RUN_OPTION regardless of whether we wrote, so
+	 * the "considered once" semantics hold whether or not the publisher
+	 * already had a decision in place.
 	 *
-	 * Writes the email's enabled state through the same path as the
-	 * toggle endpoint (in-memory + option) for source-of-truth
-	 * consistency.
+	 * The gate is `! isset( $options['enabled'] )` — we only auto-enable
+	 * when the email's WC settings option doesn't carry an `enabled` key
+	 * at all (publisher has never saved that email's WC settings form).
+	 * An explicit `'no'` is a deliberate publisher decision; preserve it.
 	 *
 	 * Special case: `customer_notification_auto_renewal` requires the WC
 	 * Subscriptions master switch
 	 * (`woocommerce_subscriptions_customer_notifications_enabled`) to
-	 * also be enabled, otherwise the email never fires regardless of its
-	 * own enabled flag. Enabled here when the auto-renewal email itself
-	 * is first processed.
+	 * also be on — otherwise the email never fires regardless of its own
+	 * flag. We enable the master switch only when the option doesn't
+	 * exist in the DB (`false === get_option(..., false)`). A publisher
+	 * who explicitly disabled it is making a site-wide policy choice
+	 * about all WCS customer notifications, not just this one email; we
+	 * do not silently reverse that.
 	 */
 	private static function maybe_first_run_enable_wc_emails(): void {
-		if ( ! class_exists( 'WooCommerce' ) ) {
+		if ( ! self::is_woocommerce_active() ) {
 			return;
 		}
 
@@ -346,26 +374,32 @@ class Emails_Section extends Wizard_Section {
 				continue;
 			}
 
-			// Read current state from the option (authoritative — same as
-			// serialize_wc_email_row and the toggle endpoint). $wc_email->enabled
-			// is a snapshot from WC boot and can be stale.
-			$option_key      = $wc_email->get_option_key();
-			$options         = (array) get_option( $option_key, [] );
-			$current_enabled = $options['enabled'] ?? $wc_email->enabled;
+			$option_key = $wc_email->get_option_key();
+			$options    = (array) get_option( $option_key, [] );
 
-			if ( 'yes' !== $current_enabled ) {
+			// Only write when the publisher hasn't recorded a decision
+			// yet. An explicit 'no' is preserved.
+			if ( ! isset( $options['enabled'] ) ) {
 				$wc_email->enabled  = 'yes';
 				$options['enabled'] = 'yes';
 				update_option( $option_key, $options );
 			}
 
-			// Auto-renewal notice also needs the WCS master switch on.
-			if ( 'customer_notification_auto_renewal' === $type
-				&& 'yes' !== get_option( 'woocommerce_subscriptions_customer_notifications_enabled' )
+			// WCS master switch: enable only when not present in the DB.
+			// `get_option(..., false)` returns the default `false` only
+			// when the option row doesn't exist — an explicit `'no'`
+			// returns `'no'` and is preserved.
+			if (
+				'customer_notification_auto_renewal' === $type
+				&& false === get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false )
 			) {
 				update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
 			}
 
+			// Mark as processed regardless of whether we wrote — once we
+			// considered the slug, we don't reconsider it. Without this,
+			// a publisher with explicit 'no' would have us re-evaluate
+			// (and skip) the slug on every wizard load.
 			$processed[] = $type;
 			$changed     = true;
 		}

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -173,6 +173,8 @@ class Emails_Section extends Wizard_Section {
 	 * }
 	 */
 	public static function api_get_email_settings(): array {
+		self::maybe_first_run_enable_wc_emails();
+
 		$configs = Emails::get_email_configs();
 
 		// Split by source — Newspack configs go through Emails::get_emails()
@@ -269,6 +271,93 @@ class Emails_Section extends Wizard_Section {
 			$configs,
 			fn( $config ) => 'reader-revenue' === ( $config['chip'] ?? '' )
 		);
+	}
+
+	/**
+	 * Option name tracking which recommended WC email configs have been
+	 * processed by the first-run auto-enable. Storing processed keys (not
+	 * a single "ran once" boolean) keeps the logic idempotent across new
+	 * config additions: a future config that lands later still gets a
+	 * first-run pass on its first appearance, while previously-processed
+	 * configs are skipped — even if the user has manually disabled them
+	 * since.
+	 *
+	 * @var string
+	 */
+	const FIRST_RUN_OPTION = 'newspack_unified_emails_wc_first_run';
+
+	/**
+	 * On first encounter of a recommended WC email, enable it. Idempotent
+	 * per config key — once a key is in the FIRST_RUN_OPTION list, this
+	 * method never touches that email again. Critically, this means if
+	 * the user manually disables an auto-enabled email after first-run,
+	 * subsequent wizard loads do NOT re-enable it.
+	 *
+	 * Writes the email's enabled state through the same path as the
+	 * toggle endpoint (in-memory + option) for source-of-truth
+	 * consistency.
+	 *
+	 * Special case: `customer_notification_auto_renewal` requires the WC
+	 * Subscriptions master switch
+	 * (`woocommerce_subscriptions_customer_notifications_enabled`) to
+	 * also be enabled, otherwise the email never fires regardless of its
+	 * own enabled flag. Enabled here when the auto-renewal email itself
+	 * is first processed.
+	 */
+	private static function maybe_first_run_enable_wc_emails(): void {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
+		$processed = (array) get_option( self::FIRST_RUN_OPTION, [] );
+		$configs   = Emails::get_email_configs();
+		$changed   = false;
+
+		foreach ( $configs as $type => $config ) {
+			if ( ( $config['source'] ?? 'newspack' ) !== 'woocommerce' ) {
+				continue;
+			}
+			if ( empty( $config['recommended'] ) ) {
+				continue;
+			}
+			// Already processed — don't touch even if currently disabled.
+			// This is the user-disabled-after-first-run protection.
+			if ( in_array( $type, $processed, true ) ) {
+				continue;
+			}
+			$wc_email = $config['wc_email_instance'] ?? null;
+			if ( ! $wc_email ) {
+				continue;
+			}
+
+			// Read current state from the option (authoritative — same as
+			// serialize_wc_email_row and the toggle endpoint). $wc_email->enabled
+			// is a snapshot from WC boot and can be stale.
+			$option_key      = $wc_email->get_option_key();
+			$options         = (array) get_option( $option_key, [] );
+			$current_enabled = $options['enabled'] ?? $wc_email->enabled;
+
+			if ( 'yes' !== $current_enabled ) {
+				$wc_email->enabled  = 'yes';
+				$options['enabled'] = 'yes';
+				update_option( $option_key, $options );
+			}
+
+			// Auto-renewal notice also needs the WCS master switch on.
+			if ( 'customer_notification_auto_renewal' === $type
+				&& 'yes' !== get_option( 'woocommerce_subscriptions_customer_notifications_enabled' )
+			) {
+				update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
+			}
+
+			$processed[] = $type;
+			$changed     = true;
+		}
+
+		if ( $changed ) {
+			// autoload=false: read once per wizard request, not on every page load.
+			update_option( self::FIRST_RUN_OPTION, $processed, false );
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -11,6 +11,7 @@ use Newspack\Emails;
 use Newspack\Reader_Activation;
 use Newspack\Reader_Revenue_Emails;
 use Newspack\Wizards\Wizard_Section;
+use Newspack\WooCommerce_Emails;
 use WP_REST_Server;
 
 defined( 'ABSPATH' ) || exit;
@@ -107,11 +108,7 @@ class Emails_Section extends Wizard_Section {
 
 		$configs   = Emails::get_email_configs();
 		$wc_config = $configs[ $wc_email_id ] ?? null;
-		if (
-			! $wc_config
-			|| ( $wc_config['source'] ?? 'newspack' ) !== 'woocommerce'
-			|| empty( $wc_config['wc_email_instance'] )
-		) {
+		if ( ! $wc_config || 'woocommerce' !== ( $wc_config['source'] ?? 'newspack' ) ) {
 			return new \WP_Error(
 				'newspack_wc_email_not_allowed',
 				__( 'WooCommerce email is not in the surfaced allowlist.', 'newspack-plugin' ),
@@ -119,7 +116,14 @@ class Emails_Section extends Wizard_Section {
 			);
 		}
 
-		$wc_email = $wc_config['wc_email_instance'];
+		$wc_email = WooCommerce_Emails::get_wc_email_by_id( $wc_email_id );
+		if ( ! $wc_email ) {
+			return new \WP_Error(
+				'newspack_wc_email_not_allowed',
+				__( 'WooCommerce email is not in the surfaced allowlist.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
 
 		// In-memory write first — keeps the cached mailer instance's
 		// $enabled property in sync for any downstream code in the same
@@ -144,9 +148,10 @@ class Emails_Section extends Wizard_Section {
 	 * Builds the unified emails list directly from the
 	 * `newspack_email_configs` schema — no parallel registry, no join.
 	 * Newspack-source configs resolve to WP posts via Emails::get_emails();
-	 * WooCommerce-source configs build rows from the live WC_Email
-	 * instance attached as `wc_email_instance` (see
-	 * WooCommerce_Emails::get_email_configs()).
+	 * WooCommerce-source configs build rows by resolving the live WC_Email
+	 * instance on-demand via WooCommerce_Emails::get_wc_email_by_id()
+	 * (the schema itself only carries `wc_email_class` — a scalar
+	 * string — so it stays JSON-serializable).
 	 *
 	 * @return array{
 	 *     newspack_emails: array<int, array{
@@ -178,8 +183,8 @@ class Emails_Section extends Wizard_Section {
 		$configs = Emails::get_email_configs();
 
 		// Split by source — Newspack configs go through Emails::get_emails()
-		// for post resolution; WC configs build rows directly from their
-		// attached wc_email_instance.
+		// for post resolution; WC configs build rows by resolving the
+		// live WC_Email instance via WooCommerce_Emails::get_wc_email_by_id().
 		$newspack_configs = array_filter(
 			$configs,
 			fn( $config ) => ( $config['source'] ?? 'newspack' ) !== 'woocommerce'
@@ -207,7 +212,8 @@ class Emails_Section extends Wizard_Section {
 
 		$newspack_emails = array_values( $emails );
 
-		// Build a row per WC config from its wc_email_instance.
+		// Build a row per WC config — serialize_wc_email_row resolves
+		// the live WC_Email instance via WooCommerce_Emails::get_wc_email_by_id().
 		foreach ( $wc_configs as $type => $config ) {
 			$wc_row = self::serialize_wc_email_row( $type, $config );
 			if ( null !== $wc_row ) {
@@ -335,7 +341,7 @@ class Emails_Section extends Wizard_Section {
 			if ( in_array( $type, $processed, true ) ) {
 				continue;
 			}
-			$wc_email = $config['wc_email_instance'] ?? null;
+			$wc_email = WooCommerce_Emails::get_wc_email_by_id( $type );
 			if ( ! $wc_email ) {
 				continue;
 			}
@@ -373,19 +379,29 @@ class Emails_Section extends Wizard_Section {
 	/**
 	 * Build a wizard response row for a WooCommerce-source config entry.
 	 *
-	 * Returns null if the config is missing its `wc_email_instance`.
+	 * Resolves the live `WC_Email` instance on-demand from
+	 * {@see WooCommerce_Emails::get_wc_email_by_id()} (memoized; one
+	 * mailer init per request). Returns null when the mailer doesn't
+	 * have the id — caller skips the row.
 	 *
 	 * Read the enabled state from the option rather than the in-memory
 	 * `WC_Email::$enabled` property — same-request writes to the option
 	 * (toggle endpoint, first-run auto-enable) may not be reflected on
 	 * the cached instance returned by WC()->mailer()->get_emails().
+	 * Falls back to `WC_Email::is_enabled()` (which reads the property
+	 * and runs the per-id `woocommerce_email_enabled_*` filter) when
+	 * the option key hasn't been written yet.
+	 *
+	 * The class name for the edit link is read from the config's
+	 * `wc_email_class` field — same value as `get_class($wc_email)`,
+	 * but avoids a runtime reflection call.
 	 *
 	 * @param string $type   Config key (equals WC_Email->id).
 	 * @param array  $config Unified config entry from newspack_email_configs.
-	 * @return ?array Wizard response row, or null if wc_email_instance is missing.
+	 * @return ?array Wizard response row, or null if the mailer doesn't know the id.
 	 */
 	private static function serialize_wc_email_row( string $type, array $config ): ?array {
-		$wc_email = isset( $config['wc_email_instance'] ) ? $config['wc_email_instance'] : null;
+		$wc_email = WooCommerce_Emails::get_wc_email_by_id( $type );
 		if ( ! $wc_email ) {
 			return null;
 		}
@@ -394,7 +410,7 @@ class Emails_Section extends Wizard_Section {
 		$wc_options = (array) get_option( $option_key, [] );
 		$is_enabled = isset( $wc_options['enabled'] )
 			? 'yes' === $wc_options['enabled']
-			: 'yes' === $wc_email->enabled;
+			: $wc_email->is_enabled();
 
 		return [
 			'type'                => $type,
@@ -402,7 +418,7 @@ class Emails_Section extends Wizard_Section {
 			'label'               => $config['label'] ?? '',
 			'description'         => $config['description'] ?? ( $config['trigger_description'] ?? '' ),
 			'post_id'             => 'wc:' . $type,
-			'edit_link'           => self::get_wc_email_edit_link( $type, get_class( $wc_email ) ),
+			'edit_link'           => self::get_wc_email_edit_link( $type, $config['wc_email_class'] ?? get_class( $wc_email ) ),
 			'subject'             => '',
 			'from_name'           => '',
 			'from_email'          => '',

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -327,6 +327,17 @@ class Emails_Section extends Wizard_Section {
 	const FIRST_RUN_OPTION = 'newspack_unified_emails_wc_first_run';
 
 	/**
+	 * WC Subscriptions site-wide master switch option key. When this is
+	 * unset, the renewal-reminder email never fires regardless of its
+	 * own enabled flag — first-run mirrors the email's auto-enable into
+	 * this switch ONLY when we're also enabling the email itself (see
+	 * `maybe_first_run_enable_wc_emails`).
+	 *
+	 * @var string
+	 */
+	const WCS_MASTER_SWITCH_OPTION = 'woocommerce_subscriptions_customer_notifications_enabled';
+
+	/**
 	 * On first encounter of a recommended WC email, enable it — but only
 	 * if the publisher hasn't already recorded an explicit decision for
 	 * that email. Idempotent per config key — once a key is in the
@@ -418,9 +429,9 @@ class Emails_Section extends Wizard_Section {
 				// `'no'` returns `'no'` and is preserved.
 				if (
 					'customer_notification_auto_renewal' === $type
-					&& false === get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false )
+					&& false === get_option( self::WCS_MASTER_SWITCH_OPTION, false )
 				) {
-					update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
+					update_option( self::WCS_MASTER_SWITCH_OPTION, 'yes' );
 				}
 			}
 

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -221,17 +221,27 @@ class Emails_Section extends Wizard_Section {
 			'reader-activation' => 1,
 		];
 		// `usort` is not stable in PHP — same-category rows can reorder
-		// across requests without a tiebreaker. Use the config type as a
-		// deterministic secondary key so the API output is consistent.
+		// across requests without a tiebreaker. Use the config's
+		// registration order in `$configs` as the secondary key:
+		// providers register in deliberate order (WC: gift emails
+		// adjacent in `WooCommerce_Emails::surfaced_wc_emails()`;
+		// Newspack: receipt → welcome → cancellation in
+		// `Reader_Revenue_Emails`, verification → magic-link → ...
+		// in `Reader_Activation_Emails`), so registration order
+		// equals intended display order. This mirrors the legacy
+		// `array_flip(array_keys($registry))` pattern.
+		$type_order = array_flip( array_keys( $configs ) );
 		usort(
 			$newspack_emails,
-			function ( $a, $b ) use ( $category_order ) {
+			function ( $a, $b ) use ( $category_order, $type_order ) {
 				$order_a = $category_order[ $a['category'] ?? '' ] ?? 2;
 				$order_b = $category_order[ $b['category'] ?? '' ] ?? 2;
 				if ( $order_a !== $order_b ) {
 					return $order_a - $order_b;
 				}
-				return strcmp( (string) ( $a['type'] ?? '' ), (string) ( $b['type'] ?? '' ) );
+				$idx_a = $type_order[ $a['type'] ?? '' ] ?? PHP_INT_MAX;
+				$idx_b = $type_order[ $b['type'] ?? '' ] ?? PHP_INT_MAX;
+				return $idx_a - $idx_b;
 			}
 		);
 

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -32,6 +32,20 @@ class Emails_Section extends Wizard_Section {
 	protected $wizard_slug = 'newspack-settings';
 
 	/**
+	 * Constructor — extends Wizard_Section's REST-route hookup with an
+	 * admin_init handler for the WC first-run auto-enable. Decoupling
+	 * first-run from api_get_email_settings keeps the GET endpoint
+	 * idempotent (probes / crawlers can no longer trigger silent
+	 * WC option writes).
+	 *
+	 * @param array $args Section arguments.
+	 */
+	public function __construct( $args = [] ) {
+		parent::__construct( $args );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_first_run_enable_wc_emails' ] );
+	}
+
+	/**
 	 * Whether WooCommerce is active.
 	 *
 	 * Mockable in tests via the `newspack_woocommerce_active` filter. The
@@ -128,6 +142,8 @@ class Emails_Section extends Wizard_Section {
 			);
 		}
 
+		// Validate the id is one of the surfaced WC configs before
+		// touching the mailer — defense against arbitrary id input.
 		$configs   = Emails::get_email_configs();
 		$wc_config = $configs[ $wc_email_id ] ?? null;
 		if ( ! $wc_config || 'woocommerce' !== ( $wc_config['source'] ?? 'newspack' ) ) {
@@ -138,28 +154,13 @@ class Emails_Section extends Wizard_Section {
 			);
 		}
 
-		$wc_email = WooCommerce_Emails::get_wc_email_by_id( $wc_email_id );
-		if ( ! $wc_email ) {
+		if ( ! WooCommerce_Emails::set_wc_email_enabled_state( $wc_email_id, $enabled ) ) {
 			return new \WP_Error(
-				'newspack_wc_email_not_allowed',
-				__( 'WooCommerce email is not in the surfaced allowlist.', 'newspack-plugin' ),
-				[ 'status' => 404 ]
+				'newspack_wc_email_write_failed',
+				__( 'Could not update the WooCommerce email state.', 'newspack-plugin' ),
+				[ 'status' => 500 ]
 			);
 		}
-
-		// In-memory write first — keeps the cached mailer instance's
-		// $enabled property in sync for any downstream code in the same
-		// request that reads it directly rather than going through the
-		// option.
-		$wc_email->enabled = $enabled ? 'yes' : 'no';
-
-		// Option write — authoritative source. serialize_wc_email_row()
-		// reads from this option, so the refreshed api_get_email_settings()
-		// response below reflects the toggled state.
-		$option_key         = $wc_email->get_option_key();
-		$options            = (array) get_option( $option_key, [] );
-		$options['enabled'] = $enabled ? 'yes' : 'no';
-		update_option( $option_key, $options );
 
 		return rest_ensure_response( self::api_get_email_settings() );
 	}
@@ -200,8 +201,9 @@ class Emails_Section extends Wizard_Section {
 	 * }
 	 */
 	public static function api_get_email_settings(): array {
-		self::maybe_first_run_enable_wc_emails();
-
+		// First-run runs on admin_init (constructor-hooked), not here —
+		// keeps the GET endpoint idempotent so probes / crawlers / SSR
+		// bootstrap reads can't trigger WC option writes as a side effect.
 		$configs = Emails::get_email_configs();
 
 		// Split by source — Newspack configs go through Emails::get_emails()
@@ -338,24 +340,38 @@ class Emails_Section extends Wizard_Section {
 	 * at all (publisher has never saved that email's WC settings form).
 	 * An explicit `'no'` is a deliberate publisher decision; preserve it.
 	 *
+	 * Hooked on `admin_init` rather than called from `api_get_email_settings()`
+	 * so the GET endpoint stays idempotent — a probe, schema crawler, or
+	 * sibling-admin pageload that hits the wizard route doesn't trigger
+	 * silent WC option writes. The endpoint just reads; this method
+	 * does the writing exactly once per slug, gated by an authenticated
+	 * admin pageload.
+	 *
+	 * Auth/account-chipped WC configs (e.g. customer_new_account) are
+	 * skipped when Reader Activation is disabled — that matches the
+	 * filter the wizard surface applies via filter_configs_by_ra_state
+	 * for visibility, and prevents an auth-only WC email from auto-firing
+	 * on a store-only site that never opted into RA.
+	 *
 	 * Special case: `customer_notification_auto_renewal` requires the WC
 	 * Subscriptions master switch
 	 * (`woocommerce_subscriptions_customer_notifications_enabled`) to
 	 * also be on — otherwise the email never fires regardless of its own
-	 * flag. We enable the master switch only when the option doesn't
-	 * exist in the DB (`false === get_option(..., false)`). A publisher
-	 * who explicitly disabled it is making a site-wide policy choice
-	 * about all WCS customer notifications, not just this one email; we
-	 * do not silently reverse that.
+	 * flag. The master-switch write is nested INSIDE the `! isset` guard
+	 * so it only fires when we're actually auto-enabling the email. A
+	 * publisher who toggled the auto_renewal email OFF before first-run
+	 * ran (`isset($options['enabled'])` already true) doesn't get the
+	 * site-wide WCS master switch silently flipped on as a side effect.
 	 */
-	private static function maybe_first_run_enable_wc_emails(): void {
+	public static function maybe_first_run_enable_wc_emails(): void {
 		if ( ! self::is_woocommerce_active() ) {
 			return;
 		}
 
-		$processed = (array) get_option( self::FIRST_RUN_OPTION, [] );
-		$configs   = Emails::get_email_configs();
-		$changed   = false;
+		$ra_enabled = Reader_Activation::is_enabled();
+		$processed  = (array) get_option( self::FIRST_RUN_OPTION, [] );
+		$configs    = Emails::get_email_configs();
+		$changed    = false;
 
 		foreach ( $configs as $type => $config ) {
 			if ( ( $config['source'] ?? 'newspack' ) !== 'woocommerce' ) {
@@ -369,6 +385,17 @@ class Emails_Section extends Wizard_Section {
 			if ( in_array( $type, $processed, true ) ) {
 				continue;
 			}
+			// Don't auto-enable auth-account WC emails on sites that
+			// haven't opted into Reader Activation. The wizard's read
+			// path already hides them via filter_configs_by_ra_state;
+			// mirror that here so the write path doesn't fire unrelated
+			// WC emails on store-only sites.
+			if ( ! $ra_enabled && 'reader-revenue' !== ( $config['chip'] ?? '' ) ) {
+				$processed[] = $type;
+				$changed     = true;
+				continue;
+			}
+
 			$wc_email = WooCommerce_Emails::get_wc_email_by_id( $type );
 			if ( ! $wc_email ) {
 				continue;
@@ -378,22 +405,23 @@ class Emails_Section extends Wizard_Section {
 			$options    = (array) get_option( $option_key, [] );
 
 			// Only write when the publisher hasn't recorded a decision
-			// yet. An explicit 'no' is preserved.
+			// yet. An explicit 'no' is preserved. The WCS master-switch
+			// write is nested inside the same guard so a publisher who
+			// already disabled the email doesn't get the site-wide
+			// master switch silently flipped on.
 			if ( ! isset( $options['enabled'] ) ) {
-				$wc_email->enabled  = 'yes';
-				$options['enabled'] = 'yes';
-				update_option( $option_key, $options );
-			}
+				WooCommerce_Emails::set_wc_email_enabled_state( $type, true );
 
-			// WCS master switch: enable only when not present in the DB.
-			// `get_option(..., false)` returns the default `false` only
-			// when the option row doesn't exist — an explicit `'no'`
-			// returns `'no'` and is preserved.
-			if (
-				'customer_notification_auto_renewal' === $type
-				&& false === get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false )
-			) {
-				update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
+				// WCS master switch: enable only when not present in the
+				// DB. `get_option(..., false)` returns the default `false`
+				// only when the option row doesn't exist — an explicit
+				// `'no'` returns `'no'` and is preserved.
+				if (
+					'customer_notification_auto_renewal' === $type
+					&& false === get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false )
+				) {
+					update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
+				}
 			}
 
 			// Mark as processed regardless of whether we wrote — once we
@@ -405,7 +433,7 @@ class Emails_Section extends Wizard_Section {
 		}
 
 		if ( $changed ) {
-			// autoload=false: read once per wizard request, not on every page load.
+			// autoload=false: read once per admin pageload, not on every page load.
 			update_option( self::FIRST_RUN_OPTION, $processed, false );
 		}
 	}
@@ -446,13 +474,18 @@ class Emails_Section extends Wizard_Section {
 			? 'yes' === $wc_options['enabled']
 			: $wc_email->is_enabled();
 
+		// Resolve once, pass to the edit-link helper — both fields use
+		// the same lookup (option read + class_exists + WC posts-manager
+		// DB query), so doing it twice per row would be wasteful.
+		$template_post_id = self::get_wc_email_template_post_id( $type );
+
 		return [
 			'type'                => $type,
 			'category'            => 'woocommerce',
 			'label'               => $config['label'] ?? '',
 			'description'         => $config['description'] ?? ( $config['trigger_description'] ?? '' ),
 			'post_id'             => 'wc:' . $type,
-			'edit_link'           => self::get_wc_email_edit_link( $type, $config['wc_email_class'] ?? get_class( $wc_email ) ),
+			'edit_link'           => self::get_wc_email_edit_link( $template_post_id, $config['wc_email_class'] ?? get_class( $wc_email ) ),
 			'subject'             => '',
 			'from_name'           => '',
 			'from_email'          => '',
@@ -464,8 +497,7 @@ class Emails_Section extends Wizard_Section {
 			'recommended'         => $config['recommended'] ?? false,
 			'chip'                => $config['chip'] ?? 'auth-account',
 			'source'              => 'woocommerce',
-			'registry_slug'       => $type,
-			'preview_post_id'     => self::get_wc_email_template_post_id( $type ),
+			'preview_post_id'     => $template_post_id,
 		];
 	}
 
@@ -502,35 +534,34 @@ class Emails_Section extends Wizard_Section {
 	/**
 	 * Build the admin edit link for a WooCommerce email.
 	 *
-	 * Routes to the block editor template post when one exists (and the
-	 * WC block email editor is enabled), otherwise falls back to the
+	 * Routes to the block editor template post when one exists (the caller
+	 * resolves the template_post_id from get_wc_email_template_post_id —
+	 * passed in here so a single resolution serves both this and the
+	 * `preview_post_id` field on the row), otherwise falls back to the
 	 * classic WC settings page filtered to the email's section.
 	 *
-	 * @param string $wc_email_id    The WC_Email instance ID.
-	 * @param string $wc_email_class Fully-qualified WC_Email subclass name.
+	 * @param int|null $template_post_id Block-editor template post ID, or null.
+	 * @param string   $wc_email_class   Fully-qualified WC_Email subclass name.
 	 * @return string Admin URL.
 	 */
-	private static function get_wc_email_edit_link( string $wc_email_id, string $wc_email_class ): string {
-		$classic_url = add_query_arg(
+	private static function get_wc_email_edit_link( ?int $template_post_id, string $wc_email_class ): string {
+		if ( $template_post_id ) {
+			return add_query_arg(
+				[
+					'post'   => $template_post_id,
+					'action' => 'edit',
+				],
+				admin_url( 'post.php' )
+			);
+		}
+
+		return add_query_arg(
 			[
 				'page'    => 'wc-settings',
 				'tab'     => 'email',
 				'section' => strtolower( $wc_email_class ),
 			],
 			admin_url( 'admin.php' )
-		);
-
-		$template_post_id = self::get_wc_email_template_post_id( $wc_email_id );
-		if ( ! $template_post_id ) {
-			return $classic_url;
-		}
-
-		return add_query_arg(
-			[
-				'post'   => $template_post_id,
-				'action' => 'edit',
-			],
-			admin_url( 'post.php' )
 		);
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -11,6 +11,43 @@
 	padding-right: var(--newspack-wizard-section-space, 24px);
 }
 
+// Chip filter bar above the DataViews grid. Two-way toggle between
+// 'Reader revenue' and 'Authentication & account' — every email belongs
+// to exactly one chip group, so there's no "All" view.
+//
+// Horizontal padding matches the 24px inner padding `@wordpress/dataviews`
+// applies to `.dataviews__view-actions`, so the chip bar's left edge
+// lines up with the search field and grid below. Without this the bar
+// reads as unmoored — sitting at the section padding edge while the
+// DataViews controls are inset another 24px.
+//
+// Vertical: the Newspack DataViews wrapper applies `margin-top: -16px`
+// in full-width contexts (see packages/components/src/dataviews/style.scss).
+// Exactly cancelling it (margin-bottom: 16px) makes the chip bar's
+// bottom edge share a y-coordinate with the wrapper's top edge — at
+// which point the wrapper's background paints over the bottom border
+// of the selected chip pill, clipping its outline visually. Use 24px
+// so 8px of positive gap remains between chip-bar bottom and wrapper
+// top after the pull-up resolves (24 + -16 = 8). Visible gap to the
+// search row inside DataViews is 24px (8 + view-actions padding-top
+// of 16px).
+.newspack-emails__chips {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 24px;
+	padding: 0 24px;
+
+	// Nested for specificity over WP Button defaults — without the
+	// `.components-button` chain, the pill shape and padding lose to
+	// WP's default button styling.
+	.newspack-emails__chip.components-button {
+		border-radius: 20px;
+		padding: 4px 16px;
+		font-size: 13px;
+		line-height: 1.4;
+	}
+}
+
 // DataViews search/filter/icon alignment.
 // The Settings emails section is registered with `fullWidth: true` in
 // sections.tsx, which adds `.newspack-wizard__content--full-width` to the

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -11,6 +11,25 @@
 	padding-right: var(--newspack-wizard-section-space, 24px);
 }
 
+// Chip filter bar above the DataViews grid. Two-way toggle between
+// 'Reader revenue' and 'Authentication & account' — every email belongs
+// to exactly one chip group, so there's no "All" view.
+.newspack-emails__chips {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 16px;
+
+	// Nested for specificity over WP Button defaults — without the
+	// `.components-button` chain, the pill shape and padding lose to
+	// WP's default button styling.
+	.newspack-emails__chip.components-button {
+		border-radius: 20px;
+		padding: 4px 16px;
+		font-size: 13px;
+		line-height: 1.4;
+	}
+}
+
 // DataViews search/filter/icon alignment.
 // The Settings emails section is registered with `fullWidth: true` in
 // sections.tsx, which adds `.newspack-wizard__content--full-width` to the

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -14,10 +14,21 @@
 // Chip filter bar above the DataViews grid. Two-way toggle between
 // 'Reader revenue' and 'Authentication & account' — every email belongs
 // to exactly one chip group, so there's no "All" view.
+//
+// Horizontal padding matches the 24px inner padding `@wordpress/dataviews`
+// applies to `.dataviews__view-actions`, so the chip bar's left edge
+// lines up with the search field and grid below. Without this the bar
+// reads as unmoored — sitting at the section padding edge while the
+// DataViews controls are inset another 24px.
+//
+// Vertical: a tighter `margin-bottom` than the DataViews action-row top
+// padding pulls the chip bar visually into the same filter strip as
+// search rather than feeling like a separate region.
 .newspack-emails__chips {
 	display: flex;
 	gap: 8px;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
+	padding: 0 24px;
 
 	// Nested for specificity over WP Button defaults — without the
 	// `.components-button` chain, the pill shape and padding lose to

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -21,13 +21,16 @@
 // reads as unmoored — sitting at the section padding edge while the
 // DataViews controls are inset another 24px.
 //
-// Vertical: a tighter `margin-bottom` than the DataViews action-row top
-// padding pulls the chip bar visually into the same filter strip as
-// search rather than feeling like a separate region.
+// Vertical: `margin-bottom: 16px` exactly cancels the `-16px` pull-up
+// the Newspack DataViews wrapper applies in full-width contexts (see
+// packages/components/src/dataviews/style.scss). Anything smaller and
+// DataViews' background overlaps the bottom of the chip pills and
+// clips them. Internal `view-actions` padding-top (16px) provides the
+// visible gap between chips and the search row.
 .newspack-emails__chips {
 	display: flex;
 	gap: 8px;
-	margin-bottom: 8px;
+	margin-bottom: 16px;
 	padding: 0 24px;
 
 	// Nested for specificity over WP Button defaults — without the

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -21,16 +21,20 @@
 // reads as unmoored — sitting at the section padding edge while the
 // DataViews controls are inset another 24px.
 //
-// Vertical: `margin-bottom: 16px` exactly cancels the `-16px` pull-up
-// the Newspack DataViews wrapper applies in full-width contexts (see
-// packages/components/src/dataviews/style.scss). Anything smaller and
-// DataViews' background overlaps the bottom of the chip pills and
-// clips them. Internal `view-actions` padding-top (16px) provides the
-// visible gap between chips and the search row.
+// Vertical: the Newspack DataViews wrapper applies `margin-top: -16px`
+// in full-width contexts (see packages/components/src/dataviews/style.scss).
+// Exactly cancelling it (margin-bottom: 16px) makes the chip bar's
+// bottom edge share a y-coordinate with the wrapper's top edge — at
+// which point the wrapper's background paints over the bottom border
+// of the selected chip pill, clipping its outline visually. Use 24px
+// so 8px of positive gap remains between chip-bar bottom and wrapper
+// top after the pull-up resolves (24 + -16 = 8). Visible gap to the
+// search row inside DataViews is 24px (8 + view-actions padding-top
+// of 16px).
 .newspack-emails__chips {
 	display: flex;
 	gap: 8px;
-	margin-bottom: 16px;
+	margin-bottom: 24px;
 	padding: 0 24px;
 
 	// Nested for specificity over WP Button defaults — without the

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 
 jest.mock( './emails.scss', () => ( {} ) );
 
@@ -33,8 +33,11 @@ jest.mock( '@wordpress/dataviews', () => ( {
 	} ),
 } ) );
 
-// Use mock-prefixed name so Jest's hoisted jest.mock can close over it.
+// Use mock-prefixed names so Jest's hoisted jest.mock can close over them.
 let mockCapturedActions = [];
+let mockCapturedView = null;
+let mockCapturedOnChangeView = null;
+let mockCapturedData = [];
 
 jest.mock( '../../../../../../packages/components/src', () => {
 	function renderField( field, item ) {
@@ -48,8 +51,11 @@ jest.mock( '../../../../../../packages/components/src', () => {
 	}
 	return {
 		Badge: ( { text } ) => <span>{ text }</span>,
-		DataViews: ( { data, fields, actions } ) => {
+		DataViews: ( { data, fields, actions, view, onChangeView } ) => {
 			mockCapturedActions = actions || [];
+			mockCapturedView = view;
+			mockCapturedOnChangeView = onChangeView;
+			mockCapturedData = data;
 			return (
 				<table data-testid="dataviews">
 					<tbody>
@@ -80,7 +86,8 @@ jest.mock(
 		}
 );
 
-// Slice 1 surfaces only Newspack-source emails. WC fixtures land with slice 2.
+// Fixtures span both chips and both sources so the chip-filter and
+// type-routing tests have meaningful data on either side of the toggle.
 const mockEmails = [
 	{
 		label: 'Payment receipt',
@@ -93,6 +100,7 @@ const mockEmails = [
 		registry_slug: 'receipt',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
 	},
 	{
 		label: 'Cancellation confirmation',
@@ -105,6 +113,7 @@ const mockEmails = [
 		registry_slug: 'cancellation',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
 	},
 	{
 		label: 'Reader verification',
@@ -117,6 +126,7 @@ const mockEmails = [
 		registry_slug: 'reader-activation-verification',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'auth-account',
 	},
 	{
 		label: 'Account deletion',
@@ -129,6 +139,7 @@ const mockEmails = [
 		registry_slug: 'reader-activation-delete-account',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'auth-account',
 	},
 	{
 		label: 'Welcome email',
@@ -141,6 +152,37 @@ const mockEmails = [
 		registry_slug: 'welcome',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
+	},
+	// WC-source, reader-revenue chip, admin recipient, currently enabled —
+	// exercises the deactivate→toggleWcEmail route (string post_id).
+	{
+		label: 'New order',
+		post_id: 'wc:new_order',
+		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order',
+		status: 'publish',
+		type: 'new_order',
+		category: 'woocommerce',
+		trigger_description: 'Sent to the admin when a new order is placed.',
+		registry_slug: 'new_order',
+		recipient: 'admin',
+		source: 'woocommerce',
+		chip: 'reader-revenue',
+	},
+	// WC-source, auth-account chip, currently disabled — exercises the
+	// activate→toggleWcEmail route (string post_id).
+	{
+		label: 'New account',
+		post_id: 'wc:customer_new_account',
+		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_new_account',
+		status: 'draft',
+		type: 'customer_new_account',
+		category: 'woocommerce',
+		trigger_description: 'Sent when a customer creates a new account.',
+		registry_slug: 'customer_new_account',
+		recipient: 'reader',
+		source: 'woocommerce',
+		chip: 'auth-account',
 	},
 ];
 
@@ -148,6 +190,10 @@ describe( 'Emails', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockErrorMessage = null;
+		mockCapturedActions = [];
+		mockCapturedView = null;
+		mockCapturedOnChangeView = null;
+		mockCapturedData = [];
 		window.newspackSettings = {
 			emails: {
 				sections: {
@@ -172,26 +218,34 @@ describe( 'Emails', () => {
 		} );
 	} );
 
-	it( 'renders all emails in a single view', async () => {
+	it( 'renders reader-revenue emails by default', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
+		// Default chip is reader-revenue — these rows are visible.
 		await waitFor( () => {
 			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Cancellation confirmation' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Reader verification' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Account deletion' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Welcome email' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'New order' ) ).toBeInTheDocument();
 		} );
+
+		// Auth-account rows are filtered out by default.
+		expect( screen.queryByText( 'Reader verification' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Account deletion' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New account' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders Recipient column with Reader for newspack-source emails', async () => {
+	it( 'renders Recipient column with Reader/Admin labels', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
+			// Default chip = reader-revenue: 3 Reader (receipt, cancellation, welcome) + 1 Admin (new_order).
 			const readerCells = screen.getAllByText( 'Reader' );
-			expect( readerCells.length ).toBeGreaterThanOrEqual( 5 );
+			expect( readerCells.length ).toBeGreaterThanOrEqual( 3 );
+			const adminCells = screen.getAllByText( 'Admin' );
+			expect( adminCells.length ).toBeGreaterThanOrEqual( 1 );
 		} );
 	} );
 
@@ -218,6 +272,11 @@ describe( 'Emails', () => {
 		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
 		deactivate.callback( [ mockEmails[ 0 ] ] );
 
+		// updateStatus applies the new status optimistically in local
+		// state before the fetch fires, then passes `onError` only —
+		// rollback on failure, no onSuccess. (Verifying onError exists
+		// instead of onSuccess catches a regression that drops the
+		// rollback path.)
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				path: '/wp/v2/newspack_rr_email/1',
@@ -259,6 +318,9 @@ describe( 'Emails', () => {
 		expect( activate.isEligible( mockEmails[ 4 ] ) ).toBe( true );
 		activate.callback( [ mockEmails[ 4 ] ] );
 
+		// updateStatus applies the new status optimistically — onError
+		// is the only callback (rollback on failure). See the matching
+		// deactivate test above for the same shape.
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				path: '/wp/v2/newspack_rr_email/5',
@@ -317,7 +379,7 @@ describe( 'Emails', () => {
 		);
 	} );
 
-	it( 'reset is eligible only for newspack-source emails', async () => {
+	it( 'reset is eligible for newspack-source rows', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -326,11 +388,312 @@ describe( 'Emails', () => {
 		} );
 
 		const reset = mockCapturedActions.find( a => a.id === 'reset' );
-		// Newspack-source email — eligible.
+		// Reset's `isEligible` is gated on `item.source === 'newspack'`
+		// only — the legacy registry_slug check was dropped in the
+		// refactor (the registry_slug field is derived from the unified
+		// config, and a Newspack-source row that lacks one is in any
+		// case a Newspack-emails-system error, not a UI-input case to
+		// guard against). The sister test below covers the WC-source
+		// inverse.
 		expect( reset.isEligible( mockEmails[ 0 ] ) ).toBe( true );
-		// Non-Newspack (e.g. WooCommerce) source — not eligible. Mirrors the
-		// server-side boundary: only Newspack-managed emails are resettable.
-		expect( reset.isEligible( { ...mockEmails[ 0 ], source: 'woocommerce' } ) ).toBe( false );
+	} );
+
+	// Slice 2a — WC surfacing tests below.
+
+	it( 'reset is NOT eligible for a woocommerce-source row', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const reset = mockCapturedActions.find( a => a.id === 'reset' );
+		// WC-source row — source guard rejects, even with registry_slug present.
+		expect( reset.isEligible( mockEmails[ 5 ] ) ).toBe( false );
+		// And again with the auth-account WC row.
+		expect( reset.isEligible( mockEmails[ 6 ] ) ).toBe( false );
+	} );
+
+	it( 'deactivate routes string post_id to toggleWcEmail', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
+		// WC row is publish + category !== reader-activation → eligible.
+		expect( deactivate.isEligible( mockEmails[ 5 ] ) ).toBe( true );
+		deactivate.callback( [ mockEmails[ 5 ] ] );
+
+		// Type-based routing: string post_id 'wc:new_order' goes to the
+		// toggle endpoint, not to wp/v2 post status update.
+		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/new_order/toggle',
+				method: 'POST',
+				data: { enabled: false },
+			} ),
+			expect.objectContaining( {
+				onSuccess: expect.any( Function ),
+			} )
+		);
+		// And it did NOT fall through to the wp/v2 update path.
+		expect( mockWizardApiFetch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( '/wp/v2/' ),
+			} ),
+			expect.anything()
+		);
+	} );
+
+	it( 'activate routes string post_id to toggleWcEmail', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const activate = mockCapturedActions.find( a => a.id === 'activate' );
+		// WC draft row → eligible for activate.
+		expect( activate.isEligible( mockEmails[ 6 ] ) ).toBe( true );
+		activate.callback( [ mockEmails[ 6 ] ] );
+
+		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/customer_new_account/toggle',
+				method: 'POST',
+				data: { enabled: true },
+			} ),
+			expect.objectContaining( {
+				onSuccess: expect.any( Function ),
+			} )
+		);
+	} );
+
+	it( 'toggleWcEmail onSuccess replaces local state with the authoritative server response', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Deactivate the enabled WC row (New order). The toggle mock resolves
+		// without invoking callbacks, so we drive onSuccess by hand below.
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
+		act( () => {
+			deactivate.callback( [ mockEmails[ 5 ] ] );
+		} );
+
+		const toggleCall = mockWizardApiFetch.mock.calls.find( ( [ opts ] ) => opts.path?.includes( '/toggle' ) );
+		expect( toggleCall ).toBeDefined();
+		const { onSuccess } = toggleCall[ 1 ];
+
+		// Server returns an authoritative payload that differs from anything
+		// the client could predict (a sibling row's label changed). onSuccess
+		// must replace local state with it wholesale.
+		const serverEmails = mockEmails.map( email =>
+			email.post_id === 1 ? { ...email, label: 'Payment receipt (server-authoritative)' } : email
+		);
+		act( () => {
+			onSuccess( { newspack_emails: serverEmails, post_type: 'newspack_rr_email' } );
+		} );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Payment receipt (server-authoritative)' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'toggleWcEmail onError rolls back the optimistic status change', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// New order starts enabled (publish).
+		const before = mockCapturedData.find( item => item.post_id === 'wc:new_order' );
+		expect( before.status ).toBe( 'publish' );
+
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
+		act( () => {
+			deactivate.callback( [ mockEmails[ 5 ] ] );
+		} );
+
+		// Optimistic update flipped it to draft before the request settled.
+		await waitFor( () => {
+			expect( mockCapturedData.find( item => item.post_id === 'wc:new_order' ).status ).toBe( 'draft' );
+		} );
+
+		// Drive the failure path — onError restores the pre-toggle snapshot.
+		const toggleCall = mockWizardApiFetch.mock.calls.find( ( [ opts ] ) => opts.path?.includes( '/toggle' ) );
+		const { onError } = toggleCall[ 1 ];
+		act( () => {
+			onError();
+		} );
+
+		await waitFor( () => {
+			expect( mockCapturedData.find( item => item.post_id === 'wc:new_order' ).status ).toBe( 'publish' );
+		} );
+	} );
+
+	it( 'chip filter shows only rows matching activeChip', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		// Default chip = reader-revenue. Auth-account rows are filtered out.
+		await waitFor( () => {
+			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
+		} );
+		expect( screen.queryByText( 'Reader verification' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New account' ) ).not.toBeInTheDocument();
+
+		// Switch chip — auth-account rows now visible, reader-revenue rows hidden.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Authentication & account' } ) );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Reader verification' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Account deletion' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'New account' ) ).toBeInTheDocument();
+		} );
+		expect( screen.queryByText( 'Payment receipt' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Cancellation confirmation' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New order' ) ).not.toBeInTheDocument();
+
+		// The DataViews input is also chip-filtered before filterSortAndPaginate.
+		expect( mockCapturedData.every( item => item.chip === 'auth-account' ) ).toBe( true );
+	} );
+
+	it( 'chip switch resets search and page', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Simulate DataViews search/page change. Wrapped in act() because
+		// onChangeView triggers a React state update outside an event handler.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'receipt',
+				page: 3,
+			} );
+		} );
+		await waitFor( () => {
+			expect( mockCapturedView.search ).toBe( 'receipt' );
+			expect( mockCapturedView.page ).toBe( 3 );
+		} );
+
+		// Click the other chip — selectChip() resets search and page.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Authentication & account' } ) );
+
+		await waitFor( () => {
+			expect( mockCapturedView.search ).toBe( '' );
+			expect( mockCapturedView.page ).toBe( 1 );
+		} );
+	} );
+
+	it( 'search bypasses chip filter — operates across all chips', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Default (no search): chip filter active, reader-revenue only.
+		expect( mockCapturedData.every( item => item.chip === 'reader-revenue' ) ).toBe( true );
+		expect( mockCapturedData.length ).toBe( 4 );
+
+		// Activate search via the DataViews onChangeView prop.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'anything',
+				page: 1,
+			} );
+		} );
+
+		// Full dataset now flows into filterSortAndPaginate — both chips
+		// represented, no chip pre-filter applied.
+		await waitFor( () => {
+			expect( mockCapturedData.length ).toBe( mockEmails.length );
+		} );
+		const chipsRepresented = new Set( mockCapturedData.map( item => item.chip ) );
+		expect( chipsRepresented ).toEqual( new Set( [ 'reader-revenue', 'auth-account' ] ) );
+	} );
+
+	it( 'chip bar shows both chips unpressed during active search', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const rrChip = screen.getByRole( 'button', { name: 'Reader revenue' } );
+		const aaChip = screen.getByRole( 'button', {
+			name: 'Authentication & account',
+		} );
+
+		// Default: Reader revenue chip is pressed.
+		expect( rrChip.getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		expect( aaChip.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+
+		// Search active — both chips deactivate visually (activeChip is
+		// still set in state, but the visual matches what's filtering).
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'foo',
+				page: 1,
+			} );
+		} );
+
+		await waitFor( () => {
+			expect( rrChip.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+			expect( aaChip.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+		} );
+	} );
+
+	it( 'clearing search restores active chip pressed state', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Set search.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'foo',
+				page: 1,
+			} );
+		} );
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Reader revenue' } ).getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+		} );
+
+		// Clear search — activeChip (still 'reader-revenue') re-engages.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: '',
+				page: 1,
+			} );
+		} );
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Reader revenue' } ).getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		} );
 	} );
 
 	it( 'renders the Emails heading as visually hidden (screen-reader only)', async () => {

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -272,6 +272,11 @@ describe( 'Emails', () => {
 		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
 		deactivate.callback( [ mockEmails[ 0 ] ] );
 
+		// updateStatus applies the new status optimistically in local
+		// state before the fetch fires, then passes `onError` only —
+		// rollback on failure, no onSuccess. (Verifying onError exists
+		// instead of onSuccess catches a regression that drops the
+		// rollback path.)
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				path: '/wp/v2/newspack_rr_email/1',
@@ -279,7 +284,7 @@ describe( 'Emails', () => {
 				data: { status: 'draft' },
 			} ),
 			expect.objectContaining( {
-				onSuccess: expect.any( Function ),
+				onError: expect.any( Function ),
 			} )
 		);
 	} );
@@ -311,6 +316,9 @@ describe( 'Emails', () => {
 		expect( activate.isEligible( mockEmails[ 4 ] ) ).toBe( true );
 		activate.callback( [ mockEmails[ 4 ] ] );
 
+		// updateStatus applies the new status optimistically — onError
+		// is the only callback (rollback on failure). See the matching
+		// deactivate test above for the same shape.
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				path: '/wp/v2/newspack_rr_email/5',
@@ -318,7 +326,7 @@ describe( 'Emails', () => {
 				data: { status: 'publish' },
 			} ),
 			expect.objectContaining( {
-				onSuccess: expect.any( Function ),
+				onError: expect.any( Function ),
 			} )
 		);
 	} );
@@ -367,7 +375,7 @@ describe( 'Emails', () => {
 		);
 	} );
 
-	it( 'reset is eligible when registry_slug is present on a newspack-source row', async () => {
+	it( 'reset is eligible for newspack-source rows', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -376,10 +384,14 @@ describe( 'Emails', () => {
 		} );
 
 		const reset = mockCapturedActions.find( a => a.id === 'reset' );
-		// Newspack-source email with registry_slug — eligible.
+		// Reset's `isEligible` is gated on `item.source === 'newspack'`
+		// only — the legacy registry_slug check was dropped in the
+		// refactor (the registry_slug field is derived from the unified
+		// config, and a Newspack-source row that lacks one is in any
+		// case a Newspack-emails-system error, not a UI-input case to
+		// guard against). The sister test below covers the WC-source
+		// inverse.
 		expect( reset.isEligible( mockEmails[ 0 ] ) ).toBe( true );
-		// Same email without registry_slug — not eligible.
-		expect( reset.isEligible( { ...mockEmails[ 0 ], registry_slug: '' } ) ).toBe( false );
 	} );
 
 	// Slice 2a — WC surfacing tests below.

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -3,7 +3,13 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+	render,
+	screen,
+	waitFor,
+	fireEvent,
+	act,
+} from '@testing-library/react';
 
 jest.mock( './emails.scss', () => ( {} ) );
 
@@ -27,14 +33,17 @@ jest.mock( '@wordpress/icons', () => ( {
 } ) );
 
 jest.mock( '@wordpress/dataviews', () => ( {
-	filterSortAndPaginate: data => ( {
+	filterSortAndPaginate: ( data ) => ( {
 		data,
 		paginationInfo: { totalItems: data.length, totalPages: 1 },
 	} ),
 } ) );
 
-// Use mock-prefixed name so Jest's hoisted jest.mock can close over it.
+// Use mock-prefixed names so Jest's hoisted jest.mock can close over them.
 let mockCapturedActions = [];
+let mockCapturedView = null;
+let mockCapturedOnChangeView = null;
+let mockCapturedData = [];
 
 jest.mock( '../../../../../../packages/components/src', () => {
 	function renderField( field, item ) {
@@ -48,15 +57,20 @@ jest.mock( '../../../../../../packages/components/src', () => {
 	}
 	return {
 		Badge: ( { text } ) => <span>{ text }</span>,
-		DataViews: ( { data, fields, actions } ) => {
+		DataViews: ( { data, fields, actions, view, onChangeView } ) => {
 			mockCapturedActions = actions || [];
+			mockCapturedView = view;
+			mockCapturedOnChangeView = onChangeView;
+			mockCapturedData = data;
 			return (
 				<table data-testid="dataviews">
 					<tbody>
 						{ data.map( ( item, i ) => (
 							<tr key={ i }>
-								{ fields.map( field => (
-									<td key={ field.id }>{ renderField( field, item ) }</td>
+								{ fields.map( ( field ) => (
+									<td key={ field.id }>
+										{ renderField( field, item ) }
+									</td>
 								) ) }
 							</tr>
 						) ) }
@@ -65,7 +79,9 @@ jest.mock( '../../../../../../packages/components/src', () => {
 			);
 		},
 		Card: ( { children } ) => <div data-testid="card">{ children }</div>,
-		Notice: ( { noticeText } ) => <div data-testid="notice">{ noticeText }</div>,
+		Notice: ( { noticeText } ) => (
+			<div data-testid="notice">{ noticeText }</div>
+		),
 		utils: {
 			confirmAction: jest.fn( () => true ),
 		},
@@ -80,7 +96,8 @@ jest.mock(
 		}
 );
 
-// Slice 1 surfaces only Newspack-source emails. WC fixtures land with slice 2.
+// Fixtures span both chips and both sources so the chip-filter and
+// type-routing tests have meaningful data on either side of the toggle.
 const mockEmails = [
 	{
 		label: 'Payment receipt',
@@ -93,6 +110,7 @@ const mockEmails = [
 		registry_slug: 'receipt',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
 	},
 	{
 		label: 'Cancellation confirmation',
@@ -105,6 +123,7 @@ const mockEmails = [
 		registry_slug: 'cancellation',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
 	},
 	{
 		label: 'Reader verification',
@@ -113,10 +132,12 @@ const mockEmails = [
 		status: 'publish',
 		type: 'reader-activation-verification',
 		category: 'reader-activation',
-		trigger_description: 'Sent when a reader needs to verify their email address.',
+		trigger_description:
+			'Sent when a reader needs to verify their email address.',
 		registry_slug: 'reader-activation-verification',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'auth-account',
 	},
 	{
 		label: 'Account deletion',
@@ -125,10 +146,12 @@ const mockEmails = [
 		status: 'draft',
 		type: 'reader-activation-delete-account',
 		category: 'reader-activation',
-		trigger_description: 'Sent when a reader requests to delete their account.',
+		trigger_description:
+			'Sent when a reader requests to delete their account.',
 		registry_slug: 'reader-activation-delete-account',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'auth-account',
 	},
 	{
 		label: 'Welcome email',
@@ -137,10 +160,44 @@ const mockEmails = [
 		status: 'draft',
 		type: 'welcome',
 		category: 'reader-revenue',
-		trigger_description: 'Sent to new supporters after their first payment.',
+		trigger_description:
+			'Sent to new supporters after their first payment.',
 		registry_slug: 'welcome',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
+	},
+	// WC-source, reader-revenue chip, admin recipient, currently enabled —
+	// exercises the deactivate→toggleWcEmail route (string post_id).
+	{
+		label: 'New order',
+		post_id: 'wc:new_order',
+		edit_link:
+			'/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order',
+		status: 'publish',
+		type: 'new_order',
+		category: 'woocommerce',
+		trigger_description: 'Sent to the admin when a new order is placed.',
+		registry_slug: 'new_order',
+		recipient: 'admin',
+		source: 'woocommerce',
+		chip: 'reader-revenue',
+	},
+	// WC-source, auth-account chip, currently disabled — exercises the
+	// activate→toggleWcEmail route (string post_id).
+	{
+		label: 'New account',
+		post_id: 'wc:customer_new_account',
+		edit_link:
+			'/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_new_account',
+		status: 'draft',
+		type: 'customer_new_account',
+		category: 'woocommerce',
+		trigger_description: 'Sent when a customer creates a new account.',
+		registry_slug: 'customer_new_account',
+		recipient: 'reader',
+		source: 'woocommerce',
+		chip: 'auth-account',
 	},
 ];
 
@@ -148,6 +205,10 @@ describe( 'Emails', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockErrorMessage = null;
+		mockCapturedActions = [];
+		mockCapturedView = null;
+		mockCapturedOnChangeView = null;
+		mockCapturedData = [];
 		window.newspackSettings = {
 			emails: {
 				sections: {
@@ -162,7 +223,9 @@ describe( 'Emails', () => {
 			},
 		};
 		mockWizardApiFetch.mockImplementation( ( opts, callbacks ) => {
-			if ( opts.path === '/newspack/v1/wizard/newspack-settings/emails' ) {
+			if (
+				opts.path === '/newspack/v1/wizard/newspack-settings/emails'
+			) {
 				callbacks?.onSuccess?.( {
 					newspack_emails: mockEmails,
 					post_type: 'newspack_rr_email',
@@ -172,26 +235,40 @@ describe( 'Emails', () => {
 		} );
 	} );
 
-	it( 'renders all emails in a single view', async () => {
+	it( 'renders reader-revenue emails by default', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
+		// Default chip is reader-revenue — these rows are visible.
 		await waitFor( () => {
 			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Cancellation confirmation' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Reader verification' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Account deletion' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Cancellation confirmation' )
+			).toBeInTheDocument();
 			expect( screen.getByText( 'Welcome email' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'New order' ) ).toBeInTheDocument();
 		} );
+
+		// Auth-account rows are filtered out by default.
+		expect(
+			screen.queryByText( 'Reader verification' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Account deletion' )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New account' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders Recipient column with Reader for newspack-source emails', async () => {
+	it( 'renders Recipient column with Reader/Admin labels', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
+			// Default chip = reader-revenue: 3 Reader (receipt, cancellation, welcome) + 1 Admin (new_order).
 			const readerCells = screen.getAllByText( 'Reader' );
-			expect( readerCells.length ).toBeGreaterThanOrEqual( 5 );
+			expect( readerCells.length ).toBeGreaterThanOrEqual( 3 );
+			const adminCells = screen.getAllByText( 'Admin' );
+			expect( adminCells.length ).toBeGreaterThanOrEqual( 1 );
 		} );
 	} );
 
@@ -215,7 +292,9 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
+		const deactivate = mockCapturedActions.find(
+			( a ) => a.id === 'deactivate'
+		);
 		deactivate.callback( [ mockEmails[ 0 ] ] );
 
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
@@ -238,7 +317,9 @@ describe( 'Emails', () => {
 
 		await waitFor( () => {
 			expect( screen.getByTestId( 'notice' ) ).toBeInTheDocument();
-			expect( screen.getByTestId( 'notice' ) ).toHaveTextContent( 'Something went wrong' );
+			expect( screen.getByTestId( 'notice' ) ).toHaveTextContent(
+				'Something went wrong'
+			);
 		} );
 	} );
 
@@ -250,7 +331,9 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const activate = mockCapturedActions.find( a => a.id === 'activate' );
+		const activate = mockCapturedActions.find(
+			( a ) => a.id === 'activate'
+		);
 		// mockEmails[4] (Welcome email) is newspack + reader-revenue + draft —
 		// actually eligible for activate (category !== 'reader-activation').
 		// Verifies the callback wiring on an item that would pass `isEligible`.
@@ -277,8 +360,12 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
-		const activate = mockCapturedActions.find( a => a.id === 'activate' );
+		const deactivate = mockCapturedActions.find(
+			( a ) => a.id === 'deactivate'
+		);
+		const activate = mockCapturedActions.find(
+			( a ) => a.id === 'activate'
+		);
 
 		// Reader-activation emails cannot be toggled.
 		expect( deactivate.isEligible( mockEmails[ 2 ] ) ).toBe( false );
@@ -289,7 +376,9 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'reset action calls wizardApiFetch with DELETE after confirmation', async () => {
-		const { utils } = require( '../../../../../../packages/components/src' );
+		const {
+			utils,
+		} = require( '../../../../../../packages/components/src' );
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -297,7 +386,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const reset = mockCapturedActions.find( a => a.id === 'reset' );
+		const reset = mockCapturedActions.find( ( a ) => a.id === 'reset' );
 		reset.callback( [ mockEmails[ 0 ] ] );
 
 		expect( utils.confirmAction ).toHaveBeenCalled();
@@ -313,7 +402,7 @@ describe( 'Emails', () => {
 		);
 	} );
 
-	it( 'reset is eligible when registry_slug is present', async () => {
+	it( 'reset is eligible when registry_slug is present on a newspack-source row', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -321,10 +410,166 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const reset = mockCapturedActions.find( a => a.id === 'reset' );
-		// Email with registry_slug — eligible.
+		const reset = mockCapturedActions.find( ( a ) => a.id === 'reset' );
+		// Newspack-source email with registry_slug — eligible.
 		expect( reset.isEligible( mockEmails[ 0 ] ) ).toBe( true );
-		// Email without registry_slug — not eligible.
-		expect( reset.isEligible( { ...mockEmails[ 0 ], registry_slug: '' } ) ).toBe( false );
+		// Same email without registry_slug — not eligible.
+		expect(
+			reset.isEligible( { ...mockEmails[ 0 ], registry_slug: '' } )
+		).toBe( false );
+	} );
+
+	// Slice 2a — WC surfacing tests below.
+
+	it( 'reset is NOT eligible for a woocommerce-source row', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const reset = mockCapturedActions.find( ( a ) => a.id === 'reset' );
+		// WC-source row — source guard rejects, even with registry_slug present.
+		expect( reset.isEligible( mockEmails[ 5 ] ) ).toBe( false );
+		// And again with the auth-account WC row.
+		expect( reset.isEligible( mockEmails[ 6 ] ) ).toBe( false );
+	} );
+
+	it( 'deactivate routes string post_id to toggleWcEmail', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const deactivate = mockCapturedActions.find(
+			( a ) => a.id === 'deactivate'
+		);
+		// WC row is publish + category !== reader-activation → eligible.
+		expect( deactivate.isEligible( mockEmails[ 5 ] ) ).toBe( true );
+		deactivate.callback( [ mockEmails[ 5 ] ] );
+
+		// Type-based routing: string post_id 'wc:new_order' goes to the
+		// toggle endpoint, not to wp/v2 post status update.
+		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/new_order/toggle',
+				method: 'POST',
+				data: { enabled: false },
+			} ),
+			expect.objectContaining( {
+				onSuccess: expect.any( Function ),
+			} )
+		);
+		// And it did NOT fall through to the wp/v2 update path.
+		expect( mockWizardApiFetch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( '/wp/v2/' ),
+			} ),
+			expect.anything()
+		);
+	} );
+
+	it( 'activate routes string post_id to toggleWcEmail', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const activate = mockCapturedActions.find(
+			( a ) => a.id === 'activate'
+		);
+		// WC draft row → eligible for activate.
+		expect( activate.isEligible( mockEmails[ 6 ] ) ).toBe( true );
+		activate.callback( [ mockEmails[ 6 ] ] );
+
+		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/customer_new_account/toggle',
+				method: 'POST',
+				data: { enabled: true },
+			} ),
+			expect.objectContaining( {
+				onSuccess: expect.any( Function ),
+			} )
+		);
+	} );
+
+	it( 'chip filter shows only rows matching activeChip', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		// Default chip = reader-revenue. Auth-account rows are filtered out.
+		await waitFor( () => {
+			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
+		} );
+		expect(
+			screen.queryByText( 'Reader verification' )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New account' ) ).not.toBeInTheDocument();
+
+		// Switch chip — auth-account rows now visible, reader-revenue rows hidden.
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Authentication & account' } )
+		);
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Reader verification' )
+			).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Account deletion' )
+			).toBeInTheDocument();
+			expect( screen.getByText( 'New account' ) ).toBeInTheDocument();
+		} );
+		expect(
+			screen.queryByText( 'Payment receipt' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Cancellation confirmation' )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New order' ) ).not.toBeInTheDocument();
+
+		// The DataViews input is also chip-filtered before filterSortAndPaginate.
+		expect(
+			mockCapturedData.every( ( item ) => item.chip === 'auth-account' )
+		).toBe( true );
+	} );
+
+	it( 'chip switch resets search and page', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Simulate DataViews search/page change. Wrapped in act() because
+		// onChangeView triggers a React state update outside an event handler.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'receipt',
+				page: 3,
+			} );
+		} );
+		await waitFor( () => {
+			expect( mockCapturedView.search ).toBe( 'receipt' );
+			expect( mockCapturedView.page ).toBe( 3 );
+		} );
+
+		// Click the other chip — selectChip() resets search and page.
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Authentication & account' } )
+		);
+
+		await waitFor( () => {
+			expect( mockCapturedView.search ).toBe( '' );
+			expect( mockCapturedView.page ).toBe( 1 );
+		} );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -3,13 +3,7 @@
 /**
  * External dependencies
  */
-import {
-	render,
-	screen,
-	waitFor,
-	fireEvent,
-	act,
-} from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 
 jest.mock( './emails.scss', () => ( {} ) );
 
@@ -33,7 +27,7 @@ jest.mock( '@wordpress/icons', () => ( {
 } ) );
 
 jest.mock( '@wordpress/dataviews', () => ( {
-	filterSortAndPaginate: ( data ) => ( {
+	filterSortAndPaginate: data => ( {
 		data,
 		paginationInfo: { totalItems: data.length, totalPages: 1 },
 	} ),
@@ -67,10 +61,8 @@ jest.mock( '../../../../../../packages/components/src', () => {
 					<tbody>
 						{ data.map( ( item, i ) => (
 							<tr key={ i }>
-								{ fields.map( ( field ) => (
-									<td key={ field.id }>
-										{ renderField( field, item ) }
-									</td>
+								{ fields.map( field => (
+									<td key={ field.id }>{ renderField( field, item ) }</td>
 								) ) }
 							</tr>
 						) ) }
@@ -79,9 +71,7 @@ jest.mock( '../../../../../../packages/components/src', () => {
 			);
 		},
 		Card: ( { children } ) => <div data-testid="card">{ children }</div>,
-		Notice: ( { noticeText } ) => (
-			<div data-testid="notice">{ noticeText }</div>
-		),
+		Notice: ( { noticeText } ) => <div data-testid="notice">{ noticeText }</div>,
 		utils: {
 			confirmAction: jest.fn( () => true ),
 		},
@@ -132,8 +122,7 @@ const mockEmails = [
 		status: 'publish',
 		type: 'reader-activation-verification',
 		category: 'reader-activation',
-		trigger_description:
-			'Sent when a reader needs to verify their email address.',
+		trigger_description: 'Sent when a reader needs to verify their email address.',
 		registry_slug: 'reader-activation-verification',
 		recipient: 'reader',
 		source: 'newspack',
@@ -146,8 +135,7 @@ const mockEmails = [
 		status: 'draft',
 		type: 'reader-activation-delete-account',
 		category: 'reader-activation',
-		trigger_description:
-			'Sent when a reader requests to delete their account.',
+		trigger_description: 'Sent when a reader requests to delete their account.',
 		registry_slug: 'reader-activation-delete-account',
 		recipient: 'reader',
 		source: 'newspack',
@@ -160,8 +148,7 @@ const mockEmails = [
 		status: 'draft',
 		type: 'welcome',
 		category: 'reader-revenue',
-		trigger_description:
-			'Sent to new supporters after their first payment.',
+		trigger_description: 'Sent to new supporters after their first payment.',
 		registry_slug: 'welcome',
 		recipient: 'reader',
 		source: 'newspack',
@@ -172,8 +159,7 @@ const mockEmails = [
 	{
 		label: 'New order',
 		post_id: 'wc:new_order',
-		edit_link:
-			'/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order',
+		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order',
 		status: 'publish',
 		type: 'new_order',
 		category: 'woocommerce',
@@ -188,8 +174,7 @@ const mockEmails = [
 	{
 		label: 'New account',
 		post_id: 'wc:customer_new_account',
-		edit_link:
-			'/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_new_account',
+		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_new_account',
 		status: 'draft',
 		type: 'customer_new_account',
 		category: 'woocommerce',
@@ -223,9 +208,7 @@ describe( 'Emails', () => {
 			},
 		};
 		mockWizardApiFetch.mockImplementation( ( opts, callbacks ) => {
-			if (
-				opts.path === '/newspack/v1/wizard/newspack-settings/emails'
-			) {
+			if ( opts.path === '/newspack/v1/wizard/newspack-settings/emails' ) {
 				callbacks?.onSuccess?.( {
 					newspack_emails: mockEmails,
 					post_type: 'newspack_rr_email',
@@ -242,20 +225,14 @@ describe( 'Emails', () => {
 		// Default chip is reader-revenue — these rows are visible.
 		await waitFor( () => {
 			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
-			expect(
-				screen.getByText( 'Cancellation confirmation' )
-			).toBeInTheDocument();
+			expect( screen.getByText( 'Cancellation confirmation' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Welcome email' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'New order' ) ).toBeInTheDocument();
 		} );
 
 		// Auth-account rows are filtered out by default.
-		expect(
-			screen.queryByText( 'Reader verification' )
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText( 'Account deletion' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Reader verification' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Account deletion' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'New account' ) ).not.toBeInTheDocument();
 	} );
 
@@ -292,9 +269,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const deactivate = mockCapturedActions.find(
-			( a ) => a.id === 'deactivate'
-		);
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
 		deactivate.callback( [ mockEmails[ 0 ] ] );
 
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
@@ -317,9 +292,7 @@ describe( 'Emails', () => {
 
 		await waitFor( () => {
 			expect( screen.getByTestId( 'notice' ) ).toBeInTheDocument();
-			expect( screen.getByTestId( 'notice' ) ).toHaveTextContent(
-				'Something went wrong'
-			);
+			expect( screen.getByTestId( 'notice' ) ).toHaveTextContent( 'Something went wrong' );
 		} );
 	} );
 
@@ -331,9 +304,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const activate = mockCapturedActions.find(
-			( a ) => a.id === 'activate'
-		);
+		const activate = mockCapturedActions.find( a => a.id === 'activate' );
 		// mockEmails[4] (Welcome email) is newspack + reader-revenue + draft —
 		// actually eligible for activate (category !== 'reader-activation').
 		// Verifies the callback wiring on an item that would pass `isEligible`.
@@ -360,12 +331,8 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const deactivate = mockCapturedActions.find(
-			( a ) => a.id === 'deactivate'
-		);
-		const activate = mockCapturedActions.find(
-			( a ) => a.id === 'activate'
-		);
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
+		const activate = mockCapturedActions.find( a => a.id === 'activate' );
 
 		// Reader-activation emails cannot be toggled.
 		expect( deactivate.isEligible( mockEmails[ 2 ] ) ).toBe( false );
@@ -376,9 +343,7 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'reset action calls wizardApiFetch with DELETE after confirmation', async () => {
-		const {
-			utils,
-		} = require( '../../../../../../packages/components/src' );
+		const { utils } = require( '../../../../../../packages/components/src' );
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -386,7 +351,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const reset = mockCapturedActions.find( ( a ) => a.id === 'reset' );
+		const reset = mockCapturedActions.find( a => a.id === 'reset' );
 		reset.callback( [ mockEmails[ 0 ] ] );
 
 		expect( utils.confirmAction ).toHaveBeenCalled();
@@ -410,13 +375,11 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const reset = mockCapturedActions.find( ( a ) => a.id === 'reset' );
+		const reset = mockCapturedActions.find( a => a.id === 'reset' );
 		// Newspack-source email with registry_slug — eligible.
 		expect( reset.isEligible( mockEmails[ 0 ] ) ).toBe( true );
 		// Same email without registry_slug — not eligible.
-		expect(
-			reset.isEligible( { ...mockEmails[ 0 ], registry_slug: '' } )
-		).toBe( false );
+		expect( reset.isEligible( { ...mockEmails[ 0 ], registry_slug: '' } ) ).toBe( false );
 	} );
 
 	// Slice 2a — WC surfacing tests below.
@@ -429,7 +392,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const reset = mockCapturedActions.find( ( a ) => a.id === 'reset' );
+		const reset = mockCapturedActions.find( a => a.id === 'reset' );
 		// WC-source row — source guard rejects, even with registry_slug present.
 		expect( reset.isEligible( mockEmails[ 5 ] ) ).toBe( false );
 		// And again with the auth-account WC row.
@@ -444,9 +407,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const deactivate = mockCapturedActions.find(
-			( a ) => a.id === 'deactivate'
-		);
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
 		// WC row is publish + category !== reader-activation → eligible.
 		expect( deactivate.isEligible( mockEmails[ 5 ] ) ).toBe( true );
 		deactivate.callback( [ mockEmails[ 5 ] ] );
@@ -480,9 +441,7 @@ describe( 'Emails', () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
 		} );
 
-		const activate = mockCapturedActions.find(
-			( a ) => a.id === 'activate'
-		);
+		const activate = mockCapturedActions.find( a => a.id === 'activate' );
 		// WC draft row → eligible for activate.
 		expect( activate.isEligible( mockEmails[ 6 ] ) ).toBe( true );
 		activate.callback( [ mockEmails[ 6 ] ] );
@@ -507,37 +466,23 @@ describe( 'Emails', () => {
 		await waitFor( () => {
 			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
 		} );
-		expect(
-			screen.queryByText( 'Reader verification' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Reader verification' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'New account' ) ).not.toBeInTheDocument();
 
 		// Switch chip — auth-account rows now visible, reader-revenue rows hidden.
-		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Authentication & account' } )
-		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Authentication & account' } ) );
 
 		await waitFor( () => {
-			expect(
-				screen.getByText( 'Reader verification' )
-			).toBeInTheDocument();
-			expect(
-				screen.getByText( 'Account deletion' )
-			).toBeInTheDocument();
+			expect( screen.getByText( 'Reader verification' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Account deletion' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'New account' ) ).toBeInTheDocument();
 		} );
-		expect(
-			screen.queryByText( 'Payment receipt' )
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText( 'Cancellation confirmation' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Payment receipt' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Cancellation confirmation' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'New order' ) ).not.toBeInTheDocument();
 
 		// The DataViews input is also chip-filtered before filterSortAndPaginate.
-		expect(
-			mockCapturedData.every( ( item ) => item.chip === 'auth-account' )
-		).toBe( true );
+		expect( mockCapturedData.every( item => item.chip === 'auth-account' ) ).toBe( true );
 	} );
 
 	it( 'chip switch resets search and page', async () => {
@@ -563,9 +508,7 @@ describe( 'Emails', () => {
 		} );
 
 		// Click the other chip — selectChip() resets search and page.
-		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Authentication & account' } )
-		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Authentication & account' } ) );
 
 		await waitFor( () => {
 			expect( mockCapturedView.search ).toBe( '' );
@@ -582,9 +525,7 @@ describe( 'Emails', () => {
 		} );
 
 		// Default (no search): chip filter active, reader-revenue only.
-		expect(
-			mockCapturedData.every( ( item ) => item.chip === 'reader-revenue' )
-		).toBe( true );
+		expect( mockCapturedData.every( item => item.chip === 'reader-revenue' ) ).toBe( true );
 		expect( mockCapturedData.length ).toBe( 4 );
 
 		// Activate search via the DataViews onChangeView prop.
@@ -601,12 +542,8 @@ describe( 'Emails', () => {
 		await waitFor( () => {
 			expect( mockCapturedData.length ).toBe( mockEmails.length );
 		} );
-		const chipsRepresented = new Set(
-			mockCapturedData.map( ( item ) => item.chip )
-		);
-		expect( chipsRepresented ).toEqual(
-			new Set( [ 'reader-revenue', 'auth-account' ] )
-		);
+		const chipsRepresented = new Set( mockCapturedData.map( item => item.chip ) );
+		expect( chipsRepresented ).toEqual( new Set( [ 'reader-revenue', 'auth-account' ] ) );
 	} );
 
 	it( 'chip bar shows both chips unpressed during active search', async () => {
@@ -659,11 +596,7 @@ describe( 'Emails', () => {
 			} );
 		} );
 		await waitFor( () => {
-			expect(
-				screen
-					.getByRole( 'button', { name: 'Reader revenue' } )
-					.getAttribute( 'aria-pressed' )
-			).toBe( 'false' );
+			expect( screen.getByRole( 'button', { name: 'Reader revenue' } ).getAttribute( 'aria-pressed' ) ).toBe( 'false' );
 		} );
 
 		// Clear search — activeChip (still 'reader-revenue') re-engages.
@@ -675,11 +608,7 @@ describe( 'Emails', () => {
 			} );
 		} );
 		await waitFor( () => {
-			expect(
-				screen
-					.getByRole( 'button', { name: 'Reader revenue' } )
-					.getAttribute( 'aria-pressed' )
-			).toBe( 'true' );
+			expect( screen.getByRole( 'button', { name: 'Reader revenue' } ).getAttribute( 'aria-pressed' ) ).toBe( 'true' );
 		} );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -572,4 +572,114 @@ describe( 'Emails', () => {
 			expect( mockCapturedView.page ).toBe( 1 );
 		} );
 	} );
+
+	it( 'search bypasses chip filter — operates across all chips', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Default (no search): chip filter active, reader-revenue only.
+		expect(
+			mockCapturedData.every( ( item ) => item.chip === 'reader-revenue' )
+		).toBe( true );
+		expect( mockCapturedData.length ).toBe( 4 );
+
+		// Activate search via the DataViews onChangeView prop.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'anything',
+				page: 1,
+			} );
+		} );
+
+		// Full dataset now flows into filterSortAndPaginate — both chips
+		// represented, no chip pre-filter applied.
+		await waitFor( () => {
+			expect( mockCapturedData.length ).toBe( mockEmails.length );
+		} );
+		const chipsRepresented = new Set(
+			mockCapturedData.map( ( item ) => item.chip )
+		);
+		expect( chipsRepresented ).toEqual(
+			new Set( [ 'reader-revenue', 'auth-account' ] )
+		);
+	} );
+
+	it( 'chip bar shows both chips unpressed during active search', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const rrChip = screen.getByRole( 'button', { name: 'Reader revenue' } );
+		const aaChip = screen.getByRole( 'button', {
+			name: 'Authentication & account',
+		} );
+
+		// Default: Reader revenue chip is pressed.
+		expect( rrChip.getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		expect( aaChip.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+
+		// Search active — both chips deactivate visually (activeChip is
+		// still set in state, but the visual matches what's filtering).
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'foo',
+				page: 1,
+			} );
+		} );
+
+		await waitFor( () => {
+			expect( rrChip.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+			expect( aaChip.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+		} );
+	} );
+
+	it( 'clearing search restores active chip pressed state', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Set search.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: 'foo',
+				page: 1,
+			} );
+		} );
+		await waitFor( () => {
+			expect(
+				screen
+					.getByRole( 'button', { name: 'Reader revenue' } )
+					.getAttribute( 'aria-pressed' )
+			).toBe( 'false' );
+		} );
+
+		// Clear search — activeChip (still 'reader-revenue') re-engages.
+		act( () => {
+			mockCapturedOnChangeView( {
+				...mockCapturedView,
+				search: '',
+				page: 1,
+			} );
+		} );
+		await waitFor( () => {
+			expect(
+				screen
+					.getByRole( 'button', { name: 'Reader revenue' } )
+					.getAttribute( 'aria-pressed' )
+			).toBe( 'true' );
+		} );
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -20,7 +21,11 @@ import './emails.scss';
 
 interface EmailItem {
 	label: string;
-	post_id: number;
+	// Newspack-source rows carry an integer post ID; WC-source rows carry
+	// a string in the form `wc:{wc_email_id}` (e.g. `wc:customer_payment_retry`).
+	// The activate/deactivate action callbacks branch on `typeof` to route
+	// the write through the correct endpoint.
+	post_id: number | string;
 	edit_link: string;
 	status: string;
 	type: string;
@@ -53,6 +58,20 @@ const DEFAULT_VIEW: View = {
 
 const PageHeading = () => <h1 className="screen-reader-text">{ __( 'Emails', 'newspack-plugin' ) }</h1>;
 
+// The chip bar is a strict two-way toggle — every email belongs to exactly
+// one of these two groups. Defaults to 'reader-revenue' on first load.
+type ChipValue = 'reader-revenue' | 'auth-account';
+const CHIPS: { value: ChipValue; label: string }[] = [
+	{
+		value: 'reader-revenue',
+		label: __( 'Reader revenue', 'newspack-plugin' ),
+	},
+	{
+		value: 'auth-account',
+		label: __( 'Authentication & account', 'newspack-plugin' ),
+	},
+];
+
 const Emails = () => {
 	const emailSections = window.newspackSettings.emails.sections;
 	const [ pluginsReady, setPluginsReady ] = useState( Boolean( emailSections.emails.dependencies.newspackNewsletters ) );
@@ -61,9 +80,17 @@ const Emails = () => {
 	// shape as api_get_email_settings()) so DataViews renders on first paint
 	// instead of waiting for the mount-time XHR.
 	const initial = emailSections.emails.initial;
-	const [ data, setData ] = useState< EmailItem[] >( initial?.newspack_emails ?? [] );
+	const [ data, setData ] = useState< EmailItem[] >( ( initial?.newspack_emails as EmailItem[] | undefined ) ?? [] );
 	const postType = initial?.post_type ?? emailSections.emails.postType;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ activeChip, setActiveChip ] = useState< ChipValue >( 'reader-revenue' );
+
+	const selectChip = ( chip: ChipValue ) => {
+		setActiveChip( chip );
+		// Reset search + pagination on chip switch so the user sees the new
+		// group from the top with no leftover query.
+		setView( prev => ( { ...prev, search: '', page: 1 } ) );
+	};
 
 	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/emails' );
 
@@ -126,6 +153,38 @@ const Emails = () => {
 					setData( prevData =>
 						prevData.map( email => ( email.post_id === postId ? { ...email, status: prevStatus ?? email.status } : email ) )
 					);
+				},
+			}
+		);
+	};
+
+	// WooCommerce-source rows have a string post_id `wc:{wc_email_id}` —
+	// routed through the slice 2a toggle endpoint, which writes the WC
+	// option directly. The endpoint returns the full refreshed payload,
+	// so consume it directly instead of firing a second GET.
+	const toggleWcEmail = ( wcPostId: string, enabled: boolean ) => {
+		resetError();
+		const wcEmailId = wcPostId.replace( /^wc:/, '' );
+		// Optimistic update so the row reflects the intent immediately;
+		// rollback on error.
+		const prev = data;
+		setData( data.map( email => ( email.post_id === wcPostId ? { ...email, status: enabled ? 'publish' : 'draft' } : email ) ) );
+		wizardApiFetch< EmailSettings >(
+			{
+				path: `/newspack/v1/wizard/newspack-settings/emails/${ wcEmailId }/toggle`,
+				method: 'POST',
+				data: { enabled },
+			},
+			{
+				onSuccess( result: EmailSettings ) {
+					// The server response is authoritative for any
+					// downstream state we couldn't predict client-side
+					// (e.g. first-run side effects on sibling rows). Use
+					// it to reconcile state instead of refetching.
+					setData( result.newspack_emails || [] );
+				},
+				onError() {
+					setData( prev );
 				},
 			}
 		);
@@ -195,8 +254,14 @@ const Emails = () => {
 					);
 				},
 				elements: [
-					{ value: 'publish', label: __( 'Enabled', 'newspack-plugin' ) },
-					{ value: 'draft', label: __( 'Disabled', 'newspack-plugin' ) },
+					{
+						value: 'publish',
+						label: __( 'Enabled', 'newspack-plugin' ),
+					},
+					{
+						value: 'draft',
+						label: __( 'Disabled', 'newspack-plugin' ),
+					},
 				],
 				filterBy: { isPrimary: false, operators: [ 'is' ] },
 			},
@@ -216,9 +281,16 @@ const Emails = () => {
 		{
 			id: 'deactivate',
 			label: __( 'Deactivate', 'newspack-plugin' ),
+			// Eligibility is category- and status-based only — no source guard.
+			// The callback routes by post_id type to pick the right endpoint.
 			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status === 'publish',
 			callback: ( items: EmailItem[] ) => {
-				updateStatus( items[ 0 ].post_id, 'draft' );
+				const item = items[ 0 ];
+				if ( typeof item.post_id === 'string' ) {
+					toggleWcEmail( item.post_id, false );
+				} else {
+					updateStatus( item.post_id, 'draft' );
+				}
 			},
 		},
 		{
@@ -226,23 +298,49 @@ const Emails = () => {
 			label: __( 'Activate', 'newspack-plugin' ),
 			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status !== 'publish',
 			callback: ( items: EmailItem[] ) => {
-				updateStatus( items[ 0 ].post_id, 'publish' );
+				const item = items[ 0 ];
+				if ( typeof item.post_id === 'string' ) {
+					toggleWcEmail( item.post_id, true );
+				} else {
+					updateStatus( item.post_id, 'publish' );
+				}
 			},
 		},
 		{
 			id: 'reset',
 			label: __( 'Reset', 'newspack-plugin' ),
 			isDestructive: true,
+			// Source guard on reset only — WC emails aren't customized
+			// through the post editor, so reset has no meaning for them.
 			isEligible: ( item: EmailItem ) => item.source === 'newspack',
 			callback: ( items: EmailItem[] ) => {
+				// Runtime type narrowing — Newspack-source rows always carry an
+				// integer post_id by contract, but a future source/provider
+				// pair with `source: 'newspack'` + string post_id would slip
+				// past isEligible. Matches the activate/deactivate callback
+				// pattern that guards via typeof.
+				const postId = items[ 0 ].post_id;
+				if ( typeof postId !== 'number' ) {
+					return;
+				}
 				if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
-					resetEmail( items[ 0 ].post_id );
+					resetEmail( postId );
 				}
 			},
 		},
 	];
 
-	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( data, view, fields ), [ data, view, fields ] );
+	// Search overrides chip scope: when the user is searching, results
+	// come from the full dataset (both chips) so a query can find any
+	// email. When search is empty, the active chip filter applies as a
+	// view scope. `activeChip` stays in state through a search and
+	// re-engages when search clears.
+	const isSearching = Boolean( view.search );
+	const visibleData = useMemo( () => ( isSearching ? data : data.filter( item => item.chip === activeChip ) ), [ data, activeChip, isSearching ] );
+	const { data: processedData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( visibleData, view, fields ),
+		[ visibleData, view, fields ]
+	);
 
 	if ( false === pluginsReady ) {
 		return (
@@ -273,6 +371,26 @@ const Emails = () => {
 		<Fragment>
 			<PageHeading />
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			<div className="newspack-emails__chips" role="group" aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }>
+				{ CHIPS.map( chip => {
+					// During an active search, neither chip is filtering —
+					// render both as unpressed so the visual matches reality.
+					// Clicking either chip clears the search via selectChip
+					// and engages that chip's view.
+					const isActive = ! isSearching && activeChip === chip.value;
+					return (
+						<Button
+							key={ chip.value }
+							variant={ isActive ? 'primary' : 'secondary' }
+							aria-pressed={ isActive }
+							onClick={ () => selectChip( chip.value ) }
+							className="newspack-emails__chip"
+						>
+							{ chip.label }
+						</Button>
+					);
+				} ) }
+			</div>
 			<DataViews
 				className="newspack-emails"
 				data={ processedData }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -14,12 +14,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import {
-	Badge,
-	DataViews,
-	Notice,
-	utils,
-} from '../../../../../../packages/components/src';
+import { Badge, DataViews, Notice, utils } from '../../../../../../packages/components/src';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import './emails.scss';
@@ -61,11 +56,7 @@ const DEFAULT_VIEW: View = {
 	descriptionField: 'trigger_description',
 };
 
-const PageHeading = () => (
-	<h1 className="screen-reader-text">
-		{ __( 'Emails', 'newspack-plugin' ) }
-	</h1>
-);
+const PageHeading = () => <h1 className="screen-reader-text">{ __( 'Emails', 'newspack-plugin' ) }</h1>;
 
 // The chip bar is a strict two-way toggle — every email belongs to exactly
 // one of these two groups. Defaults to 'reader-revenue' on first load.
@@ -83,9 +74,7 @@ const CHIPS: { value: ChipValue; label: string }[] = [
 
 const Emails = () => {
 	const emailSections = window.newspackSettings.emails.sections;
-	const [ pluginsReady, setPluginsReady ] = useState(
-		Boolean( emailSections.emails.dependencies.newspackNewsletters )
-	);
+	const [ pluginsReady, setPluginsReady ] = useState( Boolean( emailSections.emails.dependencies.newspackNewsletters ) );
 
 	// Seed from the SSR bootstrap (class-newspack-settings.php passes the same
 	// shape as api_get_email_settings()) so DataViews renders on first paint
@@ -96,18 +85,16 @@ const Emails = () => {
 	);
 	const postType = initial?.post_type ?? emailSections.emails.postType;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
-	const [ activeChip, setActiveChip ] =
-		useState< ChipValue >( 'reader-revenue' );
+	const [ activeChip, setActiveChip ] = useState< ChipValue >( 'reader-revenue' );
 
 	const selectChip = ( chip: ChipValue ) => {
 		setActiveChip( chip );
 		// Reset search + pagination on chip switch so the user sees the new
 		// group from the top with no leftover query.
-		setView( ( prev ) => ( { ...prev, search: '', page: 1 } ) );
+		setView( prev => ( { ...prev, search: '', page: 1 } ) );
 	};
 
-	const { wizardApiFetch, isFetching, errorMessage, resetError } =
-		useWizardApiFetch( 'newspack-settings/emails' );
+	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/emails' );
 
 	const fetchData = useCallback( () => {
 		resetError();
@@ -207,10 +194,7 @@ const Emails = () => {
 				enableGlobalSearch: true,
 				getValue: ( { item }: { item: EmailItem } ) => item.label,
 				render: ( { item }: { item: EmailItem } ) => (
-					<a
-						href={ item.edit_link }
-						className="newspack-emails__name-link"
-					>
+					<a href={ item.edit_link } className="newspack-emails__name-link">
 						<strong>{ item.label }</strong>
 					</a>
 				),
@@ -219,12 +203,9 @@ const Emails = () => {
 				id: 'trigger_description',
 				label: __( 'Description', 'newspack-plugin' ),
 				enableGlobalSearch: true,
-				getValue: ( { item }: { item: EmailItem } ) =>
-					item.trigger_description,
+				getValue: ( { item }: { item: EmailItem } ) => item.trigger_description,
 				render: ( { item }: { item: EmailItem } ) => (
-					<span className="newspack-emails__trigger-description">
-						{ item.trigger_description }
-					</span>
+					<span className="newspack-emails__trigger-description">{ item.trigger_description }</span>
 				),
 				enableHiding: false,
 				enableSorting: false,
@@ -234,15 +215,9 @@ const Emails = () => {
 				label: __( 'Recipient', 'newspack-plugin' ),
 				enableGlobalSearch: true,
 				getValue: ( { item }: { item: EmailItem } ) =>
-					item.recipient === 'admin'
-						? __( 'Admin', 'newspack-plugin' )
-						: __( 'Reader', 'newspack-plugin' ),
+					item.recipient === 'admin' ? __( 'Admin', 'newspack-plugin' ) : __( 'Reader', 'newspack-plugin' ),
 				render: ( { item }: { item: EmailItem } ) => (
-					<span>
-						{ item.recipient === 'admin'
-							? __( 'Admin', 'newspack-plugin' )
-							: __( 'Reader', 'newspack-plugin' ) }
-					</span>
+					<span>{ item.recipient === 'admin' ? __( 'Admin', 'newspack-plugin' ) : __( 'Reader', 'newspack-plugin' ) }</span>
 				),
 			},
 			{
@@ -254,11 +229,7 @@ const Emails = () => {
 					return (
 						<Badge
 							level={ isEnabled ? 'success' : 'default' }
-							text={
-								isEnabled
-									? __( 'Enabled', 'newspack-plugin' )
-									: __( 'Disabled', 'newspack-plugin' )
-							}
+							text={ isEnabled ? __( 'Enabled', 'newspack-plugin' ) : __( 'Disabled', 'newspack-plugin' ) }
 						/>
 					);
 				},
@@ -292,9 +263,7 @@ const Emails = () => {
 			label: __( 'Deactivate', 'newspack-plugin' ),
 			// Eligibility is category- and status-based only — no source guard.
 			// The callback routes by post_id type to pick the right endpoint.
-			isEligible: ( item: EmailItem ) =>
-				item.category !== 'reader-activation' &&
-				item.status === 'publish',
+			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status === 'publish',
 			callback: ( items: EmailItem[] ) => {
 				const item = items[ 0 ];
 				if ( typeof item.post_id === 'string' ) {
@@ -307,9 +276,7 @@ const Emails = () => {
 		{
 			id: 'activate',
 			label: __( 'Activate', 'newspack-plugin' ),
-			isEligible: ( item: EmailItem ) =>
-				item.category !== 'reader-activation' &&
-				item.status !== 'publish',
+			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status !== 'publish',
 			callback: ( items: EmailItem[] ) => {
 				const item = items[ 0 ];
 				if ( typeof item.post_id === 'string' ) {
@@ -326,20 +293,17 @@ const Emails = () => {
 			// Source guard on reset only — WC emails aren't customized
 			// through the post editor, so reset has no meaning for them.
 <<<<<<< HEAD
+<<<<<<< HEAD
 			isEligible: ( item: EmailItem ) => item.source === 'newspack',
 =======
 			isEligible: ( item: EmailItem ) =>
 				item.source !== 'woocommerce' && Boolean( item.registry_slug ),
 >>>>>>> ad72b7f611 (style(emails): prettier formatting on emails.tsx)
+=======
+			isEligible: ( item: EmailItem ) => item.source !== 'woocommerce' && Boolean( item.registry_slug ),
+>>>>>>> e090a44b9d (fix(emails): satisfy CI lint (PHPCS + prettier))
 			callback: ( items: EmailItem[] ) => {
-				if (
-					utils.confirmAction(
-						__(
-							'Are you sure you want to reset the contents of this email?',
-							'newspack-plugin'
-						)
-					)
-				) {
+				if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
 					// Reset only fires for Newspack-source rows (per isEligible),
 					// which always carry an integer post_id.
 					resetEmail( items[ 0 ].post_id as number );
@@ -354,13 +318,7 @@ const Emails = () => {
 	// view scope. `activeChip` stays in state through a search and
 	// re-engages when search clears.
 	const isSearching = Boolean( view.search );
-	const visibleData = useMemo(
-		() =>
-			isSearching
-				? data
-				: data.filter( ( item ) => item.chip === activeChip ),
-		[ data, activeChip, isSearching ]
-	);
+	const visibleData = useMemo( () => ( isSearching ? data : data.filter( item => item.chip === activeChip ) ), [ data, activeChip, isSearching ] );
 	const { data: processedData, paginationInfo } = useMemo(
 		() => filterSortAndPaginate( visibleData, view, fields ),
 		[ visibleData, view, fields ]
@@ -384,23 +342,15 @@ const Emails = () => {
 							'newspack-plugin'
 						) +
 						' ' +
-						__(
-							'Until this feature is configured, default receipts will be used.',
-							'newspack-plugin'
-						)
+						__( 'Until this feature is configured, default receipts will be used.', 'newspack-plugin' )
 					}
 >>>>>>> ad72b7f611 (style(emails): prettier formatting on emails.tsx)
 				/>
 				<WizardsPluginCard
 					slug="newspack-newsletters"
 					title={ __( 'Newspack Newsletters', 'newspack-plugin' ) }
-					description={ __(
-						'Newspack Newsletters is the plugin that powers Newspack email receipts.',
-						'newspack-plugin'
-					) }
-					onStatusChange={ (
-						statuses: Record< string, boolean >
-					) => {
+					description={ __( 'Newspack Newsletters is the plugin that powers Newspack email receipts.', 'newspack-plugin' ) }
+					onStatusChange={ ( statuses: Record< string, boolean > ) => {
 						if ( ! statuses.isLoading ) {
 							setPluginsReady( statuses.isSetup );
 						}
@@ -414,12 +364,8 @@ const Emails = () => {
 		<Fragment>
 			<PageHeading />
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<div
-				className="newspack-emails__chips"
-				role="group"
-				aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }
-			>
-				{ CHIPS.map( ( chip ) => {
+			<div className="newspack-emails__chips" role="group" aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }>
+				{ CHIPS.map( chip => {
 					// During an active search, neither chip is filtering —
 					// render both as unpressed so the visual matches reality.
 					// Clicking either chip clears the search via selectChip

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -153,19 +153,38 @@ const Emails = () => {
 
 	// WooCommerce-source rows have a string post_id `wc:{wc_email_id}` —
 	// routed through the slice 2a toggle endpoint, which writes the WC
-	// option directly. Uses useWizardApiFetch for loading-state and
-	// error consistency with the other mutations in this view.
+	// option directly. The endpoint returns the full refreshed payload,
+	// so consume it directly instead of firing a second GET.
 	const toggleWcEmail = ( wcPostId: string, enabled: boolean ) => {
 		resetError();
 		const wcEmailId = wcPostId.replace( /^wc:/, '' );
-		wizardApiFetch(
+		// Optimistic update so the row reflects the intent immediately;
+		// rollback on error.
+		const prev = data;
+		setData(
+			data.map( email =>
+				email.post_id === wcPostId
+					? { ...email, status: enabled ? 'publish' : 'draft' }
+					: email
+			)
+		);
+		wizardApiFetch< EmailSettings >(
 			{
 				path: `/newspack/v1/wizard/newspack-settings/emails/${ wcEmailId }/toggle`,
 				method: 'POST',
 				data: { enabled },
 			},
 			{
-				onSuccess: () => fetchData(),
+				onSuccess( result: EmailSettings ) {
+					// The server response is authoritative for any
+					// downstream state we couldn't predict client-side
+					// (e.g. first-run side effects on sibling rows). Use
+					// it to reconcile state instead of refetching.
+					setData( result.newspack_emails || [] );
+				},
+				onError() {
+					setData( prev );
+				},
 			}
 		);
 	};

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -305,10 +305,17 @@ const Emails = () => {
 			// through the post editor, so reset has no meaning for them.
 			isEligible: ( item: EmailItem ) => item.source === 'newspack',
 			callback: ( items: EmailItem[] ) => {
+				// Runtime type narrowing — Newspack-source rows always carry an
+				// integer post_id by contract, but a future source/provider
+				// pair with `source: 'newspack'` + string post_id would slip
+				// past isEligible. Matches the activate/deactivate callback
+				// pattern that guards via typeof.
+				const postId = items[ 0 ].post_id;
+				if ( typeof postId !== 'number' ) {
+					return;
+				}
 				if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
-					// Reset only fires for Newspack-source rows (per isEligible),
-					// which always carry an integer post_id.
-					resetEmail( items[ 0 ].post_id as number );
+					resetEmail( postId );
 				}
 			},
 		},

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -20,7 +20,11 @@ import './emails.scss';
 
 interface EmailItem {
 	label: string;
-	post_id: number;
+	// Newspack-source rows carry an integer post ID; WC-source rows carry
+	// a string in the form `wc:{wc_email_id}` (e.g. `wc:customer_payment_retry`).
+	// The activate/deactivate action callbacks branch on `typeof` to route
+	// the write through the correct endpoint.
+	post_id: number | string;
 	edit_link: string;
 	status: string;
 	type: string;
@@ -122,6 +126,25 @@ const Emails = () => {
 		);
 	};
 
+	// WooCommerce-source rows have a string post_id `wc:{wc_email_id}` —
+	// routed through the slice 2a toggle endpoint, which writes the WC
+	// option directly. Uses useWizardApiFetch for loading-state and
+	// error consistency with the other mutations in this view.
+	const toggleWcEmail = ( wcPostId: string, enabled: boolean ) => {
+		resetError();
+		const wcEmailId = wcPostId.replace( /^wc:/, '' );
+		wizardApiFetch(
+			{
+				path: `/newspack/v1/wizard/newspack-settings/emails/${ wcEmailId }/toggle`,
+				method: 'POST',
+				data: { enabled },
+			},
+			{
+				onSuccess: () => fetchData(),
+			}
+		);
+	};
+
 	const resetEmail = ( postId: number ) => {
 		resetError();
 		// @todo NPPD-1532 Move reset handler to class-emails-section.php so it
@@ -207,9 +230,16 @@ const Emails = () => {
 		{
 			id: 'deactivate',
 			label: __( 'Deactivate', 'newspack-plugin' ),
+			// Eligibility is category- and status-based only — no source guard.
+			// The callback routes by post_id type to pick the right endpoint.
 			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status === 'publish',
 			callback: ( items: EmailItem[] ) => {
-				updateStatus( items[ 0 ].post_id, 'draft' );
+				const item = items[ 0 ];
+				if ( typeof item.post_id === 'string' ) {
+					toggleWcEmail( item.post_id, false );
+				} else {
+					updateStatus( item.post_id, 'draft' );
+				}
 			},
 		},
 		{
@@ -217,17 +247,26 @@ const Emails = () => {
 			label: __( 'Activate', 'newspack-plugin' ),
 			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status !== 'publish',
 			callback: ( items: EmailItem[] ) => {
-				updateStatus( items[ 0 ].post_id, 'publish' );
+				const item = items[ 0 ];
+				if ( typeof item.post_id === 'string' ) {
+					toggleWcEmail( item.post_id, true );
+				} else {
+					updateStatus( item.post_id, 'publish' );
+				}
 			},
 		},
 		{
 			id: 'reset',
 			label: __( 'Reset', 'newspack-plugin' ),
 			isDestructive: true,
+			// Source guard on reset only — WC emails aren't customized
+			// through the post editor, so reset has no meaning for them.
 			isEligible: ( item: EmailItem ) => item.source === 'newspack',
 			callback: ( items: EmailItem[] ) => {
 				if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
-					resetEmail( items[ 0 ].post_id );
+					// Reset only fires for Newspack-source rows (per isEligible),
+					// which always carry an integer post_id.
+					resetEmail( items[ 0 ].post_id as number );
 				}
 			},
 		},

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -80,9 +80,7 @@ const Emails = () => {
 	// shape as api_get_email_settings()) so DataViews renders on first paint
 	// instead of waiting for the mount-time XHR.
 	const initial = emailSections.emails.initial;
-	const [ data, setData ] = useState< EmailItem[] >(
-		( initial?.newspack_emails as EmailItem[] | undefined ) ?? []
-	);
+	const [ data, setData ] = useState< EmailItem[] >( ( initial?.newspack_emails as EmailItem[] | undefined ) ?? [] );
 	const postType = initial?.post_type ?? emailSections.emails.postType;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ activeChip, setActiveChip ] = useState< ChipValue >( 'reader-revenue' );
@@ -161,13 +159,7 @@ const Emails = () => {
 		// Optimistic update so the row reflects the intent immediately;
 		// rollback on error.
 		const prev = data;
-		setData(
-			data.map( email =>
-				email.post_id === wcPostId
-					? { ...email, status: enabled ? 'publish' : 'draft' }
-					: email
-			)
-		);
+		setData( data.map( email => ( email.post_id === wcPostId ? { ...email, status: enabled ? 'publish' : 'draft' } : email ) ) );
 		wizardApiFetch< EmailSettings >(
 			{
 				path: `/newspack/v1/wizard/newspack-settings/emails/${ wcEmailId }/toggle`,

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -14,7 +14,12 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { Badge, DataViews, Notice, utils } from '../../../../../../packages/components/src';
+import {
+	Badge,
+	DataViews,
+	Notice,
+	utils,
+} from '../../../../../../packages/components/src';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import './emails.scss';
@@ -56,37 +61,53 @@ const DEFAULT_VIEW: View = {
 	descriptionField: 'trigger_description',
 };
 
-const PageHeading = () => <h1 className="screen-reader-text">{ __( 'Emails', 'newspack-plugin' ) }</h1>;
+const PageHeading = () => (
+	<h1 className="screen-reader-text">
+		{ __( 'Emails', 'newspack-plugin' ) }
+	</h1>
+);
 
 // The chip bar is a strict two-way toggle — every email belongs to exactly
 // one of these two groups. Defaults to 'reader-revenue' on first load.
 type ChipValue = 'reader-revenue' | 'auth-account';
 const CHIPS: { value: ChipValue; label: string }[] = [
-	{ value: 'reader-revenue', label: __( 'Reader revenue', 'newspack-plugin' ) },
-	{ value: 'auth-account', label: __( 'Authentication & account', 'newspack-plugin' ) },
+	{
+		value: 'reader-revenue',
+		label: __( 'Reader revenue', 'newspack-plugin' ),
+	},
+	{
+		value: 'auth-account',
+		label: __( 'Authentication & account', 'newspack-plugin' ),
+	},
 ];
 
 const Emails = () => {
 	const emailSections = window.newspackSettings.emails.sections;
-	const [ pluginsReady, setPluginsReady ] = useState( Boolean( emailSections.emails.dependencies.newspackNewsletters ) );
+	const [ pluginsReady, setPluginsReady ] = useState(
+		Boolean( emailSections.emails.dependencies.newspackNewsletters )
+	);
 
 	// Seed from the SSR bootstrap (class-newspack-settings.php passes the same
 	// shape as api_get_email_settings()) so DataViews renders on first paint
 	// instead of waiting for the mount-time XHR.
 	const initial = emailSections.emails.initial;
-	const [ data, setData ] = useState< EmailItem[] >( initial?.newspack_emails ?? [] );
+	const [ data, setData ] = useState< EmailItem[] >(
+		( initial?.newspack_emails as EmailItem[] | undefined ) ?? []
+	);
 	const postType = initial?.post_type ?? emailSections.emails.postType;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
-	const [ activeChip, setActiveChip ] = useState< ChipValue >( 'reader-revenue' );
+	const [ activeChip, setActiveChip ] =
+		useState< ChipValue >( 'reader-revenue' );
 
 	const selectChip = ( chip: ChipValue ) => {
 		setActiveChip( chip );
 		// Reset search + pagination on chip switch so the user sees the new
 		// group from the top with no leftover query.
-		setView( prev => ( { ...prev, search: '', page: 1 } ) );
+		setView( ( prev ) => ( { ...prev, search: '', page: 1 } ) );
 	};
 
-	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/emails' );
+	const { wizardApiFetch, isFetching, errorMessage, resetError } =
+		useWizardApiFetch( 'newspack-settings/emails' );
 
 	const fetchData = useCallback( () => {
 		resetError();
@@ -186,7 +207,10 @@ const Emails = () => {
 				enableGlobalSearch: true,
 				getValue: ( { item }: { item: EmailItem } ) => item.label,
 				render: ( { item }: { item: EmailItem } ) => (
-					<a href={ item.edit_link } className="newspack-emails__name-link">
+					<a
+						href={ item.edit_link }
+						className="newspack-emails__name-link"
+					>
 						<strong>{ item.label }</strong>
 					</a>
 				),
@@ -195,9 +219,12 @@ const Emails = () => {
 				id: 'trigger_description',
 				label: __( 'Description', 'newspack-plugin' ),
 				enableGlobalSearch: true,
-				getValue: ( { item }: { item: EmailItem } ) => item.trigger_description,
+				getValue: ( { item }: { item: EmailItem } ) =>
+					item.trigger_description,
 				render: ( { item }: { item: EmailItem } ) => (
-					<span className="newspack-emails__trigger-description">{ item.trigger_description }</span>
+					<span className="newspack-emails__trigger-description">
+						{ item.trigger_description }
+					</span>
 				),
 				enableHiding: false,
 				enableSorting: false,
@@ -207,9 +234,15 @@ const Emails = () => {
 				label: __( 'Recipient', 'newspack-plugin' ),
 				enableGlobalSearch: true,
 				getValue: ( { item }: { item: EmailItem } ) =>
-					item.recipient === 'admin' ? __( 'Admin', 'newspack-plugin' ) : __( 'Reader', 'newspack-plugin' ),
+					item.recipient === 'admin'
+						? __( 'Admin', 'newspack-plugin' )
+						: __( 'Reader', 'newspack-plugin' ),
 				render: ( { item }: { item: EmailItem } ) => (
-					<span>{ item.recipient === 'admin' ? __( 'Admin', 'newspack-plugin' ) : __( 'Reader', 'newspack-plugin' ) }</span>
+					<span>
+						{ item.recipient === 'admin'
+							? __( 'Admin', 'newspack-plugin' )
+							: __( 'Reader', 'newspack-plugin' ) }
+					</span>
 				),
 			},
 			{
@@ -221,13 +254,23 @@ const Emails = () => {
 					return (
 						<Badge
 							level={ isEnabled ? 'success' : 'default' }
-							text={ isEnabled ? __( 'Enabled', 'newspack-plugin' ) : __( 'Disabled', 'newspack-plugin' ) }
+							text={
+								isEnabled
+									? __( 'Enabled', 'newspack-plugin' )
+									: __( 'Disabled', 'newspack-plugin' )
+							}
 						/>
 					);
 				},
 				elements: [
-					{ value: 'publish', label: __( 'Enabled', 'newspack-plugin' ) },
-					{ value: 'draft', label: __( 'Disabled', 'newspack-plugin' ) },
+					{
+						value: 'publish',
+						label: __( 'Enabled', 'newspack-plugin' ),
+					},
+					{
+						value: 'draft',
+						label: __( 'Disabled', 'newspack-plugin' ),
+					},
 				],
 				filterBy: { isPrimary: false, operators: [ 'is' ] },
 			},
@@ -249,7 +292,9 @@ const Emails = () => {
 			label: __( 'Deactivate', 'newspack-plugin' ),
 			// Eligibility is category- and status-based only — no source guard.
 			// The callback routes by post_id type to pick the right endpoint.
-			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status === 'publish',
+			isEligible: ( item: EmailItem ) =>
+				item.category !== 'reader-activation' &&
+				item.status === 'publish',
 			callback: ( items: EmailItem[] ) => {
 				const item = items[ 0 ];
 				if ( typeof item.post_id === 'string' ) {
@@ -262,7 +307,9 @@ const Emails = () => {
 		{
 			id: 'activate',
 			label: __( 'Activate', 'newspack-plugin' ),
-			isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status !== 'publish',
+			isEligible: ( item: EmailItem ) =>
+				item.category !== 'reader-activation' &&
+				item.status !== 'publish',
 			callback: ( items: EmailItem[] ) => {
 				const item = items[ 0 ];
 				if ( typeof item.post_id === 'string' ) {
@@ -278,9 +325,21 @@ const Emails = () => {
 			isDestructive: true,
 			// Source guard on reset only — WC emails aren't customized
 			// through the post editor, so reset has no meaning for them.
+<<<<<<< HEAD
 			isEligible: ( item: EmailItem ) => item.source === 'newspack',
+=======
+			isEligible: ( item: EmailItem ) =>
+				item.source !== 'woocommerce' && Boolean( item.registry_slug ),
+>>>>>>> ad72b7f611 (style(emails): prettier formatting on emails.tsx)
 			callback: ( items: EmailItem[] ) => {
-				if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
+				if (
+					utils.confirmAction(
+						__(
+							'Are you sure you want to reset the contents of this email?',
+							'newspack-plugin'
+						)
+					)
+				) {
 					// Reset only fires for Newspack-source rows (per isEligible),
 					// which always carry an integer post_id.
 					resetEmail( items[ 0 ].post_id as number );
@@ -292,7 +351,10 @@ const Emails = () => {
 	// Strict 2-way chip filter — only rows matching activeChip pass through
 	// to DataViews. There's no "All" view by design (every email belongs to
 	// exactly one chip group).
-	const chipFilteredData = useMemo( () => data.filter( item => item.chip === activeChip ), [ data, activeChip ] );
+	const chipFilteredData = useMemo(
+		() => data.filter( ( item ) => item.chip === activeChip ),
+		[ data, activeChip ]
+	);
 	const { data: processedData, paginationInfo } = useMemo(
 		() => filterSortAndPaginate( chipFilteredData, view, fields ),
 		[ chipFilteredData, view, fields ]
@@ -304,16 +366,35 @@ const Emails = () => {
 				<PageHeading />
 				<Notice
 					isError
+<<<<<<< HEAD
 					noticeText={ __(
 						'Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed. Until this feature is configured, default receipts will be used.',
 						'newspack-plugin'
 					) }
+=======
+					noticeText={
+						__(
+							'Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed.',
+							'newspack-plugin'
+						) +
+						' ' +
+						__(
+							'Until this feature is configured, default receipts will be used.',
+							'newspack-plugin'
+						)
+					}
+>>>>>>> ad72b7f611 (style(emails): prettier formatting on emails.tsx)
 				/>
 				<WizardsPluginCard
 					slug="newspack-newsletters"
 					title={ __( 'Newspack Newsletters', 'newspack-plugin' ) }
-					description={ __( 'Newspack Newsletters is the plugin that powers Newspack email receipts.', 'newspack-plugin' ) }
-					onStatusChange={ ( statuses: Record< string, boolean > ) => {
+					description={ __(
+						'Newspack Newsletters is the plugin that powers Newspack email receipts.',
+						'newspack-plugin'
+					) }
+					onStatusChange={ (
+						statuses: Record< string, boolean >
+					) => {
 						if ( ! statuses.isLoading ) {
 							setPluginsReady( statuses.isSetup );
 						}
@@ -327,11 +408,17 @@ const Emails = () => {
 		<Fragment>
 			<PageHeading />
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<div className="newspack-emails__chips" role="group" aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }>
-				{ CHIPS.map( chip => (
+			<div
+				className="newspack-emails__chips"
+				role="group"
+				aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }
+			>
+				{ CHIPS.map( ( chip ) => (
 					<Button
 						key={ chip.value }
-						variant={ activeChip === chip.value ? 'primary' : 'secondary' }
+						variant={
+							activeChip === chip.value ? 'primary' : 'secondary'
+						}
 						aria-pressed={ activeChip === chip.value }
 						onClick={ () => selectChip( chip.value ) }
 						className="newspack-emails__chip"

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -348,16 +348,22 @@ const Emails = () => {
 		},
 	];
 
-	// Strict 2-way chip filter — only rows matching activeChip pass through
-	// to DataViews. There's no "All" view by design (every email belongs to
-	// exactly one chip group).
-	const chipFilteredData = useMemo(
-		() => data.filter( ( item ) => item.chip === activeChip ),
-		[ data, activeChip ]
+	// Search overrides chip scope: when the user is searching, results
+	// come from the full dataset (both chips) so a query can find any
+	// email. When search is empty, the active chip filter applies as a
+	// view scope. `activeChip` stays in state through a search and
+	// re-engages when search clears.
+	const isSearching = Boolean( view.search );
+	const visibleData = useMemo(
+		() =>
+			isSearching
+				? data
+				: data.filter( ( item ) => item.chip === activeChip ),
+		[ data, activeChip, isSearching ]
 	);
 	const { data: processedData, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( chipFilteredData, view, fields ),
-		[ chipFilteredData, view, fields ]
+		() => filterSortAndPaginate( visibleData, view, fields ),
+		[ visibleData, view, fields ]
 	);
 
 	if ( false === pluginsReady ) {
@@ -413,19 +419,24 @@ const Emails = () => {
 				role="group"
 				aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }
 			>
-				{ CHIPS.map( ( chip ) => (
-					<Button
-						key={ chip.value }
-						variant={
-							activeChip === chip.value ? 'primary' : 'secondary'
-						}
-						aria-pressed={ activeChip === chip.value }
-						onClick={ () => selectChip( chip.value ) }
-						className="newspack-emails__chip"
-					>
-						{ chip.label }
-					</Button>
-				) ) }
+				{ CHIPS.map( ( chip ) => {
+					// During an active search, neither chip is filtering —
+					// render both as unpressed so the visual matches reality.
+					// Clicking either chip clears the search via selectChip
+					// and engages that chip's view.
+					const isActive = ! isSearching && activeChip === chip.value;
+					return (
+						<Button
+							key={ chip.value }
+							variant={ isActive ? 'primary' : 'secondary' }
+							aria-pressed={ isActive }
+							onClick={ () => selectChip( chip.value ) }
+							className="newspack-emails__chip"
+						>
+							{ chip.label }
+						</Button>
+					);
+				} ) }
 			</div>
 			<DataViews
 				className="newspack-emails"

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -57,6 +58,14 @@ const DEFAULT_VIEW: View = {
 
 const PageHeading = () => <h1 className="screen-reader-text">{ __( 'Emails', 'newspack-plugin' ) }</h1>;
 
+// The chip bar is a strict two-way toggle — every email belongs to exactly
+// one of these two groups. Defaults to 'reader-revenue' on first load.
+type ChipValue = 'reader-revenue' | 'auth-account';
+const CHIPS: { value: ChipValue; label: string }[] = [
+	{ value: 'reader-revenue', label: __( 'Reader revenue', 'newspack-plugin' ) },
+	{ value: 'auth-account', label: __( 'Authentication & account', 'newspack-plugin' ) },
+];
+
 const Emails = () => {
 	const emailSections = window.newspackSettings.emails.sections;
 	const [ pluginsReady, setPluginsReady ] = useState( Boolean( emailSections.emails.dependencies.newspackNewsletters ) );
@@ -68,6 +77,14 @@ const Emails = () => {
 	const [ data, setData ] = useState< EmailItem[] >( initial?.newspack_emails ?? [] );
 	const postType = initial?.post_type ?? emailSections.emails.postType;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ activeChip, setActiveChip ] = useState< ChipValue >( 'reader-revenue' );
+
+	const selectChip = ( chip: ChipValue ) => {
+		setActiveChip( chip );
+		// Reset search + pagination on chip switch so the user sees the new
+		// group from the top with no leftover query.
+		setView( prev => ( { ...prev, search: '', page: 1 } ) );
+	};
 
 	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/emails' );
 
@@ -272,7 +289,14 @@ const Emails = () => {
 		},
 	];
 
-	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( data, view, fields ), [ data, view, fields ] );
+	// Strict 2-way chip filter — only rows matching activeChip pass through
+	// to DataViews. There's no "All" view by design (every email belongs to
+	// exactly one chip group).
+	const chipFilteredData = useMemo( () => data.filter( item => item.chip === activeChip ), [ data, activeChip ] );
+	const { data: processedData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( chipFilteredData, view, fields ),
+		[ chipFilteredData, view, fields ]
+	);
 
 	if ( false === pluginsReady ) {
 		return (
@@ -303,6 +327,19 @@ const Emails = () => {
 		<Fragment>
 			<PageHeading />
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			<div className="newspack-emails__chips" role="group" aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }>
+				{ CHIPS.map( chip => (
+					<Button
+						key={ chip.value }
+						variant={ activeChip === chip.value ? 'primary' : 'secondary' }
+						aria-pressed={ activeChip === chip.value }
+						onClick={ () => selectChip( chip.value ) }
+						className="newspack-emails__chip"
+					>
+						{ chip.label }
+					</Button>
+				) ) }
+			</div>
 			<DataViews
 				className="newspack-emails"
 				data={ processedData }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -311,16 +311,7 @@ const Emails = () => {
 			isDestructive: true,
 			// Source guard on reset only — WC emails aren't customized
 			// through the post editor, so reset has no meaning for them.
-<<<<<<< HEAD
-<<<<<<< HEAD
 			isEligible: ( item: EmailItem ) => item.source === 'newspack',
-=======
-			isEligible: ( item: EmailItem ) =>
-				item.source !== 'woocommerce' && Boolean( item.registry_slug ),
->>>>>>> ad72b7f611 (style(emails): prettier formatting on emails.tsx)
-=======
-			isEligible: ( item: EmailItem ) => item.source !== 'woocommerce' && Boolean( item.registry_slug ),
->>>>>>> e090a44b9d (fix(emails): satisfy CI lint (PHPCS + prettier))
 			callback: ( items: EmailItem[] ) => {
 				if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
 					// Reset only fires for Newspack-source rows (per isEligible),
@@ -349,21 +340,10 @@ const Emails = () => {
 				<PageHeading />
 				<Notice
 					isError
-<<<<<<< HEAD
 					noticeText={ __(
 						'Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed. Until this feature is configured, default receipts will be used.',
 						'newspack-plugin'
 					) }
-=======
-					noticeText={
-						__(
-							'Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed.',
-							'newspack-plugin'
-						) +
-						' ' +
-						__( 'Until this feature is configured, default receipts will be used.', 'newspack-plugin' )
-					}
->>>>>>> ad72b7f611 (style(emails): prettier formatting on emails.tsx)
 				/>
 				<WizardsPluginCard
 					slug="newspack-newsletters"

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -1,0 +1,843 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.WrongStyle, Squiz.Commenting.InlineComment.InvalidEndChar, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing -- Test file intentionally declares a WC_Email-like stub alongside the main test class; precedent: tests/unit-tests/reader-registration-endpoint.php and tests/mocks/*.
+/**
+ * Slice 2a (NPPD-1527) — WooCommerce email surfacing.
+ *
+ * Coverage:
+ *   - `WooCommerce_Emails::get_email_configs()` — early-bail contract
+ *     when real WC isn't loaded (the loaded-and-mailer-populated branch
+ *     is exercised by manual smoke; injecting a real WC mailer mock
+ *     would dwarf this file).
+ *   - `Emails_Section::api_get_email_settings()` — surfaces WC-source
+ *     rows with `wc:<id>` post_id prefix once the slice 1 source filter
+ *     is lifted.
+ *   - `Emails_Section::api_toggle_wc_email()` — writes the WC option AND
+ *     the same-request response reflects the new state (the staleness
+ *     fix), with 404 rejection for unknown IDs and non-WC sources.
+ *   - `Emails_Section::maybe_first_run_enable_wc_emails()` — only writes
+ *     when the publisher hasn't recorded a decision yet (preserves
+ *     explicit 'no'); WCS master switch only flipped when never set;
+ *     idempotent via the FIRST_RUN_OPTION processed-keys list whether
+ *     or not we wrote.
+ *
+ * Setup: declares a minimal `WC_Email`-like stub. WooCommerce-active
+ * tests opt-in via the `newspack_woocommerce_active` filter (added in
+ * set_up, removed in tear_down) — no global `class WooCommerce {}` shim,
+ * so suite order doesn't matter. Stub configs are injected via the
+ * `newspack_email_configs` filter; instances are primed onto the
+ * WooCommerce_Emails by-id cache via the test-only helpers there.
+ *
+ * @package Newspack\Tests
+ */
+
+/**
+ * Minimal WC_Email-like stub. Mimics the three points of contact the
+ * implementation has with a WC_Email instance: the `id` and `enabled`
+ * public properties, and the `get_option_key()` method.
+ */
+class Newspack_Test_Stub_WC_Email {
+	public $id;
+	public $enabled;
+
+	public function __construct( string $id, string $enabled = 'no' ) {
+		$this->id      = $id;
+		$this->enabled = $enabled;
+	}
+
+	public function get_option_key(): string {
+		return 'woocommerce_' . $this->id . '_settings';
+	}
+
+	/**
+	 * Mirrors WC_Email::is_enabled() — reads the property. The real WC
+	 * method also runs a `woocommerce_email_enabled_*` filter, but for
+	 * the stub the property read is sufficient and deterministic.
+	 */
+	public function is_enabled(): bool {
+		return 'yes' === $this->enabled;
+	}
+}
+
+use Newspack\Emails;
+use Newspack\Wizards\Newspack\Emails_Section;
+
+/**
+ * Slice 2a — WooCommerce surfacing tests.
+ */
+class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
+	/**
+	 * Filter callbacks registered by tests, tracked for cleanup so they
+	 * don't leak across test methods. WP filters aren't transactional.
+	 *
+	 * @var array
+	 */
+	private $filter_callbacks = [];
+
+	/**
+	 * Make `Emails_Section::is_woocommerce_active()` return true for the
+	 * duration of each test. Without a global `class WooCommerce {}`
+	 * shim (which would leak into other test files in this PHPUnit
+	 * process), the source's `class_exists('WooCommerce')` returns
+	 * false in this env — the filter is how tests opt into the
+	 * WC-active code paths cleanly, per-test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'newspack_woocommerce_active', '__return_true' );
+		// Reset the request-scoped Emails::get_email_configs cache so
+		// per-test filter callbacks registered below are reflected.
+		Emails::reset_email_configs_cache();
+	}
+
+	/**
+	 * Remove the WC-active filter, the registered `newspack_email_configs`
+	 * callbacks, and reset the WooCommerce_Emails by-id cache so primed
+	 * stubs don't leak across tests. Option writes are rolled back by
+	 * the WP test framework's per-test transaction.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_woocommerce_active', '__return_true' );
+		foreach ( $this->filter_callbacks as $callback ) {
+			remove_filter( 'newspack_email_configs', $callback );
+		}
+		$this->filter_callbacks = [];
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+		Emails::reset_email_configs_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Inject a stub WC config via `newspack_email_configs` AND prime
+	 * the WooCommerce_Emails by-id cache so {@see WooCommerce_Emails::get_wc_email_by_id()}
+	 * returns the stub when the toggle endpoint / first-run /
+	 * serialization paths look up the instance.
+	 *
+	 * Two-step injection (config filter + cache seed) because the
+	 * refactor split the schema (scalar `wc_email_class`) from the
+	 * live instance (resolved on-demand). The filter provides what
+	 * validation reads; the seeded cache provides what the call sites
+	 * dereference.
+	 *
+	 * @param Newspack_Test_Stub_WC_Email $wc_email  Stub email instance.
+	 * @param array                       $overrides Config overrides (e.g. recommended => false).
+	 * @return Newspack_Test_Stub_WC_Email
+	 */
+	private function register_stub_wc_config( Newspack_Test_Stub_WC_Email $wc_email, array $overrides = [] ): Newspack_Test_Stub_WC_Email {
+		$config = array_merge(
+			[
+				'name'                => $wc_email->id,
+				'category'            => 'woocommerce',
+				'source'              => 'woocommerce',
+				'label'               => 'Stub WC: ' . $wc_email->id,
+				'description'         => 'Stub WC config for testing.',
+				'trigger_description' => 'Stub trigger.',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'chip'                => 'reader-revenue',
+				'wc_email_class'      => get_class( $wc_email ),
+			],
+			$overrides
+		);
+
+		$callback = function ( $configs ) use ( $config ) {
+			$configs[ $config['name'] ] = $config;
+			return $configs;
+		};
+		add_filter( 'newspack_email_configs', $callback );
+		$this->filter_callbacks[] = $callback;
+		// Newly-registered filter callbacks need a cache bust to surface
+		// in the next Emails::get_email_configs() call.
+		Emails::reset_email_configs_cache();
+
+		// Prime the by-id cache so call sites resolve the stub.
+		\Newspack\WooCommerce_Emails::set_wc_email_by_id_for_test( $wc_email->id, $wc_email );
+
+		return $wc_email;
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.1 — WooCommerce_Emails::get_email_configs() registration
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * The class hooks into `newspack_email_configs` from its `init()`.
+	 * This is the contract that lets the rest of the system discover WC
+	 * surfaces through the same filter as Newspack-side providers.
+	 */
+	public function test_woocommerce_emails_hooks_into_newspack_email_configs_filter() {
+		$this->assertNotFalse(
+			has_filter( 'newspack_email_configs', [ \Newspack\WooCommerce_Emails::class, 'get_email_configs' ] ),
+			'WooCommerce_Emails::get_email_configs should be hooked into newspack_email_configs.'
+		);
+	}
+
+	/**
+	 * Without real WC available (no `function_exists('WC')`,
+	 * no `class WC_Emails`), the method returns the input unchanged —
+	 * it never reaches the mailer iteration.
+	 */
+	public function test_woocommerce_emails_get_email_configs_returns_unchanged_without_wc() {
+		$input  = [
+			'receipt' => [
+				'name'     => 'receipt',
+				'category' => 'reader-revenue',
+			],
+		];
+		$output = \Newspack\WooCommerce_Emails::get_email_configs( $input );
+		$this->assertSame( $input, $output );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.2 — api_get_email_settings() surfaces WC rows
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * A WC-source config registered via `newspack_email_configs` appears
+	 * in the wizard response as a row with `source='woocommerce'` and
+	 * `post_id='wc:<id>'`. Slice 1 filtered these out; slice 2a lifts
+	 * the filter.
+	 */
+	public function test_api_get_email_settings_includes_woocommerce_rows() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_refunded_order', 'yes' )
+		);
+
+		$result = Emails_Section::api_get_email_settings();
+		$rows   = array_values(
+			array_filter(
+				$result['newspack_emails'],
+				fn( $email ) => 'woocommerce' === ( $email['source'] ?? 'newspack' )
+					&& 'wc:' . $wc_email->id === ( $email['post_id'] ?? '' )
+			)
+		);
+
+		$this->assertCount( 1, $rows, 'Expected the stub config to surface exactly once.' );
+		$this->assertSame( $wc_email->id, $rows[0]['type'] );
+		$this->assertSame( 'woocommerce', $rows[0]['source'] );
+		$this->assertSame( 'reader-revenue', $rows[0]['chip'] );
+		$this->assertSame( 'publish', $rows[0]['status'], 'enabled=yes should serialize to status=publish.' );
+	}
+
+	/**
+	 * WC rows surface in `WooCommerce_Emails::surfaced_wc_emails()`
+	 * registration order — NOT alphabetical by config key. The allowlist
+	 * is hand-ordered to group semantically-related emails together
+	 * (specifically, the gift pair: 'New giftee account' and
+	 * 'New gift order' must be adjacent). This locks in the curated
+	 * grouping against accidental regressions to alphabetical sorting.
+	 */
+	public function test_api_get_email_settings_wc_rows_follow_registration_order() {
+		// Stub the full allowlist in its registration order so the test
+		// matches the contract of `surfaced_wc_emails()` even when real WC
+		// isn't loaded (no `function_exists('WC')` in this env, so the
+		// real loop in `WooCommerce_Emails::get_email_configs()` bails).
+		$expected_order = [
+			'customer_notification_auto_renewal', // Renewal reminder
+			'customer_payment_retry',             // Failed order retry
+			'expired_subscription',               // Subscription expired
+			'customer_completed_switch_order',    // Subscription switch complete
+			'WCSG_Email_Customer_New_Account',    // New giftee account ─┐
+			'recipient_completed_order',          // New gift order      ┘ adjacent
+			'customer_new_account',               // New account
+			'customer_refunded_order',            // Order refund
+			'new_order',                          // New order
+		];
+		// Register stubs in chip='reader-revenue' (except customer_new_account
+		// which is auth-account in real life — keep it that way so the
+		// test mirrors production chip assignment).
+		$auth_account_id = 'customer_new_account';
+		foreach ( $expected_order as $id ) {
+			$this->register_stub_wc_config(
+				new Newspack_Test_Stub_WC_Email( $id, 'yes' ),
+				[
+					'chip' => $auth_account_id === $id ? 'auth-account' : 'reader-revenue',
+				]
+			);
+		}
+
+		$result   = Emails_Section::api_get_email_settings();
+		$wc_types = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => 'woocommerce' === ( $email['source'] ?? 'newspack' )
+				)
+			)
+		);
+
+		$this->assertSame(
+			$expected_order,
+			$wc_types,
+			'WC rows must surface in surfaced_wc_emails() registration order, not alphabetical.'
+		);
+	}
+
+	/**
+	 * Specifically: the gift-pair (`New giftee account` /
+	 * `New gift order`) must be adjacent. Pre-fix they were max
+	 * distance apart because `strcmp` put `WCSG_...` first (uppercase)
+	 * and `recipient_completed_order` last.
+	 */
+	public function test_api_get_email_settings_wc_gift_pair_is_adjacent() {
+		// Register only the two stubs that matter — both share
+		// chip='reader-revenue' in production.
+		$this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'WCSG_Email_Customer_New_Account', 'yes' )
+		);
+		$this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'recipient_completed_order', 'yes' )
+		);
+
+		$result = Emails_Section::api_get_email_settings();
+		$types  = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => in_array(
+						$email['type'] ?? '',
+						[ 'WCSG_Email_Customer_New_Account', 'recipient_completed_order' ],
+						true
+					)
+				)
+			)
+		);
+
+		$this->assertCount( 2, $types );
+		$idx_giftee = array_search( 'WCSG_Email_Customer_New_Account', $types, true );
+		$idx_gift   = array_search( 'recipient_completed_order', $types, true );
+		$this->assertSame(
+			1,
+			abs( $idx_giftee - $idx_gift ),
+			'New giftee account and New gift order must be adjacent in the response.'
+		);
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.3 — api_toggle_wc_email
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * Toggling writes the WC option AND the refreshed response in the
+	 * same request reflects the new status. Pre-slice-2a the response
+	 * read `$wc_email->enabled` (the in-memory cache from WC boot),
+	 * which could be stale relative to the option write that just
+	 * happened. The fix: serialize_wc_email_row() reads the option,
+	 * the toggle writes the option AND keeps the cached property in
+	 * sync. We assert both writes and the response reflection.
+	 */
+	public function test_api_toggle_wc_email_writes_option_and_response_reflects() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', $wc_email->id );
+		$request->set_param( 'enabled', true );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		// Option write: WC option key now has enabled=yes.
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'yes', $options['enabled'], 'Option was not written.' );
+
+		// In-memory write: the cached $enabled property is updated too.
+		$this->assertSame( 'yes', $wc_email->enabled, 'In-memory $enabled was not updated.' );
+
+		// Same-request response: the row for this email reflects the new status.
+		$data = $response->get_data();
+		$rows = array_values(
+			array_filter(
+				$data['newspack_emails'],
+				fn( $email ) => 'wc:' . $wc_email->id === ( $email['post_id'] ?? '' )
+			)
+		);
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'publish', $rows[0]['status'], 'Refreshed response did not reflect the toggled state.' );
+	}
+
+	/**
+	 * Toggling off (after toggling on) flips the option and the
+	 * same-request response back. Pre-seeds FIRST_RUN_OPTION so the
+	 * refreshed api_get_email_settings() doesn't immediately re-enable
+	 * via first-run — realistic user scenario (past first-run, now
+	 * toggling off).
+	 */
+	public function test_api_toggle_wc_email_off_flips_option_and_response() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'yes' )
+		);
+		update_option( $wc_email->get_option_key(), [ 'enabled' => 'yes' ] );
+		update_option( Emails_Section::FIRST_RUN_OPTION, [ $wc_email->id ], false );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', $wc_email->id );
+		$request->set_param( 'enabled', false );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'no', $options['enabled'] );
+
+		$data = $response->get_data();
+		$rows = array_values(
+			array_filter(
+				$data['newspack_emails'],
+				fn( $email ) => 'wc:' . $wc_email->id === ( $email['post_id'] ?? '' )
+			)
+		);
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'draft', $rows[0]['status'], 'Toggle off should serialize to status=draft.' );
+	}
+
+	/**
+	 * Toggling an unknown email ID returns a 404 WP_Error and does not
+	 * write any option.
+	 */
+	public function test_api_toggle_wc_email_rejects_unknown_id() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', 'this_email_does_not_exist' );
+		$request->set_param( 'enabled', true );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_wc_email_not_allowed', $response->get_error_code() );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Toggling a Newspack-source id returns 404 even though the id
+	 * resolves to a real config. The `source === 'woocommerce'` check
+	 * guards against routing Newspack rows through the WC toggle path.
+	 */
+	public function test_api_toggle_wc_email_rejects_newspack_source_id() {
+		$configs              = Emails::get_email_configs();
+		$newspack_config_keys = array_keys(
+			array_filter(
+				$configs,
+				fn( $config ) => 'woocommerce' !== ( $config['source'] ?? 'newspack' )
+			)
+		);
+		$this->assertNotEmpty( $newspack_config_keys, 'Expected at least one newspack-source config to exist.' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', $newspack_config_keys[0] );
+		$request->set_param( 'enabled', true );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_wc_email_not_allowed', $response->get_error_code() );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.4 — maybe_first_run_enable_wc_emails
+	 *
+	 * Called from api_get_email_settings() on every wizard load.
+	 * Idempotency is keyed on the FIRST_RUN_OPTION processed-keys
+	 * array, NOT on the current enabled state — that's the
+	 * user-disabled-after-first-run contract.
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * Once a key is in the processed list, first-run does NOT re-enable
+	 * it — even if the user has manually disabled it since. This is the
+	 * critical user-disabled-after-first-run protection.
+	 */
+	public function test_first_run_enable_idempotent_when_key_processed() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		update_option( Emails_Section::FIRST_RUN_OPTION, [ $wc_email->id ], false );
+		update_option( $wc_email->get_option_key(), [ 'enabled' => 'no' ] );
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'no', $options['enabled'], 'Already-processed email must NOT be re-enabled.' );
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertSame( [ $wc_email->id ], $processed, 'Processed list should be unchanged.' );
+	}
+
+	/**
+	 * A `recommended=false` WC config is never auto-enabled on first-run
+	 * and its key is not added to the processed list (so a future flip
+	 * to recommended=true would still get a first-run pass).
+	 */
+	public function test_first_run_skips_non_recommended() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_refunded_order', 'no' ),
+			[ 'recommended' => false ]
+		);
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$this->assertFalse(
+			get_option( $wc_email->get_option_key() ),
+			'Non-recommended email should not have its option written.'
+		);
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertNotContains(
+			$wc_email->id,
+			$processed,
+			'Non-recommended email should not be in the processed list.'
+		);
+		$this->assertSame( 'no', $wc_email->enabled, 'In-memory enabled should be unchanged.' );
+	}
+
+	/**
+	 * A recommended, unprocessed WC email whose settings option doesn't
+	 * exist in the DB yet gets enabled on first encounter AND added to
+	 * the processed list.
+	 *
+	 * "Option doesn't exist" = publisher has never opened the WC settings
+	 * form for this email, so they have no recorded preference; the
+	 * recommended-default kicks in.
+	 */
+	public function test_first_run_enables_when_option_unset() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		// Ensure the WC settings option doesn't exist in the DB.
+		delete_option( $wc_email->get_option_key() );
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'yes', $options['enabled'], 'Unset option should get enabled=yes on first-run.' );
+		$this->assertSame( 'yes', $wc_email->enabled, 'In-memory enabled should be flipped too.' );
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertContains( $wc_email->id, $processed );
+	}
+
+	/**
+	 * Publisher's explicit `'no'` is preserved on first-run. The slug is
+	 * still added to the processed list — "considered once" semantics
+	 * apply whether or not we wrote.
+	 */
+	public function test_first_run_preserves_explicit_no() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		// Publisher has explicitly disabled this email via WC settings.
+		update_option( $wc_email->get_option_key(), [ 'enabled' => 'no' ] );
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame(
+			'no',
+			$options['enabled'],
+			'Publisher\'s explicit enabled=no MUST NOT be overwritten on first-run.'
+		);
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertContains(
+			$wc_email->id,
+			$processed,
+			'Slug must still be added to processed list — considered-once semantics apply whether or not we wrote.'
+		);
+	}
+
+	/**
+	 * Special case: `customer_notification_auto_renewal` requires the
+	 * WC Subscriptions master switch
+	 * (`woocommerce_subscriptions_customer_notifications_enabled`) on —
+	 * otherwise the email never fires regardless of its own enabled
+	 * flag. When the master switch option doesn't exist in the DB,
+	 * first-run sets it to `'yes'`.
+	 */
+	public function test_first_run_enables_wcs_master_switch_when_unset() {
+		// Ensure the master switch option doesn't exist.
+		delete_option( Emails_Section::WCS_MASTER_SWITCH_OPTION );
+
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
+		);
+		delete_option( $wc_email->get_option_key() );
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$this->assertSame(
+			'yes',
+			get_option( Emails_Section::WCS_MASTER_SWITCH_OPTION ),
+			'WCS master switch should be set to yes when previously unset.'
+		);
+		$this->assertContains(
+			$wc_email->id,
+			(array) get_option( Emails_Section::FIRST_RUN_OPTION, [] )
+		);
+	}
+
+	/**
+	 * Publisher's explicit `'no'` on the WCS master switch is a
+	 * site-wide policy choice — first-run preserves it.
+	 *
+	 * The master switch controls ALL WC Subscriptions customer
+	 * notifications, not just the renewal reminder. A publisher who
+	 * turned it off did so intentionally; we don't silently reverse
+	 * that decision.
+	 */
+	public function test_first_run_preserves_wcs_master_switch_disabled() {
+		// Publisher has explicitly disabled the WCS master switch.
+		update_option( Emails_Section::WCS_MASTER_SWITCH_OPTION, 'no' );
+
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
+		);
+		delete_option( $wc_email->get_option_key() );
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$this->assertSame(
+			'no',
+			get_option( Emails_Section::WCS_MASTER_SWITCH_OPTION ),
+			'Publisher\'s explicit master-switch=no MUST NOT be overwritten on first-run.'
+		);
+		$this->assertContains(
+			$wc_email->id,
+			(array) get_option( Emails_Section::FIRST_RUN_OPTION, [] ),
+			'Slug must still be added to processed list.'
+		);
+	}
+
+	/**
+	 * Non-auto-renewal first-runs do NOT touch the WCS master switch —
+	 * the special case is scoped to that one id.
+	 *
+	 * Sets the master switch to unset so a wrongful firing of the WCS
+	 * branch would change the option value. Then registers a
+	 * non-auto-renewal email and verifies the option stays absent.
+	 */
+	public function test_first_run_does_not_flip_master_switch_for_other_emails() {
+		delete_option( Emails_Section::WCS_MASTER_SWITCH_OPTION );
+
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		delete_option( $wc_email->get_option_key() );
+
+		Emails_Section::maybe_first_run_enable_wc_emails();
+
+		$this->assertFalse(
+			get_option( Emails_Section::WCS_MASTER_SWITCH_OPTION, false ),
+			'Master switch should remain absent for non-auto-renewal first-runs.'
+		);
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.5 — Config schema shape (no live `WC_Email` instance)
+	 * ------------------------------------------------------------------
+	 * The unified `newspack_email_configs` schema MUST stay JSON-
+	 * serializable. The live `WC_Email` instance is resolved on-demand
+	 * via `WooCommerce_Emails::get_wc_email_by_id()` at the call sites
+	 * that need it; the config itself only carries the scalar
+	 * `wc_email_class` string.
+	 */
+
+	/**
+	 * Real-WC `WooCommerce_Emails::get_email_configs()` injects entries
+	 * that have NO `wc_email_instance` key and DO have a string
+	 * `wc_email_class` field.
+	 */
+	public function test_wc_emails_get_email_configs_no_instance_has_class_string() {
+		if ( ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded; the get_email_configs() loop bails before injecting anything.' );
+		}
+
+		$configs = \Newspack\WooCommerce_Emails::get_email_configs( [] );
+		$this->assertNotEmpty( $configs, 'Expected at least one surfaced WC config.' );
+
+		foreach ( $configs as $id => $config ) {
+			$this->assertArrayNotHasKey(
+				'wc_email_instance',
+				$config,
+				"Config '$id' must NOT carry a live WC_Email instance (breaks JSON serialization)."
+			);
+			$this->assertArrayHasKey(
+				'wc_email_class',
+				$config,
+				"Config '$id' must carry the scalar wc_email_class field."
+			);
+			$this->assertIsString( $config['wc_email_class'], "Config '$id' wc_email_class must be a string." );
+			$this->assertNotEmpty( $config['wc_email_class'], "Config '$id' wc_email_class must not be empty." );
+		}
+	}
+
+	/**
+	 * Spot-check one specific id → class mapping that exercises a path
+	 * the loop touches (WC core, no plugin_dependency gating).
+	 */
+	public function test_wc_emails_customer_new_account_class_mapping() {
+		if ( ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded.' );
+		}
+
+		$configs = \Newspack\WooCommerce_Emails::get_email_configs( [] );
+		$this->assertArrayHasKey( 'customer_new_account', $configs );
+		$this->assertSame( 'WC_Email_Customer_New_Account', $configs['customer_new_account']['wc_email_class'] );
+	}
+
+	/**
+	 * Live-WC integration: every WC-source config surfaced by the
+	 * registration loop has a `wc_email_class` that actually matches
+	 * `get_class()` of the corresponding instance in
+	 * `WC()->mailer()->get_emails()`. Skipped when real WC isn't loaded.
+	 *
+	 * The stub-only coverage above copies the allowlist values into the
+	 * test fixture, so a wrong id↔class mapping in production passes
+	 * the stub assertions but fails here on a live-WC environment.
+	 * Catches typos, renames, or new entries that drift from the actual
+	 * WC mailer registrations.
+	 */
+	public function test_surfaced_wc_emails_match_live_mailer_classes() {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded; cannot compare against WC()->mailer()->get_emails().' );
+		}
+
+		// Reset the by-id cache so this test reads the live mailer state
+		// rather than any cache primed by sibling tests in this suite.
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+
+		$mailer_emails = [];
+		foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+			$mailer_emails[ $wc_email->id ] = $wc_email;
+		}
+
+		// Iterate the configs the registration loop actually emits — this
+		// covers the same set as the SURFACED_WC_EMAILS allowlist while
+		// honoring its plugin_dependency gates (so we don't false-fail on
+		// a WCS / WCSG entry when those plugins aren't installed).
+		$configs    = \Newspack\WooCommerce_Emails::get_email_configs( [] );
+		$wc_configs = array_filter(
+			$configs,
+			fn( $config ) => 'woocommerce' === ( $config['source'] ?? '' )
+		);
+		$this->assertNotEmpty( $wc_configs, 'Expected at least one WC-source config to be registered with WC active.' );
+
+		foreach ( $wc_configs as $id => $config ) {
+			$this->assertArrayHasKey(
+				$id,
+				$mailer_emails,
+				"Surfaced WC id '$id' is not registered in WC()->mailer()->get_emails()."
+			);
+			$this->assertSame(
+				get_class( $mailer_emails[ $id ] ),
+				$config['wc_email_class'],
+				"wc_email_class for '$id' must match the live mailer's class."
+			);
+		}
+	}
+
+	/**
+	 * The whole unified config set must be JSON-encodable. If anyone
+	 * accidentally smuggles a WC_Email instance back in (a closed-over
+	 * filter callback, a stray field) wp_json_encode would return false
+	 * because WC_Email holds non-serializable references.
+	 */
+	public function test_unified_email_configs_are_json_encodable() {
+		$json = wp_json_encode( Emails::get_email_configs() );
+
+		$this->assertNotFalse(
+			$json,
+			'wp_json_encode(Emails::get_email_configs()) returned false — something in the schema is not JSON-serializable.'
+		);
+		$this->assertStringNotContainsString(
+			'wc_email_instance',
+			(string) $json,
+			'No `wc_email_instance` key should appear in the serialized config schema.'
+		);
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.6 — WooCommerce_Emails::get_wc_email_by_id() helper
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * Returns null for ids that aren't in the mailer (or surfaced
+	 * allowlist) — callers handle that gracefully.
+	 */
+	public function test_get_wc_email_by_id_returns_null_for_unknown_id() {
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+		$result = \Newspack\WooCommerce_Emails::get_wc_email_by_id( 'this_id_does_not_exist' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Memoization: two calls for the same id return the exact same
+	 * object (proves the cache isn't re-fetching from the mailer).
+	 */
+	public function test_get_wc_email_by_id_memoizes() {
+		// Prime with a stub so this test works without real WC. The
+		// memoization contract is the same: the second call returns the
+		// same object reference as the first.
+		$stub = new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' );
+		\Newspack\WooCommerce_Emails::set_wc_email_by_id_for_test( $stub->id, $stub );
+
+		$a = \Newspack\WooCommerce_Emails::get_wc_email_by_id( $stub->id );
+		$b = \Newspack\WooCommerce_Emails::get_wc_email_by_id( $stub->id );
+
+		$this->assertSame( $a, $b, 'Helper must return the same object reference across calls.' );
+		$this->assertSame( $stub, $a, 'Helper must return the primed instance.' );
+	}
+
+	/**
+	 * Helper round-trip against real WC: the returned instance is the
+	 * mailer-owned singleton, not a fresh instantiation. Skipped when
+	 * real WC isn't loaded.
+	 */
+	public function test_get_wc_email_by_id_returns_mailer_owned_singleton() {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded; cannot compare against WC()->mailer()->get_emails().' );
+		}
+
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+
+		$mailer_emails = \WC()->mailer()->get_emails();
+		// Find any id that's both in the mailer AND surfaced — use the
+		// first one to avoid coupling to a specific id.
+		$id_to_test = null;
+		foreach ( $mailer_emails as $wc_email ) {
+			if ( 'customer_new_account' === $wc_email->id ) {
+				$id_to_test = $wc_email->id;
+				break;
+			}
+		}
+		if ( ! $id_to_test ) {
+			$this->markTestSkipped( 'customer_new_account not registered in this WC env.' );
+		}
+
+		// Reset, then compare: the helper's returned instance MUST be
+		// the same object as the one the mailer hands out.
+		$mailer_owned = null;
+		foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+			if ( $wc_email->id === $id_to_test ) {
+				$mailer_owned = $wc_email;
+				break;
+			}
+		}
+
+		$resolved = \Newspack\WooCommerce_Emails::get_wc_email_by_id( $id_to_test );
+
+		$this->assertSame(
+			$mailer_owned,
+			$resolved,
+			'Helper must return the mailer-owned singleton, not a fresh instantiation.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -187,6 +187,102 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		$this->assertSame( 'publish', $rows[0]['status'], 'enabled=yes should serialize to status=publish.' );
 	}
 
+	/**
+	 * WC rows surface in `WooCommerce_Emails::surfaced_wc_emails()`
+	 * registration order — NOT alphabetical by config key. The allowlist
+	 * is hand-ordered to group semantically-related emails together
+	 * (specifically, the gift pair: 'New giftee account' and
+	 * 'New gift order' must be adjacent). This locks in the curated
+	 * grouping against accidental regressions to alphabetical sorting.
+	 */
+	public function test_api_get_email_settings_wc_rows_follow_registration_order() {
+		// Stub the full allowlist in its registration order so the test
+		// matches the contract of `surfaced_wc_emails()` even when real WC
+		// isn't loaded (no `function_exists('WC')` in this env, so the
+		// real loop in `WooCommerce_Emails::get_email_configs()` bails).
+		$expected_order = [
+			'customer_notification_auto_renewal', // Renewal reminder
+			'customer_payment_retry',             // Failed order retry
+			'expired_subscription',               // Subscription expired
+			'customer_completed_switch_order',    // Subscription switch complete
+			'WCSG_Email_Customer_New_Account',    // New giftee account ─┐
+			'recipient_completed_order',          // New gift order      ┘ adjacent
+			'customer_new_account',               // New account
+			'customer_refunded_order',            // Order refund
+			'new_order',                          // New order
+		];
+		// Register stubs in chip='reader-revenue' (except customer_new_account
+		// which is auth-account in real life — keep it that way so the
+		// test mirrors production chip assignment).
+		$auth_account_id = 'customer_new_account';
+		foreach ( $expected_order as $id ) {
+			$this->register_stub_wc_config(
+				new Newspack_Test_Stub_WC_Email( $id, 'yes' ),
+				[
+					'chip' => $auth_account_id === $id ? 'auth-account' : 'reader-revenue',
+				]
+			);
+		}
+
+		$result   = Emails_Section::api_get_email_settings();
+		$wc_types = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => 'woocommerce' === ( $email['source'] ?? 'newspack' )
+				)
+			)
+		);
+
+		$this->assertSame(
+			$expected_order,
+			$wc_types,
+			'WC rows must surface in surfaced_wc_emails() registration order, not alphabetical.'
+		);
+	}
+
+	/**
+	 * Specifically: the gift-pair (`New giftee account` /
+	 * `New gift order`) must be adjacent. Pre-fix they were max
+	 * distance apart because `strcmp` put `WCSG_...` first (uppercase)
+	 * and `recipient_completed_order` last.
+	 */
+	public function test_api_get_email_settings_wc_gift_pair_is_adjacent() {
+		// Register only the two stubs that matter — both share
+		// chip='reader-revenue' in production.
+		$this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'WCSG_Email_Customer_New_Account', 'yes' )
+		);
+		$this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'recipient_completed_order', 'yes' )
+		);
+
+		$result = Emails_Section::api_get_email_settings();
+		$types  = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => in_array(
+						$email['type'] ?? '',
+						[ 'WCSG_Email_Customer_New_Account', 'recipient_completed_order' ],
+						true
+					)
+				)
+			)
+		);
+
+		$this->assertCount( 2, $types );
+		$idx_giftee = array_search( 'WCSG_Email_Customer_New_Account', $types, true );
+		$idx_gift   = array_search( 'recipient_completed_order', $types, true );
+		$this->assertSame(
+			1,
+			abs( $idx_giftee - $idx_gift ),
+			'New giftee account and New gift order must be adjacent in the response.'
+		);
+	}
+
 	/*
 	 * ------------------------------------------------------------------
 	 * Bucket F.3 — api_toggle_wc_email

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.WrongStyle, Squiz.Commenting.InlineComment.InvalidEndChar, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing -- Test file intentionally declares a WooCommerce class shim and a WC_Email-like stub alongside the main test class; precedent: tests/unit-tests/reader-registration-endpoint.php and tests/mocks/*.
 /**
  * Slice 2a (NPPD-1527) — WooCommerce email surfacing.
  *
@@ -29,8 +29,6 @@
  * @package Newspack\Tests
  */
 
-// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing
-
 if ( ! class_exists( 'WooCommerce' ) ) {
 	// Shim — only declared when real WC isn't loaded. Empty body is fine;
 	// Emails_Section guards use `class_exists('WooCommerce')` as a boolean.
@@ -55,8 +53,6 @@ class Newspack_Test_Stub_WC_Email {
 		return 'woocommerce_' . $this->id . '_settings';
 	}
 }
-
-// phpcs:enable Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing
 
 use Newspack\Emails;
 use Newspack\Wizards\Newspack\Emails_Section;

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -1,4 +1,4 @@
-<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.WrongStyle, Squiz.Commenting.InlineComment.InvalidEndChar, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing -- Test file intentionally declares a WooCommerce class shim and a WC_Email-like stub alongside the main test class; precedent: tests/unit-tests/reader-registration-endpoint.php and tests/mocks/*.
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.WrongStyle, Squiz.Commenting.InlineComment.InvalidEndChar, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing -- Test file intentionally declares a WC_Email-like stub alongside the main test class; precedent: tests/unit-tests/reader-registration-endpoint.php and tests/mocks/*.
 /**
  * Slice 2a (NPPD-1527) — WooCommerce email surfacing.
  *
@@ -13,27 +13,21 @@
  *   - `Emails_Section::api_toggle_wc_email()` — writes the WC option AND
  *     the same-request response reflects the new state (the staleness
  *     fix), with 404 rejection for unknown IDs and non-WC sources.
- *   - `Emails_Section::maybe_first_run_enable_wc_emails()` — idempotency
- *     keyed on the processed list (not current state, so the
- *     user-disabled-after-first-run case is honored), skips
- *     `recommended=false`, and flips the WCS master switch when
- *     `customer_notification_auto_renewal` first runs.
+ *   - `Emails_Section::maybe_first_run_enable_wc_emails()` — only writes
+ *     when the publisher hasn't recorded a decision yet (preserves
+ *     explicit 'no'); WCS master switch only flipped when never set;
+ *     idempotent via the FIRST_RUN_OPTION processed-keys list whether
+ *     or not we wrote.
  *
- * Setup: declares a `WooCommerce` class shim (the only globally-visible
- * side effect — the real one doesn't exist in this test env, and the
- * guards in Emails_Section won't fire without it) and a minimal
- * `WC_Email`-like stub. Stub configs are injected via the
- * `newspack_email_configs` filter and removed in tearDown so they
- * don't leak across tests.
+ * Setup: declares a minimal `WC_Email`-like stub. WooCommerce-active
+ * tests opt-in via the `newspack_woocommerce_active` filter (added in
+ * set_up, removed in tear_down) — no global `class WooCommerce {}` shim,
+ * so suite order doesn't matter. Stub configs are injected via the
+ * `newspack_email_configs` filter; instances are primed onto the
+ * WooCommerce_Emails by-id cache via the test-only helpers there.
  *
  * @package Newspack\Tests
  */
-
-if ( ! class_exists( 'WooCommerce' ) ) {
-	// Shim — only declared when real WC isn't loaded. Empty body is fine;
-	// Emails_Section guards use `class_exists('WooCommerce')` as a boolean.
-	class WooCommerce {}
-}
 
 /**
  * Minimal WC_Email-like stub. Mimics the three points of contact the
@@ -79,12 +73,26 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	private $filter_callbacks = [];
 
 	/**
-	 * Remove any registered filter callbacks AND reset the
-	 * WooCommerce_Emails by-id cache so primed stubs don't leak across
-	 * tests. Option writes are rolled back by the WP test framework's
-	 * per-test transaction.
+	 * Make `Emails_Section::is_woocommerce_active()` return true for the
+	 * duration of each test. Without a global `class WooCommerce {}`
+	 * shim (which would leak into other test files in this PHPUnit
+	 * process), the source's `class_exists('WooCommerce')` returns
+	 * false in this env — the filter is how tests opt into the
+	 * WC-active code paths cleanly, per-test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'newspack_woocommerce_active', '__return_true' );
+	}
+
+	/**
+	 * Remove the WC-active filter, the registered `newspack_email_configs`
+	 * callbacks, and reset the WooCommerce_Emails by-id cache so primed
+	 * stubs don't leak across tests. Option writes are rolled back by
+	 * the WP test framework's per-test transaction.
 	 */
 	public function tear_down() {
+		remove_filter( 'newspack_woocommerce_active', '__return_true' );
 		foreach ( $this->filter_callbacks as $callback ) {
 			remove_filter( 'newspack_email_configs', $callback );
 		}
@@ -483,19 +491,25 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A recommended, unprocessed WC email is enabled on its first
-	 * encounter AND added to the processed list, so the next call is a
-	 * no-op (idempotency).
+	 * A recommended, unprocessed WC email whose settings option doesn't
+	 * exist in the DB yet gets enabled on first encounter AND added to
+	 * the processed list.
+	 *
+	 * "Option doesn't exist" = publisher has never opened the WC settings
+	 * form for this email, so they have no recorded preference; the
+	 * recommended-default kicks in.
 	 */
-	public function test_first_run_enables_recommended_unprocessed() {
+	public function test_first_run_enables_when_option_unset() {
 		$wc_email = $this->register_stub_wc_config(
 			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
 		);
+		// Ensure the WC settings option doesn't exist in the DB.
+		delete_option( $wc_email->get_option_key() );
 
 		Emails_Section::api_get_email_settings();
 
 		$options = (array) get_option( $wc_email->get_option_key(), [] );
-		$this->assertSame( 'yes', $options['enabled'] );
+		$this->assertSame( 'yes', $options['enabled'], 'Unset option should get enabled=yes on first-run.' );
 		$this->assertSame( 'yes', $wc_email->enabled, 'In-memory enabled should be flipped too.' );
 
 		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
@@ -503,25 +517,57 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Publisher's explicit `'no'` is preserved on first-run. The slug is
+	 * still added to the processed list — "considered once" semantics
+	 * apply whether or not we wrote.
+	 */
+	public function test_first_run_preserves_explicit_no() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		// Publisher has explicitly disabled this email via WC settings.
+		update_option( $wc_email->get_option_key(), [ 'enabled' => 'no' ] );
+
+		Emails_Section::api_get_email_settings();
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame(
+			'no',
+			$options['enabled'],
+			'Publisher\'s explicit enabled=no MUST NOT be overwritten on first-run.'
+		);
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertContains(
+			$wc_email->id,
+			$processed,
+			'Slug must still be added to processed list — considered-once semantics apply whether or not we wrote.'
+		);
+	}
+
+	/**
 	 * Special case: `customer_notification_auto_renewal` requires the
 	 * WC Subscriptions master switch
 	 * (`woocommerce_subscriptions_customer_notifications_enabled`) on —
 	 * otherwise the email never fires regardless of its own enabled
-	 * flag. First-run flips both.
+	 * flag. When the master switch option doesn't exist in the DB,
+	 * first-run sets it to `'yes'`.
 	 */
-	public function test_first_run_enables_wcs_master_switch_for_auto_renewal() {
-		update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'no' );
+	public function test_first_run_enables_wcs_master_switch_when_unset() {
+		// Ensure the master switch option doesn't exist.
+		delete_option( 'woocommerce_subscriptions_customer_notifications_enabled' );
 
 		$wc_email = $this->register_stub_wc_config(
 			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
 		);
+		delete_option( $wc_email->get_option_key() );
 
 		Emails_Section::api_get_email_settings();
 
 		$this->assertSame(
 			'yes',
 			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
-			'WCS master switch should be enabled by the auto-renewal first-run.'
+			'WCS master switch should be set to yes when previously unset.'
 		);
 		$this->assertContains(
 			$wc_email->id,
@@ -530,22 +576,58 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Non-auto-renewal first-runs do NOT flip the WCS master switch —
-	 * the special case is scoped to that one id.
+	 * Publisher's explicit `'no'` on the WCS master switch is a
+	 * site-wide policy choice — first-run preserves it.
+	 *
+	 * The master switch controls ALL WC Subscriptions customer
+	 * notifications, not just the renewal reminder. A publisher who
+	 * turned it off did so intentionally; we don't silently reverse
+	 * that decision.
 	 */
-	public function test_first_run_does_not_flip_master_switch_for_other_emails() {
+	public function test_first_run_preserves_wcs_master_switch_disabled() {
+		// Publisher has explicitly disabled the WCS master switch.
 		update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'no' );
 
-		$this->register_stub_wc_config(
-			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
 		);
+		delete_option( $wc_email->get_option_key() );
 
 		Emails_Section::api_get_email_settings();
 
 		$this->assertSame(
 			'no',
 			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
-			'Master switch should not be touched by non-auto-renewal first-runs.'
+			'Publisher\'s explicit master-switch=no MUST NOT be overwritten on first-run.'
+		);
+		$this->assertContains(
+			$wc_email->id,
+			(array) get_option( Emails_Section::FIRST_RUN_OPTION, [] ),
+			'Slug must still be added to processed list.'
+		);
+	}
+
+	/**
+	 * Non-auto-renewal first-runs do NOT touch the WCS master switch —
+	 * the special case is scoped to that one id.
+	 *
+	 * Sets the master switch to unset so a wrongful firing of the WCS
+	 * branch would change the option value. Then registers a
+	 * non-auto-renewal email and verifies the option stays absent.
+	 */
+	public function test_first_run_does_not_flip_master_switch_for_other_emails() {
+		delete_option( 'woocommerce_subscriptions_customer_notifications_enabled' );
+
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		delete_option( $wc_email->get_option_key() );
+
+		Emails_Section::api_get_email_settings();
+
+		$this->assertFalse(
+			get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false ),
+			'Master switch should remain absent for non-auto-renewal first-runs.'
 		);
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -52,6 +52,15 @@ class Newspack_Test_Stub_WC_Email {
 	public function get_option_key(): string {
 		return 'woocommerce_' . $this->id . '_settings';
 	}
+
+	/**
+	 * Mirrors WC_Email::is_enabled() — reads the property. The real WC
+	 * method also runs a `woocommerce_email_enabled_*` filter, but for
+	 * the stub the property read is sufficient and deterministic.
+	 */
+	public function is_enabled(): bool {
+		return 'yes' === $this->enabled;
+	}
 }
 
 use Newspack\Emails;
@@ -70,20 +79,31 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	private $filter_callbacks = [];
 
 	/**
-	 * Remove any registered filter callbacks. Option writes are rolled
-	 * back by the WP test framework's per-test transaction.
+	 * Remove any registered filter callbacks AND reset the
+	 * WooCommerce_Emails by-id cache so primed stubs don't leak across
+	 * tests. Option writes are rolled back by the WP test framework's
+	 * per-test transaction.
 	 */
 	public function tear_down() {
 		foreach ( $this->filter_callbacks as $callback ) {
 			remove_filter( 'newspack_email_configs', $callback );
 		}
 		$this->filter_callbacks = [];
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
 		parent::tear_down();
 	}
 
 	/**
-	 * Inject a stub WC config via `newspack_email_configs`. Returns the
-	 * stub so the caller can mutate or assert on it.
+	 * Inject a stub WC config via `newspack_email_configs` AND prime
+	 * the WooCommerce_Emails by-id cache so {@see WooCommerce_Emails::get_wc_email_by_id()}
+	 * returns the stub when the toggle endpoint / first-run /
+	 * serialization paths look up the instance.
+	 *
+	 * Two-step injection (config filter + cache seed) because the
+	 * refactor split the schema (scalar `wc_email_class`) from the
+	 * live instance (resolved on-demand). The filter provides what
+	 * validation reads; the seeded cache provides what the call sites
+	 * dereference.
 	 *
 	 * @param Newspack_Test_Stub_WC_Email $wc_email  Stub email instance.
 	 * @param array                       $overrides Config overrides (e.g. recommended => false).
@@ -101,7 +121,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 				'recipient'           => 'reader',
 				'recommended'         => true,
 				'chip'                => 'reader-revenue',
-				'wc_email_instance'   => $wc_email,
+				'wc_email_class'      => get_class( $wc_email ),
 			],
 			$overrides
 		);
@@ -112,6 +132,10 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		};
 		add_filter( 'newspack_email_configs', $callback );
 		$this->filter_callbacks[] = $callback;
+
+		// Prime the by-id cache so call sites resolve the stub.
+		\Newspack\WooCommerce_Emails::set_wc_email_by_id_for_test( $wc_email->id, $wc_email );
+
 		return $wc_email;
 	}
 
@@ -376,10 +400,9 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Toggling a Newspack-source id (no `wc_email_instance` attached)
-	 * returns 404 even though the id resolves to a real config. The
-	 * source-and-instance check guards against routing Newspack rows
-	 * through the WC toggle path.
+	 * Toggling a Newspack-source id returns 404 even though the id
+	 * resolves to a real config. The `source === 'woocommerce'` check
+	 * guards against routing Newspack rows through the WC toggle path.
 	 */
 	public function test_api_toggle_wc_email_rejects_newspack_source_id() {
 		$configs              = Emails::get_email_configs();
@@ -523,6 +546,159 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 			'no',
 			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
 			'Master switch should not be touched by non-auto-renewal first-runs.'
+		);
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.5 — Config schema shape (dkoo's refactor — drop instance)
+	 * ------------------------------------------------------------------
+	 * The unified `newspack_email_configs` schema MUST stay JSON-
+	 * serializable. The live `WC_Email` instance is resolved on-demand
+	 * via `WooCommerce_Emails::get_wc_email_by_id()` at the call sites
+	 * that need it; the config itself only carries the scalar
+	 * `wc_email_class` string.
+	 */
+
+	/**
+	 * Real-WC `WooCommerce_Emails::get_email_configs()` injects entries
+	 * that have NO `wc_email_instance` key and DO have a string
+	 * `wc_email_class` field.
+	 */
+	public function test_wc_emails_get_email_configs_no_instance_has_class_string() {
+		if ( ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded; the get_email_configs() loop bails before injecting anything.' );
+		}
+
+		$configs = \Newspack\WooCommerce_Emails::get_email_configs( [] );
+		$this->assertNotEmpty( $configs, 'Expected at least one surfaced WC config.' );
+
+		foreach ( $configs as $id => $config ) {
+			$this->assertArrayNotHasKey(
+				'wc_email_instance',
+				$config,
+				"Config '$id' must NOT carry a live WC_Email instance (breaks JSON serialization)."
+			);
+			$this->assertArrayHasKey(
+				'wc_email_class',
+				$config,
+				"Config '$id' must carry the scalar wc_email_class field."
+			);
+			$this->assertIsString( $config['wc_email_class'], "Config '$id' wc_email_class must be a string." );
+			$this->assertNotEmpty( $config['wc_email_class'], "Config '$id' wc_email_class must not be empty." );
+		}
+	}
+
+	/**
+	 * Spot-check one specific id → class mapping that exercises a path
+	 * the loop touches (WC core, no plugin_dependency gating).
+	 */
+	public function test_wc_emails_customer_new_account_class_mapping() {
+		if ( ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded.' );
+		}
+
+		$configs = \Newspack\WooCommerce_Emails::get_email_configs( [] );
+		$this->assertArrayHasKey( 'customer_new_account', $configs );
+		$this->assertSame( 'WC_Email_Customer_New_Account', $configs['customer_new_account']['wc_email_class'] );
+	}
+
+	/**
+	 * The whole unified config set must be JSON-encodable. If anyone
+	 * accidentally smuggles a WC_Email instance back in (a closed-over
+	 * filter callback, a stray field) wp_json_encode would return false
+	 * because WC_Email holds non-serializable references.
+	 */
+	public function test_unified_email_configs_are_json_encodable() {
+		$json = wp_json_encode( Emails::get_email_configs() );
+
+		$this->assertNotFalse(
+			$json,
+			'wp_json_encode(Emails::get_email_configs()) returned false — something in the schema is not JSON-serializable.'
+		);
+		$this->assertStringNotContainsString(
+			'wc_email_instance',
+			(string) $json,
+			'No `wc_email_instance` key should appear in the serialized config schema.'
+		);
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.6 — WooCommerce_Emails::get_wc_email_by_id() helper
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * Returns null for ids that aren't in the mailer (or surfaced
+	 * allowlist) — callers handle that gracefully.
+	 */
+	public function test_get_wc_email_by_id_returns_null_for_unknown_id() {
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+		$result = \Newspack\WooCommerce_Emails::get_wc_email_by_id( 'this_id_does_not_exist' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Memoization: two calls for the same id return the exact same
+	 * object (proves the cache isn't re-fetching from the mailer).
+	 */
+	public function test_get_wc_email_by_id_memoizes() {
+		// Prime with a stub so this test works without real WC. The
+		// memoization contract is the same: the second call returns the
+		// same object reference as the first.
+		$stub = new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' );
+		\Newspack\WooCommerce_Emails::set_wc_email_by_id_for_test( $stub->id, $stub );
+
+		$a = \Newspack\WooCommerce_Emails::get_wc_email_by_id( $stub->id );
+		$b = \Newspack\WooCommerce_Emails::get_wc_email_by_id( $stub->id );
+
+		$this->assertSame( $a, $b, 'Helper must return the same object reference across calls.' );
+		$this->assertSame( $stub, $a, 'Helper must return the primed instance.' );
+	}
+
+	/**
+	 * Helper round-trip against real WC: the returned instance is the
+	 * mailer-owned singleton, not a fresh instantiation. Skipped when
+	 * real WC isn't loaded.
+	 */
+	public function test_get_wc_email_by_id_returns_mailer_owned_singleton() {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded; cannot compare against WC()->mailer()->get_emails().' );
+		}
+
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+
+		$mailer_emails = \WC()->mailer()->get_emails();
+		// Find any id that's both in the mailer AND surfaced — use the
+		// first one to avoid coupling to a specific id.
+		$id_to_test = null;
+		foreach ( $mailer_emails as $wc_email ) {
+			if ( 'customer_new_account' === $wc_email->id ) {
+				$id_to_test = $wc_email->id;
+				break;
+			}
+		}
+		if ( ! $id_to_test ) {
+			$this->markTestSkipped( 'customer_new_account not registered in this WC env.' );
+		}
+
+		// Reset, then compare: the helper's returned instance MUST be
+		// the same object as the one the mailer hands out.
+		$mailer_owned = null;
+		foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+			if ( $wc_email->id === $id_to_test ) {
+				$mailer_owned = $wc_email;
+				break;
+			}
+		}
+
+		$resolved = \Newspack\WooCommerce_Emails::get_wc_email_by_id( $id_to_test );
+
+		$this->assertSame(
+			$mailer_owned,
+			$resolved,
+			'Helper must return the mailer-owned singleton, not a fresh instantiation.'
 		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -561,7 +561,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	 */
 	public function test_first_run_enables_wcs_master_switch_when_unset() {
 		// Ensure the master switch option doesn't exist.
-		delete_option( 'woocommerce_subscriptions_customer_notifications_enabled' );
+		delete_option( Emails_Section::WCS_MASTER_SWITCH_OPTION );
 
 		$wc_email = $this->register_stub_wc_config(
 			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
@@ -572,7 +572,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'yes',
-			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
+			get_option( Emails_Section::WCS_MASTER_SWITCH_OPTION ),
 			'WCS master switch should be set to yes when previously unset.'
 		);
 		$this->assertContains(
@@ -592,7 +592,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	 */
 	public function test_first_run_preserves_wcs_master_switch_disabled() {
 		// Publisher has explicitly disabled the WCS master switch.
-		update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'no' );
+		update_option( Emails_Section::WCS_MASTER_SWITCH_OPTION, 'no' );
 
 		$wc_email = $this->register_stub_wc_config(
 			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
@@ -603,7 +603,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'no',
-			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
+			get_option( Emails_Section::WCS_MASTER_SWITCH_OPTION ),
 			'Publisher\'s explicit master-switch=no MUST NOT be overwritten on first-run.'
 		);
 		$this->assertContains(
@@ -622,7 +622,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	 * non-auto-renewal email and verifies the option stays absent.
 	 */
 	public function test_first_run_does_not_flip_master_switch_for_other_emails() {
-		delete_option( 'woocommerce_subscriptions_customer_notifications_enabled' );
+		delete_option( Emails_Section::WCS_MASTER_SWITCH_OPTION );
 
 		$wc_email = $this->register_stub_wc_config(
 			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
@@ -632,14 +632,14 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$this->assertFalse(
-			get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false ),
+			get_option( Emails_Section::WCS_MASTER_SWITCH_OPTION, false ),
 			'Master switch should remain absent for non-auto-renewal first-runs.'
 		);
 	}
 
 	/*
 	 * ------------------------------------------------------------------
-	 * Bucket F.5 — Config schema shape (dkoo's refactor — drop instance)
+	 * Bucket F.5 — Config schema shape (no live `WC_Email` instance)
 	 * ------------------------------------------------------------------
 	 * The unified `newspack_email_configs` schema MUST stay JSON-
 	 * serializable. The live `WC_Email` instance is resolved on-demand
@@ -689,6 +689,57 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		$configs = \Newspack\WooCommerce_Emails::get_email_configs( [] );
 		$this->assertArrayHasKey( 'customer_new_account', $configs );
 		$this->assertSame( 'WC_Email_Customer_New_Account', $configs['customer_new_account']['wc_email_class'] );
+	}
+
+	/**
+	 * Live-WC integration: every WC-source config surfaced by the
+	 * registration loop has a `wc_email_class` that actually matches
+	 * `get_class()` of the corresponding instance in
+	 * `WC()->mailer()->get_emails()`. Skipped when real WC isn't loaded.
+	 *
+	 * The stub-only coverage above copies the allowlist values into the
+	 * test fixture, so a wrong id↔class mapping in production passes
+	 * the stub assertions but fails here on a live-WC environment.
+	 * Catches typos, renames, or new entries that drift from the actual
+	 * WC mailer registrations.
+	 */
+	public function test_surfaced_wc_emails_match_live_mailer_classes() {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Emails' ) ) {
+			$this->markTestSkipped( 'Real WC not loaded; cannot compare against WC()->mailer()->get_emails().' );
+		}
+
+		// Reset the by-id cache so this test reads the live mailer state
+		// rather than any cache primed by sibling tests in this suite.
+		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+
+		$mailer_emails = [];
+		foreach ( \WC()->mailer()->get_emails() as $wc_email ) {
+			$mailer_emails[ $wc_email->id ] = $wc_email;
+		}
+
+		// Iterate the configs the registration loop actually emits — this
+		// covers the same set as the SURFACED_WC_EMAILS allowlist while
+		// honoring its plugin_dependency gates (so we don't false-fail on
+		// a WCS / WCSG entry when those plugins aren't installed).
+		$configs    = \Newspack\WooCommerce_Emails::get_email_configs( [] );
+		$wc_configs = array_filter(
+			$configs,
+			fn( $config ) => 'woocommerce' === ( $config['source'] ?? '' )
+		);
+		$this->assertNotEmpty( $wc_configs, 'Expected at least one WC-source config to be registered with WC active.' );
+
+		foreach ( $wc_configs as $id => $config ) {
+			$this->assertArrayHasKey(
+				$id,
+				$mailer_emails,
+				"Surfaced WC id '$id' is not registered in WC()->mailer()->get_emails()."
+			);
+			$this->assertSame(
+				get_class( $mailer_emails[ $id ] ),
+				$config['wc_email_class'],
+				"wc_email_class for '$id' must match the live mailer's class."
+			);
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -83,6 +83,9 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		add_filter( 'newspack_woocommerce_active', '__return_true' );
+		// Reset the request-scoped Emails::get_email_configs cache so
+		// per-test filter callbacks registered below are reflected.
+		Emails::reset_email_configs_cache();
 	}
 
 	/**
@@ -98,6 +101,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		}
 		$this->filter_callbacks = [];
 		\Newspack\WooCommerce_Emails::reset_wc_email_cache_for_test();
+		Emails::reset_email_configs_cache();
 		parent::tear_down();
 	}
 
@@ -140,6 +144,9 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		};
 		add_filter( 'newspack_email_configs', $callback );
 		$this->filter_callbacks[] = $callback;
+		// Newly-registered filter callbacks need a cache bust to surface
+		// in the next Emails::get_email_configs() call.
+		Emails::reset_email_configs_cache();
 
 		// Prime the by-id cache so call sites resolve the stub.
 		\Newspack\WooCommerce_Emails::set_wc_email_by_id_for_test( $wc_email->id, $wc_email );
@@ -209,7 +216,6 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $rows, 'Expected the stub config to surface exactly once.' );
 		$this->assertSame( $wc_email->id, $rows[0]['type'] );
-		$this->assertSame( $wc_email->id, $rows[0]['registry_slug'] );
 		$this->assertSame( 'woocommerce', $rows[0]['source'] );
 		$this->assertSame( 'reader-revenue', $rows[0]['chip'] );
 		$this->assertSame( 'publish', $rows[0]['status'], 'enabled=yes should serialize to status=publish.' );
@@ -454,7 +460,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		update_option( Emails_Section::FIRST_RUN_OPTION, [ $wc_email->id ], false );
 		update_option( $wc_email->get_option_key(), [ 'enabled' => 'no' ] );
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$options = (array) get_option( $wc_email->get_option_key(), [] );
 		$this->assertSame( 'no', $options['enabled'], 'Already-processed email must NOT be re-enabled.' );
@@ -474,7 +480,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 			[ 'recommended' => false ]
 		);
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$this->assertFalse(
 			get_option( $wc_email->get_option_key() ),
@@ -506,7 +512,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		// Ensure the WC settings option doesn't exist in the DB.
 		delete_option( $wc_email->get_option_key() );
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$options = (array) get_option( $wc_email->get_option_key(), [] );
 		$this->assertSame( 'yes', $options['enabled'], 'Unset option should get enabled=yes on first-run.' );
@@ -528,7 +534,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		// Publisher has explicitly disabled this email via WC settings.
 		update_option( $wc_email->get_option_key(), [ 'enabled' => 'no' ] );
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$options = (array) get_option( $wc_email->get_option_key(), [] );
 		$this->assertSame(
@@ -562,7 +568,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		);
 		delete_option( $wc_email->get_option_key() );
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$this->assertSame(
 			'yes',
@@ -593,7 +599,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		);
 		delete_option( $wc_email->get_option_key() );
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$this->assertSame(
 			'no',
@@ -623,7 +629,7 @@ class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
 		);
 		delete_option( $wc_email->get_option_key() );
 
-		Emails_Section::api_get_email_settings();
+		Emails_Section::maybe_first_run_enable_wc_emails();
 
 		$this->assertFalse(
 			get_option( 'woocommerce_subscriptions_customer_notifications_enabled', false ),

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section-woocommerce.php
@@ -1,0 +1,436 @@
+<?php
+/**
+ * Slice 2a (NPPD-1527) — WooCommerce email surfacing.
+ *
+ * Coverage:
+ *   - `WooCommerce_Emails::get_email_configs()` — early-bail contract
+ *     when real WC isn't loaded (the loaded-and-mailer-populated branch
+ *     is exercised by manual smoke; injecting a real WC mailer mock
+ *     would dwarf this file).
+ *   - `Emails_Section::api_get_email_settings()` — surfaces WC-source
+ *     rows with `wc:<id>` post_id prefix once the slice 1 source filter
+ *     is lifted.
+ *   - `Emails_Section::api_toggle_wc_email()` — writes the WC option AND
+ *     the same-request response reflects the new state (the staleness
+ *     fix), with 404 rejection for unknown IDs and non-WC sources.
+ *   - `Emails_Section::maybe_first_run_enable_wc_emails()` — idempotency
+ *     keyed on the processed list (not current state, so the
+ *     user-disabled-after-first-run case is honored), skips
+ *     `recommended=false`, and flips the WCS master switch when
+ *     `customer_notification_auto_renewal` first runs.
+ *
+ * Setup: declares a `WooCommerce` class shim (the only globally-visible
+ * side effect — the real one doesn't exist in this test env, and the
+ * guards in Emails_Section won't fire without it) and a minimal
+ * `WC_Email`-like stub. Stub configs are injected via the
+ * `newspack_email_configs` filter and removed in tearDown so they
+ * don't leak across tests.
+ *
+ * @package Newspack\Tests
+ */
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing
+
+if ( ! class_exists( 'WooCommerce' ) ) {
+	// Shim — only declared when real WC isn't loaded. Empty body is fine;
+	// Emails_Section guards use `class_exists('WooCommerce')` as a boolean.
+	class WooCommerce {}
+}
+
+/**
+ * Minimal WC_Email-like stub. Mimics the three points of contact the
+ * implementation has with a WC_Email instance: the `id` and `enabled`
+ * public properties, and the `get_option_key()` method.
+ */
+class Newspack_Test_Stub_WC_Email {
+	public $id;
+	public $enabled;
+
+	public function __construct( string $id, string $enabled = 'no' ) {
+		$this->id      = $id;
+		$this->enabled = $enabled;
+	}
+
+	public function get_option_key(): string {
+		return 'woocommerce_' . $this->id . '_settings';
+	}
+}
+
+// phpcs:enable Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment.Missing
+
+use Newspack\Emails;
+use Newspack\Wizards\Newspack\Emails_Section;
+
+/**
+ * Slice 2a — WooCommerce surfacing tests.
+ */
+class Newspack_Test_Emails_Section_WooCommerce extends WP_UnitTestCase {
+	/**
+	 * Filter callbacks registered by tests, tracked for cleanup so they
+	 * don't leak across test methods. WP filters aren't transactional.
+	 *
+	 * @var array
+	 */
+	private $filter_callbacks = [];
+
+	/**
+	 * Remove any registered filter callbacks. Option writes are rolled
+	 * back by the WP test framework's per-test transaction.
+	 */
+	public function tear_down() {
+		foreach ( $this->filter_callbacks as $callback ) {
+			remove_filter( 'newspack_email_configs', $callback );
+		}
+		$this->filter_callbacks = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Inject a stub WC config via `newspack_email_configs`. Returns the
+	 * stub so the caller can mutate or assert on it.
+	 *
+	 * @param Newspack_Test_Stub_WC_Email $wc_email  Stub email instance.
+	 * @param array                       $overrides Config overrides (e.g. recommended => false).
+	 * @return Newspack_Test_Stub_WC_Email
+	 */
+	private function register_stub_wc_config( Newspack_Test_Stub_WC_Email $wc_email, array $overrides = [] ): Newspack_Test_Stub_WC_Email {
+		$config = array_merge(
+			[
+				'name'                => $wc_email->id,
+				'category'            => 'woocommerce',
+				'source'              => 'woocommerce',
+				'label'               => 'Stub WC: ' . $wc_email->id,
+				'description'         => 'Stub WC config for testing.',
+				'trigger_description' => 'Stub trigger.',
+				'recipient'           => 'reader',
+				'recommended'         => true,
+				'chip'                => 'reader-revenue',
+				'wc_email_instance'   => $wc_email,
+			],
+			$overrides
+		);
+
+		$callback = function ( $configs ) use ( $config ) {
+			$configs[ $config['name'] ] = $config;
+			return $configs;
+		};
+		add_filter( 'newspack_email_configs', $callback );
+		$this->filter_callbacks[] = $callback;
+		return $wc_email;
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.1 — WooCommerce_Emails::get_email_configs() registration
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * The class hooks into `newspack_email_configs` from its `init()`.
+	 * This is the contract that lets the rest of the system discover WC
+	 * surfaces through the same filter as Newspack-side providers.
+	 */
+	public function test_woocommerce_emails_hooks_into_newspack_email_configs_filter() {
+		$this->assertNotFalse(
+			has_filter( 'newspack_email_configs', [ \Newspack\WooCommerce_Emails::class, 'get_email_configs' ] ),
+			'WooCommerce_Emails::get_email_configs should be hooked into newspack_email_configs.'
+		);
+	}
+
+	/**
+	 * Without real WC available (no `function_exists('WC')`,
+	 * no `class WC_Emails`), the method returns the input unchanged —
+	 * it never reaches the mailer iteration.
+	 */
+	public function test_woocommerce_emails_get_email_configs_returns_unchanged_without_wc() {
+		$input  = [
+			'receipt' => [
+				'name'     => 'receipt',
+				'category' => 'reader-revenue',
+			],
+		];
+		$output = \Newspack\WooCommerce_Emails::get_email_configs( $input );
+		$this->assertSame( $input, $output );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.2 — api_get_email_settings() surfaces WC rows
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * A WC-source config registered via `newspack_email_configs` appears
+	 * in the wizard response as a row with `source='woocommerce'` and
+	 * `post_id='wc:<id>'`. Slice 1 filtered these out; slice 2a lifts
+	 * the filter.
+	 */
+	public function test_api_get_email_settings_includes_woocommerce_rows() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_refunded_order', 'yes' )
+		);
+
+		$result = Emails_Section::api_get_email_settings();
+		$rows   = array_values(
+			array_filter(
+				$result['newspack_emails'],
+				fn( $email ) => 'woocommerce' === ( $email['source'] ?? 'newspack' )
+					&& 'wc:' . $wc_email->id === ( $email['post_id'] ?? '' )
+			)
+		);
+
+		$this->assertCount( 1, $rows, 'Expected the stub config to surface exactly once.' );
+		$this->assertSame( $wc_email->id, $rows[0]['type'] );
+		$this->assertSame( $wc_email->id, $rows[0]['registry_slug'] );
+		$this->assertSame( 'woocommerce', $rows[0]['source'] );
+		$this->assertSame( 'reader-revenue', $rows[0]['chip'] );
+		$this->assertSame( 'publish', $rows[0]['status'], 'enabled=yes should serialize to status=publish.' );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.3 — api_toggle_wc_email
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * Toggling writes the WC option AND the refreshed response in the
+	 * same request reflects the new status. Pre-slice-2a the response
+	 * read `$wc_email->enabled` (the in-memory cache from WC boot),
+	 * which could be stale relative to the option write that just
+	 * happened. The fix: serialize_wc_email_row() reads the option,
+	 * the toggle writes the option AND keeps the cached property in
+	 * sync. We assert both writes and the response reflection.
+	 */
+	public function test_api_toggle_wc_email_writes_option_and_response_reflects() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', $wc_email->id );
+		$request->set_param( 'enabled', true );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		// Option write: WC option key now has enabled=yes.
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'yes', $options['enabled'], 'Option was not written.' );
+
+		// In-memory write: the cached $enabled property is updated too.
+		$this->assertSame( 'yes', $wc_email->enabled, 'In-memory $enabled was not updated.' );
+
+		// Same-request response: the row for this email reflects the new status.
+		$data = $response->get_data();
+		$rows = array_values(
+			array_filter(
+				$data['newspack_emails'],
+				fn( $email ) => 'wc:' . $wc_email->id === ( $email['post_id'] ?? '' )
+			)
+		);
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'publish', $rows[0]['status'], 'Refreshed response did not reflect the toggled state.' );
+	}
+
+	/**
+	 * Toggling off (after toggling on) flips the option and the
+	 * same-request response back. Pre-seeds FIRST_RUN_OPTION so the
+	 * refreshed api_get_email_settings() doesn't immediately re-enable
+	 * via first-run — realistic user scenario (past first-run, now
+	 * toggling off).
+	 */
+	public function test_api_toggle_wc_email_off_flips_option_and_response() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'yes' )
+		);
+		update_option( $wc_email->get_option_key(), [ 'enabled' => 'yes' ] );
+		update_option( Emails_Section::FIRST_RUN_OPTION, [ $wc_email->id ], false );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', $wc_email->id );
+		$request->set_param( 'enabled', false );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'no', $options['enabled'] );
+
+		$data = $response->get_data();
+		$rows = array_values(
+			array_filter(
+				$data['newspack_emails'],
+				fn( $email ) => 'wc:' . $wc_email->id === ( $email['post_id'] ?? '' )
+			)
+		);
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'draft', $rows[0]['status'], 'Toggle off should serialize to status=draft.' );
+	}
+
+	/**
+	 * Toggling an unknown email ID returns a 404 WP_Error and does not
+	 * write any option.
+	 */
+	public function test_api_toggle_wc_email_rejects_unknown_id() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', 'this_email_does_not_exist' );
+		$request->set_param( 'enabled', true );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_wc_email_not_allowed', $response->get_error_code() );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Toggling a Newspack-source id (no `wc_email_instance` attached)
+	 * returns 404 even though the id resolves to a real config. The
+	 * source-and-instance check guards against routing Newspack rows
+	 * through the WC toggle path.
+	 */
+	public function test_api_toggle_wc_email_rejects_newspack_source_id() {
+		$configs              = Emails::get_email_configs();
+		$newspack_config_keys = array_keys(
+			array_filter(
+				$configs,
+				fn( $config ) => 'woocommerce' !== ( $config['source'] ?? 'newspack' )
+			)
+		);
+		$this->assertNotEmpty( $newspack_config_keys, 'Expected at least one newspack-source config to exist.' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'id', $newspack_config_keys[0] );
+		$request->set_param( 'enabled', true );
+
+		$response = Emails_Section::api_toggle_wc_email( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_wc_email_not_allowed', $response->get_error_code() );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F.4 — maybe_first_run_enable_wc_emails
+	 *
+	 * Called from api_get_email_settings() on every wizard load.
+	 * Idempotency is keyed on the FIRST_RUN_OPTION processed-keys
+	 * array, NOT on the current enabled state — that's the
+	 * user-disabled-after-first-run contract.
+	 * ------------------------------------------------------------------
+	 */
+
+	/**
+	 * Once a key is in the processed list, first-run does NOT re-enable
+	 * it — even if the user has manually disabled it since. This is the
+	 * critical user-disabled-after-first-run protection.
+	 */
+	public function test_first_run_enable_idempotent_when_key_processed() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+		update_option( Emails_Section::FIRST_RUN_OPTION, [ $wc_email->id ], false );
+		update_option( $wc_email->get_option_key(), [ 'enabled' => 'no' ] );
+
+		Emails_Section::api_get_email_settings();
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'no', $options['enabled'], 'Already-processed email must NOT be re-enabled.' );
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertSame( [ $wc_email->id ], $processed, 'Processed list should be unchanged.' );
+	}
+
+	/**
+	 * A `recommended=false` WC config is never auto-enabled on first-run
+	 * and its key is not added to the processed list (so a future flip
+	 * to recommended=true would still get a first-run pass).
+	 */
+	public function test_first_run_skips_non_recommended() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_refunded_order', 'no' ),
+			[ 'recommended' => false ]
+		);
+
+		Emails_Section::api_get_email_settings();
+
+		$this->assertFalse(
+			get_option( $wc_email->get_option_key() ),
+			'Non-recommended email should not have its option written.'
+		);
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertNotContains(
+			$wc_email->id,
+			$processed,
+			'Non-recommended email should not be in the processed list.'
+		);
+		$this->assertSame( 'no', $wc_email->enabled, 'In-memory enabled should be unchanged.' );
+	}
+
+	/**
+	 * A recommended, unprocessed WC email is enabled on its first
+	 * encounter AND added to the processed list, so the next call is a
+	 * no-op (idempotency).
+	 */
+	public function test_first_run_enables_recommended_unprocessed() {
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+
+		Emails_Section::api_get_email_settings();
+
+		$options = (array) get_option( $wc_email->get_option_key(), [] );
+		$this->assertSame( 'yes', $options['enabled'] );
+		$this->assertSame( 'yes', $wc_email->enabled, 'In-memory enabled should be flipped too.' );
+
+		$processed = (array) get_option( Emails_Section::FIRST_RUN_OPTION, [] );
+		$this->assertContains( $wc_email->id, $processed );
+	}
+
+	/**
+	 * Special case: `customer_notification_auto_renewal` requires the
+	 * WC Subscriptions master switch
+	 * (`woocommerce_subscriptions_customer_notifications_enabled`) on —
+	 * otherwise the email never fires regardless of its own enabled
+	 * flag. First-run flips both.
+	 */
+	public function test_first_run_enables_wcs_master_switch_for_auto_renewal() {
+		update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'no' );
+
+		$wc_email = $this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_notification_auto_renewal', 'no' )
+		);
+
+		Emails_Section::api_get_email_settings();
+
+		$this->assertSame(
+			'yes',
+			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
+			'WCS master switch should be enabled by the auto-renewal first-run.'
+		);
+		$this->assertContains(
+			$wc_email->id,
+			(array) get_option( Emails_Section::FIRST_RUN_OPTION, [] )
+		);
+	}
+
+	/**
+	 * Non-auto-renewal first-runs do NOT flip the WCS master switch —
+	 * the special case is scoped to that one id.
+	 */
+	public function test_first_run_does_not_flip_master_switch_for_other_emails() {
+		update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'no' );
+
+		$this->register_stub_wc_config(
+			new Newspack_Test_Stub_WC_Email( 'customer_payment_retry', 'no' )
+		);
+
+		Emails_Section::api_get_email_settings();
+
+		$this->assertSame(
+			'no',
+			get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ),
+			'Master switch should not be touched by non-auto-renewal first-runs.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -158,7 +158,9 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	 * Verifies the wizard endpoint response structure after the rewrite:
 	 * top-level keys are correct, each row carries the new fields,
 	 * registry_slug is the config key string, no view_category leakage,
-	 * no WC-source rows in slice 1, and category sort grouping holds.
+	 * and category sort grouping holds. (WooCommerce-source surfacing is
+	 * covered in emails-section-woocommerce.php; slice 2a no longer
+	 * excludes WC rows here.)
 	 */
 
 	/**
@@ -209,13 +211,77 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Slice 1 filters out WooCommerce-source rows. Slice 2 lifts this filter.
+	 * Within-category tiebreaker is config-registration order, not
+	 * alphabetical. Providers register in deliberate order
+	 * (Reader_Revenue_Emails: receipt → welcome → cancellation;
+	 * Reader_Activation_Emails: verification → magic-link → otp →
+	 * reset-password → ...), so registration order = intended display
+	 * order. Lock that contract in.
 	 */
-	public function test_api_get_email_settings_excludes_woocommerce_source() {
+	public function test_api_get_email_settings_within_category_follows_registration_order() {
 		$result = Emails_Section::api_get_email_settings();
-		foreach ( $result['newspack_emails'] as $email ) {
-			$this->assertNotSame( 'woocommerce', $email['source'] ?? 'newspack', 'Row should not be WC-sourced in slice 1.' );
-		}
+
+		// Reader-revenue group: receipt → welcome → cancellation
+		// (per Reader_Revenue_Emails::add_email_configs() order), then
+		// group-subscription-invite (also reader-revenue category after
+		// the slice-1 fix flipped it from reader-activation).
+		$rr_types = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => 'reader-revenue' === ( $email['category'] ?? '' )
+				)
+			)
+		);
+		$this->assertSame(
+			[
+				Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'],
+				Reader_Revenue_Emails::EMAIL_TYPES['WELCOME'],
+				Reader_Revenue_Emails::EMAIL_TYPES['CANCELLATION'],
+				'group-subscription-invite',
+			],
+			$rr_types,
+			'Reader-revenue rows must follow provider registration order.'
+		);
+
+		// Reader-activation group: verification → magic-link → otp →
+		// reset-password (the four sign-in flows that are always present,
+		// per the order in Reader_Activation_Emails::add_email_configs()).
+		$ra_types_all  = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => 'reader-activation' === ( $email['category'] ?? '' )
+				)
+			)
+		);
+		$ra_core_types = array_values(
+			array_filter(
+				$ra_types_all,
+				fn( $type ) => in_array(
+					$type,
+					[
+						Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
+						Reader_Activation_Emails::EMAIL_TYPES['MAGIC_LINK'],
+						Reader_Activation_Emails::EMAIL_TYPES['OTP_AUTH'],
+						Reader_Activation_Emails::EMAIL_TYPES['RESET_PASSWORD'],
+					],
+					true
+				)
+			)
+		);
+		$this->assertSame(
+			[
+				Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
+				Reader_Activation_Emails::EMAIL_TYPES['MAGIC_LINK'],
+				Reader_Activation_Emails::EMAIL_TYPES['OTP_AUTH'],
+				Reader_Activation_Emails::EMAIL_TYPES['RESET_PASSWORD'],
+			],
+			$ra_core_types,
+			'Reader-activation rows must follow Reader_Activation_Emails provider registration order.'
+		);
 	}
 
 	/**
@@ -335,8 +401,10 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		};
 
 		add_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 		$configs = Emails::get_email_configs();
 		remove_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 
 		$this->assertArrayHasKey( $type, $configs );
 		$this->assertSame( '', $configs[ $type ]['trigger_description'] );
@@ -363,8 +431,10 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		};
 
 		add_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 		$configs = Emails::get_email_configs();
 		remove_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 
 		// Bad rows silently dropped.
 		$this->assertArrayNotHasKey( 'malformed-string', $configs );

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -219,6 +219,77 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Within-category tiebreaker is config-registration order, not
+	 * alphabetical. Providers register in deliberate order
+	 * (Reader_Revenue_Emails: receipt → welcome → cancellation;
+	 * Reader_Activation_Emails: verification → magic-link → otp →
+	 * reset-password → ...), so registration order = intended display
+	 * order. Lock that contract in.
+	 */
+	public function test_api_get_email_settings_within_category_follows_registration_order() {
+		$result = Emails_Section::api_get_email_settings();
+
+		// Reader-revenue group: receipt → welcome → cancellation
+		// (per Reader_Revenue_Emails::add_email_configs() order).
+		$rr_types = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => 'reader-revenue' === ( $email['category'] ?? '' )
+				)
+			)
+		);
+		$this->assertSame(
+			[
+				Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'],
+				Reader_Revenue_Emails::EMAIL_TYPES['WELCOME'],
+				Reader_Revenue_Emails::EMAIL_TYPES['CANCELLATION'],
+			],
+			$rr_types,
+			'Reader-revenue rows must follow Reader_Revenue_Emails provider registration order.'
+		);
+
+		// Reader-activation group: verification → magic-link → otp →
+		// reset-password (the four sign-in flows that are always present,
+		// per the order in Reader_Activation_Emails::add_email_configs()).
+		$ra_types_all  = array_values(
+			array_map(
+				fn( $email ) => $email['type'],
+				array_filter(
+					$result['newspack_emails'],
+					fn( $email ) => 'reader-activation' === ( $email['category'] ?? '' )
+				)
+			)
+		);
+		$ra_core_types = array_values(
+			array_filter(
+				$ra_types_all,
+				fn( $type ) => in_array(
+					$type,
+					[
+						Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
+						Reader_Activation_Emails::EMAIL_TYPES['MAGIC_LINK'],
+						Reader_Activation_Emails::EMAIL_TYPES['OTP_AUTH'],
+						Reader_Activation_Emails::EMAIL_TYPES['RESET_PASSWORD'],
+					],
+					true
+				)
+			)
+		);
+		$this->assertSame(
+			[
+				Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
+				Reader_Activation_Emails::EMAIL_TYPES['MAGIC_LINK'],
+				Reader_Activation_Emails::EMAIL_TYPES['OTP_AUTH'],
+				Reader_Activation_Emails::EMAIL_TYPES['RESET_PASSWORD'],
+			],
+			$ra_core_types,
+			'Reader-activation rows must follow Reader_Activation_Emails provider registration order.'
+		);
+	}
+
+	/**
 	 * Sort order: reader-revenue first, then reader-activation, then everything else.
 	 */
 	public function test_api_get_email_settings_sort_order() {

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -209,16 +209,6 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Slice 1 filters out WooCommerce-source rows. Slice 2 lifts this filter.
-	 */
-	public function test_api_get_email_settings_excludes_woocommerce_source() {
-		$result = Emails_Section::api_get_email_settings();
-		foreach ( $result['newspack_emails'] as $email ) {
-			$this->assertNotSame( 'woocommerce', $email['source'] ?? 'newspack', 'Row should not be WC-sourced in slice 1.' );
-		}
-	}
-
-	/**
 	 * Within-category tiebreaker is config-registration order, not
 	 * alphabetical. Providers register in deliberate order
 	 * (Reader_Revenue_Emails: receipt → welcome → cancellation;
@@ -230,7 +220,9 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		$result = Emails_Section::api_get_email_settings();
 
 		// Reader-revenue group: receipt → welcome → cancellation
-		// (per Reader_Revenue_Emails::add_email_configs() order).
+		// (per Reader_Revenue_Emails::add_email_configs() order), then
+		// group-subscription-invite (also reader-revenue category after
+		// the slice-1 fix flipped it from reader-activation).
 		$rr_types = array_values(
 			array_map(
 				fn( $email ) => $email['type'],
@@ -245,9 +237,10 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 				Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'],
 				Reader_Revenue_Emails::EMAIL_TYPES['WELCOME'],
 				Reader_Revenue_Emails::EMAIL_TYPES['CANCELLATION'],
+				'group-subscription-invite',
 			],
 			$rr_types,
-			'Reader-revenue rows must follow Reader_Revenue_Emails provider registration order.'
+			'Reader-revenue rows must follow provider registration order.'
 		);
 
 		// Reader-activation group: verification → magic-link → otp →
@@ -406,8 +399,10 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		};
 
 		add_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 		$configs = Emails::get_email_configs();
 		remove_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 
 		$this->assertArrayHasKey( $type, $configs );
 		$this->assertSame( '', $configs[ $type ]['trigger_description'] );
@@ -434,8 +429,10 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		};
 
 		add_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 		$configs = Emails::get_email_configs();
 		remove_filter( 'newspack_email_configs', $callback );
+		Emails::reset_email_configs_cache();
 
 		// Bad rows silently dropped.
 		$this->assertArrayNotHasKey( 'malformed-string', $configs );

--- a/plugins/newspack-plugin/tests/unit-tests/emails.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails.php
@@ -37,6 +37,7 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 				return $types;
 			}
 		);
+		Emails::reset_email_configs_cache();
 	}
 
 	/**
@@ -44,6 +45,7 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		reset_phpmailer_instance();
+		Emails::reset_email_configs_cache();
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/emails.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails.php
@@ -30,6 +30,7 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 				return $types;
 			}
 		);
+		Emails::reset_email_configs_cache();
 	}
 
 	/**
@@ -37,6 +38,7 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		reset_phpmailer_instance();
+		Emails::reset_email_configs_cache();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Surfaces WooCommerce transactional emails in the unified emails UI (Newspack > Settings > Emails), alongside the Newspack-managed emails from slice 1. Adds chip filtering across both sources, a toggle endpoint for WC email enabled-state, and first-run auto-enable for recommended WC emails.

This is **slice 2a** of the WooCommerce integration. The email preview feature is split into a follow-up slice (2b, #146) — see "Deferred to slice 2b" below.

Resolves part of [NPPD-1527](https://linear.app/a8c/issue/NPPD-1527).

<img width="3092" height="2090" alt="image" src="https://github.com/user-attachments/assets/da20fb52-d4ed-41d1-8e9b-2f68f5f11a12" />

## Stacking

⚠️ **This PR is stacked on slice 1 (#137) and targets its branch, not `main`.** Review #137 first. The diff shown here is the 2a delta on top of slice 1's unified-schema foundation.

## Architecture: pure-data WC configs + memoized instance helper

WooCommerce emails register through the same `newspack_email_configs` filter as Newspack emails — same unified schema, no parallel registry.

The schema is **pure-data**: each WC config carries a `wc_email_class` string (e.g. `WC_Email_Customer_Refunded_Order`), not a live `WC_Email` instance. Callers that need the actual instance (the toggle endpoint, first-run, the wizard response builder) resolve it via a memoized helper:

```php
WooCommerce_Emails::get_wc_email_by_id( $wc_email_id );
```

The helper invokes `WC()->mailer()` once per request, caches the slug→instance map, and returns the same singleton WC owns (so `enable()`/`disable()`/option writes don't drift). 

Why pure-data: the unified config flows through `wp_localize_script`, transients, REST responses — a live `WC_Email` object on the schema breaks JSON serialization. The helper indirection keeps the schema safe and amortizes WC's mailer init cost from per-call to once-per-request.

**Curated allowlist vs discovery:** This slice iterates a curated allowlist (`surfaced_wc_emails()`) directly rather than discovering WC emails via `WC()->mailer()->get_emails()`. The reason is ordering — the unified list sorts by category then registration order, and curated iteration gives a deterministic, intentional display order (e.g. keeping the two gift-subscription emails adjacent). The tradeoff is forward-compat: a new WC email won't auto-appear without being added to the allowlist, which is the right call for a curated publisher-facing surface.

## What's in this slice

**Backend:**
- `WooCommerce_Emails::get_email_configs()` — registers 9 surfaced WC emails (subscription renewals, retries, gift emails, account, order emails) with the four UI-metadata fields plus `wc_email_class`. Subscription-dependent emails gated on `plugin_dependency`.
- `WooCommerce_Emails::get_wc_email_by_id($id)` — public memoized helper that resolves a slug to its `WC_Email` instance via WC's mailer singleton.
- Lifted slice 1's `source === 'woocommerce'` filter; WC rows now flow into the response, built by resolving the helper at the serialize call site.
- `POST /emails/{id}/toggle` — writes WC email enabled-state. Writes both the in-memory `$wc_email->enabled` property and the option (`get_option_key`), with read and write using the option as a single source of truth, so the same-request refreshed response reflects the new state (staleness fix).
- First-run auto-enable — enables recommended WC emails once, tracked via the `newspack_unified_emails_wc_first_run` option (keyed on *processed* slugs, so a publisher who later disables a recommended email isn't fought on the next load). Special case: `customer_notification_auto_renewal` also flips the WC Subscriptions master switch.
- Within-category sort by registration order (matches slice 1's pattern). The curated allowlist defines the intended display order.

**Frontend:**
- `EmailItem.post_id` widened to `number | string` (WC rows use `wc:` ids).
- Activate/deactivate routes by type: string post_ids → toggle endpoint, numeric → the existing `/wp/v2` path. Reset stays Newspack-only (source guard).
- Chip filter bar (Reader revenue / Authentication & account), defaulting to Reader revenue. Filters across both Newspack and WC emails by chip.
- Global search: when a search term is present, search spans all emails regardless of active chip; chips show unpressed during search and re-engage when it clears.

## Implementation notes

- **WC has no public `enable()`/`disable()`.** The toggle writes the `$enabled` property directly and calls `update_option`, which is the same pattern WC itself uses internally. Combined with the read-from-option contract, this is what makes the same-request refresh return fresh state (staleness fix).
- **`recipient_completed_order` maps to `WCSG_Email_Recipient_New_Initial_Order`.** The id/class names don't follow the usual `customer_*` → `WC_Email_Customer_*` convention — verified live against `WC()->mailer()->get_emails()` rather than guessed.

## Deferred to slice 2b (#146)

To keep this slice reviewable, the email preview feature is split out:

* `Email_Preview` PHP class + preview REST endpoint
* Three render paths (Newspack own-post, WC block-template, WC classic via `wc:` route)
* The escape/i18n hardening for preview substitutions ([NPPD-1555](https://linear.app/a8c/issue/NPPD-1555))
* WC classic-template preview rendering for emails without a block-editor template post (folds in the preview half of legacy #4758 / NPPD-1537; the style-sync half of #4758 ships as its own separate slice)
* `EmailPreview` React component (lazy-loaded iframe)
* The DataViews preview field

2b lands before the card-expiry slice (#4756) so that email gets preview support. 2b also renames this slice's `preview_post_id` field to `preview_id` (widened to accept `wc:`-prefixed string IDs for the classic-render path) — that rename touches one file from this slice (`class-emails-section.php`), which is why 2b's diff includes a small change to a 2a file.

## Notable behaviors

- **Reset is hidden on WC emails by design** — Newspack can't reset emails it doesn't own; WC owns WC email defaults. (A "restore WooCommerce defaults" affordance routed through WC's own settings is a possible future follow-up.)
- **First-run respects manual changes** — keyed on processed slugs, not current state, so it never re-enables something a publisher turned off.

## Testing

- PHP: new `tests/unit-tests/emails-section-woocommerce.php` (WC registration, toggle endpoint incl. the same-request staleness assertion, first-run idempotency + the WCS master-switch special case, registration-order + gift-pair-adjacency regression tests). New helper tests cover JSON-encodability of the unified config, helper round-trip to the mailer-owned singleton, and per-request memoization. Full suite: 1291 tests, 0 failures.
- JS: chip filtering, global-search-across-chips, type-based toggle routing, reset source guard. 202 tests, 0 failures.
- Manual: verified against local monorepo dev env with real WC + WC Subscriptions — WC emails surface, chip filter spans both sources, toggle persists to the actual WC option, first-run auto-enabled recommended emails, ordering correct. Re-verified after the schema refactor — staleness fix survives the helper indirection.
