### PR TITLE
feat(integrations): allow filtering integration settings list

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
@@ -457,7 +457,17 @@ class Integrations {
 				'required_plugins' => $integration->get_required_plugins(),
 			];
 		}
-		return $result;
+
+		/**
+		 * Filters the integration settings list shown in the Audience → Integrations UI.
+		 *
+		 * Lets a registered integration hide another's card when a takeover is in
+		 * effect (e.g. a vendor-specific ESP integration superseding the built-in
+		 * one).
+		 *
+		 * @param array $result Keyed array of integration settings.
+		 */
+		return apply_filters( 'newspack_reader_activation_integration_settings', $result );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new filter \`newspack_reader_activation_integration_settings\` at the end of \`Integrations::get_all_integration_settings()\` so a registered integration can hide another's card from the Audience → Integrations UI when a takeover is in effect.

Motivating use case: the upcoming ActiveCampaign integration in newspack-manager (see [newspack-manager#600](https://github.com/Automattic/newspack-manager/pull/600)) supersedes the built-in \`esp\` integration. Without this filter, both cards render side-by-side and admins can re-enable the standard ESP underneath AC; with it, the AC integration can drop the \`esp\` entry whenever it is enabled.

The filter is purely additive — no callers exist in this repo, so default behavior is unchanged. The matching consumer ships in newspack-manager PR #600.

### How to test the changes in this Pull Request:

1. Without any callbacks attached: load **Audience → Integrations**. The built-in \`Newsletter ESP\` card still renders exactly as before (filter is a no-op).
2. Attach a temporary callback that removes a key:
   \`\`\`php
   add_filter( 'newspack_reader_activation_integration_settings', function ( \$settings ) {
       unset( \$settings['esp'] );
       return \$settings;
   } );
   \`\`\`
   Reload the integrations page. The ESP card should be gone.
3. Confirm the REST response at \`/wp-json/newspack/v1/wizard/newspack-audience-integrations/settings\` no longer contains \`esp\` while the callback is attached.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — Filter is a pass-through; behavior is covered by the consumer in newspack-manager#600.
* [x] Have you successfully run tests with your changes locally?