### PR TITLE
fix(newspack-network): patch critical basic-ftp alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	},
 	"pnpm": {
 		"overrides": {
+			"basic-ftp": "5.3.1",
 			"@typescript-eslint/parser": "8.58.2"
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  basic-ftp: 5.3.1
   '@typescript-eslint/parser': 8.58.2
 
 importers:
@@ -4181,8 +4182,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   batch@0.6.1:
@@ -16573,7 +16574,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@5.3.1: {}
 
   batch@0.6.1: {}
 
@@ -18604,7 +18605,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Force `basic-ftp` to `5.3.1` through the root pnpm override.
- Refresh `pnpm-lock.yaml` so `newspack-network` resolves the patched `basic-ftp` version.
- Keep this scoped to the critical `newspack-network` alert path; broader audit findings remain separate.

## Context
- Dependabot alerts were enabled on the legacy `newspack-network` mirror and surfaced critical npm alerts.
- The legacy mirror auto-closes new PRs because development moved to this monorepo.
- `handlebars` is already resolved to `4.7.9` here, so this PR only needs the `basic-ftp` lockfile fix.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter newspack-network why basic-ftp`
- `pnpm --filter newspack-network why handlebars`
- `pnpm --filter newspack-network run lint`
- `pnpm --filter newspack-network run build`
- `pnpm --filter newspack-network run test`
- `git diff --check`
