### PR TITLE
fix(newspack-blocks): update swiper to patched release

### DIFF
--- a/plugins/newspack-blocks/package.json
+++ b/plugins/newspack-blocks/package.json
@@ -51,7 +51,7 @@
 		"redux": "^5.0.0",
 		"redux-saga": "^1.4.2",
 		"regenerator-runtime": "^0.14.1",
-		"swiper": "12.0.3"
+		"swiper": "12.1.2"
 	},
 	"devDependencies": {
 		"@types/lodash": "^4.17.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,8 +332,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       swiper:
-        specifier: 12.0.3
-        version: 12.0.3
+        specifier: 12.1.2
+        version: 12.1.2
     devDependencies:
       '@types/lodash':
         specifier: ^4.17.23
@@ -9779,8 +9779,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  swiper@12.0.3:
-    resolution: {integrity: sha512-BHd6U1VPEIksrXlyXjMmRWO0onmdNPaTAFduzqR3pgjvi7KfmUCAm/0cj49u2D7B0zNjMw02TSeXfinC1hDCXg==}
+  swiper@12.1.2:
+    resolution: {integrity: sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==}
     engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
@@ -22905,7 +22905,7 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swiper@12.0.3: {}
+  swiper@12.1.2: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## Summary
- Update `swiper` in `newspack-blocks` from `12.0.3` to `12.1.2`.
- Refresh `pnpm-lock.yaml` so the Dependabot critical advisory resolves to the patched version.

## Context
- Enabling Dependabot alerts on `newspack-workspace` surfaced the `swiper` critical advisory in `plugins/newspack-blocks/package.json` and `pnpm-lock.yaml`.
- This is separate from PR #174, which handles the `newspack-network` `basic-ftp` path.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @automattic/newspack-blocks why swiper`
- `pnpm audit --audit-level critical`
- `pnpm --filter @automattic/newspack-blocks run lint`
- `pnpm --filter @automattic/newspack-blocks run build`
- `pnpm --filter @automattic/newspack-blocks run test`
- `git diff --check`

Build completed with the existing webpack bundle-size warnings.
