### PR TITLE
test(network): make block-processor assertion robust to WP markup

### DIFF
--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-block-processor.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-block-processor.php
@@ -126,7 +126,7 @@ class TestBlockProcessor extends \WP_UnitTestCase {
 		// version-dependent wrapper class (e.g. `wp-block-paragraph`), so match
 		// the `<p>` element with optional attributes rather than pinning the
 		// exact markup. `raw_content` below still pins the exact serialized block.
-		$this->assertMatchesRegularExpression( '/<p[^>]*>Outgoing Processed<\/p>/', $payload['post_data']['content'] );
+		$this->assertMatchesRegularExpression( '/<p\b[^>]*>Outgoing Processed<\/p>/', $payload['post_data']['content'] );
 		$this->assertEquals( '<!-- wp:paragraph {"outgoing":"test"} --><p>Outgoing Processed</p><!-- /wp:paragraph -->', $payload['post_data']['raw_content'] );
 	}
 

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-block-processor.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-block-processor.php
@@ -123,10 +123,10 @@ class TestBlockProcessor extends \WP_UnitTestCase {
 		$payload       = $outgoing_post->get_payload();
 
 		// `content` is rendered HTML; WP core's paragraph block render adds a
-		// version-dependent wrapper class (e.g. `wp-block-paragraph`), so assert
-		// the processed text is present rather than pinning the exact markup.
-		// `raw_content` below still pins the exact serialized block markup.
-		$this->assertStringContainsString( 'Outgoing Processed', $payload['post_data']['content'] );
+		// version-dependent wrapper class (e.g. `wp-block-paragraph`), so match
+		// the `<p>` element with optional attributes rather than pinning the
+		// exact markup. `raw_content` below still pins the exact serialized block.
+		$this->assertMatchesRegularExpression( '/<p[^>]*>Outgoing Processed<\/p>/', $payload['post_data']['content'] );
 		$this->assertEquals( '<!-- wp:paragraph {"outgoing":"test"} --><p>Outgoing Processed</p><!-- /wp:paragraph -->', $payload['post_data']['raw_content'] );
 	}
 

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-block-processor.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-block-processor.php
@@ -122,7 +122,11 @@ class TestBlockProcessor extends \WP_UnitTestCase {
 		$outgoing_post = new Outgoing_Post( $post );
 		$payload       = $outgoing_post->get_payload();
 
-		$this->assertEquals( '<p>Outgoing Processed</p>', $payload['post_data']['content'] );
+		// `content` is rendered HTML; WP core's paragraph block render adds a
+		// version-dependent wrapper class (e.g. `wp-block-paragraph`), so assert
+		// the processed text is present rather than pinning the exact markup.
+		// `raw_content` below still pins the exact serialized block markup.
+		$this->assertStringContainsString( 'Outgoing Processed', $payload['post_data']['content'] );
 		$this->assertEquals( '<!-- wp:paragraph {"outgoing":"test"} --><p>Outgoing Processed</p><!-- /wp:paragraph -->', $payload['post_data']['raw_content'] );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**WordPress 7.0 changed how the paragraph block renders** — it now adds a `wp-block-paragraph` class:

| WordPress | `do_blocks('<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->')` |
|---|---|
| 6.9.4 and earlier | `<p>Hi</p>` |
| 7.0 | `<p class="wp-block-paragraph">Hi</p>` |

CI installs WordPress at "latest," so it picked up 7.0.

**This broke the `newspack-network` test suite.** `TestBlockProcessor::test_outgoing_post` asserts the *exact* rendered HTML of a distributed paragraph, so the new class no longer matches its hardcoded `<p>…</p>` expectation. The `PHPUnit / newspack-network` job fails, which **blocks every PR that touches this plugin.** (It surfaces only here because this is the one Newspack test asserting on WordPress-*rendered* paragraph output; other plugins assert on serialized markup, which is unaffected.)

**The fix** makes the assertion robust: it checks that the processed text is present in the rendered `content` rather than pinning WordPress's version-dependent wrapper markup. The adjacent `raw_content` assertion still pins the exact serialized block markup, so the transformation is fully verified. Test-only; no product change.

### How to test the changes in this Pull Request:

```bash
cd plugins/newspack-network && n test-php --filter test_outgoing_post
```

Verified across WordPress versions — same test, only the WP version and this fix change:

| WordPress | Test assertion | Result |
|---|---|---|
| 6.9.4 | original (hardcoded `<p>`) | ✅ PASS |
| 7.0 | original (hardcoded `<p>`) | ❌ FAIL — `wp-block-paragraph` |
| 7.0 | this PR (text-contains) | ✅ PASS |

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? <!-- Adjusts an existing assertion to be markup-robust; no new test needed. -->
* [x] Have you successfully run tests with your changes locally?
