### PR TITLE
fix(release): strip npm scope from package git tags

### DIFF
--- a/config/release-package.js
+++ b/config/release-package.js
@@ -9,8 +9,10 @@
  * while the npm/git-tag version advances, which is how newspack-scripts drifted
  * to 5.8.0 in-repo while publishing 5.9.x before the monorepo.
  *
- * Note: multi-semantic-release namespaces tags as `<pkgName>@<version>` and
- * ignores any tagFormat here.
+ * Note: multi-semantic-release derives tags from the package's npm name as
+ * `<npmName>@<version>` (with the npm scope stripped via patch) and ignores any
+ * tagFormat here. These libraries are all unscoped, so the patch is a no-op for
+ * them.
  */
 module.exports = {
 	branches: [

--- a/config/release.js
+++ b/config/release.js
@@ -7,7 +7,7 @@ const { gitCommitStep } = require( './release-helpers' );
  * (branches, plugin chain, prepare steps) is identical across the monorepo.
  *
  * @param {Object}  opts
- * @param {string}  opts.name        Package directory name, used for the zip asset path and label. Git tags are namespaced by multi-semantic-release as `<pkgName>@<version>` (it overrides any tagFormat), so this name does not affect tagging.
+ * @param {string}  opts.name        Package directory name, used for the zip asset path and label. multi-semantic-release derives git tags from the package's npm name as `<npmName>@<version>` (patched to strip the npm scope, so `@automattic/newspack-blocks` tags as `newspack-blocks@<version>`); this `name` does not affect tagging.
  * @param {string}  opts.phpFile     Main PHP file to bump the version in.
  * @param {boolean} [opts.npmPublish=false] Whether to publish to npm.
  */

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
 	"pnpm": {
 		"overrides": {
 			"@typescript-eslint/parser": "8.58.2"
+		},
+		"patchedDependencies": {
+			"multi-semantic-release": "patches/multi-semantic-release.patch"
 		}
 	}
 }

--- a/patches/multi-semantic-release.patch
+++ b/patches/multi-semantic-release.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/multiSemanticRelease.js b/lib/multiSemanticRelease.js
+index 4629a92993e2b794287cfa8dd026a8ee2285c548..82e9b50acdbe3e2ea7d9ba6114a67bf408af79ae 100644
+--- a/lib/multiSemanticRelease.js
++++ b/lib/multiSemanticRelease.js
+@@ -191,7 +191,8 @@ async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
+ 	// Add the package name into tagFormat.
+ 	// Thought about doing a single release for the tag (merging several packages), but it's impossible to prevent Github releasing while allowing NPM to continue.
+ 	// It'd also be difficult to merge all the assets into one release without full editing/overriding the plugins.
+-	options.tagFormat = name + "@${version}";
++	// The npm scope is stripped so scoped packages (e.g. @automattic/newspack-blocks) tag as newspack-blocks@x.y.z, matching every other workspace package and keeping git tags / GitHub releases scope-free while the npm package name stays scoped.
++	options.tagFormat = name.replace(/^@[^/]+\//, "") + "@${version}";
+ 
+ 	// These options are needed for plugins that do not rely on `pluginOptions` and extract them independently.
+ 	options._pkgOptions = pkgOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@typescript-eslint/parser': 8.58.2
 
+patchedDependencies:
+  multi-semantic-release:
+    hash: de869147a2e6f39769712c1e37db133a5723e60b2bf1d792eb5c7e58d621a638
+    path: patches/multi-semantic-release.patch
+
 importers:
 
   .:
@@ -31,7 +36,7 @@ importers:
         version: 16.4.0
       multi-semantic-release:
         specifier: ^3.0.2
-        version: 3.1.0
+        version: 3.1.0(patch_hash=de869147a2e6f39769712c1e37db133a5723e60b2bf1d792eb5c7e58d621a638)
       newspack-scripts:
         specifier: workspace:*
         version: link:packages/scripts
@@ -20520,7 +20525,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multi-semantic-release@3.1.0:
+  multi-semantic-release@3.1.0(patch_hash=de869147a2e6f39769712c1e37db133a5723e60b2bf1d792eb5c7e58d621a638):
     dependencies:
       '@manypkg/get-packages': 1.1.3
       blork: 9.3.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`multi-semantic-release` derives each package's git tag (and GitHub release) from its **npm name** as `<npmName>@<version>`, hard-coded at `multiSemanticRelease.js:194`, overriding any configured `tagFormat`. `@automattic/newspack-blocks` is the only scoped package in the workspace, so it alone tagged as `@automattic/newspack-blocks@x.y.z` while every other package tags unscoped (`newspack-newsletters@x.y.z`, etc.).

This patches msr to strip the npm scope when building the tag:

```js
options.tagFormat = name.replace( /^@[^/]+\//, "" ) + "@${version}";
```

So blocks now tags `newspack-blocks@x.y.z`, matching the rest of the workspace, for both alpha prereleases and stable releases. One uniform rule, a no-op for the 17 unscoped packages. The **npm package name stays `@automattic/newspack-blocks`** – npm publishing is driven by `package.json` `name`, not `tagFormat`, so it is unaffected.

Applied via `pnpm patch` (`patches/multi-semantic-release.patch` + `pnpm.patchedDependencies`); CI runs `pnpm exec multi-semantic-release`, so the patch is in effect on install. Targets `release` as a hotfix so the next release is unscoped; auto-syncs to `main`.

**Version continuity (already handled out-of-band):** once the tag format changes, semantic-release no longer matches the existing scoped tags, so unscoped alias tags of the current releases were seeded on this repo to keep version numbering moving forward (and avoid re-emitting an already-published npm version):

- `newspack-blocks@4.26.4` → same commit as `@automattic/newspack-blocks@4.26.4`
- `newspack-blocks@4.26.5-alpha.1` → same commit as `@automattic/newspack-blocks@4.26.5-alpha.1`

The pre-existing scoped tags/releases will be cleaned up separately.

### How to test the changes in this Pull Request:

Validated end-to-end on the release-rehearsal sandbox (`adekbadek/newspack-workspace-sandbox`) with this exact patch + the same continuity aliases:

1. **Alpha cycle** – a `fix(newspack-blocks):` commit on `alpha` released **`newspack-blocks@4.26.5-alpha.1`** (unscoped tag + GitHub prerelease); version moved forward, no scoped tag, no npm collision.
2. **Promotion** – `alpha` → `release` released **`newspack-blocks@4.26.5`** (unscoped stable tag + GitHub "Latest"); Release job and post-release branch sync both green; no scoped tag.

### Other information:

- The patch is root-level only (`config/`, `patches/`, `package.json`, lockfile); it is not attributed to any package, so merging it triggers no package release.

### Upstream

The patch is a stopgap. Filed upstream to remove the need for it: https://github.com/dhoulb/multi-semantic-release/pull/179 makes msr respect an explicitly-configured `tagFormat`. Once it lands and releases, we drop `patches/multi-semantic-release.patch` and set `tagFormat: 'newspack-blocks@${version}'` in `plugins/newspack-blocks/release.config.js`.
