### PR TITLE
fix(magic-link): wrap user_row_actions href with esc_url()

### DIFF
--- a/plugins/newspack-plugin/includes/class-magic-link.php
+++ b/plugins/newspack-plugin/includes/class-magic-link.php
@@ -1032,7 +1032,7 @@ final class Magic_Link {
 		}
 		if ( self::can_magic_link( $user->ID ) && \current_user_can( 'edit_user', $user->ID ) ) {
 			$url                                 = self::get_admin_action_url( 'send', $user->ID );
-			$actions['newspack-magic-link-send'] = '<a href="' . $url . '">' . \esc_html__( 'Send authentication link', 'newspack-plugin' ) . '</a>';
+			$actions['newspack-magic-link-send'] = '<a href="' . \esc_url( $url ) . '">' . \esc_html__( 'Send authentication link', 'newspack-plugin' ) . '</a>';
 		}
 		return $actions;
 	}


### PR DESCRIPTION
## What

\`user_row_actions()\` in \`class-magic-link.php\` outputs a URL directly into an \`href\` attribute without \`esc_url()\`:

\`\`\`php
// before
\$actions['newspack-magic-link-send'] = '<a href="' . \$url . '">' . \esc_html__( 'Send authentication link', 'newspack-plugin' ) . '</a>';
\`\`\`

Every other \`href\` in the same file already applies \`esc_url()\` — lines 1153, 1155, 1173, and 1189 all use \`echo \esc_url( self::get_admin_action_url(...) )\`. This call was the one omission.

## Why

VIP Go coding standards require \`esc_url()\` on any URL placed in an \`href\` attribute. The codebase's own pattern in the same file demonstrates the correct approach.

## Change

One character change — wrap \`\$url\` with \`\esc_url()\` to match all sibling calls.

---

*Developed with AI assistance (GitHub Copilot + Claude) for code review and pattern matching; the fix and description are my own.*