### PR TITLE
feat(n): mount standalone plugins from repos/ for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .env
+# Standalone/local plugin checkouts outside the monorepo (see AGENTS.md);
+# mounted at /newspack-repos and symlinked into the active site.
 repos
 logs
 html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ newspack-workspace is the Newspack monorepo. It contains all product plugins, th
 - `plugins/<name>/` - Product plugins (12 total).
 - `themes/<name>/` - Themes (newspack-theme, newspack-block-theme).
 - `packages/<name>/` - Shared libraries (scripts, components, colors, icons).
+- `repos/<name>/` - Standalone/local plugin checkouts that live outside the monorepo (e.g. private or customer-specific plugins, `newspack-manager`). Gitignored; mounted at `/newspack-repos` and symlinked into the active site by `bin/link-repos.sh`. `repos/` may itself be a symlink to an existing checkouts directory (Docker follows the mount-source symlink).
 
 Each directory is a standalone WordPress plugin/theme that can be zipped and installed independently.
 

--- a/bin/link-repos.sh
+++ b/bin/link-repos.sh
@@ -27,6 +27,26 @@ for dir in "$PLUGINS_PATH"/*/; do
 	fi
 done
 
+# Symlink standalone repos from /newspack-repos/ into wp-content/plugins/.
+# These are separate checkouts under the gitignored repos/ directory (e.g.
+# private or customer-specific plugins, newspack-manager) that live outside the
+# monorepo. The mount is optional, so skip silently when repos/ is empty/absent.
+REPOS_PATH="/newspack-repos"
+if [ -d "$REPOS_PATH" ]; then
+	for dir in "$REPOS_PATH"/*/; do
+		[ -d "$dir" ] || continue
+		name=$(basename "$dir")
+		link="$WP_PATH/plugins/$name"
+		# -L also catches dangling symlinks that -e (which follows links) misses.
+		if [ -L "${link}" ] || [ -e "${link}" ]; then
+			echo "$name already symlinked"
+		else
+			echo "Symlinking standalone repo $name"
+			ln -s "$dir" "$link" || true
+		fi
+	done
+fi
+
 # Symlink themes. The classic theme contains child themes as subdirectories.
 for dir in "$THEMES_PATH"/*/; do
 	name=$(basename "$dir")

--- a/docker-compose-82.yml
+++ b/docker-compose-82.yml
@@ -44,6 +44,7 @@ services:
       - .:/newspack-monorepo
       - ./plugins:/newspack-plugins
       - ./themes:/newspack-themes
+      - ./repos:/newspack-repos
       - ./html:/var/www/html
       - ./manager-html:/var/www/manager-html
       - ./additional-sites-html:/var/www/additional-sites-html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - .:/newspack-monorepo
       - ./plugins:/newspack-plugins
       - ./themes:/newspack-themes
+      - ./repos:/newspack-repos
       - ./html:/var/www/html
       - ./manager-html:/var/www/manager-html
       - ./additional-sites-html:/var/www/additional-sites-html


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Restores the pre-monorepo ability to run a **locally-checked-out plugin that lives outside the monorepo** (e.g. `newspack-manager`, customer-specific plugins) in the local Docker env, without committing it to the monorepo.

- `docker-compose.yml` / `docker-compose-82.yml`: mount `./repos` at `/newspack-repos`.
- `bin/link-repos.sh`: symlink each `/newspack-repos/*` checkout into the active site's `wp-content/plugins/` (same mechanism already used for `/newspack-plugins/*`). Skips dangling symlinks so it's idempotent.
- `.gitignore`: `repos` is already ignored — added a clarifying comment.
- `AGENTS.md`: document the `repos/` convention.

`repos/` is gitignored, and may itself be a **symlink** to an existing checkouts directory (Docker follows the mount-source symlink), so no files need to be copied or duplicated.

#### Relationship to #154

This is intentionally the **minimal slice** of #154. #154 (+564/-110, currently a CONFLICTING draft) bundles two things: (1) this small config restore, and (2) a much larger subsystem to spin up **isolated environments with git worktrees of standalone repos** (`bin/env.sh` +163, `bin/worktree.sh` +157, `bin/build-repos.sh` +77, a `# newspack-wt:` compose-metadata parser, tier registry in `bin/repos.local.sh`). That second feature is where most of the complexity and the merge conflicts live.

This PR ships only what's needed to mount and activate a local plugin on the **main** dev site (~25 lines). It does **not** add the `repos.local.sh` registry or the env/worktree integration — those can land separately if wanted. No overlap that would conflict with the rest of #154's surface.

### How to test the changes in this Pull Request:

1. Put a standalone plugin checkout at `repos/<name>/` (or symlink `repos` to an existing checkouts dir: `ln -s /path/to/checkouts repos`).
2. `n start` (or `n restart` if already running) so the new `/newspack-repos` mount is picked up.
3. `docker exec newspack_dev /var/scripts/link-repos.sh` — the standalone plugin is symlinked into `wp-content/plugins/`.
4. `n wp plugin activate <name>` — activates cleanly.
5. `git status` — nothing from `repos/` appears (gitignored).

Verified locally with `newspack-manager` (clean activation, `EXIT=0`, no fatal) and a throwaway minimal plugin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (n/a — Docker/shell tooling)
* [x] Have you successfully run tests with your changes locally?