### PR TITLE
ci: notify Slack on alpha and stable releases

### DIFF
--- a/.github/scripts/notify-release.sh
+++ b/.github/scripts/notify-release.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Release-success Slack notification for the monorepo, run in the `release` job
+# right after multi-semantic-release publishes.
+#
+# A single push to `release`/`alpha` publishes a GitHub release + git tag
+# (`<pkg>@<version>`) for every plugin/theme with releasable commits. This posts
+# ONE summary message listing all of them, routed by branch to a workspace:
+#
+#   - release branch -> a8c workspace (stable),  reusing SLACK_AUTH_TOKEN.
+#   - alpha   branch -> Newspack workspace (alpha), using SLACK_NEWSPACK_BOT_TOKEN.
+#
+# hotfix/* and epic/* are intentionally silent (the workflow step's `if` already
+# excludes them; the case below is defence in depth).
+#
+# Released packages are detected by diffing the tag list captured before the
+# release step ($TAGS_BEFORE_FILE) against the tags present now. The legacy
+# per-repo ":ship: ... released: <url>" pings were sent by Zapier, which the
+# monorepo no longer drives; this restores that notification in-repo.
+#
+# A failure here never fails the job: the release has already happened, so a
+# Slack hiccup must not turn the run red. Set SLACK_DRY_RUN=1 to print the
+# payload instead of posting (for local testing).
+
+set -euo pipefail
+
+REF="${GITHUB_REF_NAME:-}"
+
+case "$REF" in
+  release)
+    TOKEN="${SLACK_AUTH_TOKEN:-}"
+    CHANNEL="${SLACK_A8C_RELEASE_CHANNEL_ID:-}"
+    VERB="released"
+    CC_SUBTEAM="${SLACK_SUPPORT_TEAM_SUBTEAM_ID:-}"
+    ;;
+  alpha)
+    TOKEN="${SLACK_NEWSPACK_BOT_TOKEN:-}"
+    CHANNEL="${SLACK_NEWSPACK_RELEASE_CHANNEL_ID:-}"
+    VERB="alpha version released"
+    CC_SUBTEAM=""
+    ;;
+  *)
+    echo "[notify-release] Branch '$REF' does not notify. Skipping."
+    exit 0
+    ;;
+esac
+
+if [ -z "${TAGS_BEFORE_FILE:-}" ] || [ ! -f "$TAGS_BEFORE_FILE" ]; then
+  echo "[notify-release] No tag snapshot at '${TAGS_BEFORE_FILE:-}'. Cannot determine released packages. Skipping."
+  exit 0
+fi
+
+# Tags created by this release run = present now but not in the pre-release
+# snapshot. Both sides must be sorted for comm.
+NEW_TAGS=$(comm -13 <(sort "$TAGS_BEFORE_FILE") <(git tag | sort) || true)
+
+if [ -z "$NEW_TAGS" ]; then
+  echo "[notify-release] No new tags; nothing was released. Skipping."
+  exit 0
+fi
+
+if [ -z "$TOKEN" ] || [ -z "$CHANNEL" ]; then
+  echo "[notify-release] Missing Slack token and/or channel for '$REF'. Cannot notify."
+  exit 0
+fi
+
+# Build the chat.postMessage JSON in node so package names are escaped safely.
+# Each tag becomes a line: ":ship: <Display Name> <verb>: <release url>", with
+# the URL wrapped in <> so Slack links it reliably despite the '@' in the tag.
+PAYLOAD=$(
+  TAGS="$NEW_TAGS" \
+  VERB="$VERB" \
+  CC_SUBTEAM="$CC_SUBTEAM" \
+  CHANNEL="$CHANNEL" \
+  SERVER="${GITHUB_SERVER_URL:-https://github.com}" \
+  REPO="${GITHUB_REPOSITORY:-}" \
+  node -e '
+    const tags = process.env.TAGS.split("\n").map(s => s.trim()).filter(Boolean);
+    const verb = process.env.VERB;
+    const server = process.env.SERVER.replace(/\/+$/, "");
+    const repo = process.env.REPO;
+    const display = pkg => pkg.split("-").filter(Boolean)
+      .map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    const lines = tags.map(tag => {
+      const at = tag.lastIndexOf("@");
+      const pkg = at === -1 ? tag : tag.slice(0, at);
+      const url = `${server}/${repo}/releases/tag/${tag}`;
+      return `:ship: ${display(pkg)} ${verb}: <${url}>`;
+    });
+    let text = lines.join("\n");
+    if (process.env.CC_SUBTEAM) {
+      text += `\n(cc <!subteam^${process.env.CC_SUBTEAM}>)`;
+    }
+    process.stdout.write(JSON.stringify({ channel: process.env.CHANNEL, text }));
+  '
+)
+
+if [ -n "${SLACK_DRY_RUN:-}" ]; then
+  echo "[notify-release] DRY RUN -- would post to Slack:"
+  echo "$PAYLOAD"
+  exit 0
+fi
+
+RESPONSE=$(
+  curl -sS \
+    --data "$PAYLOAD" \
+    -H 'Content-type: application/json; charset=utf-8' \
+    -H "Authorization: Bearer $TOKEN" \
+    -X POST https://slack.com/api/chat.postMessage
+) || {
+  echo "[notify-release] WARNING: curl to Slack failed."
+  exit 0
+}
+
+if echo "$RESPONSE" | grep -q '"ok":true'; then
+  echo "[notify-release] Notified Slack for '$REF'."
+else
+  echo "[notify-release] WARNING: Slack notification failed: $RESPONSE"
+fi
+exit 0

