### PR TITLE
refactor(emails): move Reset endpoint to emails-settings namespace (NPPD-1535)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-donations.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-donations.php
@@ -48,15 +48,8 @@ class Audience_Donations extends Wizard {
 
 	/**
 	 * Add Donations page.
-	 *
-	 * The Donations wizard manages Newspack-platform (WooCommerce-backed) donations.
-	 * Other platforms (NRH, "other") are configured elsewhere, so the submenu entry
-	 * is hidden unless the reader revenue platform is Newspack.
 	 */
 	public function add_page() {
-		if ( ! Donations::is_platform_wc() ) {
-			return;
-		}
 		add_submenu_page(
 			$this->parent_slug,
 			$this->get_name(),
@@ -130,16 +123,6 @@ class Audience_Donations extends Wizard {
 				],
 			]
 		);
-
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/emails/(?P<id>\d+)',
-			[
-				'methods'             => \WP_REST_Server::DELETABLE,
-				'callback'            => [ $this, 'api_reset_donation_email' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
 	}
 
 	/**
@@ -174,17 +157,11 @@ class Audience_Donations extends Wizard {
 	public function fetch_all_data() {
 		$platform = Donations::get_platform_slug();
 
-		// get_donation_settings() returns a WP_Error when the WooCommerce suite isn't
-		// fully active (e.g. platform is 'wc' but Subscriptions is missing). Surface an
-		// empty array in that case so the response doesn't carry a serialized WP_Error;
-		// missing plugins are reported separately via plugin_status below.
-		$donation_settings = Donations::get_donation_settings();
-
 		$args = [
 			'platform_data'      => [
 				'platform' => $platform,
 			],
-			'donation_data'      => is_wp_error( $donation_settings ) ? [] : $donation_settings,
+			'donation_data'      => Donations::get_donation_settings(),
 			'donation_page'      => Donations::get_donation_page_info(),
 			'product_validation' => $this->validate_donation_products(),
 		];
@@ -227,55 +204,6 @@ class Audience_Donations extends Wizard {
 		}
 
 		return rest_ensure_response( $this->fetch_all_data() );
-	}
-
-	/**
-	 * Reset donation email template.
-	 * We acheive this by trashing the email template post.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 *
-	 * @return WP_Error|WP_REST_Response
-	 */
-	public function api_reset_donation_email( $request ) {
-		$params = $request->get_params();
-		$id     = $params['id'];
-		$email  = get_post( $id );
-
-		// Source boundary: this route can only ever reset Newspack-managed
-		// emails. The `post_type === Emails::POST_TYPE` check below is the
-		// enforcement — non-Newspack sources are never stored as POST_TYPE
-		// posts. WooCommerce-source rows are live `WC_Email` objects with
-		// `wc:`-prefixed string ids, which additionally can't match the
-		// route's numeric-only `(?P<id>\d+)` pattern. So a direct REST call
-		// cannot reset a row the UI gates behind `source === 'newspack'`.
-		// NPPD-1532 moves this handler under wizard/newspack-settings/emails;
-		// the boundary check moves with it.
-		if ( $email === null || $email->post_type !== Emails::POST_TYPE ) {
-			return new WP_Error(
-				'newspack_reset_donation_email_invalid_arg',
-				esc_html__( 'Invalid argument: no email template matches the provided id.', 'newspack-plugin' ),
-				[
-					'status' => 400,
-					'level'  => 'notice',
-				]
-			);
-		}
-
-		if ( ! wp_trash_post( $id ) ) {
-			return new WP_Error(
-				'newspack_reset_donation_email_reset_failed',
-				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
-				[
-					'status' => 400,
-					'level'  => 'notice',
-				]
-			);
-		}
-
-		return rest_ensure_response(
-			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
-		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-donations.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-donations.php
@@ -123,16 +123,6 @@ class Audience_Donations extends Wizard {
 				],
 			]
 		);
-
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/emails/(?P<id>\d+)',
-			[
-				'methods'             => \WP_REST_Server::DELETABLE,
-				'callback'            => [ $this, 'api_reset_donation_email' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
 	}
 
 	/**
@@ -214,46 +204,6 @@ class Audience_Donations extends Wizard {
 		}
 
 		return rest_ensure_response( $this->fetch_all_data() );
-	}
-
-	/**
-	 * Reset donation email template.
-	 * We acheive this by trashing the email template post.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 *
-	 * @return WP_Error|WP_REST_Response
-	 */
-	public function api_reset_donation_email( $request ) {
-		$params = $request->get_params();
-		$id     = $params['id'];
-		$email  = get_post( $id );
-
-		if ( $email === null || $email->post_type !== Emails::POST_TYPE ) {
-			return new WP_Error(
-				'newspack_reset_donation_email_invalid_arg',
-				esc_html__( 'Invalid argument: no email template matches the provided id.', 'newspack-plugin' ),
-				[
-					'status' => 400,
-					'level'  => 'notice',
-				]
-			);
-		}
-
-		if ( ! wp_trash_post( $id ) ) {
-			return new WP_Error(
-				'newspack_reset_donation_email_reset_failed',
-				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
-				[
-					'status' => 400,
-					'level'  => 'notice',
-				]
-			);
-		}
-
-		return rest_ensure_response(
-			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
-		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -12,6 +12,7 @@ use Newspack\Reader_Activation;
 use Newspack\Reader_Revenue_Emails;
 use Newspack\Wizards\Wizard_Section;
 use Newspack\WooCommerce_Emails;
+use WP_Error;
 use WP_REST_Server;
 
 defined( 'ABSPATH' ) || exit;
@@ -27,9 +28,25 @@ class Emails_Section extends Wizard_Section {
 	/**
 	 * Containing wizard slug.
 	 *
+	 * Vestigial: the actual REST path is constructed from `self::REST_BASE`,
+	 * not this property. The parent `Wizard_Section::__construct` overwrites
+	 * this from the `wizard_slug` arg passed by `Wizard::load_wizard_sections`
+	 * anyway. Kept for parity with sibling sections and any inherited base-
+	 * class behavior that reads it.
+	 *
 	 * @var string
 	 */
 	protected $wizard_slug = 'newspack-settings';
+
+	/**
+	 * REST base path for Emails endpoints.
+	 *
+	 * Hardcoded to 'newspack-settings' for API stability. When NPPD-1538
+	 * later moves the Emails screen from Newspack > Settings to Audience >
+	 * Configuration, this REST path MUST stay at 'newspack-settings' —
+	 * external callers and the frontend depend on it. Do NOT change.
+	 */
+	const REST_BASE = 'wizard/newspack-settings/emails';
 
 	/**
 	 * Constructor — extends Wizard_Section's REST-route hookup with an
@@ -73,11 +90,35 @@ class Emails_Section extends Wizard_Section {
 	public function register_rest_routes() {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'wizard/' . $this->wizard_slug . '/emails',
+			self::REST_BASE,
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_email_settings' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		// Reset endpoint — trashes the email template post so the next
+		// read recreates it from the default template. Owns the action
+		// the donations wizard used to register at
+		// `/wizard/newspack-audience-donations/emails/{id}` — consolidated
+		// under the emails namespace in NPPD-1535. Registered
+		// unconditionally; resetting a Newspack-managed email has no WC
+		// dependency.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_BASE . '/(?P<id>\d+)',
+			[
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => [ __CLASS__, 'api_reset_email' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					],
+				],
 			]
 		);
 
@@ -86,7 +127,7 @@ class Emails_Section extends Wizard_Section {
 		if ( self::is_woocommerce_active() ) {
 			register_rest_route(
 				NEWSPACK_API_NAMESPACE,
-				'wizard/' . $this->wizard_slug . '/emails/(?P<id>[A-Za-z0-9_]+)/toggle',
+				self::REST_BASE . '/(?P<id>[A-Za-z0-9_]+)/toggle',
 				[
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ __CLASS__, 'api_toggle_wc_email' ],
@@ -163,6 +204,64 @@ class Emails_Section extends Wizard_Section {
 		}
 
 		return rest_ensure_response( self::api_get_email_settings() );
+	}
+
+	/**
+	 * Reset an email template by trashing the email post.
+	 *
+	 * Ported from `Audience_Donations::api_reset_donation_email` in
+	 * NPPD-1535 — the endpoint conceptually belongs under the emails
+	 * namespace, not the donations wizard. Returns the refreshed email
+	 * list (same shape the donations endpoint returned) so existing
+	 * callers stay compatible.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public static function api_reset_email( $request ) {
+		$id    = $request->get_param( 'id' );
+		$email = get_post( $id );
+
+		// Source boundary: this route can only ever reset Newspack-managed
+		// emails. The `POST_TYPE === $email->post_type` check below is the
+		// enforcement — non-Newspack sources are never stored as POST_TYPE
+		// posts. WooCommerce-source rows are live `WC_Email` objects with
+		// `wc:`-prefixed string ids, which additionally can't match the
+		// route's numeric-only `(?P<id>\d+)` pattern (`absint`-sanitized).
+		// So a direct REST call cannot reset a row the UI gates behind
+		// `source === 'newspack'`.
+		if ( null === $email || Emails::POST_TYPE !== $email->post_type ) {
+			return new WP_Error(
+				'newspack_reset_email_invalid_arg',
+				esc_html__( 'Invalid argument: no email template matches the provided id.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		if ( ! wp_trash_post( $id ) ) {
+			return new WP_Error(
+				'newspack_reset_email_reset_failed',
+				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		// Returns the raw Emails::get_emails() array, not the enriched
+		// api_get_email_settings() shape that the sibling api_toggle_wc_email
+		// returns. Preserves the legacy donations-endpoint contract
+		// (callers depending on the raw shape don't break on the move).
+		// Aligning sibling endpoints in this class on a single shape is
+		// tracked separately — see NPPD-1569.
+		return rest_ensure_response(
+			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -28,6 +28,12 @@ class Emails_Section extends Wizard_Section {
 	/**
 	 * Containing wizard slug.
 	 *
+	 * Vestigial: the actual REST path is constructed from `self::REST_BASE`,
+	 * not this property. The parent `Wizard_Section::__construct` overwrites
+	 * this from the `wizard_slug` arg passed by `Wizard::load_wizard_sections`
+	 * anyway. Kept for parity with sibling sections and any inherited base-
+	 * class behavior that reads it.
+	 *
 	 * @var string
 	 */
 	protected $wizard_slug = 'newspack-settings';
@@ -35,9 +41,10 @@ class Emails_Section extends Wizard_Section {
 	/**
 	 * REST base path for Emails endpoints.
 	 *
-	 * Hardcoded to 'newspack-settings' for API stability — even though
-	 * Emails moved to the Audience wizard in NPPD-1538, external callers
-	 * and the frontend depend on this path. Do NOT change.
+	 * Hardcoded to 'newspack-settings' for API stability. When NPPD-1538
+	 * later moves the Emails screen from Newspack > Settings to Audience >
+	 * Configuration, this REST path MUST stay at 'newspack-settings' —
+	 * external callers and the frontend depend on it. Do NOT change.
 	 */
 	const REST_BASE = 'wizard/newspack-settings/emails';
 
@@ -105,6 +112,13 @@ class Emails_Section extends Wizard_Section {
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => [ __CLASS__, 'api_reset_email' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					],
+				],
 			]
 		);
 
@@ -222,7 +236,7 @@ class Emails_Section extends Wizard_Section {
 
 		if ( ! wp_trash_post( $id ) ) {
 			return new WP_Error(
-				'newspack_reset_email_failed',
+				'newspack_reset_email_reset_failed',
 				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
 				[
 					'status' => 400,

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -12,6 +12,7 @@ use Newspack\Reader_Activation;
 use Newspack\Reader_Revenue_Emails;
 use Newspack\Wizards\Wizard_Section;
 use Newspack\WooCommerce_Emails;
+use WP_Error;
 use WP_REST_Server;
 
 defined( 'ABSPATH' ) || exit;
@@ -30,6 +31,15 @@ class Emails_Section extends Wizard_Section {
 	 * @var string
 	 */
 	protected $wizard_slug = 'newspack-settings';
+
+	/**
+	 * REST base path for Emails endpoints.
+	 *
+	 * Hardcoded to 'newspack-settings' for API stability — even though
+	 * Emails moved to the Audience wizard in NPPD-1538, external callers
+	 * and the frontend depend on this path. Do NOT change.
+	 */
+	const REST_BASE = 'wizard/newspack-settings/emails';
 
 	/**
 	 * Constructor — extends Wizard_Section's REST-route hookup with an
@@ -73,10 +83,27 @@ class Emails_Section extends Wizard_Section {
 	public function register_rest_routes() {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'wizard/' . $this->wizard_slug . '/emails',
+			self::REST_BASE,
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_email_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		// Reset endpoint — trashes the email template post so the next
+		// read recreates it from the default template. Owns the action
+		// the donations wizard used to register at
+		// `/wizard/newspack-audience-donations/emails/{id}` — consolidated
+		// under the emails namespace in NPPD-1535. Registered
+		// unconditionally; resetting a Newspack-managed email has no WC
+		// dependency.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_BASE . '/(?P<id>\d+)',
+			[
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => [ __CLASS__, 'api_reset_email' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
@@ -86,7 +113,7 @@ class Emails_Section extends Wizard_Section {
 		if ( self::is_woocommerce_active() ) {
 			register_rest_route(
 				NEWSPACK_API_NAMESPACE,
-				'wizard/' . $this->wizard_slug . '/emails/(?P<id>[A-Za-z0-9_]+)/toggle',
+				self::REST_BASE . '/(?P<id>[A-Za-z0-9_]+)/toggle',
 				[
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ __CLASS__, 'api_toggle_wc_email' ],
@@ -163,6 +190,50 @@ class Emails_Section extends Wizard_Section {
 		}
 
 		return rest_ensure_response( self::api_get_email_settings() );
+	}
+
+	/**
+	 * Reset an email template by trashing the email post.
+	 *
+	 * Ported from `Audience_Donations::api_reset_donation_email` in
+	 * NPPD-1535 — the endpoint conceptually belongs under the emails
+	 * namespace, not the donations wizard. Returns the refreshed email
+	 * list (same shape the donations endpoint returned) so existing
+	 * callers stay compatible.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public static function api_reset_email( $request ) {
+		$id    = $request->get_param( 'id' );
+		$email = get_post( $id );
+
+		if ( null === $email || Emails::POST_TYPE !== $email->post_type ) {
+			return new WP_Error(
+				'newspack_reset_email_invalid_arg',
+				esc_html__( 'Invalid argument: no email template matches the provided id.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		if ( ! wp_trash_post( $id ) ) {
+			return new WP_Error(
+				'newspack_reset_email_failed',
+				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		return rest_ensure_response(
+			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -245,6 +245,12 @@ class Emails_Section extends Wizard_Section {
 			);
 		}
 
+		// Returns the raw Emails::get_emails() array, not the enriched
+		// api_get_email_settings() shape that the sibling api_toggle_wc_email
+		// returns. Preserves the legacy donations-endpoint contract
+		// (callers depending on the raw shape don't break on the move).
+		// Aligning sibling endpoints in this class on a single shape is
+		// tracked separately — see NPPD-1569.
 		return rest_ensure_response(
 			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
 		);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -385,7 +385,7 @@ describe( 'Emails', () => {
 
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				path: '/newspack/v1/wizard/newspack-audience-donations/emails/1',
+				path: '/newspack/v1/wizard/newspack-settings/emails/1',
 				method: 'DELETE',
 			} ),
 			expect.objectContaining( {

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -381,7 +381,7 @@ describe( 'Emails', () => {
 
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				path: '/newspack/v1/wizard/newspack-audience-donations/emails/1',
+				path: '/newspack/v1/wizard/newspack-settings/emails/1',
 				method: 'DELETE',
 			} ),
 			expect.objectContaining( {

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -202,12 +202,9 @@ const Emails = () => {
 
 	const resetEmail = ( postId: number ) => {
 		resetError();
-		// @todo NPPD-1532 Move reset handler to class-emails-section.php so it
-		// lives under wizard/newspack-settings/emails/{id} instead of reaching
-		// into the donations wizard namespace.
 		wizardApiFetch(
 			{
-				path: `/newspack/v1/wizard/newspack-audience-donations/emails/${ postId }`,
+				path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }`,
 				method: 'DELETE',
 			},
 			{

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -193,12 +193,9 @@ const Emails = () => {
 
 	const resetEmail = ( postId: number ) => {
 		resetError();
-		// @todo NPPD-1532 Move reset handler to class-emails-section.php so it
-		// lives under wizard/newspack-settings/emails/{id} instead of reaching
-		// into the donations wizard namespace.
 		wizardApiFetch(
 			{
-				path: `/newspack/v1/wizard/newspack-audience-donations/emails/${ postId }`,
+				path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }`,
 				method: 'DELETE',
 			},
 			{

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -521,4 +521,208 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		$this->assertSame( [], Emails_Section::filter_configs_by_ra_state( true, [] ) );
 		$this->assertSame( [], Emails_Section::filter_configs_by_ra_state( false, [] ) );
 	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F — Reset endpoint (NPPD-1535)
+	 * ------------------------------------------------------------------
+	 * Validates `api_reset_email`, the DELETE
+	 * /wizard/newspack-settings/emails/{id} handler ported from
+	 * Audience_Donations in NPPD-1535. Plus architectural-lock-in
+	 * assertions that the new route is registered with the expected
+	 * permission_callback AND that the legacy donations-namespace route
+	 * is gone.
+	 */
+
+	/**
+	 * Happy path: a valid email post ID is trashed and the response
+	 * carries the refreshed list shape from `Emails::get_emails()`.
+	 */
+	public function test_reset_email_successful() {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Test email for reset',
+				'meta_input'  => [
+					Emails::EMAIL_CONFIG_NAME_META => 'receipt',
+				],
+			]
+		);
+
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', $post_id );
+
+		$response = Emails_Section::api_reset_email( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response, 'Reset on a valid email post should not error.' );
+		$this->assertSame( 'trash', get_post_status( $post_id ), 'Email post should be trashed after reset.' );
+		$this->assertIsArray( $response->get_data(), 'Response payload should be the refreshed email list array.' );
+	}
+
+	/**
+	 * Trash-failure branch: when `wp_trash_post()` fails, the handler returns
+	 * 400 with the `newspack_reset_email_reset_failed` code and leaves the
+	 * post un-trashed. The failure is forced via the `pre_trash_post`
+	 * short-circuit filter (returning non-null makes wp_trash_post() return
+	 * that value without trashing). Locks the error code introduced when the
+	 * endpoint moved off the donations namespace in NPPD-1535.
+	 */
+	public function test_reset_email_trash_failure() {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Test email for reset failure',
+				'meta_input'  => [
+					Emails::EMAIL_CONFIG_NAME_META => 'receipt',
+				],
+			]
+		);
+
+		add_filter( 'pre_trash_post', '__return_false' );
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', $post_id );
+		$response = Emails_Section::api_reset_email( $request );
+		remove_filter( 'pre_trash_post', '__return_false' );
+
+		$this->assertInstanceOf( WP_Error::class, $response, 'A failed trash must return WP_Error.' );
+		$this->assertSame( 'newspack_reset_email_reset_failed', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ), 'Post must remain un-trashed when the trash fails.' );
+	}
+
+	/**
+	 * Non-existent post ID returns 400 with the invalid_arg error code.
+	 *
+	 * Uses `wp_insert_post` + `wp_delete_post( … true )` to derive a
+	 * guaranteed-missing ID rather than a hardcoded sentinel like
+	 * `999999`. A hardcoded sentinel can collide with a real post in
+	 * long-running test suites or seeded environments — at which point
+	 * the test would fall through to the wrong-post-type branch (same
+	 * error code) and silently pass for the wrong reason.
+	 */
+	public function test_reset_email_invalid_post_id() {
+		$missing_id = wp_insert_post(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Temp post to derive a guaranteed-missing id',
+			]
+		);
+		wp_delete_post( $missing_id, true );
+
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', $missing_id );
+
+		$response = Emails_Section::api_reset_email( $request );
+
+		$this->assertNull( get_post( $missing_id ), 'Sanity: the derived id must actually be missing.' );
+		$this->assertInstanceOf( WP_Error::class, $response, 'A nonexistent post id must return WP_Error.' );
+		$this->assertSame( 'newspack_reset_email_invalid_arg', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Passing a non-email post type returns 400 with the invalid_arg error.
+	 *
+	 * Defense against accidental cross-type deletion — e.g. a request
+	 * crafted with a regular post's ID must NOT trash that post.
+	 */
+	public function test_reset_email_wrong_post_type() {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post — not an email',
+			]
+		);
+
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', $post_id );
+
+		$response = Emails_Section::api_reset_email( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, 'A non-email post type must return WP_Error.' );
+		$this->assertSame( 'newspack_reset_email_invalid_arg', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ), 'Non-email post must not be trashed by the reset endpoint.' );
+	}
+
+	/**
+	 * Architectural lock-in (permission_callback registration):
+	 *
+	 * The DELETE route's `permission_callback` is the only thing
+	 * blocking unauthenticated callers from trashing email posts.
+	 * Asserting `api_permissions_check()` works in isolation is not
+	 * enough — a regression that drops `'permission_callback' =>
+	 * [ $this, 'api_permissions_check' ]` from the route registration
+	 * would still leave the standalone method working, but WP would
+	 * default the route to `__return_true` (with a _doing_it_wrong
+	 * notice) and the endpoint would be open. So this test introspects
+	 * the actual registered route via `rest_get_server()->get_routes()`
+	 * and asserts the route entry carries a callable
+	 * `permission_callback` that is NOT `__return_true`.
+	 */
+	public function test_reset_email_route_has_permission_callback() {
+		do_action( 'rest_api_init' );
+		$routes    = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$new_path  = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-settings/emails/(?P<id>\d+)';
+		$endpoints = $routes[ $new_path ] ?? [];
+
+		$delete_endpoint = null;
+		foreach ( $endpoints as $endpoint ) {
+			$methods = $endpoint['methods'] ?? [];
+			if ( ! empty( $methods['DELETE'] ) ) {
+				$delete_endpoint = $endpoint;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $delete_endpoint, 'DELETE method on the reset route should be registered.' );
+		$this->assertArrayHasKey( 'permission_callback', $delete_endpoint, 'DELETE route must declare a permission_callback.' );
+		$this->assertNotSame( '__return_true', $delete_endpoint['permission_callback'], 'permission_callback must not default to __return_true (would leave the endpoint open).' );
+		$this->assertIsCallable( $delete_endpoint['permission_callback'], 'permission_callback must be a real callable, not a string placeholder.' );
+
+		// And the callback itself must deny anonymous callers.
+		$prev_user = get_current_user_id();
+		wp_set_current_user( 0 );
+		$result = call_user_func( $delete_endpoint['permission_callback'], new WP_REST_Request( 'DELETE' ) );
+		wp_set_current_user( $prev_user );
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'Anonymous user must be denied.' );
+		$this->assertSame( 'newspack_rest_forbidden', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Architectural lock-in (route migration):
+	 *
+	 * 1. Positive: `/newspack/v1/wizard/newspack-settings/emails/(?P<id>\d+)`
+	 *    IS registered. Without this, a refactor that removes both the
+	 *    new and legacy route registrations would silently break the
+	 *    feature while leaving the negative-only assertion below
+	 *    passing.
+	 * 2. Negative: `/newspack/v1/wizard/newspack-audience-donations/emails/(?P<id>\d+)`
+	 *    is NOT registered. NPPD-1535 moved the endpoint; this guards
+	 *    against a bad merge resurrecting `api_reset_donation_email`.
+	 *
+	 * Modeled on the route-presence/absence assertion pattern used at
+	 * `tests/unit-tests/corrections.php:53-56` (positive) and
+	 * `tests/unit-tests/content-gate/class-ip-access-rule.php:97-99`
+	 * (route shape introspection).
+	 */
+	public function test_reset_route_moved_to_emails_namespace() {
+		do_action( 'rest_api_init' );
+		$routes = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+
+		$new_path    = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-settings/emails/(?P<id>\d+)';
+		$legacy_path = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-donations/emails/(?P<id>\d+)';
+
+		$this->assertArrayHasKey( $new_path, $routes, 'The reset route at REST_BASE/{id} must be registered.' );
+		$this->assertArrayNotHasKey(
+			$legacy_path,
+			$routes,
+			'The legacy donations-namespace reset route was re-registered. NPPD-1535 moved it to /wizard/newspack-settings/emails/{id} — if you intentionally need to revert, update the frontend resetEmail() path accordingly.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -519,4 +519,128 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		$this->assertSame( [], Emails_Section::filter_configs_by_ra_state( true, [] ) );
 		$this->assertSame( [], Emails_Section::filter_configs_by_ra_state( false, [] ) );
 	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket E — Reset endpoint (NPPD-1535)
+	 * ------------------------------------------------------------------
+	 * Validates `api_reset_email`, the DELETE
+	 * /wizard/newspack-settings/emails/{id} handler ported from
+	 * Audience_Donations in NPPD-1535. Plus an architectural-lock-in
+	 * assertion that the legacy donations-namespace route is gone.
+	 */
+
+	/**
+	 * Happy path: a valid email post ID is trashed and the response
+	 * carries the refreshed list shape from `Emails::get_emails()`.
+	 */
+	public function test_reset_email_successful() {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Test email for reset',
+				'meta_input'  => [
+					Emails::EMAIL_CONFIG_NAME_META => 'receipt',
+				],
+			]
+		);
+
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', $post_id );
+
+		$response = Emails_Section::api_reset_email( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response, 'Reset on a valid email post should not error.' );
+		$this->assertSame( 'trash', get_post_status( $post_id ), 'Email post should be trashed after reset.' );
+		$this->assertIsArray( $response->get_data(), 'Response payload should be the refreshed email list array.' );
+	}
+
+	/**
+	 * Non-existent post ID returns 400 with the invalid_arg error code.
+	 */
+	public function test_reset_email_invalid_post_id() {
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', 999999 );
+
+		$response = Emails_Section::api_reset_email( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, 'A nonexistent post id must return WP_Error.' );
+		$this->assertSame( 'newspack_reset_email_invalid_arg', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Passing a non-email post type returns 400 with the invalid_arg error.
+	 *
+	 * Defense against accidental cross-type deletion — e.g. a request
+	 * crafted with a regular post's ID must NOT trash that post.
+	 */
+	public function test_reset_email_wrong_post_type() {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post — not an email',
+			]
+		);
+
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'id', $post_id );
+
+		$response = Emails_Section::api_reset_email( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, 'A non-email post type must return WP_Error.' );
+		$this->assertSame( 'newspack_reset_email_invalid_arg', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ), 'Non-email post must not be trashed by the reset endpoint.' );
+	}
+
+	/**
+	 * Permission check blocks unauthenticated callers via the 403
+	 * permission_callback inherited from Wizard_Section.
+	 *
+	 * The capability check (`manage_options`) lives on the base class,
+	 * not on `api_reset_email`. This test guards against accidentally
+	 * removing the `permission_callback` from the DELETE route's
+	 * registration in a future change.
+	 */
+	public function test_reset_email_permission_check() {
+		wp_set_current_user( 0 );
+
+		$section = new Emails_Section();
+		$result  = $section->api_permissions_check();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'newspack_rest_forbidden', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Architectural lock-in: the legacy donations-namespace reset route
+	 * MUST NOT be re-registered.
+	 *
+	 * NPPD-1535 moved the endpoint to
+	 * `/newspack/v1/wizard/newspack-settings/emails/{id}`. If a future
+	 * change accidentally resurrects the donations-side registration
+	 * (e.g. a bad merge that brings back `api_reset_donation_email`),
+	 * this test fails loudly instead of silently breaking the unified
+	 * emails wizard's reset action.
+	 *
+	 * Compare against
+	 * `tests/unit-tests/woocommerce-email-style-sync.php`'s
+	 * `test_no_customize_save_after_or_after_switch_theme_hooks` for
+	 * the same architectural-lock-in pattern.
+	 */
+	public function test_old_donations_namespace_route_no_longer_registered() {
+		do_action( 'rest_api_init' );
+		$routes      = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$legacy_path = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-donations/emails/(?P<id>\d+)';
+
+		$this->assertArrayNotHasKey(
+			$legacy_path,
+			$routes,
+			'The legacy donations-namespace reset route was re-registered. NPPD-1535 moved it to /wizard/newspack-settings/emails/{id} — if you intentionally need to revert, update the frontend resetEmail() path accordingly.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -522,12 +522,14 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 
 	/*
 	 * ------------------------------------------------------------------
-	 * Bucket E — Reset endpoint (NPPD-1535)
+	 * Bucket F — Reset endpoint (NPPD-1535)
 	 * ------------------------------------------------------------------
 	 * Validates `api_reset_email`, the DELETE
 	 * /wizard/newspack-settings/emails/{id} handler ported from
-	 * Audience_Donations in NPPD-1535. Plus an architectural-lock-in
-	 * assertion that the legacy donations-namespace route is gone.
+	 * Audience_Donations in NPPD-1535. Plus architectural-lock-in
+	 * assertions that the new route is registered with the expected
+	 * permission_callback AND that the legacy donations-namespace route
+	 * is gone.
 	 */
 
 	/**
@@ -558,13 +560,29 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 
 	/**
 	 * Non-existent post ID returns 400 with the invalid_arg error code.
+	 *
+	 * Uses `wp_insert_post` + `wp_delete_post( … true )` to derive a
+	 * guaranteed-missing ID rather than a hardcoded sentinel like
+	 * `999999`. A hardcoded sentinel can collide with a real post in
+	 * long-running test suites or seeded environments — at which point
+	 * the test would fall through to the wrong-post-type branch (same
+	 * error code) and silently pass for the wrong reason.
 	 */
 	public function test_reset_email_invalid_post_id() {
+		$missing_id = wp_insert_post(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Temp post to derive a guaranteed-missing id',
+			]
+		);
+		wp_delete_post( $missing_id, true );
+
 		$request = new WP_REST_Request( 'DELETE' );
-		$request->set_param( 'id', 999999 );
+		$request->set_param( 'id', $missing_id );
 
 		$response = Emails_Section::api_reset_email( $request );
 
+		$this->assertNull( get_post( $missing_id ), 'Sanity: the derived id must actually be missing.' );
 		$this->assertInstanceOf( WP_Error::class, $response, 'A nonexistent post id must return WP_Error.' );
 		$this->assertSame( 'newspack_reset_email_invalid_arg', $response->get_error_code() );
 		$this->assertSame( 400, $response->get_error_data()['status'] );
@@ -597,46 +615,76 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Permission check blocks unauthenticated callers via the 403
-	 * permission_callback inherited from Wizard_Section.
+	 * Architectural lock-in (permission_callback registration):
 	 *
-	 * The capability check (`manage_options`) lives on the base class,
-	 * not on `api_reset_email`. This test guards against accidentally
-	 * removing the `permission_callback` from the DELETE route's
-	 * registration in a future change.
+	 * The DELETE route's `permission_callback` is the only thing
+	 * blocking unauthenticated callers from trashing email posts.
+	 * Asserting `api_permissions_check()` works in isolation is not
+	 * enough — a regression that drops `'permission_callback' =>
+	 * [ $this, 'api_permissions_check' ]` from the route registration
+	 * would still leave the standalone method working, but WP would
+	 * default the route to `__return_true` (with a _doing_it_wrong
+	 * notice) and the endpoint would be open. So this test introspects
+	 * the actual registered route via `rest_get_server()->get_routes()`
+	 * and asserts the route entry carries a callable
+	 * `permission_callback` that is NOT `__return_true`.
 	 */
-	public function test_reset_email_permission_check() {
+	public function test_reset_email_route_has_permission_callback() {
+		do_action( 'rest_api_init' );
+		$routes    = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$new_path  = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-settings/emails/(?P<id>\d+)';
+		$endpoints = $routes[ $new_path ] ?? [];
+
+		$delete_endpoint = null;
+		foreach ( $endpoints as $endpoint ) {
+			$methods = $endpoint['methods'] ?? [];
+			if ( ! empty( $methods['DELETE'] ) ) {
+				$delete_endpoint = $endpoint;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $delete_endpoint, 'DELETE method on the reset route should be registered.' );
+		$this->assertArrayHasKey( 'permission_callback', $delete_endpoint, 'DELETE route must declare a permission_callback.' );
+		$this->assertNotSame( '__return_true', $delete_endpoint['permission_callback'], 'permission_callback must not default to __return_true (would leave the endpoint open).' );
+		$this->assertIsCallable( $delete_endpoint['permission_callback'], 'permission_callback must be a real callable, not a string placeholder.' );
+
+		// And the callback itself must deny anonymous callers.
+		$prev_user = get_current_user_id();
 		wp_set_current_user( 0 );
+		$result = call_user_func( $delete_endpoint['permission_callback'], new WP_REST_Request( 'DELETE' ) );
+		wp_set_current_user( $prev_user );
 
-		$section = new Emails_Section();
-		$result  = $section->api_permissions_check();
-
-		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertInstanceOf( WP_Error::class, $result, 'Anonymous user must be denied.' );
 		$this->assertSame( 'newspack_rest_forbidden', $result->get_error_code() );
 		$this->assertSame( 403, $result->get_error_data()['status'] );
 	}
 
 	/**
-	 * Architectural lock-in: the legacy donations-namespace reset route
-	 * MUST NOT be re-registered.
+	 * Architectural lock-in (route migration):
 	 *
-	 * NPPD-1535 moved the endpoint to
-	 * `/newspack/v1/wizard/newspack-settings/emails/{id}`. If a future
-	 * change accidentally resurrects the donations-side registration
-	 * (e.g. a bad merge that brings back `api_reset_donation_email`),
-	 * this test fails loudly instead of silently breaking the unified
-	 * emails wizard's reset action.
+	 * 1. Positive: `/newspack/v1/wizard/newspack-settings/emails/(?P<id>\d+)`
+	 *    IS registered. Without this, a refactor that removes both the
+	 *    new and legacy route registrations would silently break the
+	 *    feature while leaving the negative-only assertion below
+	 *    passing.
+	 * 2. Negative: `/newspack/v1/wizard/newspack-audience-donations/emails/(?P<id>\d+)`
+	 *    is NOT registered. NPPD-1535 moved the endpoint; this guards
+	 *    against a bad merge resurrecting `api_reset_donation_email`.
 	 *
-	 * Compare against
-	 * `tests/unit-tests/woocommerce-email-style-sync.php`'s
-	 * `test_no_customize_save_after_or_after_switch_theme_hooks` for
-	 * the same architectural-lock-in pattern.
+	 * Modeled on the route-presence/absence assertion pattern used at
+	 * `tests/unit-tests/corrections.php:53-56` (positive) and
+	 * `tests/unit-tests/content-gate/class-ip-access-rule.php:97-99`
+	 * (route shape introspection).
 	 */
-	public function test_old_donations_namespace_route_no_longer_registered() {
+	public function test_reset_route_moved_to_emails_namespace() {
 		do_action( 'rest_api_init' );
-		$routes      = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$routes = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+
+		$new_path    = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-settings/emails/(?P<id>\d+)';
 		$legacy_path = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-donations/emails/(?P<id>\d+)';
 
+		$this->assertArrayHasKey( $new_path, $routes, 'The reset route at REST_BASE/{id} must be registered.' );
 		$this->assertArrayNotHasKey(
 			$legacy_path,
 			$routes,


### PR DESCRIPTION
## Summary

Moves the email Reset endpoint out of the donations wizard namespace and into the unified emails-settings namespace where it belongs. Introduces a `REST_BASE` constant on `Emails_Section` that pins the email REST paths at `wizard/newspack-settings/emails` for API stability, with a docblock noting the pin must survive NPPD-1538's later screen relocation.

Resolves [NPPD-1535](https://linear.app/a8c/issue/NPPD-1535).

## Stacking

⚠️ **Stacked on slice 2b ([#146](https://github.com/Automattic/newspack-workspace/pull/146)).** Review order: [#137](https://github.com/Automattic/newspack-workspace/pull/137) → [#144](https://github.com/Automattic/newspack-workspace/pull/144) → [#146](https://github.com/Automattic/newspack-workspace/pull/146) → this. Stacked because slice 2b is where `Emails_Section` was rebuilt with the unified GET + toggle routes — Reset slots in next to its natural neighbors there.

## What changes

**Backend:**
- New `Emails_Section::REST_BASE = 'wizard/newspack-settings/emails'` constant. Docblock explicitly notes the path is hardcoded for API stability — even though NPPD-1538 will later move the Emails screen to the Audience wizard, the REST path must remain unchanged because external callers and the frontend depend on it.
- Existing GET + toggle routes refactored to use `self::REST_BASE` (one source of truth instead of `$this->wizard_slug` interpolation).
- New DELETE route at `self::REST_BASE . '/(?P<id>\d+)'`, registered unconditionally (no WC gate — Reset works on Newspack-managed emails regardless of WC presence).
- New `Emails_Section::api_reset_email()` static method, ported from `Audience_Donations::api_reset_donation_email()`. Error codes renamed `newspack_reset_donation_email_*` → `newspack_reset_email_*` to drop the no-longer-accurate "donation" framing.
- `Audience_Donations`: route registration and handler removed entirely. No deprecation shim — the endpoint isn't a publicly-documented API and the move ships atomically with the frontend update.

**Frontend:**
- `emails.tsx::resetEmail()` calls the new path: `/newspack/v1/wizard/newspack-settings/emails/${postId}`.
- Stale `@todo NPPD-1532` comment block deleted — the move is done.

## Looking ahead — relationship to NPPD-1538

NPPD-1538 will move the Emails screen from Newspack → Settings to Audience → Configuration. The legacy [#4759](https://github.com/Automattic/newspack-plugin/pull/4759) handles this by renaming the wizard slug (`newspack-settings` → `newspack-audience`) while explicitly pinning REST paths via a hardcoded constant. This PR pre-introduces that pattern under the same `REST_BASE` name and docblock — so when 1538 lands, it inherits the pattern rather than introducing it. 1538's diff is smaller as a result; the API-stability discipline lands in main now rather than waiting.

## Testing

Five new tests in `tests/unit-tests/emails-section.php` as a fifth bucket ("Bucket E — Reset endpoint"):

- `test_reset_email_successful` — happy path: valid post ID, post moves to trash, response is the refreshed list.
- `test_reset_email_invalid_post_id` — non-existent ID returns 400 with `newspack_reset_email_invalid_arg` (matches the legacy single-code pattern; both invalid-arg cases share the code).
- `test_reset_email_wrong_post_type` — non-email post returns 400 with `newspack_reset_email_invalid_arg` (same code as above; the API surface treats both as "the ID you passed isn't a reset-able email").
- `test_reset_email_permission_check` — unauthenticated request blocked by `permission_callback`.
- `test_old_donations_namespace_route_no_longer_registered` — **architectural lock-in test**: asserts `rest_get_server()->get_routes()` does not contain `/newspack/v1/wizard/newspack-audience-donations/emails/(?P<id>\d+)` for DELETE after `rest_api_init` fires. Prevents accidental re-introduction of the old route in a future change.

Full PHP suite: 1335 / 0 failures. Baseline against slice 2b's branch tip was 1330; the +5 tests delta matches exactly, no other test counts shifted.