### PR TITLE
fix(ci): keep workspace:* out of release commits + robust alpha maintenance

### DIFF
--- a/.github/scripts/finalize-package-versions.cjs
+++ b/.github/scripts/finalize-package-versions.cjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Commit the package.json version bumps from a release run, keeping internal
+ * `workspace:*` deps intact — in a single commit, after all packages released.
+ *
+ * Why this exists: the release configs deliberately DON'T list package.json in
+ * the @semantic-release/git prepare commit. That keeps the concrete dependency
+ * versions multi-semantic-release writes during `prepare` off the branch (they'd
+ * break the next `pnpm install --frozen-lockfile`, since the root lockfile is
+ * keyed to workspace:*), and it lets the npm `publish` phase read the
+ * concretized working-tree manifest so published packages still get real dep
+ * versions. The only thing not committing package.json loses is an up-to-date
+ * `version` on the branch — which this restores.
+ *
+ * After multi-semantic-release finishes, each released package's working-tree
+ * package.json carries msr's changes (bumped version + concretized deps),
+ * uncommitted. This script takes that working tree, reverts the internal deps
+ * back to `workspace:*` (so the branch stays lockfile-consistent), and commits.
+ * The net committed change is therefore a pure version bump — the version is
+ * msr's, which is unambiguously what this run released (unlike a git tag, whose
+ * "latest" is ambiguous once alpha and release lines share history).
+ *
+ * Run from the repo root after multi-semantic-release, before pushing. Commits
+ * the changed manifests with [skip ci]; the caller pushes.
+ *
+ * packages/* are intentionally not handled here — they have no internal
+ * workspace deps, so their own release configs still commit package.json
+ * directly (no lockfile hazard).
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { execSync } = require( 'child_process' );
+
+const root = execSync( 'git rev-parse --show-toplevel', { encoding: 'utf8' } ).trim();
+process.chdir( root );
+
+// Internal workspace package names, derived from packages/*/package.json.
+const workspaceNames = new Set();
+if ( fs.existsSync( 'packages' ) ) {
+	for ( const entry of fs.readdirSync( 'packages' ) ) {
+		const manifestPath = path.join( 'packages', entry, 'package.json' );
+		if ( ! fs.existsSync( manifestPath ) ) {
+			continue;
+		}
+		try {
+			const pkgName = JSON.parse( fs.readFileSync( manifestPath, 'utf8' ) ).name;
+			if ( pkgName ) {
+				workspaceNames.add( pkgName );
+			}
+		} catch ( e ) {
+			// Skip an unparseable package.json.
+		}
+	}
+}
+if ( workspaceNames.size === 0 ) {
+	// In this monorepo there is always at least one shared package; an empty set
+	// means the root misresolved. Fail loud rather than silently shipping
+	// concretized deps.
+	console.error( '[finalize-package-versions] no workspace package names found — aborting.' );
+	process.exit( 1 );
+}
+
+const changedPaths = [];
+for ( const group of [ 'plugins', 'themes' ] ) {
+	if ( ! fs.existsSync( group ) ) {
+		continue;
+	}
+	for ( const entry of fs.readdirSync( group ) ) {
+		const rel = path.join( group, entry, 'package.json' );
+		if ( ! fs.existsSync( rel ) ) {
+			continue;
+		}
+		const source = fs.readFileSync( rel, 'utf8' );
+		const indentMatch = source.match( /\n(\t+|[ ]+)"/ );
+		const indent = indentMatch ? indentMatch[ 1 ] : '\t';
+		const trailingNewline = source.endsWith( '\n' ) ? '\n' : '';
+		const manifest = JSON.parse( source );
+		let dirty = false;
+		for ( const section of [ 'dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies' ] ) {
+			if ( ! manifest[ section ] ) {
+				continue;
+			}
+			for ( const dep of Object.keys( manifest[ section ] ) ) {
+				if ( workspaceNames.has( dep ) && manifest[ section ][ dep ] !== 'workspace:*' ) {
+					manifest[ section ][ dep ] = 'workspace:*';
+					dirty = true;
+				}
+			}
+		}
+		if ( dirty ) {
+			fs.writeFileSync( rel, JSON.stringify( manifest, null, indent ) + trailingNewline );
+		}
+		changedPaths.push( rel );
+	}
+}
+
+// Stage every plugin/theme manifest; git only records the ones that actually
+// differ from HEAD (msr-bumped version and/or the reverted deps).
+for ( const rel of changedPaths ) {
+	execSync( `git add ${ JSON.stringify( rel ) }` );
+}
+
+const staged = execSync( 'git diff --cached --name-only', { encoding: 'utf8' } ).split( '\n' ).filter( Boolean );
+if ( staged.length === 0 ) {
+	console.log( '[finalize-package-versions] no package.json changes to commit.' );
+	process.exit( 0 );
+}
+execSync( 'git commit -m "chore(release): sync package.json versions [skip ci]"', { stdio: 'inherit' } );
+console.log( `[finalize-package-versions] committed version sync for:\n  ${ staged.join( '\n  ' ) }` );

--- a/.github/scripts/finalize-package-versions.cjs
+++ b/.github/scripts/finalize-package-versions.cjs
@@ -32,7 +32,7 @@
 
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { execSync } = require( 'child_process' );
+const { execSync, execFileSync } = require( 'child_process' );
 
 const root = execSync( 'git rev-parse --show-toplevel', { encoding: 'utf8' } ).trim();
 process.chdir( root );
@@ -100,7 +100,7 @@ for ( const group of [ 'plugins', 'themes' ] ) {
 // Stage every plugin/theme manifest; git only records the ones that actually
 // differ from HEAD (msr-bumped version and/or the reverted deps).
 for ( const rel of changedPaths ) {
-	execSync( `git add ${ JSON.stringify( rel ) }` );
+	execFileSync( 'git', [ 'add', '--', rel ] );
 }
 
 const staged = execSync( 'git diff --cached --name-only', { encoding: 'utf8' } ).split( '\n' ).filter( Boolean );

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -8,9 +8,10 @@
 #   - merge `release` back into the repository's default branch so they stay in
 #     sync, notifying Slack on conflict.
 #
-# workspace:* preservation is handled at release time (config/release.js's
-# version-bump callback reverts msr's dependency concretization before the
-# release commit), so no dependency restoration is needed here.
+# workspace:* preservation is handled by .github/scripts/finalize-package-versions.cjs,
+# which runs after multi-semantic-release (the "Sync package.json versions" step
+# in release.yml) and reverts msr's dependency concretization in its own commit,
+# so no dependency restoration is needed here.
 #
 # This lives in the monorepo (not packages/scripts, which mirrors the legacy
 # newspack-scripts repo and is overwritten by the daily sync) and targets the
@@ -45,7 +46,7 @@ notify_slack() {
 git pull origin release
 git fetch origin alpha
 
-git checkout alpha
+git checkout -B alpha origin/alpha
 
 # Decide alpha-branch maintenance by whether alpha holds any commit that release
 # does not:
@@ -61,7 +62,7 @@ git checkout alpha
 if git merge-base --is-ancestor origin/alpha release; then
   echo "[post-release] alpha is fully contained in release; resetting alpha onto release."
   git reset --hard release --
-  git push --force origin alpha
+  git push --force-with-lease=alpha:origin/alpha origin alpha
 else
   echo "[post-release] alpha has unreleased commits; merging release into alpha."
   if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -3,18 +3,19 @@
 # Post-release branch maintenance for the monorepo, run after the `release` job.
 #
 # After a release on the `release` branch:
-#   - reset the single-serving `alpha` branch onto `release` (when the release
-#     came from an alpha merge), or merge `release` into `alpha` otherwise;
-#   - restore `workspace:*` for any internal workspace dep that the release
-#     concretized (see restore_workspace_deps below);
+#   - reset the single-serving `alpha` branch onto `release` (when alpha's
+#     history is fully released), or merge `release` into `alpha` otherwise;
 #   - merge `release` back into the repository's default branch so they stay in
-#     sync (then restore workspace:* there too), notifying Slack on conflict.
+#     sync, notifying Slack on conflict.
+#
+# workspace:* preservation is handled at release time (config/release.js's
+# version-bump callback reverts msr's dependency concretization before the
+# release commit), so no dependency restoration is needed here.
 #
 # This lives in the monorepo (not packages/scripts, which mirrors the legacy
 # newspack-scripts repo and is overwritten by the daily sync) and targets the
 # repo's actual default branch rather than the hard-coded `trunk` the legacy
-# script used. Uses node only for the small workspace-deps rewrite (preinstalled
-# on ubuntu-latest runners); otherwise pure git.
+# script used.
 
 set -euo pipefail
 
@@ -23,71 +24,7 @@ set -euo pipefail
 DEFAULT_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: //p')
 DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
 
-# The last commit here is the automated release commit; the one before it
-# carries the merge info used to decide whether the release came from alpha.
-SECOND_TO_LAST_COMMIT_MSG=$(git log -n 1 --skip 1 --pretty=format:"%s")
 LATEST_VERSION_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "release")
-
-# Restore workspace:* for any internal monorepo dep
-# (newspack-{scripts,components,colors,icons}) in every plugin/theme
-# package.json, then commit if anything changed.
-#
-# Why: @semantic-release/npm's prepare step rewrites "workspace:*" to a concrete
-# version in package.json before publishing to npm (npm can't consume
-# workspace:*), and @semantic-release/git then commits that change to the
-# `release` branch as part of the release commit. Resetting alpha onto release
-# (and merging release into the default branch) carries those concrete versions
-# forward, but pnpm-lock.yaml at the workspace root is keyed to workspace:* —
-# the next `pnpm install --frozen-lockfile` then fails with
-# ERR_PNPM_OUTDATED_LOCKFILE. Restoring workspace:* here keeps both branches
-# consistent with the lockfile and lets the next trunk→alpha promotion merge
-# cleanly without any manual restoration dance.
-#
-# The commit (when needed) carries [skip ci] so it doesn't re-trigger
-# release.yml — the alpha branch tip is then a chore[skip ci], same as today,
-# and the team's normal promotion merge commit later (without [skip ci]) is
-# what fires release.yml.
-restore_workspace_deps_and_commit() {
-  local branch="$1"
-  node -e '
-    const fs = require("fs"), path = require("path");
-    const WS_PACKAGES = ["newspack-scripts", "newspack-components", "newspack-colors", "newspack-icons"];
-    const roots = ["plugins", "themes"];
-    const changed = [];
-    for (const r of roots) {
-      if (!fs.existsSync(r)) continue;
-      for (const name of fs.readdirSync(r)) {
-        const pj = path.join(r, name, "package.json");
-        if (!fs.existsSync(pj)) continue;
-        const src = fs.readFileSync(pj, "utf8");
-        const indentMatch = src.match(/\n(\t+|[ ]+)"/);
-        const indent = indentMatch ? indentMatch[1] : "  ";
-        const trail = src.endsWith("\n") ? "\n" : "";
-        const j = JSON.parse(src);
-        let dirty = false;
-        for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
-          if (!j[section]) continue;
-          for (const pkg of WS_PACKAGES) {
-            if (j[section][pkg] && j[section][pkg] !== "workspace:*") {
-              j[section][pkg] = "workspace:*";
-              dirty = true;
-            }
-          }
-        }
-        if (!dirty) continue;
-        fs.writeFileSync(pj, JSON.stringify(j, null, indent) + trail);
-        changed.push(pj);
-      }
-    }
-    for (const f of changed) process.stdout.write(f + "\0");
-  ' | while IFS= read -r -d "" f; do
-    git add -- "$f"
-  done
-  if [ -n "$(git status --porcelain)" ]; then
-    git commit -m "chore(release): restore workspace:* deps after release [skip ci]"
-    echo "[post-release] Restored workspace:* deps on $branch."
-  fi
-}
 
 # Notify Slack about a failed post-release merge into $1, if Slack is configured.
 notify_slack() {
@@ -106,18 +43,28 @@ notify_slack() {
 }
 
 git pull origin release
+git fetch origin alpha
+
 git checkout alpha
 
-if echo "$SECOND_TO_LAST_COMMIT_MSG" | grep -q '^Merge .*alpha'; then
-  echo "[post-release] Release came from the alpha branch. Resetting alpha onto release."
-  # The alpha branch is single-serving; discard its history after a release.
+# Decide alpha-branch maintenance by whether alpha holds any commit that release
+# does not:
+#   - alpha fully contained in release  => the release came from an alpha
+#     promotion (alpha's history is now released), so reset alpha onto release;
+#   - alpha has its own commits          => a hotfix landed on release, or alpha
+#     moved on, so merge release into alpha to preserve those commits.
+#
+# This ancestry test is the correct condition — reset only when no alpha work
+# would be lost — and is robust to however many per-package version commits a
+# release stacks, unlike a fixed HEAD~N offset (which silently misclassifies
+# multi-package releases).
+if git merge-base --is-ancestor origin/alpha release; then
+  echo "[post-release] alpha is fully contained in release; resetting alpha onto release."
   git reset --hard release --
-  restore_workspace_deps_and_commit alpha
   git push --force origin alpha
 else
-  echo "[post-release] Release came from a non-alpha branch (e.g. a hotfix). Merging release into alpha."
+  echo "[post-release] alpha has unreleased commits; merging release into alpha."
   if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then
-    restore_workspace_deps_and_commit alpha
     git push origin alpha
   else
     git merge --abort
@@ -129,7 +76,6 @@ fi
 echo "[post-release] Merging release into $DEFAULT_BRANCH."
 git checkout "$DEFAULT_BRANCH"
 if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then
-  restore_workspace_deps_and_commit "$DEFAULT_BRANCH"
   git push origin "$DEFAULT_BRANCH"
 else
   git merge --abort

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,20 @@ jobs:
           # auth 401s. Set it to the same secret so npm actually authenticates.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=12288
+      # package.json is deliberately excluded from the @semantic-release/git
+      # prepare commit: that keeps multi-semantic-release's concretized
+      # workspace:* deps off the branch (they'd break the next
+      # `pnpm install --frozen-lockfile`, since the root lockfile is keyed to
+      # workspace:*), while the npm publish phase still reads the concretized
+      # working tree. The only thing lost is an up-to-date version on the branch,
+      # which this step restores: it takes msr's working-tree version bumps,
+      # reverts the internal deps back to workspace:*, and commits them once.
+      # The [skip ci] commit won't re-trigger this workflow, and post-release.sh's
+      # ancestry check is unaffected by the extra commit.
+      - name: Sync package.json versions
+        run: |
+          node .github/scripts/finalize-package-versions.cjs
+          git push origin "HEAD:${GITHUB_REF_NAME}"
 
   # Branch maintenance after a stable release: reset alpha and sync release into
   # the default branch. Only runs on the release branch (not alpha/hotfix/epic).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,13 @@ jobs:
       - name: Sync package.json versions
         run: |
           node .github/scripts/finalize-package-versions.cjs
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          # The release is already published by this point, so the branch must not
+          # be left without the synced version. If a concurrent push to the same
+          # ref rejects ours, rebase the sync commit on top and retry.
+          git push origin "HEAD:${GITHUB_REF_NAME}" || {
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
+          }
 
   # Branch maintenance after a stable release: reset alpha and sync release into
   # the default branch. Only runs on the release branch (not alpha/hotfix/epic).

--- a/config/release.js
+++ b/config/release.js
@@ -60,7 +60,7 @@ module.exports = function releaseConfig( { name, phpFile, npmPublish = false } )
 			],
 			{
 				path: '@semantic-release/git',
-				assets: [ phpFile, 'package.json', 'CHANGELOG.md' ],
+				assets: [ phpFile, 'CHANGELOG.md' ],
 				message:
 					'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
 			},

--- a/themes/newspack-block-theme/release.config.js
+++ b/themes/newspack-block-theme/release.config.js
@@ -23,7 +23,7 @@ module.exports = {
 		],
 		{
 			path: '@semantic-release/git',
-			assets: [ 'package.json', 'package-lock.json', 'CHANGELOG.md', 'src/scss/_theme-description.scss', 'functions.php' ],
+			assets: [ 'CHANGELOG.md', 'src/scss/_theme-description.scss', 'functions.php' ],
 			message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
 		},
 	],

--- a/themes/newspack-block-theme/release.config.js
+++ b/themes/newspack-block-theme/release.config.js
@@ -15,9 +15,11 @@ module.exports = {
 		[
 			'semantic-release-version-bump',
 			{
-				// build script is run before semantic-release, so the version in *.css files
-				// have to be updated explicitly
-				files: [ 'src/scss/_theme-description.scss', 'functions.php' ],
+				// build script is run before semantic-release, so the version in the
+				// built (gitignored) *.css files has to be bumped explicitly here, before
+				// release:archive zips them — otherwise the theme's style.css Version
+				// header ships stale.
+				files: [ 'src/scss/_theme-description.scss', 'functions.php', 'style.css', 'style-rtl.css' ],
 				callback: 'npm run release:archive',
 			},
 		],

--- a/themes/newspack-theme/.releaserc.js
+++ b/themes/newspack-theme/.releaserc.js
@@ -47,8 +47,6 @@ module.exports = {
 			path: '@semantic-release/git',
 			assets: [
 				...THEMES.map( name => `${ name }/sass/theme-description.scss` ),
-				'package.json',
-				'package-lock.json',
 				'CHANGELOG.md',
 			],
 			message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Two release-pipeline correctness fixes for the pnpm + multi-semantic-release monorepo, validated end-to-end on the sandbox.

**1. Keep `workspace:*` out of release commits (root-cause fix).**
multi-semantic-release rewrites internal `workspace:*` deps (`newspack-scripts`/`components`/`colors`/`icons`) to concrete versions during `prepare`. Committing `package.json` in the `@semantic-release/git` step persisted that to the branch, breaking the next `pnpm install --frozen-lockfile` (root lockfile is keyed to `workspace:*`) — the bug that forced manual restore commits on #143/#149.

Fix: **drop `package.json` from the `@semantic-release/git` prepare commit** in every config (the `config/release.js` plugin factory + both theme configs). The branch no longer receives concretized deps, and the npm `publish` phase still reads the concretized working tree — so `@automattic/newspack-blocks` (the one `npmPublish: true` plugin, with `workspace:*` runtime deps) still publishes real dep versions. This is semantic-release's default behaviour (don't commit `package.json`).

The only thing that loses is an up-to-date `version` in the branch `package.json`. A new post-`multi-semantic-release` step (`.github/scripts/finalize-package-versions.cjs`) restores it: it takes msr's working-tree version bumps, reverts internal deps back to `workspace:*`, and commits them once (`[skip ci]`). The WP-facing version (PHP header / theme `style.css` / `_theme-description.scss`) is untouched by all this — `semantic-release-version-bump` still bumps and commits those, and `package.json` is excluded from the plugin/theme zips anyway.

**2. Robust alpha branch maintenance.** `post-release.sh`'s old reset detection (`git log -n1 --skip 1` vs `^Merge .*alpha`) was effectively dead code — the job checks out the merge commit and msr stacks one version commit per package, so `HEAD~1` was never the merge marker; alpha was always merged, never reset. Replaced with an ancestry test: reset alpha onto release iff `alpha` is fully contained in `release`, else merge. Correct for single- and multi-package releases, and immune to the extra finalize commit.

### How to test the changes in this Pull Request:

Validated on the sandbox (`adekbadek/newspack-workspace-sandbox`):
1. Full matrix across **all 14 units (12 plugins + both themes)**: alpha, hotfix (alpha ahead → post-release **merge**, alpha preserved), release promotion (→ **reset**), second hotfix (alpha == release → reset edge). Every run: `release`/`alpha`/`main` end `workspace:*`, zero concretized deps, versions current.
2. **Release-zip verification** (hotfix touching a plugin + both themes):
   - `newspack-sponsors` zip → PHP header `Version: 2.2.7-hotfix-zip-verify.1` ✓ (`package.json` excluded ✓)
   - `newspack-theme` zip → `style.css` `Version: 2.23.4-hotfix-zip-verify.1` ✓
   - `newspack-block-theme` → `_theme-description.scss` + `functions.php` `Version: 1.28.6-hotfix-zip-verify.1` ✓
   - finalize commit synced all `package.json` versions with `workspace:*` intact ✓

### Notes:

- Supersedes earlier approaches on this branch (post-hoc restore, then prepare-time preserve). The preserve-in-`prepare` variant broke `@automattic/newspack-blocks`' npm publish (it reverted deps before `publish`); dropping `package.json` from the commit avoids the publish-vs-commit tension entirely.
- Pre-existing, out of scope: `newspack-block-theme`'s built `style.css` carries the pre-build version (its `style.css` isn't in that theme's `semantic-release-version-bump` `files`, and the build runs before the bump). Not introduced here; worth a separate look if the block theme's WP-displayed version should track the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)