--- a/.github/scripts/notify-release.sh
+++ b/.github/scripts/notify-release.sh
@@ -24,6 +24,13 @@
 
 set -euo pipefail
 
+# A failure here must never fail the release job (the release has already
+# happened). Any unhandled error under `set -e` degrades to a warning and a
+# clean exit, rather than turning the run red. Intentional control-flow
+# "failures" (grep -q, comm, the guarded curl) are exempt because bash does not
+# trigger ERR for commands whose status is tested.
+trap 'echo "[notify-release] WARNING: unexpected error in: ${BASH_COMMAND}. Skipping notification."; exit 0' ERR
+
 REF="${GITHUB_REF_NAME:-}"
 
 case "$REF" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
               composer install --no-dev --no-interaction --no-scripts --working-dir="${dir}"
             fi
           done
+      # Snapshot existing tags so the post-release Slack step can diff them
+      # against the tags multi-semantic-release creates and report exactly which
+      # packages were published.
+      - name: Snapshot existing tags
+        run: git tag > "$RUNNER_TEMP/tags-before.txt"
       - name: Release
         run: pnpm exec multi-semantic-release --sequential-init
         env:
@@ -100,6 +105,20 @@ jobs:
             git pull --rebase origin "${GITHUB_REF_NAME}"
             git push origin "HEAD:${GITHUB_REF_NAME}"
           }
+
+      # Post a release-success summary to Slack: stable releases (release branch)
+      # go to the a8c workspace, alpha releases to the Newspack workspace. Only
+      # these two branches notify; hotfix/* and epic/* publish silently.
+      - name: Notify Slack of release
+        if: ${{ success() && ( github.ref_name == 'release' || github.ref_name == 'alpha' ) }}
+        env:
+          TAGS_BEFORE_FILE: ${{ runner.temp }}/tags-before.txt
+          SLACK_AUTH_TOKEN: ${{ secrets.SLACK_AUTH_TOKEN }}
+          SLACK_NEWSPACK_BOT_TOKEN: ${{ secrets.SLACK_NEWSPACK_BOT_TOKEN }}
+          SLACK_A8C_RELEASE_CHANNEL_ID: ${{ vars.SLACK_A8C_RELEASE_CHANNEL_ID }}
+          SLACK_NEWSPACK_RELEASE_CHANNEL_ID: ${{ vars.SLACK_NEWSPACK_RELEASE_CHANNEL_ID }}
+          SLACK_SUPPORT_TEAM_SUBTEAM_ID: ${{ vars.SLACK_SUPPORT_TEAM_SUBTEAM_ID }}
+        run: ./.github/scripts/notify-release.sh
 
   # Branch maintenance after a stable release: reset alpha and sync release into
   # the default branch. Only runs on the release branch (not alpha/hotfix/epic).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,9 @@ jobs:
           TAGS_BEFORE_FILE: ${{ runner.temp }}/tags-before.txt
           SLACK_AUTH_TOKEN: ${{ github.ref_name == 'release' && secrets.SLACK_AUTH_TOKEN || '' }}
           SLACK_NEWSPACK_BOT_TOKEN: ${{ github.ref_name == 'alpha' && secrets.SLACK_NEWSPACK_BOT_TOKEN || '' }}
-          SLACK_A8C_RELEASE_CHANNEL_ID: ${{ vars.SLACK_A8C_RELEASE_CHANNEL_ID }}
-          SLACK_NEWSPACK_RELEASE_CHANNEL_ID: ${{ vars.SLACK_NEWSPACK_RELEASE_CHANNEL_ID }}
-          SLACK_SUPPORT_TEAM_SUBTEAM_ID: ${{ github.ref_name == 'release' && vars.SLACK_SUPPORT_TEAM_SUBTEAM_ID || '' }}
+          SLACK_A8C_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_A8C_RELEASE_CHANNEL_ID }}
+          SLACK_NEWSPACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_NEWSPACK_RELEASE_CHANNEL_ID }}
+          SLACK_SUPPORT_TEAM_SUBTEAM_ID: ${{ github.ref_name == 'release' && secrets.SLACK_SUPPORT_TEAM_SUBTEAM_ID || '' }}
         run: ./.github/scripts/notify-release.sh
 
   # Branch maintenance after a stable release: reset alpha and sync release into

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,15 +109,21 @@ jobs:
       # Post a release-success summary to Slack: stable releases (release branch)
       # go to the a8c workspace, alpha releases to the Newspack workspace. Only
       # these two branches notify; hotfix/* and epic/* publish silently.
