### PR TITLE
fix(network): preserve node future schedule on origin publish re-sync

### DIFF
--- a/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
@@ -722,6 +722,36 @@ class Incoming_Post {
 				$postarr['post_status'] = $post_data['post_status'];
 			}
 
+			/**
+			 * Preserve a node's local future schedule.
+			 *
+			 * If the linked node post has been locally scheduled (`future`) and
+			 * the origin re-syncs an edit while still `publish`, do not let the
+			 * sync overwrite the node's schedule. Overwriting `post_date_gmt`
+			 * with the origin's (past) date trips WP core's future-with-past-date
+			 * check and auto-publishes the node post ahead of its intended time,
+			 * while the public permalink keeps the future local `post_date`.
+			 * Content/title/taxonomy/meta still flow.
+			 *
+			 * Scoped to incoming `publish` only: origin-side removal or
+			 * unpublishing (`trash`/`draft`/`pending`/`private`) still propagates
+			 * so a retracted story doesn't stay scheduled to publish on the node.
+			 *
+			 * A node's local schedule deliberately takes precedence over any
+			 * `status_on_publish` hold applied above: manually scheduling the
+			 * node post is the more recent, explicit editor intent.
+			 */
+			if (
+				! $is_new_post
+				&& $this->post instanceof WP_Post
+				&& 'future' === $this->post->post_status
+				&& 'publish' === $post_data['post_status']
+			) {
+				$postarr['post_status']   = 'future';
+				$postarr['post_date']     = $this->post->post_date;
+				$postarr['post_date_gmt'] = $this->post->post_date_gmt;
+			}
+
 			$postarr['post_author'] = 0;
 			if ( ! empty( $post_data['author'] ) ) {
 				$post_author = self::get_incoming_wp_user_author( $this->get_original_site_url(), $post_data['author'] );

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -387,6 +387,102 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPM-2871: An origin `publish` re-sync must not unschedule a node post
+	 * that has been locally rescheduled to `future`. Content still flows.
+	 */
+	public function test_origin_publish_preserves_node_future_schedule() {
+		// Linked post arrives and is created (sample payload is post_status=publish, status_on_publish=draft → draft).
+		$post_id = $this->incoming_post->insert();
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+
+		// Node editor reschedules locally to a future date.
+		$future_gmt = '2099-12-31 10:16:00';
+		wp_update_post(
+			[
+				'ID'            => $post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_gmt,
+				'post_date_gmt' => $future_gmt,
+			]
+		);
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+
+		// Origin edits and re-syncs as `publish` with its own (past) date_gmt.
+		$payload = $this->get_sample_payload();
+		$payload['post_data']['post_status'] = 'publish';
+		$payload['post_data']['title']       = 'Edited By Origin';
+		$payload['post_data']['date_gmt']    = '2021-01-01 00:00:00';
+		$this->incoming_post->insert( $payload );
+
+		// Node schedule must be preserved (status + both date fields coherent).
+		$this->assertSame( 'future', get_post_status( $post_id ), 'Node post must stay scheduled.' );
+		$this->assertSame( $future_gmt, get_post_field( 'post_date_gmt', $post_id ), 'Node GMT date must be preserved.' );
+		$this->assertSame( $future_gmt, get_post_field( 'post_date', $post_id ), 'Node local date must be preserved.' );
+
+		// Content still flows through.
+		$this->assertSame( 'Edited By Origin', get_the_title( $post_id ) );
+	}
+
+	/**
+	 * NPPM-2871: The future-schedule guard is scoped to incoming `publish`.
+	 * An origin-side removal (`trash`) must still propagate to a locally
+	 * scheduled node post — a retracted story must not stay scheduled.
+	 */
+	public function test_origin_trash_still_propagates_to_scheduled_node() {
+		$post_id = $this->incoming_post->insert();
+
+		// Node editor reschedules locally to a future date.
+		$future_gmt = '2099-12-31 10:16:00';
+		wp_update_post(
+			[
+				'ID'            => $post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_gmt,
+				'post_date_gmt' => $future_gmt,
+			]
+		);
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+
+		// Origin trashes the story.
+		$payload = $this->get_sample_payload();
+		$payload['post_data']['post_status'] = 'trash';
+		$this->incoming_post->insert( $payload );
+
+		// Removal propagates despite the local schedule.
+		$this->assertSame( 'trash', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * NPPM-2871: An origin-side unpublish to `draft` must also reach a locally
+	 * scheduled node post. `draft` takes a different WP path than `trash`
+	 * (a `future`→`draft` transition through `wp_update_post`), so cover it
+	 * explicitly to lock the guard's `publish`-only scope.
+	 */
+	public function test_origin_draft_unpublish_propagates_to_scheduled_node() {
+		$post_id = $this->incoming_post->insert();
+
+		// Node editor reschedules locally to a future date.
+		$future_gmt = '2099-12-31 10:16:00';
+		wp_update_post(
+			[
+				'ID'            => $post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_gmt,
+				'post_date_gmt' => $future_gmt,
+			]
+		);
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+
+		// Origin unpublishes the story back to draft.
+		$payload = $this->get_sample_payload();
+		$payload['post_data']['post_status'] = 'draft';
+		$this->incoming_post->insert( $payload );
+
+		// Unpublish propagates despite the local schedule.
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+	}
+
+	/**
 	 * Test delete.
 	 */
 	public function test_delete() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a post is distributed from an origin site to a linked node, the node's editor can reschedule their copy to publish at a future date. Currently, a later edit on the origin re-syncs to the node and overwrites the node copy's `post_date_gmt` with the origin's (earlier) date. Because the node copy is still in `future` status, WordPress core's future-with-past-date check then flips it straight to `publish` — so the node post goes live ahead of its scheduled time, while the displayed date still shows the future date the editor picked.

This fixes it on the node side, in `Incoming_Post::insert()`: when the linked node post is locally scheduled (`future`) and the incoming origin update is a normal `publish` re-sync, the node's `post_status`, `post_date`, and `post_date_gmt` are preserved instead of overwritten. The post stays scheduled for the editor's chosen time, and title/content/taxonomy/meta from the origin still flow through.

The guard is deliberately scoped to incoming `publish` only: if the origin removes or unpublishes the post (`trash`/`draft`/`pending`/`private`), that still propagates to the node, so a retracted story doesn't stay scheduled to publish. It builds on the existing `status_on_publish` handling and doesn't change behavior for any post that isn't locally scheduled on the node.

Closes NPPM-2871.

### How to test the changes in this Pull Request:

Covered by unit tests in `Incoming_Post`. From the repo root:

1. Core case — a locally scheduled node post survives an origin `publish` re-sync:
   ```bash
   cd plugins/newspack-network && n test-php --filter test_origin_publish_preserves_node_future_schedule
   ```
   Asserts the node post stays `future` with its scheduled date intact, and the origin's title edit still syncs.
2. Scoping — origin removal/unpublish still reaches a scheduled node post:
   ```bash
   n test-php --filter test_origin_trash_still_propagates_to_scheduled_node
   n test-php --filter test_origin_draft_unpublish_propagates_to_scheduled_node
   ```
3. End-to-end (optional, needs a hub + node): distribute a post as draft to a node, schedule the node copy for a future date, then edit the origin. Before the fix the node post publishes immediately with a future-dated stamp; after, it stays Scheduled.

### Release risk: Low

| Signal | Score | Detail |
|--------|-------|--------|
| 1. Contract surface | Low | In-contract-dir but internal-only — a guard inside node-side `Incoming_Post::insert()`; no public method/hook/REST/exported-class touched. |
| 2. Surface type | Low | Internal single-file PHP behavior fix; no DB schema, auth/payment, mass-comm, render, or signature change. |
| 3. Publisher exposure | Low | Behavior-change dimension. `newspack-network` (narrow-adoption) further gated by data state: only fires when a node post is locally `future` AND origin re-syncs `publish`. |
| 4. Change shape | Medium | 30 prod LOC / 1 file + 96 test LOC (tests added) → Low, nudged up one step for this status/date method's prior-fix history (#302 et al.). |

Driven by change-shape (Medium — a tiny fix in a status/date method with prior-fix history); contract surface, surface type, and publisher exposure all Low (internal, data-gated). Pre-review + Codex + Copilot came back clean.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
