### PR TITLE
fix: derive package name from package.json

### DIFF
--- a/bin/build-repos.sh
+++ b/bin/build-repos.sh
@@ -19,9 +19,16 @@ find_project() {
 }
 
 # Translate a container path under /newspack-{plugins,themes}/<name> to the
-# pnpm filter selector (the workspace package's directory name).
+# pnpm filter selector for a workspace package: the package's actual `name`
+# read from its package.json. We can't derive this from the folder, because a
+# package's name often differs from its directory (plugins/newspack-plugin is
+# named "newspack", plugins/newspack-blocks is "@automattic/newspack-blocks").
+# A bare `--filter <dirname>` matches no projects there, so pnpm silently builds
+# nothing and exits 0. Falls back to the basename if no name is found.
 package_filter_for_dir() {
-    basename "$1"
+    local name
+    name=$(sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1/package.json" 2>/dev/null | head -n1)
+    if [ -n "$name" ]; then echo "$name"; else basename "$1"; fi
 }
 
 # Build a standalone repos/ checkout with its own toolchain. These live outside


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`n build <plugin>` was silently building nothing for `newspack-plugin` and
`newspack-blocks`, leaving their `dist/` files stale.

`build-repos.sh` selected the package to build with `pnpm --filter <folder-name>`.
But pnpm's `--filter` matches a package's **name**, not its folder — and a couple
of packages have a name that differs from their directory:

- `plugins/newspack-plugin` is named `newspack`
- `plugins/newspack-blocks` is named `@automattic/newspack-blocks`

For those, `pnpm --filter newspack-plugin` matched zero projects, printed
"No projects matched the filters", and **exited 0** — so the build looked like it
succeeded but never ran. `dist/` only ever updated via `n build all` or `n watch`.

This PR reads the real package `name` from each project's `package.json` instead
of guessing it from the folder name, so the filter always matches. Falls back to
the folder name if no `name` is found.

### How to test the changes in this Pull Request:

1. Edit a source file in `plugins/newspack-plugin/src/` (or just note a `dist/`
   file's timestamp).
2. Run `n build newspack-plugin`.
3. Confirm the files in `plugins/newspack-plugin/dist/` are rewritten (new
   timestamps) and the log shows `Building ... (package: newspack)` followed by
   `webpack ... compiled`. Before this fix it printed
   "No projects matched the filters" and `dist/` was untouched.
4. Repeat with `n build newspack-blocks`.
