### PR TITLE
docs(integrations): document oauth field type and required plugins

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
@@ -131,6 +131,7 @@ class My_Integration extends Integration {
 | `handle_logged_in_user_registration( $user, $request )` | Called when a logged-in user attempts to register again via the frontend. Use to update user data, link the account, record a new event, etc. Default is a no-op. |
 | `get_my_account_menu_item()` | Return `[ 'slug' => ..., 'label' => ..., 'position' => ... ]` to add a tab to the WooCommerce My Account page. Default returns `null` (no tab). |
 | `render_my_account_page( $value )` | Echo markup for the integration's My Account page. Called inside the WooCommerce account template. |
+| `get_required_plugins()` | Declare third-party plugins this integration depends on. Return an array of `[ 'slug' => ..., 'name' => ..., 'is_active' => ..., 'is_installed' => ... ]` entries. The Integrations UI uses this to surface a "Requires …" affordance and disable the card when a dependency is missing or inactive. Default `[]`. |
 
 ---
 
@@ -151,7 +152,29 @@ Settings fields are declared statically in `register_settings_fields()` and stor
 ]
 ```
 
-Supported `type` values: `text`, `password`, `textarea`, `number`, `checkbox`, `select`, `metadata`. The base class sanitizes values per type before persisting.
+Supported `type` values: `text`, `password`, `textarea`, `number`, `checkbox`, `select`, `metadata`, `oauth`, `hidden`. The base class sanitizes values per type before persisting.
+
+`oauth` and `hidden` are **managed field types**: `Integrations::update_integration_settings()` calls `is_managed_settings_field()` and skips them, so admin clients can't overwrite them by POSTing to the settings REST endpoint. They're writable only from trusted PHP via `update_settings_field_value()`. See `Integration::MANAGED_FIELD_TYPES`.
+
+### `oauth` field type
+
+`oauth` renders as a Connect / Disconnect button on the integration's settings card. The stored value is the human-readable identity of the connection (account email, workspace name, etc.) — it's shown next to the Disconnect button when present, and its presence toggles the card between "Connect" and "connected" states.
+
+Two render-time properties drive the buttons; declare them in `get_settings_config()` (not the static `register_settings_fields()`) since they typically depend on a nonce or the current user:
+
+| Key | Purpose |
+| --- | --- |
+| `oauth_url` | Target of the **Connect** button. Usually a remote authorize URL with `redirect_uri` pointing back to your callback. |
+| `disconnect_url` | Target of the **Disconnect** button. Usually a local admin URL that revokes the remote grant, clears stored tokens, and redirects back to the integrations screen. |
+
+Typical wiring:
+
+1. Declare the field statically with `'type' => 'oauth'` (and any siblings — `'hidden'` token fields for the access/refresh tokens, scopes, etc.).
+2. Override `get_settings_config()` to attach `oauth_url` and `disconnect_url` for the current request.
+3. Register an OAuth callback endpoint that exchanges the code, writes the tokens and the display identity via `update_settings_field_value()`, and redirects back to the integrations screen.
+4. Implement `is_set_up()` to return `true` only when the identity field is populated, so the Integrations UI marks the card ready.
+
+Because the field skips the REST save path, no admin client can spoof a connection by POSTing a value — every write goes through your callback.
 
 ### Reading and writing
 

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
@@ -131,7 +131,7 @@ class My_Integration extends Integration {
 | `handle_logged_in_user_registration( $user, $request )` | Called when a logged-in user attempts to register again via the frontend. Use to update user data, link the account, record a new event, etc. Default is a no-op. |
 | `get_my_account_menu_item()` | Return `[ 'slug' => ..., 'label' => ..., 'position' => ... ]` to add a tab to the WooCommerce My Account page. Default returns `null` (no tab). |
 | `render_my_account_page( $value )` | Echo markup for the integration's My Account page. Called inside the WooCommerce account template. |
-| `get_required_plugins()` | Declare third-party plugins this integration depends on. Return an array of `[ 'slug' => ..., 'name' => ..., 'is_active' => ..., 'is_installed' => ... ]` entries. The Integrations UI uses this to surface a "Requires …" affordance and disable the card when a dependency is missing or inactive. Default `[]`. |
+| `get_required_plugins()` | Declare third-party plugins this integration depends on. Return an array of `[ 'slug' => ..., 'name' => ..., 'is_active' => ..., 'is_installed' => ... ]` entries. The Integrations UI uses this to gate the card: when every missing dependency is at least installed, it offers an **Activate** action; when any dependency is uninstalled, the card stays disabled with a "Requires …" affordance. Default `[]`. |
 
 ---
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Brings the reader-activation integrations framework README in line with three changes that landed since it was last edited:

- **`oauth` and `hidden` field types** (from #4639): added to the supported `type` list, with a new "managed field types" paragraph explaining why admin POSTs to the settings REST endpoint skip them.
- **`oauth` field type subsection**: documents what the field renders as (Connect / Disconnect button), the render-time `oauth_url` / `disconnect_url` properties that belong in `get_settings_config()`, and a four-step wiring recipe (declare → attach URLs → handle callback → gate `is_set_up()`). OAuth is the common third-party connection strategy, so it's worth a dedicated section rather than a one-liner.
- **`get_required_plugins()` override** (from #4721): added to the Optional overrides table with the `slug` / `name` / `is_active` / `is_installed` contract that drives the inactive-plugin affordance on the Integrations card.

Docs only — no code changes.

### How to test the changes in this Pull Request:

1. Open `plugins/newspack-plugin/includes/reader-activation/integrations/README.md` in a Markdown preview.
2. Confirm the **Optional overrides** table now lists `get_required_plugins()` with the correct return-shape contract.
3. In **Settings Fields → Field declaration**, confirm `oauth` and `hidden` appear in the supported `type` list and that the "managed field types" paragraph names `Integrations::update_integration_settings()` and `is_managed_settings_field()`.
4. Confirm the new **`oauth` field type** subsection covers: the Connect / Disconnect rendering, the `oauth_url` / `disconnect_url` properties, the four-step wiring recipe, and the spoofing-prevention note.
5. Cross-check the table values against the code:
   - `Integration::MANAGED_FIELD_TYPES` in `class-integration.php` should contain `'oauth'` and `'hidden'`.
   - `get_required_plugins()` in `class-integration.php` should match the documented signature.
   - `settings-field.js` should render `oauth` as a Connect / Disconnect button using `field.oauth_url` and `field.disconnect_url`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?