### PR TITLE
feat(emails): move sender/contact settings into Emails screen via Settings modal (NPPD-1566)

### DIFF
--- a/plugins/newspack-plugin/includes/emails/class-emails.php
+++ b/plugins/newspack-plugin/includes/emails/class-emails.php
@@ -43,6 +43,7 @@ class Emails {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'init', [ __CLASS__, 'register_sender_settings' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'newspack_newsletters_email_editor_cpts', [ __CLASS__, 'register_email_cpt_with_email_editor' ] );
@@ -938,9 +939,7 @@ class Emails {
 			}
 			$from_email .= $sitename;
 		}
-		if ( Reader_Activation::is_enabled() ) {
-			$from_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_email_address', $from_email );
-		}
+		$from_email = self::saved_sender_setting_or_default( 'sender_email_address', $from_email );
 		return apply_filters( 'newspack_from_email', $from_email );
 	}
 
@@ -951,9 +950,7 @@ class Emails {
 	 */
 	public static function get_reply_to_email() {
 		$reply_to_email = get_bloginfo( 'admin_email' );
-		if ( Reader_Activation::is_enabled() ) {
-			$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', $reply_to_email );
-		}
+		$reply_to_email = self::saved_sender_setting_or_default( 'contact_email_address', $reply_to_email );
 		return apply_filters( 'newspack_reply_to_email', $reply_to_email );
 	}
 
@@ -966,10 +963,132 @@ class Emails {
 	 */
 	public static function get_from_name() {
 		$from_name = get_bloginfo( 'name' );
-		if ( Reader_Activation::is_enabled() ) {
-			$from_name = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_name', $from_name );
-		}
+		$from_name = self::saved_sender_setting_or_default( 'sender_name', $from_name );
 		return apply_filters( 'newspack_from_name', $from_name );
+	}
+
+	/**
+	 * Resolve a saved transactional-email sender/contact setting,
+	 * falling back to a derived default when unset or empty.
+	 *
+	 * The saved override is honored REGARDLESS of Reader Activation
+	 * state. The Emails > Settings modal surfaces and writes these
+	 * settings whether or not RA is enabled, so silently ignoring a
+	 * saved value when RA is off (the previous behavior) would discard
+	 * an explicit publisher choice and send with the derived default.
+	 * RA visibility rules are kept separate from sender resolution.
+	 *
+	 * An empty stored value means "use the derived default" — this is
+	 * the modal's revert-to-default signal — so empty never overrides.
+	 *
+	 * @param string $key     Option key suffix (e.g. 'sender_name'),
+	 *                        appended to Reader_Activation::OPTIONS_PREFIX.
+	 * @param string $default Derived default to use when unset/empty.
+	 * @return string Saved value when non-empty, otherwise $default.
+	 */
+	private static function saved_sender_setting_or_default( $key, $default ) {
+		$saved = get_option( Reader_Activation::OPTIONS_PREFIX . $key, '' );
+		if ( is_string( $saved ) && '' !== $saved ) {
+			return $saved;
+		}
+		return $default;
+	}
+
+	/**
+	 * Register option-layer sanitization for the three transactional
+	 * sender/contact settings, so EVERY writer inherits the same guard:
+	 * the Emails > Settings route, the legacy Audience-Management route,
+	 * and any future REST/cron writer. `register_setting()` attaches a
+	 * `sanitize_option_{$option}` filter that `update_option()` always
+	 * runs, so route-level validation can't be bypassed at the option.
+	 *
+	 * Hooked on `init` (not `admin_init`) so the guard is attached on
+	 * every request type — a cron or REST write must not slip past an
+	 * admin-only filter.
+	 *
+	 * The route keeps its own inline `is_email()` for a friendly inline
+	 * error; this is the integrity backstop beneath it.
+	 *
+	 * @return void
+	 */
+	public static function register_sender_settings() {
+		// sender_name flows into the mail `From:` header.
+		// sanitize_text_field strips CR/LF — load-bearing header-injection
+		// defense. Empty is preserved (the revert-to-default signal).
+		register_setting(
+			'newspack_emails',
+			Reader_Activation::OPTIONS_PREFIX . 'sender_name',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			]
+		);
+		// register_setting's sanitize_callback receives only $value (it
+		// adds the filter with accepted_args = 1), so each email option
+		// gets a dedicated callback that knows its own key — needed to
+		// look up the last-good stored value on the invalid-coerce path.
+		register_setting(
+			'newspack_emails',
+			Reader_Activation::OPTIONS_PREFIX . 'sender_email_address',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_sender_email_address_option' ],
+			]
+		);
+		register_setting(
+			'newspack_emails',
+			Reader_Activation::OPTIONS_PREFIX . 'contact_email_address',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_contact_email_address_option' ],
+			]
+		);
+	}
+
+	/**
+	 * Option-layer sanitizer for the sender email address.
+	 *
+	 * @param mixed $value Incoming option value.
+	 * @return string Sanitized value.
+	 */
+	public static function sanitize_sender_email_address_option( $value ) {
+		return self::sanitize_email_setting( $value, Reader_Activation::OPTIONS_PREFIX . 'sender_email_address' );
+	}
+
+	/**
+	 * Option-layer sanitizer for the contact (reply-to) email address.
+	 *
+	 * @param mixed $value Incoming option value.
+	 * @return string Sanitized value.
+	 */
+	public static function sanitize_contact_email_address_option( $value ) {
+		return self::sanitize_email_setting( $value, Reader_Activation::OPTIONS_PREFIX . 'contact_email_address' );
+	}
+
+	/**
+	 * Shared email-setting sanitizer. Empty is never blocked or coerced
+	 * — it is the revert-to-derived-default signal. A non-empty value
+	 * that fails `is_email()` (e.g. a legacy/cron writer bypassing the
+	 * route's guard) is coerced to the LAST-GOOD stored value rather
+	 * than to empty, so an invalid write can't silently wipe a good
+	 * saved address down to the derived default.
+	 *
+	 * @param mixed  $value  Incoming option value.
+	 * @param string $option Full option name (to read the prior value).
+	 * @return string Sanitized value.
+	 */
+	private static function sanitize_email_setting( $value, $option ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return '';
+		}
+		if ( is_email( $value ) ) {
+			return sanitize_email( $value );
+		}
+		$existing = get_option( $option, '' );
+		if ( is_string( $existing ) && '' !== $existing ) {
+			return $existing;
+		}
+		return '';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -803,26 +803,10 @@ final class Reader_Activation {
 	 */
 	public static function get_prerequisites_status() {
 		$prerequisites = [
-			'emails'           => [
-				'active'      => self::is_transactional_email_configured(),
-				'label'       => __( 'Transactional Emails', 'newspack-plugin' ),
-				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox. To customize the content of these emails, visit Advanced Settings below.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
-				'fields'      => [
-					'sender_name'           => [
-						'label'       => __( 'Sender Name', 'newspack-plugin' ),
-						'description' => __( 'Name to use as the sender of transactional emails.', 'newspack-plugin' ),
-					],
-					'sender_email_address'  => [
-						'label'       => __( 'Sender Email Address', 'newspack-plugin' ),
-						'description' => __( 'Email address to use as the sender of transactional emails.', 'newspack-plugin' ),
-					],
-					'contact_email_address' => [
-						'label'       => __( 'Contact Email Address', 'newspack-plugin' ),
-						'description' => __( 'This email will be used as "Reply-To" for transactional emails as well.', 'newspack-plugin' ),
-					],
-				],
-			],
+			// NPPD-1566: the 'emails' prerequisite was removed here — the
+			// three transactional-email settings now live in the Emails
+			// Settings modal with valid derived defaults, so they're no
+			// longer a gating prereq for Reader Activation.
 			'terms_conditions' => [
 				'active'      => self::is_terms_configured(),
 				'label'       => __( 'Legal Pages', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-emails-section.php
@@ -122,6 +122,84 @@ class Emails_Section extends Wizard_Section {
 			]
 		);
 
+		// GET — Read the three transactional-email setting values used
+		// by `Emails::get_from_name()`, `get_from_email()`, and
+		// `get_reply_to_email()`. INTENTIONALLY does NOT call
+		// `Reader_Activation::get_setting()`: that helper resolves to
+		// (saved OR derived), collapsing the two states the modal
+		// must keep separate. The handler returns raw `get_option`
+		// values at the top level (empty when no override is saved)
+		// and derived defaults under a `defaults` sub-array, so the
+		// frontend can render saved-override as `value=` and the
+		// dynamic default as `placeholder=`. Future refactors must
+		// preserve this split — calling `get_setting()` here would
+		// silently break the value-vs-placeholder contract and
+		// re-introduce the launch-safety bug where first-save locked
+		// derived defaults in as static option rows.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_BASE . '/settings',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		// POST — Save the three transactional-email setting values.
+		// Args-block sanitization is belt-and-suspenders; the handler
+		// re-validates via `is_email()` because `sanitize_email()` leaves
+		// partials intact (e.g. "user@" passes sanitize but fails is_email).
+		// Writes delegate to `Reader_Activation::update_setting()`, which
+		// preserves the `newspack_reader_activation_*` option-key location.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_BASE . '/settings',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ __CLASS__, 'api_update_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					// `sender_name` flows into the mail `From:` header via
+					// `Emails::get_from_name()`. `sanitize_text_field()`
+					// strips CR/LF (and other control chars), which is what
+					// closes the header-injection vector here — that
+					// newline-stripping is LOAD-BEARING, not incidental. If
+					// this callback is ever swapped for one that preserves
+					// newlines, re-add an explicit `str_replace`/`preg_replace`
+					// CR/LF guard before the value reaches the header, or
+					// header injection silently reopens.
+					'sender_name'           => [
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					// Email fields use `sanitize_text_field`, NOT
+					// `sanitize_email`. `sanitize_email` collapses
+					// partially-typed input ('user@', 'newaddress') to
+					// '' BEFORE the handler runs — which then treats
+					// the empty value as "intentional revert" and
+					// `delete_option`s the publisher's previously
+					// saved override. The `newspack_invalid_sender_email`
+					// / `newspack_invalid_contact_email` WP_Errors
+					// would be unreachable for typo input. Use
+					// `sanitize_text_field` to preserve the typo so the
+					// handler's `is_email()` guard rejects it with a
+					// proper 400.
+					'sender_email_address'  => [
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'contact_email_address' => [
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+
 		// Toggle endpoint for WooCommerce-source emails. Only registered
 		// when WC is loaded; without WC there are no WC configs to toggle.
 		if ( self::is_woocommerce_active() ) {
@@ -711,5 +789,195 @@ class Emails_Section extends Wizard_Section {
 			],
 			admin_url( 'admin.php' )
 		);
+	}
+
+	/**
+	 * Get the three transactional-email setting values + their derived
+	 * defaults.
+	 *
+	 * Returns the raw saved values (empty string when nothing has been
+	 * saved) alongside the derived defaults so the frontend can render
+	 * value vs. placeholder distinctly. Reading via
+	 * `Reader_Activation::get_setting()` instead would collapse the two
+	 * into a single resolved value — losing the distinction the modal
+	 * needs to keep publishers from accidentally locking in derived
+	 * defaults as static option rows on first save.
+	 *
+	 * Default-source computation is inlined rather than abstracted into
+	 * `Emails`. The `Emails::get_from_*()` helpers return the *resolved*
+	 * value (saved override OR derived fallback), so calling them here
+	 * for the "default" slot would just return the saved value when one
+	 * exists — defeating the purpose of returning both separately.
+	 * Mirror the fallback logic from `Emails::get_from_email()` for the
+	 * sender-email default (network_home_url host, w/o `www.` prefix).
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function api_get_settings() {
+		// Mirror `Emails::get_from_email()`'s default-derivation
+		// EXACTLY, including the misconfigured-host fallback. If the
+		// modal's placeholder diverged from what the send path
+		// actually emits when no override is saved, publishers would
+		// see one default in the UI and get a different from-address
+		// on outbound mail — silent UX/expectations gap. On a site
+		// where `network_home_url()` can't yield a host, both this
+		// derived default AND `Emails::get_from_email()` resolve to
+		// the literal `'no-reply@'` (broken-looking but consistent).
+		// Worth a separate follow-up to fix the broken-host case at
+		// the send path; the alignment here just keeps the two
+		// surfaces honest.
+		$home_host = (string) wp_parse_url( network_home_url(), PHP_URL_HOST );
+		if ( 'www.' === substr( $home_host, 0, 4 ) ) {
+			$home_host = substr( $home_host, 4 );
+		}
+
+		// Run each derived default through the SAME filter the send
+		// path applies (`Emails::get_from_name()` → `newspack_from_name`,
+		// `Emails::get_from_email()` → `newspack_from_email`,
+		// `Emails::get_reply_to_email()` → `newspack_reply_to_email`).
+		// When no override is saved, the send path resolves to the
+		// derived default and then filters it — so the modal placeholder
+		// must filter too, or a site that hooks any of these filters
+		// would show one default in the UI while outbound mail used
+		// another. Saved overrides stay raw (top-level keys above): they
+		// render as the input `value`, and the unfiltered stored string
+		// is what the publisher actually controls.
+		return rest_ensure_response(
+			[
+				'sender_name'           => (string) get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_name', '' ),
+				'sender_email_address'  => (string) get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_email_address', '' ),
+				'contact_email_address' => (string) get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', '' ),
+				'defaults'              => [
+					'sender_name'           => apply_filters( 'newspack_from_name', get_bloginfo( 'name' ) ),
+					'sender_email_address'  => apply_filters( 'newspack_from_email', 'no-reply@' . $home_host ),
+					'contact_email_address' => apply_filters( 'newspack_reply_to_email', get_bloginfo( 'admin_email' ) ),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Update the three transactional-email setting values.
+	 *
+	 * Empty value semantics: an empty string for any field means "revert
+	 * to the derived default" — the option row is deleted so subsequent
+	 * `get_from_*()` reads fall through to bloginfo / domain / admin
+	 * email. Without this, a publisher who'd never explicitly saved
+	 * could open the modal, see the derived defaults populated, hit
+	 * Save without realizing, and lock those derived values in as
+	 * static rows — breaking the dynamic-default behavior (later
+	 * site-title changes would no longer propagate to sender_name,
+	 * etc.).
+	 *
+	 * Format validation runs only on non-empty values. Email fields
+	 * must match `is_email()` when present; empty is treated as the
+	 * intentional-revert path, not as a validation error.
+	 *
+	 * Writes delegate to `Reader_Activation::update_setting()` for the
+	 * non-empty path (preserves the `newspack_reader_activation_*`
+	 * option-key location). Empty values bypass `update_setting` and
+	 * call `delete_option` directly — `update_setting` writes empty
+	 * strings via `update_option`, which would leave zombie option
+	 * rows; deleting is tidier and matches the "revert" intent.
+	 *
+	 * Mirrors the GET response shape so the frontend can confirm the
+	 * saved state without a second round-trip.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_Error|\WP_REST_Response Saved values, or 400 on validation failure.
+	 */
+	public static function api_update_settings( $request ) {
+		$sender_name           = $request->get_param( 'sender_name' );
+		$sender_email_address  = $request->get_param( 'sender_email_address' );
+		$contact_email_address = $request->get_param( 'contact_email_address' );
+
+		// Format validation runs only when the value is non-empty.
+		// Empty is the intentional "revert to default" path, not an
+		// error. `sanitize_email` returns "" for completely invalid
+		// input but leaves partials ("user@") intact, so the
+		// non-empty check is combined with `is_email()`.
+		if ( '' !== $sender_email_address && ! is_email( $sender_email_address ) ) {
+			return new \WP_Error(
+				'newspack_invalid_sender_email',
+				esc_html__( 'Sender email address must be a valid email address.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		if ( '' !== $contact_email_address && ! is_email( $contact_email_address ) ) {
+			return new \WP_Error(
+				'newspack_invalid_contact_email',
+				esc_html__( 'Contact email address must be a valid email address.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$updates = [
+			'sender_name'           => $sender_name,
+			'sender_email_address'  => $sender_email_address,
+			'contact_email_address' => $contact_email_address,
+		];
+		foreach ( $updates as $key => $value ) {
+			$option_key = Reader_Activation::OPTIONS_PREFIX . $key;
+
+			if ( '' === $value ) {
+				// Empty = revert. Skip when there's no row to delete:
+				// otherwise the delete + action hook fire as a phantom
+				// "change" event with nothing actually changing. The
+				// hook contract is "this setting changed" — re-saving
+				// an already-absent value isn't a change.
+				if ( false === get_option( $option_key, false ) ) {
+					continue;
+				}
+				delete_option( $option_key );
+
+				// Mirror the action `Reader_Activation::update_setting()`
+				// fires for writes so external subscribers (audit logs,
+				// ESP sync) observe revert-to-default as a setting
+				// change. Without this, the delete path is invisible
+				// to hook listeners and produces drift between the
+				// stored state and any external mirror built from the
+				// hook.
+				do_action( 'newspack_reader_activation_update_setting', $key, '' );
+				continue;
+			}
+
+			// Non-empty = write. Pre-check current value and skip
+			// no-op saves: WordPress's `update_option()` returns
+			// false in two distinct cases — genuine write failure
+			// AND no-op (new value === current value). Without this
+			// pre-check, a publisher re-saving the same value
+			// (deliberately, or because the modal opened with
+			// already-saved state) would hit the WP_Error branch and
+			// see a 500 with no actual problem. Skipping no-ops also
+			// keeps the `newspack_reader_activation_update_setting`
+			// action hook semantically honest — "this changed" means
+			// it actually changed, not "this was submitted".
+			if ( get_option( $option_key, '' ) === $value ) {
+				continue;
+			}
+
+			if ( ! Reader_Activation::update_setting( $key, $value ) ) {
+				// `update_setting()` returns false when the key isn't
+				// in `get_settings_config()` (legitimate via the
+				// `newspack_reader_activation_settings_config` filter)
+				// or when `update_option()` itself fails for a real
+				// reason (DB write error, etc.) — the no-op case is
+				// already filtered out above. Convert the silent fail
+				// into a visible 500 so the frontend renders an
+				// inline error rather than a misleading success
+				// notice.
+				return new \WP_Error(
+					'newspack_settings_write_failed',
+					esc_html__( 'Could not save transactional email settings.', 'newspack-plugin' ),
+					[ 'status' => 500 ]
+				);
+			}
+		}
+
+		// Re-read via api_get_settings() so the response carries the
+		// refreshed value/default pair — saving an empty value flips
+		// the field's "value" back to '' and the frontend's placeholder
+		// path picks up the derived default again.
+		return self::api_get_settings();
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/hooks/use-wizard-api-fetch.ts
+++ b/plugins/newspack-plugin/src/wizards/hooks/use-wizard-api-fetch.ts
@@ -229,7 +229,13 @@ export function useWizardApiFetch( slug: string ) {
 				.catch( catchCallback )
 				.finally( finallyCallback );
 
-			return promiseCache[ slug ];
+			// Return the promise we just stored, keyed by `cacheKeyPath` —
+			// the same key it was written under. Returning `promiseCache[ slug ]`
+			// (the hook's slug, a different key) handed callers `undefined`,
+			// so a `.catch()` at the call site attached to the resolved async
+			// wrapper instead of the real request and never saw the rejection
+			// `catchCallback` re-throws.
+			return promiseCache[ cacheKeyPath ];
 		},
 		[ wizardApiFetch, wizardData, updateWizardSettings, isFetching, slug ]
 	);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.scss
@@ -13,13 +13,14 @@
 
 // Chip filter bar above the DataViews grid. Two-way toggle between
 // 'Reader revenue' and 'Authentication & account' — every email belongs
-// to exactly one chip group, so there's no "All" view.
+// to exactly one chip group, so there's no "All" view. The outer
+// HStack also hosts a Settings button on the right (NPPD-1566).
 //
 // Horizontal padding matches the 24px inner padding `@wordpress/dataviews`
 // applies to `.dataviews__view-actions`, so the chip bar's left edge
-// lines up with the search field and grid below. Without this the bar
-// reads as unmoored — sitting at the section padding edge while the
-// DataViews controls are inset another 24px.
+// lines up with the search field and grid below — and the right-side
+// Settings button lines up with the DataViews actions on the right.
+// Without this the bar reads as unmoored.
 //
 // Vertical: the Newspack DataViews wrapper applies `margin-top: -16px`
 // in full-width contexts (see packages/components/src/dataviews/style.scss).
@@ -31,12 +32,15 @@
 // top after the pull-up resolves (24 + -16 = 8). Visible gap to the
 // search row inside DataViews is 24px (8 + view-actions padding-top
 // of 16px).
-.newspack-emails__chips {
-	display: flex;
-	gap: 8px;
+.newspack-emails__chip-bar {
 	margin-bottom: 24px;
 	padding: 0 24px;
+}
 
+// Layout (display: flex, gap) is provided by the HStack wrapper —
+// `spacing={2}` is WP's 8px grid unit, matching the previous custom
+// `gap: 8px`. Only the chip-pill visual styling stays in SCSS.
+.newspack-emails__chips {
 	// Nested for specificity over WP Button defaults — without the
 	// `.components-button` chain, the pill shape and padding lose to
 	// WP's default button styling.
@@ -127,13 +131,19 @@
 }
 
 // Trigger description sub-text under the title.
-// Two-line clamp keeps grid cards uniform while still showing enough context.
+//
+// Three-line clamp: the original two-line clamp truncated single-
+// sentence descriptions of normal length at 12px in the narrow grid
+// card width (e.g. card-expiry-warning, renewal-reminder). Three
+// lines fits sentence-length descriptions without forcing copy
+// reductions that hurt comprehension, while still bounding card
+// height enough to preserve grid uniformity.
 .newspack-emails__trigger-description {
 	color: wp-colors.$gray-900;
 	font-size: 12px;
 	margin-top: 4px;
 	display: -webkit-box;
-	-webkit-line-clamp: 2;
+	-webkit-line-clamp: 3;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -97,6 +97,17 @@ jest.mock( './email-preview', () => ( {
 	},
 } ) );
 
+// Stub the Settings modal — it pulls in @wordpress/data's useDispatch
+// against the wizards store, which isn't registered in this test env.
+// The grid tests don't exercise modal behavior; the modal has its own
+// test file. Render nothing here so emails.tsx mounts cleanly.
+jest.mock( './settings-modal', () => ( {
+	__esModule: true,
+	default: function MockSettingsModal() {
+		return null;
+	},
+} ) );
+
 // Fixtures span both chips and both sources so the chip-filter and
 // type-routing tests have meaningful data on either side of the toggle.
 const mockEmails = [

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies.
@@ -18,6 +18,7 @@ import { Badge, DataViews, Notice, utils } from '../../../../../../packages/comp
 import WizardsPluginCard from '../../../../wizards-plugin-card';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import EmailPreview from './email-preview';
+import SettingsModal from './settings-modal';
 import './emails.scss';
 
 interface EmailItem {
@@ -94,6 +95,7 @@ const Emails = () => {
 	const postType = initial?.post_type ?? emailSections.emails.postType;
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ activeChip, setActiveChip ] = useState< ChipValue >( 'reader-revenue' );
+	const [ showSettingsModal, setShowSettingsModal ] = useState( false );
 
 	const selectChip = ( chip: ChipValue ) => {
 		setActiveChip( chip );
@@ -384,6 +386,39 @@ const Emails = () => {
 		[ visibleData, view, fields ]
 	);
 
+	// The `preview` media field belongs to the grid view (each card
+	// renders the iframe as its top tile). DataViews v14 also renders
+	// the media field as a leading thumbnail in table view, where the
+	// EmailPreview iframe is too constrained to actually show
+	// content — leaving an empty rounded square next to every row.
+	// Strip `mediaField` from the view passed to DataViews when
+	// the user has switched to table layout; the underlying state
+	// keeps the value so toggling back to grid restores the tile.
+	const effectiveView = useMemo< View >( () => {
+		if ( 'table' === view.type ) {
+			const { mediaField: _stripped, ...rest } = view;
+			return rest as View;
+		}
+		return view;
+	}, [ view ] );
+
+	// Normalize the view DataViews hands back before persisting it.
+	// `effectiveView` strips `mediaField` while in table layout, so
+	// without this a table→grid toggle would store a grid view that
+	// lost its preview tile, leaving grid cards with no media field.
+	// Grid always carries `mediaField: 'preview'`; table never does
+	// (it's stripped in `effectiveView` regardless, but drop it here
+	// too so the persisted state stays canonical). This keeps a
+	// grid→table→grid round-trip lossless.
+	const handleChangeView = useCallback( ( nextView: View ) => {
+		if ( 'grid' === nextView.type ) {
+			setView( { ...nextView, mediaField: 'preview' } );
+			return;
+		}
+		const { mediaField: _stripped, ...rest } = nextView;
+		setView( rest as View );
+	}, [] );
+
 	if ( false === pluginsReady ) {
 		return (
 			<Fragment>
@@ -413,32 +448,44 @@ const Emails = () => {
 		<Fragment>
 			<PageHeading />
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<div className="newspack-emails__chips" role="group" aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }>
-				{ CHIPS.map( chip => {
-					// During an active search, neither chip is filtering —
-					// render both as unpressed so the visual matches reality.
-					// Clicking either chip clears the search via selectChip
-					// and engages that chip's view.
-					const isActive = ! isSearching && activeChip === chip.value;
-					return (
-						<Button
-							key={ chip.value }
-							variant={ isActive ? 'primary' : 'secondary' }
-							aria-pressed={ isActive }
-							onClick={ () => selectChip( chip.value ) }
-							className="newspack-emails__chip"
-						>
-							{ chip.label }
-						</Button>
-					);
-				} ) }
-			</div>
+			<HStack className="newspack-emails__chip-bar" justify="space-between" alignment="center">
+				<HStack
+					className="newspack-emails__chips"
+					role="group"
+					aria-label={ __( 'Filter emails by group', 'newspack-plugin' ) }
+					spacing={ 2 }
+					justify="flex-start"
+				>
+					{ CHIPS.map( chip => {
+						// During an active search, neither chip is filtering —
+						// render both as unpressed so the visual matches reality.
+						// Clicking either chip clears the search via selectChip
+						// and engages that chip's view.
+						const isActive = ! isSearching && activeChip === chip.value;
+						return (
+							<Button
+								key={ chip.value }
+								variant={ isActive ? 'primary' : 'secondary' }
+								aria-pressed={ isActive }
+								onClick={ () => selectChip( chip.value ) }
+								className="newspack-emails__chip"
+							>
+								{ chip.label }
+							</Button>
+						);
+					} ) }
+				</HStack>
+				<Button variant="secondary" onClick={ () => setShowSettingsModal( true ) }>
+					{ __( 'Settings', 'newspack-plugin' ) }
+				</Button>
+			</HStack>
+			<SettingsModal showModal={ showSettingsModal } closeModal={ () => setShowSettingsModal( false ) } />
 			<DataViews
 				className="newspack-emails"
 				data={ processedData }
 				fields={ fields }
-				view={ view }
-				onChangeView={ setView }
+				view={ effectiveView }
+				onChangeView={ handleChangeView }
 				actions={ actions }
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ { table: {}, grid: {} } }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/settings-modal.test.js
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/settings-modal.test.js
@@ -1,0 +1,475 @@
+// @jest-environment jsdom
+
+/**
+ * NPPD-1566 — settings-modal coverage. Tests render the modal with
+ * controllable mocks for useWizardApiFetch (fetch behavior),
+ * useDispatch (addNotice spy), and useConfirmDialog (dirty-discard
+ * flow). Test #1 also renders the parent emails.tsx to verify the
+ * Settings button on the chip bar opens the modal — that's why this
+ * file mirrors several of emails.test.js's parent-level mocks.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock( './emails.scss', () => ( {} ) );
+
+// Use mock-prefixed names so Jest's hoisted jest.mock can close over them.
+const mockWizardApiFetch = jest.fn();
+const mockResetError = jest.fn();
+const mockAddNotice = jest.fn();
+const mockRequestConfirm = jest.fn();
+// Mutable hook state so individual tests can drive the fetching /
+// error surfaces the modal reads. Reset in beforeEach.
+let mockIsFetching = false;
+let mockErrorMessage = null;
+
+jest.mock( '../../../../hooks/use-wizard-api-fetch', () => ( {
+	useWizardApiFetch: () => ( {
+		wizardApiFetch: ( ...args ) => mockWizardApiFetch( ...args ),
+		isFetching: mockIsFetching,
+		errorMessage: mockErrorMessage,
+		resetError: ( ...args ) => mockResetError( ...args ),
+	} ),
+} ) );
+
+// useDispatch is the modal's only @wordpress/data hook. Other consumers
+// in the render tree don't use the data store at the moment; if that
+// changes, add corresponding mock entries here.
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		addNotice: ( ...args ) => mockAddNotice( ...args ),
+	} ),
+} ) );
+
+// The modal imports WIZARD_STORE_NAMESPACE from this barrel. Loading
+// the real module would also evaluate `createReduxStore` against the
+// mocked @wordpress/data (which doesn't expose it), so stub just the
+// constant — that's all the modal reads.
+jest.mock( '../../../../../../packages/components/src/wizard/store', () => ( {
+	WIZARD_STORE_NAMESPACE: 'newspack/wizards',
+} ) );
+
+// Mocks below mirror emails.test.js's parent-level dependencies so
+// test #1 can render the grid and click the Settings button.
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: ( { icon } ) => <span data-testid="icon">{ icon }</span>,
+	envelope: 'envelope',
+} ) );
+
+// Stub @wordpress/components — settings-modal.tsx imports TextControl
+// and the experimental HStack/VStack. emails.tsx imports Button + HStack
+// from here too. Real-module load fails in this jsdom env (the barrel
+// pulls in components that need broader setup), so provide minimal
+// passthrough stubs. TextControl mirrors the real component's contract:
+// label + help + value + onChange( value ) signature, with the input
+// rendered as the label's accessible target so getByLabelText resolves.
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	// help text intentionally rendered as a sibling of the label, not
+	// a child — keeping it inside the label would fold into the input's
+	// accessible name and break getByLabelText('Sender Name'). The real
+	// TextControl uses aria-describedby for the same separation.
+	// `...rest` forwards passthrough props (e.g. `aria-invalid`) onto the
+	// input, mirroring the real TextControl's behavior, so tests can
+	// assert the accessible invalid state.
+	const TextControl = ( { label, help, value, onChange, type, required, ...rest } ) =>
+		React.createElement(
+			'div',
+			null,
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement( 'input', {
+					type: type || 'text',
+					value: value === undefined ? '' : value,
+					onChange: e => onChange( e.target.value ),
+					required: required || undefined,
+					...rest,
+				} )
+			),
+			help ? React.createElement( 'span', null, help ) : null
+		);
+	const Passthrough = ( { children } ) => React.createElement( 'div', null, children );
+	// Discard `loading` rather than spreading it to the DOM <button> —
+	// React warns on unrecognized non-boolean attributes. The real
+	// Newspack Button accepts the prop and translates it to a spinner;
+	// for tests we only need the click behavior.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const Button = ( { children, onClick, disabled, loading, ...rest } ) => React.createElement( 'button', { onClick, disabled, ...rest }, children );
+	return {
+		TextControl,
+		Button,
+		__experimentalHStack: Passthrough,
+		__experimentalVStack: Passthrough,
+	};
+} );
+
+jest.mock( '@wordpress/dataviews', () => ( {
+	filterSortAndPaginate: data => ( {
+		data,
+		paginationInfo: { totalItems: data.length, totalPages: 1 },
+	} ),
+} ) );
+
+jest.mock(
+	'../../../../wizards-plugin-card',
+	() =>
+		function MockPluginCard() {
+			return <div data-testid="plugin-card" />;
+		}
+);
+
+jest.mock( './email-preview', () => ( {
+	__esModule: true,
+	default: function MockEmailPreview() {
+		return <div data-testid="email-preview-stub" />;
+	},
+} ) );
+
+// Single mock for the packages/components/src barrel covers both the
+// grid (Badge, DataViews, Notice, utils) and the modal (Button, Modal,
+// useConfirmDialog). useConfirmDialog is captured via the top-level
+// spy so tests can assert when it was called and whether the callback
+// fired.
+jest.mock( '../../../../../../packages/components/src', () => {
+	const React = require( 'react' );
+	return {
+		Badge: ( { text } ) => <span>{ text }</span>,
+		DataViews: ( { data } ) => <div data-testid="dataviews">{ data.length }</div>,
+		Notice: ( { noticeText } ) => <div data-testid="notice">{ noticeText }</div>,
+		// Discard `loading` and `variant` rather than spreading them to
+		// the DOM button — React warns on unrecognized non-boolean
+		// attributes. Same treatment as the @wordpress/components Button
+		// mock above.
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		Button: function MockButton( { children, onClick, disabled, loading, variant, ...rest } ) {
+			return (
+				<button onClick={ onClick } disabled={ disabled } { ...rest }>
+					{ children }
+				</button>
+			);
+		},
+		Modal: function MockModal( { children, title, onRequestClose } ) {
+			return (
+				<div role="dialog" aria-label={ title }>
+					<button aria-label="Close" onClick={ onRequestClose }>
+						X
+					</button>
+					{ children }
+				</div>
+			);
+		},
+		useConfirmDialog: function MockUseConfirmDialog( opts ) {
+			return {
+				requestConfirm: function MockRequestConfirm( callback ) {
+					mockRequestConfirm( { when: opts.when, callback } );
+					// Match the real hook's contract: when=false skips
+					// the dialog and fires the callback synchronously.
+					if ( opts.when === false ) {
+						callback();
+					}
+				},
+				confirmDialog: React.createElement( 'div', { 'data-testid': 'mock-confirm-dialog' } ),
+			};
+		},
+		utils: { confirmAction: jest.fn( () => true ) },
+	};
+} );
+
+const SAMPLE_INITIAL = {
+	sender_name: 'My Site',
+	sender_email_address: 'hello@example.com',
+	contact_email_address: 'support@example.com',
+	defaults: {
+		sender_name: 'My Default Site Title',
+		sender_email_address: 'no-reply@example.com',
+		contact_email_address: 'admin@example.com',
+	},
+};
+
+// Default implementation: POST echoes the submitted data and preserves
+// the defaults block (mirrors the server returning the full
+// {values + defaults} shape on save). GET resolves with the provided
+// initial settings. Returns a settled promise so production-side
+// `.catch()` chaining (the unhandled-rejection guard) works in tests.
+const setUpFetchMock = ( initial = SAMPLE_INITIAL ) => {
+	mockWizardApiFetch.mockImplementation( ( args, handlers ) => {
+		if ( args.method === 'POST' ) {
+			if ( handlers && handlers.onSuccess ) {
+				handlers.onSuccess( { ...args.data, defaults: initial.defaults } );
+			}
+		} else if ( handlers && handlers.onSuccess ) {
+			handlers.onSuccess( initial );
+		}
+		return Promise.resolve();
+	} );
+};
+
+// GET succeeds (populates + loads the form) but POST rejects: fires the
+// modal's `onError` and returns a rejected promise, exercising the
+// modal-level `.catch()` unhandled-rejection guard. Used to assert the
+// modal stays open on save failure.
+const setUpFetchMockPostFails = ( initial = SAMPLE_INITIAL ) => {
+	mockWizardApiFetch.mockImplementation( ( args, handlers ) => {
+		if ( args.method === 'POST' ) {
+			if ( handlers && handlers.onError ) {
+				handlers.onError();
+			}
+			return Promise.reject( new Error( 'save failed' ) );
+		}
+		if ( handlers && handlers.onSuccess ) {
+			handlers.onSuccess( initial );
+		}
+		return Promise.resolve();
+	} );
+};
+
+// GET rejects: fires `onError` and returns a rejected promise so the
+// form never reaches the loaded state. Exercises the GET-rejection
+// `.catch()` guard and the `! loaded` Save gate.
+const setUpFetchMockGetFails = () => {
+	mockWizardApiFetch.mockImplementation( ( args, handlers ) => {
+		if ( handlers && handlers.onError ) {
+			handlers.onError();
+		}
+		return Promise.reject( new Error( 'load failed' ) );
+	} );
+};
+
+describe( 'SettingsModal', () => {
+	beforeEach( () => {
+		mockWizardApiFetch.mockReset();
+		mockResetError.mockReset();
+		mockAddNotice.mockReset();
+		mockRequestConfirm.mockReset();
+		mockIsFetching = false;
+		mockErrorMessage = null;
+		// Window globals emails.tsx reads at mount. Empty newspack_emails
+		// is still truthy, so the grid's mount-time fetch is skipped —
+		// only the modal will fire a fetch when opened.
+		window.newspackSettings = {
+			emails: {
+				sections: {
+					emails: {
+						dependencies: { newspackNewsletters: true },
+						initial: { newspack_emails: [], post_type: 'newspack_em' },
+						postType: 'newspack_em',
+					},
+				},
+			},
+		};
+	} );
+
+	it( 'opens the modal when the Settings button on the chip bar is clicked', async () => {
+		setUpFetchMock();
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		// Modal not yet rendered.
+		expect( screen.queryByRole( 'dialog', { name: 'Settings' } ) ).not.toBeInTheDocument();
+
+		// Click the Settings button on the chip bar.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Settings' } ) );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog', { name: 'Settings' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'saves: POSTs payload, dispatches success notice, closes modal', async () => {
+		setUpFetchMock();
+		const closeModal = jest.fn();
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ closeModal } /> );
+
+		// Wait for the GET fetch to resolve and fields to populate.
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Sender Name' ).value ).toBe( 'My Site' );
+		} );
+
+		// Edit a field to make the modal dirty (enables Save).
+		fireEvent.change( screen.getByLabelText( 'Sender Name' ), { target: { value: 'New Name' } } );
+
+		// Click Save.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		await waitFor( () => {
+			expect( closeModal ).toHaveBeenCalled();
+		} );
+
+		// POST issued against the correct endpoint with the correct payload.
+		const postCall = mockWizardApiFetch.mock.calls.find( ( [ args ] ) => args.method === 'POST' );
+		expect( postCall ).toBeDefined();
+		expect( postCall[ 0 ].path ).toBe( '/newspack/v1/wizard/newspack-settings/emails/settings' );
+		expect( postCall[ 0 ].data ).toMatchObject( { sender_name: 'New Name' } );
+
+		// Success notice dispatched against the wizards store.
+		expect( mockAddNotice ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'success',
+				message: 'Saved.',
+			} )
+		);
+	} );
+
+	it( 'cancel: prompts for confirmation when fields are dirty', async () => {
+		setUpFetchMock();
+		const closeModal = jest.fn();
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ closeModal } /> );
+
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Sender Name' ).value ).toBe( 'My Site' );
+		} );
+
+		// Dirty the form.
+		fireEvent.change( screen.getByLabelText( 'Sender Name' ), { target: { value: 'Different' } } );
+
+		// Click Cancel.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		// requestConfirm called with when=true (dirty). Callback NOT
+		// invoked — closeModal stays unfired pending user confirmation.
+		expect( mockRequestConfirm ).toHaveBeenCalledTimes( 1 );
+		expect( mockRequestConfirm.mock.calls[ 0 ][ 0 ].when ).toBe( true );
+		expect( closeModal ).not.toHaveBeenCalled();
+	} );
+
+	it( 'cancel: closes directly when fields are clean (no prompt)', async () => {
+		setUpFetchMock();
+		const closeModal = jest.fn();
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ closeModal } /> );
+
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Sender Name' ).value ).toBe( 'My Site' );
+		} );
+
+		// No edits — directly click Cancel.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		// requestConfirm called with when=false (clean). Callback fires
+		// immediately → closeModal invoked.
+		expect( mockRequestConfirm ).toHaveBeenCalledTimes( 1 );
+		expect( mockRequestConfirm.mock.calls[ 0 ][ 0 ].when ).toBe( false );
+		expect( closeModal ).toHaveBeenCalled();
+	} );
+
+	it( 'renders the inline error Notice when the hook surfaces an errorMessage', async () => {
+		setUpFetchMock();
+		mockErrorMessage = 'Could not save transactional email settings.';
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ jest.fn() } /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'notice' ) ).toHaveTextContent( 'Could not save transactional email settings.' );
+		} );
+	} );
+
+	it( 'save failure: fires onError, keeps the modal open, dispatches no success notice', async () => {
+		setUpFetchMockPostFails();
+		const closeModal = jest.fn();
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ closeModal } /> );
+
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Sender Name' ).value ).toBe( 'My Site' );
+		} );
+
+		// Dirty + valid → Save enabled.
+		fireEvent.change( screen.getByLabelText( 'Sender Name' ), { target: { value: 'New Name' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		// POST was issued and rejected (swallowed by the modal-level
+		// .catch — no unhandled rejection).
+		await waitFor( () => {
+			expect( mockWizardApiFetch.mock.calls.some( ( [ args ] ) => args.method === 'POST' ) ).toBe( true );
+		} );
+
+		// Modal stays open: closeModal never fires, no success notice.
+		expect( closeModal ).not.toHaveBeenCalled();
+		expect( mockAddNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'disables Save while a request is in flight', async () => {
+		setUpFetchMock();
+		mockIsFetching = true;
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ jest.fn() } /> );
+
+		// Form loads from the GET, then dirty + valid — the only thing
+		// keeping Save disabled is the in-flight request.
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Sender Name' ).value ).toBe( 'My Site' );
+		} );
+		fireEvent.change( screen.getByLabelText( 'Sender Name' ), { target: { value: 'New Name' } } );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	it( 'gates Save and flags the field on a malformed email', async () => {
+		setUpFetchMock();
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ jest.fn() } /> );
+
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Sender Email Address' ).value ).toBe( 'hello@example.com' );
+		} );
+
+		// Type a malformed (non-empty) email.
+		fireEvent.change( screen.getByLabelText( 'Sender Email Address' ), { target: { value: 'not-an-email' } } );
+
+		// Save is gated, the field is marked invalid, and field-level
+		// help explains the requirement.
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'Sender Email Address' ) ).toHaveAttribute( 'aria-invalid', 'true' );
+		expect( screen.getByText( 'Enter a valid email address, or leave blank to use the default.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'GET failure: leaves Save disabled even when the user dirties a field (not-loaded guard)', async () => {
+		setUpFetchMockGetFails();
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ jest.fn() } /> );
+
+		// GET rejected → form never loaded. The fields render empty.
+		await waitFor( () => {
+			expect( mockWizardApiFetch ).toHaveBeenCalled();
+		} );
+
+		// Even after a valid, dirtying edit, the `! loaded` guard keeps
+		// Save disabled so a failed GET can't be overwritten with the
+		// empty-form values.
+		fireEvent.change( screen.getByLabelText( 'Sender Name' ), { target: { value: 'Typed After Failure' } } );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	// NPPD-1566: site titles / admin emails can carry encoded HTML
+	// entities (e.g. an ampersand as `&amp;`). Both the saved values and
+	// the derived-default placeholders must render decoded.
+	it( 'decodes HTML entities in saved values and default placeholders', async () => {
+		setUpFetchMock( {
+			sender_name: 'Tom &amp; Jerry News',
+			sender_email_address: 'hello@example.com',
+			contact_email_address: 'support@example.com',
+			defaults: {
+				sender_name: 'Smith &amp; Co.',
+				sender_email_address: 'no-reply@example.com',
+				contact_email_address: 'admin@example.com',
+			},
+		} );
+		const SettingsModal = require( './settings-modal' ).default;
+		render( <SettingsModal showModal={ true } closeModal={ jest.fn() } /> );
+
+		await waitFor( () => {
+			// Saved value rendered decoded in the input.
+			expect( screen.getByLabelText( 'Sender Name' ).value ).toBe( 'Tom & Jerry News' );
+		} );
+		// Derived default rendered decoded in the placeholder.
+		expect( screen.getByLabelText( 'Sender Name' ) ).toHaveAttribute( 'placeholder', 'Smith & Co.' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/settings-modal.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/emails/settings-modal.tsx
@@ -1,0 +1,303 @@
+/**
+ * Newspack > Settings > Emails > Settings modal.
+ *
+ * Hosts the three transactional-email settings (sender_name,
+ * sender_email_address, contact_email_address) that previously lived
+ * in the Reader Activation "Transactional Emails" prerequisite card.
+ * Reads + writes the dedicated /wizard/newspack-settings/emails/settings
+ * endpoint introduced in NPPD-1566 — same underlying wp_options keys
+ * as the legacy surface, but the endpoint belongs here.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	TextControl,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Modal, Notice, useConfirmDialog } from '../../../../../../packages/components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
+import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+
+type TransactionalEmailSettings = {
+	sender_name: string;
+	sender_email_address: string;
+	contact_email_address: string;
+};
+
+// Shape returned by the GET endpoint: the three saved values at top
+// level + a `defaults` sub-object with the derived fallbacks. The
+// frontend renders saved values as the input's `value` and derived
+// defaults as the `placeholder` — keeping publishers from
+// accidentally locking in dynamic defaults as static overrides on
+// first save.
+type TransactionalEmailSettingsResponse = TransactionalEmailSettings & {
+	defaults: TransactionalEmailSettings;
+};
+
+const EMPTY_SETTINGS: TransactionalEmailSettings = {
+	sender_name: '',
+	sender_email_address: '',
+	contact_email_address: '',
+};
+
+// Decode HTML entities for display. Derived defaults come from
+// get_bloginfo( 'name' ) / the admin email, which can carry encoded
+// entities (e.g. an ampersand as `&amp;`); saved values can too. Decode
+// at the data boundary so the inputs show "Tom & Jerry" not
+// "Tom &amp; Jerry". sender_name re-saves through sanitize_text_field,
+// which does not re-encode, so the round-trip is stable.
+const decodeSettings = ( values: TransactionalEmailSettings ): TransactionalEmailSettings => ( {
+	sender_name: decodeEntities( values.sender_name ),
+	sender_email_address: decodeEntities( values.sender_email_address ),
+	contact_email_address: decodeEntities( values.contact_email_address ),
+} );
+
+// Mirrors the server-side `is_email()` gate: any string with an `@`, a
+// dot in the domain, and no embedded whitespace. Used to disable Save
+// before firing a POST that would 400 anyway.
+const isValidEmail = ( value: string | undefined | null ): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test( ( value ?? '' ).trim() );
+
+const SettingsModal = ( { showModal, closeModal }: { showModal: boolean; closeModal: () => void } ) => {
+	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/emails/settings' );
+	const { addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	// `settings` is the editable working copy of the saved values;
+	// `initial` is the last-known-saved snapshot for dirty comparison.
+	// `defaults` holds the server's derived fallbacks (blog title,
+	// no-reply@domain, admin email) used as placeholder hints — never
+	// edited by the user, never sent on POST.
+	const [ settings, setSettings ] = useState< TransactionalEmailSettings >( EMPTY_SETTINGS );
+	const [ initial, setInitial ] = useState< TransactionalEmailSettings >( EMPTY_SETTINGS );
+	const [ defaults, setDefaults ] = useState< TransactionalEmailSettings >( EMPTY_SETTINGS );
+	// `loaded` gates Save: without it, a publisher could overwrite the
+	// real saved values with empty strings if GET failed and they
+	// hit Save before realizing.
+	const [ loaded, setLoaded ] = useState( false );
+
+	useEffect( () => {
+		if ( ! showModal ) {
+			return;
+		}
+		resetError();
+		// Reset local snapshot before the GET so reopen renders an
+		// empty form (gated from Save by `! loaded`) instead of
+		// briefly flashing the previous open's values. Without this,
+		// the first paint after reopen renders whatever was in state
+		// when the modal last closed — confusing if a concurrent
+		// actor (CLI, second admin tab) changed the underlying options
+		// between sessions.
+		setSettings( EMPTY_SETTINGS );
+		setInitial( EMPTY_SETTINGS );
+		setDefaults( EMPTY_SETTINGS );
+		setLoaded( false );
+		wizardApiFetch< TransactionalEmailSettingsResponse >(
+			{
+				path: '/newspack/v1/wizard/newspack-settings/emails/settings',
+				isCached: false,
+			},
+			{
+				onSuccess( result: TransactionalEmailSettingsResponse ) {
+					const values = decodeSettings( {
+						sender_name: result.sender_name,
+						sender_email_address: result.sender_email_address,
+						contact_email_address: result.contact_email_address,
+					} );
+					setSettings( values );
+					setInitial( values );
+					setDefaults( decodeSettings( result.defaults ) );
+					setLoaded( true );
+				},
+				onError() {
+					// Error surfaces via `errorMessage` from the hook;
+					// the inline Notice below renders it. Empty handler
+					// blocks the rejection from becoming an unhandled
+					// promise rejection in the console.
+				},
+			}
+		).catch( () => {
+			// See handleSave below for the rationale on swallowing
+			// the re-thrown rejection.
+		} );
+		// `wizardApiFetch` and `resetError` are stable across renders per
+		// the hook's contract; including them would re-fire the fetch
+		// inappropriately. Mirrors the pattern at emails.tsx mount-time fetch.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ showModal ] );
+
+	const isDirty = JSON.stringify( settings ) !== JSON.stringify( initial );
+
+	// Per-field validation: empty is the intentional "revert to
+	// default" path, so it's accepted for every field. Email fields
+	// must validate when non-empty. Sender name has no format
+	// requirement. Plain expressions rather than `useMemo` — the dep
+	// `settings` is a new object reference on every keystroke, so a
+	// memo would never hit; the wrapping was misleading without
+	// behavior.
+	//
+	// These per-field flags drive both the aggregate Save gate AND the
+	// inline field-level help/`aria-invalid` below, so a disabled Save
+	// button always has a visible, screen-reader-announced reason next
+	// to the offending field rather than a dead button with no cue.
+	const isSenderEmailInvalid = settings.sender_email_address !== '' && ! isValidEmail( settings.sender_email_address );
+	const isContactEmailInvalid = settings.contact_email_address !== '' && ! isValidEmail( settings.contact_email_address );
+	const isClientSideValid = ! isSenderEmailInvalid && ! isContactEmailInvalid;
+
+	const handleSave = () => {
+		if ( isFetching ) {
+			return;
+		}
+		resetError();
+		wizardApiFetch< TransactionalEmailSettingsResponse >(
+			{
+				path: '/newspack/v1/wizard/newspack-settings/emails/settings',
+				method: 'POST',
+				data: settings,
+			},
+			{
+				onSuccess( result: TransactionalEmailSettingsResponse ) {
+					// Reconcile from the server's response so client state
+					// reflects post-sanitization values exactly — and so
+					// fields that were just cleared flip back to their
+					// derived-default placeholder presentation.
+					const values = decodeSettings( {
+						sender_name: result.sender_name,
+						sender_email_address: result.sender_email_address,
+						contact_email_address: result.contact_email_address,
+					} );
+					setInitial( values );
+					setSettings( values );
+					setDefaults( decodeSettings( result.defaults ) );
+					addNotice( {
+						message: __( 'Saved.', 'newspack-plugin' ),
+						type: 'success',
+						id: 'newspack-emails-settings-saved',
+					} );
+					closeModal();
+				},
+				onError() {
+					// The hook surfaces the message via `errorMessage`
+					// and renders it through the inline Notice below.
+					// This handler is intentionally empty — its presence
+					// keeps `useWizardApiFetch`'s `on('onError', ...)`
+					// from no-op'ing into an unhandled promise rejection.
+				},
+			}
+		).catch( () => {
+			// `useWizardApiFetch` re-throws after firing `onError` to
+			// preserve the contract of an async API. Swallow here so the
+			// rejection doesn't surface as "Uncaught (in promise)" in
+			// the console — the error UX (inline Notice) is already
+			// handled above.
+		} );
+	};
+
+	const { confirmDialog, requestConfirm } = useConfirmDialog( {
+		when: isDirty,
+		message: __( 'You have unsaved changes. Discard them?', 'newspack-plugin' ),
+		confirmButtonText: __( 'Discard', 'newspack-plugin' ),
+		cancelButtonText: __( 'Keep editing', 'newspack-plugin' ),
+		isDestructive: true,
+	} );
+
+	// All three close paths (Cancel button, X, click-outside, Escape)
+	// route through this — `requestConfirm` checks `when` and either
+	// pops the discard dialog or invokes `closeModal` immediately.
+	const handleClose = () => {
+		requestConfirm( closeModal );
+	};
+
+	if ( ! showModal ) {
+		return null;
+	}
+
+	// Field-level message shown (and announced via `aria-describedby`,
+	// which `TextControl` wires from `help`) when an email field holds
+	// a malformed non-empty value. Declared after the early return so
+	// the `__()` call isn't evaluated on the not-rendered path.
+	const invalidEmailHelp = __( 'Enter a valid email address, or leave blank to use the default.', 'newspack-plugin' );
+
+	return (
+		// The wrapping div is an escape hatch for a ReactNode/ReactElement
+		// type mismatch on `confirmDialog` — Fragment-wrapping triggers a
+		// TS error against the React 18 strict ReactNode shape. Both
+		// Modal and confirmDialog portal to document.body, so this div
+		// has no rendered children and occupies a zero-height slot in
+		// the Emails view flow. The class is here so future CSS can
+		// target it intentionally (or, more importantly, NOT target it
+		// via accidental sibling-combinator selectors on unclassed divs).
+		<div className="newspack-emails__settings-modal-wrap">
+			{ confirmDialog }
+			<Modal onRequestClose={ handleClose } size="medium" title={ __( 'Settings', 'newspack-plugin' ) }>
+				<p>{ __( 'Configure the sender details and reply-to address for transactional emails sent to your readers.', 'newspack-plugin' ) }</p>
+				{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+				<VStack>
+					<TextControl
+						label={ __( 'Sender Name', 'newspack-plugin' ) }
+						help={ __( 'Name to use as the sender of transactional emails. Leave blank to use your site title.', 'newspack-plugin' ) }
+						value={ settings.sender_name }
+						placeholder={ defaults.sender_name }
+						onChange={ ( value: string ) => setSettings( { ...settings, sender_name: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Sender Email Address', 'newspack-plugin' ) }
+						help={
+							isSenderEmailInvalid
+								? invalidEmailHelp
+								: __(
+										"Email address to use as the sender of transactional emails. Leave blank to use a no-reply address at your site's domain.",
+										'newspack-plugin'
+								  )
+						}
+						type="email"
+						value={ settings.sender_email_address }
+						placeholder={ defaults.sender_email_address }
+						aria-invalid={ isSenderEmailInvalid }
+						onChange={ ( value: string ) => setSettings( { ...settings, sender_email_address: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Contact Email Address', 'newspack-plugin' ) }
+						help={
+							isContactEmailInvalid
+								? invalidEmailHelp
+								: __(
+										"This email will be used as 'Reply-To' for transactional emails. Leave blank to use your site's admin email.",
+										'newspack-plugin'
+								  )
+						}
+						type="email"
+						value={ settings.contact_email_address }
+						placeholder={ defaults.contact_email_address }
+						aria-invalid={ isContactEmailInvalid }
+						onChange={ ( value: string ) => setSettings( { ...settings, contact_email_address: value } ) }
+					/>
+				</VStack>
+				<HStack justify="end">
+					<Button variant="tertiary" disabled={ isFetching } onClick={ handleClose }>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+					<Button
+						variant="primary"
+						disabled={ ! loaded || isFetching || ! isDirty || ! isClientSideValid }
+						loading={ isFetching }
+						onClick={ handleSave }
+					>
+						{ __( 'Save', 'newspack-plugin' ) }
+					</Button>
+				</HStack>
+			</Modal>
+		</div>
+	);
+};
+
+export default SettingsModal;

--- a/plugins/newspack-plugin/tests/unit-tests/emails-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails-section.php
@@ -725,4 +725,488 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 			'The legacy donations-namespace reset route was re-registered. NPPD-1535 moved it to /wizard/newspack-settings/emails/{id} — if you intentionally need to revert, update the frontend resetEmail() path accordingly.'
 		);
 	}
+
+	/*
+	 * ------------------------------------------------------------------
+	 * Bucket F — Settings endpoint (NPPD-1566)
+	 * ------------------------------------------------------------------
+	 * GET + POST /wizard/newspack-settings/emails/settings carry the
+	 * three transactional-email setting values (sender_name,
+	 * sender_email_address, contact_email_address) previously surfaced
+	 * in the Reader Activation prerequisite card. The endpoint lives
+	 * in Emails_Section; writes delegate to Reader_Activation::update_setting()
+	 * so the underlying newspack_reader_activation_* wp_options keys
+	 * are unchanged.
+	 */
+
+	/**
+	 * GET returns the three saved values + a `defaults` sub-array with
+	 * the derived defaults. Saved values come through as the option
+	 * values; defaults stay constant regardless of overrides.
+	 */
+	public function test_get_settings_returns_three_fields() {
+		update_option( 'newspack_reader_activation_sender_name', 'Test Sender' );
+		update_option( 'newspack_reader_activation_sender_email_address', 'sender@example.test' );
+		update_option( 'newspack_reader_activation_contact_email_address', 'contact@example.test' );
+
+		$response = Emails_Section::api_get_settings();
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$data = $response->get_data();
+		$this->assertSame( 'Test Sender', $data['sender_name'] );
+		$this->assertSame( 'sender@example.test', $data['sender_email_address'] );
+		$this->assertSame( 'contact@example.test', $data['contact_email_address'] );
+
+		// Defaults are derived from bloginfo / domain regardless of
+		// whether overrides are saved. Type-check rather than value-check
+		// since the bootstrap's site title / admin email vary.
+		$this->assertArrayHasKey( 'defaults', $data );
+		$this->assertIsString( $data['defaults']['sender_name'] );
+		$this->assertIsString( $data['defaults']['sender_email_address'] );
+		$this->assertStringStartsWith( 'no-reply@', $data['defaults']['sender_email_address'] );
+		$this->assertIsString( $data['defaults']['contact_email_address'] );
+
+		delete_option( 'newspack_reader_activation_sender_name' );
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+	}
+
+	/**
+	 * GET on a fresh install (no overrides saved) returns empty strings
+	 * for the three top-level keys and populated derived defaults. This
+	 * is the load-bearing case for the launch-safety story — publishers
+	 * who've never explicitly saved should see empty fields with
+	 * placeholder hints, not auto-derived values that could be locked
+	 * in on first save.
+	 */
+	public function test_get_settings_returns_empty_values_when_no_override_saved() {
+		// Belt-and-suspenders: no preceding update_option in this test,
+		// but make sure no leftover state from a sibling test bleeds in.
+		delete_option( 'newspack_reader_activation_sender_name' );
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+
+		$data = Emails_Section::api_get_settings()->get_data();
+
+		$this->assertSame( '', $data['sender_name'] );
+		$this->assertSame( '', $data['sender_email_address'] );
+		$this->assertSame( '', $data['contact_email_address'] );
+
+		// Defaults still populated even with no overrides.
+		$this->assertNotEmpty( $data['defaults']['sender_name'] );
+		$this->assertNotEmpty( $data['defaults']['sender_email_address'] );
+		$this->assertNotEmpty( $data['defaults']['contact_email_address'] );
+	}
+
+	/**
+	 * POST with valid non-empty values writes the three options and
+	 * returns the refreshed `{values + defaults}` shape via api_get_settings.
+	 */
+	public function test_post_settings_persists_three_fields() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', 'My Site' );
+		$request->set_param( 'sender_email_address', 'hello@example.test' );
+		$request->set_param( 'contact_email_address', 'support@example.test' );
+
+		$response = Emails_Section::api_update_settings( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		// Underlying wp_options keys are unchanged from the legacy surface.
+		$this->assertSame( 'My Site', get_option( 'newspack_reader_activation_sender_name' ) );
+		$this->assertSame( 'hello@example.test', get_option( 'newspack_reader_activation_sender_email_address' ) );
+		$this->assertSame( 'support@example.test', get_option( 'newspack_reader_activation_contact_email_address' ) );
+
+		// Response carries the refreshed value/default pair.
+		$data = $response->get_data();
+		$this->assertSame( 'My Site', $data['sender_name'] );
+		$this->assertSame( 'hello@example.test', $data['sender_email_address'] );
+		$this->assertSame( 'support@example.test', $data['contact_email_address'] );
+		$this->assertArrayHasKey( 'defaults', $data );
+
+		delete_option( 'newspack_reader_activation_sender_name' );
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+	}
+
+	/**
+	 * Invalid sender_email_address returns 400 + newspack_invalid_sender_email.
+	 *
+	 * The handler call below mirrors what reaches it through the live
+	 * REST route: the args' `sanitize_text_field` callback passes
+	 * 'not-an-email' through unchanged (sanitize_text_field strips
+	 * tags + trims whitespace, but does not collapse non-email input).
+	 * The handler's `is_email()` guard then rejects it with 400. This
+	 * test would silently succeed against an unreachable code path if
+	 * the args callback ever regressed to `sanitize_email`, which
+	 * collapses the input to '' BEFORE the handler sees it — and the
+	 * empty-as-revert branch would then delete the publisher's
+	 * previously saved override without surfacing a validation error.
+	 */
+	public function test_post_settings_rejects_invalid_email_in_sender() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', 'My Site' );
+		$request->set_param( 'sender_email_address', 'not-an-email' );
+		$request->set_param( 'contact_email_address', 'support@example.test' );
+
+		$response = Emails_Section::api_update_settings( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_invalid_sender_email', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+
+		// No options written on validation failure.
+		$this->assertFalse( get_option( 'newspack_reader_activation_sender_name' ) );
+	}
+
+	/**
+	 * Invalid contact_email_address returns 400 + newspack_invalid_contact_email.
+	 */
+	public function test_post_settings_rejects_invalid_email_in_contact() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', 'My Site' );
+		$request->set_param( 'sender_email_address', 'sender@example.test' );
+		$request->set_param( 'contact_email_address', 'also-not-an-email' );
+
+		$response = Emails_Section::api_update_settings( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_invalid_contact_email', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Regression guard: the args' `sanitize_callback` for email fields
+	 * must NOT be `sanitize_email`. Dispatching a typo email through
+	 * the live REST route runs the args sanitize before the handler;
+	 * `sanitize_email` collapses non-conforming input to '' so the
+	 * handler's `'' === $value` branch would `delete_option()` the
+	 * publisher's saved override and return 200 OK — bypassing the
+	 * `is_email()` validation entirely. `sanitize_text_field`
+	 * preserves the typo so the handler rejects it with a proper 400.
+	 *
+	 * This test introspects the actually-registered route's args
+	 * config rather than running the route end-to-end, because the
+	 * test bootstrap doesn't always register Newspack REST routes
+	 * deterministically.
+	 */
+	public function test_post_settings_args_use_text_field_sanitizer_for_emails() {
+		// register_rest_route normally complains when called outside
+		// `rest_api_init`; we're calling register_rest_routes()
+		// directly to introspect what would be registered through the
+		// normal lifecycle. Acknowledge the notice rather than fire
+		// the whole action chain (which would re-register every
+		// Newspack REST route as a side effect).
+		$this->setExpectedIncorrectUsage( 'register_rest_route' );
+
+		global $wp_rest_server;
+		$prev_server    = $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		( new Emails_Section( [ 'wizard_slug' => 'newspack-settings' ] ) )->register_rest_routes();
+		$routes         = $wp_rest_server->get_routes();
+		$wp_rest_server = $prev_server;
+
+		$route_key = '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-settings/emails/settings';
+		$this->assertArrayHasKey( $route_key, $routes );
+
+		// Find the POST endpoint config in the registered routes. WP
+		// stores `methods` as an associative array of method => true.
+		$post_endpoint = null;
+		foreach ( $routes[ $route_key ] as $endpoint ) {
+			if ( ! empty( $endpoint['methods']['POST'] ) ) {
+				$post_endpoint = $endpoint;
+				break;
+			}
+		}
+		$this->assertNotNull( $post_endpoint, 'POST endpoint should be registered.' );
+
+		foreach ( [ 'sender_email_address', 'contact_email_address' ] as $field ) {
+			$this->assertNotSame(
+				'sanitize_email',
+				$post_endpoint['args'][ $field ]['sanitize_callback'] ?? null,
+				"sanitize_email on '$field' silently collapses typo input to '' before the handler runs, defeating the is_email() guard. Use sanitize_text_field."
+			);
+			$this->assertSame(
+				'sanitize_text_field',
+				$post_endpoint['args'][ $field ]['sanitize_callback'] ?? null,
+				"Expected '$field' to use sanitize_text_field as args sanitize callback."
+			);
+		}
+	}
+
+	/**
+	 * The `defaults.sender_email_address` returned by api_get_settings()
+	 * MUST match the value `Emails::get_from_email()` returns when no
+	 * override is saved. If they diverge, the modal's placeholder
+	 * shows one default while outbound mail is sent from another —
+	 * silent UX gap. Locks the contract: any future change to the
+	 * default-derivation logic on either side has to update both,
+	 * or this test fails.
+	 */
+	public function test_get_settings_default_sender_email_matches_send_path() {
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+
+		$data = Emails_Section::api_get_settings()->get_data();
+		$this->assertSame(
+			Emails::get_from_email(),
+			$data['defaults']['sender_email_address'],
+			'Modal placeholder must match Emails::get_from_email() default-fallback when no override saved.'
+		);
+	}
+
+	/**
+	 * Same alignment contract for sender_name (against
+	 * Emails::get_from_name()) and contact_email_address (against
+	 * Emails::get_reply_to_email()). Locks both surfaces against
+	 * silent divergence.
+	 */
+	public function test_get_settings_defaults_match_send_path_helpers() {
+		delete_option( 'newspack_reader_activation_sender_name' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+
+		$data = Emails_Section::api_get_settings()->get_data();
+		$this->assertSame(
+			Emails::get_from_name(),
+			$data['defaults']['sender_name'],
+			'Modal placeholder must match Emails::get_from_name() default-fallback.'
+		);
+		$this->assertSame(
+			Emails::get_reply_to_email(),
+			$data['defaults']['contact_email_address'],
+			'Modal placeholder must match Emails::get_reply_to_email() default-fallback.'
+		);
+	}
+
+	/**
+	 * POSTing an empty value for any field deletes the option row,
+	 * reverting that field to its derived default. This is the
+	 * load-bearing case for letting publishers "unset" a previously
+	 * saved override and re-engage the dynamic-default behavior.
+	 */
+	public function test_post_settings_empty_value_deletes_option() {
+		// Pre-condition: a saved override exists.
+		update_option( 'newspack_reader_activation_sender_name', 'Old Override' );
+		$this->assertSame( 'Old Override', get_option( 'newspack_reader_activation_sender_name' ) );
+
+		// POST with empty sender_name — other fields valid so the
+		// handler reaches the write path.
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', '' );
+		$request->set_param( 'sender_email_address', 'sender@example.test' );
+		$request->set_param( 'contact_email_address', 'contact@example.test' );
+
+		$response = Emails_Section::api_update_settings( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		// Option row is gone — get_option returns the default `false`
+		// (no row exists), not the previously-saved 'Old Override'.
+		$this->assertFalse( get_option( 'newspack_reader_activation_sender_name' ) );
+
+		// Response carries '' for the cleared field and populated
+		// values for the others.
+		$data = $response->get_data();
+		$this->assertSame( '', $data['sender_name'] );
+		$this->assertSame( 'sender@example.test', $data['sender_email_address'] );
+		$this->assertSame( 'contact@example.test', $data['contact_email_address'] );
+
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+	}
+
+	/**
+	 * If `Reader_Activation::update_setting()` returns false (the key
+	 * was removed from get_settings_config(), e.g. via the
+	 * `newspack_reader_activation_settings_config` filter, or
+	 * update_option itself failed), the handler must surface a
+	 * `newspack_settings_write_failed` WP_Error rather than silently
+	 * proceed to return `api_get_settings()` — which would look like a
+	 * successful save while the option was never written.
+	 */
+	public function test_post_settings_returns_error_when_update_setting_fails() {
+		$filter = function ( $config ) {
+			unset( $config['sender_name'] );
+			return $config;
+		};
+		add_filter( 'newspack_reader_activation_settings_config', $filter );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', 'My Site' );
+		$request->set_param( 'sender_email_address', 'sender@example.test' );
+		$request->set_param( 'contact_email_address', 'contact@example.test' );
+
+		$response = Emails_Section::api_update_settings( $request );
+
+		remove_filter( 'newspack_reader_activation_settings_config', $filter );
+
+		// The filter-removal of sender_name causes update_setting() to
+		// return false on the first non-empty write; the handler must
+		// convert that into a visible 500 rather than the misleading
+		// 200 OK + empty re-read.
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'newspack_settings_write_failed', $response->get_error_code() );
+		$this->assertSame( 500, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Empty-value revert path fires `newspack_reader_activation_update_setting`
+	 * with an empty value so external subscribers (audit logs, ESP
+	 * sync) observe the change. Without this, the delete path would
+	 * be invisible to hook listeners, producing drift between the
+	 * stored state and any external mirror built from the hook.
+	 */
+	public function test_post_settings_empty_value_fires_update_setting_action() {
+		update_option( 'newspack_reader_activation_sender_name', 'Old Override' );
+
+		$captured = [];
+		$callback = function ( $key, $value ) use ( &$captured ) {
+			$captured[] = [ $key, $value ];
+		};
+		add_action( 'newspack_reader_activation_update_setting', $callback, 10, 2 );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', '' );
+		$request->set_param( 'sender_email_address', 'sender@example.test' );
+		$request->set_param( 'contact_email_address', 'contact@example.test' );
+
+		$response = Emails_Section::api_update_settings( $request );
+
+		remove_action( 'newspack_reader_activation_update_setting', $callback, 10 );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		// Should have fired for sender_name (empty/revert path) and
+		// the two non-empty writes (via update_setting internal).
+		$sender_name_events = array_filter( $captured, fn( $e ) => 'sender_name' === $e[0] );
+		$this->assertCount( 1, $sender_name_events, 'Empty-revert path should fire update_setting action once.' );
+		$this->assertSame( '', array_values( $sender_name_events )[0][1] );
+
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+	}
+
+	/**
+	 * Re-saving the same value must return success, not 500.
+	 *
+	 * WordPress's `update_option()` returns false in two distinct
+	 * cases: genuine write failure AND no-op (new value === current
+	 * value). The handler's `! update_setting(...)` check treats
+	 * both as failure. Without a pre-check skipping no-ops, hitting
+	 * Save twice in a row with the same value 500s on the second
+	 * call. Pre-check via `get_option` and `continue` past unchanged
+	 * fields.
+	 *
+	 * Also asserts the action hook does NOT fire on the no-op
+	 * re-save — "this changed" semantics. (`update_setting`
+	 * unconditionally fires the hook before reaching update_option,
+	 * so the only way to keep the no-op silent is to bypass
+	 * update_setting entirely when value is unchanged.)
+	 */
+	public function test_post_settings_idempotent_when_value_unchanged() {
+		// First save.
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', 'Same Site' );
+		$request->set_param( 'sender_email_address', 'same@example.test' );
+		$request->set_param( 'contact_email_address', 'same-contact@example.test' );
+
+		$first_response = Emails_Section::api_update_settings( $request );
+		$this->assertNotInstanceOf( WP_Error::class, $first_response );
+
+		// Second save with identical values — must NOT 500.
+		$captured = [];
+		$callback = function ( $key, $value ) use ( &$captured ) {
+			$captured[] = [ $key, $value ];
+		};
+		add_action( 'newspack_reader_activation_update_setting', $callback, 10, 2 );
+
+		$second_response = Emails_Section::api_update_settings( $request );
+
+		remove_action( 'newspack_reader_activation_update_setting', $callback, 10 );
+
+		$this->assertNotInstanceOf(
+			WP_Error::class,
+			$second_response,
+			'Re-saving identical values must not 500. update_option() returns false on no-op, which the handler must distinguish from genuine write failure.'
+		);
+		$this->assertSame(
+			[],
+			$captured,
+			'newspack_reader_activation_update_setting must NOT fire on no-op re-saves — the hook means "this changed", not "this was submitted".'
+		);
+
+		// Response shape is still correct (reads back current state).
+		$data = $second_response->get_data();
+		$this->assertSame( 'Same Site', $data['sender_name'] );
+		$this->assertSame( 'same@example.test', $data['sender_email_address'] );
+		$this->assertSame( 'same-contact@example.test', $data['contact_email_address'] );
+
+		delete_option( 'newspack_reader_activation_sender_name' );
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+	}
+
+	/**
+	 * Empty-revert on an already-absent option must be a no-op:
+	 * delete_option returns false when the row doesn't exist (same
+	 * return as a genuine failure, but semantically different), and
+	 * firing the action hook would be a phantom "change" event with
+	 * nothing actually changing.
+	 */
+	public function test_post_settings_empty_value_idempotent_when_already_empty() {
+		// Belt-and-suspenders: ensure no row exists.
+		delete_option( 'newspack_reader_activation_sender_name' );
+
+		$captured = [];
+		$callback = function ( $key, $value ) use ( &$captured ) {
+			$captured[] = [ $key, $value ];
+		};
+		add_action( 'newspack_reader_activation_update_setting', $callback, 10, 2 );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'sender_name', '' );
+		$request->set_param( 'sender_email_address', 'sender@example.test' );
+		$request->set_param( 'contact_email_address', 'contact@example.test' );
+
+		$response = Emails_Section::api_update_settings( $request );
+
+		remove_action( 'newspack_reader_activation_update_setting', $callback, 10 );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		// Action hook should NOT have fired for sender_name — there
+		// was no row to delete, no actual change. The two non-empty
+		// writes DO fire the hook via update_setting() internally,
+		// but the empty-already-absent path must stay silent.
+		$sender_name_events = array_filter( $captured, fn( $e ) => 'sender_name' === $e[0] );
+		$this->assertSame(
+			[],
+			array_values( $sender_name_events ),
+			'Empty-revert on an already-absent option must not fire the update_setting action hook.'
+		);
+
+		// And the option row still doesn't exist (we didn't accidentally create one).
+		$this->assertFalse( get_option( 'newspack_reader_activation_sender_name' ) );
+
+		delete_option( 'newspack_reader_activation_sender_email_address' );
+		delete_option( 'newspack_reader_activation_contact_email_address' );
+	}
+
+	/**
+	 * The settings endpoints inherit Wizard_Section's manage_options
+	 * default — a subscriber-level user hitting api_permissions_check()
+	 * gets WP_Error 403. Both GET and POST share the same permission
+	 * callback, so testing the section's permission method once covers
+	 * the gating for both methods.
+	 */
+	public function test_settings_endpoint_permission_check() {
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$prev_user     = get_current_user_id();
+		wp_set_current_user( $subscriber_id );
+
+		$section = new Emails_Section();
+		$result  = $section->api_permissions_check();
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'Subscriber should be denied.' );
+		$this->assertSame( 'newspack_rest_forbidden', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+
+		wp_set_current_user( $prev_user );
+		wp_delete_user( $subscriber_id );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/emails.php
+++ b/plugins/newspack-plugin/tests/unit-tests/emails.php
@@ -46,6 +46,82 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 	public function tear_down() {
 		reset_phpmailer_instance();
 		Emails::reset_email_configs_cache();
+		delete_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'sender_name' );
+		delete_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'sender_email_address' );
+		delete_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'contact_email_address' );
+	}
+
+	/**
+	 * NPPD-1566: the saved sender/contact overrides are honored by the
+	 * send path REGARDLESS of Reader Activation state. Reader Activation
+	 * is disabled in the test environment by default, so these assertions
+	 * exercise exactly the previously-broken path: a publisher saves the
+	 * settings via the Emails modal with RA off, and the send path must
+	 * use them instead of silently falling back to derived defaults.
+	 */
+	public function test_sender_settings_honored_regardless_of_reader_activation() {
+		$prefix = \Newspack\Reader_Activation::OPTIONS_PREFIX;
+		update_option( $prefix . 'sender_name', 'Custom Sender' );
+		update_option( $prefix . 'sender_email_address', 'sender@example.com' );
+		update_option( $prefix . 'contact_email_address', 'contact@example.com' );
+
+		self::assertSame( 'Custom Sender', Emails::get_from_name(), 'Saved sender_name must be honored with RA off.' );
+		self::assertSame( 'sender@example.com', Emails::get_from_email(), 'Saved sender_email must be honored with RA off.' );
+		self::assertSame( 'contact@example.com', Emails::get_reply_to_email(), 'Saved contact_email must be honored with RA off.' );
+	}
+
+	/**
+	 * An empty (or absent) saved value is the revert-to-default signal:
+	 * the send path falls back to the derived default rather than sending
+	 * with a blank sender.
+	 */
+	public function test_sender_settings_fall_back_to_defaults_when_empty() {
+		$prefix = \Newspack\Reader_Activation::OPTIONS_PREFIX;
+		update_option( $prefix . 'sender_name', '' );
+		delete_option( $prefix . 'sender_email_address' );
+
+		self::assertSame( get_bloginfo( 'name' ), Emails::get_from_name(), 'Empty sender_name must fall back to the site title.' );
+		self::assertStringStartsWith( 'no-reply@', Emails::get_from_email(), 'Absent sender_email must fall back to the derived no-reply default.' );
+	}
+
+	/**
+	 * NPPD-1575: the option-layer guard (registered via register_setting)
+	 * validates the email keys for EVERY writer — including a direct
+	 * update_option() that bypasses the Emails route's inline is_email().
+	 * A valid address is stored; a malformed one is coerced to the
+	 * last-good stored value (never wiping a good address); empty is the
+	 * revert signal and is preserved.
+	 */
+	public function test_email_option_sanitization_applies_to_any_writer() {
+		Emails::register_sender_settings(); // Ensure the sanitize filters are attached.
+		$option = \Newspack\Reader_Activation::OPTIONS_PREFIX . 'sender_email_address';
+
+		// Valid address is stored (sanitized).
+		update_option( $option, 'good@example.com' );
+		self::assertSame( 'good@example.com', get_option( $option ), 'Valid address must persist.' );
+
+		// Malformed non-empty write (bypassing the route guard) is coerced
+		// to the last-good stored value, not allowed to wipe it.
+		update_option( $option, 'not-an-email' );
+		self::assertSame( 'good@example.com', get_option( $option ), 'Invalid address must coerce to last-good, not overwrite it.' );
+
+		// Empty is the revert-to-default signal and is preserved.
+		update_option( $option, '' );
+		self::assertSame( '', get_option( $option ), 'Empty must be preserved as the revert signal.' );
+	}
+
+	/**
+	 * The sender_name option strips CR/LF via sanitize_text_field at the
+	 * option layer, so a From:-header injection attempt can't be stored
+	 * even by a writer that skips the route.
+	 */
+	public function test_sender_name_option_strips_newlines() {
+		Emails::register_sender_settings();
+		$option = \Newspack\Reader_Activation::OPTIONS_PREFIX . 'sender_name';
+
+		update_option( $option, "Evil\r\nBcc: victim@example.com" );
+		self::assertStringNotContainsString( "\r", get_option( $option ), 'CR must be stripped from sender_name.' );
+		self::assertStringNotContainsString( "\n", get_option( $option ), 'LF must be stripped from sender_name.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
@@ -282,17 +282,20 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'reader_revenue', $prerequisites, 'Reader Revenue prerequisite should be removed.' );
 		$this->assertArrayNotHasKey( 'ras_campaign', $prerequisites, 'Campaign defaults prerequisite should be removed.' );
+		// NPPD-1566: the Transactional Emails prerequisite was removed — its
+		// settings moved to the Emails screen with valid derived defaults, so
+		// they no longer gate Reader Activation.
+		$this->assertArrayNotHasKey( 'emails', $prerequisites, 'Transactional Emails prerequisite should be removed (NPPD-1566).' );
 
-		// First three are always present and ordered.
+		// First two are always present and ordered.
 		$keys = array_keys( $prerequisites );
-		$this->assertSame( 'emails', $keys[0], 'Transactional Emails should be first.' );
-		$this->assertSame( 'terms_conditions', $keys[1], 'Legal Pages should be second.' );
-		$this->assertSame( 'recaptcha', $keys[2], 'reCAPTCHA should be third.' );
+		$this->assertSame( 'terms_conditions', $keys[0], 'Legal Pages should be first.' );
+		$this->assertSame( 'recaptcha', $keys[1], 'reCAPTCHA should be second.' );
 
 		// ESP is gated on Newspack Newsletters; in the test env it is absent.
 		if ( class_exists( '\Newspack_Newsletters' ) ) {
 			$this->assertArrayHasKey( 'esp', $prerequisites, 'ESP should be present when Newsletters exists.' );
-			$this->assertSame( 'esp', $keys[3], 'ESP should be fourth when present.' );
+			$this->assertSame( 'esp', $keys[2], 'ESP should be third when present.' );
 		} else {
 			$this->assertArrayNotHasKey( 'esp', $prerequisites, 'ESP should be absent without Newsletters.' );
 		}


### PR DESCRIPTION
## Summary

Moves the three transactional-email settings (sender name, sender email, contact email) out of their existing home in Audience > Configuration > Transactional Emails prerequisite card and into the unified Emails screen via a "Settings" button + modal in the chip bar header.

Resolves [NPPD-1566](https://linear.app/a8c/issue/NPPD-1566).

<img width="1122" height="1232" alt="image" src="https://github.com/user-attachments/assets/bd056173-50f5-401d-81ee-c28ac7786aaf" />

## Stacking

⚠️ **Stacked on slice 2b ([#146](https://github.com/Automattic/newspack-workspace/pull/146))** and targets its branch, not `main`. Review order: [#137](https://github.com/Automattic/newspack-workspace/pull/137) → [#144](https://github.com/Automattic/newspack-workspace/pull/144) → [#146](https://github.com/Automattic/newspack-workspace/pull/146) → this.

When [NPPD-1538](https://linear.app/a8c/issue/NPPD-1538) eventually moves the Emails screen from Newspack > Settings to Audience > Configuration, this PR's frontend changes get relocated naturally as part of that move. No coordination needed between this PR and NPPD-1538's work.

## Headline design decision: preserve dynamic-default behavior

The most important thing in this PR isn't moving the fields — it's preserving the *semantic contract* of how those fields work today.

Today, when the three options are unset in `wp_options`, the system computes defaults dynamically every time they're read:
- `sender_name` → `get_bloginfo('name')` (the current site title)
- `sender_email_address` → `no-reply@{current domain}`
- `contact_email_address` → `get_option('admin_email')` (the current admin email)

This means a publisher who changes their site title, domain, or admin email gets transactional emails updated automatically. **The naive "move the fields to a new UI" approach would silently destroy this behavior** — the first time a publisher opens the new modal and clicks Save (even with no edits), the dynamically-derived values would be written to `wp_options` as static rows. Subsequent site-title or admin-email changes would no longer propagate.

This was caught during smoke testing rather than at design time. The fix is the architectural pattern this PR ships:

**GET endpoint returns saved values and derived defaults separately:**
```json
{
  "sender_name": "",                              // empty if unset
  "sender_email_address": "",
  "contact_email_address": "",
  "defaults": {
    "sender_name": "My Newsroom",                 // computed each request
    "sender_email_address": "no-reply@example.com",
    "contact_email_address": "admin@example.com"
  }
}
```

**Frontend renders saved values as `value=` and derived defaults as `placeholder=`** on each `TextControl`, so publishers visually distinguish "what I've explicitly set" from "what the system is computing."

**POST endpoint accepts empty values as "revert to derived default"** — empty strings trigger `delete_option()` on the underlying option row, restoring the dynamic-default behavior. Email-format validation only fires when the value is non-empty.

**Result:** publishers can hit Save with no edits and nothing breaks. The dynamic-default behavior is preserved by construction.

Helper text on each field reinforces the affordance: "Leave blank to use your site title" / "Leave blank to use no-reply@..." / "Leave blank to use your site's admin email."

## Architectural notes

**New dedicated REST endpoint** rather than reusing the existing `audience-management` POST. Routes registered on `Emails_Section` under the same `REST_BASE` constant that [NPPD-1535 (#158)](https://github.com/Automattic/newspack-workspace/pull/158) introduces:

- `GET /newspack/v1/wizard/newspack-settings/emails/settings` — reads via `Reader_Activation::get_setting()` (defaults flow through site title, no-reply address, admin email helpers)
- `POST /newspack/v1/wizard/newspack-settings/emails/settings` — validates, sanitizes, delegates writes to `Reader_Activation::update_setting()` (option storage location unchanged at `newspack_reader_activation_*`)

The dedicated endpoint aligns with the discipline NPPD-1535 established: email-related REST routes belong under `newspack-settings/emails/*`, not in the donations wizard or the `audience-management` catchall. Reusing the shared POST would have been the smallest-change choice but would have undone that alignment.

**Both this PR and #158 declare `REST_BASE` independently** (slice 2b doesn't have it yet). Whichever PR merges first, the other's `REST_BASE` declaration collapses cleanly on rebase — the declarations are byte-identical with the same docblock.

## Validation

Recon found that the three fields currently have **no validation at all** — no schema-level sanitize, no `sanitize_email()`, no format checks. Today the system happily persists "not-an-email" as a sender email address, breaking deliverability silently.

This PR adds light validation as part of the move:

- **Email fields** (`sender_email_address`, `contact_email_address`): `type="email"` HTML5 attribute on the frontend + server-side `sanitize_email()` + `is_email()` validation. Returns 400 with `newspack_invalid_sender_email` / `newspack_invalid_contact_email` on failure. Validation fires only when the value is non-empty (since empty = revert).
- **Client-side gating:** Save button is disabled when any non-empty email field fails client-side format validation, preventing the submit-fail-resubmit loop that would otherwise occur on partial values like `user@`.
- **Sender name:** server-side `sanitize_text_field()`. Empty is valid (triggers revert to derived default); no `required` HTML5 attribute.

The current absence of validation looks like an oversight given these are email fields; the move is the natural moment to add it.

## UI changes

**Chip bar layout:** wrapped in `<HStack justify="space-between">`. Chips on the left (existing), Settings button on the right (new). Button is text-only ("Settings"), no icon, variant=secondary.

**Settings modal:** opened on Settings button click. Matches the pattern established by `advanced-settings.tsx` in the newsletters/premium-newsletters wizard:

- Title: "Settings"
- Header text: "Configure the sender details and reply-to address for transactional emails sent to your readers."
- Body: three `TextControl` fields with `placeholder=` showing the derived defaults
- Footer: Cancel (tertiary) + Save (primary, disabled when not loaded, fetching, not dirty, or client-side-invalid)
- Dirty detection via `JSON.stringify` comparison against initial state
- Cancel/X/Escape/click-outside when dirty: `useConfirmDialog` from `packages/components/src/hooks/use-confirm-dialog.tsx` asks confirmation before discarding
- Save success: `addNotice` from the `newspack/wizards` store with type=success → modal closes
- Save failure: error surfaced inline in the modal, no close

The toast uses `addNotice` from the Newspack wizards store (which has its `WizardSnackbar` already mounted at the Wizard level), not `createNotice` from `@wordpress/notices`. Matches the existing convention.

## Audience-side cleanup

Removes the Transactional Emails prerequisite card from `Reader_Activation::get_prerequisites_status()` (lines 946-965 deleted). The three fields' settings keys are independently defined in `get_settings_config()` and survive — only the prereq card's UI definition goes away.

Dual-surface state (leaving the card in place, both UIs editing the same options) was the alternative and would have been confusing: publishers would have two locations editing the same data with no clear winner.

The `newspack_reader_activation_emails_skipped` option becomes an orphan after this removal. Harmless — no consumer — but could be cleaned up in a follow-up if anyone cares.

## Testing

**7 new PHP tests** (`tests/unit-tests/emails-section.php`, Bucket F):
- `test_get_settings_returns_three_fields` (happy path with saved values)
- `test_get_settings_returns_empty_values_when_no_override_saved` (launch-safety lock-in: fresh-install case returns empty values + populated defaults)
- `test_post_settings_persists_three_fields` (happy path: saves all three)
- `test_post_settings_empty_value_deletes_option` (revert semantics: empty triggers `delete_option`)
- `test_post_settings_rejects_invalid_email_in_sender` (400 + `newspack_invalid_sender_email`)
- `test_post_settings_rejects_invalid_email_in_contact` (400 + `newspack_invalid_contact_email`)
- `test_settings_endpoint_permission_check` (subscriber-level user blocked, both GET and POST)

**4 new JS tests** (`settings-modal.test.js`):
- `test_modal_opens_on_settings_button_click`
- `test_modal_save_calls_post_endpoint_and_closes_with_notice`
- `test_modal_cancel_prompts_when_dirty`
- `test_modal_cancel_no_prompt_when_clean`

PHP suite: 1330 → 1337 (+7 tests / +39 assertions, no other counts shifted). JS suite: 213 → 217 (+4 tests / +1 suite, no regressions).

## Known pre-existing tsc noise

`emails.tsx` has 4 pre-existing tsc errors on lines 350, 441, 444, 448 — DataViews v14 type narrowness on the reset action's `isDestructive` and DataViews component prop type widening. Verified pre-existing baseline (errors present before this PR's changes; this PR adds zero new tsc errors). Worth a small cleanup follow-up; out of scope here.
