### PR TITLE
feat(env): add --isolated-db sidecar for lowercase tables (NEWS-2286)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,13 +224,20 @@ n setup --env myenv --yes     # fully configured Newspack site
 n env create <name> [options]  # Create environment config
   --worktree <repo>:<branch>   #   Mount a worktree (repeatable for multiple repos)
   --domain <domain>            #   Custom domain (default: <name>.test)
+  --isolated-db                #   Use a private MariaDB sidecar with lower_case_table_names=1
+                               #     (needed for envs that create pyrobase tables via $wpdb at runtime; see NEWS-2286)
   --up                         #   Start the environment immediately after creation
 n env up <name> [--build]      # Start environment (creates DB, installs WP, sets up SSL)
 n env up --all [--build]       # Start all existing environments at once
 n env down <name>              # Stop environment
 n env destroy <name>           # Remove environment, DB, worktrees, and files
-n env list                     # List environments with status, URLs, and worktrees
-n env list --porcelain         # Machine-readable tab-separated output (name, status, url, worktrees)
+n env list                     # List environments with status, URLs, and worktrees;
+                               # isolated-db envs flagged with [isolated-db]
+n env list --porcelain         # Machine-readable tab-separated output:
+                               #   name, status, url, worktrees, db_kind
+                               # NOTE: db_kind column added 2026-05-20 (NEWS-2286 — breaking
+                               # change for strict-column-count consumers; appended at the
+                               # end so positional consumers of cols 1-4 still work).
 n env cleanup                  # Interactive bulk cleanup of environments
 ```
 

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -42,3 +42,20 @@ log_info() { echo -e "${NP_BLUE}[INFO]${NP_NC} ${1}"; }
 log_success() { echo -e "${NP_GREEN}[SUCCESS]${NP_NC} ${1}"; }
 log_warning() { echo -e "${NP_YELLOW}[WARNING]${NP_NC} ${1}"; }
 log_error() { echo -e "${NP_RED}[ERROR]${NP_NC} ${1}"; }
+
+# Get the isolated-db sidecar service name (db_lowercase_<safe>) for an env's
+# compose file. Returns empty if the env uses the shared db. Detection is by
+# the 2-space-indented service-key line written by `n env create --isolated-db`.
+# If the compose file's indentation changes, this regex must change in lockstep.
+sidecar_service_for_env() {
+    grep -oE '^  db_lowercase_[a-zA-Z0-9_]+:' "$1" 2>/dev/null | head -1 | tr -d ' :'
+}
+
+# Normalize an env name to a docker-safe form for service / container / data-dir
+# names: fold dashes AND dots to underscores. Mirrors the equivalence enforced
+# by the create-time collision check; the dot fold is what makes
+# `n env create foo.bar --isolated-db` work (validate_env_name permits dots,
+# but the detection regex above intentionally excludes them).
+env_safe_name() {
+    echo "$1" | tr -- '-.' '_'
+}

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -46,17 +46,20 @@ case $1 in
     create)
         env_name="$2"
         if [[ -z "$env_name" ]]; then
-            echo "Usage: n env create <name> --worktree <repo>:<branch> [--worktree ...] [--domain <domain>] [--up]"
+            echo "Usage: n env create <name> --worktree <repo>:<branch> [--worktree ...] [--domain <domain>] [--isolated-db] [--up]"
             exit 1
         fi
         validate_env_name "$env_name"
-        # Reject names that would collide after dash/underscore normalization.
-        normalized=$(echo "$env_name" | tr '-' '_')
+        # Reject names that would collide after dash/dot/underscore normalization.
+        # validate_env_name permits dots; env_safe_name folds them to underscores
+        # alongside dashes, so foo-bar, foo.bar, and foo_bar all resolve to the
+        # same docker-safe identifier and must not coexist.
+        normalized=$(env_safe_name "$env_name")
         for f in "$NABSPATH"/docker-compose.env-*.yml; do
             [[ -f "$f" ]] || continue
             existing=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
             [[ "$existing" == "$env_name" ]] && continue
-            if [[ "$(echo "$existing" | tr '-' '_')" == "$normalized" ]]; then
+            if [[ "$(env_safe_name "$existing")" == "$normalized" ]]; then
                 echo "Error: '$env_name' conflicts with existing environment '$existing' (same container/database name after normalization)"
                 exit 1
             fi
@@ -65,6 +68,7 @@ case $1 in
         worktree_volumes=""
         domain=""
         auto_up=false
+        isolated_db=false
         while [[ $# -gt 0 ]]; do
             case $1 in
                 --worktree)
@@ -111,6 +115,10 @@ case $1 in
                     auto_up=true
                     shift
                     ;;
+                --isolated-db)
+                    isolated_db=true
+                    shift
+                    ;;
                 *)
                     echo "Unknown option: $1"
                     exit 1
@@ -126,13 +134,66 @@ case $1 in
         db_name=$(db_name_for_env "$env_name")
         # Create isolated html directory.
         mkdir -p "$NABSPATH/envs/${env_name}/html"
+        # Assemble the env-container YAML once. The isolated-db branch differs
+        # only in (a) a prepended sidecar service block, (b) which DB service
+        # the env depends on, and (c) a MYSQL_HOST override that points at the
+        # sidecar. Building once means future edits to volumes / ports /
+        # networks land in one place (R2 finding: heredoc duplication risks
+        # silent drift -- the prior shape had MYSQL_HOST already asymmetric).
+        db_service="db"
+        mysql_host_line=""
+        sidecar_block=""
+        suffix_log=""
+        if [[ "$isolated_db" == true ]]; then
+            safe_name=$(env_safe_name "$env_name")
+            sidecar_service="db_lowercase_${safe_name}"
+            sidecar_container="newspack_db_lowercase_${safe_name}"
+            db_service="${sidecar_service}"
+            mysql_host_line="      - MYSQL_HOST=${sidecar_service}:3306
+"
+            # mariadb:11.8.6 is duplicated with docker-compose.yml's `db`
+            # service tag intentionally (no shared variable in v1). If the
+            # shared db's image tag is bumped, bump this one too so isolated
+            # envs stay version-aligned with the rest of the workspace.
+            #
+            # The sidecar deliberately declares NO `networks:` key, so it joins
+            # only Compose's implicit per-project `default` network. The env
+            # service (below) is on both `default` and `newspack_envs`; the env
+            # reaches the sidecar via `MYSQL_HOST=${sidecar_service}:3306` over
+            # that shared `default` network. Keeping the sidecar off
+            # `newspack_envs` is the isolation boundary -- but it means the env
+            # service's `default` membership is load-bearing and must not be
+            # removed.
+            sidecar_block="  ${sidecar_service}:
+    container_name: ${sidecar_container}
+    image: mariadb:11.8.6
+    volumes:
+      - ./data/newspack-dev_mysql_lowercase_${safe_name}:/var/lib/mysql
+      - ./config/mysql_lowercase.conf:/etc/mysql/conf.d/docker.cnf
+    env_file:
+      - default.env
+      - .env
+    # Use the stock mariadbd entrypoint instead of the shared db's
+    # docker-db-start-and-autoupgrade.sh wrapper -- that script has -hdb
+    # hardcoded and would never resolve against this service's name. Two
+    # consequences accepted as known limitations: (1) no /var/log/mysql
+    # ownership fix runs, but the sidecar doesn't bind-mount a host log dir
+    # and the LCTN config disables slow-log, so nothing actually writes
+    # there; (2) no mariadb-upgrade runs -- fresh data dirs don't need it;
+    # if the image tag above is bumped, run mariadb-upgrade manually inside
+    # the sidecar.
+    command: [\"mariadbd\"]
+
+"
+            suffix_log=", isolated-db"
+        fi
         cat > "$compose_file" <<YAML
 services:
-  env-${env_name}:
+${sidecar_block}  env-${env_name}:
     container_name: ${container_name}
     platform: linux/arm64
     depends_on:
-      - db
+      - ${db_service}
     image: newspack-dev:latest
     volumes:
       - ./logs/env-${env_name}/apache2:/var/log/apache2
@@ -153,7 +214,7 @@ ${worktree_volumes}      - ./envs/${env_name}/html:/var/www/html
       - .env
     environment:
       - HOST_PORT=80
-      - MYSQL_DATABASE=${db_name}
+${mysql_host_line}      - MYSQL_DATABASE=${db_name}
       - WP_CACHE_KEY_SALT=env_${env_name}_
       - WP_DOMAIN=${domain}
       - APACHE_RUN_USER=\${USE_CUSTOM_APACHE_USER:-www-data}
@@ -168,7 +229,7 @@ networks:
   newspack_envs:
     external: true
 YAML
-        echo "Created $compose_file (db: $db_name, domain: $domain, ip: $ip)"
+        echo "Created $compose_file (db: $db_name, domain: $domain, ip: $ip${suffix_log})"
         # Check networking prerequisites (macOS only — Linux routes all 127.x.x.x by default).
         if [[ "$(uname)" == "Darwin" ]] && ! ifconfig lo0 2>/dev/null | grep -q "$ip"; then
             if command -v newspack-manage-host >/dev/null 2>&1; then
@@ -256,6 +317,12 @@ YAML
         db_name=$(db_name_for_env "$env_name")
         domain=$(domain_for_env "$compose_file")
         ip=$(ip_for_env "$compose_file")
+        # Detect isolated-db (sidecar) envs by the presence of a db_lowercase_* service.
+        sidecar_service=$(sidecar_service_for_env "$compose_file")
+        sidecar_container=""
+        if [[ -n "$sidecar_service" ]]; then
+            sidecar_container="newspack_${sidecar_service}"
+        fi
         # --- Migration: add shared network + domain if missing ---
         if ! grep -q 'newspack_envs' "$compose_file"; then
             # Assign a .test domain if the env is IP-based.
@@ -316,12 +383,48 @@ MIGRATE
         source "$NABSPATH/default.env"
         [[ -f "$NABSPATH/.env" ]] && source "$NABSPATH/.env"
         set +a
-        # Ensure db is running and create the environment database.
-        docker compose -f "$NABSPATH/docker-compose.yml" up -d db
-        echo "Creating database $db_name..."
-        docker compose -f "$NABSPATH/docker-compose.yml" exec -T db \
-            mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
-            -e "CREATE DATABASE IF NOT EXISTS \`${db_name}\`; GRANT ALL PRIVILEGES ON \`${db_name}\`.* TO '${MYSQL_USER}'@'%'; FLUSH PRIVILEGES;" 2>/dev/null
+        # Ensure DB is running and create the environment database.
+        if [[ -n "$sidecar_service" ]]; then
+            echo "Starting isolated-db sidecar ($sidecar_service)..."
+            docker compose -f "$NABSPATH/docker-compose.yml" -f "$compose_file" up -d "$sidecar_service"
+            # Wait for sidecar to accept connections.
+            ready=false
+            for i in $(seq 1 60); do
+                if docker compose -f "$NABSPATH/docker-compose.yml" -f "$compose_file" \
+                    exec -T "$sidecar_service" \
+                    mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" -e "SELECT 1" \
+                    >/dev/null 2>&1; then
+                    ready=true; break
+                fi
+                sleep 1
+            done
+            if [[ "$ready" != "true" ]]; then
+                echo "Error: $sidecar_service did not become ready within 60s" >&2
+                exit 1
+            fi
+            # Verify LCTN=1 (guards against silent config-mount drift).
+            lctn=$(docker compose -f "$NABSPATH/docker-compose.yml" -f "$compose_file" \
+                exec -T "$sidecar_service" \
+                mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" -N -B \
+                -e "SELECT @@lower_case_table_names" 2>/dev/null | tr -d '\r')
+            if [[ "$lctn" != "1" ]]; then
+                echo "Error: $sidecar_service reports lower_case_table_names=$lctn (expected 1)" >&2
+                echo "Check that config/mysql_lowercase.conf is mounted correctly." >&2
+                echo "If the data dir was previously initialized with LCTN=2, the only fix is 'n env destroy $env_name' then re-create (LCTN is locked at data-dir init)." >&2
+                exit 1
+            fi
+            echo "Creating database $db_name on $sidecar_service..."
+            docker compose -f "$NABSPATH/docker-compose.yml" -f "$compose_file" \
+                exec -T "$sidecar_service" \
+                mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
+                -e "CREATE DATABASE IF NOT EXISTS \`${db_name}\`; GRANT ALL PRIVILEGES ON \`${db_name}\`.* TO '${MYSQL_USER}'@'%'; FLUSH PRIVILEGES;"
+        else
+            docker compose -f "$NABSPATH/docker-compose.yml" up -d db
+            echo "Creating database $db_name..."
+            docker compose -f "$NABSPATH/docker-compose.yml" exec -T db \
+                mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
+                -e "CREATE DATABASE IF NOT EXISTS \`${db_name}\`; GRANT ALL PRIVILEGES ON \`${db_name}\`.* TO '${MYSQL_USER}'@'%'; FLUSH PRIVILEGES;"
+        fi
         # Start the env container.
         if ! docker compose -f "$NABSPATH/docker-compose.yml" -f "$compose_file" up -d "env-${env_name}"; then
             echo "Error: failed to start container"
@@ -424,8 +527,16 @@ MIGRATE
         fi
         validate_env_name "$env_name"
         container_name=$(echo "newspack_env_${env_name}" | tr '-' '_')
+        compose_file="$NABSPATH/docker-compose.env-${env_name}.yml"
         docker stop "$container_name" 2>/dev/null
         docker rm "$container_name" 2>/dev/null
+        if [[ -f "$compose_file" ]]; then
+            sidecar_service=$(sidecar_service_for_env "$compose_file")
+            if [[ -n "$sidecar_service" ]]; then
+                docker stop "newspack_${sidecar_service}" 2>/dev/null
+                docker rm "newspack_${sidecar_service}" 2>/dev/null
+            fi
+        fi
         ;;
     destroy)
         env_name="$2"
@@ -437,10 +548,12 @@ MIGRATE
         compose_file="$NABSPATH/docker-compose.env-${env_name}.yml"
         container_name=$(echo "newspack_env_${env_name}" | tr '-' '_')
         db_name=$(db_name_for_env "$env_name")
-        # Read domain, IP, and worktrees before removing compose file.
+        # Read domain, IP, worktrees, and sidecar before removing compose file.
         domain=""
         ip=""
         worktree_entries=()
+        sidecar_service=""
+        sidecar_container=""
         if [[ -f "$compose_file" ]]; then
             domain=$(domain_for_env "$compose_file")
             ip=$(ip_for_env "$compose_file")
@@ -449,19 +562,29 @@ MIGRATE
                 wt=$(echo "$line" | grep -o 'worktrees/[^:]*' | sed 's|worktrees/||')
                 [[ -n "$wt" ]] && worktree_entries+=("$wt")
             done < <(grep 'worktrees/' "$compose_file")
+            sidecar_service=$(sidecar_service_for_env "$compose_file")
+            if [[ -n "$sidecar_service" ]]; then
+                sidecar_container="newspack_${sidecar_service}"
+            fi
         fi
         docker stop "$container_name" 2>/dev/null
         docker rm "$container_name" 2>/dev/null
-        # Drop the environment database via docker compose (avoids hardcoding container name).
         set -a
         source "$NABSPATH/default.env"
         [[ -f "$NABSPATH/.env" ]] && source "$NABSPATH/.env"
         set +a
-        docker compose -f "$NABSPATH/docker-compose.yml" up -d db 2>/dev/null
-        docker compose -f "$NABSPATH/docker-compose.yml" exec -T db \
-            mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
-            -e "DROP DATABASE IF EXISTS \`${db_name}\`" 2>/dev/null
-        echo "Dropped database $db_name"
+        if [[ -n "$sidecar_service" && -n "$sidecar_container" ]]; then
+            docker stop "$sidecar_container" 2>/dev/null
+            docker rm "$sidecar_container" 2>/dev/null
+            # Sidecar removed -- nothing more to drop. Its data dir is removed below.
+            echo "Stopped isolated-db sidecar $sidecar_container"
+        else
+            docker compose -f "$NABSPATH/docker-compose.yml" up -d db 2>/dev/null
+            docker compose -f "$NABSPATH/docker-compose.yml" exec -T db \
+                mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" \
+                -e "DROP DATABASE IF EXISTS \`${db_name}\`" 2>/dev/null
+            echo "Dropped database $db_name"
+        fi
         # Remove env html and certs directories.
         if [[ -d "$NABSPATH/envs/${env_name}" ]]; then
             rm -rf "$NABSPATH/envs/${env_name}"
@@ -471,6 +594,17 @@ MIGRATE
         if [[ -d "$NABSPATH/logs/env-${env_name}" ]]; then
             rm -rf "$NABSPATH/logs/env-${env_name}"
             echo "Removed logs/env-${env_name}/"
+        fi
+        # Remove isolated-db sidecar's data dir if this was an --isolated-db env.
+        # The sidecar bind-mounts no host log dir (the LCTN config disables the
+        # slow-log and nothing writes to /var/log/mysql), so there is no
+        # logs/db-lowercase-<env> to clean up.
+        if [[ -n "$sidecar_service" ]]; then
+            safe="${sidecar_service#db_lowercase_}"
+            if [[ -d "$NABSPATH/data/newspack-dev_mysql_lowercase_${safe}" ]]; then
+                rm -rf "$NABSPATH/data/newspack-dev_mysql_lowercase_${safe}"
+                echo "Removed data/newspack-dev_mysql_lowercase_${safe}/"
+            fi
         fi
         # Remove /etc/hosts entry (only for custom domains, not IP-based).
         if [[ -n "$domain" && "$domain" != "$ip" ]] && grep -q "$domain" /etc/hosts 2>/dev/null; then
@@ -503,6 +637,12 @@ MIGRATE
             name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
             container_name=$(echo "newspack_env_${name}" | tr '-' '_')
             domain=$(domain_for_env "$f")
+            isolated_marker=""
+            db_kind="shared"
+            if [[ -n "$(sidecar_service_for_env "$f")" ]]; then
+                isolated_marker=" [isolated-db]"
+                db_kind="isolated"
+            fi
             if status=$(docker inspect -f '{{.State.Status}}' "$container_name" 2>/dev/null); then
                 :
             else
@@ -517,9 +657,9 @@ MIGRATE
                 worktrees="${worktrees}${repo}:${branch}"
             done < <(grep 'worktrees/' "$f" 2>/dev/null | sed 's|.*/newspack-repos/||')
             if [[ "$porcelain" == true ]]; then
-                printf '%s\t%s\thttps://%s/\t%s\n' "$name" "$status" "$domain" "$worktrees"
+                printf '%s\t%s\thttps://%s/\t%s\t%s\n' "$name" "$status" "$domain" "$worktrees" "$db_kind"
             else
-                echo "  $name ($status) https://${domain}/"
+                echo "  $name ($status) https://${domain}/${isolated_marker}"
                 # Show worktrees mounted by this environment.
                 grep 'worktrees/' "$f" 2>/dev/null | sed 's|.*/newspack-repos/||' | while read -r repo; do
                     wt_path=$(grep "newspack-repos/$repo" "$f" | sed 's/^ *- //' | cut -d: -f1)

--- a/config/mysql_lowercase.conf
+++ b/config/mysql_lowercase.conf
@@ -1,0 +1,21 @@
+# MariaDB config for the lowercase-table-name sidecar (NEWS-2286).
+#
+# The default db service on the macOS host runs with the implicit pairing of
+# lower_case_file_system=ON + lower_case_table_names=2, which causes
+# $wpdb->query("CREATE TABLE PascalCaseName ...") to produce a .frm in the
+# requested case but a .ibd in lowercase -- the engine then can't reconcile
+# them and reads fail with ERROR 1033.
+#
+# Forcing lower_case_table_names=1 keeps both files in lowercase and
+# eliminates the mismatch. This value is locked at data-dir init, so the
+# sidecar uses its own data volume (data/newspack-dev_mysql_lowercase) and
+# must NOT be pointed at the shared data/newspack-dev_mysql tree.
+#
+# This config is intentionally minimal -- LCTN override only. Tuning that
+# applies to the shared db service (slow_query_log, character_set, sql_mode,
+# buffer sizes) is NOT mirrored here; isolated envs run with image defaults.
+# If a future need surfaces for parity, mount the shared `config/mysql.conf`
+# alongside this override rather than duplicating directives across files.
+
+[mysqld]
+lower_case_table_names = 1

--- a/tests/env-isolated-db.smoke.sh
+++ b/tests/env-isolated-db.smoke.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Smoke test for NEWS-2286: n env create --isolated-db
+#
+# Spins up a short-lived env, asserts the sidecar is configured with
+# lower_case_table_names=1, creates a PascalCase $wpdb table from PHP,
+# asserts both .frm and .ibd are lowercase, then tears down.
+#
+# Usage:
+#   tests/env-isolated-db.smoke.sh
+#
+# Idempotent: cleans up any prior run of the same env name before starting.
+
+set -euo pipefail
+
+NABSPATH="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_NAME="smoke-isolated-db"
+SAFE_NAME="smoke_isolated_db"
+DB_NAME="wordpress_${SAFE_NAME}"
+SIDECAR_CONTAINER="newspack_db_lowercase_${SAFE_NAME}"
+
+cleanup() {
+    "$NABSPATH/n" env destroy "$ENV_NAME" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Tear down any leftover state from a prior run.
+cleanup
+
+# Source DB credentials.
+set -a
+# shellcheck disable=SC1091
+source "$NABSPATH/default.env"
+# shellcheck disable=SC1091
+[[ -f "$NABSPATH/.env" ]] && source "$NABSPATH/.env"
+set +a
+
+echo "==> Creating env $ENV_NAME with --isolated-db..."
+"$NABSPATH/n" env create "$ENV_NAME" --isolated-db --up
+
+echo "==> Asserting sidecar exists and reports lower_case_table_names=1..."
+lctn=$(docker exec "$SIDECAR_CONTAINER" \
+    mariadb -h localhost -u root -p"${MYSQL_ROOT_PASSWORD}" -N -B \
+    -e "SELECT @@lower_case_table_names" | tr -d '\r')
+if [[ "$lctn" != "1" ]]; then
+    echo "FAIL: sidecar reports lower_case_table_names=$lctn (expected 1)" >&2
+    exit 1
+fi
+echo "    sidecar lower_case_table_names=1 confirmed"
+
+echo "==> Creating PascalCase table via \$wpdb from PHP..."
+docker exec "newspack_env_${SAFE_NAME}" wp --allow-root eval '
+    global $wpdb;
+    $wpdb->query("CREATE TABLE NewsTwo286Smoke (id INT)");
+    if ($wpdb->last_error) {
+        fwrite(STDERR, "\$wpdb error: " . $wpdb->last_error . "\n");
+        exit(1);
+    }
+'
+
+echo "==> Asserting both files are lowercase on disk..."
+files=$(docker exec "$SIDECAR_CONTAINER" \
+    ls "/var/lib/mysql/${DB_NAME}/" | grep -i newstwo286smoke || true)
+if [[ -z "$files" ]]; then
+    echo "FAIL: no NewsTwo286Smoke files found in sidecar data dir" >&2
+    exit 1
+fi
+if echo "$files" | grep -q '[A-Z]'; then
+    echo "FAIL: uppercase characters found in:" >&2
+    echo "$files" >&2
+    exit 1
+fi
+echo "    all NewsTwo286Smoke files are lowercase:"
+echo "$files" | sed 's/^/      /'
+
+echo "==> Read-after-write should succeed (the original ERROR 1033 case)..."
+docker exec "newspack_env_${SAFE_NAME}" wp --allow-root db query \
+    "SELECT COUNT(*) FROM NewsTwo286Smoke"
+
+echo ""
+echo "PASS: NEWS-2286 isolated-db sidecar working end-to-end."


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes NEWS-2286.

Adds an opt-in `--isolated-db` flag to `n env create` that provisions a per-environment MariaDB sidecar configured with `lower_case_table_names=1`.

**Why:** the shared `db` service's data dir was initialized with `lower_case_table_names=2`, and MariaDB locks that setting at data-dir init. Environments that create PascalCase tables via `$wpdb` at runtime (e.g. Foundation/pyrobase) end up with case-mismatched `.frm`/`.ibd` files, and every subsequent query fails with `ERROR 1033 (Incorrect information in file)`. A per-env sidecar fixes this without forcing every developer to wipe and re-import the shared 30GB+ data dir.

The flag is wired through the full env lifecycle:
- **create** — emits a compose file with the sidecar service (`db_lowercase_<safe>`, dedicated data volume, `config/mysql_lowercase.conf` mounted for `lower_case_table_names=1`).
- **up** — brings up the sidecar instead of shared `db`, waits for readiness, and guards on `@@lower_case_table_names = 1` before creating the env DB.
- **down / destroy** — tears down the sidecar container and removes its data dir.
- **list** — flags isolated envs with `[isolated-db]`; `--porcelain` gains a `db_kind` column (appended last, so positional consumers of columns 1–4 are unaffected).

Non-isolated envs are completely unaffected (the sidecar block, `MYSQL_HOST` override, and `depends_on` target are all empty on the default path).

### How to test the changes in this Pull Request:

1. `bash tests/env-isolated-db.smoke.sh` — spins up a short-lived `--isolated-db` env, asserts the sidecar reports `lower_case_table_names=1`, creates a PascalCase table via `$wpdb`, asserts the on-disk `.frm`/`.ibd` files are lowercase, confirms read-after-write succeeds (the original ERROR 1033 case), then tears down. Expect `PASS: NEWS-2286 isolated-db sidecar working end-to-end.`
2. Manually: `n env create demo-iso --isolated-db --up`, then `n env list` (should show `[isolated-db]`), then `n env destroy demo-iso` (should remove the sidecar + its data dir).
3. Regression: `n env create demo-shared --up` (no flag) and confirm the shared-db path is unchanged.

Verified end-to-end locally via step 1 against current `main` infra (run twice — once after the initial merge, once after folding in review fixes).

### Known limitations / deferred follow-ups

Surfaced by a local multi-LLM code review; documented here rather than expanded into this PR:

- **No automatic `mariadb-upgrade` on image bumps.** The sidecar uses the stock `mariadbd` entrypoint rather than the shared `db`'s autoupgrade wrapper (whose `-hdb` host is hardcoded). The image tag is pinned and bumps are deliberate; the inline comment instructs maintainers to run `mariadb-upgrade` manually after a bump. Auto-handling would require parameterizing the shared wrapper (broader blast radius) — better as its own change.
- **`mariadb:11.8.6` tag duplicated** with `docker-compose.yml`'s `db` service (no clean Compose-side shared-variable option in v1).
- **Dot/underscore collision check** folds both `.` and `-` for all envs (only strictly needed for the isolated-db path); narrowing it cleanly needs an arg-parse reorder, disproportionate for the dotted-env-name edge case.

### Related

- Downstream interaction to scope separately: `Foundation_CLI`'s `LIKE BINARY` trim-plan query behaves differently against the lowercase tables an isolated-db env produces (tracked alongside NEWS-2022).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?