### PR TITLE
feat(emails): email preview — Newspack + WC block + WC classic (NPPD-1525, slice 2b)

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -167,6 +167,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-emails-section.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-email-preview.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-syndication-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-seo-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-pixels-section.php';

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
@@ -1,0 +1,803 @@
+<?php
+/**
+ * Email preview rendering for the Settings → Emails screen.
+ *
+ * Renders a publisher-facing preview of a transactional email by substituting
+ * known template tokens with realistic sample values. Used by the unified
+ * email management UI to display a per-card thumbnail.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Emails;
+use Newspack\Logger;
+use Newspack\WooCommerce_Emails;
+use Newspack_Newsletters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Email Preview Class.
+ */
+class Email_Preview {
+
+	/**
+	 * Get the rendered HTML for an email post, with sample token values substituted.
+	 *
+	 * Falls back to the registered template file's HTML when the post's saved
+	 * EMAIL_HTML_META is empty (i.e. the email has never been customized).
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string|false Rendered HTML, or false if the email can't be resolved.
+	 */
+	public static function get_preview_html( int $post_id ) {
+		if ( ! self::is_supported() ) {
+			return false;
+		}
+
+		$html = self::get_source_html( $post_id );
+		if ( empty( $html ) ) {
+			return false;
+		}
+
+		return self::apply_sample_substitutions( $html, $post_id );
+	}
+
+	/**
+	 * Get the source HTML for an email post.
+	 *
+	 * Reads the saved EMAIL_HTML_META first; falls back to the registered
+	 * template's default email_html when that meta is empty.
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string Source HTML, or empty string if unavailable.
+	 */
+	private static function get_source_html( int $post_id ): string {
+		$html = get_post_meta( $post_id, Newspack_Newsletters::EMAIL_HTML_META, true );
+		if ( ! empty( $html ) ) {
+			return $html;
+		}
+
+		// Fallback: look up the registered template for this post type and use its default HTML.
+		$type = get_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, true );
+		if ( empty( $type ) ) {
+			return '';
+		}
+
+		// Look up the registered template and include it to get the default HTML.
+		// The template file returns an array with an 'email_html' key.
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		if ( ! isset( $configs[ $type ], $configs[ $type ]['template'] ) ) {
+			return '';
+		}
+
+		$template_path = $configs[ $type ]['template'];
+
+		// `$template_path` comes through the `newspack_email_configs`
+		// filter. A malicious or buggy third-party hook could supply any
+		// readable file path on the server (LFI) or — worse — point at an
+		// attacker-uploaded `.php` file (RCE via top-level side effects on
+		// include). `is_readable` doesn't gate against either. Constrain
+		// the path to within the plugin tree and require a `.php`
+		// extension before including. realpath() also resolves any
+		// `../` traversal away from the plugin root.
+		//
+		// Assumption: the jail boundary is `realpath( dirname(
+		// NEWSPACK_PLUGIN_FILE ) )` — the plugin's own resolved tree. On
+		// installs where the plugin (or a sibling plugin a third-party
+		// `newspack_email_configs` callback legitimately points at) lives
+		// behind a symlink — devkit/composer-installer or some Atomic
+		// layouts — the resolved target may fall outside this tree and be
+		// rejected. That errs CLOSED (no LFI/RCE), at the cost of a silent
+		// empty preview for those edge templates; acceptable given the
+		// security posture. See the rejected-path test in
+		// tests/unit-tests/email-preview.php.
+		$resolved = realpath( $template_path );
+		$plugin_root = realpath( dirname( NEWSPACK_PLUGIN_FILE ) );
+		if (
+			false === $resolved
+			|| false === $plugin_root
+			|| 0 !== strpos( $resolved, $plugin_root . DIRECTORY_SEPARATOR )
+			|| '.php' !== substr( $resolved, -4 )
+		) {
+			return '';
+		}
+
+		$template_data = include $resolved;
+		if ( ! is_array( $template_data ) || empty( $template_data['email_html'] ) ) {
+			return '';
+		}
+
+		return $template_data['email_html'];
+	}
+
+	/**
+	 * Apply sample-value substitutions to email HTML.
+	 *
+	 * Site/branding tokens use the publisher's real site config (so the preview
+	 * reflects their actual branding). Reader/transaction tokens use stable
+	 * fake values. Action URLs are replaced with anchor placeholders so
+	 * preview iframes don't trigger live navigation.
+	 *
+	 * @param string $html    Source HTML containing *TOKEN* placeholders.
+	 * @param int    $post_id The email post being previewed (passed to the filter).
+	 *
+	 * @return string HTML with tokens substituted.
+	 */
+	private static function apply_sample_substitutions( string $html, int $post_id = 0 ): string {
+		$substitutions = self::get_sample_substitutions();
+
+		/**
+		 * Filters the sample substitution map used for email previews.
+		 *
+		 * The map is structured as three sub-arrays keyed by escaping context:
+		 * - 'html': Tokens rendered as visible text (escaped with esc_html()).
+		 * - 'url':  Tokens used in href/src attributes (escaped with esc_url()).
+		 * - 'raw':  Tokens containing pre-escaped HTML (not escaped again).
+		 *
+		 * @param array $substitutions Structured map of `*TOKEN*` => sample value.
+		 * @param int   $post_id       The email post being previewed (0 if unknown).
+		 */
+		$substitutions = apply_filters( 'newspack_email_preview_substitutions', $substitutions, $post_id );
+
+		// Validate the filtered value — fall back to defaults if a filter broke the structure.
+		if (
+			! is_array( $substitutions )
+			|| ! isset( $substitutions['html'], $substitutions['url'], $substitutions['raw'] )
+			|| ! is_array( $substitutions['html'] )
+			|| ! is_array( $substitutions['url'] )
+			|| ! is_array( $substitutions['raw'] )
+		) {
+			$substitutions = self::get_sample_substitutions();
+		}
+
+		// Escape HTML-text tokens.
+		$html_map = array_map( 'esc_html', $substitutions['html'] );
+		// Escape URL tokens.
+		$url_map = array_map( 'esc_url', $substitutions['url'] );
+		// Raw tokens carry pre-escaped markup from our own builder, but the
+		// `newspack_email_preview_substitutions` filter can replace the whole
+		// `raw` bucket. A misbehaving third-party callback could hand back a
+		// non-string value or unsanitized HTML, which strtr would drop into
+		// the iframe srcDoc verbatim. Coerce each value to a string and run
+		// it through wp_kses_post() so the sandbox isn't the only thing
+		// containing post-filter raw markup. Our own raw values
+		// (`<a href="mailto:…">`, `<strong>…</strong>`) survive wp_kses_post
+		// unchanged.
+		$raw_map = array_map(
+			static fn( $value ) => wp_kses_post( is_string( $value ) ? $value : '' ),
+			$substitutions['raw']
+		);
+
+		return strtr( $html, array_merge( $html_map, $url_map, $raw_map ) );
+	}
+
+	/**
+	 * Get the substitution map of email-template tokens to sample values.
+	 *
+	 * Returns a three-key array grouped by escaping context:
+	 * - 'html': Tokens rendered as visible text (escaped with esc_html() at call site).
+	 * - 'url':  Tokens used in href/src attributes (escaped with esc_url() at call site).
+	 * - 'raw':  Tokens containing pre-escaped HTML markup (not escaped again).
+	 *
+	 * @return array{ html: array<string, string>, url: array<string, string>, raw: array<string, string> }
+	 */
+	public static function get_sample_substitutions(): array {
+		$site_logo_url   = wp_get_attachment_url( get_theme_mod( 'custom_logo' ) );
+		$site_title      = get_bloginfo( 'name' );
+		$site_url        = get_bloginfo( 'wpurl' );
+		$reply_to_email  = Emails::get_reply_to_email();
+		$site_address    = self::get_site_address();
+		// *SITE_CONTACT* lives in the 'raw' bucket (pre-escaped HTML, NOT
+		// re-escaped at strtr-time), so the values interpolated here MUST
+		// be escaped at construction time. get_bloginfo('name') and the
+		// WC store address are admin-controlled strings — if an admin
+		// (or a role-elevation supply-chain compromise) sets the site
+		// title to a `<script>` or malformed tag, the unescaped version
+		// would inject into the iframe's srcDoc. Iframe sandbox blocks
+		// script execution today, but breaks rendering and would be
+		// immediately exploitable if `allow-scripts` were ever added.
+		$site_contact = $site_address
+			? sprintf( '<strong>%s</strong> — %s', esc_html( $site_title ), esc_html( $site_address ) )
+			: esc_html( $site_title );
+
+		return [
+			// Tokens rendered as visible text inside HTML — escaped with esc_html().
+			'html' => [
+				// Site / branding — real values from the publisher's config.
+				'*SITE_TITLE*'            => $site_title,
+				'*SITE_ADDRESS*'          => $site_address,
+
+				// Reader identity — stable sample values.
+				'*BILLING_FIRST_NAME*'    => __( 'Sample', 'newspack-plugin' ),
+				'*BILLING_LAST_NAME*'     => __( 'Reader', 'newspack-plugin' ),
+				'*BILLING_NAME*'          => __( 'Sample Reader', 'newspack-plugin' ),
+				'*PENDING_EMAIL_ADDRESS*' => 'sample.reader@example.com',
+
+				// Transaction / subscription details.
+				'*AMOUNT*'                => '$25.00',
+				'*PAYMENT_METHOD*'        => __( 'Visa ending in 4242', 'newspack-plugin' ),
+				'*PRODUCT_NAME*'          => __( 'Monthly Membership', 'newspack-plugin' ),
+				'*BILLING_FREQUENCY*'     => __( 'monthly', 'newspack-plugin' ),
+				'*DATE*'                  => wp_date( get_option( 'date_format', 'F j, Y' ) ),
+				'*CANCELLATION_TITLE*'    => __( 'Subscription Cancelled', 'newspack-plugin' ),
+				'*CANCELLATION_TYPE*'     => __( 'subscription', 'newspack-plugin' ),
+				// CTA button label — used by the cancellation template
+				// (includes/templates/reader-revenue-emails/cancellation.php).
+				'*BUTTON_TEXT*'           => __( 'Manage subscription', 'newspack-plugin' ),
+
+				// Card expiry warning details.
+				'*CARD_LAST_4*'           => '4242',
+				'*EXPIRY_DATE*'           => '12/2026',
+				'*RENEWAL_DATE*'          => wp_date( get_option( 'date_format', 'F j, Y' ), strtotime( '+1 year' ) ),
+
+				// OTP code — stable sample value.
+				'*MAGIC_LINK_OTP*'        => '123456',
+			],
+
+			// Tokens used in href/src attributes — escaped with esc_url().
+			'url'  => [
+				'*SITE_URL*'               => $site_url,
+				'*SUBSCRIPTION_URL*'       => '#',
+				'*SITE_LOGO*'              => $site_logo_url ? $site_logo_url : '',
+				'*ACCOUNT_URL*'            => '#',
+				'*CANCELLATION_URL*'       => '#',
+				'*EMAIL_CANCELLATION_URL*' => '#',
+				'*EMAIL_VERIFICATION_URL*' => '#',
+				'*VERIFICATION_URL*'       => '#',
+				'*RECEIPT_URL*'            => '#',
+				'*MAGIC_LINK_URL*'         => '#',
+				'*PASSWORD_RESET_LINK*'    => '#',
+				'*SET_PASSWORD_LINK*'      => '#',
+				'*DELETION_LINK*'          => '#',
+				'*WP_LOGIN_URL*'           => '#',
+				'*UPDATE_PAYMENT_URL*'     => '#',
+			],
+
+			// Tokens containing pre-escaped HTML — NOT escaped again.
+			'raw'  => [
+				'*CONTACT_EMAIL*' => sprintf( '<a href="%s">%s</a>', esc_url( 'mailto:' . $reply_to_email ), esc_html( $reply_to_email ) ),
+				'*SITE_CONTACT*'  => $site_contact,
+			],
+		];
+	}
+
+	/**
+	 * Get the site's store address as a formatted string.
+	 *
+	 * Mirrors the logic in Emails::get_email_payload() so the preview
+	 * shows the same address format the real email would use.
+	 *
+	 * @return string Formatted site address, or empty string.
+	 */
+	private static function get_site_address(): string {
+		if ( class_exists( 'WC' ) ) {
+			$base_address  = WC()->countries->get_base_address();
+			$base_city     = WC()->countries->get_base_city();
+			$base_postcode = WC()->countries->get_base_postcode();
+		} else {
+			$base_address  = get_option( 'woocommerce_store_address', '' );
+			$base_city     = get_option( 'woocommerce_store_city', '' );
+			$base_postcode = get_option( 'woocommerce_store_postcode', '' );
+		}
+
+		if ( ! $base_address ) {
+			return '';
+		}
+
+		if ( ! $base_city && ! $base_postcode ) {
+			return $base_address;
+		}
+
+		return sprintf(
+			/* translators: 1: street address, 2: city, 3: postcode. */
+			__( '%1$s, %2$s %3$s', 'newspack-plugin' ),
+			$base_address,
+			$base_city,
+			$base_postcode
+		);
+	}
+
+	/**
+	 * Whether a numeric `woo_email` post maps to a WC email that the wizard
+	 * currently surfaces.
+	 *
+	 * Reverse-resolves the post → WC_Email class name via the WC posts
+	 * manager, then confirms a `source='woocommerce'` entry in
+	 * {@see Emails::get_email_configs()} carries that class. Returns false
+	 * when WC isn't loaded, the post doesn't reverse-resolve, or no surfaced
+	 * config matches — i.e. a stale/orphan template post.
+	 *
+	 * @param int $post_id The woo_email post ID.
+	 * @return bool
+	 */
+	private static function woo_email_post_is_surfaced( int $post_id ): bool {
+		$manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		if ( ! class_exists( $manager_class ) ) {
+			return false;
+		}
+
+		$email_class_name = $manager_class::get_instance()->get_email_type_class_name_from_post_id( $post_id );
+		if ( empty( $email_class_name ) ) {
+			return false;
+		}
+
+		foreach ( Emails::get_email_configs() as $config ) {
+			if (
+				'woocommerce' === ( $config['source'] ?? '' )
+				&& ( $config['wc_email_class'] ?? '' ) === $email_class_name
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get rendered preview HTML for a WooCommerce block-editor email template.
+	 *
+	 * Tries the block-editor render path first (BlockEmailRenderer) which
+	 * produces HTML styled with the site's theme.json colors and logo — the
+	 * same output the block email editor preview shows. Falls back to
+	 * EmailPreview::render() (legacy WC template with woocommerce_email_*
+	 * option colors) if the block path is unavailable or fails.
+	 *
+	 * @param int $post_id ID of the woo_email post.
+	 *
+	 * @return string|false Rendered HTML, or false if unavailable.
+	 */
+	private static function get_wc_preview_html( int $post_id ) {
+		$manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		$preview_class = 'Automattic\\WooCommerce\\Internal\\Admin\\EmailPreview\\EmailPreview';
+
+		if ( ! class_exists( $manager_class ) || ! class_exists( $preview_class ) ) {
+			return false;
+		}
+
+		// Reverse-lookup: post ID → email class name (e.g. 'WC_Email_New_Order').
+		$email_class_name = $manager_class::get_instance()->get_email_type_class_name_from_post_id( $post_id );
+		if ( empty( $email_class_name ) ) {
+			return false;
+		}
+
+		// Check transient cache (block render is ~180 ms per email).
+		$cache_key = self::get_wc_preview_cache_key( $post_id );
+		$cached    = get_transient( $cache_key );
+		if ( is_string( $cached ) && '' !== $cached ) {
+			return $cached;
+		}
+
+		// Set up the WC_Email with a dummy order/user so both render paths
+		// have realistic sample data to work with.
+		try {
+			$preview = $preview_class::instance();
+			$preview->set_email_type( $email_class_name );
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+
+		// Try the block-editor render path (themed, with site logo + theme colors).
+		$block_html = self::try_block_render( $preview, $post_id, $email_class_name );
+		if ( ! empty( $block_html ) ) {
+			set_transient( $cache_key, $block_html, HOUR_IN_SECONDS );
+			return $block_html;
+		}
+
+		// Fallback: legacy render via EmailPreview (WC default styling).
+		// NOT cached under $cache_key: caching the classic result here would
+		// mask block-path recovery for up to an hour — a single transient
+		// block failure (e.g. mid-WC-update) would pin the classic render
+		// even after the block path comes back online. Classic render is
+		// fast (~30-50 ms), so re-rendering each request is cheap and lets
+		// the block path retry. Mirrors get_wc_classic_preview_html, which
+		// also doesn't cache.
+		try {
+			return $preview->render();
+		} catch ( \Throwable $e ) {
+			Logger::log(
+				"WC EmailPreview::render() legacy fallback threw for woo_email post $post_id ($email_class_name): " . $e->getMessage(),
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Build the transient cache key for a WC email preview.
+	 *
+	 * Includes the post's modified date AND a short branding fingerprint.
+	 * The modified date catches template edits; the fingerprint catches
+	 * branding changes (theme color/logo, WC email option colors) that the
+	 * block render bakes in but that don't bump post_modified — without it a
+	 * branding change would serve a stale thumbnail until the TTL expires.
+	 * Old transients expire via TTL.
+	 *
+	 * @param int $post_id The woo_email post ID.
+	 * @return string Transient key (well within the 172-char option-name limit).
+	 */
+	private static function get_wc_preview_cache_key( int $post_id ): string {
+		$post     = get_post( $post_id );
+		$modified = $post ? strtotime( $post->post_modified_gmt ) : 0;
+
+		// 8 hex chars of an md5 over the branding inputs the block render
+		// reflects. Cheap to compute and collision-resistant enough for a
+		// cache-busting fingerprint (not a security boundary).
+		$fingerprint = substr(
+			md5(
+				(string) wp_json_encode(
+					[
+						get_theme_mod( 'custom_logo' ),
+						get_option( 'woocommerce_email_base_color' ),
+						get_option( 'woocommerce_email_background_color' ),
+						get_option( 'woocommerce_email_body_background_color' ),
+						get_option( 'woocommerce_email_text_color' ),
+					]
+				)
+			),
+			0,
+			8
+		);
+
+		return 'newspack_wc_email_preview_' . $post_id . '_' . $modified . '_' . $fingerprint;
+	}
+
+	/**
+	 * Attempt to render a WC email through the block-editor pipeline.
+	 *
+	 * Uses BlockEmailRenderer::maybe_render_block_email() which renders
+	 * through the email-editor package's Renderer — applying theme.json
+	 * global styles, CSS inlining, and personalization tag replacement.
+	 *
+	 * @param object $preview          WC EmailPreview instance (with email type already set).
+	 * @param int    $post_id          The woo_email post ID being previewed.
+	 * @param string $email_class_name The WC_Email class name (for logging).
+	 *
+	 * @return string|null Rendered HTML, or null if the block path is unavailable.
+	 */
+	private static function try_block_render( $preview, int $post_id, string $email_class_name ): ?string {
+		$renderer_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\BlockEmailRenderer';
+
+		if ( ! class_exists( $renderer_class ) || ! function_exists( 'wc_get_container' ) ) {
+			Logger::log(
+				"BlockEmailRenderer not available for woo_email post $post_id ($email_class_name); using legacy preview.",
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return null;
+		}
+
+		// Track whether set_up_filters() ran to completion. If it threw
+		// mid-way, clean_up_filters() may not be safe to call (it could
+		// reference state that set_up_filters never initialized). The
+		// flag gates the cleanup so we don't risk a second throw bubbling
+		// past this method's catch.
+		$filters_set_up = false;
+		try {
+			$preview->set_up_filters();
+			$filters_set_up = true;
+			$renderer = wc_get_container()->get( $renderer_class );
+			$html     = $renderer->maybe_render_block_email( $preview->get_email() );
+			$preview->clean_up_filters();
+
+			if ( empty( $html ) ) {
+				Logger::log(
+					"BlockEmailRenderer returned empty for woo_email post $post_id ($email_class_name); using legacy preview.",
+					'NEWSPACK-EMAILS',
+					'warning'
+				);
+				return null;
+			}
+
+			return $html;
+		} catch ( \Throwable $e ) {
+			if ( $filters_set_up ) {
+				// Wrap the cleanup in its own try/catch — a second throw
+				// from clean_up_filters() would otherwise escape past this
+				// method's catch and bubble up to api_get_preview as a
+				// 500 fatal with no graceful fallback to legacy preview.
+				try {
+					$preview->clean_up_filters();
+				} catch ( \Throwable $cleanup_e ) {
+					Logger::log(
+						'clean_up_filters() also threw during BlockEmailRenderer recovery: ' . $cleanup_e->getMessage(),
+						'NEWSPACK-EMAILS',
+						'warning'
+					);
+				}
+			}
+			Logger::log(
+				'BlockEmailRenderer threw ' . get_class( $e ) . " for woo_email post $post_id ($email_class_name): " . $e->getMessage() . '; using legacy preview.',
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Is email preview supported on this install?
+	 *
+	 * Requires Newspack Newsletters (the same dependency that gates
+	 * email management in general).
+	 *
+	 * @return bool
+	 */
+	private static function is_supported(): bool {
+		return class_exists( 'Newspack_Newsletters' );
+	}
+
+	/**
+	 * Initialize the class. Hooked from class-newspack.php inclusion.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+	}
+
+	/**
+	 * Register the email-preview REST endpoint.
+	 *
+	 * Accepts two identifier shapes:
+	 * - Numeric post ID (Newspack emails, WC block-editor template posts).
+	 * - `wc:{email_id}` strings (WC classic-template emails with no
+	 *   block-editor template post — e.g. WC Subscriptions emails).
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function register_rest_routes(): void {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'wizard/newspack-settings/emails/(?P<id>\d+|wc:[\w-]+)/preview',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_preview' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						// Mirror the URL path regex as an arg-level guard so a
+						// malformed id supplied out-of-band (body/query) is
+						// rejected before api_get_preview runs, not just one in
+						// the URL segment.
+						'validate_callback' => static function ( $value ) {
+							return 1 === preg_match( '/^(\d+|wc:[\w-]+)$/', (string) $value );
+						},
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * REST handler: return preview HTML for an email.
+	 *
+	 * Handles two identifier shapes:
+	 * - Numeric: resolves to a post (newspack_rr_email or woo_email).
+	 * - `wc:{email_id}`: routes to a WC email render path. If a
+	 *   block-editor template post exists for the email, uses the block
+	 *   render (themed + cached); otherwise falls back to WC's legacy
+	 *   classic render.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function api_get_preview( $request ) {
+		$id = (string) $request->get_param( 'id' );
+
+		// WC classic / block-template path (e.g. "wc:customer_payment_retry").
+		if ( str_starts_with( $id, 'wc:' ) ) {
+			$wc_email_id = substr( $id, 3 );
+
+			// Validate against the unified email config schema before any
+			// resolution. The id must map to a config that's
+			// source='woocommerce' — otherwise reject. The slice 1
+			// unified-config refactor removed the parallel registry
+			// lookup the legacy implementation used; `get_email_configs()`
+			// is the single source of truth.
+			$configs   = Emails::get_email_configs();
+			$wc_config = $configs[ $wc_email_id ] ?? null;
+			if ( ! $wc_config || 'woocommerce' !== ( $wc_config['source'] ?? '' ) ) {
+				return new \WP_Error(
+					'newspack_email_preview_not_found',
+					__( 'Email not found.', 'newspack-plugin' ),
+					[ 'status' => 404 ]
+				);
+			}
+
+			// Prefer the block-editor render path when a template post
+			// exists (themed + cached). Otherwise fall back to WC's
+			// legacy classic render for emails without a template post
+			// (WC Subscriptions, etc.).
+			$template_post_id = Emails_Section::get_wc_email_template_post_id( $wc_email_id );
+			if ( $template_post_id ) {
+				// `get_wc_email_template_post_id` is a raw WC option read
+				// — it doesn't verify the referenced post still exists or
+				// is in an editable status. If the publisher trashed the
+				// template post but the WC posts-manager option still
+				// references the trashed ID, we'd render the trashed
+				// content. Mirror the numeric branch's allowlist guard.
+				$template_post = get_post( $template_post_id );
+				if (
+					$template_post
+					&& 'woo_email' === $template_post->post_type
+					&& in_array( $template_post->post_status, [ 'publish', 'draft', 'pending' ], true )
+				) {
+					$html = self::get_wc_preview_html( $template_post_id );
+				} else {
+					$html = self::get_wc_classic_preview_html( $wc_email_id );
+				}
+			} else {
+				$html = self::get_wc_classic_preview_html( $wc_email_id );
+			}
+
+			if ( false === $html || empty( $html ) ) {
+				return new \WP_Error(
+					'newspack_email_preview_unavailable',
+					__( 'Email preview is unavailable.', 'newspack-plugin' ),
+					[ 'status' => 500 ]
+				);
+			}
+
+			return rest_ensure_response(
+				[
+					'html' => $html,
+					'id'   => $id,
+				]
+			);
+		}
+
+		// Numeric post ID path (Newspack emails, WC block-editor template posts).
+		$post_id = absint( $id );
+		if ( ! $post_id ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// Don't preview trashed or auto-draft posts — they shouldn't be
+		// reachable from the wizard's surfaced list, and previewing them
+		// leaks their stored HTML through the endpoint. `manage_options`
+		// gates this so the leak is admin-only, but the allowlist keeps
+		// the endpoint scoped to publish-track statuses anyway.
+		if ( ! in_array( $post->post_status, [ 'publish', 'draft', 'pending' ], true ) ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( 'woo_email' === $post->post_type ) {
+			// Reverse-resolve the post → WC email class and confirm a
+			// currently-surfaced source='woocommerce' config carries it
+			// before rendering. Without this, a stale/orphan woo_email post
+			// the wizard no longer surfaces would still render through this
+			// endpoint (the `wc:` branch already validates against
+			// get_email_configs(); this brings the numeric branch in line).
+			if ( ! self::woo_email_post_is_surfaced( $post_id ) ) {
+				return new \WP_Error(
+					'newspack_email_preview_not_found',
+					__( 'Email not found.', 'newspack-plugin' ),
+					[ 'status' => 404 ]
+				);
+			}
+			$html = self::get_wc_preview_html( $post_id );
+		} elseif ( Emails::POST_TYPE === $post->post_type ) {
+			$html = self::get_preview_html( $post_id );
+		} else {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( false === $html || empty( $html ) ) {
+			return new \WP_Error(
+				'newspack_email_preview_unavailable',
+				__( 'Email preview is unavailable.', 'newspack-plugin' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return rest_ensure_response(
+			[
+				'html' => $html,
+				'id'   => $post_id,
+			]
+		);
+	}
+
+	/**
+	 * Render a WC classic-template email via WC's legacy EmailPreview.
+	 *
+	 * Used for WC emails that have no block-editor template post (e.g.
+	 * WC Subs emails). The rendered HTML uses `woocommerce_email_*` option
+	 * colors which a separate style-sync slice keeps in sync with the
+	 * site's brand.
+	 *
+	 * Not cached — classic render is fast (~30–50 ms) and
+	 * `woocommerce_email_*` options change without a post_modified
+	 * timestamp to key against. The lazy-loading IntersectionObserver in
+	 * the frontend limits concurrency in practice.
+	 *
+	 * @param string $wc_email_id The WC_Email ID (e.g. 'customer_payment_retry').
+	 *
+	 * @return string|false Rendered HTML, or false if unavailable.
+	 */
+	public static function get_wc_classic_preview_html( string $wc_email_id ) {
+		$preview_class = 'Automattic\\WooCommerce\\Internal\\Admin\\EmailPreview\\EmailPreview';
+
+		if ( ! class_exists( 'WooCommerce' ) || ! class_exists( $preview_class ) ) {
+			return false;
+		}
+
+		// Resolve email ID → class name via the slice 2a memoized helper
+		// instead of re-walking the mailer here. The helper already
+		// memoizes the slug→instance map per request, so this honors that
+		// cache instead of paying a fresh mailer init on every preview.
+		$wc_email = WooCommerce_Emails::get_wc_email_by_id( $wc_email_id );
+		if ( ! $wc_email ) {
+			return false;
+		}
+		$wc_email_class = get_class( $wc_email );
+
+		// Wrap the preview instantiation + render in a try so a third-party
+		// hook (e.g. `woocommerce_email_setup_locale`) throwing inside
+		// WC's EmailPreview chain degrades to the logged-false return
+		// instead of bubbling up to api_get_preview as a 500.
+		try {
+			$preview = $preview_class::instance();
+			$preview->set_email_type( $wc_email_class );
+			return $preview->render();
+		} catch ( \Throwable $e ) {
+			Logger::log(
+				"WC EmailPreview::render() failed for '$wc_email_id' ($wc_email_class): " . $e->getMessage(),
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Permissions check for the preview endpoint. Mirrors other Newspack email endpoints.
+	 *
+	 * @codeCoverageIgnore
+	 * @return bool|\WP_Error
+	 */
+	public static function api_permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack-plugin' ),
+				[ 'status' => 403 ]
+			);
+		}
+		return true;
+	}
+}
+
+
+Email_Preview::init();

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
@@ -513,6 +513,19 @@ class Email_Preview {
 			);
 		}
 
+		// Don't preview trashed or auto-draft posts — they shouldn't be
+		// reachable from the wizard's surfaced list, and previewing them
+		// leaks their stored HTML through the endpoint. `manage_options`
+		// gates this so the leak is admin-only, but the allowlist keeps
+		// the endpoint scoped to publish-track statuses anyway.
+		if ( ! in_array( $post->post_status, [ 'publish', 'draft', 'pending' ], true ) ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
 		if ( 'woo_email' === $post->post_type ) {
 			$html = self::get_wc_preview_html( $post_id );
 		} elseif ( Emails::POST_TYPE === $post->post_type ) {
@@ -565,19 +578,23 @@ class Email_Preview {
 			return false;
 		}
 
-		// Resolve email ID → class name via the mailer's registered emails.
-		$wc_email_class = null;
-		foreach ( \WC()->mailer()->get_emails() as $class_name => $instance ) {
-			if ( $instance->id === $wc_email_id ) {
-				$wc_email_class = $class_name;
-				break;
-			}
-		}
-		if ( ! $wc_email_class ) {
-			return false;
-		}
-
+		// Wrap the WC interactions (mailer lookup, preview instantiation,
+		// render) in a single try so a throw at any step — including a
+		// shim `\WC()` whose `mailer()` doesn't behave like the real one
+		// — degrades to the logged-false return instead of bubbling.
 		try {
+			// Resolve email ID → class name via the mailer's registered emails.
+			$wc_email_class = null;
+			foreach ( \WC()->mailer()->get_emails() as $class_name => $instance ) {
+				if ( $instance->id === $wc_email_id ) {
+					$wc_email_class = $class_name;
+					break;
+				}
+			}
+			if ( ! $wc_email_class ) {
+				return false;
+			}
+
 			$preview = $preview_class::instance();
 			$preview->set_email_type( $wc_email_class );
 			return $preview->render();

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
@@ -13,6 +13,7 @@ namespace Newspack\Wizards\Newspack;
 
 use Newspack\Emails;
 use Newspack\Logger;
+use Newspack\WooCommerce_Emails;
 use Newspack_Newsletters;
 
 defined( 'ABSPATH' ) || exit;
@@ -75,11 +76,27 @@ class Email_Preview {
 		}
 
 		$template_path = $configs[ $type ]['template'];
-		if ( ! is_readable( $template_path ) ) {
+
+		// `$template_path` comes through the `newspack_email_configs`
+		// filter. A malicious or buggy third-party hook could supply any
+		// readable file path on the server (LFI) or — worse — point at an
+		// attacker-uploaded `.php` file (RCE via top-level side effects on
+		// include). `is_readable` doesn't gate against either. Constrain
+		// the path to within the plugin tree and require a `.php`
+		// extension before including. realpath() also resolves any
+		// `../` traversal away from the plugin root.
+		$resolved = realpath( $template_path );
+		$plugin_root = realpath( dirname( NEWSPACK_PLUGIN_FILE ) );
+		if (
+			false === $resolved
+			|| false === $plugin_root
+			|| 0 !== strpos( $resolved, $plugin_root . DIRECTORY_SEPARATOR )
+			|| '.php' !== substr( $resolved, -4 )
+		) {
 			return '';
 		}
 
-		$template_data = include $template_path;
+		$template_data = include $resolved;
 		if ( ! is_array( $template_data ) || empty( $template_data['email_html'] ) ) {
 			return '';
 		}
@@ -153,9 +170,18 @@ class Email_Preview {
 		$site_url        = get_bloginfo( 'wpurl' );
 		$reply_to_email  = Emails::get_reply_to_email();
 		$site_address    = self::get_site_address();
-		$site_contact    = $site_address
-			? sprintf( '<strong>%s</strong> — %s', $site_title, $site_address )
-			: $site_title;
+		// *SITE_CONTACT* lives in the 'raw' bucket (pre-escaped HTML, NOT
+		// re-escaped at strtr-time), so the values interpolated here MUST
+		// be escaped at construction time. get_bloginfo('name') and the
+		// WC store address are admin-controlled strings — if an admin
+		// (or a role-elevation supply-chain compromise) sets the site
+		// title to a `<script>` or malformed tag, the unescaped version
+		// would inject into the iframe's srcDoc. Iframe sandbox blocks
+		// script execution today, but breaks rendering and would be
+		// immediately exploitable if `allow-scripts` were ever added.
+		$site_contact = $site_address
+			? sprintf( '<strong>%s</strong> — %s', esc_html( $site_title ), esc_html( $site_address ) )
+			: esc_html( $site_title );
 
 		return [
 			// Tokens rendered as visible text inside HTML — escaped with esc_html().
@@ -353,8 +379,15 @@ class Email_Preview {
 			return null;
 		}
 
+		// Track whether set_up_filters() ran to completion. If it threw
+		// mid-way, clean_up_filters() may not be safe to call (it could
+		// reference state that set_up_filters never initialized). The
+		// flag gates the cleanup so we don't risk a second throw bubbling
+		// past this method's catch.
+		$filters_set_up = false;
 		try {
 			$preview->set_up_filters();
+			$filters_set_up = true;
 			$renderer = wc_get_container()->get( $renderer_class );
 			$html     = $renderer->maybe_render_block_email( $preview->get_email() );
 			$preview->clean_up_filters();
@@ -370,7 +403,21 @@ class Email_Preview {
 
 			return $html;
 		} catch ( \Throwable $e ) {
-			$preview->clean_up_filters();
+			if ( $filters_set_up ) {
+				// Wrap the cleanup in its own try/catch — a second throw
+				// from clean_up_filters() would otherwise escape past this
+				// method's catch and bubble up to api_get_preview as a
+				// 500 fatal with no graceful fallback to legacy preview.
+				try {
+					$preview->clean_up_filters();
+				} catch ( \Throwable $cleanup_e ) {
+					Logger::log(
+						'clean_up_filters() also threw during BlockEmailRenderer recovery: ' . $cleanup_e->getMessage(),
+						'NEWSPACK-EMAILS',
+						'warning'
+					);
+				}
+			}
 			Logger::log(
 				'BlockEmailRenderer threw ' . get_class( $e ) . " for woo_email post $post_id ($email_class_name): " . $e->getMessage() . '; using legacy preview.',
 				'NEWSPACK-EMAILS',
@@ -473,7 +520,21 @@ class Email_Preview {
 			// (WC Subscriptions, etc.).
 			$template_post_id = Emails_Section::get_wc_email_template_post_id( $wc_email_id );
 			if ( $template_post_id ) {
-				$html = self::get_wc_preview_html( $template_post_id );
+				// `get_wc_email_template_post_id` is a raw WC option read
+				// — it doesn't verify the referenced post still exists or
+				// is in an editable status. If the publisher trashed the
+				// template post but the WC posts-manager option still
+				// references the trashed ID, we'd render the trashed
+				// content. Mirror the numeric branch's allowlist guard.
+				$template_post = get_post( $template_post_id );
+				if (
+					$template_post
+					&& in_array( $template_post->post_status, [ 'publish', 'draft', 'pending' ], true )
+				) {
+					$html = self::get_wc_preview_html( $template_post_id );
+				} else {
+					$html = self::get_wc_classic_preview_html( $wc_email_id );
+				}
 			} else {
 				$html = self::get_wc_classic_preview_html( $wc_email_id );
 			}
@@ -578,23 +639,21 @@ class Email_Preview {
 			return false;
 		}
 
-		// Wrap the WC interactions (mailer lookup, preview instantiation,
-		// render) in a single try so a throw at any step — including a
-		// shim `\WC()` whose `mailer()` doesn't behave like the real one
-		// — degrades to the logged-false return instead of bubbling.
-		try {
-			// Resolve email ID → class name via the mailer's registered emails.
-			$wc_email_class = null;
-			foreach ( \WC()->mailer()->get_emails() as $class_name => $instance ) {
-				if ( $instance->id === $wc_email_id ) {
-					$wc_email_class = $class_name;
-					break;
-				}
-			}
-			if ( ! $wc_email_class ) {
-				return false;
-			}
+		// Resolve email ID → class name via the slice 2a memoized helper
+		// instead of re-walking the mailer here. The helper already
+		// memoizes the slug→instance map per request, so this honors that
+		// cache instead of paying a fresh mailer init on every preview.
+		$wc_email = WooCommerce_Emails::get_wc_email_by_id( $wc_email_id );
+		if ( ! $wc_email ) {
+			return false;
+		}
+		$wc_email_class = get_class( $wc_email );
 
+		// Wrap the preview instantiation + render in a try so a third-party
+		// hook (e.g. `woocommerce_email_setup_locale`) throwing inside
+		// WC's EmailPreview chain degrades to the logged-false return
+		// instead of bubbling up to api_get_preview as a 500.
+		try {
 			$preview = $preview_class::instance();
 			$preview->set_email_type( $wc_email_class );
 			return $preview->render();

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
@@ -1,0 +1,494 @@
+<?php
+/**
+ * Email preview rendering for the Settings → Emails screen.
+ *
+ * Renders a publisher-facing preview of a transactional email by substituting
+ * known template tokens with realistic sample values. Used by the unified
+ * email management UI to display a per-card thumbnail.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Emails;
+use Newspack\Logger;
+use Newspack_Newsletters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Email Preview Class.
+ */
+class Email_Preview {
+
+	/**
+	 * Get the rendered HTML for an email post, with sample token values substituted.
+	 *
+	 * Falls back to the registered template file's HTML when the post's saved
+	 * EMAIL_HTML_META is empty (i.e. the email has never been customized).
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string|false Rendered HTML, or false if the email can't be resolved.
+	 */
+	public static function get_preview_html( int $post_id ) {
+		if ( ! self::is_supported() ) {
+			return false;
+		}
+
+		$html = self::get_source_html( $post_id );
+		if ( empty( $html ) ) {
+			return false;
+		}
+
+		return self::apply_sample_substitutions( $html, $post_id );
+	}
+
+	/**
+	 * Get the source HTML for an email post.
+	 *
+	 * Reads the saved EMAIL_HTML_META first; falls back to the registered
+	 * template's default email_html when that meta is empty.
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string Source HTML, or empty string if unavailable.
+	 */
+	private static function get_source_html( int $post_id ): string {
+		$html = get_post_meta( $post_id, Newspack_Newsletters::EMAIL_HTML_META, true );
+		if ( ! empty( $html ) ) {
+			return $html;
+		}
+
+		// Fallback: look up the registered template for this post type and use its default HTML.
+		$type = get_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, true );
+		if ( empty( $type ) ) {
+			return '';
+		}
+
+		// Look up the registered template and include it to get the default HTML.
+		// The template file returns an array with an 'email_html' key.
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		if ( ! isset( $configs[ $type ], $configs[ $type ]['template'] ) ) {
+			return '';
+		}
+
+		$template_path = $configs[ $type ]['template'];
+		if ( ! is_readable( $template_path ) ) {
+			return '';
+		}
+
+		$template_data = include $template_path;
+		if ( ! is_array( $template_data ) || empty( $template_data['email_html'] ) ) {
+			return '';
+		}
+
+		return $template_data['email_html'];
+	}
+
+	/**
+	 * Apply sample-value substitutions to email HTML.
+	 *
+	 * Site/branding tokens use the publisher's real site config (so the preview
+	 * reflects their actual branding). Reader/transaction tokens use stable
+	 * fake values. Action URLs are replaced with anchor placeholders so
+	 * preview iframes don't trigger live navigation.
+	 *
+	 * @param string $html    Source HTML containing *TOKEN* placeholders.
+	 * @param int    $post_id The email post being previewed (passed to the filter).
+	 *
+	 * @return string HTML with tokens substituted.
+	 */
+	private static function apply_sample_substitutions( string $html, int $post_id = 0 ): string {
+		$substitutions = self::get_sample_substitutions();
+
+		/**
+		 * Filters the sample substitution map used for email previews.
+		 *
+		 * The map is structured as three sub-arrays keyed by escaping context:
+		 * - 'html': Tokens rendered as visible text (escaped with esc_html()).
+		 * - 'url':  Tokens used in href/src attributes (escaped with esc_url()).
+		 * - 'raw':  Tokens containing pre-escaped HTML (not escaped again).
+		 *
+		 * @param array $substitutions Structured map of `*TOKEN*` => sample value.
+		 * @param int   $post_id       The email post being previewed (0 if unknown).
+		 */
+		$substitutions = apply_filters( 'newspack_email_preview_substitutions', $substitutions, $post_id );
+
+		// Validate the filtered value — fall back to defaults if a filter broke the structure.
+		if (
+			! is_array( $substitutions )
+			|| ! isset( $substitutions['html'], $substitutions['url'], $substitutions['raw'] )
+			|| ! is_array( $substitutions['html'] )
+			|| ! is_array( $substitutions['url'] )
+			|| ! is_array( $substitutions['raw'] )
+		) {
+			$substitutions = self::get_sample_substitutions();
+		}
+
+		// Escape HTML-text tokens.
+		$html_map = array_map( 'esc_html', $substitutions['html'] );
+		// Escape URL tokens.
+		$url_map = array_map( 'esc_url', $substitutions['url'] );
+		// Raw tokens are already safe (contain pre-escaped markup).
+		$raw_map = $substitutions['raw'];
+
+		return strtr( $html, array_merge( $html_map, $url_map, $raw_map ) );
+	}
+
+	/**
+	 * Get the substitution map of email-template tokens to sample values.
+	 *
+	 * Returns a three-key array grouped by escaping context:
+	 * - 'html': Tokens rendered as visible text (escaped with esc_html() at call site).
+	 * - 'url':  Tokens used in href/src attributes (escaped with esc_url() at call site).
+	 * - 'raw':  Tokens containing pre-escaped HTML markup (not escaped again).
+	 *
+	 * @return array{ html: array<string, string>, url: array<string, string>, raw: array<string, string> }
+	 */
+	public static function get_sample_substitutions(): array {
+		$site_logo_url   = wp_get_attachment_url( get_theme_mod( 'custom_logo' ) );
+		$site_title      = get_bloginfo( 'name' );
+		$site_url        = get_bloginfo( 'wpurl' );
+		$reply_to_email  = Emails::get_reply_to_email();
+		$site_address    = self::get_site_address();
+		$site_contact    = $site_address
+			? sprintf( '<strong>%s</strong> — %s', $site_title, $site_address )
+			: $site_title;
+
+		return [
+			// Tokens rendered as visible text inside HTML — escaped with esc_html().
+			'html' => [
+				// Site / branding — real values from the publisher's config.
+				'*SITE_TITLE*'            => $site_title,
+				'*SITE_ADDRESS*'          => $site_address,
+
+				// Reader identity — stable sample values.
+				'*BILLING_FIRST_NAME*'    => __( 'Sample', 'newspack-plugin' ),
+				'*BILLING_LAST_NAME*'     => __( 'Reader', 'newspack-plugin' ),
+				'*BILLING_NAME*'          => __( 'Sample Reader', 'newspack-plugin' ),
+				'*PENDING_EMAIL_ADDRESS*' => 'sample.reader@example.com',
+
+				// Transaction / subscription details.
+				'*AMOUNT*'                => '$25.00',
+				'*PAYMENT_METHOD*'        => __( 'Visa ending in 4242', 'newspack-plugin' ),
+				'*PRODUCT_NAME*'          => __( 'Monthly Membership', 'newspack-plugin' ),
+				'*BILLING_FREQUENCY*'     => __( 'monthly', 'newspack-plugin' ),
+				'*DATE*'                  => wp_date( get_option( 'date_format', 'F j, Y' ) ),
+				'*CANCELLATION_TITLE*'    => __( 'Subscription Cancelled', 'newspack-plugin' ),
+				'*CANCELLATION_TYPE*'     => __( 'subscription', 'newspack-plugin' ),
+
+				// Card expiry warning details.
+				'*CARD_LAST_4*'           => '4242',
+				'*EXPIRY_DATE*'           => '12/2026',
+				'*RENEWAL_DATE*'          => wp_date( get_option( 'date_format', 'F j, Y' ), strtotime( '+1 year' ) ),
+
+				// OTP code — stable sample value.
+				'*MAGIC_LINK_OTP*'        => '123456',
+			],
+
+			// Tokens used in href/src attributes — escaped with esc_url().
+			'url'  => [
+				'*SITE_URL*'               => $site_url,
+				'*SITE_LOGO*'              => $site_logo_url ? $site_logo_url : '',
+				'*ACCOUNT_URL*'            => '#',
+				'*CANCELLATION_URL*'       => '#',
+				'*EMAIL_CANCELLATION_URL*' => '#',
+				'*EMAIL_VERIFICATION_URL*' => '#',
+				'*VERIFICATION_URL*'       => '#',
+				'*RECEIPT_URL*'            => '#',
+				'*MAGIC_LINK_URL*'         => '#',
+				'*PASSWORD_RESET_LINK*'    => '#',
+				'*SET_PASSWORD_LINK*'      => '#',
+				'*DELETION_LINK*'          => '#',
+				'*WP_LOGIN_URL*'           => '#',
+				'*UPDATE_PAYMENT_URL*'     => '#',
+			],
+
+			// Tokens containing pre-escaped HTML — NOT escaped again.
+			'raw'  => [
+				'*CONTACT_EMAIL*' => sprintf( '<a href="%s">%s</a>', esc_url( 'mailto:' . $reply_to_email ), esc_html( $reply_to_email ) ),
+				'*SITE_CONTACT*'  => $site_contact,
+			],
+		];
+	}
+
+	/**
+	 * Get the site's store address as a formatted string.
+	 *
+	 * Mirrors the logic in Emails::get_email_payload() so the preview
+	 * shows the same address format the real email would use.
+	 *
+	 * @return string Formatted site address, or empty string.
+	 */
+	private static function get_site_address(): string {
+		if ( class_exists( 'WC' ) ) {
+			$base_address  = WC()->countries->get_base_address();
+			$base_city     = WC()->countries->get_base_city();
+			$base_postcode = WC()->countries->get_base_postcode();
+		} else {
+			$base_address  = get_option( 'woocommerce_store_address', '' );
+			$base_city     = get_option( 'woocommerce_store_city', '' );
+			$base_postcode = get_option( 'woocommerce_store_postcode', '' );
+		}
+
+		if ( ! $base_address ) {
+			return '';
+		}
+
+		if ( ! $base_city && ! $base_postcode ) {
+			return $base_address;
+		}
+
+		return sprintf(
+			/* translators: 1: street address, 2: city, 3: postcode. */
+			__( '%1$s, %2$s %3$s', 'newspack-plugin' ),
+			$base_address,
+			$base_city,
+			$base_postcode
+		);
+	}
+
+	/**
+	 * Get rendered preview HTML for a WooCommerce block-editor email template.
+	 *
+	 * Tries the block-editor render path first (BlockEmailRenderer) which
+	 * produces HTML styled with the site's theme.json colors and logo — the
+	 * same output the block email editor preview shows. Falls back to
+	 * EmailPreview::render() (legacy WC template with woocommerce_email_*
+	 * option colors) if the block path is unavailable or fails.
+	 *
+	 * @param int $post_id ID of the woo_email post.
+	 *
+	 * @return string|false Rendered HTML, or false if unavailable.
+	 */
+	private static function get_wc_preview_html( int $post_id ) {
+		$manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		$preview_class = 'Automattic\\WooCommerce\\Internal\\Admin\\EmailPreview\\EmailPreview';
+
+		if ( ! class_exists( $manager_class ) || ! class_exists( $preview_class ) ) {
+			return false;
+		}
+
+		// Reverse-lookup: post ID → email class name (e.g. 'WC_Email_New_Order').
+		$email_class_name = $manager_class::get_instance()->get_email_type_class_name_from_post_id( $post_id );
+		if ( empty( $email_class_name ) ) {
+			return false;
+		}
+
+		// Check transient cache (block render is ~180 ms per email).
+		$cache_key = self::get_wc_preview_cache_key( $post_id );
+		$cached    = get_transient( $cache_key );
+		if ( is_string( $cached ) && '' !== $cached ) {
+			return $cached;
+		}
+
+		// Set up the WC_Email with a dummy order/user so both render paths
+		// have realistic sample data to work with.
+		try {
+			$preview = $preview_class::instance();
+			$preview->set_email_type( $email_class_name );
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+
+		// Try the block-editor render path (themed, with site logo + theme colors).
+		$block_html = self::try_block_render( $preview, $post_id, $email_class_name );
+		if ( ! empty( $block_html ) ) {
+			set_transient( $cache_key, $block_html, HOUR_IN_SECONDS );
+			return $block_html;
+		}
+
+		// Fallback: legacy render via EmailPreview (WC default styling).
+		try {
+			$html = $preview->render();
+			if ( ! empty( $html ) ) {
+				set_transient( $cache_key, $html, HOUR_IN_SECONDS );
+			}
+			return $html;
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Build the transient cache key for a WC email preview.
+	 *
+	 * Includes the post's modified date so the cache naturally misses
+	 * after an edit — this is the sole invalidation mechanism. Old
+	 * transients expire via TTL.
+	 *
+	 * @param int $post_id The woo_email post ID.
+	 * @return string Transient key (max 172 chars — within the 172-char limit).
+	 */
+	private static function get_wc_preview_cache_key( int $post_id ): string {
+		$post     = get_post( $post_id );
+		$modified = $post ? strtotime( $post->post_modified_gmt ) : 0;
+		return 'newspack_wc_email_preview_' . $post_id . '_' . $modified;
+	}
+
+	/**
+	 * Attempt to render a WC email through the block-editor pipeline.
+	 *
+	 * Uses BlockEmailRenderer::maybe_render_block_email() which renders
+	 * through the email-editor package's Renderer — applying theme.json
+	 * global styles, CSS inlining, and personalization tag replacement.
+	 *
+	 * @param object $preview          WC EmailPreview instance (with email type already set).
+	 * @param int    $post_id          The woo_email post ID being previewed.
+	 * @param string $email_class_name The WC_Email class name (for logging).
+	 *
+	 * @return string|null Rendered HTML, or null if the block path is unavailable.
+	 */
+	private static function try_block_render( $preview, int $post_id, string $email_class_name ): ?string {
+		$renderer_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\BlockEmailRenderer';
+
+		if ( ! class_exists( $renderer_class ) || ! function_exists( 'wc_get_container' ) ) {
+			Logger::log(
+				"BlockEmailRenderer not available for woo_email post $post_id ($email_class_name); using legacy preview.",
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return null;
+		}
+
+		try {
+			$preview->set_up_filters();
+			$renderer = wc_get_container()->get( $renderer_class );
+			$html     = $renderer->maybe_render_block_email( $preview->get_email() );
+			$preview->clean_up_filters();
+
+			if ( empty( $html ) ) {
+				Logger::log(
+					"BlockEmailRenderer returned empty for woo_email post $post_id ($email_class_name); using legacy preview.",
+					'NEWSPACK-EMAILS',
+					'warning'
+				);
+				return null;
+			}
+
+			return $html;
+		} catch ( \Throwable $e ) {
+			$preview->clean_up_filters();
+			Logger::log(
+				'BlockEmailRenderer threw ' . get_class( $e ) . " for woo_email post $post_id ($email_class_name): " . $e->getMessage() . '; using legacy preview.',
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Is email preview supported on this install?
+	 *
+	 * Requires Newspack Newsletters (the same dependency that gates
+	 * email management in general).
+	 *
+	 * @return bool
+	 */
+	private static function is_supported(): bool {
+		return class_exists( 'Newspack_Newsletters' );
+	}
+
+	/**
+	 * Initialize the class. Hooked from class-newspack.php inclusion.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+	}
+
+	/**
+	 * Register the email-preview REST endpoint.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function register_rest_routes(): void {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'wizard/newspack-settings/emails/(?P<id>\d+)/preview',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_preview' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * REST handler: return preview HTML for an email post.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function api_get_preview( $request ) {
+		$post_id = (int) $request->get_param( 'id' );
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( 'woo_email' === $post->post_type ) {
+			$html = self::get_wc_preview_html( $post_id );
+		} elseif ( Emails::POST_TYPE === $post->post_type ) {
+			$html = self::get_preview_html( $post_id );
+		} else {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( false === $html || empty( $html ) ) {
+			return new \WP_Error(
+				'newspack_email_preview_unavailable',
+				__( 'Email preview is unavailable.', 'newspack-plugin' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return rest_ensure_response(
+			[
+				'html' => $html,
+				'id'   => $post_id,
+			]
+		);
+	}
+
+	/**
+	 * Permissions check for the preview endpoint. Mirrors other Newspack email endpoints.
+	 *
+	 * @codeCoverageIgnore
+	 * @return bool|\WP_Error
+	 */
+	public static function api_permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack-plugin' ),
+				[ 'status' => 403 ]
+			);
+		}
+		return true;
+	}
+}
+
+
+Email_Preview::init();

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-email-preview.php
@@ -404,12 +404,17 @@ class Email_Preview {
 	/**
 	 * Register the email-preview REST endpoint.
 	 *
+	 * Accepts two identifier shapes:
+	 * - Numeric post ID (Newspack emails, WC block-editor template posts).
+	 * - `wc:{email_id}` strings (WC classic-template emails with no
+	 *   block-editor template post — e.g. WC Subscriptions emails).
+	 *
 	 * @codeCoverageIgnore
 	 */
 	public static function register_rest_routes(): void {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'wizard/newspack-settings/emails/(?P<id>\d+)/preview',
+			'wizard/newspack-settings/emails/(?P<id>\d+|wc:[\w-]+)/preview',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_preview' ],
@@ -417,8 +422,8 @@ class Email_Preview {
 				'args'                => [
 					'id' => [
 						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -426,14 +431,78 @@ class Email_Preview {
 	}
 
 	/**
-	 * REST handler: return preview HTML for an email post.
+	 * REST handler: return preview HTML for an email.
+	 *
+	 * Handles two identifier shapes:
+	 * - Numeric: resolves to a post (newspack_rr_email or woo_email).
+	 * - `wc:{email_id}`: routes to a WC email render path. If a
+	 *   block-editor template post exists for the email, uses the block
+	 *   render (themed + cached); otherwise falls back to WC's legacy
+	 *   classic render.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 *
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function api_get_preview( $request ) {
-		$post_id = (int) $request->get_param( 'id' );
+		$id = (string) $request->get_param( 'id' );
+
+		// WC classic / block-template path (e.g. "wc:customer_payment_retry").
+		if ( str_starts_with( $id, 'wc:' ) ) {
+			$wc_email_id = substr( $id, 3 );
+
+			// Validate against the unified email config schema before any
+			// resolution. The id must map to a config that's
+			// source='woocommerce' — otherwise reject. The slice 1
+			// unified-config refactor removed the parallel registry
+			// lookup the legacy implementation used; `get_email_configs()`
+			// is the single source of truth.
+			$configs   = Emails::get_email_configs();
+			$wc_config = $configs[ $wc_email_id ] ?? null;
+			if ( ! $wc_config || 'woocommerce' !== ( $wc_config['source'] ?? '' ) ) {
+				return new \WP_Error(
+					'newspack_email_preview_not_found',
+					__( 'Email not found.', 'newspack-plugin' ),
+					[ 'status' => 404 ]
+				);
+			}
+
+			// Prefer the block-editor render path when a template post
+			// exists (themed + cached). Otherwise fall back to WC's
+			// legacy classic render for emails without a template post
+			// (WC Subscriptions, etc.).
+			$template_post_id = Emails_Section::get_wc_email_template_post_id( $wc_email_id );
+			if ( $template_post_id ) {
+				$html = self::get_wc_preview_html( $template_post_id );
+			} else {
+				$html = self::get_wc_classic_preview_html( $wc_email_id );
+			}
+
+			if ( false === $html || empty( $html ) ) {
+				return new \WP_Error(
+					'newspack_email_preview_unavailable',
+					__( 'Email preview is unavailable.', 'newspack-plugin' ),
+					[ 'status' => 500 ]
+				);
+			}
+
+			return rest_ensure_response(
+				[
+					'html' => $html,
+					'id'   => $id,
+				]
+			);
+		}
+
+		// Numeric post ID path (Newspack emails, WC block-editor template posts).
+		$post_id = absint( $id );
+		if ( ! $post_id ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
@@ -470,6 +539,56 @@ class Email_Preview {
 				'id'   => $post_id,
 			]
 		);
+	}
+
+	/**
+	 * Render a WC classic-template email via WC's legacy EmailPreview.
+	 *
+	 * Used for WC emails that have no block-editor template post (e.g.
+	 * WC Subs emails). The rendered HTML uses `woocommerce_email_*` option
+	 * colors which a separate style-sync slice keeps in sync with the
+	 * site's brand.
+	 *
+	 * Not cached — classic render is fast (~30–50 ms) and
+	 * `woocommerce_email_*` options change without a post_modified
+	 * timestamp to key against. The lazy-loading IntersectionObserver in
+	 * the frontend limits concurrency in practice.
+	 *
+	 * @param string $wc_email_id The WC_Email ID (e.g. 'customer_payment_retry').
+	 *
+	 * @return string|false Rendered HTML, or false if unavailable.
+	 */
+	public static function get_wc_classic_preview_html( string $wc_email_id ) {
+		$preview_class = 'Automattic\\WooCommerce\\Internal\\Admin\\EmailPreview\\EmailPreview';
+
+		if ( ! class_exists( 'WooCommerce' ) || ! class_exists( $preview_class ) ) {
+			return false;
+		}
+
+		// Resolve email ID → class name via the mailer's registered emails.
+		$wc_email_class = null;
+		foreach ( \WC()->mailer()->get_emails() as $class_name => $instance ) {
+			if ( $instance->id === $wc_email_id ) {
+				$wc_email_class = $class_name;
+				break;
+			}
+		}
+		if ( ! $wc_email_class ) {
+			return false;
+		}
+
+		try {
+			$preview = $preview_class::instance();
+			$preview->set_email_type( $wc_email_class );
+			return $preview->render();
+		} catch ( \Throwable $e ) {
+			Logger::log(
+				"WC EmailPreview::render() failed for '$wc_email_id' ($wc_email_class): " . $e->getMessage(),
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return false;
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -195,7 +195,7 @@ class Emails_Section extends Wizard_Section {
 	 *         recommended:         bool,
 	 *         chip:                'auth-account'|'reader-revenue',
 	 *         source:              'newspack'|'woocommerce',
-	 *         preview_post_id?:    ?int,
+	 *         preview_id?:         int|string|null,
 	 *     }>,
 	 *     post_type: string,
 	 * }
@@ -508,10 +508,20 @@ class Emails_Section extends Wizard_Section {
 			? 'yes' === $wc_options['enabled']
 			: $wc_email->is_enabled();
 
-		// Resolve once, pass to the edit-link helper — both fields use
-		// the same lookup (option read + class_exists + WC posts-manager
-		// DB query), so doing it twice per row would be wasteful.
-		$template_post_id = self::get_wc_email_template_post_id( $type );
+		// Resolve the block-editor template post ID once — used for both
+		// the edit-link (block-editor route when available) and the
+		// preview-id smart fallback below. Doing it twice per row would
+		// re-pay the option read + class_exists + WC posts-manager DB
+		// query for no gain.
+		$block_template_post_id = self::get_wc_email_template_post_id( $type );
+
+		// Smart-fallback preview identifier — if a block-editor template
+		// post exists for this WC email, emit its integer post ID so the
+		// preview endpoint can render via the block path. Otherwise emit
+		// the `wc:{id}` string so it routes to WC's classic render
+		// (Email_Preview::get_wc_classic_preview_html). Always one of
+		// integer | string — never null on WC rows.
+		$preview_id = $block_template_post_id ?? ( 'wc:' . $type );
 
 		return [
 			'type'                => $type,
@@ -519,7 +529,7 @@ class Emails_Section extends Wizard_Section {
 			'label'               => $config['label'] ?? '',
 			'description'         => $config['description'] ?? ( $config['trigger_description'] ?? '' ),
 			'post_id'             => 'wc:' . $type,
-			'edit_link'           => self::get_wc_email_edit_link( $template_post_id, $config['wc_email_class'] ?? get_class( $wc_email ) ),
+			'edit_link'           => self::get_wc_email_edit_link( $block_template_post_id, $config['wc_email_class'] ?? get_class( $wc_email ) ),
 			'subject'             => '',
 			'from_name'           => '',
 			'from_email'          => '',
@@ -531,7 +541,7 @@ class Emails_Section extends Wizard_Section {
 			'recommended'         => $config['recommended'] ?? false,
 			'chip'                => $config['chip'] ?? 'auth-account',
 			'source'              => 'woocommerce',
-			'preview_post_id'     => $template_post_id,
+			'preview_id'          => $preview_id,
 		];
 	}
 
@@ -541,13 +551,18 @@ class Emails_Section extends Wizard_Section {
 	 * Returns null when the WC block email editor is disabled, when the
 	 * WC posts-manager class isn't loaded, or when no template post
 	 * exists for this email ID. Self-contained — depends only on WC core
-	 * (the option and the posts-manager class). No Email_Preview machinery
-	 * involved; that ships with slice 2b.
+	 * (the option and the posts-manager class).
+	 *
+	 * Public because Email_Preview consumes it from outside this class
+	 * when validating the `wc:{id}` route path — needs to decide between
+	 * block-editor render (template post present) and classic render
+	 * (no template post). serialize_wc_email_row() also consumes it
+	 * to emit the smart-fallback preview_id field.
 	 *
 	 * @param string $wc_email_id The WC_Email instance ID.
 	 * @return ?int Template post ID, or null.
 	 */
-	private static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
+	public static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
 		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
 			return null;
 		}

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -195,7 +195,7 @@ class Emails_Section extends Wizard_Section {
 	 *         recommended:         bool,
 	 *         chip:                'auth-account'|'reader-revenue',
 	 *         source:              'newspack'|'woocommerce',
-	 *         preview_post_id?:    ?int,
+	 *         preview_id?:         int|string|null,
 	 *     }>,
 	 *     post_type: string,
 	 * }
@@ -485,10 +485,20 @@ class Emails_Section extends Wizard_Section {
 			? 'yes' === $wc_options['enabled']
 			: $wc_email->is_enabled();
 
-		// Resolve once, pass to the edit-link helper — both fields use
-		// the same lookup (option read + class_exists + WC posts-manager
-		// DB query), so doing it twice per row would be wasteful.
-		$template_post_id = self::get_wc_email_template_post_id( $type );
+		// Resolve the block-editor template post ID once — used for both
+		// the edit-link (block-editor route when available) and the
+		// preview-id smart fallback below. Doing it twice per row would
+		// re-pay the option read + class_exists + WC posts-manager DB
+		// query for no gain.
+		$block_template_post_id = self::get_wc_email_template_post_id( $type );
+
+		// Smart-fallback preview identifier — if a block-editor template
+		// post exists for this WC email, emit its integer post ID so the
+		// preview endpoint can render via the block path. Otherwise emit
+		// the `wc:{id}` string so it routes to WC's classic render
+		// (Email_Preview::get_wc_classic_preview_html). Always one of
+		// integer | string — never null on WC rows.
+		$preview_id = $block_template_post_id ?? ( 'wc:' . $type );
 
 		return [
 			'type'                => $type,
@@ -496,7 +506,7 @@ class Emails_Section extends Wizard_Section {
 			'label'               => $config['label'] ?? '',
 			'description'         => $config['description'] ?? ( $config['trigger_description'] ?? '' ),
 			'post_id'             => 'wc:' . $type,
-			'edit_link'           => self::get_wc_email_edit_link( $template_post_id, $config['wc_email_class'] ?? get_class( $wc_email ) ),
+			'edit_link'           => self::get_wc_email_edit_link( $block_template_post_id, $config['wc_email_class'] ?? get_class( $wc_email ) ),
 			'subject'             => '',
 			'from_name'           => '',
 			'from_email'          => '',
@@ -508,7 +518,7 @@ class Emails_Section extends Wizard_Section {
 			'recommended'         => $config['recommended'] ?? false,
 			'chip'                => $config['chip'] ?? 'auth-account',
 			'source'              => 'woocommerce',
-			'preview_post_id'     => $template_post_id,
+			'preview_id'          => $preview_id,
 		];
 	}
 
@@ -518,13 +528,18 @@ class Emails_Section extends Wizard_Section {
 	 * Returns null when the WC block email editor is disabled, when the
 	 * WC posts-manager class isn't loaded, or when no template post
 	 * exists for this email ID. Self-contained — depends only on WC core
-	 * (the option and the posts-manager class). No Email_Preview machinery
-	 * involved; that ships with slice 2b.
+	 * (the option and the posts-manager class).
+	 *
+	 * Public because Email_Preview consumes it from outside this class
+	 * when validating the `wc:{id}` route path — needs to decide between
+	 * block-editor render (template post present) and classic render
+	 * (no template post). serialize_wc_email_row() also consumes it
+	 * to emit the smart-fallback preview_id field.
 	 *
 	 * @param string $wc_email_id The WC_Email instance ID.
 	 * @return ?int Template post ID, or null.
 	 */
-	private static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
+	public static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
 		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
 			return null;
 		}

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.scss
@@ -1,0 +1,40 @@
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+// Email preview thumbnail container.
+.newspack-email-preview {
+	width: 100%;
+	aspect-ratio: 1;
+	overflow: hidden;
+	position: relative;
+	background: transparent;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&__iframe {
+		width: 848px;
+		height: auto;
+		border: 0;
+		position: absolute;
+		top: 0;
+		left: 0;
+		transform-origin: top left;
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 200ms ease-out;
+	}
+
+	&.is-ready &__iframe {
+		opacity: 1;
+	}
+
+	// Loading / error placeholder overlay.
+	&__placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		color: wp-colors.$gray-400;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -1,0 +1,283 @@
+/**
+ * External dependencies
+ */
+import { render, waitFor, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import EmailPreview from './email-preview';
+
+// Mock @wordpress/api-fetch — jest.mock is hoisted above imports.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// Store observer instances so tests can trigger intersection.
+let observerInstances = [];
+
+// Save the originals before any test overwrites them. In jsdom both
+// are `undefined` by default; afterAll restores or deletes per case so
+// the globals don't leak into suites Jest runs next in the same worker
+// (which would silently hand them my stubs instead of the jsdom default).
+const originalIntersectionObserver = global.IntersectionObserver;
+const originalResizeObserver = global.ResizeObserver;
+
+// Default IntersectionObserver mock: triggers immediately.
+function createObserverMock( triggerImmediately = true ) {
+	observerInstances = [];
+	global.IntersectionObserver = class {
+		constructor( callback ) {
+			this.callback = callback;
+			observerInstances.push( this );
+		}
+		observe() {
+			if ( triggerImmediately ) {
+				this.callback( [ { isIntersecting: true } ] );
+			}
+		}
+		disconnect() {}
+	};
+}
+
+// ResizeObserver mock: immediately reports a 300px-wide container.
+function createResizeObserverMock() {
+	global.ResizeObserver = class {
+		constructor( callback ) {
+			this.callback = callback;
+		}
+		observe() {
+			this.callback( [ { contentRect: { width: 300 } } ] );
+		}
+		disconnect() {}
+	};
+}
+
+/**
+ * Helper: simulate iframe onLoad and stub contentDocument so
+ * handleIframeLoad resolves immediately (no pending assets).
+ */
+function simulateIframeLoad( iframe ) {
+	Object.defineProperty( iframe, 'contentDocument', {
+		value: {
+			querySelectorAll: () => [],
+			body: { scrollHeight: 900 },
+		},
+		configurable: true,
+	} );
+	iframe.dispatchEvent( new Event( 'load' ) );
+}
+
+describe( 'EmailPreview', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		createObserverMock( true );
+		createResizeObserverMock();
+	} );
+
+	afterAll( () => {
+		// Restore (or delete) the observer globals so they don't leak
+		// into whatever suite Jest runs next in the same worker.
+		if ( undefined === originalIntersectionObserver ) {
+			delete global.IntersectionObserver;
+		} else {
+			global.IntersectionObserver = originalIntersectionObserver;
+		}
+		if ( undefined === originalResizeObserver ) {
+			delete global.ResizeObserver;
+		} else {
+			global.ResizeObserver = originalResizeObserver;
+		}
+	} );
+
+	it( 'renders loading state while fetching', async () => {
+		// Keep the promise pending so we can observe the loading state.
+		apiFetch.mockReturnValue( new Promise( () => {} ) );
+
+		render( <EmailPreview postId={ 123 } /> );
+
+		expect( document.querySelector( '.newspack-email-preview__placeholder' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders iframe on successful fetch and gains is-ready after load', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Hello Sample Reader</p></body></html>',
+			id: 123,
+		} );
+
+		render( <EmailPreview postId={ 123 } /> );
+
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Sample Reader' );
+		} );
+
+		// Simulate iframe load (also fires automatically in jsdom, but explicit
+		// call ensures the contentDocument stub is in place for assertion).
+		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+		simulateIframeLoad( iframe );
+
+		const container = document.querySelector( '.newspack-email-preview' );
+		await waitFor( () => {
+			expect( container.classList.contains( 'is-ready' ) ).toBe( true );
+		} );
+	} );
+
+	it( 'renders fallback placeholder on fetch error', async () => {
+		apiFetch.mockRejectedValue( new Error( 'Server error' ) );
+
+		render( <EmailPreview postId={ 456 } /> );
+
+		await waitFor( () => {
+			const placeholder = document.querySelector( '.newspack-email-preview__placeholder' );
+			expect( placeholder ).toBeTruthy();
+			// No iframe should be present.
+			expect( document.querySelector( '.newspack-email-preview__iframe' ) ).toBeNull();
+		} );
+	} );
+
+	it( 'does not fetch until element is visible', () => {
+		// Observer that does NOT trigger intersection.
+		createObserverMock( false );
+
+		render( <EmailPreview postId={ 789 } /> );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches the correct endpoint path', async () => {
+		apiFetch.mockResolvedValue( { html: '<p>Test</p>', id: 42 } );
+
+		render( <EmailPreview postId={ 42 } /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/42/preview',
+			} );
+		} );
+	} );
+
+	it( 'resets state when postId changes', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>First email</p></body></html>',
+			id: 1,
+		} );
+
+		const { rerender } = render( <EmailPreview postId={ 1 } /> );
+
+		// Wait for first render to complete.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+		} );
+
+		// Simulate onLoad for first email.
+		simulateIframeLoad( document.querySelector( '.newspack-email-preview__iframe' ) );
+		await waitFor( () => {
+			expect( document.querySelector( '.newspack-email-preview' ).classList.contains( 'is-ready' ) ).toBe( true );
+		} );
+
+		// Change postId — should reset and re-fetch.
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Second email</p></body></html>',
+			id: 2,
+		} );
+
+		rerender( <EmailPreview postId={ 2 } /> );
+
+		// New iframe should appear with updated content.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		} );
+	} );
+
+	it( 'cancelled fetch does not update state when postId changes mid-flight', async () => {
+		// First fetch: controlled promise that resolves AFTER the second.
+		let resolveFirst;
+		const firstPromise = new Promise( resolve => {
+			resolveFirst = resolve;
+		} );
+		apiFetch.mockReturnValueOnce( firstPromise );
+
+		const { rerender } = render( <EmailPreview postId={ 1 } /> );
+
+		// Change postId before first fetch resolves.
+		apiFetch.mockResolvedValueOnce( {
+			html: '<html><body><p>Second email</p></body></html>',
+			id: 2,
+		} );
+
+		rerender( <EmailPreview postId={ 2 } /> );
+
+		// Wait for second fetch to render.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		} );
+
+		// Now resolve the first (stale) fetch — it should NOT overwrite the iframe.
+		await act( async () => {
+			resolveFirst( {
+				html: '<html><body><p>First email (stale)</p></body></html>',
+				id: 1,
+			} );
+		} );
+
+		// The iframe should still show the second email, not the stale first.
+		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+		expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		expect( iframe.getAttribute( 'srcdoc' ) ).not.toContain( 'First email' );
+	} );
+
+	// Slice 2b.2 widened the prop type from `number` to `number | string`
+	// to accept `wc:{id}` identifiers (WC classic-template emails). The
+	// component is API-shape-agnostic — these tests verify that string
+	// postIds flow through the path interpolation and into the iframe
+	// just like numeric ones.
+
+	it( 'fetches the correct endpoint path for a wc: string postId', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<p>WC Preview</p>',
+			id: 'wc:customer_payment_retry',
+		} );
+
+		render( <EmailPreview postId="wc:customer_payment_retry" /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/wc:customer_payment_retry/preview',
+			} );
+		} );
+	} );
+
+	it( 'renders iframe for a wc: string postId', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Classic WC email</p></body></html>',
+			id: 'wc:expired_subscription',
+		} );
+
+		render( <EmailPreview postId="wc:expired_subscription" /> );
+
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Classic WC email' );
+		} );
+	} );
+
+	// Note: The safety timeout (8s fallback for slow assets) and the iframe
+	// onError handler are not tested here because jsdom automatically fires
+	// the iframe load event when srcDoc is set, which prevents us from
+	// simulating pending-asset scenarios. These defensive measures work in
+	// real browsers but require an integration/e2e test environment.
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -1,0 +1,256 @@
+/**
+ * EmailPreview — renders a scaled thumbnail of an email template.
+ *
+ * Lazy-loads via IntersectionObserver: the REST fetch only fires once the
+ * component scrolls into view. On success an iframe with srcDoc displays the
+ * rendered HTML; on error an envelope icon placeholder is shown instead.
+ *
+ * Rendering contract mirrors NewsletterPreview in newspack-newsletters:
+ * 848 px source viewport, 1 : 1 aspect ratio, fade-in via `is-ready` class,
+ * and iframe height measured from the loaded document.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+import { Icon, envelope } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import './email-preview.scss';
+
+interface EmailPreviewProps {
+	// Accepts both numeric post IDs (newspack_rr_email posts and WC
+	// block-editor template posts) and `wc:{email_id}` strings (WC
+	// classic-template emails routed through Email_Preview's wc: branch).
+	postId: number | string;
+}
+
+const IFRAME_WIDTH = 848;
+
+const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
+	const containerRef = useRef< HTMLDivElement >( null );
+	const iframeRef = useRef< HTMLIFrameElement >( null );
+	const safetyTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const [ isVisible, setIsVisible ] = useState( false );
+	const [ html, setHtml ] = useState< string | null >( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ hasError, setHasError ] = useState( false );
+	const [ scale, setScale ] = useState< number | null >( null );
+	const [ iframeHeight, setIframeHeight ] = useState< number | null >( null );
+	const [ isReady, setIsReady ] = useState( false );
+
+	// Observe visibility — fetch only when the thumbnail enters the viewport.
+	useEffect( () => {
+		if ( isVisible ) {
+			return;
+		}
+		if ( typeof IntersectionObserver === 'undefined' ) {
+			setIsVisible( true );
+			return;
+		}
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			entries => {
+				if ( entries[ 0 ]?.isIntersecting ) {
+					setIsVisible( true );
+				}
+			},
+			{ rootMargin: '200px' }
+		);
+
+		observer.observe( node );
+		return () => observer.disconnect();
+	}, [ isVisible ] );
+
+	// Measure container width and compute iframe scale.
+	useEffect( () => {
+		if ( typeof ResizeObserver === 'undefined' ) {
+			setScale( 1 );
+			return;
+		}
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const ro = new ResizeObserver( ( [ entry ] ) => {
+			setScale( entry.contentRect.width / IFRAME_WIDTH );
+		} );
+
+		ro.observe( node );
+		return () => ro.disconnect();
+	}, [] );
+
+	// Fetch preview HTML once visible. Cancel on postId change or unmount.
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		// Clear any lingering safety timer from a previous postId.
+		if ( safetyTimerRef.current ) {
+			clearTimeout( safetyTimerRef.current );
+			safetyTimerRef.current = null;
+		}
+
+		setIsLoading( true );
+		setIsReady( false );
+		setIframeHeight( null );
+		setHasError( false );
+		setHtml( null );
+		apiFetch< { html: string; id: number | string } >( {
+			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
+		} )
+			.then( response => {
+				if ( ! cancelled ) {
+					setHtml( response.html );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setHasError( true );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+		};
+	}, [ isVisible, postId ] );
+
+	// Handle iframe load: wait for stylesheets and images, then measure height and reveal.
+	const handleIframeLoad = useCallback( () => {
+		const doc = iframeRef.current?.contentDocument;
+		if ( ! doc ) {
+			return;
+		}
+
+		// Wire up listeners before checking loaded state to avoid a race where
+		// the asset finishes between the check and the listener attachment.
+		const awaitLink = ( link: HTMLLinkElement ) =>
+			new Promise< void >( resolve => {
+				link.addEventListener( 'load', () => resolve(), { once: true } );
+				link.addEventListener( 'error', () => resolve(), { once: true } );
+				if ( link.sheet ) {
+					resolve();
+				}
+			} );
+		const awaitImg = ( img: HTMLImageElement ) =>
+			new Promise< void >( resolve => {
+				img.addEventListener( 'load', () => resolve(), { once: true } );
+				img.addEventListener( 'error', () => resolve(), { once: true } );
+				if ( img.complete ) {
+					resolve();
+				}
+			} );
+
+		const linkPromises = Array.from( doc.querySelectorAll< HTMLLinkElement >( 'link[rel="stylesheet"]' ) ).map( awaitLink );
+		const imgPromises = Array.from( doc.querySelectorAll< HTMLImageElement >( 'img' ) ).map( awaitImg );
+
+		let finalized = false;
+		const finalize = () => {
+			if ( finalized ) {
+				return;
+			}
+			finalized = true;
+			// Guard against postId changing mid-load: by the time the
+			// Promise.all resolves (or the 8s safety fires), the iframe
+			// may have been re-mounted with a different srcDoc — check
+			// that the captured `doc` still belongs to the live iframe
+			// before applying its measurements to component state.
+			if ( iframeRef.current?.contentDocument !== doc ) {
+				return;
+			}
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+			setIframeHeight( doc.body.scrollHeight );
+			setIsReady( true );
+		};
+
+		// 8 s safety so a slow asset never strands the spinner.
+		safetyTimerRef.current = setTimeout( finalize, 8000 );
+
+		Promise.all( [ ...linkPromises, ...imgPromises ] ).then( finalize );
+	}, [] );
+
+	const showSpinner = ! hasError && ! isReady && ( isLoading || Boolean( html ) );
+
+	return (
+		<div ref={ containerRef } className={ `newspack-email-preview${ isReady ? ' is-ready' : '' }` }>
+			{ showSpinner && (
+				<div className="newspack-email-preview__placeholder">
+					<Spinner />
+				</div>
+			) }
+			{ hasError && (
+				<div className="newspack-email-preview__placeholder">
+					<Icon icon={ envelope } size={ 48 } />
+				</div>
+			) }
+			{ html && ! hasError && scale !== null && scale > 0 && (
+				<iframe
+					ref={ iframeRef }
+					className="newspack-email-preview__iframe"
+					srcDoc={ html }
+					/* sandbox: allow-same-origin is required so handleIframeLoad can
+					 * read contentDocument (body.scrollHeight, stylesheet load state).
+					 * Without allow-scripts, JS cannot execute. Without allow-forms,
+					 * form submissions are blocked.
+					 *
+					 * SECURITY: DO NOT add `allow-scripts` here without ALSO removing
+					 * `allow-same-origin`. The combination `allow-same-origin allow-scripts`
+					 * is equivalent to no sandbox at all — JS inside the iframe can
+					 * reach `top.document` and exfiltrate the admin nonce. The srcDoc
+					 * content includes admin-supplied HTML (EMAIL_HTML_META) and
+					 * publisher-controlled values like the site title, so the
+					 * sandbox is load-bearing for XSS containment. If interactive
+					 * previews are needed later, use `allow-scripts` only and
+					 * communicate height via postMessage instead of contentDocument
+					 * reads.
+					 *
+					 * NOTE: `<meta http-equiv="refresh">` still works inside a
+					 * srcDoc iframe with `allow-same-origin` even without
+					 * `allow-scripts`. It's not a security issue (the email HTML
+					 * is admin-supplied), but a meta-refresh in a publisher's
+					 * template would make this thumbnail reload every N seconds
+					 * and spin the CPU. If that's ever observed, strip
+					 * meta-refresh tags from the preview HTML server-side. */
+					aria-hidden="true"
+					sandbox="allow-same-origin"
+					tabIndex={ -1 }
+					title={ __( 'Email preview', 'newspack-plugin' ) }
+					onLoad={ handleIframeLoad }
+					onError={ () => setHasError( true ) }
+					style={ {
+						transform: `scale(${ scale })`,
+						height: iframeHeight ? `${ iframeHeight }px` : undefined,
+					} }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default EmailPreview;

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -1,0 +1,228 @@
+/**
+ * EmailPreview — renders a scaled thumbnail of an email template.
+ *
+ * Lazy-loads via IntersectionObserver: the REST fetch only fires once the
+ * component scrolls into view. On success an iframe with srcDoc displays the
+ * rendered HTML; on error an envelope icon placeholder is shown instead.
+ *
+ * Rendering contract mirrors NewsletterPreview in newspack-newsletters:
+ * 848 px source viewport, 1 : 1 aspect ratio, fade-in via `is-ready` class,
+ * and iframe height measured from the loaded document.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+import { Icon, envelope } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import './email-preview.scss';
+
+interface EmailPreviewProps {
+	// Accepts both numeric post IDs (newspack_rr_email posts and WC
+	// block-editor template posts) and `wc:{email_id}` strings (WC
+	// classic-template emails routed through Email_Preview's wc: branch).
+	postId: number | string;
+}
+
+const IFRAME_WIDTH = 848;
+
+const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
+	const containerRef = useRef< HTMLDivElement >( null );
+	const iframeRef = useRef< HTMLIFrameElement >( null );
+	const safetyTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const [ isVisible, setIsVisible ] = useState( false );
+	const [ html, setHtml ] = useState< string | null >( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ hasError, setHasError ] = useState( false );
+	const [ scale, setScale ] = useState< number | null >( null );
+	const [ iframeHeight, setIframeHeight ] = useState< number | null >( null );
+	const [ isReady, setIsReady ] = useState( false );
+
+	// Observe visibility — fetch only when the thumbnail enters the viewport.
+	useEffect( () => {
+		if ( isVisible ) {
+			return;
+		}
+		if ( typeof IntersectionObserver === 'undefined' ) {
+			setIsVisible( true );
+			return;
+		}
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			entries => {
+				if ( entries[ 0 ]?.isIntersecting ) {
+					setIsVisible( true );
+				}
+			},
+			{ rootMargin: '200px' }
+		);
+
+		observer.observe( node );
+		return () => observer.disconnect();
+	}, [ isVisible ] );
+
+	// Measure container width and compute iframe scale.
+	useEffect( () => {
+		if ( typeof ResizeObserver === 'undefined' ) {
+			setScale( 1 );
+			return;
+		}
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const ro = new ResizeObserver( ( [ entry ] ) => {
+			setScale( entry.contentRect.width / IFRAME_WIDTH );
+		} );
+
+		ro.observe( node );
+		return () => ro.disconnect();
+	}, [] );
+
+	// Fetch preview HTML once visible. Cancel on postId change or unmount.
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		// Clear any lingering safety timer from a previous postId.
+		if ( safetyTimerRef.current ) {
+			clearTimeout( safetyTimerRef.current );
+			safetyTimerRef.current = null;
+		}
+
+		setIsLoading( true );
+		setIsReady( false );
+		setIframeHeight( null );
+		setHasError( false );
+		setHtml( null );
+		apiFetch< { html: string; id: number | string } >( {
+			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
+		} )
+			.then( response => {
+				if ( ! cancelled ) {
+					setHtml( response.html );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setHasError( true );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+		};
+	}, [ isVisible, postId ] );
+
+	// Handle iframe load: wait for stylesheets and images, then measure height and reveal.
+	const handleIframeLoad = useCallback( () => {
+		const doc = iframeRef.current?.contentDocument;
+		if ( ! doc ) {
+			return;
+		}
+
+		// Wire up listeners before checking loaded state to avoid a race where
+		// the asset finishes between the check and the listener attachment.
+		const awaitLink = ( link: HTMLLinkElement ) =>
+			new Promise< void >( resolve => {
+				link.addEventListener( 'load', () => resolve(), { once: true } );
+				link.addEventListener( 'error', () => resolve(), { once: true } );
+				if ( link.sheet ) {
+					resolve();
+				}
+			} );
+		const awaitImg = ( img: HTMLImageElement ) =>
+			new Promise< void >( resolve => {
+				img.addEventListener( 'load', () => resolve(), { once: true } );
+				img.addEventListener( 'error', () => resolve(), { once: true } );
+				if ( img.complete ) {
+					resolve();
+				}
+			} );
+
+		const linkPromises = Array.from( doc.querySelectorAll< HTMLLinkElement >( 'link[rel="stylesheet"]' ) ).map( awaitLink );
+		const imgPromises = Array.from( doc.querySelectorAll< HTMLImageElement >( 'img' ) ).map( awaitImg );
+
+		let finalized = false;
+		const finalize = () => {
+			if ( finalized ) {
+				return;
+			}
+			finalized = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+			setIframeHeight( doc.body.scrollHeight );
+			setIsReady( true );
+		};
+
+		// 8 s safety so a slow asset never strands the spinner.
+		safetyTimerRef.current = setTimeout( finalize, 8000 );
+
+		Promise.all( [ ...linkPromises, ...imgPromises ] ).then( finalize );
+	}, [] );
+
+	const showSpinner = ! hasError && ! isReady && ( isLoading || Boolean( html ) );
+
+	return (
+		<div ref={ containerRef } className={ `newspack-email-preview${ isReady ? ' is-ready' : '' }` }>
+			{ showSpinner && (
+				<div className="newspack-email-preview__placeholder">
+					<Spinner />
+				</div>
+			) }
+			{ hasError && (
+				<div className="newspack-email-preview__placeholder">
+					<Icon icon={ envelope } size={ 48 } />
+				</div>
+			) }
+			{ html && ! hasError && scale !== null && scale > 0 && (
+				<iframe
+					ref={ iframeRef }
+					className="newspack-email-preview__iframe"
+					srcDoc={ html }
+					/* sandbox: allow-same-origin is required so handleIframeLoad can
+					 * read contentDocument (body.scrollHeight, stylesheet load state).
+					 * Without allow-scripts, JS cannot execute. Without allow-forms,
+					 * form submissions are blocked. */
+					sandbox="allow-same-origin"
+					tabIndex={ -1 }
+					title={ __( 'Email preview', 'newspack-plugin' ) }
+					onLoad={ handleIframeLoad }
+					onError={ () => setHasError( true ) }
+					style={ {
+						transform: `scale(${ scale })`,
+						height: iframeHeight ? `${ iframeHeight }px` : undefined,
+					} }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default EmailPreview;

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -173,6 +173,14 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 				return;
 			}
 			finalized = true;
+			// Guard against postId changing mid-load: by the time the
+			// Promise.all resolves (or the 8s safety fires), the iframe
+			// may have been re-mounted with a different srcDoc — check
+			// that the captured `doc` still belongs to the live iframe
+			// before applying its measurements to component state.
+			if ( iframeRef.current?.contentDocument !== doc ) {
+				return;
+			}
 			if ( safetyTimerRef.current ) {
 				clearTimeout( safetyTimerRef.current );
 				safetyTimerRef.current = null;
@@ -209,7 +217,18 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					/* sandbox: allow-same-origin is required so handleIframeLoad can
 					 * read contentDocument (body.scrollHeight, stylesheet load state).
 					 * Without allow-scripts, JS cannot execute. Without allow-forms,
-					 * form submissions are blocked. */
+					 * form submissions are blocked.
+					 *
+					 * SECURITY: DO NOT add `allow-scripts` here without ALSO removing
+					 * `allow-same-origin`. The combination `allow-same-origin allow-scripts`
+					 * is equivalent to no sandbox at all — JS inside the iframe can
+					 * reach `top.document` and exfiltrate the admin nonce. The srcDoc
+					 * content includes admin-supplied HTML (EMAIL_HTML_META) and
+					 * publisher-controlled values like the site title, so the
+					 * sandbox is load-bearing for XSS containment. If interactive
+					 * previews are needed later, use `allow-scripts` only and
+					 * communicate height via postMessage instead of contentDocument
+					 * reads. */
 					sandbox="allow-same-origin"
 					tabIndex={ -1 }
 					title={ __( 'Email preview', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -83,6 +83,30 @@
 	}
 }
 
+// Preview-tile anchor — wraps the EmailPreview iframe in the
+// DataViews media slot. Clicking the tile navigates to the email's
+// edit page (mirrors the title link).
+//
+// The anchor needs a visible focus ring even though its child is an
+// iframe with `pointer-events: none` and `tabIndex=-1` — the anchor
+// is the only keyboard-navigable element in this tile, and assistive
+// tech reads its aria-label ("Edit {email label}"). Without a focus
+// ring, keyboard users can't tell when the tile is focused.
+.newspack-emails-tab .newspack-emails__preview-link {
+	display: block;
+	border-radius: 4px;
+	text-decoration: none;
+
+	// Matches the design-system canonical `outline: 2px solid;
+	// outline-offset: 1px;` used by the sibling .newspack-emails__name-link.
+	// Consistency over tile-size customisation — both anchors in this
+	// view get the same focus treatment.
+	&:focus-visible {
+		outline: 2px solid;
+		outline-offset: 1px;
+	}
+}
+
 // Clickable name link in grid/table view.
 // Scope under `.newspack-emails-tab` (2-class specificity) so the rule
 // wins against WP's default `a` link color, which would otherwise paint

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -89,9 +89,13 @@
 	border-radius: 4px;
 	text-decoration: none;
 
+	// Matches the design-system canonical `outline: 2px solid;
+	// outline-offset: 1px;` used by the sibling .newspack-emails__name-link.
+	// Consistency over tile-size customisation — both anchors in this
+	// view get the same focus treatment.
 	&:focus-visible {
 		outline: 2px solid;
-		outline-offset: 2px;
+		outline-offset: 1px;
 	}
 }
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -75,6 +75,26 @@
 	}
 }
 
+// Preview-tile anchor — wraps the EmailPreview iframe in the
+// DataViews media slot. Clicking the tile navigates to the email's
+// edit page (mirrors the title link).
+//
+// The anchor needs a visible focus ring even though its child is an
+// iframe with `pointer-events: none` and `tabIndex=-1` — the anchor
+// is the only keyboard-navigable element in this tile, and assistive
+// tech reads its aria-label ("Edit {email label}"). Without a focus
+// ring, keyboard users can't tell when the tile is focused.
+.newspack-emails-tab .newspack-emails__preview-link {
+	display: block;
+	border-radius: 4px;
+	text-decoration: none;
+
+	&:focus-visible {
+		outline: 2px solid;
+		outline-offset: 2px;
+	}
+}
+
 // Clickable name link in grid/table view.
 // Scope under `.newspack-emails-tab` (2-class specificity) so the rule
 // wins against WP's default `a` link color, which would otherwise paint

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -86,6 +86,17 @@ jest.mock(
 		}
 );
 
+// Mock EmailPreview so we don't run its IntersectionObserver +
+// apiFetch in every emails test. The stub exposes the postId prop
+// via a data-attribute so the preview-field tests can assert which
+// id reached the component for each row.
+jest.mock( './email-preview', () => ( {
+	__esModule: true,
+	default: function MockEmailPreview( { postId } ) {
+		return <div data-testid="email-preview-stub" data-post-id={ String( postId ) } />;
+	},
+} ) );
+
 // Fixtures span both chips and both sources so the chip-filter and
 // type-routing tests have meaningful data on either side of the toggle.
 const mockEmails = [
@@ -155,10 +166,12 @@ const mockEmails = [
 		chip: 'reader-revenue',
 	},
 	// WC-source, reader-revenue chip, admin recipient, currently enabled —
-	// exercises the deactivate→toggleWcEmail route (string post_id).
+	// exercises the deactivate→toggleWcEmail route (string post_id) AND
+	// the BLOCK-template preview path (preview_id is an integer post ID).
 	{
 		label: 'New order',
 		post_id: 'wc:new_order',
+		preview_id: 999,
 		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order',
 		status: 'publish',
 		type: 'new_order',
@@ -170,10 +183,12 @@ const mockEmails = [
 		chip: 'reader-revenue',
 	},
 	// WC-source, auth-account chip, currently disabled — exercises the
-	// activate→toggleWcEmail route (string post_id).
+	// activate→toggleWcEmail route (string post_id) AND the CLASSIC
+	// preview path (preview_id is a wc:{id} string, no block template).
 	{
 		label: 'New account',
 		post_id: 'wc:customer_new_account',
+		preview_id: 'wc:customer_new_account',
 		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_new_account',
 		status: 'draft',
 		type: 'customer_new_account',
@@ -693,6 +708,59 @@ describe( 'Emails', () => {
 		} );
 		await waitFor( () => {
 			expect( screen.getByRole( 'button', { name: 'Reader revenue' } ).getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		} );
+	} );
+
+	// Slice 2b.5 — DataViews preview field. The render uses a smart
+	// fallback: `item.preview_id ?? item.post_id` (with a typeof guard
+	// rejecting wc:strings as a fallback target). Newspack rows have no
+	// preview_id, so they fall back to their integer post_id. WC rows
+	// emit preview_id directly — integer for block-template emails,
+	// `wc:{id}` string for classic-template emails.
+
+	it( 'preview field renders an anchor with aria-label for each row', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Default chip = reader-revenue: receipt, cancellation, welcome,
+		// new order. Each row's preview field renders an anchor with an
+		// aria-label of the form "Edit {label}".
+		expect( screen.getByRole( 'link', { name: 'Edit Payment receipt' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Edit Cancellation confirmation' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Edit Welcome email' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Edit New order' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'preview field passes the right id to EmailPreview for each render path', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const previews = screen.getAllByTestId( 'email-preview-stub' );
+		const ids = previews.map( el => el.getAttribute( 'data-post-id' ) );
+
+		// Default chip = reader-revenue. Expected ids on this chip:
+		// - Newspack rows fall back to integer post_id: receipt=1,
+		//   cancellation=2, welcome=5
+		// - WC block-template row uses preview_id (integer): new_order=999
+		expect( ids ).toEqual( expect.arrayContaining( [ '1', '2', '5', '999' ] ) );
+
+		// Switch to auth-account chip so the WC classic row surfaces.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Authentication & account' } ) );
+
+		await waitFor( () => {
+			const aaPreviews = screen.getAllByTestId( 'email-preview-stub' );
+			const aaIds = aaPreviews.map( el => el.getAttribute( 'data-post-id' ) );
+			// Newspack RA fallback: verification=3, delete-account=4.
+			// WC classic row uses preview_id (string): customer_new_account.
+			expect( aaIds ).toEqual( expect.arrayContaining( [ '3', '4', 'wc:customer_new_account' ] ) );
 		} );
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -86,6 +86,17 @@ jest.mock(
 		}
 );
 
+// Mock EmailPreview so we don't run its IntersectionObserver +
+// apiFetch in every emails test. The stub exposes the postId prop
+// via a data-attribute so the preview-field tests can assert which
+// id reached the component for each row.
+jest.mock( './email-preview', () => ( {
+	__esModule: true,
+	default: function MockEmailPreview( { postId } ) {
+		return <div data-testid="email-preview-stub" data-post-id={ String( postId ) } />;
+	},
+} ) );
+
 // Fixtures span both chips and both sources so the chip-filter and
 // type-routing tests have meaningful data on either side of the toggle.
 const mockEmails = [
@@ -155,10 +166,12 @@ const mockEmails = [
 		chip: 'reader-revenue',
 	},
 	// WC-source, reader-revenue chip, admin recipient, currently enabled —
-	// exercises the deactivate→toggleWcEmail route (string post_id).
+	// exercises the deactivate→toggleWcEmail route (string post_id) AND
+	// the BLOCK-template preview path (preview_id is an integer post ID).
 	{
 		label: 'New order',
 		post_id: 'wc:new_order',
+		preview_id: 999,
 		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order',
 		status: 'publish',
 		type: 'new_order',
@@ -170,10 +183,12 @@ const mockEmails = [
 		chip: 'reader-revenue',
 	},
 	// WC-source, auth-account chip, currently disabled — exercises the
-	// activate→toggleWcEmail route (string post_id).
+	// activate→toggleWcEmail route (string post_id) AND the CLASSIC
+	// preview path (preview_id is a wc:{id} string, no block template).
 	{
 		label: 'New account',
 		post_id: 'wc:customer_new_account',
+		preview_id: 'wc:customer_new_account',
 		edit_link: '/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_new_account',
 		status: 'draft',
 		type: 'customer_new_account',
@@ -621,6 +636,59 @@ describe( 'Emails', () => {
 		} );
 		await waitFor( () => {
 			expect( screen.getByRole( 'button', { name: 'Reader revenue' } ).getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		} );
+	} );
+
+	// Slice 2b.5 — DataViews preview field. The render uses a smart
+	// fallback: `item.preview_id ?? item.post_id` (with a typeof guard
+	// rejecting wc:strings as a fallback target). Newspack rows have no
+	// preview_id, so they fall back to their integer post_id. WC rows
+	// emit preview_id directly — integer for block-template emails,
+	// `wc:{id}` string for classic-template emails.
+
+	it( 'preview field renders an anchor with aria-label for each row', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		// Default chip = reader-revenue: receipt, cancellation, welcome,
+		// new order. Each row's preview field renders an anchor with an
+		// aria-label of the form "Edit {label}".
+		expect( screen.getByRole( 'link', { name: 'Edit Payment receipt' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Edit Cancellation confirmation' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Edit Welcome email' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Edit New order' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'preview field passes the right id to EmailPreview for each render path', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const previews = screen.getAllByTestId( 'email-preview-stub' );
+		const ids = previews.map( el => el.getAttribute( 'data-post-id' ) );
+
+		// Default chip = reader-revenue. Expected ids on this chip:
+		// - Newspack rows fall back to integer post_id: receipt=1,
+		//   cancellation=2, welcome=5
+		// - WC block-template row uses preview_id (integer): new_order=999
+		expect( ids ).toEqual( expect.arrayContaining( [ '1', '2', '5', '999' ] ) );
+
+		// Switch to auth-account chip so the WC classic row surfaces.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Authentication & account' } ) );
+
+		await waitFor( () => {
+			const aaPreviews = screen.getAllByTestId( 'email-preview-stub' );
+			const aaIds = aaPreviews.map( el => el.getAttribute( 'data-post-id' ) );
+			// Newspack RA fallback: verification=3, delete-account=4.
+			// WC classic row uses preview_id (string): customer_new_account.
+			expect( aaIds ).toEqual( expect.arrayContaining( [ '3', '4', 'wc:customer_new_account' ] ) );
 		} );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
@@ -17,6 +17,7 @@ import { Button } from '@wordpress/components';
 import { Badge, DataViews, Notice, utils } from '../../../../../../packages/components/src';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+import EmailPreview from './email-preview';
 import './emails.scss';
 
 interface EmailItem {
@@ -26,6 +27,12 @@ interface EmailItem {
 	// The activate/deactivate action callbacks branch on `typeof` to route
 	// the write through the correct endpoint.
 	post_id: number | string;
+	// Preview identifier the EmailPreview component sends to the
+	// /preview endpoint. Newspack rows don't emit this — the field
+	// render falls back to post_id. WC rows emit either an integer
+	// (block-editor template post) or a `wc:{id}` string (classic
+	// template) via the smart fallback in serialize_wc_email_row.
+	preview_id?: number | string | null;
 	edit_link: string;
 	status: string;
 	type: string;
@@ -54,6 +61,9 @@ const DEFAULT_VIEW: View = {
 	layout: {},
 	titleField: 'name',
 	descriptionField: 'trigger_description',
+	// v14 grid layout resolves this to find the field by id and
+	// render it as the card's media tile (top of each card).
+	mediaField: 'preview',
 };
 
 const PageHeading = () => <h1 className="screen-reader-text">{ __( 'Emails', 'newspack-plugin' ) }</h1>;
@@ -208,6 +218,41 @@ const Emails = () => {
 
 	const fields: Field< EmailItem >[] = useMemo(
 		() => [
+			{
+				id: 'preview',
+				label: __( 'Preview', 'newspack-plugin' ),
+				type: 'media',
+				enableSorting: false,
+				enableHiding: true,
+				render: ( { item }: { item: EmailItem } ) => {
+					// Smart fallback: WC rows emit `preview_id` via
+					// serialize_wc_email_row (integer block-template post ID
+					// or `wc:{id}` string). Newspack rows don't emit it —
+					// they use their own integer post_id as the preview id
+					// (the REST endpoint routes by post_type).
+					const previewId = item.preview_id ?? ( typeof item.post_id === 'number' ? item.post_id : null );
+					if ( ! previewId ) {
+						return null;
+					}
+					// aria-label gives the anchor an accessible name —
+					// the iframe inside has tabIndex=-1 and only a
+					// generic "Email preview" title, so the wrapper
+					// anchor is what assistive tech announces.
+					return (
+						<a
+							href={ item.edit_link }
+							className="newspack-emails__preview-link"
+							aria-label={ sprintf(
+								/* translators: %s: email label. */
+								__( 'Edit %s', 'newspack-plugin' ),
+								item.label
+							) }
+						>
+							<EmailPreview postId={ previewId } />
+						</a>
+					);
+				},
+			},
 			{
 				id: 'name',
 				label: __( 'Email', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
@@ -17,6 +17,7 @@ import { Button } from '@wordpress/components';
 import { Badge, DataViews, Notice, utils } from '../../../../../../packages/components/src';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+import EmailPreview from './email-preview';
 import './emails.scss';
 
 interface EmailItem {
@@ -26,6 +27,12 @@ interface EmailItem {
 	// The activate/deactivate action callbacks branch on `typeof` to route
 	// the write through the correct endpoint.
 	post_id: number | string;
+	// Preview identifier the EmailPreview component sends to the
+	// /preview endpoint. Newspack rows don't emit this — the field
+	// render falls back to post_id. WC rows emit either an integer
+	// (block-editor template post) or a `wc:{id}` string (classic
+	// template) via the smart fallback in serialize_wc_email_row.
+	preview_id?: number | string | null;
 	edit_link: string;
 	status: string;
 	type: string;
@@ -54,6 +61,9 @@ const DEFAULT_VIEW: View = {
 	layout: {},
 	titleField: 'name',
 	descriptionField: 'trigger_description',
+	// v14 grid layout resolves this to find the field by id and
+	// render it as the card's media tile (top of each card).
+	mediaField: 'preview',
 };
 
 const PageHeading = () => <h1 className="screen-reader-text">{ __( 'Emails', 'newspack-plugin' ) }</h1>;
@@ -199,6 +209,41 @@ const Emails = () => {
 
 	const fields: Field< EmailItem >[] = useMemo(
 		() => [
+			{
+				id: 'preview',
+				label: __( 'Preview', 'newspack-plugin' ),
+				type: 'media',
+				enableSorting: false,
+				enableHiding: true,
+				render: ( { item }: { item: EmailItem } ) => {
+					// Smart fallback: WC rows emit `preview_id` via
+					// serialize_wc_email_row (integer block-template post ID
+					// or `wc:{id}` string). Newspack rows don't emit it —
+					// they use their own integer post_id as the preview id
+					// (the REST endpoint routes by post_type).
+					const previewId = item.preview_id ?? ( typeof item.post_id === 'number' ? item.post_id : null );
+					if ( ! previewId ) {
+						return null;
+					}
+					// aria-label gives the anchor an accessible name —
+					// the iframe inside has tabIndex=-1 and only a
+					// generic "Email preview" title, so the wrapper
+					// anchor is what assistive tech announces.
+					return (
+						<a
+							href={ item.edit_link }
+							className="newspack-emails__preview-link"
+							aria-label={ sprintf(
+								/* translators: %s: email label. */
+								__( 'Edit %s', 'newspack-plugin' ),
+								item.label
+							) }
+						>
+							<EmailPreview postId={ previewId } />
+						</a>
+					);
+				},
+			},
 			{
 				id: 'name',
 				label: __( 'Email', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/tests/unit-tests/email-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/email-preview.php
@@ -1,0 +1,508 @@
+<?php
+/**
+ * Tests Email_Preview.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Emails;
+use Newspack\Wizards\Newspack\Email_Preview;
+
+require_once __DIR__ . '/../mocks/newsletters-mocks.php';
+
+/**
+ * Tests Email_Preview.
+ */
+class Newspack_Test_Email_Preview extends WP_UnitTestCase {
+
+	/**
+	 * Test email config name.
+	 *
+	 * @var string
+	 */
+	private static $test_config_name = 'test-preview-config';
+
+	/**
+	 * Filter callback reference so it can be removed in tear_down().
+	 *
+	 * @var callable
+	 */
+	private $config_filter_callback;
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->config_filter_callback = function ( $types ) {
+			$types[ self::$test_config_name ] = [
+				'name'        => self::$test_config_name,
+				'label'       => __( 'Test preview config', 'newspack' ),
+				'description' => __( 'Email for testing preview.', 'newspack' ),
+				'template'    => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
+				'category'    => 'test',
+			];
+			return $types;
+		};
+		add_filter( 'newspack_email_configs', $this->config_filter_callback );
+		\Newspack\Emails::reset_email_configs_cache();
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_email_configs', $this->config_filter_callback );
+		\Newspack\Emails::reset_email_configs_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: create a newspack_rr_email post with the test config type.
+	 *
+	 * @param string $html Optional stored email HTML.
+	 * @return int Post ID.
+	 */
+	private function create_email_post( string $html = '' ): int {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, self::$test_config_name );
+		if ( ! empty( $html ) ) {
+			update_post_meta( $post_id, \Newspack_Newsletters::EMAIL_HTML_META, $html );
+		}
+		return $post_id;
+	}
+
+	/**
+	 * The substitution map has the expected three-key structure.
+	 */
+	public function test_sample_substitutions_structure() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		self::assertIsArray( $subs );
+		self::assertArrayHasKey( 'html', $subs, 'Missing "html" key.' );
+		self::assertArrayHasKey( 'url', $subs, 'Missing "url" key.' );
+		self::assertArrayHasKey( 'raw', $subs, 'Missing "raw" key.' );
+		self::assertCount( 3, $subs, 'Substitution map should have exactly 3 top-level keys.' );
+	}
+
+	/**
+	 * The sample-substitutions map contains all expected token keys.
+	 */
+	public function test_sample_substitutions_map() {
+		$subs = Email_Preview::get_sample_substitutions();
+		$all  = array_merge( $subs['html'], $subs['url'], $subs['raw'] );
+
+		self::assertGreaterThanOrEqual( 32, count( $all ), 'Substitution map should have at least 32 entries.' );
+
+		$expected_keys = [
+			'*SITE_TITLE*',
+			'*SITE_URL*',
+			'*SITE_LOGO*',
+			'*BILLING_NAME*',
+			'*BILLING_FIRST_NAME*',
+			'*AMOUNT*',
+			'*PAYMENT_METHOD*',
+			'*DATE*',
+			'*ACCOUNT_URL*',
+			'*MAGIC_LINK_OTP*',
+		];
+		foreach ( $expected_keys as $key ) {
+			self::assertArrayHasKey( $key, $all, "Missing expected token: $key" );
+		}
+	}
+
+	/**
+	 * HTML metacharacters in html-context tokens are escaped.
+	 */
+	public function test_html_tokens_are_escaped() {
+		$source_html = '<html><body>Hello *BILLING_FIRST_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Inject a malicious value via the filter.
+		$filter = function ( $subs ) {
+			$subs['html']['*BILLING_FIRST_NAME*'] = '<script>alert(1)</script>';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $filter );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( '&lt;script&gt;', $result, 'HTML metacharacters should be escaped.' );
+		self::assertStringNotContainsString( '<script>alert(1)</script>', $result, 'Raw script tag should not appear.' );
+
+		remove_filter( 'newspack_email_preview_substitutions', $filter );
+	}
+
+	/**
+	 * URL tokens reject dangerous protocols.
+	 */
+	public function test_url_tokens_are_sanitized() {
+		$source_html = '<html><body><a href="*ACCOUNT_URL*">Account</a></body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$filter = function ( $subs ) {
+			$subs['url']['*ACCOUNT_URL*'] = 'javascript:alert(1)';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $filter );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringNotContainsString( 'javascript:', $result, 'javascript: protocol should be rejected by esc_url().' );
+
+		remove_filter( 'newspack_email_preview_substitutions', $filter );
+	}
+
+	/**
+	 * Raw tokens preserve their pre-escaped HTML intact.
+	 */
+	public function test_raw_tokens_are_not_double_escaped() {
+		$source_html = '<html><body>Contact: *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( '<a href=', $result, 'CONTACT_EMAIL <a> tag should be preserved.' );
+		self::assertStringNotContainsString( '&lt;a href=', $result, 'CONTACT_EMAIL <a> tag should not be double-escaped.' );
+	}
+
+	/**
+	 * Raw-bucket value-construction escapes admin-controlled inputs.
+	 *
+	 * *SITE_CONTACT* lives in the 'raw' bucket (not re-escaped at
+	 * strtr-time), so the values built into it MUST be escaped at
+	 * construction. The bucket includes get_bloginfo('name') and the WC
+	 * store address — both admin-controlled. An admin (or a role-elevation
+	 * supply-chain attack) writing `<img onerror=...>` to the site title
+	 * must not flow through to the iframe's srcDoc raw.
+	 */
+	public function test_site_contact_escapes_admin_controlled_values() {
+		$original_blogname = get_option( 'blogname' );
+		update_option( 'blogname', 'Acme <img src=x onerror=alert(1)>' );
+
+		$source_html = '<html><body>From: *SITE_CONTACT*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		update_option( 'blogname', $original_blogname );
+
+		// The dangerous form is the unescaped HTML element — angle brackets
+		// must be escaped to `&lt;...&gt;`. The literal text `onerror=`
+		// inside escaped content (`&lt;img ... onerror=...&gt;`) is safe
+		// because the browser won't interpret it as an attribute.
+		self::assertStringNotContainsString(
+			'<img src=x',
+			$result,
+			'Raw-bucket *SITE_CONTACT* must escape the unescaped `<img>` tag.'
+		);
+		self::assertStringContainsString(
+			'&lt;img',
+			$result,
+			'Raw-bucket *SITE_CONTACT* must HTML-encode angle brackets in the site title.'
+		);
+	}
+
+	/**
+	 * CONTACT_EMAIL resolves through Emails::get_reply_to_email() — not admin_email.
+	 *
+	 * Pins the fix for the function_exists() bug: function_exists() cannot
+	 * test class methods, so the guard was always false and the token fell
+	 * back to admin_email regardless of the Reader Activation contact setting.
+	 */
+	public function test_contact_email_uses_reply_to_email() {
+		$custom_email = 'reply@example.org';
+		add_filter( 'newspack_reply_to_email', fn() => $custom_email );
+
+		$source_html = '<html><body>Contact us at *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( $custom_email, $result, 'CONTACT_EMAIL should resolve to the filtered reply-to address.' );
+		self::assertStringNotContainsString( '*CONTACT_EMAIL*', $result, 'Raw CONTACT_EMAIL token should not remain.' );
+
+		remove_all_filters( 'newspack_reply_to_email' );
+	}
+
+	/**
+	 * Tests that get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
+	 */
+	public function test_get_preview_html_with_stored_meta() {
+		$source_html = '<html><body>Hello *BILLING_NAME*, your total is *AMOUNT*.</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertStringContainsString( 'Sample Reader', $result, 'BILLING_NAME should be substituted.' );
+		self::assertStringContainsString( '$25.00', $result, 'AMOUNT should be substituted.' );
+		self::assertStringNotContainsString( '*BILLING_NAME*', $result, 'Raw token should not remain.' );
+		self::assertStringNotContainsString( '*AMOUNT*', $result, 'Raw token should not remain.' );
+	}
+
+	/**
+	 * Tests that get_preview_html() falls back to template HTML when no stored meta exists.
+	 */
+	public function test_get_preview_html_fallback_to_template() {
+		$post_id = $this->create_email_post();
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertNotEmpty( $result, 'Fallback to template should produce non-empty HTML.' );
+		// The receipt template contains "Thank you!" — verify substitution ran.
+		self::assertStringContainsString( 'Thank you!', $result );
+	}
+
+	/**
+	 * Tests that get_preview_html() returns false for a nonexistent post.
+	 */
+	public function test_get_preview_html_returns_false_for_nonexistent() {
+		$result = Email_Preview::get_preview_html( 999999 );
+		self::assertFalse( $result );
+	}
+
+	/**
+	 * Permission check rejects non-admin users.
+	 */
+	public function test_api_permissions_check_rejects_non_admin() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$result = Email_Preview::api_permissions_check();
+		self::assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * REST API returns 404 for a post that is not of the email post type.
+	 */
+	public function test_api_get_preview_returns_404_for_wrong_post_type() {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'id', (string) $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * REST API returns HTML and id on success.
+	 */
+	public function test_api_get_preview_returns_html() {
+		$source_html = '<html><body>Preview for *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'id', (string) $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_REST_Response', $response );
+
+		$data = $response->get_data();
+		self::assertArrayHasKey( 'html', $data );
+		self::assertArrayHasKey( 'id', $data );
+		self::assertEquals( $post_id, $data['id'] );
+		self::assertStringContainsString( 'Sample Reader', $data['html'] );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * wc:{id} route (slice 2b.2 — folded in from PR #4758)
+	 * ------------------------------------------------------------------
+	 * The route accepts `wc:{email_id}` strings alongside numeric post
+	 * IDs. Validation is against the unified email config schema
+	 * filtered to source==='woocommerce'. Routing picks block-editor
+	 * render when a template post exists, falls back to classic
+	 * render otherwise.
+	 */
+
+	/**
+	 * REST API returns 404 for a wc: identifier that doesn't resolve to a
+	 * woocommerce-source config in the unified schema.
+	 */
+	public function test_api_get_preview_returns_404_for_unregistered_wc_email() {
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:nonexistent_email/preview' );
+		$request->set_param( 'id', 'wc:nonexistent_email' );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * REST API also rejects wc: identifiers for configs whose source
+	 * isn't 'woocommerce' — guards against spoofing a newspack-source
+	 * config through the wc: branch.
+	 */
+	public function test_api_get_preview_rejects_wc_path_for_non_wc_source() {
+		// Inject a newspack-source config under a wc-style id key.
+		$callback = function ( $configs ) {
+			$configs['fake_wc_id'] = [
+				'name'     => 'fake_wc_id',
+				'source'   => 'newspack', // Wrong source — should reject the wc: path.
+				'category' => 'reader-revenue',
+			];
+			return $configs;
+		};
+		add_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:fake_wc_id/preview' );
+		$request->set_param( 'id', 'wc:fake_wc_id' );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		remove_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+	}
+
+	/**
+	 * Get_wc_classic_preview_html returns false when the WC internal
+	 * EmailPreview class isn't available (e.g. real WooCommerce not
+	 * loaded in the test env, even when a `class WooCommerce` shim
+	 * declared by a sibling test file flips class_exists('WooCommerce')
+	 * to true).
+	 */
+	public function test_wc_classic_preview_returns_false_without_internal_preview_class() {
+		$result = Email_Preview::get_wc_classic_preview_html( 'customer_payment_retry' );
+		self::assertFalse( $result );
+	}
+
+	/**
+	 * Valid wc: id with no template post → routes to classic render
+	 * → classic render fails (no internal WC class in test env)
+	 * → endpoint returns 500 with `newspack_email_preview_unavailable`.
+	 *
+	 * Confirms the route widening + validation + classic branch decision
+	 * + failure-mode handling all wire correctly. Doesn't assert HTML
+	 * because real WC rendering needs WC core loaded; the 500 path is
+	 * the observable signal that everything before classic-render
+	 * executed correctly.
+	 */
+	public function test_api_get_preview_wc_path_reaches_classic_render() {
+		$wc_id    = 'customer_payment_retry';
+		$callback = function ( $configs ) use ( $wc_id ) {
+			$configs[ $wc_id ] = [
+				'name'     => $wc_id,
+				'source'   => 'woocommerce',
+				'category' => 'woocommerce',
+				'label'    => 'Test WC',
+			];
+			return $configs;
+		};
+		add_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:' . $wc_id . '/preview' );
+		$request->set_param( 'id', 'wc:' . $wc_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		remove_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_unavailable', $response->get_error_code() );
+		self::assertEquals( 500, $response->get_error_data()['status'] );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * NPPD-1555 shape-validation fallback (extension XSS resistance)
+	 * ------------------------------------------------------------------
+	 * The `newspack_email_preview_substitutions` filter is wrapped in
+	 * shape validation — if a third-party filter returns a non-array,
+	 * drops a sub-array, or replaces one with a non-array, the call
+	 * site falls back to the unfiltered defaults instead of skipping
+	 * escaping or crashing.
+	 */
+
+	/**
+	 * Malformed filter response (non-array) reverts to defaults — the
+	 * preview still renders with proper escaping applied.
+	 */
+	public function test_substitutions_filter_shape_validation_fallback_non_array() {
+		$source_html = '<html><body>Hello *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Broken filter — returns a non-array. The shape validation must
+		// catch this and fall back to defaults, not skip escaping.
+		$broken = fn () => 'oops not an array';
+		add_filter( 'newspack_email_preview_substitutions', $broken );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		remove_filter( 'newspack_email_preview_substitutions', $broken );
+
+		// Substitution should still happen (proves defaults kicked in).
+		self::assertStringContainsString( 'Sample Reader', $result );
+		self::assertStringNotContainsString( '*BILLING_NAME*', $result );
+	}
+
+	/**
+	 * Filter response missing a required sub-array (drops `url`) reverts
+	 * to defaults.
+	 */
+	public function test_substitutions_filter_shape_validation_fallback_missing_subarray() {
+		$source_html = '<html><body>Visit <a href="*SITE_URL*">us</a> as *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Broken filter — drops the 'url' sub-array entirely.
+		$broken = function ( $subs ) {
+			unset( $subs['url'] );
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $broken );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		remove_filter( 'newspack_email_preview_substitutions', $broken );
+
+		// URL token must still resolve (proves defaults kicked in even
+		// though the broken filter tried to drop the whole map).
+		self::assertStringNotContainsString( '*SITE_URL*', $result );
+		// And the html-side substitution must also still work.
+		self::assertStringContainsString( 'Sample Reader', $result );
+	}
+
+	/**
+	 * Filter response where a sub-array is replaced with a non-array
+	 * reverts to defaults (and importantly: doesn't strip escaping by
+	 * silently merging a malformed structure).
+	 */
+	public function test_substitutions_filter_shape_validation_fallback_non_array_subarray() {
+		$source_html = '<html><body>Hello *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Broken filter — replaces 'html' sub-array with a string.
+		// Without shape validation this would crash array_map().
+		$broken = function ( $subs ) {
+			$subs['html'] = 'totally wrong type';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $broken );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		remove_filter( 'newspack_email_preview_substitutions', $broken );
+
+		// No crash, defaults applied.
+		self::assertIsString( $result );
+		self::assertStringContainsString( 'Sample Reader', $result );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/email-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/email-preview.php
@@ -46,6 +46,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 			return $types;
 		};
 		add_filter( 'newspack_email_configs', $this->config_filter_callback );
+		\Newspack\Emails::reset_email_configs_cache();
 	}
 
 	/**
@@ -53,6 +54,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_filter( 'newspack_email_configs', $this->config_filter_callback );
+		\Newspack\Emails::reset_email_configs_cache();
 		parent::tear_down();
 	}
 
@@ -334,6 +336,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 			return $configs;
 		};
 		add_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
 
 		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:fake_wc_id/preview' );
 		$request->set_param( 'id', 'wc:fake_wc_id' );
@@ -341,6 +344,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 		$response = Email_Preview::api_get_preview( $request );
 
 		remove_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
 
 		self::assertInstanceOf( 'WP_Error', $response );
 		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
@@ -381,6 +385,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 			return $configs;
 		};
 		add_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
 
 		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:' . $wc_id . '/preview' );
 		$request->set_param( 'id', 'wc:' . $wc_id );
@@ -388,6 +393,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 		$response = Email_Preview::api_get_preview( $request );
 
 		remove_filter( 'newspack_email_configs', $callback );
+		\Newspack\Emails::reset_email_configs_cache();
 
 		self::assertInstanceOf( 'WP_Error', $response );
 		self::assertEquals( 'newspack_email_preview_unavailable', $response->get_error_code() );

--- a/plugins/newspack-plugin/tests/unit-tests/email-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/email-preview.php
@@ -173,19 +173,40 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Translatable sample strings are wrapped in __().
+	 * Raw-bucket value-construction escapes admin-controlled inputs.
+	 *
+	 * *SITE_CONTACT* lives in the 'raw' bucket (not re-escaped at
+	 * strtr-time), so the values built into it MUST be escaped at
+	 * construction. The bucket includes get_bloginfo('name') and the WC
+	 * store address — both admin-controlled. An admin (or a role-elevation
+	 * supply-chain attack) writing `<img onerror=...>` to the site title
+	 * must not flow through to the iframe's srcDoc raw.
 	 */
-	public function test_translated_strings() {
-		$subs = Email_Preview::get_sample_substitutions();
+	public function test_site_contact_escapes_admin_controlled_values() {
+		$original_blogname = get_option( 'blogname' );
+		update_option( 'blogname', 'Acme <img src=x onerror=alert(1)>' );
 
-		// These values should match __() output (in English they're identical,
-		// but this asserts the wrapping is in place).
-		self::assertEquals( __( 'Sample', 'newspack-plugin' ), $subs['html']['*BILLING_FIRST_NAME*'] );
-		self::assertEquals( __( 'Reader', 'newspack-plugin' ), $subs['html']['*BILLING_LAST_NAME*'] );
-		self::assertEquals( __( 'Sample Reader', 'newspack-plugin' ), $subs['html']['*BILLING_NAME*'] );
-		self::assertEquals( __( 'Visa ending in 4242', 'newspack-plugin' ), $subs['html']['*PAYMENT_METHOD*'] );
-		self::assertEquals( __( 'Monthly Membership', 'newspack-plugin' ), $subs['html']['*PRODUCT_NAME*'] );
-		self::assertEquals( __( 'monthly', 'newspack-plugin' ), $subs['html']['*BILLING_FREQUENCY*'] );
+		$source_html = '<html><body>From: *SITE_CONTACT*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		update_option( 'blogname', $original_blogname );
+
+		// The dangerous form is the unescaped HTML element — angle brackets
+		// must be escaped to `&lt;...&gt;`. The literal text `onerror=`
+		// inside escaped content (`&lt;img ... onerror=...&gt;`) is safe
+		// because the browser won't interpret it as an attribute.
+		self::assertStringNotContainsString(
+			'<img src=x',
+			$result,
+			'Raw-bucket *SITE_CONTACT* must escape the unescaped `<img>` tag.'
+		);
+		self::assertStringContainsString(
+			'&lt;img',
+			$result,
+			'Raw-bucket *SITE_CONTACT* must HTML-encode angle brackets in the site title.'
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/email-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/email-preview.php
@@ -1,0 +1,481 @@
+<?php
+/**
+ * Tests Email_Preview.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Emails;
+use Newspack\Wizards\Newspack\Email_Preview;
+
+require_once __DIR__ . '/../mocks/newsletters-mocks.php';
+
+/**
+ * Tests Email_Preview.
+ */
+class Newspack_Test_Email_Preview extends WP_UnitTestCase {
+
+	/**
+	 * Test email config name.
+	 *
+	 * @var string
+	 */
+	private static $test_config_name = 'test-preview-config';
+
+	/**
+	 * Filter callback reference so it can be removed in tear_down().
+	 *
+	 * @var callable
+	 */
+	private $config_filter_callback;
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->config_filter_callback = function ( $types ) {
+			$types[ self::$test_config_name ] = [
+				'name'        => self::$test_config_name,
+				'label'       => __( 'Test preview config', 'newspack' ),
+				'description' => __( 'Email for testing preview.', 'newspack' ),
+				'template'    => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
+				'category'    => 'test',
+			];
+			return $types;
+		};
+		add_filter( 'newspack_email_configs', $this->config_filter_callback );
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_email_configs', $this->config_filter_callback );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: create a newspack_rr_email post with the test config type.
+	 *
+	 * @param string $html Optional stored email HTML.
+	 * @return int Post ID.
+	 */
+	private function create_email_post( string $html = '' ): int {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, self::$test_config_name );
+		if ( ! empty( $html ) ) {
+			update_post_meta( $post_id, \Newspack_Newsletters::EMAIL_HTML_META, $html );
+		}
+		return $post_id;
+	}
+
+	/**
+	 * The substitution map has the expected three-key structure.
+	 */
+	public function test_sample_substitutions_structure() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		self::assertIsArray( $subs );
+		self::assertArrayHasKey( 'html', $subs, 'Missing "html" key.' );
+		self::assertArrayHasKey( 'url', $subs, 'Missing "url" key.' );
+		self::assertArrayHasKey( 'raw', $subs, 'Missing "raw" key.' );
+		self::assertCount( 3, $subs, 'Substitution map should have exactly 3 top-level keys.' );
+	}
+
+	/**
+	 * The sample-substitutions map contains all expected token keys.
+	 */
+	public function test_sample_substitutions_map() {
+		$subs = Email_Preview::get_sample_substitutions();
+		$all  = array_merge( $subs['html'], $subs['url'], $subs['raw'] );
+
+		self::assertGreaterThanOrEqual( 32, count( $all ), 'Substitution map should have at least 32 entries.' );
+
+		$expected_keys = [
+			'*SITE_TITLE*',
+			'*SITE_URL*',
+			'*SITE_LOGO*',
+			'*BILLING_NAME*',
+			'*BILLING_FIRST_NAME*',
+			'*AMOUNT*',
+			'*PAYMENT_METHOD*',
+			'*DATE*',
+			'*ACCOUNT_URL*',
+			'*MAGIC_LINK_OTP*',
+		];
+		foreach ( $expected_keys as $key ) {
+			self::assertArrayHasKey( $key, $all, "Missing expected token: $key" );
+		}
+	}
+
+	/**
+	 * HTML metacharacters in html-context tokens are escaped.
+	 */
+	public function test_html_tokens_are_escaped() {
+		$source_html = '<html><body>Hello *BILLING_FIRST_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Inject a malicious value via the filter.
+		$filter = function ( $subs ) {
+			$subs['html']['*BILLING_FIRST_NAME*'] = '<script>alert(1)</script>';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $filter );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( '&lt;script&gt;', $result, 'HTML metacharacters should be escaped.' );
+		self::assertStringNotContainsString( '<script>alert(1)</script>', $result, 'Raw script tag should not appear.' );
+
+		remove_filter( 'newspack_email_preview_substitutions', $filter );
+	}
+
+	/**
+	 * URL tokens reject dangerous protocols.
+	 */
+	public function test_url_tokens_are_sanitized() {
+		$source_html = '<html><body><a href="*ACCOUNT_URL*">Account</a></body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$filter = function ( $subs ) {
+			$subs['url']['*ACCOUNT_URL*'] = 'javascript:alert(1)';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $filter );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringNotContainsString( 'javascript:', $result, 'javascript: protocol should be rejected by esc_url().' );
+
+		remove_filter( 'newspack_email_preview_substitutions', $filter );
+	}
+
+	/**
+	 * Raw tokens preserve their pre-escaped HTML intact.
+	 */
+	public function test_raw_tokens_are_not_double_escaped() {
+		$source_html = '<html><body>Contact: *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( '<a href=', $result, 'CONTACT_EMAIL <a> tag should be preserved.' );
+		self::assertStringNotContainsString( '&lt;a href=', $result, 'CONTACT_EMAIL <a> tag should not be double-escaped.' );
+	}
+
+	/**
+	 * Translatable sample strings are wrapped in __().
+	 */
+	public function test_translated_strings() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		// These values should match __() output (in English they're identical,
+		// but this asserts the wrapping is in place).
+		self::assertEquals( __( 'Sample', 'newspack-plugin' ), $subs['html']['*BILLING_FIRST_NAME*'] );
+		self::assertEquals( __( 'Reader', 'newspack-plugin' ), $subs['html']['*BILLING_LAST_NAME*'] );
+		self::assertEquals( __( 'Sample Reader', 'newspack-plugin' ), $subs['html']['*BILLING_NAME*'] );
+		self::assertEquals( __( 'Visa ending in 4242', 'newspack-plugin' ), $subs['html']['*PAYMENT_METHOD*'] );
+		self::assertEquals( __( 'Monthly Membership', 'newspack-plugin' ), $subs['html']['*PRODUCT_NAME*'] );
+		self::assertEquals( __( 'monthly', 'newspack-plugin' ), $subs['html']['*BILLING_FREQUENCY*'] );
+	}
+
+	/**
+	 * CONTACT_EMAIL resolves through Emails::get_reply_to_email() — not admin_email.
+	 *
+	 * Pins the fix for the function_exists() bug: function_exists() cannot
+	 * test class methods, so the guard was always false and the token fell
+	 * back to admin_email regardless of the Reader Activation contact setting.
+	 */
+	public function test_contact_email_uses_reply_to_email() {
+		$custom_email = 'reply@example.org';
+		add_filter( 'newspack_reply_to_email', fn() => $custom_email );
+
+		$source_html = '<html><body>Contact us at *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( $custom_email, $result, 'CONTACT_EMAIL should resolve to the filtered reply-to address.' );
+		self::assertStringNotContainsString( '*CONTACT_EMAIL*', $result, 'Raw CONTACT_EMAIL token should not remain.' );
+
+		remove_all_filters( 'newspack_reply_to_email' );
+	}
+
+	/**
+	 * Tests that get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
+	 */
+	public function test_get_preview_html_with_stored_meta() {
+		$source_html = '<html><body>Hello *BILLING_NAME*, your total is *AMOUNT*.</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertStringContainsString( 'Sample Reader', $result, 'BILLING_NAME should be substituted.' );
+		self::assertStringContainsString( '$25.00', $result, 'AMOUNT should be substituted.' );
+		self::assertStringNotContainsString( '*BILLING_NAME*', $result, 'Raw token should not remain.' );
+		self::assertStringNotContainsString( '*AMOUNT*', $result, 'Raw token should not remain.' );
+	}
+
+	/**
+	 * Tests that get_preview_html() falls back to template HTML when no stored meta exists.
+	 */
+	public function test_get_preview_html_fallback_to_template() {
+		$post_id = $this->create_email_post();
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertNotEmpty( $result, 'Fallback to template should produce non-empty HTML.' );
+		// The receipt template contains "Thank you!" — verify substitution ran.
+		self::assertStringContainsString( 'Thank you!', $result );
+	}
+
+	/**
+	 * Tests that get_preview_html() returns false for a nonexistent post.
+	 */
+	public function test_get_preview_html_returns_false_for_nonexistent() {
+		$result = Email_Preview::get_preview_html( 999999 );
+		self::assertFalse( $result );
+	}
+
+	/**
+	 * Permission check rejects non-admin users.
+	 */
+	public function test_api_permissions_check_rejects_non_admin() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$result = Email_Preview::api_permissions_check();
+		self::assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * REST API returns 404 for a post that is not of the email post type.
+	 */
+	public function test_api_get_preview_returns_404_for_wrong_post_type() {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'id', (string) $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * REST API returns HTML and id on success.
+	 */
+	public function test_api_get_preview_returns_html() {
+		$source_html = '<html><body>Preview for *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'id', (string) $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_REST_Response', $response );
+
+		$data = $response->get_data();
+		self::assertArrayHasKey( 'html', $data );
+		self::assertArrayHasKey( 'id', $data );
+		self::assertEquals( $post_id, $data['id'] );
+		self::assertStringContainsString( 'Sample Reader', $data['html'] );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * wc:{id} route (slice 2b.2 — folded in from PR #4758)
+	 * ------------------------------------------------------------------
+	 * The route accepts `wc:{email_id}` strings alongside numeric post
+	 * IDs. Validation is against the unified email config schema
+	 * filtered to source==='woocommerce'. Routing picks block-editor
+	 * render when a template post exists, falls back to classic
+	 * render otherwise.
+	 */
+
+	/**
+	 * REST API returns 404 for a wc: identifier that doesn't resolve to a
+	 * woocommerce-source config in the unified schema.
+	 */
+	public function test_api_get_preview_returns_404_for_unregistered_wc_email() {
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:nonexistent_email/preview' );
+		$request->set_param( 'id', 'wc:nonexistent_email' );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * REST API also rejects wc: identifiers for configs whose source
+	 * isn't 'woocommerce' — guards against spoofing a newspack-source
+	 * config through the wc: branch.
+	 */
+	public function test_api_get_preview_rejects_wc_path_for_non_wc_source() {
+		// Inject a newspack-source config under a wc-style id key.
+		$callback = function ( $configs ) {
+			$configs['fake_wc_id'] = [
+				'name'     => 'fake_wc_id',
+				'source'   => 'newspack', // Wrong source — should reject the wc: path.
+				'category' => 'reader-revenue',
+			];
+			return $configs;
+		};
+		add_filter( 'newspack_email_configs', $callback );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:fake_wc_id/preview' );
+		$request->set_param( 'id', 'wc:fake_wc_id' );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		remove_filter( 'newspack_email_configs', $callback );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+	}
+
+	/**
+	 * Get_wc_classic_preview_html returns false when the WC internal
+	 * EmailPreview class isn't available (e.g. real WooCommerce not
+	 * loaded in the test env, even when a `class WooCommerce` shim
+	 * declared by a sibling test file flips class_exists('WooCommerce')
+	 * to true).
+	 */
+	public function test_wc_classic_preview_returns_false_without_internal_preview_class() {
+		$result = Email_Preview::get_wc_classic_preview_html( 'customer_payment_retry' );
+		self::assertFalse( $result );
+	}
+
+	/**
+	 * Valid wc: id with no template post → routes to classic render
+	 * → classic render fails (no internal WC class in test env)
+	 * → endpoint returns 500 with `newspack_email_preview_unavailable`.
+	 *
+	 * Confirms the route widening + validation + classic branch decision
+	 * + failure-mode handling all wire correctly. Doesn't assert HTML
+	 * because real WC rendering needs WC core loaded; the 500 path is
+	 * the observable signal that everything before classic-render
+	 * executed correctly.
+	 */
+	public function test_api_get_preview_wc_path_reaches_classic_render() {
+		$wc_id    = 'customer_payment_retry';
+		$callback = function ( $configs ) use ( $wc_id ) {
+			$configs[ $wc_id ] = [
+				'name'     => $wc_id,
+				'source'   => 'woocommerce',
+				'category' => 'woocommerce',
+				'label'    => 'Test WC',
+			];
+			return $configs;
+		};
+		add_filter( 'newspack_email_configs', $callback );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:' . $wc_id . '/preview' );
+		$request->set_param( 'id', 'wc:' . $wc_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		remove_filter( 'newspack_email_configs', $callback );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_unavailable', $response->get_error_code() );
+		self::assertEquals( 500, $response->get_error_data()['status'] );
+	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * NPPD-1555 shape-validation fallback (extension XSS resistance)
+	 * ------------------------------------------------------------------
+	 * The `newspack_email_preview_substitutions` filter is wrapped in
+	 * shape validation — if a third-party filter returns a non-array,
+	 * drops a sub-array, or replaces one with a non-array, the call
+	 * site falls back to the unfiltered defaults instead of skipping
+	 * escaping or crashing.
+	 */
+
+	/**
+	 * Malformed filter response (non-array) reverts to defaults — the
+	 * preview still renders with proper escaping applied.
+	 */
+	public function test_substitutions_filter_shape_validation_fallback_non_array() {
+		$source_html = '<html><body>Hello *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Broken filter — returns a non-array. The shape validation must
+		// catch this and fall back to defaults, not skip escaping.
+		$broken = fn () => 'oops not an array';
+		add_filter( 'newspack_email_preview_substitutions', $broken );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		remove_filter( 'newspack_email_preview_substitutions', $broken );
+
+		// Substitution should still happen (proves defaults kicked in).
+		self::assertStringContainsString( 'Sample Reader', $result );
+		self::assertStringNotContainsString( '*BILLING_NAME*', $result );
+	}
+
+	/**
+	 * Filter response missing a required sub-array (drops `url`) reverts
+	 * to defaults.
+	 */
+	public function test_substitutions_filter_shape_validation_fallback_missing_subarray() {
+		$source_html = '<html><body>Visit <a href="*SITE_URL*">us</a> as *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Broken filter — drops the 'url' sub-array entirely.
+		$broken = function ( $subs ) {
+			unset( $subs['url'] );
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $broken );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		remove_filter( 'newspack_email_preview_substitutions', $broken );
+
+		// URL token must still resolve (proves defaults kicked in even
+		// though the broken filter tried to drop the whole map).
+		self::assertStringNotContainsString( '*SITE_URL*', $result );
+		// And the html-side substitution must also still work.
+		self::assertStringContainsString( 'Sample Reader', $result );
+	}
+
+	/**
+	 * Filter response where a sub-array is replaced with a non-array
+	 * reverts to defaults (and importantly: doesn't strip escaping by
+	 * silently merging a malformed structure).
+	 */
+	public function test_substitutions_filter_shape_validation_fallback_non_array_subarray() {
+		$source_html = '<html><body>Hello *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Broken filter — replaces 'html' sub-array with a string.
+		// Without shape validation this would crash array_map().
+		$broken = function ( $subs ) {
+			$subs['html'] = 'totally wrong type';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $broken );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		remove_filter( 'newspack_email_preview_substitutions', $broken );
+
+		// No crash, defaults applied.
+		self::assertIsString( $result );
+		self::assertStringContainsString( 'Sample Reader', $result );
+	}
+}


### PR DESCRIPTION
## Summary

Adds per-card email preview thumbnails to the unified emails wizard (Newspack > Settings > Emails). Each card in the grid renders an iframe scaled-down preview of the email's actual HTML, lazy-loaded as the card enters the viewport.

Three render paths, all routed through a single REST endpoint:
- **Newspack emails** preview via their own integer post_id (the `newspack_rr_email` post). Template tokens get substituted with realistic sample values.
- **WC block-template emails** preview via the integer `preview_id` (the `woo_email` template post), using WC's block email renderer (themed, transient-cached).
- **WC classic-template emails** preview via the `wc:{email_id}` string `preview_id` (e.g. WC Subs emails that have no block template), using WC's legacy `EmailPreview::render()`.

Resolves [NPPD-1525](https://linear.app/a8c/issue/NPPD-1525), folds in [NPPD-1555](https://linear.app/a8c/issue/NPPD-1555), and folds in the preview half of [NPPD-1537](https://linear.app/a8c/issue/NPPD-1537).

<img width="3096" height="3188" alt="image" src="https://github.com/user-attachments/assets/c69db8fb-6c0c-4710-84f3-d740f9732f4e" />

## Stacking

⚠️ **This PR is stacked on slice 2a (#144), which is stacked on slice 1 (#137).** Review order:

1. **#137** — slice 1, unified `newspack_email_configs` schema foundation. Targets `main`.
2. **#144** — slice 2a, WC surfacing + chip filter + DataViews grid. Targets #137's branch.
3. **This PR** — slice 2b, preview thumbnails. Targets #144's branch.

The diff shown here is the 2b delta on top of slice 2a's foundation. Final merge order: 137 → main, 144 → 137 (now main), this → 144 (now main).

## Architecture

`Email_Preview` (new class in `includes/wizards/newspack/`) handles all three render paths behind one REST endpoint:

```
GET /newspack/v1/wizard/newspack-settings/emails/{id}/preview
```

Where `{id}` matches `\d+|wc:[\w-]+` — integer post IDs OR `wc:{email_id}` strings. The handler routes:

- Numeric → `get_post()` → if `post_type === 'newspack_rr_email'`: token-substitution render; if `post_type === 'woo_email'`: WC block render.
- `wc:` string → validate against `Emails::get_email_configs()` filtered to `source === 'woocommerce'`; if a block-editor template post exists, use the block render path; otherwise fall through to WC's classic `EmailPreview::render()`.

Validation throughout is against the unified config schema introduced in slice 1 — no parallel registry lookups, no `get_email_registry()` references.

**Folded from PR #4758 (NPPD-1537):** the WC classic render path + the `wc:` route widening. The style-sync half of #4758 (`WooCommerce_Email_Style_Sync` class that writes site brand color/logo into WC option-driven email templates) ships as its own separate slice — it has no implementation coupling to the preview machinery, only an intent coupling, and keeping it standalone preserves reviewability per slice.

## NPPD-1555 escape/i18n hardening — baked into the class port

The legacy slice 2 file at HEAD already had the complete fix; ports as part of the class. All four components present:

1. **Three-tier substitution map** in `get_sample_substitutions()` — entries grouped by escaping context: `html` (rendered as visible text, applied with `esc_html()`), `url` (used in href/src attributes, applied with `esc_url()`), `raw` (already pre-escaped HTML, passed through).
2. **Per-context escaping** in `apply_sample_substitutions()` — `array_map( 'esc_html', $substitutions['html'] )` etc., then `array_merge` into a single map for `strtr`.
3. **Shape-validation fallback** on the `newspack_email_preview_substitutions` filter — if a third-party filter drops a sub-array, returns non-array, or replaces a sub-array with a non-array, the call site reverts to unfiltered defaults instead of skipping escaping or crashing. XSS-resistant against extension misuse.
4. **Translatable sample strings** — `__( 'Sample', 'newspack-plugin' )`, `__( 'Visa ending in 4242', 'newspack-plugin' )`, etc. The preview renders in the publisher's locale.

PHP tests cover all three escape contexts plus the shape-validation fallback across three malformation modes.

## One small touch to a slice 2a file

`includes/wizards/newspack/class-emails-section.php` gets ~5 lines changed in `serialize_wc_email_row()`:

- The emitted preview field is renamed `preview_post_id` → `preview_id` and widened to `int | string | null`.
- Smart-fallback emission: `$preview_id = $block_template_post_id ?? ( 'wc:' . $type )` — block-editor template post ID when one exists, `wc:{id}` string otherwise.
- `get_wc_email_template_post_id()` flipped from `private` to `public` so `Email_Preview` can consume it.

Why a 2a file in this PR: the field name and shape are part of the preview contract. Landing them here avoids a downstream rename across freshly-shipped 2b files. No 2a frontend consumer reads the old `preview_post_id` name — verified via grep + the slice 2a Jest suite passes unchanged after the rename.

## Accessibility

The DataViews preview field's render wraps `<EmailPreview>` in an anchor:

```tsx
<a
    href={ item.edit_link }
    className="newspack-emails__preview-link"
    aria-label={ sprintf( __( 'Edit %s', 'newspack-plugin' ), item.label ) }
>
    <EmailPreview postId={ previewId } />
</a>
```

The iframe inside has `tabIndex={-1}` + `pointer-events: none`, so the wrapper anchor is the sole keyboard-focusable element in the tile. The anchor's `aria-label` gives assistive tech a specific destination ("Edit Payment receipt") instead of the iframe's generic "Email preview" title.

`.newspack-emails__preview-link:focus-visible` uses `outline: 2px solid; outline-offset: 1px;` — matches the design-system canonical and the sibling `.newspack-emails__name-link` rule.

Slice 1's design review had flagged the previous icon-only preview placeholder for missing both aria-label and focus ring; this port resolves both.

## Local-env note: Jest ENOMEM flake on high-CPU dev machines

On dev machines where Docker has a high CPU allocation (e.g. 8+ vCPUs) but constrained memory (< 16GB), `pnpm --filter newspack run test` may intermittently bail an unrelated test suite with `ENOMEM: not enough memory, open .../expect/build/spyMatchers.js` during framework setup.

**Why it happens:** Jest defaults to `(CPUs - 1)` workers. On my 8-CPU local Docker container that's 7 workers, each loading the full Jest framework + transforms. The +11 tests this slice adds nudge the worker pool over the memory threshold.

**Why CI is unaffected:** GitHub-hosted `ubuntu-latest` runners have 4 vCPUs / 16 GB RAM — Jest defaults to 3 workers with ~5 GB headroom each. Slice 2a's CI ran Jest cleanly on the same workflow; slice 2b's incremental memory cost is well within CI's budget. Measured failure rate on my local: 15% (3 of 20 full-suite runs). Measured failure rate when running just the two new test files in isolation: 0/many.

**Workspace fix shape (not in 2b's scope):** cap `maxWorkers` in `packages/scripts/scripts/test.js` (the newspack-scripts shared test runner). One-line change, scales across the monorepo. Worth a passing mention to Adam next time we're in that area.

## Testing

- **PHP**: new `tests/unit-tests/email-preview.php` — 20 tests, 63 assertions. Covers three-tier escape structure, XSS prevention (`<script>` escaped, `javascript:` rejected by `esc_url()`), raw tokens preserve pre-escaped markup, translatable sample strings, the `*CONTACT_EMAIL*` reply-to-email resolution (pins the legacy `function_exists` bug fix), token substitution from stored meta + template fallback, REST 404 cases (wrong post type, unregistered `wc:` id, non-WC source masquerading via wc: route), WC-classic-render-reachability via the 500 path, NPPD-1555 shape-validation fallback across three malformation modes. Full PHP suite: **1305 tests, 4256 assertions, 1 pre-existing unrelated skip, 0 failures.**
- **JS**: new `email-preview.test.js` — 9 tests covering EmailPreview lifecycle (loading, success, error, IntersectionObserver gating, postId reset, cancelled-fetch race, `wc:` string postId path). `emails.test.js` +2 tests verifying the field wiring (anchor + aria-label, smart-fallback `previewId` resolution across Newspack + WC block + WC classic rows). Full Jest suite: 21 suites, **213 tests, 0 failures** (when complete; see local-env note above for the intermittent ENOMEM bail).
- **Manual**: smoke verified on local Docker WP — all three render paths produce iframe thumbnails. Newspack rows show themed token-substituted previews; WC block-template emails show WC's block-rendered output; classic WC Subs emails (e.g. Renewal reminder) show WC's classic-styled output via the `wc:` route. Tab-focus shows the focus ring; VoiceOver announces the anchor's aria-label.