### PR TITLE
build: hoist babel-loader so plugin webpack configs resolve under pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -15,6 +15,12 @@ public-hoist-pattern[]=eslint-plugin-*
 public-hoist-pattern[]=eslint-config-*
 public-hoist-pattern[]=@typescript-eslint/*
 
+# Some plugins' webpack.config.js resolve babel-loader directly via
+# require.resolve() from the plugin context (e.g. newspack-ads, newspack-blocks)
+# without declaring it -- it's provided transitively by the WP scripts
+# toolchain. Hoist it so those configs resolve under pnpm's strict layout.
+public-hoist-pattern[]=babel-loader
+
 # Peer dep resolution.
 legacy-peer-deps=true
 auto-install-peers=true

--- a/.npmrc
+++ b/.npmrc
@@ -15,10 +15,11 @@ public-hoist-pattern[]=eslint-plugin-*
 public-hoist-pattern[]=eslint-config-*
 public-hoist-pattern[]=@typescript-eslint/*
 
-# Some plugins' webpack.config.js resolve babel-loader directly via
-# require.resolve() from the plugin context (e.g. newspack-ads, newspack-blocks)
-# without declaring it -- it's provided transitively by the WP scripts
-# toolchain. Hoist it so those configs resolve under pnpm's strict layout.
+# Some plugins' webpack.config.js reference babel-loader from the plugin
+# context without declaring it -- newspack-ads via require.resolve('babel-loader'),
+# newspack-blocks as a `loader: 'babel-loader'` rule -- relying on it being
+# provided transitively by the WP scripts toolchain. Hoist it so those configs
+# resolve under pnpm's strict layout.
 public-hoist-pattern[]=babel-loader
 
 # Peer dep resolution.

--- a/bin/build-repos.sh
+++ b/bin/build-repos.sh
@@ -55,7 +55,11 @@ cd "$MONOREPO_ROOT"
 # Workspace install: pnpm resolves `workspace:*` deps (e.g. newspack-scripts)
 # and links shared bins into each package's node_modules/.bin.
 if [ "$MODE" = "ci" ]; then
-    pnpm install --frozen-lockfile
+    # CI=true keeps pnpm non-interactive so a one-time node_modules re-layout
+    # (e.g. after a hoist-pattern change in .npmrc) auto-purges instead of
+    # blocking on a confirmation prompt -- `n` runs pnpm via `docker exec`
+    # without a TTY in non-interactive contexts, where that prompt aborts.
+    CI=true pnpm install --frozen-lockfile
 else
     pnpm install
 fi


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes `n ci-build all` failing to build `newspack-ads` with `Cannot find module 'babel-loader'`.

**Root cause:** `newspack-ads/webpack.config.js` (and `newspack-blocks`) resolve babel-loader directly via `require.resolve('babel-loader')` from the *plugin* context, but neither declares it as a dependency — it's provided transitively by the WP scripts toolchain. Under pnpm's strict `node_modules` layout, an undeclared transitive package isn't resolvable from the plugin, so the build throws `MODULE_NOT_FOUND`. The root build (`pnpm --filter './plugins/*' run build`) bails on the first failure, so `newspack-network` and others were aborted as collateral (they have no babel-loader issue of their own).

**Fix:**
- `.npmrc`: `public-hoist-pattern[]=babel-loader` — hoist it to the root so the configs resolve, matching exactly how `@wordpress/*` is already handled here (imported/required without being declared).
- `bin/build-repos.sh`: run the ci-mode `pnpm install` with `CI=true`. Applying the new hoist requires a one-time `node_modules` re-layout, and pnpm prompts to confirm purging the modules dir; `n` runs pnpm via `docker exec` without a TTY in non-interactive contexts, where that prompt aborts the install. `CI=true` makes it non-interactive (the install already uses `--frozen-lockfile`, so there's no other behavior change).

### How to test the changes in this Pull Request:

1. On `main`, `n ci-build all` fails building `newspack-ads` with `Cannot find module 'babel-loader'`.
2. On this branch, `n ci-build newspack-ads` and `n ci-build newspack-network` both compile.

Verified locally: after the hoist, `babel-loader` resolves at the workspace root; `n ci-build newspack-ads` runs non-interactively and webpack compiles (`newspack-ads` with warnings only; `newspack-network` clean).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (n/a - build config)
* [x] Have you successfully run tests with your changes locally?