### PR TITLE
fix(newspack-theme): apply ad background color to Broadstreet ads

### DIFF
--- a/themes/newspack-theme/newspack-theme/inc/color-patterns.php
+++ b/themes/newspack-theme/newspack-theme/inc/color-patterns.php
@@ -201,7 +201,8 @@ function newspack_custom_colors_css() {
 			.newspack_global_ad,
 			.newspack_global_ad.global_above_header,
 			.widget_newspack-ads-widget,
-			div[class*="newspack-ads-blocks-ad-unit"] {
+			div[class*="newspack-ads-blocks-ad-unit"],
+			broadstreet-zone-container {
 				background-color: ' . esc_attr( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
 			}
 		';

--- a/themes/newspack-theme/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/themes/newspack-theme/newspack-theme/sass/plugins/newspack-ads.scss
@@ -157,4 +157,16 @@ body {
 	div[class*="newspack-ads-blocks-ad-unit"] {
 		padding: 8px;
 	}
+
+	// Match the ad background treatment for ads served by the standalone
+	// Broadstreet plugin, whose JS hydrates each zone into a
+	// <broadstreet-zone-container> custom element the theme's other selectors
+	// don't target. (selector-type-no-unknown is already disabled above, for
+	// amp-ad.) See NPPM-2829.
+	broadstreet-zone-container {
+		align-items: center;
+		display: flex;
+		justify-content: center;
+		padding: 8px;
+	}
 }


### PR DESCRIPTION
## Summary

Fixes [NPPM-2829](https://linear.app/a8c/issue/NPPM-2829/newspack-theme-ad-background-color-customizer-setting-doesnt-apply-to).

The Newspack Theme's **Ads Background Color** Customizer setting (Appearance → Customize → Colors) applies a chosen background behind ads. It worked for ads rendered with Newspack Ads markup (`.newspack_global_ad`, `div[class*="newspack-ads-blocks-ad-unit"]`, etc.) but **not** for ads embedded via the standalone Broadstreet WordPress plugin, which renders `<broadstreet-zone-container>` / `<broadstreet-zone>` custom elements that none of the theme's selectors targeted. Reported by Fort Worth Report.

This is a CSS-only change that makes the Broadstreet container inherit the same treatment as Newspack ad units.

<img width="836" height="372" alt="Screenshot 2026-05-29 at 5 12 16 PM" src="https://github.com/user-attachments/assets/0ddbec2c-ae7c-43dc-ad34-39e1d765d0b5" />

## Changes

- **`inc/color-patterns.php`** — add `broadstreet-zone-container` to the ad background-color selector list (already gated on `ads_color === 'custom'`).
- **`sass/plugins/newspack-ads.scss`** — add a `broadstreet-zone-container` rule inside `.custom-ad-bg`: `display: flex` + centering + `8px` padding, mirroring the Newspack ad-unit treatment. This promotes the inline custom element to a block-level full-width wrapper so the background spans the column and the ad centers.

## Why target `broadstreet-zone-container`

The Broadstreet plugin's PHP only emits a bare `<broadstreet-zone>`; the `<broadstreet-zone-container>` wrapper is created client-side by Broadstreet's CDN script when it hydrates the zone and injects the ad. That container is the structural parallel to Newspack's outer `div[class*="newspack-ads-blocks-ad-unit"]` wrapper, and targeting it (rather than the bare zone) avoids painting an empty colored box before the ad loads. All styling is gated on the publisher having set a custom ad background, so sites on the default background are untouched.

## Out of scope

- Legacy Broadstreet "old tags" `<script>` mode and AMP `<amp-ad>` output (different markup; AMP is legacy).
- Publisher-defined `custom_selector` renaming the zone element.

## Testing

1. On a site with a custom **Ads Background Color** (Appearance → Customize → Colors → Custom + a visible color), view a post containing a standalone-Broadstreet ad.
2. The chosen background renders behind the ad, centered, with 8px padding — matching Newspack-served ads.
3. With Ads Background Color = **Default**, the Broadstreet container receives no added styling (no regression).

Verified locally in an isolated environment using markup mimicking Broadstreet's hydrated DOM (injected via a mu-plugin to bypass content sanitization): body receives `custom-ad-bg`, the runtime `color-patterns.php` rule emits `broadstreet-zone-container{background-color: …}`, and the compiled stylesheet serves the flex/padding rule.

> Note: compiled theme CSS is gitignored and built by CI on release, so this PR contains source (SCSS + PHP) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
