### PR TITLE
chore(n): harden global watch dispatcher and fix env path remap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,12 +160,12 @@ dispatcher that watches source files across `plugins/`, `themes/` and
 unit, that unit's own incremental watcher (`wp-scripts start`) is started and
 owns its rebuilds from then on — so only units you actually touch get a watcher,
 never all of them at once. Units without a `watch` script fall back to a one-off
-`build` per change; units with neither are skipped.
+`build` when files under their `src/` change; units with neither are skipped.
 
 When you're iterating hard on a single project, prefer `n watch <name>` (or
 `n watch` from inside it): the warm webpack watcher rebuilds incrementally in
 well under a second, whereas the global watch pays a fresh build the first time
-it sees each unit.
+it sees a unit that has no incremental `watch` script.
 
 ### WordPress CLI
 ```bash

--- a/bin/watch-all.mjs
+++ b/bin/watch-all.mjs
@@ -94,17 +94,25 @@ function spawnWarmWatcher( unit ) {
 	warmChildren.set( unit.key, child );
 	prefixStream( child.stdout, unit.name );
 	prefixStream( child.stderr, unit.name );
+	// Disarm only if this exact child is still the unit's tracked watcher, so a
+	// late event from a replaced child can't delete a freshly re-armed one. Both
+	// handlers may run for the same child (Node doesn't guarantee 'error' and
+	// 'exit' are exclusive); the identity check makes that idempotent.
+	const disarm = () => {
+		if ( warmChildren.get( unit.key ) === child ) {
+			warmChildren.delete( unit.key );
+			unitState.delete( unit.key ); // allow a fresh spawn on next change.
+		}
+	};
 	// Without an 'error' listener a failed spawn (ENOENT/EACCES) throws as an
 	// unhandled exception and takes the whole dispatcher down.
 	child.on( 'error', ( error ) => {
 		log( `${ unit.name }: failed to start watcher (${ error.message }); will re-arm on next change` );
-		warmChildren.delete( unit.key );
-		unitState.delete( unit.key );
+		disarm();
 	} );
 	child.on( 'exit', ( code ) => {
 		log( `${ unit.name }: watcher exited (code ${ code }); will re-arm on next change` );
-		warmChildren.delete( unit.key );
-		unitState.delete( unit.key ); // allow a fresh spawn if it died.
+		disarm();
 	} );
 }
 
@@ -133,17 +141,29 @@ function drainBuildQueue() {
 	}
 	building = true;
 	log( `${ unit.name }: building (one-shot)` );
+	// detached so the child leads its own process group; killing -pid on
+	// shutdown takes down pnpm and the build tooling it spawns together.
 	const child = spawn(
 		'pnpm',
 		[ '--filter', unit.filter, 'run', '--if-present', 'build' ],
-		{ cwd: ROOT, stdio: 'inherit' }
+		{ cwd: ROOT, stdio: 'inherit', detached: true }
 	);
 	activeBuild = child;
 	// Release the queue whether the build finishes or fails to spawn; without
 	// the 'error' handler a spawn failure would leave `building` stuck true and
-	// silently wedge every later one-shot build.
+	// silently wedge every later one-shot build. Guard against running twice:
+	// Node does not guarantee 'error' and 'exit' are mutually exclusive, and a
+	// double release would null a *later* build's activeBuild and start a second
+	// concurrent build, breaking the one-build-at-a-time invariant.
+	let released = false;
 	const release = () => {
-		activeBuild = null;
+		if ( released ) {
+			return;
+		}
+		released = true;
+		if ( activeBuild === child ) {
+			activeBuild = null;
+		}
 		building = false;
 		drainBuildQueue();
 	};
@@ -208,7 +228,8 @@ function shutdown() {
 	debounceTimers.clear();
 	for ( const child of warmChildren.values() ) {
 		try {
-			// Guard against an undefined pid from a synchronous spawn failure.
+			// Guard against an undefined pid when spawn failed before a child
+			// process existed (e.g. ENOENT).
 			if ( child.pid ) {
 				process.kill( -child.pid, 'SIGTERM' );
 			}
@@ -216,12 +237,13 @@ function shutdown() {
 			// Child already gone -- nothing to clean up.
 		}
 	}
-	// The in-flight one-shot build inherits our stdio and isn't detached, so a
-	// terminal Ctrl-C reaches it already; signal it directly too for the
-	// programmatic SIGTERM path so it doesn't outlive the dispatcher.
+	// Kill the in-flight one-shot build's process group too. Like the warm
+	// watchers it is spawned detached, so -pid takes down pnpm and the build
+	// tooling it spawns together (a direct kill would leave those descendants
+	// orphaned on the programmatic SIGTERM path).
 	if ( activeBuild && activeBuild.pid ) {
 		try {
-			activeBuild.kill( 'SIGTERM' );
+			process.kill( -activeBuild.pid, 'SIGTERM' );
 		} catch {
 			// Already exited -- nothing to clean up.
 		}

--- a/bin/watch-all.mjs
+++ b/bin/watch-all.mjs
@@ -27,8 +27,11 @@ import path from 'node:path';
 const ROOT = process.cwd();
 const AREAS = [ 'plugins', 'themes', 'packages' ];
 // Source files worth reacting to. PHP is interpreted (no build step) and is
-// served live off the bind mount, so it is intentionally excluded.
-const BUILD_RELEVANT = /\.(jsx?|tsx?|scss|css)$/;
+// served live off the bind mount, so it is intentionally excluded. block.json
+// is included: it is imported by block entrypoints (`import metadata from
+// './block.json'`) and is a real webpack input, so a cold unit whose first edit
+// is block metadata must still start its watcher.
+const BUILD_RELEVANT = /\.(jsx?|tsx?|scss|css)$|(^|\/)block\.json$/;
 // Directories never worth watching: VCS, dependencies and build outputs.
 const IGNORED_DIR = /(^|\/)(node_modules|vendor|\.git|dist|build)(\/|$)/;
 const DEBOUNCE_MS = 300;
