### PR TITLE
feat(insights): extract GA4 Data API client (NPPD-1647)

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -346,6 +346,43 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
+	 * List the event parameter names of every custom dimension currently
+	 * registered on the connected GA4 property.
+	 *
+	 * Unlike status(), this returns the full set actually present on the
+	 * property — not just the intersection with Newspack's standard set — so
+	 * callers can authoritatively check whether an arbitrary `customEvent:`
+	 * dimension (e.g. `post_id`) is available before querying the Data API.
+	 *
+	 * Reuses the same Newspack-OAuth-then-Site-Kit auth fallback and property
+	 * resolution as the rest of this class.
+	 *
+	 * @return string[]|\WP_Error Registered parameter names, or WP_Error if the
+	 *                            property or Admin API can't be reached.
+	 */
+	public static function get_registered_parameter_names() {
+		$property_id = self::get_property_id();
+		if ( ! $property_id ) {
+			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured in Site Kit.' );
+		}
+
+		$existing = self::with_admin_client(
+			function ( $client, $source ) use ( $property_id ) {
+				try {
+					return $client->list_custom_dimensions( $property_id );
+				} catch ( \Throwable $e ) {
+					return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+				}
+			}
+		);
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+
+		return array_values( array_filter( array_column( $existing, 'parameterName' ) ) );
+	}
+
+	/**
 	 * Provision Newspack's standard GA4 custom dimensions.
 	 *
 	 * Idempotent: existing dimensions on the property are detected by

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -346,19 +346,24 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * List the event parameter names of every custom dimension currently
+	 * List the parameter names of every EVENT-scoped custom dimension currently
 	 * registered on the connected GA4 property.
 	 *
-	 * Unlike status(), this returns the full set actually present on the
-	 * property — not just the intersection with Newspack's standard set — so
-	 * callers can authoritatively check whether an arbitrary `customEvent:`
+	 * Scoped to EVENT dimensions specifically because the Data API references
+	 * those as `customEvent:<param>` (USER-scoped dimensions are `customUser:`),
+	 * so callers checking a `customEvent:` reference must not be satisfied by a
+	 * same-named USER-scoped dimension.
+	 *
+	 * Unlike status(), this returns the full event-scoped set actually present
+	 * on the property — not just the intersection with Newspack's standard set —
+	 * so callers can authoritatively check whether an arbitrary `customEvent:`
 	 * dimension (e.g. `post_id`) is available before querying the Data API.
 	 *
 	 * Reuses the same Newspack-OAuth-then-Site-Kit auth fallback and property
 	 * resolution as the rest of this class.
 	 *
-	 * @return string[]|\WP_Error Registered parameter names, or WP_Error if the
-	 *                            property or Admin API can't be reached.
+	 * @return string[]|\WP_Error Registered event-scoped parameter names, or
+	 *                            WP_Error if the property or Admin API can't be reached.
 	 */
 	public static function get_registered_parameter_names() {
 		$property_id = self::get_property_id();
@@ -379,7 +384,14 @@ final class GA4_Custom_Dimensions {
 			return $existing;
 		}
 
-		return array_values( array_filter( array_column( $existing, 'parameterName' ) ) );
+		$event_scoped = array_filter(
+			$existing,
+			function ( $dimension ) {
+				return isset( $dimension['scope'] ) && 'EVENT' === $dimension['scope'];
+			}
+		);
+
+		return array_values( array_filter( array_column( $event_scoped, 'parameterName' ) ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -359,14 +359,20 @@ final class GA4_Custom_Dimensions {
 	 * so callers can authoritatively check whether an arbitrary `customEvent:`
 	 * dimension (e.g. `post_id`) is available before querying the Data API.
 	 *
-	 * Reuses the same Newspack-OAuth-then-Site-Kit auth fallback and property
-	 * resolution as the rest of this class.
+	 * Reuses the same Newspack-OAuth-then-Site-Kit auth fallback as the rest of
+	 * this class.
+	 *
+	 * @param string|null $property_id GA4 property ID to list dimensions for. When
+	 *                                 null (default), resolves Site Kit's configured
+	 *                                 property. Pass an explicit ID so the Admin API
+	 *                                 lookup matches the Data API property being
+	 *                                 queried (the lists can differ per property).
 	 *
 	 * @return string[]|\WP_Error Registered event-scoped parameter names, or
 	 *                            WP_Error if the property or Admin API can't be reached.
 	 */
-	public static function get_registered_parameter_names() {
-		$property_id = self::get_property_id();
+	public static function get_registered_parameter_names( ?string $property_id = null ) {
+		$property_id = $property_id ?? self::get_property_id();
 		if ( ! $property_id ) {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured in Site Kit.' );
 		}

--- a/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
@@ -172,7 +172,9 @@ final class Client {
 	 */
 	private static function get_registered_parameter_names_cached( string $property_id ) {
 		if ( ! array_key_exists( $property_id, self::$registered_dimensions_cache ) ) {
-			self::$registered_dimensions_cache[ $property_id ] = GA4_Custom_Dimensions::get_registered_parameter_names();
+			// Pass the queried property through so the Admin API lookup matches the
+			// Data API property — not whatever Site Kit happens to have configured.
+			self::$registered_dimensions_cache[ $property_id ] = GA4_Custom_Dimensions::get_registered_parameter_names( $property_id );
 		}
 		return self::$registered_dimensions_cache[ $property_id ];
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Newspack Insights — GA4 Data API client.
+ *
+ * Generic primitives for GA4 Data API `runReport` calls, used by the Insights
+ * metric orchestrators (Audience, Engagement, future tabs) for the v1 GA4-first
+ * dispatch path while the BigQuery proxy (NPPD-1630) is built. The orchestrators
+ * compose their own request bodies; this client knows nothing about specific
+ * metrics, tabs, or dimensions.
+ *
+ * Auth reuses Newspack's existing Google connection — the same
+ * `\Newspack\Google_OAuth::get_oauth2_credentials()` token the GA4 Admin API
+ * client already relies on. The Newspack `analytics` scope covers both the
+ * Admin API and the Data API, so no publisher reconnection is needed.
+ *
+ * Custom dimension detection is authoritative: before issuing a query that
+ * references any `customEvent:<param>` dimension, the client checks the params
+ * actually registered on the property via
+ * `\Newspack\GA4_Custom_Dimensions::get_registered_parameter_names()` and
+ * returns a `custom_dimension_missing` WP_Error (listing the missing params) so
+ * the affected MetricCard can render the spec's overlay. This folds in what was
+ * scoped as a v1.1 "boot-time probe" — the data is already available.
+ *
+ * Source: generalized from the GA4 Data API client in
+ * Automattic/newspack-gate-intelligence (NGI_GA4), dropping the gate-specific
+ * orchestration. See NPPD-1647.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\GA4;
+
+use Newspack\Google_OAuth;
+use Newspack\GA4_Custom_Dimensions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * GA4 Data API client.
+ */
+final class Client {
+
+	/**
+	 * GA4 Data API base URL. The property and method are appended as
+	 * `/{property_id}:runReport`.
+	 */
+	const DATA_API_URL = 'https://analyticsdata.googleapis.com/v1beta/properties';
+
+	/**
+	 * Run a single GA4 Data API report.
+	 *
+	 * @param string $property_id The publisher's GA4 property ID (numeric, no "properties/" prefix).
+	 * @param array  $body        The runReport request body (dateRanges, dimensions, metrics, dimensionFilter, etc.).
+	 *
+	 * @return array|\WP_Error Decoded report response on success, WP_Error on failure.
+	 *
+	 * Error codes:
+	 *   - 'missing_dependency': the Newspack Google_OAuth class is unavailable.
+	 *   - 'not_connected': no Newspack Google connection / credentials.
+	 *   - 'no_token': credentials present but the access token is empty.
+	 *   - 'custom_dimension_missing': the query references customEvent:<param>
+	 *     dimensions not registered on the property. WP_Error data carries
+	 *     `[ 'dimensions' => string[] ]` (the missing parameter names).
+	 *   - 'ga4_api_error': non-2xx response from the Data API. Data carries
+	 *     `[ 'http_code' => int ]`.
+	 *   - HTTP/network errors bubble up from wp_remote_post() as their own WP_Error.
+	 */
+	public static function run_report( string $property_id, array $body ) {
+		// Authoritative custom-dimension pre-check, before spending the API call.
+		$requested = self::extract_custom_dimensions( $body );
+		if ( ! empty( $requested ) ) {
+			$registered = GA4_Custom_Dimensions::get_registered_parameter_names();
+			// Only block on a definitive answer. If the registered list can't be
+			// resolved (WP_Error), fall through and let the Data API respond — a
+			// genuinely missing dimension surfaces as an API error rather than
+			// silently suppressing the metric.
+			if ( ! is_wp_error( $registered ) ) {
+				$missing = array_values( array_diff( $requested, $registered ) );
+				if ( ! empty( $missing ) ) {
+					return new \WP_Error(
+						'custom_dimension_missing',
+						sprintf(
+							/* translators: %s: comma-separated list of GA4 custom dimension parameter names. */
+							__( 'GA4 custom dimension(s) not registered on this property: %s', 'newspack-plugin' ),
+							implode( ', ', $missing )
+						),
+						[ 'dimensions' => $missing ]
+					);
+				}
+			}
+		}
+
+		$token = self::get_access_token();
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
+
+		$response = wp_remote_post(
+			self::DATA_API_URL . '/' . rawurlencode( $property_id ) . ':runReport',
+			[
+				'timeout' => 15, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+				'headers' => [
+					'Authorization' => 'Bearer ' . $token,
+					'Content-Type'  => 'application/json',
+				],
+				'body'    => wp_json_encode( $body ),
+			]
+		);
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $code < 200 || $code >= 300 ) {
+			return new \WP_Error(
+				'ga4_api_error',
+				is_array( $data ) && isset( $data['error']['message'] ) ? $data['error']['message'] : 'HTTP ' . $code,
+				[ 'http_code' => $code ]
+			);
+		}
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	/**
+	 * Run multiple GA4 Data API reports sequentially. Convenience wrapper for
+	 * orchestrators that need several reports to compose one metric (ratios,
+	 * multi-tuple geo filters, etc.). Each result is independent: a per-report
+	 * failure is returned as a WP_Error in that slot, never aborting the batch.
+	 *
+	 * @param string $property_id The publisher's GA4 property ID.
+	 * @param array  $bodies      Map of caller-chosen label => runReport request body.
+	 *
+	 * @return array Map of the same labels => (array response | WP_Error).
+	 */
+	public static function batch_run_reports( string $property_id, array $bodies ): array {
+		$results = [];
+		foreach ( $bodies as $key => $body ) {
+			$results[ $key ] = self::run_report( $property_id, $body );
+		}
+		return $results;
+	}
+
+	/**
+	 * Resolve a Google access token from Newspack's existing OAuth connection.
+	 *
+	 * @return string|\WP_Error
+	 */
+	private static function get_access_token() {
+		if ( ! class_exists( '\Newspack\Google_OAuth' ) ) {
+			return new \WP_Error(
+				'missing_dependency',
+				__( 'The Newspack plugin is required for GA4 Data API access.', 'newspack-plugin' )
+			);
+		}
+		if ( ! Google_OAuth::is_oauth_configured() ) {
+			return new \WP_Error(
+				'not_connected',
+				__( 'Connect Google Analytics in Newspack → Connections to see this tab.', 'newspack-plugin' )
+			);
+		}
+		$credentials = Google_OAuth::get_oauth2_credentials();
+		if ( ! $credentials ) {
+			return new \WP_Error(
+				'not_connected',
+				__( 'Connect Google Analytics in Newspack → Connections to see this tab.', 'newspack-plugin' )
+			);
+		}
+		$token = $credentials->getAccessToken();
+		if ( empty( $token ) ) {
+			return new \WP_Error(
+				'no_token',
+				__( 'Google credentials found but the access token is empty. Reconnect in Newspack → Connections.', 'newspack-plugin' )
+			);
+		}
+		return $token;
+	}
+
+	/**
+	 * Collect the `customEvent:<param>` parameter names referenced anywhere in a
+	 * runReport body — both in the `dimensions` array and inside the
+	 * `dimensionFilter` expression tree. The latter matters because article-scope
+	 * queries often reference `customEvent:post_id` only in a filter on an
+	 * otherwise dimensionless report (e.g. a screenPageViews count).
+	 *
+	 * @param array $body The runReport request body.
+	 * @return string[] Unique parameter names without the `customEvent:` prefix.
+	 */
+	private static function extract_custom_dimensions( array $body ): array {
+		$names = [];
+
+		foreach ( $body['dimensions'] ?? [] as $dimension ) {
+			$name = $dimension['name'] ?? '';
+			if ( self::is_custom_event_field( $name ) ) {
+				$names[] = self::strip_custom_event_prefix( $name );
+			}
+		}
+
+		if ( ! empty( $body['dimensionFilter'] ) && is_array( $body['dimensionFilter'] ) ) {
+			$names = array_merge( $names, self::extract_from_filter_expression( $body['dimensionFilter'] ) );
+		}
+
+		return array_values( array_unique( $names ) );
+	}
+
+	/**
+	 * Recursively walk a GA4 FilterExpression, collecting customEvent parameter
+	 * names from leaf filters. Handles `filter`, `andGroup`, `orGroup`, and
+	 * `notExpression` nodes.
+	 *
+	 * @param array $expression A GA4 FilterExpression node.
+	 * @return string[] Parameter names without the `customEvent:` prefix.
+	 */
+	private static function extract_from_filter_expression( array $expression ): array {
+		$names = [];
+
+		$field = $expression['filter']['fieldName'] ?? '';
+		if ( self::is_custom_event_field( $field ) ) {
+			$names[] = self::strip_custom_event_prefix( $field );
+		}
+
+		foreach ( [ 'andGroup', 'orGroup' ] as $group ) {
+			$expressions = $expression[ $group ]['expressions'] ?? [];
+			if ( is_array( $expressions ) ) {
+				foreach ( $expressions as $sub ) {
+					if ( is_array( $sub ) ) {
+						$names = array_merge( $names, self::extract_from_filter_expression( $sub ) );
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $expression['notExpression'] ) && is_array( $expression['notExpression'] ) ) {
+			$names = array_merge( $names, self::extract_from_filter_expression( $expression['notExpression'] ) );
+		}
+
+		return $names;
+	}
+
+	/**
+	 * Whether a GA4 field name references a custom event-scoped dimension.
+	 *
+	 * @param string $field A GA4 dimension/field name.
+	 * @return bool Whether it is a customEvent:<param> reference.
+	 */
+	private static function is_custom_event_field( $field ): bool {
+		return is_string( $field ) && 0 === strpos( $field, 'customEvent:' );
+	}
+
+	/**
+	 * Strip the `customEvent:` prefix from a field name to get the bare param.
+	 *
+	 * @param string $field A `customEvent:<param>` field name.
+	 * @return string The bare parameter name.
+	 */
+	private static function strip_custom_event_prefix( string $field ): string {
+		return substr( $field, strlen( 'customEvent:' ) );
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
@@ -47,6 +47,17 @@ final class Client {
 	const DATA_API_URL = 'https://analyticsdata.googleapis.com/v1beta/properties';
 
 	/**
+	 * Per-request memo of registered EVENT-scoped custom-dimension parameter
+	 * names (or a WP_Error), keyed by property ID. Orchestrators issue several
+	 * reports per request — and batch_run_reports() calls run_report() in a loop
+	 * — so the registered-dimension lookup (an Admin API round-trip) is cached
+	 * for the duration of the request to avoid amplifying calls and latency.
+	 *
+	 * @var array<string,string[]|\WP_Error>
+	 */
+	private static $registered_dimensions_cache = [];
+
+	/**
 	 * Run a single GA4 Data API report.
 	 *
 	 * @param string $property_id The publisher's GA4 property ID (numeric, no "properties/" prefix).
@@ -66,10 +77,17 @@ final class Client {
 	 *   - HTTP/network errors bubble up from wp_remote_post() as their own WP_Error.
 	 */
 	public static function run_report( string $property_id, array $body ) {
+		if ( '' === trim( $property_id ) ) {
+			return new \WP_Error(
+				'invalid_property_id',
+				__( 'A GA4 property ID is required to run a report.', 'newspack-plugin' )
+			);
+		}
+
 		// Authoritative custom-dimension pre-check, before spending the API call.
 		$requested = self::extract_custom_dimensions( $body );
 		if ( ! empty( $requested ) ) {
-			$registered = GA4_Custom_Dimensions::get_registered_parameter_names();
+			$registered = self::get_registered_parameter_names_cached( $property_id );
 			// Only block on a definitive answer. If the registered list can't be
 			// resolved (WP_Error), fall through and let the Data API respond — a
 			// genuinely missing dimension surfaces as an API error rather than
@@ -144,6 +162,22 @@ final class Client {
 	}
 
 	/**
+	 * Registered EVENT-scoped custom-dimension parameter names for a property,
+	 * memoized for the duration of the request. The result (success or WP_Error)
+	 * is cached so repeated reports in one request — including batch runs — make
+	 * at most one Admin API lookup per property.
+	 *
+	 * @param string $property_id The GA4 property ID.
+	 * @return string[]|\WP_Error
+	 */
+	private static function get_registered_parameter_names_cached( string $property_id ) {
+		if ( ! array_key_exists( $property_id, self::$registered_dimensions_cache ) ) {
+			self::$registered_dimensions_cache[ $property_id ] = GA4_Custom_Dimensions::get_registered_parameter_names();
+		}
+		return self::$registered_dimensions_cache[ $property_id ];
+	}
+
+	/**
 	 * Resolve a Google access token from Newspack's existing OAuth connection.
 	 *
 	 * @return string|\WP_Error
@@ -201,6 +235,15 @@ final class Client {
 		if ( ! empty( $body['dimensionFilter'] ) && is_array( $body['dimensionFilter'] ) ) {
 			$names = array_merge( $names, self::extract_from_filter_expression( $body['dimensionFilter'] ) );
 		}
+
+		// Drop empty names (e.g. a bare "customEvent:" with no parameter) so they
+		// never reach the missing-dimension diff or the user-facing message.
+		$names = array_filter(
+			$names,
+			function ( $name ) {
+				return '' !== $name;
+			}
+		);
 
 		return array_values( array_unique( $names ) );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/insights-ga4-client.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-ga4-client.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Tests for the Insights GA4 Data API client.
+ *
+ * Covers the deterministic, network-free logic: custom-dimension extraction
+ * from both the dimensions array and the dimensionFilter expression tree, the
+ * requested-vs-registered diff that drives the `custom_dimension_missing`
+ * error, and the property-less guard on the registered-dimensions lookup.
+ *
+ * The full run_report() success/HTTP paths require a live OAuth connection and
+ * are covered by the manual smoke test documented on NPPD-1647.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Insights\GA4\Client;
+use Newspack\GA4_Custom_Dimensions;
+
+/**
+ * Test the \Newspack\Insights\GA4\Client class.
+ */
+class Newspack_Test_Insights_GA4_Client extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private static method on Client via reflection.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_private( $method, array $args ) {
+		$reflection = new ReflectionMethod( Client::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invoke( null, ...$args );
+	}
+
+	/**
+	 * Extracts customEvent dimensions from the `dimensions` array; standard
+	 * dimensions are ignored.
+	 */
+	public function test_extract_custom_dimensions_from_dimensions_array() {
+		$body = [
+			'dimensions' => [
+				[ 'name' => 'date' ],
+				[ 'name' => 'customEvent:post_id' ],
+				[ 'name' => 'deviceCategory' ],
+				[ 'name' => 'customEvent:author' ],
+			],
+		];
+
+		$this->assertSame(
+			[ 'post_id', 'author' ],
+			$this->invoke_private( 'extract_custom_dimensions', [ $body ] )
+		);
+	}
+
+	/**
+	 * Detects customEvent dimensions referenced only inside a dimensionFilter
+	 * tree (no entry in the dimensions array) — the article-scope pattern used
+	 * by screenPageViews-only queries in the Insights formulas.
+	 */
+	public function test_extract_custom_dimensions_from_filter_tree() {
+		$body = [
+			'metrics'         => [ [ 'name' => 'screenPageViews' ] ],
+			'dimensionFilter' => [
+				'andGroup' => [
+					'expressions' => [
+						[
+							'filter' => [
+								'fieldName'    => 'eventName',
+								'stringFilter' => [
+									'matchType' => 'EXACT',
+									'value'     => 'scroll',
+								],
+							],
+						],
+						[
+							'filter' => [
+								'fieldName'    => 'customEvent:post_id',
+								'stringFilter' => [
+									'matchType' => 'FULL_REGEXP',
+									'value'     => '.+',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			[ 'post_id' ],
+			$this->invoke_private( 'extract_custom_dimensions', [ $body ] )
+		);
+	}
+
+	/**
+	 * Merges customEvent references from both the dimensions array and the
+	 * filter tree, de-duplicating overlaps.
+	 */
+	public function test_extract_custom_dimensions_merges_and_dedupes() {
+		$body = [
+			'dimensions'      => [
+				[ 'name' => 'customEvent:author' ],
+			],
+			'dimensionFilter' => [
+				'andGroup' => [
+					'expressions' => [
+						[
+							'filter' => [
+								'fieldName'    => 'customEvent:post_id',
+								'stringFilter' => [ 'value' => '.+' ],
+							],
+						],
+						[
+							'filter' => [
+								'fieldName'    => 'customEvent:author',
+								'stringFilter' => [ 'value' => '.+' ],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->invoke_private( 'extract_custom_dimensions', [ $body ] );
+		sort( $result );
+		$this->assertSame( [ 'author', 'post_id' ], $result );
+	}
+
+	/**
+	 * A query with no customEvent references yields an empty list (so run_report
+	 * skips the registration pre-check entirely).
+	 */
+	public function test_extract_custom_dimensions_returns_empty_when_none() {
+		$body = [
+			'dimensions' => [
+				[ 'name' => 'date' ],
+				[ 'name' => 'deviceCategory' ],
+			],
+			'metrics'    => [ [ 'name' => 'totalUsers' ] ],
+		];
+
+		$this->assertSame( [], $this->invoke_private( 'extract_custom_dimensions', [ $body ] ) );
+	}
+
+	/**
+	 * The requested-vs-registered diff that drives the custom_dimension_missing
+	 * error: a body referencing post_id and author, against a property that has
+	 * only post_id registered, yields author as missing. Mirrors the inline
+	 * computation in run_report().
+	 */
+	public function test_missing_dimension_diff_against_registered_set() {
+		$body = [
+			'dimensions'      => [ [ 'name' => 'customEvent:author' ] ],
+			'dimensionFilter' => [
+				'filter' => [
+					'fieldName'    => 'customEvent:post_id',
+					'stringFilter' => [ 'value' => '.+' ],
+				],
+			],
+		];
+
+		$requested  = $this->invoke_private( 'extract_custom_dimensions', [ $body ] );
+		$registered = [ 'post_id' ];
+		$missing    = array_values( array_diff( $requested, $registered ) );
+
+		$this->assertSame( [ 'author' ], $missing );
+	}
+
+	/**
+	 * Returns a WP_Error from get_registered_parameter_names() when no GA4
+	 * property is configured in Site Kit — the guard that lets run_report() fall
+	 * through to the live API rather than wrongly reporting every dimension as missing.
+	 */
+	public function test_registered_parameter_names_without_property_returns_wp_error() {
+		$previous = get_option( 'googlesitekit_analytics-4_settings', false );
+		delete_option( 'googlesitekit_analytics-4_settings' );
+
+		$result = GA4_Custom_Dimensions::get_registered_parameter_names();
+		$this->assertWPError( $result );
+
+		if ( false !== $previous ) {
+			update_option( 'googlesitekit_analytics-4_settings', $previous );
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights-ga4-client.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-ga4-client.php
@@ -169,6 +169,34 @@ class Newspack_Test_Insights_GA4_Client extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A bare `customEvent:` reference with no parameter name is dropped rather
+	 * than surfacing as an empty entry in the missing-dimension diff/message.
+	 */
+	public function test_extract_custom_dimensions_drops_empty_param() {
+		$body = [
+			'dimensions' => [
+				[ 'name' => 'customEvent:' ],
+				[ 'name' => 'customEvent:post_id' ],
+			],
+		];
+
+		$this->assertSame(
+			[ 'post_id' ],
+			$this->invoke_private( 'extract_custom_dimensions', [ $body ] )
+		);
+	}
+
+	/**
+	 * Returns a clear WP_Error from run_report() for an empty/whitespace
+	 * property ID before doing any other work.
+	 */
+	public function test_run_report_rejects_empty_property_id() {
+		$result = Client::run_report( '   ', [ 'metrics' => [ [ 'name' => 'totalUsers' ] ] ] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_property_id', $result->get_error_code() );
+	}
+
+	/**
 	 * Returns a WP_Error from get_registered_parameter_names() when no GA4
 	 * property is configured in Site Kit — the guard that lets run_report() fall
 	 * through to the live API rather than wrongly reporting every dimension as missing.
@@ -177,11 +205,13 @@ class Newspack_Test_Insights_GA4_Client extends WP_UnitTestCase {
 		$previous = get_option( 'googlesitekit_analytics-4_settings', false );
 		delete_option( 'googlesitekit_analytics-4_settings' );
 
-		$result = GA4_Custom_Dimensions::get_registered_parameter_names();
-		$this->assertWPError( $result );
-
-		if ( false !== $previous ) {
-			update_option( 'googlesitekit_analytics-4_settings', $previous );
+		try {
+			$result = GA4_Custom_Dimensions::get_registered_parameter_names();
+			$this->assertWPError( $result );
+		} finally {
+			if ( false !== $previous ) {
+				update_option( 'googlesitekit_analytics-4_settings', $previous );
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Lands \Newspack\Insights\GA4\Client as the GA4 Data API data adapter for Insights v1. Source: extracted from Automattic/newspack-gate-intelligence (github.a8c.com) and generalized to drop gate-specific orchestration. The client exposes only generic runReport primitives so metric orchestrators across tabs can compose their own report bodies.

Required because Insights v1 for Audience (Tab 1) and Engagement (Tab 2) ships powered by GA4 Data API while the BQ proxy (NPPD-1630) is still being built. Publishers need this data now, GA4 gives us real data on day 1, and v1.1 swaps each tab to BigQuery per-tab via a feature constant. The metric orchestrators (NPPD-1648) are blocked on this; the UI (NPPD-1649) is blocked on the orchestrators.

Stacked on nppd-1604-insights-tab-4-gates because that's where the rest of the Insights backend lives, specifically the existing metric orchestrator family (Gates_Metric, Subscribers_Metric, Donors_Metric) at includes/wizards/insights/metrics/. Retargets to main when 1604 merges.

## What's in this PR
### The GA4 Data API client

\Newspack\Insights\GA4\Client at includes/wizards/insights/ga4/class-client.php
Two public methods:

run_report( string $property_id, array $body ): single runReport call
batch_run_reports( string $property_id, array $bodies ): convenience wrapper for orchestrators that need multiple report calls per metric


No metric-specific knowledge. Composes the HTTP call, parses the response, surfaces structured errors via WP_Error.

### OAuth token via existing Newspack Google connection (no OAuth_Adapter)

Pre-flight surfaced that newspack-plugin already has \Newspack\Google_OAuth_GA4_Client doing the Admin API equivalent of the OAuth-token-via-Google_OAuth dance. The new client lifts that pattern instead of duplicating it.
The original ticket scope included a separate OAuth_Adapter class. Dropped after recon. Client::run_report() calls \Newspack\Google_OAuth::get_oauth2_credentials() directly (same source the Admin client uses).
Existing Newspack Google connections already include the analytics scope, so no publisher reconnection is needed.

### Authoritative custom dimension detection

Pre-flight also surfaced \Newspack\GA4_Custom_Dimensions which already lists and creates custom dimensions via the GA4 Admin API. Reused it.
Added GA4_Custom_Dimensions::get_registered_parameter_names() (one new method, reuses the existing property-resolution + Newspack-OAuth → Site-Kit fallback pattern).
Before any customEvent:* query, the client checks which custom dimensions are registered in the publisher's GA4 property. Missing dimensions return WP_Error( 'custom_dimension_missing', ..., [ 'dimensions' => $missing ] ) so the forthcoming orchestrators can render the per-card overlay.
More correct than the original ticket's "infer from empty rows" heuristic, and folds the v1.1 "boot-time probe" into v1 for nearly free.

### Filter-tree scanning for custom dimensions

Detection scans the dimensionFilter tree too, not just the dimensions array.
Reason: the most common article-scope pattern in the Insights docs is customEvent:post_id referenced only in the filter (e.g., a screenPageViews metric with no dimensions, but a filter restricting to singular content via customEvent:post_id IS NOT NULL). Without filter scanning, those queries would miss the dimension check entirely.
Covered by a unit test.

### Tests

tests/unit-tests/insights-ga4-client.php with 6 tests covering dimension extraction from the dimensions array, dimension extraction from the dimensionFilter tree, the custom_dimension_missing error shape, and the no-op case where a query has no custom dimensions.

## How to test
Pre-requisite: a publisher with Newspack Google connection configured and a valid GA4 property registered via Site Kit.

./n start
./n wp shell

Run the smoke test:

```
php$property_id = '123456789'; // Replace with your test publisher's GA4 property ID.

$result = \Newspack\Insights\GA4\Client::run_report( $property_id, [
    'dateRanges' => [ [ 'startDate' => '30daysAgo', 'endDate' => 'today' ] ],
    'metrics'    => [ [ 'name' => 'totalUsers' ] ],
] );
print_r( $result );  // Expect an array with rows containing a totalUsers value.
```

Verify:

-  print_r shows a real totalUsers integer from the publisher's property
-  No custom_dimension_missing WP_Error on the dimensionless smoke test query
-  If the publisher has no Newspack Google connection, the client returns the appropriate not_connected WP_Error rather than crashing
-  PHPUnit on the new test file shows 6/6 passing: phpunit tests/unit-tests/insights-ga4-client.php
-  PHPCS clean on the new files