### PR TITLE
ci: auto-update behind Dependabot PR branches on main push

### DIFF
--- a/.github/workflows/dependabot-branch-auto-update.yml
+++ b/.github/workflows/dependabot-branch-auto-update.yml
@@ -1,0 +1,57 @@
+name: Dependabot branch auto-update
+
+# When main moves, Dependabot PRs that already have auto-merge enabled fall
+# behind. Branch protection on main requires branches to be up to date, and
+# GitHub's auto-merge does not self-update a behind branch, so those PRs stall
+# with a green CI run that no longer matches the new base.
+#
+# This updates the branch of every open Dependabot PR that has auto-merge
+# enabled and is behind main, so it re-tests against the new base and its
+# standing auto-merge can complete. Approvals survive the update because main
+# does not dismiss stale reviews.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# A push that lands while an update run is in flight supersedes it: the newer
+# run re-derives the behind set from the latest main, so cancelling is safe.
+concurrency:
+  group: dependabot-branch-auto-update
+  cancel-in-progress: true
+
+jobs:
+  update-behind-dependabot-prs:
+    name: Update behind Dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      # GH_TOKEN is a PAT, not GITHUB_TOKEN, on purpose: a branch update pushed
+      # with GITHUB_TOKEN would not trigger ci.yml, leaving "CI OK" pending for
+      # the new head forever. A PAT-authored push fires CI normally.
+      - name: Update branches of behind, auto-merge-enabled Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          prs=$(gh pr list --repo "$REPO" \
+            --author 'app/dependabot' \
+            --state open \
+            --json number,mergeStateStatus,autoMergeRequest \
+            --jq '.[] | select(.autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number')
+
+          if [ -z "$prs" ]; then
+            echo "No behind, auto-merge-enabled Dependabot PRs to update."
+            exit 0
+          fi
+
+          for pr in $prs; do
+            echo "Updating branch for PR #$pr"
+            if ! gh api "repos/$REPO/pulls/$pr/update-branch" -X PUT; then
+              echo "::warning::Could not update PR #$pr (it may have just merged, or the branch has conflicts)."
+            fi
+          done


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds `.github/workflows/dependabot-branch-auto-update.yml`, a workflow that runs on every push to `main` and updates the branch of any open Dependabot PR that **has auto-merge enabled** and is **behind** `main`.

**Why.** `main` has branch protection with *Require branches to be up to date before merging* (`required_status_checks.strict: true`). The `auto-merge.yml` workflow already approves minor/patch (and non-major grouped) Dependabot PRs and enables auto-merge on them, but GitHub's auto-merge does **not** self-update a branch that falls behind. So the moment one PR merges, every other auto-merge-enabled Dependabot PR goes `BEHIND` and stalls indefinitely with a now-stale green CI run. This closes that gap without weakening protection for human PRs (the alternative would be unchecking strict mode repo-wide, or adopting a merge queue).

**How it works.**
- Trigger: `push` to `main`.
- Selects open `app/dependabot` PRs where `autoMergeRequest != null` **and** `mergeStateStatus == "BEHIND"`, then calls `PUT /repos/{repo}/pulls/{n}/update-branch` on each.
- Uses the `GH_TOKEN` **PAT** (not `GITHUB_TOKEN`) on purpose: a branch update pushed with `GITHUB_TOKEN` would not trigger `ci.yml`, leaving `CI OK` pending for the new head forever. A PAT-authored push fires CI normally, and the standing auto-merge then completes.
- Approvals survive the update because `main` has `dismiss_stale_reviews: false`, so no re-approval is needed.
- `concurrency` with `cancel-in-progress` lets a newer `main` push supersede an in-flight run (it re-derives the behind set from the latest base).

**Scope note / trade-off.** This deliberately targets only auto-merge-enabled PRs (i.e. the minor/patch ones `auto-merge.yml` already cleared), so it never churns CI on the major PRs left for human review. With several auto-merge PRs open at once, each merge re-triggers the workflow and the remaining PRs are updated again, so it converges over a few CI rounds rather than all at once. That is inherent to strict mode without a merge queue; the workflow just automates the nudging that is otherwise manual.

Closes # .

### How to test the changes in this Pull Request:

1. With this workflow on `main`, have two minor/patch Dependabot PRs open and approved with auto-merge enabled (e.g. via `auto-merge.yml`).
2. Let one of them merge. Confirm the other flips to `BEHIND`.
3. On the resulting push to `main`, confirm this workflow runs, updates the behind PR's branch, CI re-runs, and the PR merges without manual intervention.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (N/A - CI workflow)
* [ ] Have you successfully run tests with your changes locally? (N/A - runs against live PR state)