### PR TITLE
ci(release): skip version-bump commits on hotfix/epic branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,14 @@ jobs:
       # reverts the internal deps back to workspace:*, and commits them once.
       # The [skip ci] commit won't re-trigger this workflow, and post-release.sh's
       # ancestry check is unaffected by the extra commit.
+      #
+      # Skipped on hotfix/* and epic/* branches: those are out-of-schedule
+      # prereleases whose bumped files are deliberately kept off the branch (the
+      # release configs drop their @semantic-release/git commit there too), so
+      # the hotfix PR diff stays clean. The prerelease zip is built from the
+      # working tree regardless, so nothing downstream needs this commit.
       - name: Sync package.json versions
+        if: ${{ !startsWith( github.ref_name, 'hotfix/' ) && !startsWith( github.ref_name, 'epic/' ) }}
         run: |
           node .github/scripts/finalize-package-versions.cjs
           # The release is already published by this point, so the branch must not

--- a/config/release-helpers.js
+++ b/config/release-helpers.js
@@ -1,0 +1,47 @@
+/**
+ * Whether the release is running on a `hotfix/*` or `epic/*` branch.
+ *
+ * The branch name is read from GITHUB_REF_NAME (set by GitHub Actions). Outside
+ * CI it is undefined and this returns false, so local config evaluation is a
+ * no-op.
+ *
+ * @return {boolean} True on a hotfix/* or epic/* branch.
+ */
+function isHotfixOrEpicBranch() {
+	const branch = process.env.GITHUB_REF_NAME || '';
+	return /^(hotfix|epic)\//.test( branch );
+}
+
+/**
+ * The `@semantic-release/git` prepare step that commits a release's version
+ * bumps back to the branch — or nothing at all on `hotfix/*` and `epic/*`.
+ *
+ * Out-of-schedule hotfix/epic prereleases build their zip and tag from the
+ * working-tree bump, so committing the bumped files (PHP/CSS version headers,
+ * CHANGELOG.md) back to the branch would only add `chore(release)` bot commits
+ * and version churn to the hotfix PR diff. Legacy newspack-scripts skipped the
+ * commit step on these branches for the same reason. (package.json is committed
+ * separately by .github/scripts/finalize-package-versions.cjs, which release.yml
+ * likewise skips on these branches.)
+ *
+ * Spread the result into a `prepare` array:
+ *   prepare: [ ...otherSteps, ...gitCommitStep( [ phpFile, 'CHANGELOG.md' ] ) ]
+ *
+ * @param {string[]} assets Files to include in the release commit.
+ * @return {Array} `[]` on hotfix/epic branches, otherwise `[ gitStep ]`.
+ */
+function gitCommitStep( assets ) {
+	if ( isHotfixOrEpicBranch() ) {
+		return [];
+	}
+	return [
+		{
+			path: '@semantic-release/git',
+			assets,
+			message:
+				'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+		},
+	];
+}
+
+module.exports = { gitCommitStep };

--- a/config/release.js
+++ b/config/release.js
@@ -1,3 +1,5 @@
+const { gitCommitStep } = require( './release-helpers' );
+
 /**
  * Shared release config factory for multi-semantic-release.
  *
@@ -58,12 +60,7 @@ module.exports = function releaseConfig( { name, phpFile, npmPublish = false } )
 					callback: 'npm run release:archive',
 				},
 			],
-			{
-				path: '@semantic-release/git',
-				assets: [ phpFile, 'CHANGELOG.md' ],
-				message:
-					'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-			},
+			...gitCommitStep( [ phpFile, 'CHANGELOG.md' ] ),
 		],
 	};
 };

--- a/themes/newspack-block-theme/release.config.js
+++ b/themes/newspack-block-theme/release.config.js
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const { gitCommitStep } = require( '../../config/release-helpers' );
+
 module.exports = {
 	branches: [
 		'release',
@@ -23,11 +25,7 @@ module.exports = {
 				callback: 'npm run release:archive',
 			},
 		],
-		{
-			path: '@semantic-release/git',
-			assets: [ 'CHANGELOG.md', 'src/scss/_theme-description.scss', 'functions.php' ],
-			message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-		},
+		...gitCommitStep( [ 'CHANGELOG.md', 'src/scss/_theme-description.scss', 'functions.php' ] ),
 	],
 	plugins: [
 		'@semantic-release/commit-analyzer',

--- a/themes/newspack-theme/.releaserc.js
+++ b/themes/newspack-theme/.releaserc.js
@@ -1,3 +1,5 @@
+const { gitCommitStep } = require( '../../config/release-helpers' );
+
 const THEMES = [
 	'newspack-theme',
 	'newspack-joseph',
@@ -43,14 +45,10 @@ module.exports = {
 				callback: 'npm run release:archive',
 			},
 		],
-		{
-			path: '@semantic-release/git',
-			assets: [
-				...THEMES.map( name => `${ name }/sass/theme-description.scss` ),
-				'CHANGELOG.md',
-			],
-			message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-		},
+		...gitCommitStep( [
+			...THEMES.map( name => `${ name }/sass/theme-description.scss` ),
+			'CHANGELOG.md',
+		] ),
 	],
 	plugins: [
 		'@semantic-release/commit-analyzer',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Out-of-schedule `hotfix/*` and `epic/*` releases were committing the version bump back to the branch, so hotfix PR diffs picked up `chore(release)` bot commits and version churn (`newspack.php` / `*.scss` / `CHANGELOG.md` / `package.json`) that reviewers had to mentally filter out. Legacy `newspack-scripts` deliberately skipped the commit step on these branches; this restores that behaviour in the monorepo.

There are two commit-back paths, both now guarded for `hotfix/*` and `epic/*`:

1. The `@semantic-release/git` prepare step in each release config (`config/release.js` plus both theme configs) commits `newspack.php`/`*.scss` + `CHANGELOG.md`.
2. The `Sync package.json versions` step in `release.yml` runs `finalize-package-versions.cjs`, which commits the `package.json` version bump.

A shared helper `config/release-branch.js` (`isHotfixOrEpicBranch()`, reading `GITHUB_REF_NAME`) drives the config-side guard so the branch check isn't duplicated across the three configs; the workflow step is gated with a matching `if:` condition.

On `release`/`alpha`/local the behaviour is unchanged (commit-back still happens); on `hotfix/*` and `epic/*` nothing is committed back, so the prerelease zip/tag are still produced (from the working-tree bump) but the PR diff stays clean.

Targeted at `release` (where hotfix branches are cut from) so it takes effect on the next hotfix; the post-release job merges `release` into `main` and `alpha`, so it propagates to the other lines automatically. The `ci(release):` type is intentional — the patch touches `themes/newspack-*/` paths, and a `fix:`/`feat:` subject would make multi-semantic-release cut spurious theme releases.

### How to test the changes in this Pull Request:

Verified end-to-end on a sandbox repo:

1. Cut a `hotfix/verify-release-guard` branch off the sandbox `release` carrying this change plus a `fix:` commit, and pushed it to trigger the Release workflow.
2. Confirmed the run:
   - **No bot commit pushed back** — the branch tip after the run equalled the pushed HEAD.
   - **`Sync package.json versions` step skipped.**
   - **Prerelease still cut** — GH pre-release + tag `newspack@6.43.1-hotfix-verify-release-guard.1` created, tag pointing at the pushed HEAD.
   - **Zip version correct** — `newspack-plugin.zip` carried `Version: 6.43.1-hotfix-verify-release-guard.1` in both the header and `NEWSPACK_PLUGIN_VERSION`, with `package.json` excluded from the zip.
3. All sandbox artifacts (branch, tag, release, semantic-release note) cleaned up afterward.

Also validated locally that the `@semantic-release/git` step is present for `release`/`alpha`/local and absent for `hotfix/*` and `epic/*`, across all three release configs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? <!-- N/A: release-pipeline config; verified via the sandbox e2e run above. -->
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)