@@ -40,6 +43,10 @@ const warmChildren = new Map(); // unit key -> spawned `npm run watch` child.
 const debounceTimers = new Map(); // unit key -> pending one-shot timer.
 const buildQueue = []; // units awaiting a serialized one-shot build.
 let building = false;
+let activeBuild = null; // the in-flight one-shot build child, for shutdown.
+// One-shot units whose non-src change we've already explained, so the notice
+// (see onChange) is logged at most once per unit rather than on every edit.
+const oneShotNonSrcNoticed = new Set();
 
 function log( message ) {
 	process.stdout.write( `[watch-all] ${ message }\n` );
@@ -87,6 +94,13 @@ function spawnWarmWatcher( unit ) {
 	warmChildren.set( unit.key, child );
 	prefixStream( child.stdout, unit.name );
 	prefixStream( child.stderr, unit.name );
+	// Without an 'error' listener a failed spawn (ENOENT/EACCES) throws as an
+	// unhandled exception and takes the whole dispatcher down.
+	child.on( 'error', ( error ) => {
+		log( `${ unit.name }: failed to start watcher (${ error.message }); will re-arm on next change` );
+		warmChildren.delete( unit.key );
+		unitState.delete( unit.key );
+	} );
 	child.on( 'exit', ( code ) => {
 		log( `${ unit.name }: watcher exited (code ${ code }); will re-arm on next change` );
 		warmChildren.delete( unit.key );
@@ -124,10 +138,22 @@ function drainBuildQueue() {
 		[ '--filter', unit.filter, 'run', '--if-present', 'build' ],
 		{ cwd: ROOT, stdio: 'inherit' }
 	);
-	child.on( 'exit', ( code ) => {
-		log( `${ unit.name }: build ${ code === 0 ? 'done' : `failed (code ${ code })` }` );
+	activeBuild = child;
+	// Release the queue whether the build finishes or fails to spawn; without
+	// the 'error' handler a spawn failure would leave `building` stuck true and
+	// silently wedge every later one-shot build.
+	const release = () => {
+		activeBuild = null;
 		building = false;
 		drainBuildQueue();
+	};
+	child.on( 'error', ( error ) => {
+		log( `${ unit.name }: build failed to start (${ error.message })` );
+		release();
+	} );
+	child.on( 'exit', ( code ) => {
+		log( `${ unit.name }: build ${ code === 0 ? 'done' : `failed (code ${ code })` }` );
+		release();
 	} );
 }
 
@@ -160,8 +186,14 @@ function onChange( relPath ) {
 	// One-shot units have no incremental watcher to own their output, so a build
 	// that writes build-relevant files (e.g. copied .scss) would re-trigger
 	// itself endlessly. Gate on src/ -- build outputs land in dist/build/etc.,
-	// never in src/ -- so only genuine source edits drive a rebuild.
+	// never in src/ -- so only genuine source edits drive a rebuild. A one-shot
+	// unit whose sources live outside src/ (e.g. at the package root or in lib/)
+	// is unsupported by this gate; surface that once so it isn't silent.
 	if ( ! relPath.startsWith( `${ unit.key }/src/` ) ) {
+		if ( ! oneShotNonSrcNoticed.has( unit.key ) ) {
+			oneShotNonSrcNoticed.add( unit.key );
+			log( `${ unit.name }: ignoring change outside src/ (${ relPath }); one-shot builds only react to ${ unit.key }/src/` );
+		}
 		return;
 	}
 	scheduleOneShotBuild( unit );
@@ -169,11 +201,29 @@ function onChange( relPath ) {
 
 function shutdown() {
 	log( 'shutting down watchers' );
+	// Drop pending debounced builds so nothing new is spawned mid-shutdown.
+	for ( const timer of debounceTimers.values() ) {
+		clearTimeout( timer );
+	}
+	debounceTimers.clear();
 	for ( const child of warmChildren.values() ) {
 		try {
-			process.kill( -child.pid, 'SIGTERM' );
+			// Guard against an undefined pid from a synchronous spawn failure.
+			if ( child.pid ) {
+				process.kill( -child.pid, 'SIGTERM' );
+			}
 		} catch {
 			// Child already gone -- nothing to clean up.
+		}
+	}
+	// The in-flight one-shot build inherits our stdio and isn't detached, so a
+	// terminal Ctrl-C reaches it already; signal it directly too for the
+	// programmatic SIGTERM path so it doesn't outlive the dispatcher.
+	if ( activeBuild && activeBuild.pid ) {
+		try {
+			activeBuild.kill( 'SIGTERM' );
+		} catch {
+			// Already exited -- nothing to clean up.
 		}
 	}
 	process.exit( 0 );

--- a/bin/watch-repo.sh
+++ b/bin/watch-repo.sh
@@ -17,10 +17,12 @@ fi
 
 PROJECT_DIR=$(find_project "$1")
 
-# Run from the monorepo mount. pnpm links workspace deps with relative symlinks
-# (e.g. node_modules/newspack-scripts -> ../../../packages/scripts) that only
-# resolve under /newspack-monorepo; the standalone /newspack-{plugins,themes}
-# mounts make those symlinks escape their root, breaking the watch toolchain.
+# Run from the monorepo mount. For workspace plugins/themes, pnpm links deps with
+# relative symlinks (e.g. node_modules/newspack-scripts -> ../../../packages/scripts)
+# that only resolve under /newspack-monorepo; the standalone /newspack-{plugins,themes}
+# mounts make those symlinks escape their root, breaking the watch toolchain. The
+# /newspack-repos remap is just path-normalization parity -- standalone repos/
+# checkouts live outside the pnpm workspace and build with their own toolchain.
 #
 # Only adopt the remap when it points at the SAME directory. In the main
 # container /newspack-plugins/<name> and /newspack-monorepo/plugins/<name> are

--- a/bin/watch-repo.sh
+++ b/bin/watch-repo.sh
@@ -21,9 +21,20 @@ PROJECT_DIR=$(find_project "$1")
 # (e.g. node_modules/newspack-scripts -> ../../../packages/scripts) that only
 # resolve under /newspack-monorepo; the standalone /newspack-{plugins,themes}
 # mounts make those symlinks escape their root, breaking the watch toolchain.
-PROJECT_DIR="${PROJECT_DIR/#\/newspack-plugins//newspack-monorepo/plugins}"
-PROJECT_DIR="${PROJECT_DIR/#\/newspack-themes//newspack-monorepo/themes}"
-PROJECT_DIR="${PROJECT_DIR/#\/newspack-repos//newspack-monorepo/repos}"
+#
+# Only adopt the remap when it points at the SAME directory. In the main
+# container /newspack-plugins/<name> and /newspack-monorepo/plugins/<name> are
+# the same mount, so the remap is a safe prefix swap. In an isolated env a
+# worktree override is mounted at /newspack-plugins/<name> while
+# /newspack-monorepo/plugins/<name> is the base checkout -- remapping there would
+# silently watch the wrong branch, so the -ef guard keeps the worktree mount.
+remapped="$PROJECT_DIR"
+remapped="${remapped/#\/newspack-plugins//newspack-monorepo/plugins}"
+remapped="${remapped/#\/newspack-themes//newspack-monorepo/themes}"
+remapped="${remapped/#\/newspack-repos//newspack-monorepo/repos}"
+if [ "$remapped" != "$PROJECT_DIR" ] && [ "$remapped" -ef "$PROJECT_DIR" ]; then
+	PROJECT_DIR="$remapped"
+fi
 
 cd "$PROJECT_DIR"
 npm run watch

--- a/n
+++ b/n
@@ -398,7 +398,9 @@ case $1 in
         fi
         if [[ -z "$target_folder" ]]; then
             # No project: watch every unit from the monorepo root, spawning each
-            # unit's own watcher lazily on its first edit.
+            # unit's own watcher lazily on its first edit. Note this also covers
+            # running `n watch` from a non-project dir (e.g. additional-sites-html/
+            # or manager-html/), where cwd detection yields no target_folder.
             docker exec $DOCKER_IT $USER_COMMAND $TARGET_CONTAINER sh -c "/var/scripts/watch-all.sh"
         else
             # Run the script directly (no `sh -c`) and quote the folder so a


### PR DESCRIPTION
## Summary

Addresses the code-review feedback on #188. **Base is `feat/global-watch`**, so this is a stacked PR — review/merge it into #188's branch (it'll fold into #188 before that lands on `main`). All changes are dev-tooling (`n`, `bin/`, `AGENTS.md`); no plugin/runtime code.

## Changes (mapped to review findings)

**🔴 should-fix**
- **B1 — env path remap watched the wrong branch.** `bin/watch-repo.sh` unconditionally rewrote `/newspack-plugins/<name>` → `/newspack-monorepo/plugins/<name>`. In an isolated env that's the *base* checkout, not the mounted worktree override, so `n watch <name>` there silently rebuilt `main`. Now each remap is guarded with an `-ef` (same-inode) check: it fires in the main container (same dir) and for non-overridden plugins in an env, but is skipped for a worktree override (different dir), preserving the correct branch.

**🟡 suggestions**
- **S1 — spawn `error` handlers.** Both the warm watcher (`npm run watch`) and the one-shot build (`pnpm … build`) now have `child.on('error', …)`. Previously a failed spawn (ENOENT/EACCES) threw as an unhandled exception (warm) or left `building` stuck `true` and wedged the one-shot queue (one-shot).
- **S2 — `block.json` watched.** `BUILD_RELEVANT` now matches `block.json` (imported by block entrypoints, a real webpack input), so a cold unit whose first edit is block metadata still starts its watcher.
- **S3 — shutdown cleanup.** `shutdown()` now clears pending debounce timers and terminates the in-flight one-shot build, not just the warm watchers.
- **S4 — docs.** `AGENTS.md` corrected: one-shot units rebuild on `src/` changes (not "per change"), and the cold-build cost applies only to units without a `watch` script (not "each unit").

**⚪️ nits**
- **N1 — `process.kill(-child.pid)`** guarded against an undefined pid.
- **N2 —** comment noting `n watch` from a non-project dir (`additional-sites-html/`, `manager-html/`) falls through to the global watch.
- **N3 —** one-shot units whose change is outside `src/` now log a one-time notice instead of being silently ignored.

The `_navigation.scss` "scope creep" flagged in review was a false positive (already in `main` via #164); nothing to do.

## Verification

- `node --check bin/watch-all.mjs`, `bash -n` on `n`, `bin/watch-repo.sh`, `bin/watch-all.sh` — all clean.
- **B1** reproduced and fixed live in a throwaway isolated env with a worktree override: the old remap resolved to the base (wrong branch); the `-ef`-guarded version resolves to the worktree, while a non-overridden plugin still gets the remap.
- **Functional smoke test** of the dispatcher against a fixture with stubbed `npm`/`pnpm`: warm cold-start, **`block.json` cold-start**, one-shot build + completion, skip-unit notice, one-time non-`src/` notice (logged exactly once), and **deterministic shutdown** (both warm watcher process groups killed, no leaked processes; dispatcher exits cleanly on SIGINT).
- `block.json` regex checked against positive/negative cases (matches `block.json`, not `package.json`/`composer.json`/`block.json.bak`).

## Out of scope (flagged, not fixed)

- chokidar occasionally emits its `ready` event twice, so the startup banner can print twice. Verified this is **pre-existing on `feat/global-watch`** (identical behavior base vs. this branch) and timing-dependent — likely the array-of-paths + `awaitWriteFinish` combo. Left untouched since it wasn't part of the review and the root cause needs its own look.
- Fully *running* `n watch` for a worktree-overridden plugin inside an env still won't work — that worktree's pnpm symlinks escape the single-subdir mount. The B1 guard just turns the silent wrong-branch build into a correct build / honest failure; full support is a separate enhancement.
