### PR TITLE
chore(prettier): complete config coverage and fix stale refs

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -190,7 +190,7 @@ module.exports = {
 To configure Prettier rules, extend this repo's config by creating a `.prettierrc.js` file like so:
 
 ```js
-const baseConfig = require( './node_modules/newspack-scripts/config/prettier.config.js' );
+const baseConfig = require( 'newspack-scripts/config/prettier.config.js' );
 
 module.exports = {
 	...baseConfig,

--- a/packages/scripts/bin/newspack-scripts.js
+++ b/packages/scripts/bin/newspack-scripts.js
@@ -14,13 +14,9 @@ const [ scriptName, ...nodeArgs ] = process.argv.slice( 2 );
  * @param {string} name Script name.
  * @return {string} Resolved script path.
  */
-const resolveScript = ( name ) => {
+const resolveScript = name => {
 	if ( process.env.GITHUB_ACTIONS ) {
-		const githubScriptPath = path.resolve(
-			__dirname,
-			'../scripts/github/',
-			name + '.js'
-		);
+		const githubScriptPath = path.resolve( __dirname, '../scripts/github/', name + '.js' );
 		if ( fs.existsSync( githubScriptPath ) ) {
 			return githubScriptPath;
 		}
@@ -28,22 +24,8 @@ const resolveScript = ( name ) => {
 	return require.resolve( '../scripts/' + name );
 };
 
-if (
-	[
-		'test',
-		'commit',
-		'commitlint',
-		'release',
-		'semantic-release',
-		'typescript-check',
-		'wp-scripts',
-	].includes( scriptName )
-) {
-	const result = spawn.sync(
-		process.execPath,
-		[ resolveScript( scriptName ), ...nodeArgs ],
-		{ stdio: 'inherit' }
-	);
+if ( [ 'test', 'commit', 'commitlint', 'release', 'semantic-release', 'typescript-check', 'wp-scripts' ].includes( scriptName ) ) {
+	const result = spawn.sync( process.execPath, [ resolveScript( scriptName ), ...nodeArgs ], { stdio: 'inherit' } );
 	if ( result.signal ) {
 		if ( result.signal === 'SIGKILL' ) {
 			utils.log(

--- a/packages/scripts/config/babel.config.js
+++ b/packages/scripts/config/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = ( api ) => {
+module.exports = api => {
 	api.cache( true );
 	return {
 		presets: [ '@wordpress/babel-preset-default' ],

--- a/packages/scripts/config/eslintrc.js
+++ b/packages/scripts/config/eslintrc.js
@@ -31,13 +31,7 @@ module.exports = {
 			},
 		},
 	},
-	ignorePatterns: [
-		'dist/',
-		'node_modules/',
-		'release/',
-		'scripts/',
-		'/vendor',
-	],
+	ignorePatterns: [ 'dist/', 'node_modules/', 'release/', 'scripts/', '/vendor' ],
 	rules: {
 		'arrow-parens': 'off',
 		camelcase: 'off',
@@ -49,10 +43,7 @@ module.exports = {
 		// See https://github.com/WordPress/gutenberg/blob/e035f71/packages/dependency-extraction-webpack-plugin/README.md#behavior-with-scripts
 		// Unfortunately there's no "ignore" option for this rule, so it's disabled altogether.
 		'import/no-extraneous-dependencies': 'off',
-		'import/no-unresolved': [
-			'error',
-			{ ignore: GLOBALLY_AVAILABLE_PACKAGES },
-		],
+		'import/no-unresolved': [ 'error', { ignore: GLOBALLY_AVAILABLE_PACKAGES } ],
 		'import/namespace': 'off',
 		// There's a conflict with prettier here:
 		'react/jsx-curly-spacing': 'off',

--- a/packages/scripts/config/getWebpackConfig.js
+++ b/packages/scripts/config/getWebpackConfig.js
@@ -6,15 +6,12 @@ module.exports = ( ...args ) => {
 	let config = { ...defaultConfig };
 
 	// Merge config extensions into default config.
-	args.forEach( ( extension ) => {
+	args.forEach( extension => {
 		config = { ...config, ...extension };
 	} );
 
 	// Ensure that webpack resolves modules from the Newspack Scripts node_modules as well as the root repo's node_modules.
-	config.resolve.modules = [
-		path.resolve( __dirname, '../node_modules' ),
-		'node_modules',
-	];
+	config.resolve.modules = [ path.resolve( __dirname, '../node_modules' ), 'node_modules' ];
 
 	// Clear cacheGroups so that CSS files don't get the `style-` prefix.
 	if ( config?.optimization?.splitChunks?.cacheGroups?.style ) {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -83,6 +83,5 @@
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
-	],
-	"prettier": "@wordpress/prettier-config"
+	]
 }

--- a/packages/scripts/scripts/commitlint.js
+++ b/packages/scripts/scripts/commitlint.js
@@ -4,12 +4,8 @@ const spawn = require( 'cross-spawn' );
 const path = require( 'path' );
 const commitlint = require.resolve( '@commitlint/cli/cli' );
 
-const result = spawn.sync(
-	commitlint,
-	[ '--config', path.resolve( __dirname, '../config/commitlint.config.js' ) ],
-	{
-		stdio: 'inherit',
-	}
-);
+const result = spawn.sync( commitlint, [ '--config', path.resolve( __dirname, '../config/commitlint.config.js' ) ], {
+	stdio: 'inherit',
+} );
 
 process.exit( result.status );

--- a/packages/scripts/scripts/github/release.js
+++ b/packages/scripts/scripts/github/release.js
@@ -4,9 +4,7 @@ const utils = require( '../utils/index.js' );
 
 const semanticRelease = require( 'semantic-release' );
 
-const { files, ...otherArgs } = require( 'yargs/yargs' )(
-	process.argv.slice( 2 )
-).parse();
+const { files, ...otherArgs } = require( 'yargs/yargs' )( process.argv.slice( 2 ) ).parse();
 
 const filesList = files.split( ',' );
 
@@ -32,8 +30,8 @@ const releaseAssetPath = `./release/${ repoName }.zip`;
 
 utils.log( `Releasing ${ repoName }…` );
 
-const getConfig = ({ gitBranchName }) => {
-	const branchType = gitBranchName.split("/")[0];
+const getConfig = ( { gitBranchName } ) => {
+	const branchType = gitBranchName.split( '/' )[ 0 ];
 	const githubConfig = {
 		assets: [
 			{
@@ -45,13 +43,13 @@ const getConfig = ({ gitBranchName }) => {
 	};
 
 	// Only post GH PR comments for alpha, hotfix/*, and release branches.
-	if ( ! ["alpha", "hotfix", "release"].includes(branchType) ) {
+	if ( ! [ 'alpha', 'hotfix', 'release' ].includes( branchType ) ) {
 		githubConfig.successComment = false;
 		githubConfig.failComment = false;
 	}
 
 	// Only publish alpha and release branches to NPM.
-	const shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN ) && ["alpha", "release"].includes(branchType);
+	const shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN ) && [ 'alpha', 'release' ].includes( branchType );
 	if ( shouldPublishOnNPM ) {
 		utils.log( `Will publish to npm.` );
 	}
@@ -63,44 +61,41 @@ const getConfig = ({ gitBranchName }) => {
 
 		branches: [
 			// `release` branch is published on the main distribution channel (a new version on GH).
-			"release",
+			'release',
 			// `alpha` branch – for regular pre-releases.
 			{
-				name: "alpha",
+				name: 'alpha',
 				prerelease: true,
 			},
 			// `hotfix/*` branches – for releases outside of the release schedule.
 			{
-				name: "hotfix/*",
+				name: 'hotfix/*',
 				// With `prerelease: true`, the `name` would be used for the pre-release tag. A name with a `/`
 				// is not valid, though. See https://semver.org/#spec-item-9.
 				prerelease: '${name.replace(/\\//g, "-")}',
 			},
 			// `epic/*` branches – for beta testing/QA pre-release builds.
 			{
-				name: "epic/*",
+				name: 'epic/*',
 				// With `prerelease: true`, the `name` would be used for the pre-release tag. A name with a `/`
 				// is not valid, though. See https://semver.org/#spec-item-9.
 				prerelease: '${name.replace(/\\//g, "-")}',
 			},
 		],
-		prepare: ["@semantic-release/changelog", "@semantic-release/npm"],
+		prepare: [ '@semantic-release/changelog', '@semantic-release/npm' ],
 		plugins: [
-			"@semantic-release/commit-analyzer",
-			"@semantic-release/release-notes-generator",
+			'@semantic-release/commit-analyzer',
+			'@semantic-release/release-notes-generator',
 			[
 				// Whether to publish on npm.
-				"@semantic-release/npm",
+				'@semantic-release/npm',
 				{
 					npmPublish: shouldPublishOnNPM,
 				},
 			],
-			"semantic-release-version-bump",
+			'semantic-release-version-bump',
 			// Add the built ZIP archive to GH release.
-			[
-				"@semantic-release/github",
-				githubConfig,
-			],
+			[ '@semantic-release/github', githubConfig ],
 		],
 	};
 
@@ -124,28 +119,16 @@ const getConfig = ({ gitBranchName }) => {
 		let assets = filesList;
 		// These assets should be added to source control after a release.
 		if ( branchType === 'release' ) {
-			assets = [
-				...filesList,
-				'package.json',
-				'package-lock.json',
-				'CHANGELOG.md',
-			];
+			assets = [ ...filesList, 'package.json', 'package-lock.json', 'CHANGELOG.md' ];
 		}
-		utils.log(
-			`On ${ branchType } branch, following files will be updated: ${ assets.join(
-				', '
-			) }`
-		);
+		utils.log( `On ${ branchType } branch, following files will be updated: ${ assets.join( ', ' ) }` );
 		config.prepare.push( {
 			path: '@semantic-release/git',
 			assets,
-			message:
-				'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+			message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
 		} );
 	} else {
-		utils.log(
-			`This branch is ${ branchType }, plugin files and the changelog will *not* be updated.`
-		);
+		utils.log( `This branch is ${ branchType }, plugin files and the changelog will *not* be updated.` );
 	}
 
 	return config;
@@ -155,25 +138,19 @@ const run = async () => {
 	try {
 		const gitBranch = await utils.getGitBranch();
 
-		const result = await semanticRelease.default(
-			getConfig( { gitBranchName: gitBranch } )
-		);
+		const result = await semanticRelease.default( getConfig( { gitBranchName: gitBranch } ) );
 
 		if ( result ) {
 			const { lastRelease, commits, nextRelease, releases } = result;
 
-			utils.log(
-				`Published ${ nextRelease.type } release version ${ nextRelease.version } containing ${ commits.length } commits.`
-			);
+			utils.log( `Published ${ nextRelease.type } release version ${ nextRelease.version } containing ${ commits.length } commits.` );
 
 			if ( lastRelease.version ) {
 				utils.log( `The last release was "${ lastRelease.version }".` );
 			}
 
 			for ( const release of releases ) {
-				utils.log(
-					`The release was published with plugin "${ release.pluginName }".`
-				);
+				utils.log( `The release was published with plugin "${ release.pluginName }".` );
 			}
 		} else {
 			utils.log( 'No release published.' );

--- a/packages/scripts/scripts/github/verify-release-asset.js
+++ b/packages/scripts/scripts/github/verify-release-asset.js
@@ -10,9 +10,7 @@ const releaseAssetPath = path.resolve( `./release/${ repoName }.zip` );
 
 async function prepare() {
 	if ( ! repoName ) {
-		throw new Error(
-			'GITHUB_REPOSITORY is not set; cannot determine release asset path.'
-		);
+		throw new Error( 'GITHUB_REPOSITORY is not set; cannot determine release asset path.' );
 	}
 	if ( ! fs.existsSync( releaseAssetPath ) ) {
 		throw new Error(

--- a/packages/scripts/scripts/release.js
+++ b/packages/scripts/scripts/release.js
@@ -4,33 +4,31 @@ const utils = require( './utils/index.js' );
 
 const semanticRelease = require( 'semantic-release' );
 
-const { files, ...otherArgs } = require( 'yargs/yargs' )(
-	process.argv.slice( 2 )
-).parse();
+const { files, ...otherArgs } = require( 'yargs/yargs' )( process.argv.slice( 2 ) ).parse();
 
 const filesList = files.split( ',' );
 
 utils.log( `Releasing ${ process.env.CIRCLE_PROJECT_REPONAME }…` );
 
-const getConfig = ({ gitBranchName }) => {
-	const branchType = gitBranchName.split("/")[0];
+const getConfig = ( { gitBranchName } ) => {
+	const branchType = gitBranchName.split( '/' )[ 0 ];
 	const githubConfig = {
 		assets: [
 			{
-				path: `./release/${process.env.CIRCLE_PROJECT_REPONAME}.zip`,
-				label: `${process.env.CIRCLE_PROJECT_REPONAME}.zip`,
+				path: `./release/${ process.env.CIRCLE_PROJECT_REPONAME }.zip`,
+				label: `${ process.env.CIRCLE_PROJECT_REPONAME }.zip`,
 			},
 		],
 	};
 
 	// Only post GH PR comments for alpha, hotfix/*, and release branches.
-	if ( ! ["alpha", "hotfix", "release"].includes(branchType) ) {
+	if ( ! [ 'alpha', 'hotfix', 'release' ].includes( branchType ) ) {
 		githubConfig.successComment = false;
 		githubConfig.failComment = false;
 	}
 
 	// Only publish alpha and release branches to NPM.
-	const shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN ) && ["alpha", "release"].includes(branchType);
+	const shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN ) && [ 'alpha', 'release' ].includes( branchType );
 	if ( shouldPublishOnNPM ) {
 		utils.log( `Will publish to npm.` );
 	}
@@ -42,44 +40,41 @@ const getConfig = ({ gitBranchName }) => {
 
 		branches: [
 			// `release` branch is published on the main distribution channel (a new version on GH).
-			"release",
+			'release',
 			// `alpha` branch – for regular pre-releases.
 			{
-				name: "alpha",
+				name: 'alpha',
 				prerelease: true,
 			},
 			// `hotfix/*` branches – for releases outside of the release schedule.
 			{
-				name: "hotfix/*",
+				name: 'hotfix/*',
 				// With `prerelease: true`, the `name` would be used for the pre-release tag. A name with a `/`
 				// is not valid, though. See https://semver.org/#spec-item-9.
 				prerelease: '${name.replace(/\\//g, "-")}',
 			},
 			// `epic/*` branches – for beta testing/QA pre-release builds.
 			{
-				name: "epic/*",
+				name: 'epic/*',
 				// With `prerelease: true`, the `name` would be used for the pre-release tag. A name with a `/`
 				// is not valid, though. See https://semver.org/#spec-item-9.
 				prerelease: '${name.replace(/\\//g, "-")}',
 			},
 		],
-		prepare: ["@semantic-release/changelog", "@semantic-release/npm"],
+		prepare: [ '@semantic-release/changelog', '@semantic-release/npm' ],
 		plugins: [
-			"@semantic-release/commit-analyzer",
-			"@semantic-release/release-notes-generator",
+			'@semantic-release/commit-analyzer',
+			'@semantic-release/release-notes-generator',
 			[
 				// Whether to publish on npm.
-				"@semantic-release/npm",
+				'@semantic-release/npm',
 				{
 					npmPublish: shouldPublishOnNPM,
 				},
 			],
-			"semantic-release-version-bump",
+			'semantic-release-version-bump',
 			// Add the built ZIP archive to GH release.
-			[
-				"@semantic-release/github",
-				githubConfig,
-			],
+			[ '@semantic-release/github', githubConfig ],
 		],
 	};
 
@@ -98,28 +93,16 @@ const getConfig = ({ gitBranchName }) => {
 		let assets = filesList;
 		// These assets should be added to source control after a release.
 		if ( branchType === 'release' ) {
-			assets = [
-				...filesList,
-				'package.json',
-				'package-lock.json',
-				'CHANGELOG.md',
-			];
+			assets = [ ...filesList, 'package.json', 'package-lock.json', 'CHANGELOG.md' ];
 		}
-		utils.log(
-			`On ${ branchType } branch, following files will be updated: ${ assets.join(
-				', '
-			) }`
-		);
+		utils.log( `On ${ branchType } branch, following files will be updated: ${ assets.join( ', ' ) }` );
 		config.prepare.push( {
 			path: '@semantic-release/git',
 			assets,
-			message:
-				'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+			message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
 		} );
 	} else {
-		utils.log(
-			`This branch is ${ branchType }, plugin files and the changelog will *not* be updated.`
-		);
+		utils.log( `This branch is ${ branchType }, plugin files and the changelog will *not* be updated.` );
 	}
 
 	return config;
@@ -129,25 +112,19 @@ const run = async () => {
 	try {
 		const gitBranch = await utils.getGitBranch();
 
-		const result = await semanticRelease.default(
-			getConfig( { gitBranchName: gitBranch } )
-		);
+		const result = await semanticRelease.default( getConfig( { gitBranchName: gitBranch } ) );
 
 		if ( result ) {
 			const { lastRelease, commits, nextRelease, releases } = result;
 
-			utils.log(
-				`Published ${ nextRelease.type } release version ${ nextRelease.version } containing ${ commits.length } commits.`
-			);
+			utils.log( `Published ${ nextRelease.type } release version ${ nextRelease.version } containing ${ commits.length } commits.` );
 
 			if ( lastRelease.version ) {
 				utils.log( `The last release was "${ lastRelease.version }".` );
 			}
 
 			for ( const release of releases ) {
-				utils.log(
-					`The release was published with plugin "${ release.pluginName }".`
-				);
+				utils.log( `The release was published with plugin "${ release.pluginName }".` );
 			}
 		} else {
 			utils.log( 'No release published.' );

--- a/packages/scripts/scripts/test.js
+++ b/packages/scripts/scripts/test.js
@@ -30,17 +30,9 @@ const JEST_CONFIG = {
 	moduleNameMapper: {
 		'\\.(scss|css)$': path.resolve( __dirname, 'utils/babelJestTransformer.js' ),
 	},
-	modulePaths: [
-		path.resolve( modules.rootDirectory, 'node_modules' ),
-		path.resolve( __dirname, '../node_modules' ),
-	],
+	modulePaths: [ path.resolve( modules.rootDirectory, 'node_modules' ), path.resolve( __dirname, '../node_modules' ) ],
 	testEnvironment: 'jsdom',
-	collectCoverageFrom: [
-		'**/*.{js,jsx}',
-		'!**/node_modules/**',
-		'!**/dist/**',
-		'!**/vendor/**',
-	],
+	collectCoverageFrom: [ '**/*.{js,jsx}', '!**/node_modules/**', '!**/dist/**', '!**/vendor/**' ],
 };
 
 args.push( '--config', JSON.stringify( JEST_CONFIG ) );
