### PR TITLE
feat(insights): wizard chrome (NPPD-1602)

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -165,6 +165,15 @@ final class Newspack {
 		// Newspack Wizards and Sections.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-dashboard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-audience.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-engagement.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-conversion.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-gates.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-prompts.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-subscribers.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-donors.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-advertising.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-emails-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-syndication-section.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -69,6 +69,7 @@ class Wizards {
 			'audience-content-gates'  => new Audience_Content_Gates(),
 			'audience-donations'      => new Audience_Donations(),
 			'audience-integrations'   => new Audience_Integrations(),
+			'insights'                => new Insights_Wizard(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),
@@ -77,6 +78,18 @@ class Wizards {
 		if ( Memberships::is_active() ) {
 			self::$wizards['audience-subscriptions'] = new Audience_Subscriptions();
 		}
+
+		// Initialize Insights section classes. These are plain classes (not
+		// Wizard_Section subclasses) that hold the hook points for future
+		// per-tab REST endpoint registration as each tab's data layer lands.
+		Insights_Section_Audience::init();
+		Insights_Section_Engagement::init();
+		Insights_Section_Conversion::init();
+		Insights_Section_Gates::init();
+		Insights_Section_Prompts::init();
+		Insights_Section_Subscribers::init();
+		Insights_Section_Donors::init();
+		Insights_Section_Advertising::init();
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -69,7 +69,6 @@ class Wizards {
 			'audience-content-gates'  => new Audience_Content_Gates(),
 			'audience-donations'      => new Audience_Donations(),
 			'audience-integrations'   => new Audience_Integrations(),
-			'insights'                => new Insights_Wizard(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),
@@ -79,17 +78,24 @@ class Wizards {
 			self::$wizards['audience-subscriptions'] = new Audience_Subscriptions();
 		}
 
-		// Initialize Insights section classes. These are plain classes (not
-		// Wizard_Section subclasses) that hold the hook points for future
-		// per-tab REST endpoint registration as each tab's data layer lands.
-		Insights_Section_Audience::init();
-		Insights_Section_Engagement::init();
-		Insights_Section_Conversion::init();
-		Insights_Section_Gates::init();
-		Insights_Section_Prompts::init();
-		Insights_Section_Subscribers::init();
-		Insights_Section_Donors::init();
-		Insights_Section_Advertising::init();
+		// Insights wizard + section init are gated together. The wizard's
+		// own constructor short-circuits when the feature flag is off and
+		// each section's init() self-gates too, but registering the
+		// instance and firing eight no-op init()s leaves stale state in
+		// self::$wizards (which Wizards::get_url() and Wizards::menu_order()
+		// read from). Keeping the gate at this layer is the single source
+		// of truth.
+		if ( Insights_Wizard::is_enabled() ) {
+			self::$wizards['insights'] = new Insights_Wizard();
+			Insights_Section_Audience::init();
+			Insights_Section_Engagement::init();
+			Insights_Section_Conversion::init();
+			Insights_Section_Gates::init();
+			Insights_Section_Prompts::init();
+			Insights_Section_Subscribers::init();
+			Insights_Section_Donors::init();
+			Insights_Section_Advertising::init();
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -35,6 +35,9 @@ class Insights_Section_Advertising {
 	 * arrive (NPPD-1618).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Insights — Advertising section (NPPD-1602).
+ *
+ * Advertising tab scope: GAM-driven ad performance. Impressions, fill
+ * rate, eCPM, revenue by placement / ad unit. Requires GA4 to be
+ * receiving GAM event data; visibility gated on GAM dataset presence
+ * in the publisher's BigQuery export.
+ *
+ * Future REST endpoints for the Advertising tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Advertising section.
+ */
+class Insights_Section_Advertising {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Advertising';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1624).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -32,7 +32,7 @@ class Insights_Section_Advertising {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1624).
+	 * arrive (NPPD-1618).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Newspack Insights — Audience section (NPPD-1602).
+ *
+ * Audience tab scope: who is reading, where they come from, how
+ * engaged the audience is at a high level. The "lobby" of the Insights
+ * page — answers "what's the shape of my audience this period?"
+ *
+ * Future REST endpoints for the Audience tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Audience section.
+ */
+class Insights_Section_Audience {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Audience';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1604).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -34,6 +34,9 @@ class Insights_Section_Audience {
 	 * arrive (NPPD-1608).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -31,7 +31,7 @@ class Insights_Section_Audience {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1604).
+	 * arrive (NPPD-1608).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Insights — Conversion Journey section (NPPD-1602).
+ *
+ * Conversion Journey tab scope: the funnel from anonymous reader to
+ * registered to subscriber. Time-to-convert distributions, step-over-step
+ * drop-off, and attribution to gates/prompts. Lives between Engagement
+ * (depth of consumption) and the per-surface tabs (Gates, Prompts).
+ *
+ * Future REST endpoints for the Conversion tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Conversion section.
+ */
+class Insights_Section_Conversion {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Conversion Journey';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1608).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -35,6 +35,9 @@ class Insights_Section_Conversion {
 	 * arrive (NPPD-1609).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -32,7 +32,7 @@ class Insights_Section_Conversion {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1608).
+	 * arrive (NPPD-1609).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
@@ -35,6 +35,9 @@ class Insights_Section_Donors {
 	 * arrive (NPPD-1617).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Insights — Donors section (NPPD-1602).
+ *
+ * Donors tab scope: donation activity. One-time vs recurring, donor
+ * mix, average gift size, retention of recurring donors. Like
+ * Subscribers, local-DB-driven (WooCommerce + Donations). Visible only
+ * when the publisher has donation activity in the period.
+ *
+ * Future REST endpoints for the Donors tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Donors section.
+ */
+class Insights_Section_Donors {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Donors';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1618).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
@@ -32,7 +32,7 @@ class Insights_Section_Donors {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1618).
+	 * arrive (NPPD-1617).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Newspack Insights — Engagement section (NPPD-1602).
+ *
+ * Engagement tab scope: how deeply readers interact with content —
+ * scroll depth, time on page, return visits. Distinct from Audience
+ * (who) by focusing on behavior depth (how).
+ *
+ * Future REST endpoints for the Engagement tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Engagement section.
+ */
+class Insights_Section_Engagement {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Engagement';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1607).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -34,6 +34,9 @@ class Insights_Section_Engagement {
 	 * arrive (NPPD-1624).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -31,7 +31,7 @@ class Insights_Section_Engagement {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1607).
+	 * arrive (NPPD-1624).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -35,6 +35,9 @@ class Insights_Section_Gates {
 	 * arrive (NPPD-1604).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Insights — Gates section (NPPD-1602).
+ *
+ * Gates tab scope: per-gate performance. Regwall, paywall, soft/hard
+ * gates — impressions, registrations, paid checkouts, attributed
+ * revenue. The "instrumentation surface" view of the conversion
+ * journey, broken down per gate configuration.
+ *
+ * Future REST endpoints for the Gates tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Gates section.
+ */
+class Insights_Section_Gates {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Gates';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1609).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -32,7 +32,7 @@ class Insights_Section_Gates {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1609).
+	 * arrive (NPPD-1604).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Newspack Insights — Prompts section (NPPD-1602).
+ *
+ * Prompts tab scope: per-campaign / per-prompt performance from the
+ * Campaigns surface. Impressions, click-throughs, gate fires attributed
+ * to specific overlay / inline / popup prompts. Complements the Gates
+ * tab — Gates is "what conversion surface fired"; Prompts is "what
+ * editorial campaign drove the fire."
+ *
+ * Future REST endpoints for the Prompts tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Prompts section.
+ */
+class Insights_Section_Prompts {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Prompts';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1616).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
@@ -36,6 +36,9 @@ class Insights_Section_Prompts {
 	 * arrive (NPPD-1607).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
@@ -33,7 +33,7 @@ class Insights_Section_Prompts {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1616).
+	 * arrive (NPPD-1607).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -35,6 +35,9 @@ class Insights_Section_Subscribers {
 	 * arrive (NPPD-1616).
 	 */
 	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
 		self::register_hooks();
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Insights — Subscribers section (NPPD-1602).
+ *
+ * Subscribers tab scope: paid subscriber base health. Active subs,
+ * MRR / ARPU, churn, cohort retention, plan mix. Local-DB-driven
+ * (WooCommerce + Memberships); does NOT need BigQuery. Visible only
+ * when the publisher has non-donation subscription products.
+ *
+ * Future REST endpoints for the Subscribers tab register from
+ * {@see self::register_hooks()}. Currently a stub; the React side renders
+ * a "Coming soon" placeholder for this tab.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Subscribers section.
+ */
+class Insights_Section_Subscribers {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Subscribers';
+
+	/**
+	 * Initialize. Hooks REST endpoints for this tab when implementations
+	 * arrive (NPPD-1617).
+	 */
+	public static function init() {
+		self::register_hooks();
+	}
+
+	/**
+	 * Register hooks for this section. Currently a stub.
+	 */
+	public static function register_hooks() {}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -32,7 +32,7 @@ class Insights_Section_Subscribers {
 
 	/**
 	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1617).
+	 * arrive (NPPD-1616).
 	 */
 	public static function init() {
 		self::register_hooks();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -46,6 +46,44 @@ class Insights_Wizard extends Wizard {
 	public $parent_menu = 'newspack-dashboard';
 
 	/**
+	 * Checks if the feature is enabled.
+	 *
+	 * True when:
+	 * - NEWSPACK_INSIGHTS_ENABLED is defined and true.
+	 *
+	 * Feature-flagged for gradual rollout.
+	 * Remove this gate once fully released.
+	 *
+	 * @return bool True if the feature is enabled, false otherwise.
+	 */
+	public static function is_enabled() {
+		/**
+		 * Enables the Newspack Insights feature.
+		 *
+		 * @constant NEWSPACK_INSIGHTS_ENABLED
+		 * @type     bool
+		 * @default  Insights feature disabled
+		 * @status   draft
+		 *
+		 * @example define( 'NEWSPACK_INSIGHTS_ENABLED', true );
+		 */
+		return defined( 'NEWSPACK_INSIGHTS_ENABLED' ) && NEWSPACK_INSIGHTS_ENABLED;
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * Bails before parent registration when the feature flag is disabled,
+	 * so no menu item, asset enqueue, or admin hooks are registered.
+	 */
+	public function __construct() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+		parent::__construct();
+	}
+
+	/**
 	 * Get the name for this wizard.
 	 *
 	 * @return string

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -85,24 +85,22 @@ class Insights_Wizard extends Wizard {
 		$thirty_ago = $today->modify( '-29 days' );
 
 		return [
-			/*
-			 * Tab visibility. Real computation (feature detection: GAM
-			 * dataset presence, scroll event presence, non-donation
-			 * subscription product count, donation activity count) needs
-			 * the BigQuery wrapper (NPPD-1598) plus Woo queries. Stubbed
-			 * to all-on for now per the prompt's scope note.
-			 */
-			'tabs'             => [
-				'audience'     => true,
-				'engagement'   => true,
-				'conversion'   => true,
-				'gates'        => true,
-				'prompts'      => true,
-				'subscribers'  => true,
-				'donors'       => true,
-				'advertising'  => true,
+			// Tab visibility. Real computation (feature detection: GAM
+			// dataset presence, scroll event presence, non-donation
+			// subscription product count, donation activity count) needs
+			// the BigQuery wrapper (NPPD-1598) plus Woo queries. Stubbed
+			// to all-on for now per the prompt's scope note.
+			'tabs'              => [
+				'audience'    => true,
+				'engagement'  => true,
+				'conversion'  => true,
+				'gates'       => true,
+				'prompts'     => true,
+				'subscribers' => true,
+				'donors'      => true,
+				'advertising' => true,
 			],
-			'defaultDateRange' => [
+			'defaultDateRange'  => [
 				'preset' => 'last-30',
 				'start'  => $thirty_ago->format( 'Y-m-d' ),
 				'end'    => $today->format( 'Y-m-d' ),

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -78,8 +78,11 @@ class Insights_Wizard extends Wizard {
 	 * @return array
 	 */
 	protected function get_boot_config() {
+		// current_datetime() returns DateTimeImmutable; modify() returns a new
+		// instance and does not mutate $today. -29 days yields an inclusive
+		// 30-day window ending today (today + 29 prior days = 30 days).
 		$today      = current_datetime();
-		$thirty_ago = $today->modify( '-30 days' );
+		$thirty_ago = $today->modify( '-29 days' );
 
 		return [
 			/*

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Newspack Insights Wizard (NPPD-1602).
+ *
+ * Top-level wizard chrome for the Insights page. Tab routing happens
+ * entirely on the React side via URL query persistence; this PHP wizard
+ * registers the admin page and localizes the boot config (tab visibility,
+ * default date range, timezone, settings URL).
+ *
+ * Section classes (Insights_Section_*) live alongside this file and exist
+ * for future per-tab REST endpoint registration when each tab's data layer
+ * lands in subsequent issues.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insights Wizard.
+ */
+class Insights_Wizard extends Wizard {
+
+	/**
+	 * Admin page slug.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-insights';
+
+	/**
+	 * Capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Parent menu item slug. Nests under the top-level Newspack admin menu,
+	 * matching the Setup wizard's precedent.
+	 *
+	 * @var string
+	 */
+	public $parent_menu = 'newspack-dashboard';
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return esc_html__( 'Insights', 'newspack-plugin' );
+	}
+
+	/**
+	 * Enqueue the shared modern-wizard bundle and localize boot config.
+	 *
+	 * The React view is registered in src/wizards/index.tsx under the
+	 * 'newspack-insights' key.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
+			return;
+		}
+
+		wp_enqueue_script( 'newspack-wizards' );
+
+		wp_localize_script( 'newspack-wizards', 'newspackInsights', $this->get_boot_config() );
+	}
+
+	/**
+	 * Build the boot config consumed by the React entry.
+	 *
+	 * @return array
+	 */
+	protected function get_boot_config() {
+		$today      = current_datetime();
+		$thirty_ago = $today->modify( '-30 days' );
+
+		return [
+			/*
+			 * Tab visibility. Real computation (feature detection: GAM
+			 * dataset presence, scroll event presence, non-donation
+			 * subscription product count, donation activity count) needs
+			 * the BigQuery wrapper (NPPD-1598) plus Woo queries. Stubbed
+			 * to all-on for now per the prompt's scope note.
+			 */
+			'tabs'             => [
+				'audience'     => true,
+				'engagement'   => true,
+				'conversion'   => true,
+				'gates'        => true,
+				'prompts'      => true,
+				'subscribers'  => true,
+				'donors'       => true,
+				'advertising'  => true,
+			],
+			'defaultDateRange' => [
+				'preset' => 'last-30',
+				'start'  => $thirty_ago->format( 'Y-m-d' ),
+				'end'    => $today->format( 'Y-m-d' ),
+			],
+			'defaultComparison' => false,
+			'timezone'          => wp_timezone_string(),
+			'settingsUrl'       => admin_url( 'admin.php?page=newspack-settings' ),
+		];
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/index.tsx
@@ -36,6 +36,10 @@ const components: Record< string, any > = {
 		label: __( 'Settings', 'newspack-plugin' ),
 		component: lazy( () => import( /* webpackChunkName: "newspack-wizards" */ './newspack/views/settings' ) ),
 	},
+	'newspack-insights': {
+		label: __( 'Insights', 'newspack-plugin' ),
+		component: lazy( () => import( /* webpackChunkName: "insights-wizard" */ './insights' ) ),
+	},
 	'newspack-audience': {
 		label: __( 'Audience', 'newspack-plugin' ),
 		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/setup' ) ),

--- a/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
@@ -1,0 +1,38 @@
+/**
+ * ComparisonToggle
+ *
+ * Checkbox to enable "compare to previous period". Component owns no
+ * state — caller wires it to useComparisonMode.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export interface ComparisonToggleProps {
+	enabled: boolean;
+	onChange: ( v: boolean ) => void;
+	className?: string;
+}
+
+const ComparisonToggle = ( {
+	enabled,
+	onChange,
+	className,
+}: ComparisonToggleProps ) => {
+	return (
+		<label className={ className ?? 'newspack-insights__comparison-toggle' }>
+			<input
+				type="checkbox"
+				checked={ enabled }
+				onChange={ e => onChange( e.target.checked ) }
+			/>
+			<span className="newspack-insights__comparison-toggle-label">
+				{ __( 'Compare to previous period', 'newspack-plugin' ) }
+			</span>
+		</label>
+	);
+};
+
+export default ComparisonToggle;

--- a/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
@@ -1,14 +1,19 @@
 /**
  * ComparisonToggle
  *
- * Checkbox to enable "compare to previous period". Component owns no
- * state — caller wires it to useComparisonMode.
+ * "Compare to previous period" checkbox. Uses @wordpress/components
+ * CheckboxControl per Newspack admin convention (built-in label
+ * association, focus ring, and a11y semantics — the previous raw
+ * <input type="checkbox"> had no styled focus state).
+ *
+ * Component owns no state — caller wires it to useComparisonMode.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
 
 export interface ComparisonToggleProps {
 	enabled: boolean;
@@ -16,14 +21,15 @@ export interface ComparisonToggleProps {
 	className?: string;
 }
 
-const ComparisonToggle = ( { enabled, onChange, className }: ComparisonToggleProps ) => {
-	const inputId = 'newspack-insights-comparison-toggle';
-	return (
-		<label className={ className ?? 'newspack-insights__comparison-toggle' } htmlFor={ inputId }>
-			<input id={ inputId } type="checkbox" checked={ enabled } onChange={ e => onChange( e.target.checked ) } />
-			<span className="newspack-insights__comparison-toggle-label">{ __( 'Compare to previous period', 'newspack-plugin' ) }</span>
-		</label>
-	);
-};
+const ComparisonToggle = ( { enabled, onChange, className }: ComparisonToggleProps ) => (
+	<div className={ className ?? 'newspack-insights__comparison-toggle' }>
+		<CheckboxControl
+			__nextHasNoMarginBottom
+			label={ __( 'Compare to previous period', 'newspack-plugin' ) }
+			checked={ enabled }
+			onChange={ onChange }
+		/>
+	</div>
+);
 
 export default ComparisonToggle;

--- a/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
@@ -16,21 +16,12 @@ export interface ComparisonToggleProps {
 	className?: string;
 }
 
-const ComparisonToggle = ( {
-	enabled,
-	onChange,
-	className,
-}: ComparisonToggleProps ) => {
+const ComparisonToggle = ( { enabled, onChange, className }: ComparisonToggleProps ) => {
+	const inputId = 'newspack-insights-comparison-toggle';
 	return (
-		<label className={ className ?? 'newspack-insights__comparison-toggle' }>
-			<input
-				type="checkbox"
-				checked={ enabled }
-				onChange={ e => onChange( e.target.checked ) }
-			/>
-			<span className="newspack-insights__comparison-toggle-label">
-				{ __( 'Compare to previous period', 'newspack-plugin' ) }
-			</span>
+		<label className={ className ?? 'newspack-insights__comparison-toggle' } htmlFor={ inputId }>
+			<input id={ inputId } type="checkbox" checked={ enabled } onChange={ e => onChange( e.target.checked ) } />
+			<span className="newspack-insights__comparison-toggle-label">{ __( 'Compare to previous period', 'newspack-plugin' ) }</span>
 		</label>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
@@ -1,0 +1,97 @@
+/**
+ * DateRangePicker
+ *
+ * Preset-driven date range selector. Six presets (last-7, last-30 default,
+ * last-90, this-month, last-month, custom). Custom mode reveals two date
+ * inputs.
+ *
+ * Component owns no state — caller wires it to useDateRange.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	DATE_RANGE_PRESETS,
+	type DateRange,
+	type DateRangePreset,
+} from '../state/useDateRange';
+
+export interface DateRangePickerProps {
+	range: DateRange;
+	onPresetChange: ( preset: DateRangePreset ) => void;
+	onCustomChange: ( start: string, end: string ) => void;
+	className?: string;
+}
+
+const DateRangePicker = ( {
+	range,
+	onPresetChange,
+	onCustomChange,
+	className,
+}: DateRangePickerProps ) => {
+	return (
+		<div className={ className ?? 'newspack-insights__date-range-picker' }>
+			<label className="newspack-insights__date-range-picker-label">
+				<span className="screen-reader-text">
+					{ __( 'Date range', 'newspack-plugin' ) }
+				</span>
+				<select
+					className="newspack-insights__date-range-picker-select"
+					value={ range.preset }
+					onChange={ e =>
+						onPresetChange( e.target.value as DateRangePreset )
+					}
+				>
+					{ DATE_RANGE_PRESETS.map( p => (
+						<option key={ p.key } value={ p.key }>
+							{ p.label }
+						</option>
+					) ) }
+				</select>
+			</label>
+
+			{ range.preset === 'custom' && (
+				<div className="newspack-insights__date-range-picker-custom">
+					<label>
+						<span className="screen-reader-text">
+							{ __( 'Start date', 'newspack-plugin' ) }
+						</span>
+						<input
+							type="date"
+							value={ range.start }
+							onChange={ e =>
+								onCustomChange( e.target.value, range.end )
+							}
+						/>
+					</label>
+					<span
+						className="newspack-insights__date-range-picker-sep"
+						aria-hidden="true"
+					>
+						{ '→' }
+					</span>
+					<label>
+						<span className="screen-reader-text">
+							{ __( 'End date', 'newspack-plugin' ) }
+						</span>
+						<input
+							type="date"
+							value={ range.end }
+							onChange={ e =>
+								onCustomChange( range.start, e.target.value )
+							}
+						/>
+					</label>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default DateRangePicker;

--- a/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
@@ -5,6 +5,10 @@
  * last-90, this-month, last-month, custom). Custom mode reveals two date
  * inputs.
  *
+ * Uses @wordpress/components SelectControl for the preset dropdown per
+ * Newspack admin convention. The custom date inputs stay as
+ * <input type="date"> because WordPress doesn't ship a date control.
+ *
  * Component owns no state — caller wires it to useDateRange.
  */
 
@@ -12,6 +16,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -26,26 +31,21 @@ export interface DateRangePickerProps {
 }
 
 const DateRangePicker = ( { range, onPresetChange, onCustomChange, className }: DateRangePickerProps ) => {
-	const presetId = 'newspack-insights-date-range-preset';
 	const startId = 'newspack-insights-date-range-start';
 	const endId = 'newspack-insights-date-range-end';
+	const options = DATE_RANGE_PRESETS.map( p => ( { value: p.key, label: p.label } ) );
+
 	return (
 		<div className={ className ?? 'newspack-insights__date-range-picker' }>
-			<label className="newspack-insights__date-range-picker-label" htmlFor={ presetId }>
-				<span className="screen-reader-text">{ __( 'Date range', 'newspack-plugin' ) }</span>
-				<select
-					id={ presetId }
-					className="newspack-insights__date-range-picker-select"
-					value={ range.preset }
-					onChange={ e => onPresetChange( e.target.value as DateRangePreset ) }
-				>
-					{ DATE_RANGE_PRESETS.map( p => (
-						<option key={ p.key } value={ p.key }>
-							{ p.label }
-						</option>
-					) ) }
-				</select>
-			</label>
+			<SelectControl
+				className="newspack-insights__date-range-picker-select"
+				label={ __( 'Date range', 'newspack-plugin' ) }
+				hideLabelFromVision
+				__nextHasNoMarginBottom
+				value={ range.preset }
+				options={ options }
+				onChange={ value => onPresetChange( value as DateRangePreset ) }
+			/>
 
 			{ range.preset === 'custom' && (
 				<div className="newspack-insights__date-range-picker-custom">

--- a/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
@@ -16,11 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	DATE_RANGE_PRESETS,
-	type DateRange,
-	type DateRangePreset,
-} from '../state/useDateRange';
+import { DATE_RANGE_PRESETS, type DateRange, type DateRangePreset } from '../state/useDateRange';
 
 export interface DateRangePickerProps {
 	range: DateRange;
@@ -29,24 +25,19 @@ export interface DateRangePickerProps {
 	className?: string;
 }
 
-const DateRangePicker = ( {
-	range,
-	onPresetChange,
-	onCustomChange,
-	className,
-}: DateRangePickerProps ) => {
+const DateRangePicker = ( { range, onPresetChange, onCustomChange, className }: DateRangePickerProps ) => {
+	const presetId = 'newspack-insights-date-range-preset';
+	const startId = 'newspack-insights-date-range-start';
+	const endId = 'newspack-insights-date-range-end';
 	return (
 		<div className={ className ?? 'newspack-insights__date-range-picker' }>
-			<label className="newspack-insights__date-range-picker-label">
-				<span className="screen-reader-text">
-					{ __( 'Date range', 'newspack-plugin' ) }
-				</span>
+			<label className="newspack-insights__date-range-picker-label" htmlFor={ presetId }>
+				<span className="screen-reader-text">{ __( 'Date range', 'newspack-plugin' ) }</span>
 				<select
+					id={ presetId }
 					className="newspack-insights__date-range-picker-select"
 					value={ range.preset }
-					onChange={ e =>
-						onPresetChange( e.target.value as DateRangePreset )
-					}
+					onChange={ e => onPresetChange( e.target.value as DateRangePreset ) }
 				>
 					{ DATE_RANGE_PRESETS.map( p => (
 						<option key={ p.key } value={ p.key }>
@@ -58,35 +49,16 @@ const DateRangePicker = ( {
 
 			{ range.preset === 'custom' && (
 				<div className="newspack-insights__date-range-picker-custom">
-					<label>
-						<span className="screen-reader-text">
-							{ __( 'Start date', 'newspack-plugin' ) }
-						</span>
-						<input
-							type="date"
-							value={ range.start }
-							onChange={ e =>
-								onCustomChange( e.target.value, range.end )
-							}
-						/>
+					<label htmlFor={ startId }>
+						<span className="screen-reader-text">{ __( 'Start date', 'newspack-plugin' ) }</span>
+						<input id={ startId } type="date" value={ range.start } onChange={ e => onCustomChange( e.target.value, range.end ) } />
 					</label>
-					<span
-						className="newspack-insights__date-range-picker-sep"
-						aria-hidden="true"
-					>
+					<span className="newspack-insights__date-range-picker-sep" aria-hidden="true">
 						{ '→' }
 					</span>
-					<label>
-						<span className="screen-reader-text">
-							{ __( 'End date', 'newspack-plugin' ) }
-						</span>
-						<input
-							type="date"
-							value={ range.end }
-							onChange={ e =>
-								onCustomChange( range.start, e.target.value )
-							}
-						/>
+					<label htmlFor={ endId }>
+						<span className="screen-reader-text">{ __( 'End date', 'newspack-plugin' ) }</span>
+						<input id={ endId } type="date" value={ range.end } onChange={ e => onCustomChange( range.start, e.target.value ) } />
 					</label>
 				</div>
 			) }

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -23,11 +23,7 @@ import ComparisonToggle from './ComparisonToggle';
 import DateRangePicker from './DateRangePicker';
 import LastUpdated from './LastUpdated';
 import TabContent from './TabContent';
-import TabNavigation, {
-	ALL_TABS,
-	type TabKey,
-	type TabVisibility,
-} from './TabNavigation';
+import TabNavigation, { ALL_TABS, type TabKey, type TabVisibility } from './TabNavigation';
 import useComparisonMode from '../state/useComparisonMode';
 import useDateRange, { type DateRange } from '../state/useDateRange';
 
@@ -50,24 +46,19 @@ export interface InsightsWizardProps {
 
 const TAB_KEYS = ALL_TABS.map( t => t.key );
 
-const isTabKey = ( v: unknown ): v is TabKey =>
-	typeof v === 'string' && ( TAB_KEYS as readonly string[] ).includes( v );
+const isTabKey = ( v: unknown ): v is TabKey => typeof v === 'string' && ( TAB_KEYS as readonly string[] ).includes( v );
 
 /**
  * The list of visible tabs derived from the boot config visibility map.
  */
-const getVisibleTabs = ( visibility: TabVisibility ): TabKey[] =>
-	TAB_KEYS.filter( k => visibility[ k as TabKey ] ) as TabKey[];
+const getVisibleTabs = ( visibility: TabVisibility ): TabKey[] => TAB_KEYS.filter( k => visibility[ k as TabKey ] ) as TabKey[];
 
 /**
  * Read initial active tab from URL ?tab=, falling back to the first
  * visible tab. Returns null if no tabs are visible — caller renders an
  * empty state in that case rather than forcing an arbitrary tab key.
  */
-const readInitialTab = (
-	visibility: TabVisibility,
-	visibleTabs: TabKey[]
-): TabKey | null => {
+const readInitialTab = ( visibility: TabVisibility, visibleTabs: TabKey[] ): TabKey | null => {
 	if ( visibleTabs.length === 0 ) {
 		return null;
 	}
@@ -95,9 +86,7 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 	const visibleTabs = getVisibleTabs( config.tabs );
 	const initialTab = readInitialTab( config.tabs, visibleTabs );
 
-	const [ activeTab, setActiveTabState ] = useState< TabKey | null >(
-		() => initialTab
-	);
+	const [ activeTab, setActiveTabState ] = useState< TabKey | null >( () => initialTab );
 
 	const setActiveTab = useCallback( ( tab: TabKey ) => {
 		setActiveTabState( tab );
@@ -113,11 +102,14 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 		defaultRange: config.defaultDateRange,
 	} );
 
-	const { enabled: comparisonEnabled, setEnabled: setComparisonEnabled, previousRange } =
-		useComparisonMode( {
-			defaultEnabled: config.defaultComparison,
-			currentRange: range,
-		} );
+	const {
+		enabled: comparisonEnabled,
+		setEnabled: setComparisonEnabled,
+		previousRange,
+	} = useComparisonMode( {
+		defaultEnabled: config.defaultComparison,
+		currentRange: range,
+	} );
 
 	const hasVisibleTabs = visibleTabs.length > 0;
 
@@ -125,30 +117,18 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 		<div className="newspack-insights">
 			<header className="newspack-insights__header">
 				<div className="newspack-insights__header-left">
-					<h1 className="newspack-insights__title">
-						{ __( 'Insights', 'newspack-plugin' ) }
-					</h1>
+					<h1 className="newspack-insights__title">{ __( 'Insights', 'newspack-plugin' ) }</h1>
 				</div>
 				<div className="newspack-insights__header-right">
 					{ hasVisibleTabs && (
 						<>
-							<DateRangePicker
-								range={ range }
-								onPresetChange={ setPreset }
-								onCustomChange={ setCustom }
-							/>
-							<ComparisonToggle
-								enabled={ comparisonEnabled }
-								onChange={ setComparisonEnabled }
-							/>
+							<DateRangePicker range={ range } onPresetChange={ setPreset } onCustomChange={ setCustom } />
+							<ComparisonToggle enabled={ comparisonEnabled } onChange={ setComparisonEnabled } />
 							<LastUpdated timestamp={ config.lastUpdated ?? null } />
 						</>
 					) }
 					{ config.settingsUrl && (
-						<a
-							className="newspack-insights__settings-link"
-							href={ config.settingsUrl }
-						>
+						<a className="newspack-insights__settings-link" href={ config.settingsUrl }>
 							{ __( 'Settings', 'newspack-plugin' ) }
 						</a>
 					) }
@@ -157,22 +137,12 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 
 			{ hasVisibleTabs && activeTab ? (
 				<>
-					<TabNavigation
-						activeTab={ activeTab }
-						visibility={ config.tabs }
-						onTabChange={ setActiveTab }
-					/>
-					<TabContent
-						activeTab={ activeTab }
-						range={ range }
-						previousRange={ previousRange }
-					/>
+					<TabNavigation activeTab={ activeTab } visibility={ config.tabs } onTabChange={ setActiveTab } />
+					<TabContent activeTab={ activeTab } range={ range } previousRange={ previousRange } />
 				</>
 			) : (
 				<div className="newspack-insights__empty" role="status">
-					<h2 className="newspack-insights__empty-title">
-						{ __( 'No insights sections available', 'newspack-plugin' ) }
-					</h2>
+					<h2 className="newspack-insights__empty-title">{ __( 'No insights sections available', 'newspack-plugin' ) }</h2>
 					<p className="newspack-insights__empty-message">
 						{ __(
 							'Insights sections light up as data sources become available for this site. Check back after you have receivers configured, or visit Settings to configure data sources.',

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -1,0 +1,144 @@
+/**
+ * InsightsWizard
+ *
+ * Top-level chrome for the Newspack Insights wizard. Owns active tab,
+ * date range, and comparison-mode state; renders header (title +
+ * LastUpdated), date picker, comparison toggle, tab navigation, and
+ * the lazy-loaded tab content.
+ *
+ * Tab routing happens entirely client-side via URL query persistence so
+ * tabs are linkable and refresh restores state.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ComparisonToggle from './ComparisonToggle';
+import DateRangePicker from './DateRangePicker';
+import LastUpdated from './LastUpdated';
+import TabContent from './TabContent';
+import TabNavigation, {
+	ALL_TABS,
+	type TabKey,
+	type TabVisibility,
+} from './TabNavigation';
+import useComparisonMode from '../state/useComparisonMode';
+import useDateRange, { type DateRange } from '../state/useDateRange';
+
+export interface InsightsBootConfig {
+	tabs: TabVisibility;
+	defaultDateRange: DateRange;
+	defaultComparison: boolean;
+	timezone: string;
+	settingsUrl: string;
+	/**
+	 * Optional ISO 8601 timestamp of the most recent cache update for the
+	 * currently-displayed data. Null while no data has loaded.
+	 */
+	lastUpdated?: string | null;
+}
+
+export interface InsightsWizardProps {
+	config: InsightsBootConfig;
+}
+
+const TAB_KEYS = ALL_TABS.map( t => t.key );
+
+const isTabKey = ( v: unknown ): v is TabKey =>
+	typeof v === 'string' && ( TAB_KEYS as readonly string[] ).includes( v );
+
+/**
+ * Read initial active tab from URL ?tab=, falling back to the first
+ * visible tab. (Not necessarily 'audience' — if audience is hidden
+ * for this publisher, the first visible one wins.)
+ */
+const readInitialTab = ( visibility: TabVisibility ): TabKey => {
+	const visible = TAB_KEYS.filter( k => visibility[ k as TabKey ] ) as TabKey[];
+	const fallback = visible[ 0 ] ?? 'audience';
+	if ( typeof window === 'undefined' ) {
+		return fallback;
+	}
+	const fromUrl = new URLSearchParams( window.location.search ).get( 'tab' );
+	if ( isTabKey( fromUrl ) && visibility[ fromUrl ] ) {
+		return fromUrl;
+	}
+	return fallback;
+};
+
+const writeTabToUrl = ( tab: TabKey ) => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const params = new URLSearchParams( window.location.search );
+	params.set( 'tab', tab );
+	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
+	window.history.replaceState( window.history.state, '', next );
+};
+
+const InsightsWizard = ( { config }: InsightsWizardProps ) => {
+	const [ activeTab, setActiveTabState ] = useState< TabKey >( () =>
+		readInitialTab( config.tabs )
+	);
+
+	const setActiveTab = useCallback( ( tab: TabKey ) => {
+		setActiveTabState( tab );
+	}, [] );
+
+	useEffect( () => {
+		writeTabToUrl( activeTab );
+	}, [ activeTab ] );
+
+	const { range, setPreset, setCustom } = useDateRange( {
+		defaultRange: config.defaultDateRange,
+	} );
+
+	const { enabled: comparisonEnabled, setEnabled: setComparisonEnabled, previousRange } =
+		useComparisonMode( {
+			defaultEnabled: config.defaultComparison,
+			currentRange: range,
+		} );
+
+	return (
+		<div className="newspack-insights">
+			<header className="newspack-insights__header">
+				<div className="newspack-insights__header-left">
+					<h1 className="newspack-insights__title">
+						{ __( 'Insights', 'newspack-plugin' ) }
+					</h1>
+				</div>
+				<div className="newspack-insights__header-right">
+					<DateRangePicker
+						range={ range }
+						onPresetChange={ setPreset }
+						onCustomChange={ setCustom }
+					/>
+					<ComparisonToggle
+						enabled={ comparisonEnabled }
+						onChange={ setComparisonEnabled }
+					/>
+					<LastUpdated timestamp={ config.lastUpdated ?? null } />
+				</div>
+			</header>
+
+			<TabNavigation
+				activeTab={ activeTab }
+				visibility={ config.tabs }
+				onTabChange={ setActiveTab }
+			/>
+
+			<TabContent
+				activeTab={ activeTab }
+				range={ range }
+				previousRange={ previousRange }
+			/>
+		</div>
+	);
+};
+
+export default InsightsWizard;

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -54,21 +54,31 @@ const isTabKey = ( v: unknown ): v is TabKey =>
 	typeof v === 'string' && ( TAB_KEYS as readonly string[] ).includes( v );
 
 /**
- * Read initial active tab from URL ?tab=, falling back to the first
- * visible tab. (Not necessarily 'audience' — if audience is hidden
- * for this publisher, the first visible one wins.)
+ * The list of visible tabs derived from the boot config visibility map.
  */
-const readInitialTab = ( visibility: TabVisibility ): TabKey => {
-	const visible = TAB_KEYS.filter( k => visibility[ k as TabKey ] ) as TabKey[];
-	const fallback = visible[ 0 ] ?? 'audience';
+const getVisibleTabs = ( visibility: TabVisibility ): TabKey[] =>
+	TAB_KEYS.filter( k => visibility[ k as TabKey ] ) as TabKey[];
+
+/**
+ * Read initial active tab from URL ?tab=, falling back to the first
+ * visible tab. Returns null if no tabs are visible — caller renders an
+ * empty state in that case rather than forcing an arbitrary tab key.
+ */
+const readInitialTab = (
+	visibility: TabVisibility,
+	visibleTabs: TabKey[]
+): TabKey | null => {
+	if ( visibleTabs.length === 0 ) {
+		return null;
+	}
 	if ( typeof window === 'undefined' ) {
-		return fallback;
+		return visibleTabs[ 0 ];
 	}
 	const fromUrl = new URLSearchParams( window.location.search ).get( 'tab' );
 	if ( isTabKey( fromUrl ) && visibility[ fromUrl ] ) {
 		return fromUrl;
 	}
-	return fallback;
+	return visibleTabs[ 0 ];
 };
 
 const writeTabToUrl = ( tab: TabKey ) => {
@@ -82,8 +92,11 @@ const writeTabToUrl = ( tab: TabKey ) => {
 };
 
 const InsightsWizard = ( { config }: InsightsWizardProps ) => {
-	const [ activeTab, setActiveTabState ] = useState< TabKey >( () =>
-		readInitialTab( config.tabs )
+	const visibleTabs = getVisibleTabs( config.tabs );
+	const initialTab = readInitialTab( config.tabs, visibleTabs );
+
+	const [ activeTab, setActiveTabState ] = useState< TabKey | null >(
+		() => initialTab
 	);
 
 	const setActiveTab = useCallback( ( tab: TabKey ) => {
@@ -91,7 +104,9 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 	}, [] );
 
 	useEffect( () => {
-		writeTabToUrl( activeTab );
+		if ( activeTab ) {
+			writeTabToUrl( activeTab );
+		}
 	}, [ activeTab ] );
 
 	const { range, setPreset, setCustom } = useDateRange( {
@@ -104,6 +119,8 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 			currentRange: range,
 		} );
 
+	const hasVisibleTabs = visibleTabs.length > 0;
+
 	return (
 		<div className="newspack-insights">
 			<header className="newspack-insights__header">
@@ -113,30 +130,57 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 					</h1>
 				</div>
 				<div className="newspack-insights__header-right">
-					<DateRangePicker
-						range={ range }
-						onPresetChange={ setPreset }
-						onCustomChange={ setCustom }
-					/>
-					<ComparisonToggle
-						enabled={ comparisonEnabled }
-						onChange={ setComparisonEnabled }
-					/>
-					<LastUpdated timestamp={ config.lastUpdated ?? null } />
+					{ hasVisibleTabs && (
+						<>
+							<DateRangePicker
+								range={ range }
+								onPresetChange={ setPreset }
+								onCustomChange={ setCustom }
+							/>
+							<ComparisonToggle
+								enabled={ comparisonEnabled }
+								onChange={ setComparisonEnabled }
+							/>
+							<LastUpdated timestamp={ config.lastUpdated ?? null } />
+						</>
+					) }
+					{ config.settingsUrl && (
+						<a
+							className="newspack-insights__settings-link"
+							href={ config.settingsUrl }
+						>
+							{ __( 'Settings', 'newspack-plugin' ) }
+						</a>
+					) }
 				</div>
 			</header>
 
-			<TabNavigation
-				activeTab={ activeTab }
-				visibility={ config.tabs }
-				onTabChange={ setActiveTab }
-			/>
-
-			<TabContent
-				activeTab={ activeTab }
-				range={ range }
-				previousRange={ previousRange }
-			/>
+			{ hasVisibleTabs && activeTab ? (
+				<>
+					<TabNavigation
+						activeTab={ activeTab }
+						visibility={ config.tabs }
+						onTabChange={ setActiveTab }
+					/>
+					<TabContent
+						activeTab={ activeTab }
+						range={ range }
+						previousRange={ previousRange }
+					/>
+				</>
+			) : (
+				<div className="newspack-insights__empty" role="status">
+					<h2 className="newspack-insights__empty-title">
+						{ __( 'No insights sections available', 'newspack-plugin' ) }
+					</h2>
+					<p className="newspack-insights__empty-message">
+						{ __(
+							'Insights sections light up as data sources become available for this site. Check back after you have receivers configured, or visit Settings to configure data sources.',
+							'newspack-plugin'
+						) }
+					</p>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -19,8 +19,11 @@ export interface LastUpdatedProps {
 }
 
 const formatRelative = ( ts: Date, now: Date ): string => {
+	// Math.floor (not Math.round) so a 30-second-old timestamp stays in
+	// the "just now" branch instead of rounding up to "1 minute ago".
+	// Same reasoning applies to the hour / day branches below.
 	const diffMs = now.getTime() - ts.getTime();
-	const diffMin = Math.round( diffMs / ( 1000 * 60 ) );
+	const diffMin = Math.floor( diffMs / ( 1000 * 60 ) );
 	if ( diffMin < 1 ) {
 		return __( 'Updated just now', 'newspack-plugin' );
 	}
@@ -31,7 +34,7 @@ const formatRelative = ( ts: Date, now: Date ): string => {
 			diffMin
 		);
 	}
-	const diffHr = Math.round( diffMin / 60 );
+	const diffHr = Math.floor( diffMin / 60 );
 	if ( diffHr < 24 ) {
 		return sprintf(
 			/* translators: %d is number of hours */
@@ -39,7 +42,7 @@ const formatRelative = ( ts: Date, now: Date ): string => {
 			diffHr
 		);
 	}
-	const diffDay = Math.round( diffHr / 24 );
+	const diffDay = Math.floor( diffHr / 24 );
 	return sprintf(
 		/* translators: %d is number of days */
 		__( 'Updated %d days ago', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -59,10 +59,7 @@ const LastUpdated = ( { timestamp, className }: LastUpdatedProps ) => {
 	const label = formatRelative( ts, now );
 	const absolute = ts.toLocaleString();
 	return (
-		<span
-			className={ className ?? 'newspack-insights__last-updated' }
-			title={ absolute }
-		>
+		<span className={ className ?? 'newspack-insights__last-updated' } title={ absolute }>
 			{ label }
 		</span>
 	);

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -1,0 +1,71 @@
+/**
+ * LastUpdated
+ *
+ * Header-row timestamp display. Renders "Updated X minutes ago" or
+ * absolute time depending on staleness. Renders nothing if no timestamp
+ * is available (e.g., chrome is loaded before first cache hit).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+export interface LastUpdatedProps {
+	/** ISO 8601 timestamp of the most recent cache update, or null if unknown. */
+	timestamp: string | null;
+	/** Optional className for wrapper styling overrides. */
+	className?: string;
+}
+
+const formatRelative = ( ts: Date, now: Date ): string => {
+	const diffMs = now.getTime() - ts.getTime();
+	const diffMin = Math.round( diffMs / ( 1000 * 60 ) );
+	if ( diffMin < 1 ) {
+		return __( 'Updated just now', 'newspack-plugin' );
+	}
+	if ( diffMin < 60 ) {
+		return sprintf(
+			/* translators: %d is number of minutes */
+			__( 'Updated %d minutes ago', 'newspack-plugin' ),
+			diffMin
+		);
+	}
+	const diffHr = Math.round( diffMin / 60 );
+	if ( diffHr < 24 ) {
+		return sprintf(
+			/* translators: %d is number of hours */
+			__( 'Updated %d hours ago', 'newspack-plugin' ),
+			diffHr
+		);
+	}
+	const diffDay = Math.round( diffHr / 24 );
+	return sprintf(
+		/* translators: %d is number of days */
+		__( 'Updated %d days ago', 'newspack-plugin' ),
+		diffDay
+	);
+};
+
+const LastUpdated = ( { timestamp, className }: LastUpdatedProps ) => {
+	if ( ! timestamp ) {
+		return null;
+	}
+	const ts = new Date( timestamp );
+	if ( Number.isNaN( ts.getTime() ) ) {
+		return null;
+	}
+	const now = new Date();
+	const label = formatRelative( ts, now );
+	const absolute = ts.toLocaleString();
+	return (
+		<span
+			className={ className ?? 'newspack-insights__last-updated' }
+			title={ absolute }
+		>
+			{ label }
+		</span>
+	);
+};
+
+export default LastUpdated;

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
@@ -34,11 +34,7 @@ export interface TabContentProps {
 }
 
 const Fallback = () => (
-	<div
-		className="newspack-insights__tab-fallback"
-		role="status"
-		aria-live="polite"
-	>
+	<div className="newspack-insights__tab-fallback" role="status" aria-live="polite">
 		{ __( 'Loading…', 'newspack-plugin' ) }
 	</div>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
@@ -3,14 +3,17 @@
  *
  * Lazy-loads the appropriate tab component based on activeTab and renders
  * it inside a Suspense boundary with a skeleton fallback. Each tab is
- * code-split via React.lazy.
+ * code-split via React.lazy. An ErrorBoundary wraps Suspense so a chunk
+ * load failure (deploy mid-session, ad blocker, transient network) shows
+ * a recoverable message instead of crashing the wizard.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lazy, Suspense } from '@wordpress/element';
+import { Component, lazy, Suspense } from '@wordpress/element';
+import type { ErrorInfo, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -27,10 +30,18 @@ const SubscribersTab = lazy( () => import( '../tabs/SubscribersTab' ) );
 const DonorsTab = lazy( () => import( '../tabs/DonorsTab' ) );
 const AdvertisingTab = lazy( () => import( '../tabs/AdvertisingTab' ) );
 
-export interface TabContentProps {
-	activeTab: TabKey;
+/**
+ * Props every tab component receives. Exported so each tab module can
+ * type its own props from the same source, satisfying strict-mode TS
+ * when TabContent passes range / previousRange via the spread below.
+ */
+export interface TabSectionProps {
 	range: DateRange;
 	previousRange: DateRange | null;
+}
+
+export interface TabContentProps extends TabSectionProps {
+	activeTab: TabKey;
 }
 
 const Fallback = () => (
@@ -39,26 +50,67 @@ const Fallback = () => (
 	</div>
 );
 
-const TabContent = ( props: TabContentProps ) => {
-	const { activeTab } = props;
+interface TabErrorBoundaryProps {
+	children: ReactNode;
+}
+
+interface TabErrorBoundaryState {
+	error: Error | null;
+}
+
+class TabErrorBoundary extends Component< TabErrorBoundaryProps, TabErrorBoundaryState > {
+	state: TabErrorBoundaryState = { error: null };
+
+	static getDerivedStateFromError( error: Error ): TabErrorBoundaryState {
+		return { error };
+	}
+
+	componentDidCatch( error: Error, info: ErrorInfo ): void {
+		// eslint-disable-next-line no-console
+		console.error( 'Insights tab failed to load', error, info );
+	}
+
+	handleReload = (): void => {
+		if ( typeof window !== 'undefined' ) {
+			window.location.reload();
+		}
+	};
+
+	render() {
+		if ( this.state.error ) {
+			return (
+				<div className="newspack-insights__tab-error" role="alert">
+					<p>{ __( 'This section could not be loaded.', 'newspack-plugin' ) }</p>
+					<button type="button" className="newspack-insights__tab-error-action" onClick={ this.handleReload }>
+						{ __( 'Reload the page', 'newspack-plugin' ) }
+					</button>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}
+
+const TabContent = ( { activeTab, range, previousRange }: TabContentProps ) => {
+	const sectionProps: TabSectionProps = { range, previousRange };
 	const renderTab = () => {
 		switch ( activeTab ) {
 			case 'audience':
-				return <AudienceTab { ...props } />;
+				return <AudienceTab { ...sectionProps } />;
 			case 'engagement':
-				return <EngagementTab { ...props } />;
+				return <EngagementTab { ...sectionProps } />;
 			case 'conversion':
-				return <ConversionTab { ...props } />;
+				return <ConversionTab { ...sectionProps } />;
 			case 'gates':
-				return <GatesTab { ...props } />;
+				return <GatesTab { ...sectionProps } />;
 			case 'prompts':
-				return <PromptsTab { ...props } />;
+				return <PromptsTab { ...sectionProps } />;
 			case 'subscribers':
-				return <SubscribersTab { ...props } />;
+				return <SubscribersTab { ...sectionProps } />;
 			case 'donors':
-				return <DonorsTab { ...props } />;
+				return <DonorsTab { ...sectionProps } />;
 			case 'advertising':
-				return <AdvertisingTab { ...props } />;
+				return <AdvertisingTab { ...sectionProps } />;
 			default:
 				return null;
 		}
@@ -70,7 +122,9 @@ const TabContent = ( props: TabContentProps ) => {
 			id={ `newspack-insights-panel-${ activeTab }` }
 			aria-labelledby={ `newspack-insights-tab-${ activeTab }` }
 		>
-			<Suspense fallback={ <Fallback /> }>{ renderTab() }</Suspense>
+			<TabErrorBoundary>
+				<Suspense fallback={ <Fallback /> }>{ renderTab() }</Suspense>
+			</TabErrorBoundary>
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
@@ -1,0 +1,82 @@
+/**
+ * TabContent
+ *
+ * Lazy-loads the appropriate tab component based on activeTab and renders
+ * it inside a Suspense boundary with a skeleton fallback. Each tab is
+ * code-split via React.lazy.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { lazy, Suspense } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { TabKey } from './TabNavigation';
+import type { DateRange } from '../state/useDateRange';
+
+const AudienceTab = lazy( () => import( '../tabs/AudienceTab' ) );
+const EngagementTab = lazy( () => import( '../tabs/EngagementTab' ) );
+const ConversionTab = lazy( () => import( '../tabs/ConversionTab' ) );
+const GatesTab = lazy( () => import( '../tabs/GatesTab' ) );
+const PromptsTab = lazy( () => import( '../tabs/PromptsTab' ) );
+const SubscribersTab = lazy( () => import( '../tabs/SubscribersTab' ) );
+const DonorsTab = lazy( () => import( '../tabs/DonorsTab' ) );
+const AdvertisingTab = lazy( () => import( '../tabs/AdvertisingTab' ) );
+
+export interface TabContentProps {
+	activeTab: TabKey;
+	range: DateRange;
+	previousRange: DateRange | null;
+}
+
+const Fallback = () => (
+	<div
+		className="newspack-insights__tab-fallback"
+		role="status"
+		aria-live="polite"
+	>
+		{ __( 'Loading…', 'newspack-plugin' ) }
+	</div>
+);
+
+const TabContent = ( props: TabContentProps ) => {
+	const { activeTab } = props;
+	const renderTab = () => {
+		switch ( activeTab ) {
+			case 'audience':
+				return <AudienceTab { ...props } />;
+			case 'engagement':
+				return <EngagementTab { ...props } />;
+			case 'conversion':
+				return <ConversionTab { ...props } />;
+			case 'gates':
+				return <GatesTab { ...props } />;
+			case 'prompts':
+				return <PromptsTab { ...props } />;
+			case 'subscribers':
+				return <SubscribersTab { ...props } />;
+			case 'donors':
+				return <DonorsTab { ...props } />;
+			case 'advertising':
+				return <AdvertisingTab { ...props } />;
+			default:
+				return null;
+		}
+	};
+	return (
+		<div
+			className="newspack-insights__tab-content"
+			role="tabpanel"
+			id={ `newspack-insights-panel-${ activeTab }` }
+			aria-labelledby={ `newspack-insights-tab-${ activeTab }` }
+		>
+			<Suspense fallback={ <Fallback /> }>{ renderTab() }</Suspense>
+		</div>
+	);
+};
+
+export default TabContent;

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
@@ -1,0 +1,88 @@
+/**
+ * TabNavigation
+ *
+ * Horizontal tab bar for the Insights wizard. Visibility per tab is
+ * driven by props (computed at boot from feature detection — stubbed
+ * all-on for now). Active tab highlighting per design spec.
+ *
+ * Component owns no state — caller passes activeTab and onTabChange.
+ */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+export type TabKey =
+	| 'audience'
+	| 'engagement'
+	| 'conversion'
+	| 'gates'
+	| 'prompts'
+	| 'subscribers'
+	| 'donors'
+	| 'advertising';
+
+export interface TabDef {
+	key: TabKey;
+	label: string;
+}
+
+export const ALL_TABS: TabDef[] = [
+	{ key: 'audience', label: 'Audience' },
+	{ key: 'engagement', label: 'Engagement' },
+	{ key: 'conversion', label: 'Conversion Journey' },
+	{ key: 'gates', label: 'Gates' },
+	{ key: 'prompts', label: 'Prompts' },
+	{ key: 'subscribers', label: 'Subscribers' },
+	{ key: 'donors', label: 'Donors' },
+	{ key: 'advertising', label: 'Advertising' },
+];
+
+export type TabVisibility = Record< TabKey, boolean >;
+
+export interface TabNavigationProps {
+	activeTab: TabKey;
+	visibility: TabVisibility;
+	onTabChange: ( tab: TabKey ) => void;
+	className?: string;
+}
+
+const TabNavigation = ( {
+	activeTab,
+	visibility,
+	onTabChange,
+	className,
+}: TabNavigationProps ) => {
+	const visibleTabs = ALL_TABS.filter( t => visibility[ t.key ] );
+	return (
+		<nav
+			className={ classnames( 'newspack-insights__tabs', className ) }
+			role="tablist"
+			aria-label="Insights sections"
+		>
+			{ visibleTabs.map( tab => {
+				const isActive = tab.key === activeTab;
+				return (
+					<button
+						key={ tab.key }
+						type="button"
+						role="tab"
+						aria-selected={ isActive }
+						aria-controls={ `newspack-insights-panel-${ tab.key }` }
+						id={ `newspack-insights-tab-${ tab.key }` }
+						className={ classnames(
+							'newspack-insights__tab',
+							isActive && 'is-active'
+						) }
+						onClick={ () => onTabChange( tab.key ) }
+					>
+						{ tab.label }
+					</button>
+				);
+			} ) }
+		</nav>
+	);
+};
+
+export default TabNavigation;

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
@@ -18,15 +18,7 @@ import { __ } from '@wordpress/i18n';
  */
 import classnames from 'classnames';
 
-export type TabKey =
-	| 'audience'
-	| 'engagement'
-	| 'conversion'
-	| 'gates'
-	| 'prompts'
-	| 'subscribers'
-	| 'donors'
-	| 'advertising';
+export type TabKey = 'audience' | 'engagement' | 'conversion' | 'gates' | 'prompts' | 'subscribers' | 'donors' | 'advertising';
 
 export interface TabDef {
 	key: TabKey;
@@ -53,15 +45,10 @@ export interface TabNavigationProps {
 	className?: string;
 }
 
-const TabNavigation = ( {
-	activeTab,
-	visibility,
-	onTabChange,
-	className,
-}: TabNavigationProps ) => {
+const TabNavigation = ( { activeTab, visibility, onTabChange, className }: TabNavigationProps ) => {
 	const visibleTabs = ALL_TABS.filter( t => visibility[ t.key ] );
 	return (
-		<nav
+		<div
 			className={ classnames( 'newspack-insights__tabs', className ) }
 			role="tablist"
 			aria-label={ __( 'Insights sections', 'newspack-plugin' ) }
@@ -76,17 +63,14 @@ const TabNavigation = ( {
 						aria-selected={ isActive }
 						aria-controls={ `newspack-insights-panel-${ tab.key }` }
 						id={ `newspack-insights-tab-${ tab.key }` }
-						className={ classnames(
-							'newspack-insights__tab',
-							isActive && 'is-active'
-						) }
+						className={ classnames( 'newspack-insights__tab', isActive && 'is-active' ) }
 						onClick={ () => onTabChange( tab.key ) }
 					>
 						{ tab.label }
 					</button>
 				);
 			} ) }
-		</nav>
+		</div>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
@@ -5,6 +5,10 @@
  * driven by props (computed at boot from feature detection — stubbed
  * all-on for now). Active tab highlighting per design spec.
  *
+ * Implements the WAI-ARIA tabs pattern: roving tabindex (only the
+ * active tab is in the tab order; others use tabIndex={-1}) and
+ * arrow / Home / End keyboard navigation between tabs.
+ *
  * Component owns no state — caller passes activeTab and onTabChange.
  */
 
@@ -12,6 +16,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useCallback, useRef } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -47,24 +52,67 @@ export interface TabNavigationProps {
 
 const TabNavigation = ( { activeTab, visibility, onTabChange, className }: TabNavigationProps ) => {
 	const visibleTabs = ALL_TABS.filter( t => visibility[ t.key ] );
+	const tabsRef = useRef< Record< TabKey, HTMLButtonElement | null > >( {} as Record< TabKey, HTMLButtonElement | null > );
+
+	const focusTab = useCallback(
+		( key: TabKey ) => {
+			tabsRef.current[ key ]?.focus();
+			onTabChange( key );
+		},
+		[ onTabChange ]
+	);
+
+	const handleKeyDown = useCallback(
+		( e: React.KeyboardEvent< HTMLButtonElement >, index: number ) => {
+			if ( visibleTabs.length === 0 ) {
+				return;
+			}
+			let nextIndex: number | null = null;
+			switch ( e.key ) {
+				case 'ArrowRight':
+					nextIndex = ( index + 1 ) % visibleTabs.length;
+					break;
+				case 'ArrowLeft':
+					nextIndex = ( index - 1 + visibleTabs.length ) % visibleTabs.length;
+					break;
+				case 'Home':
+					nextIndex = 0;
+					break;
+				case 'End':
+					nextIndex = visibleTabs.length - 1;
+					break;
+				default:
+					return;
+			}
+			e.preventDefault();
+			focusTab( visibleTabs[ nextIndex ].key );
+		},
+		[ visibleTabs, focusTab ]
+	);
+
 	return (
 		<div
 			className={ classnames( 'newspack-insights__tabs', className ) }
 			role="tablist"
 			aria-label={ __( 'Insights sections', 'newspack-plugin' ) }
 		>
-			{ visibleTabs.map( tab => {
+			{ visibleTabs.map( ( tab, index ) => {
 				const isActive = tab.key === activeTab;
 				return (
 					<button
 						key={ tab.key }
+						ref={ el => {
+							tabsRef.current[ tab.key ] = el;
+						} }
 						type="button"
 						role="tab"
 						aria-selected={ isActive }
 						aria-controls={ `newspack-insights-panel-${ tab.key }` }
 						id={ `newspack-insights-tab-${ tab.key }` }
+						tabIndex={ isActive ? 0 : -1 }
 						className={ classnames( 'newspack-insights__tab', isActive && 'is-active' ) }
 						onClick={ () => onTabChange( tab.key ) }
+						onKeyDown={ e => handleKeyDown( e, index ) }
 					>
 						{ tab.label }
 					</button>

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
@@ -9,6 +9,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import classnames from 'classnames';
@@ -29,14 +34,14 @@ export interface TabDef {
 }
 
 export const ALL_TABS: TabDef[] = [
-	{ key: 'audience', label: 'Audience' },
-	{ key: 'engagement', label: 'Engagement' },
-	{ key: 'conversion', label: 'Conversion Journey' },
-	{ key: 'gates', label: 'Gates' },
-	{ key: 'prompts', label: 'Prompts' },
-	{ key: 'subscribers', label: 'Subscribers' },
-	{ key: 'donors', label: 'Donors' },
-	{ key: 'advertising', label: 'Advertising' },
+	{ key: 'audience', label: __( 'Audience', 'newspack-plugin' ) },
+	{ key: 'engagement', label: __( 'Engagement', 'newspack-plugin' ) },
+	{ key: 'conversion', label: __( 'Conversion Journey', 'newspack-plugin' ) },
+	{ key: 'gates', label: __( 'Gates', 'newspack-plugin' ) },
+	{ key: 'prompts', label: __( 'Prompts', 'newspack-plugin' ) },
+	{ key: 'subscribers', label: __( 'Subscribers', 'newspack-plugin' ) },
+	{ key: 'donors', label: __( 'Donors', 'newspack-plugin' ) },
+	{ key: 'advertising', label: __( 'Advertising', 'newspack-plugin' ) },
 ];
 
 export type TabVisibility = Record< TabKey, boolean >;
@@ -59,7 +64,7 @@ const TabNavigation = ( {
 		<nav
 			className={ classnames( 'newspack-insights__tabs', className ) }
 			role="tablist"
-			aria-label="Insights sections"
+			aria-label={ __( 'Insights sections', 'newspack-plugin' ) }
 		>
 			{ visibleTabs.map( tab => {
 				const isActive = tab.key === activeTab;

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -9,9 +9,7 @@
 /**
  * Internal dependencies
  */
-import InsightsWizard, {
-	type InsightsBootConfig,
-} from './components/InsightsWizard';
+import InsightsWizard, { type InsightsBootConfig } from './components/InsightsWizard';
 import './style.scss';
 
 declare global {
@@ -33,8 +31,7 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 	},
 	defaultDateRange: ( () => {
 		const pad = ( n: number ) => String( n ).padStart( 2, '0' );
-		const toISO = ( d: Date ) =>
-			`${ d.getFullYear() }-${ pad( d.getMonth() + 1 ) }-${ pad( d.getDate() ) }`;
+		const toISO = ( d: Date ) => `${ d.getFullYear() }-${ pad( d.getMonth() + 1 ) }-${ pad( d.getDate() ) }`;
 		const today = new Date();
 		const thirtyAgo = new Date( today );
 		// Inclusive 30-day window ending today: today + 29 prior days = 30 days.

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -37,7 +37,8 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 			`${ d.getFullYear() }-${ pad( d.getMonth() + 1 ) }-${ pad( d.getDate() ) }`;
 		const today = new Date();
 		const thirtyAgo = new Date( today );
-		thirtyAgo.setDate( thirtyAgo.getDate() - 30 );
+		// Inclusive 30-day window ending today: today + 29 prior days = 30 days.
+		thirtyAgo.setDate( thirtyAgo.getDate() - 29 );
 		return {
 			preset: 'last-30' as const,
 			start: toISO( thirtyAgo ),

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * Newspack Insights wizard React entry (NPPD-1602).
+ *
+ * Loaded lazily by src/wizards/index.tsx when ?page=newspack-insights.
+ * Reads boot config from window.newspackInsights (set by the PHP
+ * wizard via wp_localize_script) and mounts InsightsWizard.
+ */
+
+/**
+ * Internal dependencies
+ */
+import InsightsWizard, {
+	type InsightsBootConfig,
+} from './components/InsightsWizard';
+import './style.scss';
+
+declare global {
+	interface Window {
+		newspackInsights?: InsightsBootConfig;
+	}
+}
+
+const FALLBACK_CONFIG: InsightsBootConfig = {
+	tabs: {
+		audience: true,
+		engagement: true,
+		conversion: true,
+		gates: true,
+		prompts: true,
+		subscribers: true,
+		donors: true,
+		advertising: true,
+	},
+	defaultDateRange: ( () => {
+		const pad = ( n: number ) => String( n ).padStart( 2, '0' );
+		const toISO = ( d: Date ) =>
+			`${ d.getFullYear() }-${ pad( d.getMonth() + 1 ) }-${ pad( d.getDate() ) }`;
+		const today = new Date();
+		const thirtyAgo = new Date( today );
+		thirtyAgo.setDate( thirtyAgo.getDate() - 30 );
+		return {
+			preset: 'last-30' as const,
+			start: toISO( thirtyAgo ),
+			end: toISO( today ),
+		};
+	} )(),
+	defaultComparison: false,
+	timezone: 'UTC',
+	settingsUrl: '',
+	lastUpdated: null,
+};
+
+const Index = () => {
+	const config = window.newspackInsights ?? FALLBACK_CONFIG;
+	return <InsightsWizard config={ config } />;
+};
+
+export default Index;

--- a/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
@@ -19,8 +19,7 @@ import type { DateRange } from './useDateRange';
 
 const pad2 = ( n: number ) => String( n ).padStart( 2, '0' );
 
-const toISO = ( d: Date ): string =>
-	`${ d.getFullYear() }-${ pad2( d.getMonth() + 1 ) }-${ pad2( d.getDate() ) }`;
+const toISO = ( d: Date ): string => `${ d.getFullYear() }-${ pad2( d.getMonth() + 1 ) }-${ pad2( d.getDate() ) }`;
 
 const fromISO = ( s: string ): Date | null => {
 	const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec( s );
@@ -43,9 +42,7 @@ const daysBetween = ( a: Date, b: Date ): number => {
  *      previous = 2026-04-01 to 2026-04-30 (30 days, ending the day before
  *      current starts so the two windows don't overlap)
  */
-export const computePreviousRange = (
-	current: DateRange
-): DateRange | null => {
+export const computePreviousRange = ( current: DateRange ): DateRange | null => {
 	const start = fromISO( current.start );
 	const end = fromISO( current.end );
 	if ( ! start || ! end ) {
@@ -105,10 +102,7 @@ export interface UseComparisonModeReturn {
 	previousRange: DateRange | null;
 }
 
-const useComparisonMode = ( {
-	defaultEnabled,
-	currentRange,
-}: UseComparisonModeOptions ): UseComparisonModeReturn => {
+const useComparisonMode = ( { defaultEnabled, currentRange }: UseComparisonModeOptions ): UseComparisonModeReturn => {
 	const [ enabled, setEnabledState ] = useState< boolean >( () => {
 		const fromUrl = readUrl();
 		return fromUrl !== undefined ? fromUrl : defaultEnabled;
@@ -122,10 +116,7 @@ const useComparisonMode = ( {
 		setEnabledState( v );
 	}, [] );
 
-	const previousRange = useMemo(
-		() => ( enabled ? computePreviousRange( currentRange ) : null ),
-		[ enabled, currentRange ]
-	);
+	const previousRange = useMemo( () => ( enabled ? computePreviousRange( currentRange ) : null ), [ enabled, currentRange ] );
 
 	return { enabled, setEnabled, previousRange };
 };

--- a/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
@@ -82,11 +82,12 @@ const writeUrl = ( enabled: boolean ) => {
 		return;
 	}
 	const params = new URLSearchParams( window.location.search );
-	if ( enabled ) {
-		params.set( 'compare', '1' );
-	} else {
-		params.delete( 'compare' );
-	}
+	// Persist both states explicitly. Previously the disabled state
+	// deleted the param, which meant an explicit user choice of
+	// "disabled" would silently revert to the boot config default on
+	// refresh whenever that default is true. `readUrl` already accepts
+	// '0' so this round-trips cleanly.
+	params.set( 'compare', enabled ? '1' : '0' );
 	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
 	window.history.replaceState( window.history.state, '', next );
 };

--- a/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
@@ -1,0 +1,133 @@
+/**
+ * useComparisonMode
+ *
+ * Owns the "compare to previous period" toggle. When enabled, computes
+ * the previous-period range as the same length immediately preceding the
+ * current range. Hydrates from URL query (?compare=1) and persists on
+ * change.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from './useDateRange';
+
+const pad2 = ( n: number ) => String( n ).padStart( 2, '0' );
+
+const toISO = ( d: Date ): string =>
+	`${ d.getFullYear() }-${ pad2( d.getMonth() + 1 ) }-${ pad2( d.getDate() ) }`;
+
+const fromISO = ( s: string ): Date | null => {
+	const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec( s );
+	if ( ! m ) {
+		return null;
+	}
+	return new Date( Number( m[ 1 ] ), Number( m[ 2 ] ) - 1, Number( m[ 3 ] ) );
+};
+
+const daysBetween = ( a: Date, b: Date ): number => {
+	const ms = b.getTime() - a.getTime();
+	return Math.round( ms / ( 1000 * 60 * 60 * 24 ) );
+};
+
+/**
+ * Same-length-back. Previous period is the [start - N days, start - 1 day]
+ * window where N is the length of the current range.
+ *
+ * e.g. current = 2026-05-01 to 2026-05-30 (30 days)
+ *      previous = 2026-04-01 to 2026-04-30 (30 days, ending the day before
+ *      current starts so the two windows don't overlap)
+ */
+export const computePreviousRange = (
+	current: DateRange
+): DateRange | null => {
+	const start = fromISO( current.start );
+	const end = fromISO( current.end );
+	if ( ! start || ! end ) {
+		return null;
+	}
+	const lengthDays = daysBetween( start, end );
+	if ( lengthDays < 0 ) {
+		return null;
+	}
+	const prevEnd = new Date( start );
+	prevEnd.setDate( prevEnd.getDate() - 1 );
+	const prevStart = new Date( prevEnd );
+	prevStart.setDate( prevStart.getDate() - lengthDays );
+	return {
+		preset: 'custom',
+		start: toISO( prevStart ),
+		end: toISO( prevEnd ),
+	};
+};
+
+const readUrl = (): boolean | undefined => {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+	const v = new URLSearchParams( window.location.search ).get( 'compare' );
+	if ( v === '1' ) {
+		return true;
+	}
+	if ( v === '0' ) {
+		return false;
+	}
+	return undefined;
+};
+
+const writeUrl = ( enabled: boolean ) => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const params = new URLSearchParams( window.location.search );
+	if ( enabled ) {
+		params.set( 'compare', '1' );
+	} else {
+		params.delete( 'compare' );
+	}
+	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
+	window.history.replaceState( window.history.state, '', next );
+};
+
+export interface UseComparisonModeOptions {
+	defaultEnabled: boolean;
+	currentRange: DateRange;
+}
+
+export interface UseComparisonModeReturn {
+	enabled: boolean;
+	setEnabled: ( v: boolean ) => void;
+	previousRange: DateRange | null;
+}
+
+const useComparisonMode = ( {
+	defaultEnabled,
+	currentRange,
+}: UseComparisonModeOptions ): UseComparisonModeReturn => {
+	const [ enabled, setEnabledState ] = useState< boolean >( () => {
+		const fromUrl = readUrl();
+		return fromUrl !== undefined ? fromUrl : defaultEnabled;
+	} );
+
+	useEffect( () => {
+		writeUrl( enabled );
+	}, [ enabled ] );
+
+	const setEnabled = useCallback( ( v: boolean ) => {
+		setEnabledState( v );
+	}, [] );
+
+	const previousRange = useMemo(
+		() => ( enabled ? computePreviousRange( currentRange ) : null ),
+		[ enabled, currentRange ]
+	);
+
+	return { enabled, setEnabled, previousRange };
+};
+
+export default useComparisonMode;

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -1,0 +1,204 @@
+/**
+ * useDateRange
+ *
+ * Owns the active date range state for the Insights wizard. Hydrates
+ * initial state from URL query (so refresh / direct links preserve range)
+ * with fallback to the boot config default; persists changes back to URL
+ * via history.replaceState (no history pollution).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+export type DateRangePreset =
+	| 'last-7'
+	| 'last-30'
+	| 'last-90'
+	| 'this-month'
+	| 'last-month'
+	| 'custom';
+
+export interface DateRange {
+	preset: DateRangePreset;
+	start: string; // YYYY-MM-DD
+	end: string; // YYYY-MM-DD
+}
+
+export interface DateRangePresetDef {
+	key: DateRangePreset;
+	label: string;
+}
+
+export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
+	{ key: 'last-7', label: 'Last 7 days' },
+	{ key: 'last-30', label: 'Last 30 days' },
+	{ key: 'last-90', label: 'Last 90 days' },
+	{ key: 'this-month', label: 'This month' },
+	{ key: 'last-month', label: 'Last month' },
+	{ key: 'custom', label: 'Custom' },
+];
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidISODate = ( s: unknown ): s is string =>
+	typeof s === 'string' && ISO_DATE_RE.test( s );
+
+const isPreset = ( v: unknown ): v is DateRangePreset =>
+	typeof v === 'string' &&
+	DATE_RANGE_PRESETS.some( p => p.key === v );
+
+const pad2 = ( n: number ) => String( n ).padStart( 2, '0' );
+
+const toISO = ( d: Date ): string =>
+	`${ d.getFullYear() }-${ pad2( d.getMonth() + 1 ) }-${ pad2( d.getDate() ) }`;
+
+/**
+ * Compute a range from a preset, anchored to today.
+ *
+ * Returns null for 'custom' — the caller supplies start/end directly.
+ */
+export const computeRangeForPreset = (
+	preset: DateRangePreset,
+	today: Date = new Date()
+): { start: string; end: string } | null => {
+	if ( preset === 'custom' ) {
+		return null;
+	}
+	const end = toISO( today );
+	if ( preset === 'last-7' ) {
+		const s = new Date( today );
+		s.setDate( s.getDate() - 7 );
+		return { start: toISO( s ), end };
+	}
+	if ( preset === 'last-30' ) {
+		const s = new Date( today );
+		s.setDate( s.getDate() - 30 );
+		return { start: toISO( s ), end };
+	}
+	if ( preset === 'last-90' ) {
+		const s = new Date( today );
+		s.setDate( s.getDate() - 90 );
+		return { start: toISO( s ), end };
+	}
+	if ( preset === 'this-month' ) {
+		const s = new Date( today.getFullYear(), today.getMonth(), 1 );
+		return { start: toISO( s ), end };
+	}
+	if ( preset === 'last-month' ) {
+		const s = new Date( today.getFullYear(), today.getMonth() - 1, 1 );
+		const e = new Date( today.getFullYear(), today.getMonth(), 0 );
+		return { start: toISO( s ), end: toISO( e ) };
+	}
+	return null;
+};
+
+const readUrl = (): Partial< DateRange > => {
+	if ( typeof window === 'undefined' ) {
+		return {};
+	}
+	const params = new URLSearchParams( window.location.search );
+	const preset = params.get( 'range' );
+	const start = params.get( 'start' );
+	const end = params.get( 'end' );
+	const out: Partial< DateRange > = {};
+	if ( isPreset( preset ) ) {
+		out.preset = preset;
+	}
+	if ( isValidISODate( start ) ) {
+		out.start = start;
+	}
+	if ( isValidISODate( end ) ) {
+		out.end = end;
+	}
+	return out;
+};
+
+const writeUrl = ( range: DateRange ) => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const params = new URLSearchParams( window.location.search );
+	params.set( 'range', range.preset );
+	if ( range.preset === 'custom' ) {
+		params.set( 'start', range.start );
+		params.set( 'end', range.end );
+	} else {
+		params.delete( 'start' );
+		params.delete( 'end' );
+	}
+	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
+	window.history.replaceState( window.history.state, '', next );
+};
+
+export interface UseDateRangeOptions {
+	defaultRange: DateRange;
+}
+
+export interface UseDateRangeReturn {
+	range: DateRange;
+	setPreset: ( preset: DateRangePreset ) => void;
+	setCustom: ( start: string, end: string ) => void;
+}
+
+/**
+ * Hydrate from URL first, fall back to defaultRange. Persist on change.
+ */
+const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeReturn => {
+	const [ range, setRange ] = useState< DateRange >( () => {
+		const fromUrl = readUrl();
+		// Custom preset requires both start and end from URL; otherwise fall
+		// back to default.
+		if ( fromUrl.preset === 'custom' ) {
+			if ( fromUrl.start && fromUrl.end ) {
+				return {
+					preset: 'custom',
+					start: fromUrl.start,
+					end: fromUrl.end,
+				};
+			}
+			return defaultRange;
+		}
+		if ( fromUrl.preset ) {
+			const computed = computeRangeForPreset( fromUrl.preset );
+			if ( computed ) {
+				return { preset: fromUrl.preset, ...computed };
+			}
+		}
+		return defaultRange;
+	} );
+
+	useEffect( () => {
+		writeUrl( range );
+	}, [ range ] );
+
+	const setPreset = useCallback( ( preset: DateRangePreset ) => {
+		if ( preset === 'custom' ) {
+			// Custom needs explicit start/end; setCustom handles that path.
+			// Hitting "Custom" without supplying dates keeps the current
+			// range but flags it as custom so the picker opens.
+			setRange( prev => ( {
+				preset: 'custom',
+				start: prev.start,
+				end: prev.end,
+			} ) );
+			return;
+		}
+		const computed = computeRangeForPreset( preset );
+		if ( computed ) {
+			setRange( { preset, ...computed } );
+		}
+	}, [] );
+
+	const setCustom = useCallback( ( start: string, end: string ) => {
+		if ( ! isValidISODate( start ) || ! isValidISODate( end ) ) {
+			return;
+		}
+		setRange( { preset: 'custom', start, end } );
+	}, [] );
+
+	return { range, setPreset, setCustom };
+};
+
+export default useDateRange;

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -37,7 +37,20 @@ export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-const isValidISODate = ( s: unknown ): s is string => typeof s === 'string' && ISO_DATE_RE.test( s );
+/**
+ * Validate a YYYY-MM-DD string. Checks both the shape AND that the parsed
+ * date round-trips back to the same string — otherwise inputs like
+ * '2026-99-99' would pass the regex and silently roll over to a future
+ * month when used as a Date.
+ */
+const isValidISODate = ( s: unknown ): s is string => {
+	if ( typeof s !== 'string' || ! ISO_DATE_RE.test( s ) ) {
+		return false;
+	}
+	const [ y, m, d ] = s.split( '-' ).map( Number );
+	const parsed = new Date( y, m - 1, d );
+	return parsed.getFullYear() === y && parsed.getMonth() === m - 1 && parsed.getDate() === d;
+};
 
 const isPreset = ( v: unknown ): v is DateRangePreset => typeof v === 'string' && DATE_RANGE_PRESETS.some( p => p.key === v );
 
@@ -187,7 +200,13 @@ const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeRetu
 		if ( ! isValidISODate( start ) || ! isValidISODate( end ) ) {
 			return;
 		}
-		setRange( { preset: 'custom', start, end } );
+		// Normalize so the earlier date is always start. The picker has
+		// two independent <input type="date"> fields and editing one
+		// before the other can transiently produce start > end, which
+		// otherwise propagates a nonsensical range into the URL and
+		// breaks computePreviousRange.
+		const [ s, e ] = start <= end ? [ start, end ] : [ end, start ];
+		setRange( { preset: 'custom', start: s, end: e } );
 	}, [] );
 
 	return { range, setPreset, setCustom };

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -13,13 +13,7 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 
-export type DateRangePreset =
-	| 'last-7'
-	| 'last-30'
-	| 'last-90'
-	| 'this-month'
-	| 'last-month'
-	| 'custom';
+export type DateRangePreset = 'last-7' | 'last-30' | 'last-90' | 'this-month' | 'last-month' | 'custom';
 
 export interface DateRange {
 	preset: DateRangePreset;
@@ -43,17 +37,13 @@ export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-const isValidISODate = ( s: unknown ): s is string =>
-	typeof s === 'string' && ISO_DATE_RE.test( s );
+const isValidISODate = ( s: unknown ): s is string => typeof s === 'string' && ISO_DATE_RE.test( s );
 
-const isPreset = ( v: unknown ): v is DateRangePreset =>
-	typeof v === 'string' &&
-	DATE_RANGE_PRESETS.some( p => p.key === v );
+const isPreset = ( v: unknown ): v is DateRangePreset => typeof v === 'string' && DATE_RANGE_PRESETS.some( p => p.key === v );
 
 const pad2 = ( n: number ) => String( n ).padStart( 2, '0' );
 
-const toISO = ( d: Date ): string =>
-	`${ d.getFullYear() }-${ pad2( d.getMonth() + 1 ) }-${ pad2( d.getDate() ) }`;
+const toISO = ( d: Date ): string => `${ d.getFullYear() }-${ pad2( d.getMonth() + 1 ) }-${ pad2( d.getDate() ) }`;
 
 /**
  * Compute a range from a preset, anchored to today.
@@ -64,10 +54,7 @@ const toISO = ( d: Date ): string =>
  *
  * Returns null for 'custom' — the caller supplies start/end directly.
  */
-export const computeRangeForPreset = (
-	preset: DateRangePreset,
-	today: Date = new Date()
-): { start: string; end: string } | null => {
+export const computeRangeForPreset = ( preset: DateRangePreset, today: Date = new Date() ): { start: string; end: string } | null => {
 	if ( preset === 'custom' ) {
 		return null;
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -57,6 +57,10 @@ const toISO = ( d: Date ): string =>
 /**
  * Compute a range from a preset, anchored to today.
  *
+ * "Last N days" presets produce an inclusive N-day window ending today —
+ * e.g. "Last 7 days" on Jun 7 = Jun 1 → Jun 7 (7 days total). So we
+ * subtract (N - 1) days, not N.
+ *
  * Returns null for 'custom' — the caller supplies start/end directly.
  */
 export const computeRangeForPreset = (
@@ -69,17 +73,17 @@ export const computeRangeForPreset = (
 	const end = toISO( today );
 	if ( preset === 'last-7' ) {
 		const s = new Date( today );
-		s.setDate( s.getDate() - 7 );
+		s.setDate( s.getDate() - 6 );
 		return { start: toISO( s ), end };
 	}
 	if ( preset === 'last-30' ) {
 		const s = new Date( today );
-		s.setDate( s.getDate() - 30 );
+		s.setDate( s.getDate() - 29 );
 		return { start: toISO( s ), end };
 	}
 	if ( preset === 'last-90' ) {
 		const s = new Date( today );
-		s.setDate( s.getDate() - 90 );
+		s.setDate( s.getDate() - 89 );
 		return { start: toISO( s ), end };
 	}
 	if ( preset === 'this-month' ) {

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -10,6 +10,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 
 export type DateRangePreset =
@@ -32,12 +33,12 @@ export interface DateRangePresetDef {
 }
 
 export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
-	{ key: 'last-7', label: 'Last 7 days' },
-	{ key: 'last-30', label: 'Last 30 days' },
-	{ key: 'last-90', label: 'Last 90 days' },
-	{ key: 'this-month', label: 'This month' },
-	{ key: 'last-month', label: 'Last month' },
-	{ key: 'custom', label: 'Custom' },
+	{ key: 'last-7', label: __( 'Last 7 days', 'newspack-plugin' ) },
+	{ key: 'last-30', label: __( 'Last 30 days', 'newspack-plugin' ) },
+	{ key: 'last-90', label: __( 'Last 90 days', 'newspack-plugin' ) },
+	{ key: 'this-month', label: __( 'This month', 'newspack-plugin' ) },
+	{ key: 'last-month', label: __( 'Last month', 'newspack-plugin' ) },
+	{ key: 'custom', label: __( 'Custom', 'newspack-plugin' ) },
 ];
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -52,6 +52,55 @@
 		color: wp-colors.$gray-600;
 	}
 
+	&__settings-link {
+		font-size: 13px;
+		font-weight: 500;
+		color: var(--wp-admin-theme-color);
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration: underline;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: 2px;
+		}
+	}
+
+	// Empty state — rendered when no tabs are visible (rare; only when all
+	// feature-detection checks fail). Header still renders so the Settings
+	// link is reachable.
+
+	&__empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 320px;
+		padding: 48px 24px;
+		text-align: center;
+		gap: 12px;
+	}
+
+	&__empty-title {
+		font-size: 22px;
+		font-weight: 600;
+		line-height: 1.2;
+		color: wp-colors.$gray-900;
+		margin: 0;
+	}
+
+	&__empty-message {
+		font-size: 14px;
+		font-weight: 400;
+		line-height: 1.4;
+		color: wp-colors.$gray-700;
+		max-width: 480px;
+		margin: 0;
+	}
+
 	// Date range picker
 
 	&__date-range-picker {

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -1,0 +1,192 @@
+/**
+ * Newspack Insights wizard chrome (NPPD-1602)
+ *
+ * Per spec at ~/Sites/insights-docs/component-design-spec.md. Owns
+ * page-level layout (header, tab nav, tab content area) plus styles for
+ * the chrome-only components (DateRangePicker, ComparisonToggle,
+ * LastUpdated, tab stub). Per-component metric viz styles live in
+ * packages/components/src/<component>/ and don't belong here.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+.newspack-insights {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 24px 24px 64px;
+	color: wp-colors.$gray-900;
+
+	&__header {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 16px;
+		margin-bottom: 24px;
+	}
+
+	&__header-left {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	&__header-right {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 16px;
+	}
+
+	&__title {
+		font-size: 28px;
+		font-weight: 600;
+		line-height: 1.2;
+		margin: 0;
+	}
+
+	&__last-updated {
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 1.4;
+		color: wp-colors.$gray-600;
+	}
+
+	// Date range picker
+
+	&__date-range-picker {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	&__date-range-picker-select {
+		font-size: 13px;
+		padding: 6px 10px;
+		border: 1px solid wp-colors.$gray-300;
+		border-radius: 4px;
+		background: #fff;
+		color: wp-colors.$gray-900;
+		cursor: pointer;
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: -2px;
+		}
+	}
+
+	&__date-range-picker-custom {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+
+		input[type="date"] {
+			font-size: 13px;
+			padding: 6px 8px;
+			border: 1px solid wp-colors.$gray-300;
+			border-radius: 4px;
+			background: #fff;
+			color: wp-colors.$gray-900;
+		}
+	}
+
+	&__date-range-picker-sep {
+		color: wp-colors.$gray-600;
+		font-size: 13px;
+	}
+
+	// Comparison toggle
+
+	&__comparison-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 13px;
+		font-weight: 400;
+		color: wp-colors.$gray-700;
+		cursor: pointer;
+
+		input[type="checkbox"] {
+			margin: 0;
+		}
+	}
+
+	// Tab navigation
+
+	&__tabs {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0;
+		margin-bottom: 24px;
+		border-bottom: 1px solid wp-colors.$gray-200;
+	}
+
+	&__tab {
+		appearance: none;
+		background: transparent;
+		border: 0;
+		padding: 12px 16px;
+		margin: 0 0 -1px 0;
+		font-size: 13px;
+		font-weight: 500;
+		color: wp-colors.$gray-700;
+		cursor: pointer;
+		border-bottom: 2px solid transparent;
+		transition: color 120ms ease, border-color 120ms ease;
+
+		&:hover {
+			color: wp-colors.$gray-900;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: -2px;
+		}
+
+		&.is-active {
+			color: var(--wp-admin-theme-color);
+			border-bottom-color: var(--wp-admin-theme-color);
+		}
+	}
+
+	// Tab content area
+
+	&__tab-content {
+		min-height: 320px;
+	}
+
+	&__tab-fallback {
+		padding: 64px 24px;
+		text-align: center;
+		color: wp-colors.$gray-600;
+		font-size: 13px;
+	}
+
+	// Tab stub ("Coming soon")
+
+	&__tab-stub {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 320px;
+		padding: 48px 24px;
+		text-align: center;
+		gap: 8px;
+	}
+
+	&__tab-stub-title {
+		font-size: 22px;
+		font-weight: 600;
+		line-height: 1.2;
+		color: wp-colors.$gray-900;
+		margin: 0;
+	}
+
+	&__tab-stub-message {
+		font-size: 14px;
+		font-weight: 400;
+		color: wp-colors.$gray-600;
+		margin: 0;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -109,19 +109,13 @@
 		gap: 8px;
 	}
 
+	// SelectControl + CheckboxControl from @wordpress/components carry
+	// their own admin-pattern styles, focus rings, and a11y. We only
+	// keep a wrapper override here for the SelectControl so it sits
+	// flush with the picker row (the component's default margin-bottom
+	// is opted out via __nextHasNoMarginBottom on the JS side).
 	&__date-range-picker-select {
-		font-size: 13px;
-		padding: 6px 10px;
-		border: 1px solid wp-colors.$gray-300;
-		border-radius: 4px;
-		background: #fff;
-		color: wp-colors.$gray-900;
-		cursor: pointer;
-
-		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color);
-			outline-offset: -2px;
-		}
+		width: auto;
 	}
 
 	&__date-range-picker-custom {
@@ -136,28 +130,17 @@
 			border-radius: 4px;
 			background: #fff;
 			color: wp-colors.$gray-900;
+
+			&:focus-visible {
+				outline: 2px solid var(--wp-admin-theme-color);
+				outline-offset: 1px;
+			}
 		}
 	}
 
 	&__date-range-picker-sep {
 		color: wp-colors.$gray-600;
 		font-size: 13px;
-	}
-
-	// Comparison toggle
-
-	&__comparison-toggle {
-		display: inline-flex;
-		align-items: center;
-		gap: 6px;
-		font-size: 13px;
-		font-weight: 400;
-		color: wp-colors.$gray-700;
-		cursor: pointer;
-
-		input[type="checkbox"] {
-			margin: 0;
-		}
 	}
 
 	// Tab navigation

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const AdvertisingTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Advertising', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Advertising', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -1,7 +1,7 @@
 /**
  * AdvertisingTab
  *
- * Stub. Real content lands in NPPD-1624.
+ * Stub. Real content lands in NPPD-1618.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * AdvertisingTab
+ *
+ * Stub. Real content lands in NPPD-1624.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const AdvertisingTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Advertising', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default AdvertisingTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -1,7 +1,9 @@
 /**
  * AdvertisingTab
  *
- * Stub. Real content lands in NPPD-1618.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const AdvertisingTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const AdvertisingTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Advertising', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const AudienceTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Audience', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Audience', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -1,7 +1,7 @@
 /**
  * AudienceTab
  *
- * Stub. Real content lands in NPPD-1604.
+ * Stub. Real content lands in NPPD-1608.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * AudienceTab
+ *
+ * Stub. Real content lands in NPPD-1604.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const AudienceTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Audience', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default AudienceTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -1,7 +1,9 @@
 /**
  * AudienceTab
  *
- * Stub. Real content lands in NPPD-1608.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const AudienceTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const AudienceTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Audience', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const ConversionTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Conversion Journey', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Conversion Journey', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -1,7 +1,7 @@
 /**
  * ConversionTab
  *
- * Stub. Real content lands in NPPD-1608.
+ * Stub. Real content lands in NPPD-1609.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * ConversionTab
+ *
+ * Stub. Real content lands in NPPD-1608.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const ConversionTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Conversion Journey', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default ConversionTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -1,7 +1,9 @@
 /**
  * ConversionTab
  *
- * Stub. Real content lands in NPPD-1609.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,9 +11,15 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const ConversionTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ConversionTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">{ __( 'Conversion Journey', 'newspack-plugin' ) }</h2>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Conversion', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const DonorsTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Donors', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Donors', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -1,7 +1,7 @@
 /**
  * DonorsTab
  *
- * Stub. Real content lands in NPPD-1618.
+ * Stub. Real content lands in NPPD-1617.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * DonorsTab
+ *
+ * Stub. Real content lands in NPPD-1618.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const DonorsTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Donors', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default DonorsTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -1,7 +1,9 @@
 /**
  * DonorsTab
  *
- * Stub. Real content lands in NPPD-1617.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const DonorsTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const DonorsTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Donors', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const EngagementTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Engagement', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Engagement', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
@@ -1,7 +1,7 @@
 /**
  * EngagementTab
  *
- * Stub. Real content lands in NPPD-1607.
+ * Stub. Real content lands in NPPD-1624.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * EngagementTab
+ *
+ * Stub. Real content lands in NPPD-1607.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const EngagementTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Engagement', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default EngagementTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
@@ -1,7 +1,9 @@
 /**
  * EngagementTab
  *
- * Stub. Real content lands in NPPD-1624.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const EngagementTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const EngagementTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Engagement', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const GatesTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Gates', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Gates', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
@@ -1,7 +1,7 @@
 /**
  * GatesTab
  *
- * Stub. Real content lands in NPPD-1609.
+ * Stub. Real content lands in NPPD-1604.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * GatesTab
+ *
+ * Stub. Real content lands in NPPD-1609.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const GatesTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Gates', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default GatesTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
@@ -1,7 +1,9 @@
 /**
  * GatesTab
  *
- * Stub. Real content lands in NPPD-1604.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const GatesTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const GatesTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Gates', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const PromptsTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Prompts', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Prompts', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -1,7 +1,7 @@
 /**
  * PromptsTab
  *
- * Stub. Real content lands in NPPD-1616.
+ * Stub. Real content lands in NPPD-1607.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * PromptsTab
+ *
+ * Stub. Real content lands in NPPD-1616.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const PromptsTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Prompts', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default PromptsTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -1,7 +1,9 @@
 /**
  * PromptsTab
  *
- * Stub. Real content lands in NPPD-1607.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const PromptsTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const PromptsTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Prompts', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -11,12 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const SubscribersTab = () => (
 	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">
-			{ __( 'Subscribers', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__tab-stub-message">
-			{ __( 'Coming soon', 'newspack-plugin' ) }
-		</p>
+		<h2 className="newspack-insights__tab-stub-title">{ __( 'Subscribers', 'newspack-plugin' ) }</h2>
+		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
 	</div>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -1,7 +1,7 @@
 /**
  * SubscribersTab
  *
- * Stub. Real content lands in NPPD-1617.
+ * Stub. Real content lands in NPPD-1616.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -1,0 +1,23 @@
+/**
+ * SubscribersTab
+ *
+ * Stub. Real content lands in NPPD-1617.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const SubscribersTab = () => (
+	<div className="newspack-insights__tab-stub">
+		<h2 className="newspack-insights__tab-stub-title">
+			{ __( 'Subscribers', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__tab-stub-message">
+			{ __( 'Coming soon', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default SubscribersTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -1,7 +1,9 @@
 /**
  * SubscribersTab
  *
- * Stub. Real content lands in NPPD-1616.
+ * Stub. Accepts the standard TabSectionProps so TabContent can spread
+ * range/previousRange without a TypeScript strict-mode mismatch.
+ * Real content lands in a follow-up issue.
  */
 
 /**
@@ -9,7 +11,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const SubscribersTab = () => (
+/**
+ * Internal dependencies
+ */
+import type { TabSectionProps } from '../components/TabContent';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const SubscribersTab = ( _props: TabSectionProps ) => (
 	<div className="newspack-insights__tab-stub">
 		<h2 className="newspack-insights__tab-stub-title">{ __( 'Subscribers', 'newspack-plugin' ) }</h2>
 		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>


### PR DESCRIPTION
## Summary
Builds the wp-admin page shell for Newspack Insights — the page registration, navigation, date range picker, comparison toggle, tab routing, and stub tab content. This is foundation work; no per-tab content ships in this PR.
This is the first PR in a multi-PR sequence implementing the Newspack Insights feature, a native wp-admin data hub that replaces publisher Looker Studio dashboards. 

<img width="2630" height="860" alt="image" src="https://github.com/user-attachments/assets/17ebaa2d-9be6-4372-952f-b30cba287ff6" />

## What's in this PR
**PHP**

Insights_Wizard class extending Wizard, registered under the Newspack admin menu
Slug: newspack-insights, capability: manage_options, parent menu: newspack-dashboard
8 section stub classes in includes/wizards/insights/, one per tab — plain classes with static init() hook points for future REST registration and SECTION_NAME constants. Doc blocks describe each tab's scope and reference its Linear issue.

**React**

- Lazy-loaded entry registered in the wizards map
- InsightsWizard top-level component with persistent state across tabs (date range, comparison mode)
- DateRangePicker with presets: Last 7 days, Last 30 days (default), Last 90 days, This month, Last month, Custom
- ComparisonToggle for "vs previous period" — when enabled, emits computed previous-period range based on current selection
- TabNavigation with 8 tabs and conditional visibility (currently stubbed all-on; real detection lands per-tab as data sources come online)
- TabContent lazy-loads per-tab components with Suspense boundaries
- 8 stub tab components rendering "Coming soon" placeholders
- URL query persistence for active tab, date range, and comparison mode — refresh keeps state, tabs are linkable
- LastUpdated timestamp display (empty for now; populated when real data flows)

## Why a new convention in the wizards directory

This is a third convention alongside the existing Audience sibling-wizards pattern and Settings Wizard_Section pattern. The Insights UX requires shared persistent state across all 8 tabs (date range, comparison mode, "last updated" timestamp). The sibling-wizards pattern fights that because each tab is a page reload that loses state. The Settings section pattern doesn't address UI routing. Client-side routing with URL query persistence is the only path that gives the publisher experience we need.

Section classes are plain classes (NOT extending Wizard_Section) with a static init() hook point for future REST registration once each tab's data layer lands.

## Feature flag

The wizard is gated behind a `NEWSPACK_INSIGHTS_ENABLED` constant (default: off). Publishers see nothing until the constant is defined in `wp-config.php`. This lets us merge subsequent Insights PRs incrementally to main without exposing the in-progress feature.

The flag follows the `Private_Tags::is_enabled()` pattern from `includes/tags/class-private-tags.php` and is removed once Insights is ready for general release.

## Testing

- [ ] Without the constant defined: Insights submenu absent, page returns 404/forbidden, no JS chunk loaded
- [ ] With `define( 'NEWSPACK_INSIGHTS_ENABLED', true );` in wp-config: submenu appears, page renders, JS chunk loads
- [ ] Toggling the constant on/off cleanly switches visibility
- [ ] Menu item appears at WP Admin → Newspack → Insights — class loadable verified server-side via `wp eval`
- [ ] All 8 tabs clickable, each shows "Coming soon" stub
- [ ] Date range picker presets all work (last-7 / last-30 / last-90 / this-month / last-month / custom) and produce **inclusive** windows of the named length
- [ ] Comparison toggle persists across tab switches
- [ ] URL query string updates on tab/range/compare changes (`?tab=`, `?range=`, `?compare=`)
- [ ] Hard refresh restores state from URL
- [ ] Settings link visible in header and follows to `settingsUrl`
- [ ] With all visibility flags false, page renders the empty state with Settings link still reachable