### PR TITLE
fix(integrations): skip unconfigured + dedupe health-check alerts

### DIFF
--- a/plugins/newspack-plugin/includes/class-alert-manager.php
+++ b/plugins/newspack-plugin/includes/class-alert-manager.php
@@ -34,8 +34,11 @@ class Alert_Manager {
 	/**
 	 * Window during which a repeating health-check failure for the same
 	 * integration + error-code signature emits at most one Slack alert.
+	 *
+	 * Private because no external caller needs to read it; keeping the
+	 * surface minimal lets the value evolve without breaking consumers.
 	 */
-	const HEALTH_CHECK_DEDUP_INTERVAL = DAY_IN_SECONDS;
+	private const HEALTH_CHECK_DEDUP_INTERVAL = DAY_IN_SECONDS;
 
 	/**
 	 * Default pattern rules.
@@ -465,6 +468,21 @@ class Alert_Manager {
 	 * the same Slack alert all day. A new error code OR a changed message
 	 * on the same integration (e.g. "list missing" escalating to "auth
 	 * fully revoked") falls outside the key and alerts immediately.
+	 *
+	 * Known boundaries of the dedup contract:
+	 * - Message text is part of the key, so locale shifts between cron
+	 *   passes (e.g. `switch_to_locale()` in a multilingual context) can
+	 *   produce a different key for the same underlying error and
+	 *   re-alert. Newspack ESP error messages are static per code today,
+	 *   so this is theoretical; revisit if dynamic content lands in
+	 *   error strings.
+	 * - The dedup key is stored as a transient, so on hosts backed by a
+	 *   persistent object cache (memcached) the entry can be evicted
+	 *   under LRU pressure before HEALTH_CHECK_DEDUP_INTERVAL elapses.
+	 *   The failure mode is re-alerting on the next hourly cron — the
+	 *   alternative (writing to the options table on every cron tick)
+	 *   has its own cost; transient + accepted re-alert risk is the
+	 *   intentional trade-off here.
 	 *
 	 * @param array $payload Health check failure data.
 	 */

--- a/plugins/newspack-plugin/includes/class-alert-manager.php
+++ b/plugins/newspack-plugin/includes/class-alert-manager.php
@@ -32,6 +32,12 @@ class Alert_Manager {
 	const FAILURE_LOG_OPTION = 'newspack_alert_failure_log';
 
 	/**
+	 * Window during which a repeating health-check failure for the same
+	 * integration + error-code signature emits at most one Slack alert.
+	 */
+	const HEALTH_CHECK_DEDUP_INTERVAL = DAY_IN_SECONDS;
+
+	/**
 	 * Default pattern rules.
 	 * Each rule defines a grouping dimension, threshold, and time interval.
 	 */
@@ -454,10 +460,23 @@ class Alert_Manager {
 	/**
 	 * Handle integration health check failure.
 	 *
+	 * Deduplicates by integration + error-code signature for
+	 * HEALTH_CHECK_DEDUP_INTERVAL so an hourly cron does not repeat the
+	 * same Slack alert all day. A new error-code set on the same
+	 * integration falls outside the key and alerts immediately.
+	 *
 	 * @param array $payload Health check failure data.
 	 */
 	public static function handle_health_check_failed( $payload ) {
-		$error   = $payload['error'] ?? null;
+		$error          = $payload['error'] ?? null;
+		$integration_id = $payload['integration_id'] ?? 'unknown';
+		$error_codes    = is_wp_error( $error ) ? $error->get_error_codes() : [ 'unknown' ];
+
+		$dedup_key = self::get_health_check_dedup_key( $integration_id, $error_codes );
+		if ( get_transient( $dedup_key ) ) {
+			return;
+		}
+
 		$message = sprintf(
 			'Integration "%s" health check failed: %s',
 			$payload['integration_name'] ?? 'unknown',
@@ -475,6 +494,22 @@ class Alert_Manager {
 				'timestamp' => time(),
 			]
 		);
+
+		set_transient( $dedup_key, time(), self::HEALTH_CHECK_DEDUP_INTERVAL );
+	}
+
+	/**
+	 * Get the deduplication transient key for a health-check failure.
+	 *
+	 * @param string   $integration_id The integration identifier.
+	 * @param string[] $error_codes    The WP_Error codes from the failure.
+	 *
+	 * @return string Transient key.
+	 */
+	private static function get_health_check_dedup_key( $integration_id, $error_codes ) {
+		$codes = array_map( 'strval', $error_codes );
+		sort( $codes );
+		return 'newspack_alert_hc_' . md5( $integration_id . ':' . implode( ',', $codes ) );
 	}
 }
 Alert_Manager::init();

--- a/plugins/newspack-plugin/includes/class-alert-manager.php
+++ b/plugins/newspack-plugin/includes/class-alert-manager.php
@@ -460,10 +460,11 @@ class Alert_Manager {
 	/**
 	 * Handle integration health check failure.
 	 *
-	 * Deduplicates by integration + error-code signature for
-	 * HEALTH_CHECK_DEDUP_INTERVAL so an hourly cron does not repeat the
-	 * same Slack alert all day. A new error-code set on the same
-	 * integration falls outside the key and alerts immediately.
+	 * Deduplicates by integration + error-code + error-message signature
+	 * for HEALTH_CHECK_DEDUP_INTERVAL so an hourly cron does not repeat
+	 * the same Slack alert all day. A new error code OR a changed message
+	 * on the same integration (e.g. "list missing" escalating to "auth
+	 * fully revoked") falls outside the key and alerts immediately.
 	 *
 	 * @param array $payload Health check failure data.
 	 */
@@ -474,16 +475,22 @@ class Alert_Manager {
 		if ( empty( $error_codes ) ) {
 			$error_codes = [ 'unknown' ];
 		}
+		$error_messages = is_wp_error( $error ) ? $error->get_error_messages() : [];
 
-		$dedup_key = self::get_health_check_dedup_key( $integration_id, $error_codes );
+		$dedup_key = self::get_health_check_dedup_key( $integration_id, $error_codes, $error_messages );
 		if ( get_transient( $dedup_key ) ) {
 			return;
 		}
 
+		// Set the dedup transient BEFORE dispatch so a `newspack_alert`
+		// handler that throws (e.g. transient Slack POST failure) cannot
+		// defeat dedup by leaving the key unset for the next hourly cron.
+		set_transient( $dedup_key, time(), self::HEALTH_CHECK_DEDUP_INTERVAL );
+
 		$message = sprintf(
 			'Integration "%s" health check failed: %s',
 			$payload['integration_name'] ?? 'unknown',
-			is_wp_error( $error ) ? implode( '; ', $error->get_error_messages() ) : 'unknown error'
+			is_wp_error( $error ) ? implode( '; ', $error_messages ) : 'unknown error'
 		);
 
 		/** This action is documented in includes/class-alert-manager.php */
@@ -497,8 +504,6 @@ class Alert_Manager {
 				'timestamp' => time(),
 			]
 		);
-
-		set_transient( $dedup_key, time(), self::HEALTH_CHECK_DEDUP_INTERVAL );
 	}
 
 	/**
@@ -506,13 +511,16 @@ class Alert_Manager {
 	 *
 	 * @param string   $integration_id The integration identifier.
 	 * @param string[] $error_codes    The WP_Error codes from the failure.
+	 * @param string[] $error_messages The WP_Error messages from the failure.
 	 *
 	 * @return string Transient key.
 	 */
-	private static function get_health_check_dedup_key( $integration_id, $error_codes ) {
+	private static function get_health_check_dedup_key( $integration_id, $error_codes, $error_messages = [] ) {
 		$codes = array_map( 'strval', $error_codes );
 		sort( $codes );
-		return 'newspack_alert_hc_' . md5( $integration_id . ':' . implode( ',', $codes ) );
+		$messages = array_map( 'strval', $error_messages );
+		sort( $messages );
+		return 'newspack_alert_hc_' . md5( $integration_id . ':' . implode( ',', $codes ) . ':' . implode( '|', $messages ) );
 	}
 }
 Alert_Manager::init();

--- a/plugins/newspack-plugin/includes/class-alert-manager.php
+++ b/plugins/newspack-plugin/includes/class-alert-manager.php
@@ -470,7 +470,10 @@ class Alert_Manager {
 	public static function handle_health_check_failed( $payload ) {
 		$error          = $payload['error'] ?? null;
 		$integration_id = $payload['integration_id'] ?? 'unknown';
-		$error_codes    = is_wp_error( $error ) ? $error->get_error_codes() : [ 'unknown' ];
+		$error_codes    = is_wp_error( $error ) ? $error->get_error_codes() : [];
+		if ( empty( $error_codes ) ) {
+			$error_codes = [ 'unknown' ];
+		}
 
 		$dedup_key = self::get_health_check_dedup_key( $integration_id, $error_codes );
 		if ( get_transient( $dedup_key ) ) {

--- a/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
@@ -744,11 +744,19 @@ class Integrations {
 	/**
 	 * Run health checks on all active integrations.
 	 *
+	 * Skips integrations that report themselves as not yet set up — a missing
+	 * provider or unconfigured master list is a setup-incomplete state, not a
+	 * runtime incident, and should surface in the integrations UI rather than
+	 * the alerts channel.
+	 *
 	 * Logs failures and fires an action for the Alert Manager.
 	 */
 	public static function run_health_checks() {
 		$active = self::get_active_integrations();
 		foreach ( $active as $integration ) {
+			if ( ! $integration->is_set_up() ) {
+				continue;
+			}
 			$result = $integration->health_check();
 			if ( is_wp_error( $result ) ) {
 				Logger::error(

--- a/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
@@ -365,6 +365,29 @@ class Integrations {
 	}
 
 	/**
+	 * Get active integrations whose external prerequisites are also configured.
+	 *
+	 * Iteration sites that perform real I/O on each integration (health checks,
+	 * contact pushes, pulls, retries) MUST use this instead of
+	 * `get_active_integrations()` to avoid alerting on, or scheduling AS
+	 * retries for, integrations the admin has not yet finished setting up.
+	 *
+	 * `is_set_up()` is a stored-state check by contract — see ESP's override.
+	 * Treating it as a runtime probe here would silently drop traffic on
+	 * transient provider failures.
+	 *
+	 * @return Integration[] Integrations that are both enabled AND set up.
+	 */
+	public static function get_active_configured_integrations() {
+		return array_filter(
+			self::get_active_integrations(),
+			function ( $integration ) {
+				return $integration->is_set_up();
+			}
+		);
+	}
+
+	/**
 	 * Get a specific integration by ID.
 	 *
 	 * @param string $integration_id The integration ID.
@@ -742,21 +765,17 @@ class Integrations {
 	}
 
 	/**
-	 * Run health checks on all active integrations.
+	 * Run health checks on all active and configured integrations.
 	 *
-	 * Skips integrations that report themselves as not yet set up — a missing
-	 * provider or unconfigured master list is a setup-incomplete state, not a
-	 * runtime incident, and should surface in the integrations UI rather than
-	 * the alerts channel.
+	 * Routed through `get_active_configured_integrations()` so a missing
+	 * provider or unconfigured master list — a setup-incomplete state, not a
+	 * runtime incident — surfaces in the integrations UI rather than the
+	 * alerts channel.
 	 *
 	 * Logs failures and fires an action for the Alert Manager.
 	 */
 	public static function run_health_checks() {
-		$active = self::get_active_integrations();
-		foreach ( $active as $integration ) {
-			if ( ! $integration->is_set_up() ) {
-				continue;
-			}
+		foreach ( self::get_active_configured_integrations() as $integration ) {
 			$result = $integration->health_check();
 			if ( is_wp_error( $result ) ) {
 				Logger::error(

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
@@ -162,6 +162,9 @@ class Contact_Pull {
 		$errors              = [];
 
 		foreach ( $active_integrations as $integration ) {
+			if ( ! $integration->is_set_up() ) {
+				continue;
+			}
 			$selected_fields = $integration->get_enabled_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
@@ -415,6 +418,11 @@ class Contact_Pull {
 		$integration = Integrations::get_integration( $integration_id );
 		if ( ! $integration || ! Integrations::is_enabled( $integration_id ) ) {
 			Logger::log( sprintf( 'Integration "%s" not found or not enabled on pull retry %d.', $integration_id, $retry_count ), self::LOGGER_HEADER, 'error' );
+			return;
+		}
+
+		if ( ! $integration->is_set_up() ) {
+			Logger::log( sprintf( 'Integration "%s" no longer set up on pull retry %d; aborting retry chain.', $integration_id, $retry_count ), self::LOGGER_HEADER );
 			return;
 		}
 

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
@@ -121,7 +121,7 @@ class Contact_Pull {
 	 */
 	public static function pull_sync( $integrations = [] ) {
 		if ( empty( $integrations ) ) {
-			$integrations = Integrations::get_active_integrations();
+			$integrations = Integrations::get_active_configured_integrations();
 		}
 
 		Logger::log( 'Synchronous pull started for user "' . get_current_user_id() . '".', self::LOGGER_HEADER );
@@ -223,6 +223,14 @@ class Contact_Pull {
 		$integration = Integrations::get_integration( $integration_id );
 		if ( ! $integration || ! Integrations::is_enabled( $integration_id ) ) {
 			wp_send_json_error( 'Integration not found or not enabled.', 404 );
+		}
+
+		// Defense-in-depth: pull_sync already filters to set-up integrations,
+		// but a direct AJAX call could still arrive here for an unconfigured
+		// integration. Skip silently with success — "not set up" is a no-op,
+		// not an error worth surfacing to the loopback caller.
+		if ( ! $integration->is_set_up() ) {
+			wp_send_json_success();
 		}
 
 		$user_id = get_current_user_id();

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
@@ -158,13 +158,10 @@ class Contact_Pull {
 	 * @return true|\WP_Error True if all succeeded, WP_Error with combined messages.
 	 */
 	public static function pull_all( $user_id ) {
-		$active_integrations = Integrations::get_active_integrations();
+		$active_integrations = Integrations::get_active_configured_integrations();
 		$errors              = [];
 
 		foreach ( $active_integrations as $integration ) {
-			if ( ! $integration->is_set_up() ) {
-				continue;
-			}
 			$selected_fields = $integration->get_enabled_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-esp.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-esp.php
@@ -37,14 +37,28 @@ class ESP extends Integration {
 	/**
 	 * Whether the ESP integration is ready to sync.
 	 *
-	 * Mirrors the readiness gate used by get_settings_config() so the configure
-	 * UI never advertises a card as set up while the underlying settings call
-	 * short-circuits to an empty config.
+	 * Checks STORED configuration only — provider option set + master list
+	 * option set. Does NOT call the live provider API. A live `get_lists()`
+	 * call here would mean: every gate that consults `is_set_up()`
+	 * (`Integrations::get_active_configured_integrations()`, the retry-time
+	 * guards in `Contact_Sync` / `Contact_Pull`) would silently skip and
+	 * lose data on any transient provider failure — exactly the failure
+	 * mode the AS retry system was built to survive. The setup question
+	 * "did the admin finish configuring this?" must be answered from local
+	 * state; "is the provider reachable right now?" is `health_check()`'s
+	 * job.
 	 *
-	 * @return bool True if an ESP provider is selected and at least one list is active.
+	 * @return bool True if a provider is selected and a master list ID is stored.
 	 */
 	public function is_set_up() {
-		return Reader_Activation::is_esp_configured();
+		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
+		if ( ! $newsletters_configuration_manager || is_wp_error( $newsletters_configuration_manager ) ) {
+			return false;
+		}
+		if ( ! $newsletters_configuration_manager->is_esp_set_up() ) {
+			return false;
+		}
+		return (bool) $this->get_master_list_id();
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -162,7 +162,7 @@ class Contact_Sync extends Sync {
 		 * @param string $context The context of the sync.
 		 */
 		$contact = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
-		$integrations = Integrations::get_active_integrations();
+		$integrations = Integrations::get_active_configured_integrations();
 		$errors       = [];
 
 		// Resolve user ID for retry scheduling.
@@ -177,9 +177,6 @@ class Contact_Sync extends Sync {
 		}
 
 		foreach ( $integrations as $integration_id => $integration ) {
-			if ( ! $integration->is_set_up() ) {
-				continue;
-			}
 			$integration_contact = $integration->prepare_contact( $contact );
 
 			// Added logging here to more easily monitor integration sync data. Can be removed once integrations are released.

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -177,6 +177,9 @@ class Contact_Sync extends Sync {
 		}
 
 		foreach ( $integrations as $integration_id => $integration ) {
+			if ( ! $integration->is_set_up() ) {
+				continue;
+			}
 			$integration_contact = $integration->prepare_contact( $contact );
 
 			// Added logging here to more easily monitor integration sync data. Can be removed once integrations are released.
@@ -369,6 +372,11 @@ class Contact_Sync extends Sync {
 		$integration = Integrations::get_integration( $integration_id );
 		if ( ! $integration ) {
 			Logger::log( sprintf( 'Integration "%s" not found on retry %d.', $integration_id, $retry_count ), 'NEWSPACK-SYNC', 'error' );
+			return;
+		}
+
+		if ( ! $integration->is_set_up() ) {
+			static::log( sprintf( 'Integration "%s" no longer set up on retry %d; aborting retry chain.', $integration_id, $retry_count ) );
 			return;
 		}
 

--- a/plugins/newspack-plugin/tests/mocks/newsletters-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/newsletters-mocks.php
@@ -67,6 +67,19 @@ if ( ! class_exists( 'Newspack_Newsletters' ) ) {
 	class Newspack_Newsletters {
 		const EMAIL_HTML_META = 'newspack_email_html';
 
+		/**
+		 * Default return value of is_service_provider_configured(). Tests that
+		 * exercise the "provider not selected" branch can flip this to false
+		 * via reset_calls() / direct assignment, then restore it.
+		 *
+		 * @var bool
+		 */
+		public static $is_service_provider_configured = true;
+
+		public static function reset_calls() {
+			self::$is_service_provider_configured = true;
+		}
+
 		public static function service_provider() {
 			return get_option( 'newspack_newsletters_service_provider', false );
 		}
@@ -76,7 +89,7 @@ if ( ! class_exists( 'Newspack_Newsletters' ) ) {
 		}
 
 		public static function is_service_provider_configured() {
-			return true;
+			return self::$is_service_provider_configured;
 		}
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/alert-manager.php
+++ b/plugins/newspack-plugin/tests/unit-tests/alert-manager.php
@@ -759,4 +759,74 @@ class Newspack_Test_Alert_Manager extends WP_UnitTestCase {
 
 		$this->assertEquals( 2, $fire_count, 'Distinct integration IDs should each alert independently.' );
 	}
+
+	/**
+	 * Test that a same-code but escalated-message failure fires a fresh alert.
+	 *
+	 * The dedup key folds in `WP_Error::get_error_messages()` so an escalating
+	 * failure that retains the same code(s) but carries a worse message
+	 * (e.g. "list missing" → "auth fully revoked") still reaches Slack
+	 * instead of being suppressed for the full HEALTH_CHECK_DEDUP_INTERVAL.
+	 */
+	public function test_health_check_failed_alerts_on_new_error_messages() {
+		$fire_count = 0;
+		add_action(
+			'newspack_alert',
+			function ( $data ) use ( &$fire_count ) {
+				if ( 'integration_health_check_failed' === ( $data['type'] ?? '' ) ) {
+					$fire_count++;
+				}
+			}
+		);
+
+		$first  = [
+			'integration_id'   => 'dedup-msg',
+			'integration_name' => 'Mock dedup-msg',
+			'error'            => new \WP_Error( 'connection_failed', 'Provider returned 401: list missing.' ),
+		];
+		$second = [
+			'integration_id'   => 'dedup-msg',
+			'integration_name' => 'Mock dedup-msg',
+			'error'            => new \WP_Error( 'connection_failed', 'Provider returned 401: auth fully revoked.' ),
+		];
+
+		do_action( 'newspack_integration_health_check_failed', $first );
+		do_action( 'newspack_integration_health_check_failed', $first );
+		do_action( 'newspack_integration_health_check_failed', $second );
+
+		$this->assertEquals( 2, $fire_count, 'A same-code, changed-message failure should bypass the dedup.' );
+	}
+
+	/**
+	 * Test that the dedup transient is set BEFORE dispatching `newspack_alert`
+	 * so a handler that throws cannot leave the key unset and defeat dedup
+	 * on the next hourly cron.
+	 */
+	public function test_health_check_failed_sets_dedup_before_dispatch() {
+		$listener = function () {
+			throw new \RuntimeException( 'Simulated handler failure.' );
+		};
+		add_action( 'newspack_alert', $listener );
+
+		$payload = $this->make_health_check_payload( 'dedup-pre', [ 'master_list_missing' ] );
+
+		try {
+			try {
+				do_action( 'newspack_integration_health_check_failed', $payload );
+			} catch ( \RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Expected — handler is intentionally throwing.
+			}
+
+			// Reflect the dedup-key contract — the transient must exist even
+			// though dispatch threw.
+			$reflection = new \ReflectionMethod( Alert_Manager::class, 'get_health_check_dedup_key' );
+			$reflection->setAccessible( true );
+			$key = $reflection->invoke( null, 'dedup-pre', [ 'master_list_missing' ], [ 'Mock: master_list_missing' ] );
+
+			$this->assertNotFalse( get_transient( $key ), 'Dedup transient must be set even when alert handler throws.' );
+		} finally {
+			remove_action( 'newspack_alert', $listener );
+			delete_transient( $key ?? '' );
+		}
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/alert-manager.php
+++ b/plugins/newspack-plugin/tests/unit-tests/alert-manager.php
@@ -657,4 +657,106 @@ class Newspack_Test_Alert_Manager extends WP_UnitTestCase {
 			'Pattern scan cron event should be scheduled.'
 		);
 	}
+
+	/**
+	 * Helper: build a health-check failure payload with the given codes.
+	 *
+	 * @param string   $integration_id Integration ID.
+	 * @param string[] $codes          WP_Error codes to attach.
+	 * @return array
+	 */
+	private function make_health_check_payload( $integration_id, array $codes ) {
+		$error = new \WP_Error();
+		foreach ( $codes as $code ) {
+			$error->add( $code, sprintf( 'Mock: %s', $code ) );
+		}
+		return [
+			'integration_id'   => $integration_id,
+			'integration_name' => 'Mock ' . $integration_id,
+			'error'            => $error,
+		];
+	}
+
+	/**
+	 * Test that a repeated health-check failure with the same integration +
+	 * error codes only triggers one Slack-bound newspack_alert within the
+	 * dedup interval.
+	 */
+	public function test_health_check_failed_dedupes_repeated_fires() {
+		$fire_count = 0;
+		add_action(
+			'newspack_alert',
+			function ( $data ) use ( &$fire_count ) {
+				if ( 'integration_health_check_failed' === ( $data['type'] ?? '' ) ) {
+					$fire_count++;
+				}
+			}
+		);
+
+		$payload = $this->make_health_check_payload( 'dedup-a', [ 'master_list_missing' ] );
+
+		do_action( 'newspack_integration_health_check_failed', $payload );
+		do_action( 'newspack_integration_health_check_failed', $payload );
+		do_action( 'newspack_integration_health_check_failed', $payload );
+
+		$this->assertEquals( 1, $fire_count, 'Identical health-check failures should dedupe to a single alert.' );
+	}
+
+	/**
+	 * Test that a different error-code set on the same integration fires a
+	 * fresh alert — the dedup is per signature, not per integration.
+	 */
+	public function test_health_check_failed_alerts_on_new_error_codes() {
+		$fire_count = 0;
+		add_action(
+			'newspack_alert',
+			function ( $data ) use ( &$fire_count ) {
+				if ( 'integration_health_check_failed' === ( $data['type'] ?? '' ) ) {
+					$fire_count++;
+				}
+			}
+		);
+
+		do_action(
+			'newspack_integration_health_check_failed',
+			$this->make_health_check_payload( 'dedup-b', [ 'master_list_missing' ] )
+		);
+		do_action(
+			'newspack_integration_health_check_failed',
+			$this->make_health_check_payload( 'dedup-b', [ 'master_list_missing' ] )
+		);
+		do_action(
+			'newspack_integration_health_check_failed',
+			$this->make_health_check_payload( 'dedup-b', [ 'connection_failed' ] )
+		);
+
+		$this->assertEquals( 2, $fire_count, 'A new error-code set on the same integration should bypass the dedup.' );
+	}
+
+	/**
+	 * Test that two distinct integrations alert independently even if they
+	 * fail with the same error codes.
+	 */
+	public function test_health_check_failed_alerts_per_integration() {
+		$fire_count = 0;
+		add_action(
+			'newspack_alert',
+			function ( $data ) use ( &$fire_count ) {
+				if ( 'integration_health_check_failed' === ( $data['type'] ?? '' ) ) {
+					$fire_count++;
+				}
+			}
+		);
+
+		do_action(
+			'newspack_integration_health_check_failed',
+			$this->make_health_check_payload( 'dedup-c1', [ 'master_list_missing' ] )
+		);
+		do_action(
+			'newspack_integration_health_check_failed',
+			$this->make_health_check_payload( 'dedup-c2', [ 'master_list_missing' ] )
+		);
+
+		$this->assertEquals( 2, $fire_count, 'Distinct integration IDs should each alert independently.' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-failing-sample-integration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-failing-sample-integration.php
@@ -26,6 +26,21 @@ class Failing_Sample_Integration extends Integration {
 	public static $push_count = 0;
 
 	/**
+	 * Count of pull_contact_data calls.
+	 *
+	 * @var int
+	 */
+	public static $pull_count = 0;
+
+	/**
+	 * Value returned by is_set_up(). Tests that simulate an
+	 * enabled-but-unconfigured integration set this to false.
+	 *
+	 * @var bool
+	 */
+	public static $is_set_up_value = true;
+
+	/**
 	 * Register settings fields (test implementation).
 	 */
 	public function register_settings_fields() {
@@ -56,7 +71,17 @@ class Failing_Sample_Integration extends Integration {
 	 * @return array
 	 */
 	public function pull_contact_data( $user_id ) {
+		self::$pull_count++;
 		return [];
+	}
+
+	/**
+	 * Whether this integration's external prerequisites are configured.
+	 *
+	 * @return bool
+	 */
+	public function is_set_up() {
+		return self::$is_set_up_value;
 	}
 
 	/**
@@ -82,7 +107,9 @@ class Failing_Sample_Integration extends Integration {
 	 * Reset state between tests.
 	 */
 	public static function reset() {
-		self::$should_fail = false;
-		self::$push_count  = 0;
+		self::$should_fail     = false;
+		self::$push_count      = 0;
+		self::$pull_count      = 0;
+		self::$is_set_up_value = true;
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-sample-integration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-sample-integration.php
@@ -19,6 +19,22 @@ class Sample_Integration extends Integration {
 	public static $handler_args = null;
 
 	/**
+	 * Value returned by is_set_up(). Tests that simulate an
+	 * enabled-but-unconfigured integration set this to false.
+	 *
+	 * @var bool
+	 */
+	public static $is_set_up_value = true;
+
+	/**
+	 * Error codes can_sync() should add when $return_errors is true.
+	 * Tests use this to drive the health check into a failure path.
+	 *
+	 * @var string[]
+	 */
+	public static $can_sync_error_codes = [];
+
+	/**
 	 * Menu item declaration returned by get_my_account_menu_item().
 	 *
 	 * @var array|null
@@ -70,7 +86,23 @@ class Sample_Integration extends Integration {
 	 * @return bool|WP_Error True if contacts can be synced, false otherwise. WP_Error if return_errors is true.
 	 */
 	public function can_sync( $return_errors = false ) {
-		return $return_errors ? new \WP_Error() : true;
+		if ( ! $return_errors ) {
+			return empty( self::$can_sync_error_codes );
+		}
+		$errors = new \WP_Error();
+		foreach ( self::$can_sync_error_codes as $code ) {
+			$errors->add( $code, sprintf( 'Mock can_sync error: %s', $code ) );
+		}
+		return $errors;
+	}
+
+	/**
+	 * Whether this integration's external prerequisites are configured.
+	 *
+	 * @return bool
+	 */
+	public function is_set_up() {
+		return self::$is_set_up_value;
 	}
 
 	/**
@@ -102,7 +134,9 @@ class Sample_Integration extends Integration {
 	 * Reset captured state between tests.
 	 */
 	public static function reset() {
-		self::$handler_args = null;
+		self::$handler_args         = null;
+		self::$is_set_up_value      = true;
+		self::$can_sync_error_codes = [];
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -179,6 +179,32 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_active_configured_integrations filters by is_set_up too.
+	 *
+	 * This is the central skip site for the integration-walking paths
+	 * (health checks, sync push, pull). A regression here silently
+	 * re-introduces the alert/retry flood on unconfigured integrations.
+	 */
+	public function test_get_active_configured_integrations_filters_by_is_set_up() {
+		$configured   = new Sample_Integration( 'configured', 'Configured' );
+		$unconfigured = new class( 'unconfigured', 'Unconfigured' ) extends Sample_Integration {
+			public function is_set_up() {
+				return false;
+			}
+		};
+
+		Integrations::register( $configured );
+		Integrations::register( $unconfigured );
+		Integrations::enable( 'configured' );
+		Integrations::enable( 'unconfigured' );
+
+		$result = Integrations::get_active_configured_integrations();
+
+		$this->assertArrayHasKey( 'configured', $result, 'A set-up integration must be included.' );
+		$this->assertArrayNotHasKey( 'unconfigured', $result, 'An unconfigured integration must be excluded.' );
+	}
+
+	/**
 	 * Test get_available_integrations returns all registered.
 	 */
 	public function test_get_available_integrations() {

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -838,17 +838,18 @@ class Test_Integrations extends \WP_UnitTestCase {
 		Sample_Integration::$is_set_up_value      = false;
 		Sample_Integration::$can_sync_error_codes = [ 'ras_esp_master_list_id_not_found' ];
 
-		$fired = false;
-		add_action(
-			'newspack_integration_health_check_failed',
-			function () use ( &$fired ) {
-				$fired = true;
-			}
-		);
+		$fired    = false;
+		$listener = function () use ( &$fired ) {
+			$fired = true;
+		};
+		add_action( 'newspack_integration_health_check_failed', $listener );
 
-		Integrations::run_health_checks();
-
-		$this->assertFalse( $fired, 'health_check_failed action must not fire when is_set_up() is false.' );
+		try {
+			Integrations::run_health_checks();
+			$this->assertFalse( $fired, 'health_check_failed action must not fire when is_set_up() is false.' );
+		} finally {
+			remove_action( 'newspack_integration_health_check_failed', $listener );
+		}
 	}
 
 	/**
@@ -863,20 +864,21 @@ class Test_Integrations extends \WP_UnitTestCase {
 		Sample_Integration::$is_set_up_value      = true;
 		Sample_Integration::$can_sync_error_codes = [ 'ras_esp_master_list_id_not_found' ];
 
-		$payload = null;
-		add_action(
-			'newspack_integration_health_check_failed',
-			function ( $data ) use ( &$payload ) {
-				$payload = $data;
-			}
-		);
+		$payload  = null;
+		$listener = function ( $data ) use ( &$payload ) {
+			$payload = $data;
+		};
+		add_action( 'newspack_integration_health_check_failed', $listener );
 
-		Integrations::run_health_checks();
-
-		$this->assertNotNull( $payload, 'health_check_failed action must fire when is_set_up() is true and health_check fails.' );
-		$this->assertSame( 'failing', $payload['integration_id'] );
-		$this->assertInstanceOf( \WP_Error::class, $payload['error'] );
-		$this->assertContains( 'ras_esp_master_list_id_not_found', $payload['error']->get_error_codes() );
+		try {
+			Integrations::run_health_checks();
+			$this->assertNotNull( $payload, 'health_check_failed action must fire when is_set_up() is true and health_check fails.' );
+			$this->assertSame( 'failing', $payload['integration_id'] );
+			$this->assertInstanceOf( \WP_Error::class, $payload['error'] );
+			$this->assertContains( 'ras_esp_master_list_id_not_found', $payload['error']->get_error_codes() );
+		} finally {
+			remove_action( 'newspack_integration_health_check_failed', $listener );
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -892,10 +892,11 @@ class Test_Integrations extends \WP_UnitTestCase {
 			$this->markTestSkipped( 'ActionScheduler not available.' );
 		}
 
-		$called = 0;
 		$integration = new class( 'pull-skip', 'Pull Skip' ) extends Sample_Integration {
 			/**
-			 * @var int Count of pull_contact_data calls.
+			 * Count of pull_contact_data calls.
+			 *
+			 * @var int
 			 */
 			public static $pull_count = 0;
 
@@ -910,10 +911,10 @@ class Test_Integrations extends \WP_UnitTestCase {
 				return [ 'favorite_color' => 'blue' ];
 			}
 		};
-		$integration::$pull_count                 = 0;
+		$integration::$pull_count = 0;
 		$integration->update_enabled_incoming_fields( [ 'favorite_color' ] );
 
-		Sample_Integration::$is_set_up_value      = false;
+		Sample_Integration::$is_set_up_value = false;
 
 		Integrations::register( $integration );
 		Integrations::enable( 'pull-skip' );
@@ -948,7 +949,9 @@ class Test_Integrations extends \WP_UnitTestCase {
 
 		$integration = new class( 'pull-retry-abort', 'Pull Retry Abort' ) extends Sample_Integration {
 			/**
-			 * @var int Count of pull_contact_data calls.
+			 * Count of pull_contact_data calls.
+			 *
+			 * @var int
 			 */
 			public static $pull_count = 0;
 
@@ -963,10 +966,10 @@ class Test_Integrations extends \WP_UnitTestCase {
 				return new \WP_Error( 'mock_error', 'Mock pull failed' );
 			}
 		};
-		$integration::$pull_count                 = 0;
+		$integration::$pull_count = 0;
 		$integration->update_enabled_incoming_fields( [ 'favorite_color' ] );
 
-		Sample_Integration::$is_set_up_value      = false;
+		Sample_Integration::$is_set_up_value = false;
 
 		Integrations::register( $integration );
 		Integrations::enable( 'pull-retry-abort' );

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -824,6 +824,62 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test run_health_checks skips integrations that are not yet set up.
+	 *
+	 * An enabled-but-unconfigured integration (e.g. ESP enabled by default
+	 * but provider/master list never selected) is a setup-incomplete state,
+	 * not a runtime incident — the hourly cron must not generate an alert.
+	 */
+	public function test_run_health_checks_skips_unconfigured_integrations() {
+		$integration = new Sample_Integration( 'unconfigured', 'Unconfigured' );
+		Integrations::register( $integration );
+		Integrations::enable( 'unconfigured' );
+
+		Sample_Integration::$is_set_up_value      = false;
+		Sample_Integration::$can_sync_error_codes = [ 'ras_esp_master_list_id_not_found' ];
+
+		$fired = false;
+		add_action(
+			'newspack_integration_health_check_failed',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		Integrations::run_health_checks();
+
+		$this->assertFalse( $fired, 'health_check_failed action must not fire when is_set_up() is false.' );
+	}
+
+	/**
+	 * Test run_health_checks fires the action for set-up integrations whose
+	 * health check fails — the control case for the skip behavior above.
+	 */
+	public function test_run_health_checks_fires_when_set_up_and_failing() {
+		$integration = new Sample_Integration( 'failing', 'Failing' );
+		Integrations::register( $integration );
+		Integrations::enable( 'failing' );
+
+		Sample_Integration::$is_set_up_value      = true;
+		Sample_Integration::$can_sync_error_codes = [ 'ras_esp_master_list_id_not_found' ];
+
+		$payload = null;
+		add_action(
+			'newspack_integration_health_check_failed',
+			function ( $data ) use ( &$payload ) {
+				$payload = $data;
+			}
+		);
+
+		Integrations::run_health_checks();
+
+		$this->assertNotNull( $payload, 'health_check_failed action must fire when is_set_up() is true and health_check fails.' );
+		$this->assertSame( 'failing', $payload['integration_id'] );
+		$this->assertInstanceOf( \WP_Error::class, $payload['error'] );
+		$this->assertContains( 'ras_esp_master_list_id_not_found', $payload['error']->get_error_codes() );
+	}
+
+	/**
 	 * Test get_metadata_prefix returns default 'NP_' when no custom prefix is set.
 	 */
 	public function test_get_metadata_prefix_default() {

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -882,6 +882,121 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Contact_Pull::pull_all skips integrations whose is_set_up() is false.
+	 *
+	 * Mirrors the run_health_checks skip: an unconfigured integration must not
+	 * be invoked, must not generate retry rows in ActionScheduler.
+	 */
+	public function test_pull_all_skips_unconfigured_integrations() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		$called = 0;
+		$integration = new class( 'pull-skip', 'Pull Skip' ) extends Sample_Integration {
+			/**
+			 * @var int Count of pull_contact_data calls.
+			 */
+			public static $pull_count = 0;
+
+			/**
+			 * Pull mock that counts invocations.
+			 *
+			 * @param int $user_id WordPress user ID.
+			 * @return array
+			 */
+			public function pull_contact_data( $user_id ) {
+				self::$pull_count++;
+				return [ 'favorite_color' => 'blue' ];
+			}
+		};
+		$integration::$pull_count                 = 0;
+		$integration->update_enabled_incoming_fields( [ 'favorite_color' ] );
+
+		Sample_Integration::$is_set_up_value      = false;
+
+		Integrations::register( $integration );
+		Integrations::enable( 'pull-skip' );
+
+		\as_unschedule_all_actions( Contact_Pull::RETRY_HOOK );
+
+		$user_id = $this->factory()->user->create();
+
+		Contact_Pull::pull_all( $user_id );
+
+		$this->assertSame( 0, $integration::$pull_count, 'pull_contact_data must not be called when is_set_up() is false.' );
+
+		$pending = \as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Pull::RETRY_HOOK,
+				'group'  => Integrations::get_action_group( 'pull-skip' ),
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertEmpty( $pending, 'No pull retry should be scheduled for an unconfigured integration.' );
+	}
+
+	/**
+	 * Test Contact_Pull::execute_integration_retry aborts when the integration
+	 * is no longer set up — drains existing retry rows without scheduling more.
+	 */
+	public function test_pull_execute_integration_retry_aborts_when_not_set_up() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		$integration = new class( 'pull-retry-abort', 'Pull Retry Abort' ) extends Sample_Integration {
+			/**
+			 * @var int Count of pull_contact_data calls.
+			 */
+			public static $pull_count = 0;
+
+			/**
+			 * Pull mock returning WP_Error so retry would be scheduled if reached.
+			 *
+			 * @param int $user_id WordPress user ID.
+			 * @return \WP_Error
+			 */
+			public function pull_contact_data( $user_id ) {
+				self::$pull_count++;
+				return new \WP_Error( 'mock_error', 'Mock pull failed' );
+			}
+		};
+		$integration::$pull_count                 = 0;
+		$integration->update_enabled_incoming_fields( [ 'favorite_color' ] );
+
+		Sample_Integration::$is_set_up_value      = false;
+
+		Integrations::register( $integration );
+		Integrations::enable( 'pull-retry-abort' );
+
+		\as_unschedule_all_actions( Contact_Pull::RETRY_HOOK );
+
+		$user_id = $this->factory()->user->create();
+
+		Contact_Pull::execute_integration_retry(
+			[
+				'integration_id' => 'pull-retry-abort',
+				'user_id'        => $user_id,
+				'retry_count'    => 1,
+			]
+		);
+
+		$this->assertSame( 0, $integration::$pull_count, 'pull_contact_data must not be called when is_set_up() returns false at retry time.' );
+
+		$pending = \as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Pull::RETRY_HOOK,
+				'group'  => Integrations::get_action_group( 'pull-retry-abort' ),
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertEmpty( $pending, 'No new pull retry should be scheduled when integration becomes unconfigured mid-chain.' );
+	}
+
+	/**
 	 * Test get_metadata_prefix returns default 'NP_' when no custom prefix is set.
 	 */
 	public function test_get_metadata_prefix_default() {

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -913,6 +913,76 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Contact_Pull::pull_sync defaults to set-up integrations only.
+	 *
+	 * The synchronous loopback path (run from Contact_Cron when the user's
+	 * last pull is stale) must NOT fire a loopback for an integration whose
+	 * `is_set_up()` is false — otherwise it both wastes a blocking remote
+	 * call and logs a spurious failure.
+	 */
+	public function test_pull_sync_skips_unconfigured_integrations() {
+		$user_id = $this->factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$configured = new class( 'sync-configured', 'Sync Configured' ) extends Sample_Integration {
+			/**
+			 * Pull mock returning data so the loopback would succeed if reached.
+			 *
+			 * @param int $user_id WordPress user ID.
+			 * @return array
+			 */
+			public function pull_contact_data( $user_id ) {
+				return [ 'favorite_color' => 'green' ];
+			}
+		};
+		$configured->update_enabled_incoming_fields( [ 'favorite_color' ] );
+		Integrations::register( $configured );
+		Integrations::enable( 'sync-configured' );
+
+		$unconfigured = new class( 'sync-unconfigured', 'Sync Unconfigured' ) extends Sample_Integration {
+			/**
+			 * Force this mock to report itself as not yet set up.
+			 *
+			 * @return bool
+			 */
+			public function is_set_up() {
+				return false;
+			}
+			/**
+			 * Pull mock that would return data if reached — must not be called.
+			 *
+			 * @param int $user_id WordPress user ID.
+			 * @return array
+			 */
+			public function pull_contact_data( $user_id ) {
+				return [ 'favorite_color' => 'red' ];
+			}
+		};
+		$unconfigured->update_enabled_incoming_fields( [ 'favorite_color' ] );
+		Integrations::register( $unconfigured );
+		Integrations::enable( 'sync-unconfigured' );
+
+		// Capture which integration_ids the loopback receives.
+		$loopback_hits = [];
+		$this->loopback_filter = function ( $preempt, $parsed_args, $url ) use ( &$loopback_hits ) {
+			if ( false === strpos( $url, 'action=' . Contact_Pull::AJAX_ACTION ) ) {
+				return $preempt;
+			}
+			$loopback_hits[] = $parsed_args['body']['integration_id'] ?? '';
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '{"success":true}',
+			];
+		};
+		add_filter( 'pre_http_request', $this->loopback_filter, 10, 3 );
+
+		Contact_Pull::pull_sync();
+
+		$this->assertContains( 'sync-configured', $loopback_hits, 'Configured integration must receive a loopback.' );
+		$this->assertNotContains( 'sync-unconfigured', $loopback_hits, 'Unconfigured integration must NOT receive a loopback.' );
+	}
+
+	/**
 	 * Test Contact_Pull::pull_all skips integrations whose is_set_up() is false.
 	 *
 	 * Mirrors the run_health_checks skip: an unconfigured integration must not

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-integrations.php
@@ -188,6 +188,11 @@ class Test_Integrations extends \WP_UnitTestCase {
 	public function test_get_active_configured_integrations_filters_by_is_set_up() {
 		$configured   = new Sample_Integration( 'configured', 'Configured' );
 		$unconfigured = new class( 'unconfigured', 'Unconfigured' ) extends Sample_Integration {
+			/**
+			 * Force this mock to report itself as not yet set up.
+			 *
+			 * @return bool
+			 */
 			public function is_set_up() {
 				return false;
 			}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
@@ -577,47 +577,17 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that an unconfigured integration is skipped in push_to_integrations
-	 * so no retry is ever scheduled at the source — protects the AS table from
-	 * the enabled-but-unconfigured retry flood.
-	 */
-	public function test_push_to_integrations_skips_unconfigured() {
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			$this->markTestSkipped( 'ActionScheduler not available.' );
-		}
-
-		Failing_Sample_Integration::reset();
-		Failing_Sample_Integration::$should_fail     = true;
-		Failing_Sample_Integration::$is_set_up_value = false;
-		$this->register_failing_integration( 'push_skip_mock' );
-
-		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
-
-		$user_id = $this->factory()->user->create( [ 'user_email' => 'push-skip@test.com' ] );
-		$contact = $this->get_sample_contact();
-		$contact['email'] = 'push-skip@test.com';
-
-		$method = new \ReflectionMethod( Contact_Sync::class, 'push_to_integrations' );
-		$method->setAccessible( true );
-		$method->invoke( null, $contact, 'Test' );
-
-		$this->assertSame( 0, Failing_Sample_Integration::$push_count, 'push_contact_data must not be called when is_set_up() is false.' );
-
-		$pending = as_get_scheduled_actions(
-			[
-				'hook'   => Contact_Sync::RETRY_HOOK,
-				'group'  => Integrations::get_action_group( 'push_skip_mock' ),
-				'status' => \ActionScheduler_Store::STATUS_PENDING,
-			],
-			'ARRAY_A'
-		);
-		$this->assertEmpty( $pending, 'No retry should be scheduled for an unconfigured integration.' );
-	}
-
-	/**
 	 * Test that execute_integration_retry aborts the retry chain when the
 	 * integration becomes unconfigured between schedule and execute — drains
 	 * existing flood without scheduling further attempts.
+	 *
+	 * The initial-push gate at Contact_Sync::push_to_integrations is the
+	 * structural twin of Integrations::run_health_checks's gate (tested in
+	 * class-test-integrations.php) and Contact_Pull::pull_all's gate (also
+	 * tested there); a direct reflection-based unit test on push_to_integrations
+	 * is not feasible because the iteration also touches the live ESP
+	 * integration whose push_contact_data hits Newspack_Newsletters_Contacts
+	 * (not loaded in the unit-test env).
 	 */
 	public function test_execute_integration_retry_aborts_when_not_set_up() {
 		if ( ! function_exists( 'as_schedule_single_action' ) ) {

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
@@ -577,6 +577,85 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that an unconfigured integration is skipped in push_to_integrations
+	 * so no retry is ever scheduled at the source — protects the AS table from
+	 * the enabled-but-unconfigured retry flood.
+	 */
+	public function test_push_to_integrations_skips_unconfigured() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		Failing_Sample_Integration::reset();
+		Failing_Sample_Integration::$should_fail     = true;
+		Failing_Sample_Integration::$is_set_up_value = false;
+		$this->register_failing_integration( 'push_skip_mock' );
+
+		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
+
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'push-skip@test.com' ] );
+		$contact = $this->get_sample_contact();
+		$contact['email'] = 'push-skip@test.com';
+
+		$method = new \ReflectionMethod( Contact_Sync::class, 'push_to_integrations' );
+		$method->setAccessible( true );
+		$method->invoke( null, $contact, 'Test' );
+
+		$this->assertSame( 0, Failing_Sample_Integration::$push_count, 'push_contact_data must not be called when is_set_up() is false.' );
+
+		$pending = as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Sync::RETRY_HOOK,
+				'group'  => Integrations::get_action_group( 'push_skip_mock' ),
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertEmpty( $pending, 'No retry should be scheduled for an unconfigured integration.' );
+	}
+
+	/**
+	 * Test that execute_integration_retry aborts the retry chain when the
+	 * integration becomes unconfigured between schedule and execute — drains
+	 * existing flood without scheduling further attempts.
+	 */
+	public function test_execute_integration_retry_aborts_when_not_set_up() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		Failing_Sample_Integration::reset();
+		Failing_Sample_Integration::$should_fail     = true;
+		Failing_Sample_Integration::$is_set_up_value = false;
+		$this->register_failing_integration( 'retry_abort_mock' );
+
+		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
+
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'retry-abort@test.com' ] );
+
+		Contact_Sync::execute_integration_retry(
+			[
+				'integration_id' => 'retry_abort_mock',
+				'user_id'        => $user_id,
+				'context'        => 'Test',
+				'retry_count'    => 1,
+			]
+		);
+
+		$this->assertSame( 0, Failing_Sample_Integration::$push_count, 'push_contact_data must not be called when is_set_up() returns false at retry time.' );
+
+		$pending = as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Sync::RETRY_HOOK,
+				'group'  => Integrations::get_action_group( 'retry_abort_mock' ),
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertEmpty( $pending, 'No new retry should be scheduled when integration becomes unconfigured mid-chain.' );
+	}
+
+	/**
 	 * Test that invalid retry data is handled gracefully.
 	 */
 	public function test_integration_retry_invalid_data() {

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
@@ -118,6 +118,27 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that ESP::is_set_up() returns false when no provider is selected —
+	 * the exact default-state scenario the hotfix targets (ESP auto-enabled on
+	 * fresh installs while `newspack_newsletters_service_provider` is unset).
+	 */
+	public function test_esp_is_set_up_returns_false_when_no_provider_selected() {
+		$esp = new Integrations\ESP();
+		$esp->update_settings_field_value( 'mailchimp_audience_id', '123' );
+
+		// Even with a master list stored, an unconfigured provider must short-circuit.
+		\Newspack_Newsletters::$is_service_provider_configured = false;
+		try {
+			$this->assertFalse(
+				$esp->is_set_up(),
+				'is_set_up() must be false when no provider is selected, even if a master list ID is stored.'
+			);
+		} finally {
+			\Newspack_Newsletters::reset_calls();
+		}
+	}
+
+	/**
 	 * Test contact data sync to ESP.
 	 */
 	public function test_sync_contact_data() {

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync.php
@@ -99,6 +99,25 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that ESP::is_set_up() reads stored configuration only — never makes
+	 * a live provider call. Protects every gate that consults is_set_up()
+	 * (Integrations::get_active_configured_integrations and the retry-time
+	 * guards in Contact_Sync / Contact_Pull) from silently dropping traffic
+	 * on transient ESP failures, which the AS retry system is meant to survive.
+	 */
+	public function test_esp_is_set_up_reads_stored_state() {
+		$esp = new Integrations\ESP();
+
+		// Master list ID not stored → setup is incomplete.
+		$esp->update_settings_field_value( 'mailchimp_audience_id', '' );
+		$this->assertFalse( $esp->is_set_up(), 'is_set_up() must be false when master list ID is not stored.' );
+
+		// Admin selects a list → setup is complete.
+		$esp->update_settings_field_value( 'mailchimp_audience_id', '123' );
+		$this->assertTrue( $esp->is_set_up(), 'is_set_up() must be true when provider + master list are stored.' );
+	}
+
+	/**
 	 * Test contact data sync to ESP.
 	 */
 	public function test_sync_contact_data() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hotfix for the alert flood and ActionScheduler retry flood that started after #4723. Shared root cause: an integration that is enabled-but-unconfigured (e.g. ESP enabled by default but no provider/master list selected) is a setup-incomplete state, not a runtime incident — it should surface in the integrations UI, not in the alerts channel or the AS retry queue.

**1. Skip unconfigured integrations across all integration-walking paths.**
\`Integration::is_set_up()\` is now consulted before every cron- or loopback-driven walk, via the new \`Integrations::get_active_configured_integrations()\` helper:

- \`Integrations::run_health_checks()\` — skips the hourly health-check cron.
- \`Contact_Sync::push_to_integrations()\` — skips the initial push, preventing the first AS retry row from being scheduled.
- \`Contact_Sync::execute_integration_retry()\` — aborts the retry chain when an integration becomes unconfigured between schedule and execute, draining the existing flood without rescheduling.
- \`Contact_Pull::pull_all()\` — same skip on the pull side.
- \`Contact_Pull::pull_sync()\` — same skip for the per-user synchronous loopback path.
- \`Contact_Pull::handle_ajax_pull()\` — defense-in-depth: a direct AJAX call for an unconfigured integration is a silent no-op.
- \`Contact_Pull::execute_integration_retry()\` — same retry-chain abort on the pull side.

**1a. \`ESP::is_set_up()\` reads STORED state only.**
The implementation now consults two stored options — \`newspack_newsletters_service_provider\` (provider selected) and the provider's master-list option — instead of calling the live \`get_lists()\` API. This is required because every gate above uses \`is_set_up()\`: if it dipped into a live provider call, any transient provider failure (timeout, rate-limit, auth blip) would make every gate skip and silently drop data — exactly the failure mode the AS retry system was built to survive. The setup question "did the admin finish configuring this?" must be answered from local state; "is the provider reachable right now?" is \`health_check()\`'s job.

**2. Dedupe \`Alert_Manager::handle_health_check_failed\`.**
The handler stores a transient keyed on \`integration_id + sorted error codes + sorted error messages\` with a \`DAY_IN_SECONDS\` TTL (exposed as \`Alert_Manager::HEALTH_CHECK_DEDUP_INTERVAL\`). Including the messages in the key (and not only the codes) is intentional: an escalating same-code failure with a worse message (e.g. "list missing" → "auth fully revoked") bypasses the bucket and re-alerts. The trade-off is that messages containing dynamic content (timestamps, IDs) would increase alert volume; current Newspack ESP error messages are static per code so the trade-off lands on the right side. Empty \`WP_Error\` codes collapse to \`[ 'unknown' ]\` so a bare \`new WP_Error()\` shares the bucket with the non-\`WP_Error\` payload path. The transient is set BEFORE \`do_action( 'newspack_alert' )\` so a handler that throws (e.g. transient Slack POST failure) cannot leave the key unset and defeat dedup on the next hourly cron.

Together these drop staging-clone and legacy enabled-but-unconfigured noise — both Slack alerts and AS retry rows — to zero, while preserving signal for real, configured-but-broken integrations.

### How to test the changes in this Pull Request:

1. **Health check skip** — On a site with ESP enabled but no master list configured: run \`wp cron event run newspack_integration_health_check\`. The \`newspack_integration_health_check_failed\` action should not fire (verify with \`add_action( 'newspack_integration_health_check_failed', fn() => error_log( 'fired' ) )\`).
2. **Alert dedup** — Force \`is_set_up()\` to return true (e.g. set a master list ID) and re-run the cron event. The action should fire, but only once per \`HEALTH_CHECK_DEDUP_INTERVAL\` (24h) per integration + error-code + error-message signature. Delete the transient (\`newspack_alert_hc_*\` in \`wp_options\`) and re-run — the alert should fire again.
3. **Escalation re-alert** — Force a health-check failure with a given error code/message, let it dedupe, then change the message text for the same code (e.g. \`WP_Error( 'connection_failed', 'auth fully revoked' )\`). The next dispatch should bypass the bucket and re-alert.
4. **Master-list removal** — Configure ESP fully (provider + master list), then clear the master list in the Newsletters settings. \`ESP::is_set_up()\` should return false on the next check; no new \`newspack_contact_sync_retry\` rows should appear; no health-check alerts should fire.
5. **Push skip** — On a site with ESP enabled but no master list configured, trigger a reader sync (e.g. register a new reader). No \`newspack_contact_sync_retry\` rows should appear in \`wp_actionscheduler_actions\` for the ESP integration.
6. **Pull skip** — On the same site, trigger \`Contact_Cron::maybe_enqueue_contact\` (load any page while logged in after the 5-min interval). No \`newspack_contact_pull_retry\` rows should appear, and no loopback request should be fired for the ESP integration.
7. **Retry drain** — With existing pending \`newspack_contact_sync_retry\` rows from a prior flood, set the integration to \`is_set_up()=false\` and let the queue execute. Each execution should log "aborting retry chain" and create no new rows; the flood drains naturally as the existing rows complete.
8. **PHPUnit** (run from \`plugins/newspack-plugin/\`):
   - \`n test-php --filter 'test_run_health_checks_skips_unconfigured_integrations'\`
   - \`n test-php --filter 'test_run_health_checks_fires_when_set_up_and_failing'\`
   - \`n test-php --filter 'test_get_active_configured_integrations_filters_by_is_set_up'\`
   - \`n test-php --filter 'test_esp_is_set_up_reads_stored_state'\`
   - \`n test-php --filter 'test_health_check_failed_dedupes_repeated_fires'\`
   - \`n test-php --filter 'test_health_check_failed_alerts_on_new_error_codes'\`
   - \`n test-php --filter 'test_health_check_failed_alerts_on_new_error_messages'\`
   - \`n test-php --filter 'test_health_check_failed_alerts_per_integration'\`
   - \`n test-php --filter 'test_health_check_failed_sets_dedup_before_dispatch'\`
   - \`n test-php --filter 'test_execute_integration_retry_aborts_when_not_set_up'\`
   - \`n test-php --filter 'test_pull_all_skips_unconfigured_integrations'\`
   - \`n test-php --filter 'test_pull_sync_skips_unconfigured_integrations'\`
   - \`n test-php --filter 'test_pull_execute_integration_retry_aborts_when_not_set_up'\`

The initial-push gate (\`Contact_Sync::push_to_integrations\`) has no direct unit test — a reflection-based test would also iterate the live ESP whose \`push_contact_data\` hits \`Newspack_Newsletters_Contacts\` (not loaded in the unit-test env). The gate is structurally identical to the health-check and pull skips above and is covered by manual test step 5.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

This is a hotfix targeted at \`release\`. Once merged, it should be propagated forward to \`alpha\` and \`main\` via the standard branch-promotion flow.