@@ -51,4 +43,4 @@ const result = spawn.sync( wpScripts, args, {
 	env: { ...process.env, NODE_ENV: 'development' },
 } );
 
-process.exit(result.status);
+process.exit( result.status );

--- a/packages/scripts/scripts/utils/index.js
+++ b/packages/scripts/scripts/utils/index.js
@@ -3,9 +3,7 @@ const { exec } = require( 'child_process' );
 const { version } = require( '../../package.json' );
 
 const log = ( content, type ) => {
-	console.log(
-		`[newspack-scripts@${ version }]${ type ? `[${ type }]` : '' } ${ content }`
-	);
+	console.log( `[newspack-scripts@${ version }]${ type ? `[${ type }]` : '' } ${ content }` );
 };
 
 const getGitBranch = () =>

--- a/packages/scripts/scripts/utils/jestSetup.js
+++ b/packages/scripts/scripts/utils/jestSetup.js
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 // matchMedia does not exist in JSDOM, see https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty( window, 'matchMedia', {
 	writable: true,
-	value: jest.fn().mockImplementation( ( query ) => ( {
+	value: jest.fn().mockImplementation( query => ( {
 		matches: false,
 		media: query,
 		onchange: null,

--- a/packages/scripts/scripts/utils/modules.js
+++ b/packages/scripts/scripts/utils/modules.js
@@ -10,10 +10,7 @@ module.exports = {
 			return [ cmd, ...args ];
 		}
 
-		const defaults = [
-			'--config',
-			'webpack.config.js',
-		];
+		const defaults = [ '--config', 'webpack.config.js' ];
 
 		// Default build path: ./dist
 		if ( ! args.includes( '--output-path' ) ) {

--- a/plugins/newspack-network/.prettierrc.js
+++ b/plugins/newspack-network/.prettierrc.js
@@ -1,0 +1,5 @@
+const baseConfig = require( 'newspack-scripts/config/prettier.config.js' );
+
+module.exports = {
+	...baseConfig
+};

--- a/plugins/newspack-network/includes/hub/admin/js/event-log.js
+++ b/plugins/newspack-network/includes/hub/admin/js/event-log.js
@@ -2,9 +2,7 @@
 
 ( function ( $ ) {
 	$( document ).ready( function () {
-		const dataColumns = document.querySelectorAll(
-			'.newspack-network-data-column'
-		);
+		const dataColumns = document.querySelectorAll( '.newspack-network-data-column' );
 		dataColumns.forEach( function ( column ) {
 			const buttonEl = column.querySelector( 'button' );
 			const textEl = column.querySelector( 'textarea' );
@@ -19,11 +17,9 @@
 				navigator.clipboard
 					.writeText( text )
 					.then( function () {
-						buttonEl.textContent =
-							newspackNetworkEventLogLabels.copied;
+						buttonEl.textContent = newspackNetworkEventLogLabels.copied;
 						setTimeout( function () {
-							buttonEl.textContent =
-								newspackNetworkEventLogLabels.copy;
+							buttonEl.textContent = newspackNetworkEventLogLabels.copy;
 							buttonEl.disabled = false;
 						}, 1000 );
 					} )

--- a/plugins/newspack-network/src/components/post-panel-row.js
+++ b/plugins/newspack-network/src/components/post-panel-row.js
@@ -11,13 +11,8 @@ import { forwardRef } from '@wordpress/element';
 
 const PostPanelRow = forwardRef( ( { className, label, children }, ref ) => {
 	return (
-		<HStack
-			className={ clsx( 'editor-post-panel__row', className ) }
-			ref={ ref }
-		>
-			{ label && (
-				<div className="editor-post-panel__row-label">{ label }</div>
-			) }
+		<HStack className={ clsx( 'editor-post-panel__row', className ) } ref={ ref }>
+			{ label && <div className="editor-post-panel__row-label">{ label }</div> }
 			<div className="editor-post-panel__row-control">{ children }</div>
 		</HStack>
 	);

--- a/plugins/newspack-network/src/components/post-status.js
+++ b/plugins/newspack-network/src/components/post-status.js
@@ -3,12 +3,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Dropdown,
-	__experimentalVStack as VStack,
-	RadioControl,
-} from '@wordpress/components';
+import { Button, Dropdown, __experimentalVStack as VStack, RadioControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
@@ -43,13 +38,7 @@ const STATUS_OPTIONS = [
 	},
 ];
 
-export default function PostStatus( {
-	label,
-	description,
-	status,
-	onChange,
-	disabled,
-} ) {
+export default function PostStatus( { label, description, status, onChange, disabled } ) {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 	// Memoize popoverProps to avoid returning a new object every time.
 	const popoverProps = useMemo(
@@ -67,11 +56,7 @@ export default function PostStatus( {
 	);
 
 	return (
-		<PostPanelRow
-			label={ __( 'Status' ) }
-			description={ description }
-			ref={ setPopoverAnchor }
-		>
+		<PostPanelRow label={ __( 'Status' ) } description={ description } ref={ setPopoverAnchor }>
 			<Dropdown
 				className="editor-post-status"
 				contentClassName="editor-change-status__content"
@@ -97,12 +82,7 @@ export default function PostStatus( {
 				) }
 				renderContent={ ( { onClose } ) => (
 					<>
-						<InspectorPopoverHeader
-							title={
-								label ? label : __( 'Status & visibility' )
-							}
-							onClose={ onClose }
-						/>
+						<InspectorPopoverHeader title={ label ? label : __( 'Status & visibility' ) } onClose={ onClose } />
 						{ description && <p>{ description }</p> }
 						<form>
 							<VStack spacing={ 4 }>

--- a/plugins/newspack-network/src/content-distribution/content-distribution-panel/index.js
+++ b/plugins/newspack-network/src/content-distribution/content-distribution-panel/index.js
@@ -20,21 +20,11 @@ const ContentDistributionPanel = ( { header, body, footer, buttons } ) => {
 			className="newspack-network-content-distribution-panel"
 		>
 			<Panel>
-				<PanelBody className="content-distribution-panel-header">
-					{ header }
-				</PanelBody>
-				<PanelBody className="content-distribution-panel-body">
-					{ body }
-				</PanelBody>
-				<PanelBody className="content-distribution-panel-footer">
-					{ footer }
-				</PanelBody>
+				<PanelBody className="content-distribution-panel-header">{ header }</PanelBody>
+				<PanelBody className="content-distribution-panel-body">{ body }</PanelBody>
+				<PanelBody className="content-distribution-panel-footer">{ footer }</PanelBody>
 				<PanelBody className="content-distribution-panel-buttons">
-					<Flex
-						direction="column"
-						className="content-distribution-panel__button-column"
-						gap={ 4 }
-					>
+					<Flex direction="column" className="content-distribution-panel__button-column" gap={ 4 }>
 						{ buttons }
 					</Flex>
 				</PanelBody>

--- a/plugins/newspack-network/src/content-distribution/incoming-post/index.js
+++ b/plugins/newspack-network/src/content-distribution/incoming-post/index.js
@@ -26,19 +26,16 @@ const unlinked = newspack_network_incoming_post.unlinked;
 
 function IncomingPost() {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { lockPostAutosaving, unlockPostAutosaving } =
-		useDispatch( 'core/editor' );
+	const { lockPostAutosaving, unlockPostAutosaving } = useDispatch( 'core/editor' );
 	const { openGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const [ isUnLinkedToggling, setIsUnLinkedToggling ] = useState( false );
 	const [ isUnLinked, setIsUnLinked ] = useState( false );
-	const [ hasInitializedSidebar, setHasInitializedSidebar ] =
-		useState( false );
+	const [ hasInitializedSidebar, setHasInitializedSidebar ] = useState( false );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
-	const { postId, areMetaBoxesInitialized } = useSelect( ( select ) => {
+	const { postId, areMetaBoxesInitialized } = useSelect( select => {
 		const { getCurrentPostId } = select( 'core/editor' );
-		const { areMetaBoxesInitialized: _areMetaBoxesInitialized } =
-			select( 'core/edit-post' );
+		const { areMetaBoxesInitialized: _areMetaBoxesInitialized } = select( 'core/edit-post' );
 		return {
 			postId: getCurrentPostId(),
 			areMetaBoxesInitialized: _areMetaBoxesInitialized(),
@@ -51,9 +48,7 @@ function IncomingPost() {
 
 	useEffect( () => {
 		if ( ! hasInitializedSidebar && areMetaBoxesInitialized ) {
-			openGeneralSidebar(
-				'newspack-network-incoming-post/newspack-network-content-distribution-panel'
-			);
+			openGeneralSidebar( 'newspack-network-incoming-post/newspack-network-content-distribution-panel' );
 			setHasInitializedSidebar( true ); // We only want to strongarm this once.
 		}
 	}, [ areMetaBoxesInitialized ] );
@@ -64,10 +59,7 @@ function IncomingPost() {
 			isUnLinked
 				? sprintf(
 						// translators: %s: original site URL.
-						__(
-							'Originally distributed from %s.',
-							'newspack-network'
-						),
+						__( 'Originally distributed from %s.', 'newspack-network' ),
 						originalSiteUrl
 				  )
 				: sprintf(
@@ -88,15 +80,10 @@ function IncomingPost() {
 			lockPostAutosaving( lockName );
 		}
 		// Toggle the CSS overlay.
-		document
-			.querySelector( '#editor' )
-			?.classList.toggle(
-				'newspack-network-incoming-post-linked',
-				! isUnLinked
-			);
+		document.querySelector( '#editor' )?.classList.toggle( 'newspack-network-incoming-post-linked', ! isUnLinked );
 	}, [ isUnLinked ] );
 
-	const toggleUnlinkedState = async ( _unlinked ) => {
+	const toggleUnlinkedState = async _unlinked => {
 		return apiFetch( {
 			path: `newspack-network/v1/content-distribution/unlink/${ postId }`,
 			method: 'POST',
@@ -104,13 +91,13 @@ function IncomingPost() {
 				unlinked: _unlinked,
 			},
 		} )
-			.then( ( data ) => {
+			.then( data => {
 				setIsUnLinked( data.unlinked );
 			} )
-			.catch( ( error ) => createNotice( 'error', error.message ) );
+			.catch( error => createNotice( 'error', error.message ) );
 	};
 
-	const toggleUnlinkedClicked = ( _unlinked ) => {
+	const toggleUnlinkedClicked = _unlinked => {
 		setIsUnLinkedToggling( true );
 		if ( isUnLinked ) {
 			// For relinking, we need to save the post (it will be overwritten by the origin post)
@@ -120,9 +107,7 @@ function IncomingPost() {
 				.savePost()
 				.then( () => {
 					// Remove the 'draft saved' notice.
-					wp.data
-						.dispatch( 'core/notices' )
-						.removeNotice( 'SAVE_POST_NOTICE_ID' );
+					wp.data.dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
 					toggleUnlinkedState( _unlinked ).then( () => {
 						setIsUnLinkedToggling( false );
 						setIsUnLinked( false );
@@ -165,20 +150,13 @@ function IncomingPost() {
 						  )
 						: sprintf(
 								// translators: %1$s: post type
-								__(
-									'This %1$s is linked to its origin. Edits to the origin %1$s will update this version.',
-									'newspack-network'
-								),
+								__( 'This %1$s is linked to its origin. Edits to the origin %1$s will update this version.', 'newspack-network' ),
 								newspack_network_incoming_post.postTypeLabel.toLowerCase()
 						  )
 				}
 				buttons={
 					<>
-						<Button
-							variant="secondary"
-							target="_blank"
-							href={ originalPostEditUrl }
-						>
+						<Button variant="secondary" target="_blank" href={ originalPostEditUrl }>
 							{ sprintf(
 								// translators: %s: post type
 								__( 'Edit origin %s', 'newspack-network' ),
@@ -200,18 +178,12 @@ function IncomingPost() {
 								: ! isUnLinked
 								? sprintf(
 										// translators: %s: post type
-										__(
-											'Unlink from origin %s',
-											'newspack-network'
-										),
+										__( 'Unlink from origin %s', 'newspack-network' ),
 										newspack_network_incoming_post.postTypeLabel.toLowerCase()
 								  )
 								: sprintf(
 										// translators: %s: post type
-										__(
-											'Relink to origin %s',
-											'newspack-network'
-										),
+										__( 'Relink to origin %s', 'newspack-network' ),
 										newspack_network_incoming_post.postTypeLabel.toLowerCase()
 								  ) }
 						</Button>
@@ -225,28 +197,18 @@ function IncomingPost() {
 					setShowConfirmDialog( false );
 				} }
 				onCancel={ () => setShowConfirmDialog( false ) }
-				confirmButtonText={
-					isUnLinked
-						? __( 'Relink', 'newspack-network' )
-						: __( 'Unlink', 'newspack-network' )
-				}
+				confirmButtonText={ isUnLinked ? __( 'Relink', 'newspack-network' ) : __( 'Unlink', 'newspack-network' ) }
 				size="small"
 			>
 				{ isUnLinked
 					? sprintf(
 							// translators: %s: post type
-							__(
-								"Are you sure you want to relink this %s to its origin? Any changes you've made will be lost.",
-								'newspack-network'
-							),
+							__( "Are you sure you want to relink this %s to its origin? Any changes you've made will be lost.", 'newspack-network' ),
 							newspack_network_incoming_post.postTypeLabel.toLowerCase()
 					  )
 					: sprintf(
 							// translators: %s: post type
-							__(
-								'Are you sure you want to unlink this %s from its origin?',
-								'newspack-network'
-							),
+							__( 'Are you sure you want to unlink this %s from its origin?', 'newspack-network' ),
 							newspack_network_incoming_post.postTypeLabel.toLowerCase()
 					  ) }
 			</ConfirmDialog>

--- a/plugins/newspack-network/src/content-distribution/outgoing-post/index.js
+++ b/plugins/newspack-network/src/content-distribution/outgoing-post/index.js
@@ -9,12 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { sprintf, __, _n } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	CheckboxControl,
-	TextControl,
-	Button,
-	Notice,
-} from '@wordpress/components';
+import { CheckboxControl, TextControl, Button, Notice } from '@wordpress/components';
 import { broadcast } from '../../icons';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -36,14 +31,7 @@ function OutgoingPost() {
 	const [ siteSelection, setSiteSelection ] = useState( [] );
 	const [ statusOnPublish, setStatusOnPublish ] = useState( defaultStatus );
 
-	const {
-		postId,
-		postStatus,
-		savedUrls,
-		hasChangedContent,
-		isSavingPost,
-		isCleanNewPost,
-	} = useSelect( ( select ) => {
+	const { postId, postStatus, savedUrls, hasChangedContent, isSavingPost, isCleanNewPost } = useSelect( select => {
 		const {
 			getCurrentPostId,
 			getCurrentPostAttribute,
@@ -54,8 +42,7 @@ function OutgoingPost() {
 		return {
 			postId: getCurrentPostId(),
 			postStatus: getCurrentPostAttribute( 'status' ),
-			savedUrls:
-				getCurrentPostAttribute( 'meta' )?.[ distributedMetaKey ] || [],
+			savedUrls: getCurrentPostAttribute( 'meta' )?.[ distributedMetaKey ] || [],
 			hasChangedContent: _hasChangedContent(),
 			isSavingPost: _isSavingPost(),
 			isCleanNewPost: _isCleanNewPost(),
@@ -93,20 +80,17 @@ function OutgoingPost() {
 	const { savePost } = useDispatch( 'core/editor' );
 	const { createNotice } = useDispatch( 'core/notices' );
 
-	const sites = networkSites.filter( ( url ) => url.includes( search ) );
+	const sites = networkSites.filter( url => url.includes( search ) );
 
-	const selectableSites = networkSites.filter(
-		( url ) => ! distribution.includes( url )
-	);
+	const selectableSites = networkSites.filter( url => ! distribution.includes( url ) );
 
 	const isUnpublished = postStatus !== 'publish';
 
 	const isAutoDraft = postStatus === 'auto-draft';
 
-	const isDisabled =
-		isSavingPost || isDistributing || isCleanNewPost || isAutoDraft;
+	const isDisabled = isSavingPost || isDistributing || isCleanNewPost || isAutoDraft;
 
-	const getFormattedSite = ( site ) => {
+	const getFormattedSite = site => {
 		const url = new URL( site );
 		return url.hostname;
 	};
@@ -121,19 +105,14 @@ function OutgoingPost() {
 				status_on_publish: statusOnPublish,
 			},
 		} )
-			.then( ( urls ) => {
+			.then( urls => {
 				setDistribution( urls );
 				setSiteSelection( [] );
 				createNotice(
 					'info',
 					sprintf(
 						// translators: %s: post type; %d: number of network sites
-						_n(
-							'%s distributed to one network site.',
-							'%s distributed to %d network sites.',
-							urls.length,
-							'newspack-network'
-						),
+						_n( '%s distributed to one network site.', '%s distributed to %d network sites.', urls.length, 'newspack-network' ),
 						postTypeLabel,
 						urls.length
 					),
@@ -143,7 +122,7 @@ function OutgoingPost() {
 					}
 				);
 			} )
-			.catch( ( error ) => {
+			.catch( error => {
 				createNotice( 'error', error.message );
 			} )
 			.finally( () => {
@@ -158,10 +137,7 @@ function OutgoingPost() {
 					{ isAutoDraft && (
 						<>
 							<Notice status="warning" isDismissible={ false }>
-								{ __(
-									'Save the post at least once before distributing it.',
-									'newspack-network'
-								) }
+								{ __( 'Save the post at least once before distributing it.', 'newspack-network' ) }
 							</Notice>
 							<hr />
 						</>
@@ -171,18 +147,12 @@ function OutgoingPost() {
 							{ networkSites.length === 1
 								? sprintf(
 										// translators: %s: post type
-										__(
-											'This %s has not been distributed to your network site yet.',
-											'newspack-network'
-										),
+										__( 'This %s has not been distributed to your network site yet.', 'newspack-network' ),
 										postTypeLabel.toLowerCase()
 								  )
 								: sprintf(
 										// translators: %s: post type
-										__(
-											'This %s has not been distributed to any network sites yet.',
-											'newspack-network'
-										),
+										__( 'This %s has not been distributed to any network sites yet.', 'newspack-network' ),
 										postTypeLabel.toLowerCase()
 								  ) }
 						</p>
@@ -204,10 +174,7 @@ function OutgoingPost() {
 					{ networkSites.length > 5 && (
 						<TextControl
 							__next40pxDefaultSize
-							placeholder={ __(
-								'Search available network sites',
-								'newspack-network'
-							) }
+							placeholder={ __( 'Search available network sites', 'newspack-network' ) }
 							value={ search }
 							disabled={ isDisabled }
 							onChange={ setSearch }
@@ -217,46 +184,26 @@ function OutgoingPost() {
 			}
 			body={
 				<>
-					{ networkSites.length > 1 &&
-						selectableSites.length !== 0 &&
-						sites.length === networkSites.length && (
-							<CheckboxControl
-								name="select-all"
-								label={ __( 'Select all', 'newspack-network' ) }
-								disabled={ isDisabled }
-								checked={
-									siteSelection.length ===
-									selectableSites.length
-								}
-								indeterminate={
-									siteSelection.length > 0 &&
-									siteSelection.length <
-										selectableSites.length
-								}
-								onChange={ ( checked ) => {
-									setSiteSelection(
-										checked ? selectableSites : []
-									);
-								} }
-							/>
-						) }
-					{ sites.map( ( siteUrl ) => (
+					{ networkSites.length > 1 && selectableSites.length !== 0 && sites.length === networkSites.length && (
+						<CheckboxControl
+							name="select-all"
+							label={ __( 'Select all', 'newspack-network' ) }
+							disabled={ isDisabled }
+							checked={ siteSelection.length === selectableSites.length }
+							indeterminate={ siteSelection.length > 0 && siteSelection.length < selectableSites.length }
+							onChange={ checked => {
+								setSiteSelection( checked ? selectableSites : [] );
+							} }
+						/>
+					) }
+					{ sites.map( siteUrl => (
 						<CheckboxControl
 							key={ siteUrl }
 							label={ getFormattedSite( siteUrl ) }
-							disabled={
-								isDisabled || distribution.includes( siteUrl )
-							} // Do not allow undistributing a site.
-							checked={
-								siteSelection.includes( siteUrl ) ||
-								distribution.includes( siteUrl )
-							}
-							onChange={ ( checked ) => {
-								const urls = checked
-									? [ ...siteSelection, siteUrl ]
-									: siteSelection.filter(
-											( url ) => siteUrl !== url
-									  );
+							disabled={ isDisabled || distribution.includes( siteUrl ) } // Do not allow undistributing a site.
+							checked={ siteSelection.includes( siteUrl ) || distribution.includes( siteUrl ) }
+							onChange={ checked => {
+								const urls = checked ? [ ...siteSelection, siteUrl ] : siteSelection.filter( url => siteUrl !== url );
 								setSiteSelection( urls );
 							} }
 						/>
@@ -270,18 +217,11 @@ function OutgoingPost() {
 							<span>
 								{ sprintf(
 									// translators: %d: number of network sites
-									_n(
-										'One network site selected.',
-										'%d network sites selected.',
-										siteSelection.length,
-										'newspack-network'
-									),
+									_n( 'One network site selected.', '%d network sites selected.', siteSelection.length, 'newspack-network' ),
 									siteSelection.length
 								) }
 							</span>
-							<button onClick={ () => setSiteSelection( [] ) }>
-								Clear
-							</button>
+							<button onClick={ () => setSiteSelection( [] ) }>Clear</button>
 						</p>
 					) }
 				</>
@@ -289,19 +229,8 @@ function OutgoingPost() {
 			buttons={
 				<>
 					<PostStatus
-						label={
-							isUnpublished
-								? __( 'Status on publish', 'newspack-network' )
-								: null
-						}
-						description={
-							isUnpublished
-								? __(
-										"Which status to set the post when it's published.",
-										'newspack-network'
-								  )
-								: null
-						}
+						label={ isUnpublished ? __( 'Status on publish', 'newspack-network' ) : null }
+						description={ isUnpublished ? __( "Which status to set the post when it's published.", 'newspack-network' ) : null }
 						status={ statusOnPublish }
 						onChange={ setStatusOnPublish }
 						disabled={ isDisabled }

--- a/plugins/newspack-network/src/story-budget/components/local-budgets-control.js
+++ b/plugins/newspack-network/src/story-budget/components/local-budgets-control.js
@@ -6,12 +6,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 
-export default function LocalBudgetsControl( {
-	value,
-	onChange,
-	disabled,
-	...props
-} ) {
+export default function LocalBudgetsControl( { value, onChange, disabled, ...props } ) {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ localBudgets, setLocalBudgets ] = useState( [] );
 
@@ -39,7 +34,7 @@ export default function LocalBudgetsControl( {
 					label: __( 'Select a budget', 'newspack-network' ),
 					value: '',
 				},
-				...localBudgets.map( ( budget ) => ( {
+				...localBudgets.map( budget => ( {
 					label: budget.name,
 					value: budget.id,
 				} ) ),

--- a/plugins/newspack-network/src/story-budget/components/pull-story.js
+++ b/plugins/newspack-network/src/story-budget/components/pull-story.js
@@ -41,7 +41,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 		}
 	}, [ errors ] );
 
-	const pullStory = async ( storyId ) => {
+	const pullStory = async storyId => {
 		const payload = await apiFetch( {
 			isStoryBudget: true,
 			fullPath: `newspack-network/v1/content-distribution/pull/${ storyId }`,
@@ -63,7 +63,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 		fetchStory( storyId );
 	};
 
-	const handleSubmit = ( ev ) => {
+	const handleSubmit = ev => {
 		ev.preventDefault();
 		setErrors( [] );
 		setIsLoading( true );
@@ -76,7 +76,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 				closeModal();
 				onActionPerformed?.( items );
 			} )
-			.catch( ( error ) => {
+			.catch( error => {
 				setErrors( [ ...errors, error.message ] );
 			} )
 			.finally( () => {
@@ -120,27 +120,16 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 
 				{ items.length > 1 && (
 					<div>
-						<p>
-							{ __(
-								'The following stories will be pulled:',
-								'newspack-network'
-							) }
-						</p>
+						<p>{ __( 'The following stories will be pulled:', 'newspack-network' ) }</p>
 						<ul>
-							{ items.map( ( item ) => (
+							{ items.map( item => (
 								<li key={ item.id }>{ item.name }</li>
 							) ) }
 						</ul>
 					</div>
 				) }
 
-				<LocalBudgetsControl
-					value={ budget }
-					onChange={ setBudget }
-					disabled={ isLoading }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
+				<LocalBudgetsControl value={ budget } onChange={ setBudget } disabled={ isLoading } __next40pxDefaultSize __nextHasNoMarginBottom />
 
 				<SelectControl
 					label={ __( 'Status on publish', 'newspack-network' ) }
@@ -153,12 +142,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 				/>
 
 				<HStack expanded direction="row-reverse" justify="end">
-					<Button
-						variant="primary"
-						disabled={ isLoading || ! budget }
-						isBusy={ isLoading }
-						type="submit"
-					>
+					<Button variant="primary" disabled={ isLoading || ! budget } isBusy={ isLoading } type="submit">
 						{ items.length === 1
 							? __( 'Pull story', 'newspack-network' )
 							: sprintf(
@@ -167,11 +151,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 									items.length
 							  ) }
 					</Button>
-					<Button
-						variant="tertiary"
-						onClick={ closeModal }
-						disabled={ isLoading }
-					>
+					<Button variant="tertiary" onClick={ closeModal } disabled={ isLoading }>
 						{ __( 'Cancel', 'newspack-network' ) }
 					</Button>
 				</HStack>

--- a/plugins/newspack-network/src/story-budget/index.js
+++ b/plugins/newspack-network/src/story-budget/index.js
@@ -13,30 +13,19 @@ import { addFilter } from '@wordpress/hooks';
 import PullStory from './components/pull-story';
 
 // Set the list of availables sites
-addFilter(
-	'newspack-story-budget.sites',
-	'newspack-network/story-budget',
-	() => newspackStoryBudgetNetwork.sites
-);
+addFilter( 'newspack-story-budget.sites', 'newspack-network/story-budget', () => newspackStoryBudgetNetwork.sites );
 
 // Add "Pull" to the Story Budget actions.
-addFilter(
-	'newspack-story-budget.actions',
-	'newspack-network/story-budget',
-	( actions ) => [
-		...actions,
-		{
-			id: 'pull',
-			label: __( 'Pull Story', 'newspack-network' ),
-			isEligible: ( item ) =>
-				item.metadata &&
-				item.metadata?.can_pull &&
-				! item.metadata?.is_pulled,
-			isPrimary: true,
-			supportsBulk: true,
-			icon: <Icon icon={ cloudDownload } />,
-			hideModalHeader: true,
-			RenderModal: PullStory,
-		},
-	]
-);
+addFilter( 'newspack-story-budget.actions', 'newspack-network/story-budget', actions => [
+	...actions,
+	{
+		id: 'pull',
+		label: __( 'Pull Story', 'newspack-network' ),
+		isEligible: item => item.metadata && item.metadata?.can_pull && ! item.metadata?.is_pulled,
+		isPrimary: true,
+		supportsBulk: true,
+		icon: <Icon icon={ cloudDownload } />,
+		hideModalHeader: true,
+		RenderModal: PullStory,
+	},
+] );

--- a/plugins/republication-tracker-tool/.eslintrc.js
+++ b/plugins/republication-tracker-tool/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: [ './node_modules/newspack-scripts/.eslintrc.js' ],
+};

--- a/plugins/republication-tracker-tool/.prettierrc.js
+++ b/plugins/republication-tracker-tool/.prettierrc.js
@@ -1,0 +1,5 @@
+const baseConfig = require( 'newspack-scripts/config/prettier.config.js' );
+
+module.exports = {
+	...baseConfig
+};

--- a/plugins/republication-tracker-tool/src/index.js
+++ b/plugins/republication-tracker-tool/src/index.js
@@ -8,22 +8,15 @@ import { createInterpolateElement } from '@wordpress/element';
 const META_KEY = 'republication-tracker-tool-hide-widget';
 
 const RepublicationTrackerPanel = () => {
-	const { postType, meta, filterHides, shareData } = useSelect(
-		( select ) => {
-			const editor = select( 'core/editor' );
-			return {
-				postType: editor.getCurrentPostType(),
-				meta: editor.getEditedPostAttribute( 'meta' ),
-				filterHides: editor.getEditedPostAttribute(
-					'republication_tracker_tool_filter_hides'
-				),
-				shareData: editor.getEditedPostAttribute(
-					'republication_tracker_tool_share_data'
-				),
-			};
-		},
-		[]
-	);
+	const { postType, meta, filterHides, shareData } = useSelect( select => {
+		const editor = select( 'core/editor' );
+		return {
+			postType: editor.getCurrentPostType(),
+			meta: editor.getEditedPostAttribute( 'meta' ),
+			filterHides: editor.getEditedPostAttribute( 'republication_tracker_tool_filter_hides' ),
+			shareData: editor.getEditedPostAttribute( 'republication_tracker_tool_share_data' ),
+		};
+	}, [] );
 
 	const { editPost } = useDispatch( 'core/editor' );
 
@@ -36,21 +29,12 @@ const RepublicationTrackerPanel = () => {
 	const entries = shareData?.entries ?? [];
 
 	return (
-		<PluginDocumentSettingPanel
-			name="republication-tracker-tool"
-			title={ __(
-				'Republication Widget Settings',
-				'republication-tracker-tool'
-			) }
-		>
+		<PluginDocumentSettingPanel name="republication-tracker-tool" title={ __( 'Republication Widget Settings', 'republication-tracker-tool' ) }>
 			<ToggleControl
-				label={ __(
-					'Hide Republication widget',
-					'republication-tracker-tool'
-				) }
+				label={ __( 'Hide Republication widget', 'republication-tracker-tool' ) }
 				checked={ filterHides ? true : hideWidget }
 				disabled={ filterHides }
-				onChange={ ( value ) =>
+				onChange={ value =>
 					editPost( {
 						meta: { ...( meta ?? {} ), [ META_KEY ]: value },
 					} )
@@ -79,33 +63,21 @@ const RepublicationTrackerPanel = () => {
 				}
 			/>
 			<p style={ { marginTop: '16px' } }>
-				{ __( 'Total number of views:', 'republication-tracker-tool' ) }{ ' ' }
-				{ total }
+				{ __( 'Total number of views:', 'republication-tracker-tool' ) } { total }
 			</p>
 			{ entries.length > 0 ? (
 				<table className="widefat striped">
 					<thead>
 						<tr>
-							<th>
-								{ __(
-									'Republished URL',
-									'republication-tracker-tool'
-								) }
-							</th>
-							<th>
-								{ __( 'Views', 'republication-tracker-tool' ) }
-							</th>
+							<th>{ __( 'Republished URL', 'republication-tracker-tool' ) }</th>
+							<th>{ __( 'Views', 'republication-tracker-tool' ) }</th>
 						</tr>
 					</thead>
 					<tbody>
-						{ entries.map( ( entry ) => (
+						{ entries.map( entry => (
 							<tr key={ entry.url }>
 								<td>
-									<a
-										href={ entry.url }
-										target="_blank"
-										rel="noopener noreferrer"
-									>
+									<a href={ entry.url } target="_blank" rel="noopener noreferrer">
 										{ entry.url }
 									</a>
 								</td>
@@ -115,12 +87,7 @@ const RepublicationTrackerPanel = () => {
 					</tbody>
 				</table>
 			) : (
-				<p>
-					{ __(
-						'There are no shares to display.',
-						'republication-tracker-tool'
-					) }
-				</p>
+				<p>{ __( 'There are no shares to display.', 'republication-tracker-tool' ) }</p>
 			) }
 		</PluginDocumentSettingPanel>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

Stacked on #184 (base branch is `chore/reconcile-prettier-eslint-config`). Addresses follow-up findings from that PR's review so the Prettier reconciliation is complete and self-consistent across every linted package.

**Config (`chore(prettier): …` commits)**

- **Cover `newspack-network`.** It runs `lint:js`/`format:js` and extends the shared ESLint config, but had no `.prettierrc.js`, so its editor formatting and `prettier/prettier` lint were not pinned to the canonical config (the exact gap #184 exists to close). Added a `.prettierrc.js` identical to its 11 siblings (bare-specifier re-export of `newspack-scripts/config/prettier.config.js`).
- **Cover `republication-tracker-tool`.** It ran `lint:js` with *neither* a `.eslintrc.js` nor a `.prettierrc.js`, so it used wp-scripts' default ESLint config and WP-default formatting instead of the newspack ruleset and canonical Prettier config. Added both config files (matching the other plugins) to bring it fully under the shared tooling.
- **Fix the stale public doc.** `packages/scripts/README.md` still told consumers to `require( './node_modules/newspack-scripts/config/prettier.config.js' )` — the fragile hardcoded path #184 replaces everywhere else. Updated to the bare specifier.
- **Remove a dead config key.** `packages/scripts/package.json` had `"prettier": "@wordpress/prettier-config"`, which (per Prettier's config precedence: the `package.json` key wins over `.prettierrc.js`) silently shadowed the package's own `.prettierrc.js`, so `newspack-scripts` was formatting itself with the wrong config. Removed the key so its `.prettierrc.js` (printWidth 150, arrowParens avoid) takes effect.

**Reformat (`style: …` commits)**

Activating the canonical config in the packages above makes existing JS files fail the `prettier/prettier` rule. These commits reformat them (AST-equivalent: line-joining + single-arg arrow-paren removal) so `lint:js` stays green. Kept separate from the config commits so the logical changes are reviewable apart from the mechanical churn.

### How to test the changes in this Pull Request

1. Check out the branch and run `pnpm install` at the workspace root.
2. `cd plugins/newspack-network && pnpm run lint:js` — exits 0 (the new `.prettierrc.js` is now enforced and the reformatted files pass).
3. `cd packages/scripts && pnpm run lint:js` — exits 0 (the previously-shadowed `.prettierrc.js` is now active).
4. `cd plugins/republication-tracker-tool && pnpm run lint:js` — exits 0 (now under the newspack ESLint + canonical Prettier config).
5. Confirm no `.prettierrc.js` in the tree still uses the old hardcoded `./node_modules/...` path.

### Other information

- Local validation: `newspack-network`, `newspack-scripts`, and `republication-tracker-tool` `lint:js` all exit 0; `prettier --check` is clean on each. Engine resolves to `wp-prettier@3.0.3`.
- After this PR, every package with a `lint:js` script has both a `.eslintrc.js` and a `.prettierrc.js` pinned to the shared newspack config — no linted package is left on wp-scripts/WP defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