+      # Only the workspace for this branch's release type gets its token, so an
+      # alpha run never sees the a8c token and vice versa (the empty fallback is
+      # fine: the script skips when its token/channel is unset). continue-on-error
+      # is a backstop so a notification hiccup can never fail an already-published
+      # release; the script also traps errors and exits 0 on its own.
       - name: Notify Slack of release
         if: ${{ success() && ( github.ref_name == 'release' || github.ref_name == 'alpha' ) }}
+        continue-on-error: true
         env:
           TAGS_BEFORE_FILE: ${{ runner.temp }}/tags-before.txt
-          SLACK_AUTH_TOKEN: ${{ secrets.SLACK_AUTH_TOKEN }}
-          SLACK_NEWSPACK_BOT_TOKEN: ${{ secrets.SLACK_NEWSPACK_BOT_TOKEN }}
+          SLACK_AUTH_TOKEN: ${{ github.ref_name == 'release' && secrets.SLACK_AUTH_TOKEN || '' }}
+          SLACK_NEWSPACK_BOT_TOKEN: ${{ github.ref_name == 'alpha' && secrets.SLACK_NEWSPACK_BOT_TOKEN || '' }}
           SLACK_A8C_RELEASE_CHANNEL_ID: ${{ vars.SLACK_A8C_RELEASE_CHANNEL_ID }}
           SLACK_NEWSPACK_RELEASE_CHANNEL_ID: ${{ vars.SLACK_NEWSPACK_RELEASE_CHANNEL_ID }}
-          SLACK_SUPPORT_TEAM_SUBTEAM_ID: ${{ vars.SLACK_SUPPORT_TEAM_SUBTEAM_ID }}
+          SLACK_SUPPORT_TEAM_SUBTEAM_ID: ${{ github.ref_name == 'release' && vars.SLACK_SUPPORT_TEAM_SUBTEAM_ID || '' }}
         run: ./.github/scripts/notify-release.sh
 
   # Branch maintenance after a stable release: reset alpha and sync release into


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Restores release notifications (the legacy per-repo `:ship: … released: <url>` pings were sent by Zapier, which the monorepo no longer drives). After `multi-semantic-release` publishes, a single summary message is posted to Slack, routed by branch to two **separate workspaces**:

- **Alpha** (`alpha` branch) → Newspack workspace, wording `… alpha version released`.
- **Stable** (`release` branch) → a8c workspace, wording `… released`, plus a real `@newspack-support-team` usergroup ping.
- `hotfix/*` and `epic/*` publish silently; a no-op push (nothing published) posts nothing.

Released packages are detected by snapshotting `git tag` before the release step and diffing after, so the message lists exactly what published (no hard-coded plugin list). The new a8c side reuses the existing `SLACK_AUTH_TOKEN`; only the Newspack workspace needs a new bot token. Each token is scoped to its branch (an alpha run never receives the a8c token, and vice versa). A Slack failure never fails the job (the release already happened): the script traps errors and exits 0, and the step is `continue-on-error`. `SLACK_DRY_RUN=1` prints the payload for local testing.

**Required repo config** (already set up):

| Kind | Name |
| --- | --- |
| secret | `SLACK_AUTH_TOKEN` (existing a8c token, reused) |
| secret | `SLACK_NEWSPACK_BOT_TOKEN` (new Newspack-workspace bot token) |
| secret | `SLACK_A8C_RELEASE_CHANNEL_ID` |
| secret | `SLACK_NEWSPACK_RELEASE_CHANNEL_ID` |
| secret | `SLACK_SUPPORT_TEAM_SUBTEAM_ID` |

### How to test the changes in this Pull Request:

1. Locally: run `.github/scripts/notify-release.sh` in a throwaway git repo with a pre-release tag snapshot in `TAGS_BEFORE_FILE` and new `<pkg>@<version>` tags, with `SLACK_DRY_RUN=1` and `GITHUB_REF_NAME=release` / `=alpha` — verify channel, token, verb, multi-package lines, and cc (stable only). Pipe the payload through `jq` to confirm valid JSON.
2. Verified live via a throwaway `workflow_dispatch`/push workflow that ran the real script against the configured secrets for both routes — both posted (`Notified Slack for 'alpha'` / `'release'`).
3. On a real release: push to `alpha` → one summary in the Newspack release channel; the `alpha → release` promotion → one summary in the a8c channel with the working `@newspack-support-team` ping.

### Other information:

The notify step is gated on `success()`, so if `Sync package.json versions` fails on a real release the ping is skipped even though packages published (unlikely edge). Failure pings via the existing `SLACK_AUTH_TOKEN`/`SLACK_CHANNEL_ID` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)