### PR TITLE
fix(block-theme): make sure search, menu overlay blocks don't load commons.css on front-end

### DIFF
--- a/plugins/newspack-plugin/src/blocks/overlay-menu/class-overlay-menu-block.php
+++ b/plugins/newspack-plugin/src/blocks/overlay-menu/class-overlay-menu-block.php
@@ -50,8 +50,15 @@ final class Overlay_Menu_Block {
 	 */
 	public static function render_block( array $attributes, string $content ) {
 		// The compiled view script depends on dist/commons.js (a webpack split chunk).
-		// Ensure commons is enqueued so the entry callback can execute on the frontend.
-		\Newspack\Newspack::load_common_assets();
+		// Enqueue only the commons JS; block styles come from dist/blocks.css instead.
+		\wp_register_script(
+			'newspack_commons',
+			\Newspack\Newspack::plugin_url() . '/dist/commons.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		\wp_enqueue_script( 'newspack_commons' );
 
 		$instance_id = esc_attr( $attributes['instanceId'] ?? '' );
 

--- a/plugins/newspack-plugin/src/blocks/overlay-search/class-overlay-search-block.php
+++ b/plugins/newspack-plugin/src/blocks/overlay-search/class-overlay-search-block.php
@@ -44,8 +44,15 @@ final class Overlay_Search_Block {
 	 */
 	public static function render_block( array $attributes ): string {
 		// The compiled view script depends on dist/commons.js (a webpack split chunk).
-		// Ensure commons is enqueued so the entry callback can execute on the frontend.
-		\Newspack\Newspack::load_common_assets();
+		// Enqueue only the commons JS; block styles come from dist/blocks.css instead.
+		\wp_register_script(
+			'newspack_commons',
+			\Newspack\Newspack::plugin_url() . '/dist/commons.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		\wp_enqueue_script( 'newspack_commons' );
 
 		$defaults   = [
 			'triggerText'  => __( 'Search', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Based on feedback on [this PR](https://github.com/Automattic/newspack-plugin/pull/4729#discussion_r3313809522), this change ensures the new overlay menu and overlay search blocks don't load the commons.css on the front end, since it isn't needed there.

Unfortunately the testing can't fully confirm commons.css isn't loaded because [Reader Activation ALSO enqueues this file unconditionally](https://github.com/Automattic/newspack-workspace/blob/main/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php#L162). There's a hacky step to fake a test. I'm unsure if it can be removed fully or if it's needed for RAS so I focused this PR just on the block feedback for now. 

Closes NPPD-1563

### How to test the changes in this Pull Request:

1. On a site running the block theme, add both the Overlay Menu and Overlay Search blocks to a template part or post/page and publish.
2. View on front-end and ensure they still work (clicking the buttons opens the appropriate panel/search; clicking the close button/overlay or hitting the esc key closes them).
3. Confirm there are no JS errors.
4. Confirm multiple instances of both blocks on the same page work.
5. As a hacky way to confirm this PR actually prevents these blocks from loading commons.css, you can add the following to a temp plugin or the block theme's functions.php file, and compare main to this branch:

```
  add_action( 'wp_enqueue_scripts', function () {
      remove_action( 'wp_enqueue_scripts', [ 'Newspack\Reader_Activation', 'enqueue_scripts' ] );
  }, 1 );
```
6. Confirm the overlay blocks still render correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
