### PR TITLE
fix(posts-inserter): show placeholder when block has zero posts

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1,6 +1,5 @@
 <?php
-
-0/**
+/**
  * Service Provider: ActiveCampaign Implementation
  *
  * @package Newspack

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+0/**
  * Service Provider: ActiveCampaign Implementation
  *
  * @package Newspack
@@ -982,7 +983,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			);
 		}
 		/** Clear existing test campaigns for this post. */
-		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign' );
+		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign', false );
 		if ( ! empty( $test_campaigns ) ) {
 			foreach ( $test_campaigns as $test_campaign_id ) {
 				$delete_res = $this->delete_campaign( $test_campaign_id, true );
@@ -1327,7 +1328,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$this->delete_campaign( $campaign_id, true );
 		}
 		/** Clean up existing test campaigns. */
-		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign' );
+		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign', false );
 		if ( ! empty( $test_campaigns ) ) {
 			foreach ( $test_campaigns as $test_campaign_id ) {
 				$delete_res = $this->delete_campaign( $test_campaign_id, true );
@@ -1372,7 +1373,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return;
 		}
 		/** Clean up existing test campaigns. */
-		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign' );
+		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign', false );
 		if ( ! empty( $test_campaigns ) ) {
 			foreach ( $test_campaigns as $test_campaign_id ) {
 				$delete_res = $this->delete_campaign( $test_campaign_id, true );

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
@@ -79,7 +79,7 @@ const PostsPreview = ( { isReady, blocks, className, viewportWidth }, ref ) => {
 				<Placeholder
 					icon={ pages }
 					label={ __( 'No posts found', 'newspack-newsletters' ) }
-					instructions={ __( 'Verify filtering settings.', 'newspack-newsletters' ) }
+					instructions={ __( 'Verify filter settings.', 'newspack-newsletters' ) }
 				/>
 			) }
 		</div>

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
@@ -1,10 +1,12 @@
 /**
  * WordPress dependencies.
  */
+import { __ } from '@wordpress/i18n';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Spinner } from '@wordpress/components';
+import { Placeholder, Spinner } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
+import { pages } from '@wordpress/icons';
 import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 
 /**
@@ -71,7 +73,15 @@ const PostsPreview = ( { isReady, blocks, className, viewportWidth }, ref ) => {
 			className={ classnames( 'newspack-posts-inserter__preview', className ) }
 			ref={ useMergeRefs( [ ref, useIframeBorderFix, useLayoutStyle, useCustomFontsInIframe() ] ) }
 		>
-			{ isReady ? <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> : <Spinner /> }
+			{ ! isReady && <Spinner /> }
+			{ isReady && blocks?.length > 0 && <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> }
+			{ isReady && ! blocks?.length && (
+				<Placeholder
+					icon={ pages }
+					label={ __( 'No posts found', 'newspack-newsletters' ) }
+					instructions={ __( 'Verify filtering settings.', 'newspack-newsletters' ) }
+				/>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Shows a placeholder when the Posts Inserter block has zero posts to display. This can easily happen by selecting "Display specific posts" and not selecting any posts, or by choosing a combination of post types and category filters that match zero posts.

Closes NPPM-2870.

### How to test the changes in this Pull Request:

#### While on `release`:

1. In a Newsletter post, add a Post Inserter block
2. Select "Display specific posts"
3. Observe that the placeholder collapses to a solid line
4. Click away from the block
5. Observe difficulty in interacting with the block through the post editor UI

#### Now check out this branch

6. Refresh the newsletter editor and repeat
7. Confirm that the block now shows a placeholder with message in the post editor:

<img width="605" height="131" alt="Screenshot 2026-05-29 at 4 44 54 PM" src="https://github.com/user-attachments/assets/3d6919e3-347c-47f1-b6ad-41ffac2d89ef" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
