### PR TITLE
chore: add readiness check for re-enabling release success comments

### DIFF
--- a/bin/check-success-comment-readiness.sh
+++ b/bin/check-success-comment-readiness.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Are we ready to re-enable @semantic-release/github successComment/releasedLabels?
+#
+# During the legacy->monorepo migration those options are disabled in the
+# release configs (config/release.js, themes/*/release config): the success
+# step resolves every issue/PR ref in a released commit to comment on and label
+# it, and migrated commits carry legacy-repo PR numbers that 404 in the
+# monorepo, which fails the release job.
+#
+# Re-enabling is safe when BOTH hold:
+#   1. the sync producer is off (nothing can refill the queue), and
+#   2. no commit queued for the next release references an unresolvable number.
+#
+# Temporary tooling for NPPM-2752 -- remove in the cleanup phase once the
+# success comment/label is re-enabled.
+set -euo pipefail
+
+REPO=Automattic/newspack-workspace
+RANGE="${1:-origin/release..origin/main}"   # publish queue for the next stable release
+
+git fetch -q origin release main alpha
+
+# (1) Can the queue still refill?
+sync_state=$(gh workflow list --repo "$REPO" --json name,state \
+  --jq '.[] | select(.name|test("Sync legacy")) | .state')
+echo "Sync legacy repos: ${sync_state:-not found}"
+
+# (2) Scan the actual commit range for unresolvable refs.
+stale=0
+for n in $(git log "$RANGE" --format='%s%n%b' | grep -oE '#[0-9]+' | tr -d '#' | sort -un); do
+  if ! gh api "repos/$REPO/issues/$n" >/dev/null 2>&1; then   # PRs are issues; 404 = stale
+    echo "  STALE #$n"
+    stale=$((stale + 1))
+  fi
+done
+echo "stale refs in $RANGE: $stale"
+
+if [[ "$sync_state" == "disabled" && "$stale" -eq 0 ]]; then
+  echo "READY: safe to re-enable successComment/releasedLabels."
+else
+  echo "NOT READY."
+  exit 1
+fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds `bin/check-success-comment-readiness.sh`, a small helper for the NPPM-2752 cleanup phase. `@semantic-release/github`'s `successComment`/`releasedLabels` are disabled in the release configs during the migration because migrated commits carry legacy-repo PR numbers that 404 in the monorepo and fail the release job's success step. The script reports when it's safe to turn them back on, checking the two conditions that matter:

1. **Producer off** – the `Sync legacy repos` workflow is `disabled`, so nothing can refill the queue.
2. **Publish queue clean** – no commit in the next release's range (`origin/release..origin/main` by default) references a number that doesn't resolve as a monorepo issue/PR.

Exits non-zero (NOT READY) until both hold. Pass a custom range as `$1` (e.g. `origin/release..origin/alpha`).

This is temporary tooling – it should be removed in the Phase 6 cleanup once the success comment/label is re-enabled (noted on NPPM-2752).

### How to test the changes in this Pull Request:

1. `./bin/check-success-comment-readiness.sh`
2. Today it prints `Sync legacy repos: active`, lists the STALE legacy refs still queued on `main`, and reports `NOT READY` (exit 1).
3. Pass `origin/release..origin/alpha` to scan a different range.

### Other information:

- [ ] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?