### PR TITLE
fix(jetpack): disable Newsletter (subscriptions) module

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/class-jetpack.php
+++ b/plugins/newspack-plugin/includes/plugins/class-jetpack.php
@@ -328,7 +328,7 @@ class Jetpack {
 	 * Filters out the Subscriptions (Newsletter) module from Jetpack's active-modules list at read time.
 	 * The module reports as inactive even if its slug is present in the jetpack_active_modules option.
 	 *
-	 * @param array $modules Array with modules slugs.
+	 * @param array $modules Array of module slugs.
 	 * @return array
 	 */
 	public static function remove_subscriptions_from_active( $modules ) {

--- a/plugins/newspack-plugin/includes/plugins/class-jetpack.php
+++ b/plugins/newspack-plugin/includes/plugins/class-jetpack.php
@@ -155,6 +155,10 @@ class Jetpack {
 		add_filter( 'jetpack_active_modules', [ __CLASS__, 'remove_google_analytics_from_active' ], 10, 2 );
 		add_filter( 'jetpack_get_available_modules', [ __CLASS__, 'remove_google_analytics_from_available' ] );
 
+		// Disables Subscriptions (Newsletter). Jetpack 15.9 auto-enables this; Newspack publishers use newspack-newsletters.
+		add_filter( 'jetpack_active_modules', [ __CLASS__, 'remove_subscriptions_from_active' ], 10, 2 );
+		add_filter( 'jetpack_get_available_modules', [ __CLASS__, 'remove_subscriptions_from_available' ] );
+
 		// Set Jetpack default modules on Newspack setup.
 		add_action( 'add_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
 		add_action( 'update_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
@@ -316,6 +320,29 @@ class Jetpack {
 	public static function remove_google_analytics_from_available( $modules ) {
 		if ( isset( $modules['google-analytics'] ) ) {
 			unset( $modules['google-analytics'] );
+		}
+		return $modules;
+	}
+
+	/**
+	 * Disables Subscriptions (Newsletter) module. Users will not be able to activate it.
+	 *
+	 * @param array $modules Array with modules slugs.
+	 * @return array
+	 */
+	public static function remove_subscriptions_from_active( $modules ) {
+		return array_diff( $modules, array( 'subscriptions' ) );
+	}
+
+	/**
+	 * Remove Subscriptions (Newsletter) from available modules.
+	 *
+	 * @param array $modules The array of available modules.
+	 * @return array
+	 */
+	public static function remove_subscriptions_from_available( $modules ) {
+		if ( isset( $modules['subscriptions'] ) ) {
+			unset( $modules['subscriptions'] );
 		}
 		return $modules;
 	}

--- a/plugins/newspack-plugin/includes/plugins/class-jetpack.php
+++ b/plugins/newspack-plugin/includes/plugins/class-jetpack.php
@@ -325,7 +325,8 @@ class Jetpack {
 	}
 
 	/**
-	 * Disables Subscriptions (Newsletter) module. Users will not be able to activate it.
+	 * Filters out the Subscriptions (Newsletter) module from Jetpack's active-modules list at read time.
+	 * The module reports as inactive even if its slug is present in the jetpack_active_modules option.
 	 *
 	 * @param array $modules Array with modules slugs.
 	 * @return array


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Jetpack 15.9 auto-enables the Newsletter / Subscriptions module on connected sites. Newspack offers newsletter and subscription functionality through newspack-newsletters, so we want to keep Jetpack's version inactive on Newspack sites — having both active creates an unintended overlap that can lead to confusion or undesired behavior changes for publishers.

This PR is modeled after Newspack's existing treatment of Jetpack's `google-analytics` module in the same file (introduced in 2022) — the same pair of filters on `jetpack_active_modules` and `jetpack_get_available_modules`, with `'subscriptions'` substituted for `'google-analytics'`.

Closes NPPM-2889.

### How to test the changes in this Pull Request:

1. On a local site with Jetpack active, add `subscriptions` to the active modules option (mirrors what Jetpack 15.9 does on update):

   ```bash
   docker exec newspack_dev wp --allow-root eval '
     $modules = (array) get_option("jetpack_active_modules", []);
     if ( ! in_array("subscriptions", $modules, true) ) {
       $modules[] = "subscriptions";
       update_option("jetpack_active_modules", $modules);
     }
   '
   ```

2. Without the fix:

   ```bash
   docker exec newspack_dev wp --allow-root eval 'var_dump( Jetpack::is_module_active("subscriptions") );'
   ```

   Returns `bool(true)`.

3. Apply the fix and re-run step 2. It now returns `bool(false)`. The database option is intentionally unchanged — the filter strips the slug at read time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? <!-- Mirrors the existing google-analytics denylist pattern, which has no tests. -->
* [x] Have you successfully run tests with your changes locally?
