### PR TITLE
feat(insights): audience + engagement metric orchestrators (NPPD-1648)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -187,28 +187,28 @@ class Audience_REST_Controller extends WP_REST_Controller {
 				[
 					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
 					'required'    => true,
-				] 
+				]
 			),
 			'end'           => array_merge(
 				$base,
 				[
 					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
 					'required'    => true,
-				] 
+				]
 			),
 			'compare_start' => array_merge(
 				$base,
 				[
 					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
 					'required'    => false,
-				] 
+				]
 			),
 			'compare_end'   => array_merge(
 				$base,
 				[
 					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
 					'required'    => false,
-				] 
+				]
 			),
 		];
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Newspack Insights — Tab 1 Audience REST controller (NPPD-1648).
+ *
+ * Single endpoint: `GET /newspack-insights/v1/audience`. Same date-arg
+ * validation, permission check, and date parsing conventions as
+ * {@see Gates_REST_Controller}.
+ *
+ * Response shape:
+ *   tab_error / banner_text — present (and the only keys) when GA4 isn't
+ *                             connected; React renders a single connect banner.
+ *   current  — keyed metric payload for the requested window.
+ *   previous — same for the comparison window, or null.
+ *
+ * Data comes from {@see Audience_Metric}, which dispatches GA4 (v1) vs BQ
+ * (v1.1, NPPD-1630) per the NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4 constant.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Audience REST controller.
+ */
+class Audience_REST_Controller extends WP_REST_Controller {
+
+	/**
+	 * Shared Insights namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'audience';
+
+	/**
+	 * Register the Tab 1 route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_audience_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET handler.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function get_audience_data( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
+
+		try {
+			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
+			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+		}
+		if ( $start > $end ) {
+			return new WP_Error(
+				'newspack_insights_invalid_window',
+				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$compare_start_param = $request->get_param( 'compare_start' );
+		$compare_end_param   = $request->get_param( 'compare_end' );
+		$compare_start       = null;
+		$compare_end         = null;
+		if ( $compare_start_param || $compare_end_param ) {
+			if ( ! $compare_start_param || ! $compare_end_param ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison',
+					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+			try {
+				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
+				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+			}
+			if ( $compare_start > $compare_end ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison_window',
+					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		return rest_ensure_response( $this->build_response( $start, $end, $compare_start, $compare_end ) );
+	}
+
+	/**
+	 * Assemble the top-level response. When GA4 isn't connected the metric
+	 * returns a tab_error payload, which is surfaced as the whole response.
+	 *
+	 * @param DateTimeImmutable      $start         Current window start.
+	 * @param DateTimeImmutable      $end           Current window end.
+	 * @param DateTimeImmutable|null $compare_start Prior window start.
+	 * @param DateTimeImmutable|null $compare_end   Prior window end.
+	 * @return array
+	 */
+	private function build_response(
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		?DateTimeImmutable $compare_start,
+		?DateTimeImmutable $compare_end
+	): array {
+		$current = Audience_Metric::get_all( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), false );
+		if ( isset( $current['tab_error'] ) ) {
+			return $current;
+		}
+
+		$response = [
+			'current'  => $current,
+			'previous' => null,
+		];
+		if ( $compare_start && $compare_end ) {
+			$previous = Audience_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );
+			$response['previous'] = isset( $previous['tab_error'] ) ? null : $previous;
+		}
+		return $response;
+	}
+
+	/**
+	 * Args spec.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$base = [
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+		];
+		return [
+			'start'         => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				] 
+			),
+			'end'           => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				] 
+			),
+			'compare_start' => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
+					'required'    => false,
+				] 
+			),
+			'compare_end'   => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
+					'required'    => false,
+				] 
+			),
+		];
+	}
+
+	/**
+	 * REST validate_callback.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool|WP_Error
+	 */
+	public function validate_date_string( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				/* translators: %s: the invalid date string */
+				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
+				[ 'status' => 400 ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Parse a Y-m-d string into a DateTimeImmutable.
+	 *
+	 * @param mixed        $value      Raw value.
+	 * @param DateTimeZone $tz         Timezone.
+	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
+	 * @return DateTimeImmutable
+	 * @throws Exception On parse failure.
+	 */
+	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			/* translators: %s: the invalid date string */
+			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
+		}
+		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
+	}
+
+	/**
+	 * Site timezone.
+	 *
+	 * @return DateTimeZone
+	 */
+	private function site_timezone(): DateTimeZone {
+		return wp_timezone();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
@@ -180,28 +180,28 @@ class Engagement_REST_Controller extends WP_REST_Controller {
 				[
 					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
 					'required'    => true,
-				] 
+				]
 			),
 			'end'           => array_merge(
 				$base,
 				[
 					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
 					'required'    => true,
-				] 
+				]
 			),
 			'compare_start' => array_merge(
 				$base,
 				[
 					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
 					'required'    => false,
-				] 
+				]
 			),
 			'compare_end'   => array_merge(
 				$base,
 				[
 					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
 					'required'    => false,
-				] 
+				]
 			),
 		];
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Newspack Insights — Tab 2 Engagement REST controller (NPPD-1648).
+ *
+ * Single endpoint: `GET /newspack-insights/v1/engagement`. Mirrors the
+ * date-arg validation, permission check, and response shape of
+ * {@see Audience_REST_Controller}.
+ *
+ * Data comes from {@see Engagement_Metric}, which dispatches GA4 (v1) vs BQ
+ * (v1.1, NPPD-1630) per the NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4 constant.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Engagement REST controller.
+ */
+class Engagement_REST_Controller extends WP_REST_Controller {
+
+	/**
+	 * Shared Insights namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'engagement';
+
+	/**
+	 * Register the Tab 2 route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_engagement_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET handler.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function get_engagement_data( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
+
+		try {
+			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
+			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+		}
+		if ( $start > $end ) {
+			return new WP_Error(
+				'newspack_insights_invalid_window',
+				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$compare_start_param = $request->get_param( 'compare_start' );
+		$compare_end_param   = $request->get_param( 'compare_end' );
+		$compare_start       = null;
+		$compare_end         = null;
+		if ( $compare_start_param || $compare_end_param ) {
+			if ( ! $compare_start_param || ! $compare_end_param ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison',
+					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+			try {
+				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
+				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+			}
+			if ( $compare_start > $compare_end ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison_window',
+					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		return rest_ensure_response( $this->build_response( $start, $end, $compare_start, $compare_end ) );
+	}
+
+	/**
+	 * Assemble the top-level response (tab_error surfaced when GA4 is unconnected).
+	 *
+	 * @param DateTimeImmutable      $start         Current window start.
+	 * @param DateTimeImmutable      $end           Current window end.
+	 * @param DateTimeImmutable|null $compare_start Prior window start.
+	 * @param DateTimeImmutable|null $compare_end   Prior window end.
+	 * @return array
+	 */
+	private function build_response(
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		?DateTimeImmutable $compare_start,
+		?DateTimeImmutable $compare_end
+	): array {
+		$current = Engagement_Metric::get_all( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), false );
+		if ( isset( $current['tab_error'] ) ) {
+			return $current;
+		}
+
+		$response = [
+			'current'  => $current,
+			'previous' => null,
+		];
+		if ( $compare_start && $compare_end ) {
+			$previous             = Engagement_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );
+			$response['previous'] = isset( $previous['tab_error'] ) ? null : $previous;
+		}
+		return $response;
+	}
+
+	/**
+	 * Args spec.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$base = [
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+		];
+		return [
+			'start'         => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				] 
+			),
+			'end'           => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				] 
+			),
+			'compare_start' => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
+					'required'    => false,
+				] 
+			),
+			'compare_end'   => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
+					'required'    => false,
+				] 
+			),
+		];
+	}
+
+	/**
+	 * REST validate_callback.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool|WP_Error
+	 */
+	public function validate_date_string( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				/* translators: %s: the invalid date string */
+				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
+				[ 'status' => 400 ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Parse a Y-m-d string into a DateTimeImmutable.
+	 *
+	 * @param mixed        $value      Raw value.
+	 * @param DateTimeZone $tz         Timezone.
+	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
+	 * @return DateTimeImmutable
+	 * @throws Exception On parse failure.
+	 */
+	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			/* translators: %s: the invalid date string */
+			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
+		}
+		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
+	}
+
+	/**
+	 * Site timezone.
+	 *
+	 * @return DateTimeZone
+	 */
+	private function site_timezone(): DateTimeZone {
+		return wp_timezone();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -59,7 +59,7 @@ class Insights_Section_Audience {
 	 *
 	 * @return void
 	 */
-	public static function register_hooks() {
+	public static function register_hooks(): void {
 		add_action(
 			'rest_api_init',
 			function () {

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -6,14 +6,15 @@
  * engaged the audience is at a high level. The "lobby" of the Insights
  * page — answers "what's the shape of my audience this period?"
  *
- * Future REST endpoints for the Audience tab register from
- * {@see self::register_hooks()}. Currently a stub; the React side renders
- * a "Coming soon" placeholder for this tab.
+ * The Tab 1 data layer (GA4-first, NPPD-1648) registers its REST route
+ * from {@see self::register_hooks()} via {@see \Newspack\Insights\Audience_REST_Controller}.
  *
  * @package Newspack
  */
 
 namespace Newspack;
+
+use Newspack\Insights\Audience_REST_Controller;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,18 +31,41 @@ class Insights_Section_Audience {
 	const SECTION_NAME = 'Audience';
 
 	/**
-	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1608).
+	 * Initialize. Loads the Tab 1 data layer and registers its REST route
+	 * (NPPD-1648).
 	 */
 	public static function init() {
 		if ( ! Insights_Wizard::is_enabled() ) {
 			return;
 		}
+		self::load_dependencies();
 		self::register_hooks();
 	}
 
 	/**
-	 * Register hooks for this section. Currently a stub.
+	 * Include Tab 1 PHP files (metric orchestrator + REST controller),
+	 * matching the per-section include convention.
+	 *
+	 * @return void
 	 */
-	public static function register_hooks() {}
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'metrics/class-audience-metric.php';
+		include_once $base . 'api/class-audience-rest-controller.php';
+	}
+
+	/**
+	 * Register the Tab 1 REST route.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks() {
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new Audience_REST_Controller();
+				$controller->register_routes();
+			}
+		);
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -59,7 +59,7 @@ class Insights_Section_Engagement {
 	 *
 	 * @return void
 	 */
-	public static function register_hooks() {
+	public static function register_hooks(): void {
 		add_action(
 			'rest_api_init',
 			function () {

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -6,14 +6,15 @@
  * scroll depth, time on page, return visits. Distinct from Audience
  * (who) by focusing on behavior depth (how).
  *
- * Future REST endpoints for the Engagement tab register from
- * {@see self::register_hooks()}. Currently a stub; the React side renders
- * a "Coming soon" placeholder for this tab.
+ * The Tab 2 data layer (GA4-first, NPPD-1648) registers its REST route
+ * from {@see self::register_hooks()} via {@see \Newspack\Insights\Engagement_REST_Controller}.
  *
  * @package Newspack
  */
 
 namespace Newspack;
+
+use Newspack\Insights\Engagement_REST_Controller;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,18 +31,41 @@ class Insights_Section_Engagement {
 	const SECTION_NAME = 'Engagement';
 
 	/**
-	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1624).
+	 * Initialize. Loads the Tab 2 data layer and registers its REST route
+	 * (NPPD-1648).
 	 */
 	public static function init() {
 		if ( ! Insights_Wizard::is_enabled() ) {
 			return;
 		}
+		self::load_dependencies();
 		self::register_hooks();
 	}
 
 	/**
-	 * Register hooks for this section. Currently a stub.
+	 * Include Tab 2 PHP files (metric orchestrator + REST controller),
+	 * matching the per-section include convention.
+	 *
+	 * @return void
 	 */
-	public static function register_hooks() {}
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'metrics/class-engagement-metric.php';
+		include_once $base . 'api/class-engagement-rest-controller.php';
+	}
+
+	/**
+	 * Register the Tab 2 REST route.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks() {
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new Engagement_REST_Controller();
+				$controller->register_routes();
+			}
+		);
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -14,7 +14,9 @@
  *
  * Payload shapes:
  *   scalar  : { value, computable, type: count|decimal }
- *   rate    : { value (0-1), computable, type: rate, numerator, denominator }
+ *   rate    : { value (0-1), computable, type: rate[, numerator, denominator] }
+ *             (numerator/denominator included where meaningful; some rates that
+ *             come straight from a GA4 metric omit them)
  *   rows    : { rows: [...], computable, type: breakdown|table|timeseries }
  *   overlay : { value: null, computable: false, overlay: { type, dimensions } }
  *   hidden  : { value: null, computable: false, hidden_in_v1: true }
@@ -692,7 +694,7 @@ final class Audience_Metric {
 				'value'      => null,
 				'computable' => false,
 				'type'       => 'rate',
-				'error'      => 'Local Reader Rate could not be computed: the geo breakdown exceeded the row limit and was truncated.',
+				'error'      => __( 'Local Reader Rate could not be computed: the geo breakdown exceeded the row limit and was truncated.', 'newspack-plugin' ),
 			];
 		}
 
@@ -1038,7 +1040,7 @@ final class Audience_Metric {
 		return [
 			'value'      => null,
 			'computable' => false,
-			'error'      => 'BQ path not yet implemented. See NPPD-1630.',
+			'error'      => __( 'BQ path not yet implemented. See NPPD-1630.', 'newspack-plugin' ),
 		];
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -681,6 +681,21 @@ final class Audience_Metric {
 			return $result;
 		}
 
+		// This rate is computed from the full geo row set in PHP, so a truncated
+		// response would silently skew the numerator/denominator. GA4 reports the
+		// total matching row count in `rowCount`; if it exceeds the rows actually
+		// returned, bail with an explicit error rather than reporting a wrong rate.
+		$returned_rows = count( $result['raw']['rows'] ?? [] );
+		$row_count     = isset( $result['raw']['rowCount'] ) ? (int) $result['raw']['rowCount'] : $returned_rows;
+		if ( $row_count > $returned_rows ) {
+			return [
+				'value'      => null,
+				'computable' => false,
+				'type'       => 'rate',
+				'error'      => 'Local Reader Rate could not be computed: the geo breakdown exceeded the row limit and was truncated.',
+			];
+		}
+
 		$total = 0;
 		$local = 0;
 		foreach ( $result['raw']['rows'] ?? [] as $row ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -1,0 +1,1029 @@
+<?php
+/**
+ * Newspack Insights — Audience Metric orchestrator (Tab 1, NPPD-1648).
+ *
+ * Composes GA4 Data API `runReport` bodies (translated from
+ * `~/Sites/insights-docs/formulas/tab-1-audience.md`) and returns
+ * MetricCard-ready payloads. Dispatches between GA4 (v1, default) and the
+ * BigQuery proxy (v1.1, NPPD-1630 — stubbed here) per the
+ * `NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4` constant (default true).
+ *
+ * Consumes the GA4 client landed in NPPD-1647
+ * ({@see \Newspack\Insights\GA4\Client}) and its authoritative
+ * custom-dimension detection ({@see \Newspack\GA4_Custom_Dimensions}).
+ *
+ * Payload shapes:
+ *   scalar  : { value, computable, type: count|decimal }
+ *   rate    : { value (0-1), computable, type: rate, numerator, denominator }
+ *   rows    : { rows: [...], computable, type: breakdown|table|timeseries }
+ *   overlay : { value: null, computable: false, overlay: { type, dimensions } }
+ *   hidden  : { value: null, computable: false, hidden_in_v1: true }
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+use Newspack\Insights\GA4\Client;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Audience (Tab 1) metric orchestrator.
+ */
+final class Audience_Metric {
+
+	const CACHE_TTL        = 15 * MINUTE_IN_SECONDS;
+	const CACHE_KEY_PREFIX = 'newspack_insights_audience_v1:';
+
+	/**
+	 * Whether this tab uses the GA4 path. Default true; flip the constant
+	 * to false once the BQ catalog (NPPD-1630) ships and is validated.
+	 *
+	 * @return bool
+	 */
+	private static function use_ga4(): bool {
+		return ! defined( 'NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4' ) || NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4;
+	}
+
+	/**
+	 * Resolve the GA4 property ID from Site Kit's stored settings.
+	 *
+	 * @return string Numeric property ID, or '' when none is connected.
+	 */
+	private static function resolve_property_id(): string {
+		$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
+		return is_array( $settings ) && ! empty( $settings['propertyID'] ) ? (string) $settings['propertyID'] : '';
+	}
+
+	/**
+	 * Tab-level connection check. Returns a tab_error payload when the GA4
+	 * path is active but no usable Google connection / property exists, else
+	 * null. Checking once up front avoids N rejected runReport calls.
+	 *
+	 * @return array|null
+	 */
+	public static function connection_error(): ?array {
+		if ( ! self::use_ga4() ) {
+			return null;
+		}
+		$connected = class_exists( '\Newspack\Google_OAuth' )
+			&& \Newspack\Google_OAuth::is_oauth_configured()
+			&& '' !== self::resolve_property_id();
+		if ( $connected ) {
+			return null;
+		}
+		return [
+			'tab_error'   => 'oauth_not_connected',
+			'banner_text' => __( 'Connect Google Analytics in Newspack → Connections to see this tab.', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * Full tab payload for a window. When $compare is true, also computes the
+	 * immediately-preceding same-length window under the `compare` key.
+	 *
+	 * @param string $start_date YYYY-MM-DD (site timezone).
+	 * @param string $end_date   YYYY-MM-DD (site timezone).
+	 * @param bool   $compare    Whether to attach the prior-period payload.
+	 * @return array
+	 */
+	public static function get_all( string $start_date, string $end_date, bool $compare = false ): array {
+		$error = self::connection_error();
+		if ( null !== $error ) {
+			return $error;
+		}
+
+		$payload = self::compute_window_cached( $start_date, $end_date );
+
+		if ( $compare ) {
+			[ $prior_start, $prior_end ] = self::prior_period( $start_date, $end_date );
+			$payload['compare']          = self::compute_window_cached( $prior_start, $prior_end );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Immediately-preceding window of equal length.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string[] [ prior_start, prior_end ] as YYYY-MM-DD.
+	 */
+	private static function prior_period( string $start_date, string $end_date ): array {
+		$start = new \DateTimeImmutable( $start_date );
+		$end   = new \DateTimeImmutable( $end_date );
+		$days  = (int) $start->diff( $end )->format( '%a' ) + 1;
+		$prior_end   = $start->modify( '-1 day' );
+		$prior_start = $prior_end->modify( '-' . ( $days - 1 ) . ' days' );
+		return [ $prior_start->format( 'Y-m-d' ), $prior_end->format( 'Y-m-d' ) ];
+	}
+
+	/**
+	 * Cached single-window computation, keyed by window + backend.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_window_cached( string $start_date, string $end_date ): array {
+		$use_ga4   = self::use_ga4();
+		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date . '|' . $end_date . '|' . ( $use_ga4 ? 'ga4' : 'bq' ) );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+		$payload = $use_ga4
+			? self::compute_via_ga4( $start_date, $end_date )
+			: self::compute_via_bq( $start_date, $end_date );
+		set_transient( $cache_key, $payload, self::CACHE_TTL );
+		return $payload;
+	}
+
+	/**
+	 * GA4 path — composes every metric for the window.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_via_ga4( string $start_date, string $end_date ): array {
+		$pid = self::resolve_property_id();
+		return [
+			'window'                             => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			// Reach.
+			'active_readers'                     => self::active_readers_via_ga4( $pid, $start_date, $end_date ),
+			'sessions'                           => self::sessions_via_ga4( $pid, $start_date, $end_date ),
+			'pageviews'                          => self::pageviews_via_ga4( $pid, $start_date, $end_date ),
+			'avg_sessions_per_reader'            => self::avg_sessions_per_reader_via_ga4( $pid, $start_date, $end_date ),
+			'engaged_session_rate'               => self::engaged_session_rate_via_ga4( $pid, $start_date, $end_date ),
+			// Time trends.
+			'active_readers_over_time'           => self::active_readers_over_time_via_ga4( $pid, $start_date, $end_date ),
+			'new_vs_returning_counts'            => self::new_vs_returning_counts_via_ga4( $pid, $start_date, $end_date ),
+			'new_vs_returning_over_time'         => self::new_vs_returning_over_time_via_ga4( $pid, $start_date, $end_date ),
+			'readership_by_day_of_week'          => self::readership_by_day_of_week_via_ga4( $pid, $start_date, $end_date ),
+			'readership_by_hour_of_day'          => self::readership_by_hour_of_day_via_ga4( $pid, $start_date, $end_date ),
+			// Traffic sources.
+			'traffic_sources_breakdown'          => self::traffic_sources_breakdown_via_ga4( $pid, $start_date, $end_date ),
+			'top_campaigns'                      => self::top_campaigns_via_ga4( $pid, $start_date, $end_date ),
+			// Composition.
+			'device_breakdown'                   => self::device_breakdown_via_ga4( $pid, $start_date, $end_date ),
+			'newsletter_subscriber_rate'         => self::newsletter_subscriber_rate_via_ga4( $pid, $start_date, $end_date ),
+			'newsletter_subscriber_composition'  => self::newsletter_subscriber_composition_via_ga4( $pid, $start_date, $end_date ),
+			'logged_in_reader_rate'              => self::logged_in_reader_rate_via_ga4( $pid, $start_date, $end_date ),
+			'logged_in_vs_anonymous_composition' => self::logged_in_vs_anonymous_composition_via_ga4( $pid, $start_date, $end_date ),
+			// Geographic.
+			'top_countries'                      => self::top_countries_via_ga4( $pid, $start_date, $end_date ),
+			'top_regions'                        => self::top_regions_via_ga4( $pid, $start_date, $end_date ),
+			'top_cities'                         => self::top_cities_via_ga4( $pid, $start_date, $end_date ),
+			'top_dmas'                           => self::top_dmas_via_ga4( $pid, $start_date, $end_date ),
+			'local_reader_rate'                  => self::local_reader_rate_via_ga4( $pid, $start_date, $end_date ),
+			// Content performance.
+			'top_pages_by_pageviews'             => self::top_pages_by_pageviews_via_ga4( $pid, $start_date, $end_date ),
+			'top_pages_by_reader_count'          => self::top_pages_by_reader_count_via_ga4( $pid, $start_date, $end_date ),
+			'top_authors_by_reader_count'        => self::top_authors_by_reader_count_via_ga4( $pid, $start_date, $end_date ),
+			// BQ-only (hidden in v1).
+			'returning_reader_rate_strict'       => self::hidden_in_v1_payload(),
+		];
+	}
+
+	/**
+	 * BQ path — v1 stub. Every metric returns a not_implemented error with the
+	 * same key set as the GA4 path; NPPD-1630 fills these in. BQ-only metrics
+	 * stay hidden_in_v1 even here (their GA4 counterpart can never compute them).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_via_bq( string $start_date, string $end_date ): array {
+		$keys = [
+			'active_readers',
+			'sessions',
+			'pageviews',
+			'avg_sessions_per_reader',
+			'engaged_session_rate',
+			'active_readers_over_time',
+			'new_vs_returning_counts',
+			'new_vs_returning_over_time',
+			'readership_by_day_of_week',
+			'readership_by_hour_of_day',
+			'traffic_sources_breakdown',
+			'top_campaigns',
+			'device_breakdown',
+			'newsletter_subscriber_rate',
+			'newsletter_subscriber_composition',
+			'logged_in_reader_rate',
+			'logged_in_vs_anonymous_composition',
+			'top_countries',
+			'top_regions',
+			'top_cities',
+			'top_dmas',
+			'local_reader_rate',
+			'top_pages_by_pageviews',
+			'top_pages_by_reader_count',
+			'top_authors_by_reader_count',
+		];
+		$payload = [
+			'window' => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+		];
+		foreach ( $keys as $key ) {
+			$payload[ $key ] = self::not_implemented_payload();
+		}
+		$payload['returning_reader_rate_strict'] = self::hidden_in_v1_payload();
+		return $payload;
+	}
+
+	/*
+	===================================================================
+	 * GA4-standard metrics
+	 * ===================================================================
+	 */
+
+	/**
+	 * Active Readers — totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function active_readers_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'totalUsers' ] ) );
+		return self::scalar( $result, 'count' );
+	}
+
+	/**
+	 * Sessions — sessions.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function sessions_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'sessions' ] ) );
+		return self::scalar( $result, 'count' );
+	}
+
+	/**
+	 * Pageviews — screenPageViews (conventional Data API metric).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function pageviews_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'screenPageViews' ] ) );
+		return self::scalar( $result, 'count' );
+	}
+
+	/**
+	 * Avg Sessions per Reader — sessions / totalUsers (single report).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function avg_sessions_per_reader_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'sessions', 'totalUsers' ] ) );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$row      = $result['raw']['rows'][0] ?? null;
+		$sessions = (int) ( $row['metricValues'][0]['value'] ?? 0 );
+		$users    = (int) ( $row['metricValues'][1]['value'] ?? 0 );
+		return [
+			'value'       => $users > 0 ? $sessions / $users : 0,
+			'computable'  => $users > 0,
+			'type'        => 'decimal',
+			'numerator'   => $sessions,
+			'denominator' => $users,
+		];
+	}
+
+	/**
+	 * Engaged Session Rate — engagementRate (already a 0-1 ratio).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function engaged_session_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'engagementRate' ] ) );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$raw = $result['raw']['rows'][0]['metricValues'][0]['value'] ?? null;
+		return [
+			'value'      => null === $raw ? 0.0 : (float) $raw,
+			'computable' => null !== $raw,
+			'type'       => 'rate',
+		];
+	}
+
+	/**
+	 * Active Readers Over Time — date / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function active_readers_over_time_via_ga4( string $pid, string $s, string $e ): array {
+		$body                = self::body( $s, $e, [ 'date' ], [ 'totalUsers' ] );
+		$body['orderBys']    = [ [ 'dimension' => [ 'dimensionName' => 'date' ] ] ];
+		$result              = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'date' ], [ 'active_readers' ], 'timeseries' );
+	}
+
+	/**
+	 * New vs Returning Counts — newVsReturning / totalUsers (pie).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function new_vs_returning_counts_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'newVsReturning' ], [ 'totalUsers' ] ) );
+		return self::rows( $result, [ 'reader_type' ], [ 'readers' ], 'breakdown' );
+	}
+
+	/**
+	 * New vs Returning Over Time — date + newVsReturning / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function new_vs_returning_over_time_via_ga4( string $pid, string $s, string $e ): array {
+		$body             = self::body( $s, $e, [ 'date', 'newVsReturning' ], [ 'totalUsers' ] );
+		$body['orderBys'] = [ [ 'dimension' => [ 'dimensionName' => 'date' ] ] ];
+		$result           = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'date', 'reader_type' ], [ 'readers' ], 'timeseries' );
+	}
+
+	/**
+	 * Readership by Day of Week — dayOfWeekName / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function readership_by_day_of_week_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'dayOfWeekName' ], [ 'totalUsers' ] ) );
+		return self::rows( $result, [ 'day_of_week' ], [ 'active_readers' ], 'breakdown' );
+	}
+
+	/**
+	 * Readership by Hour of Day — hour / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function readership_by_hour_of_day_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'hour' ], [ 'totalUsers' ] ) );
+		return self::rows( $result, [ 'hour' ], [ 'active_readers' ], 'breakdown' );
+	}
+
+	/**
+	 * Traffic Sources Breakdown — sessionDefaultChannelGroup / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function traffic_sources_breakdown_via_ga4( string $pid, string $s, string $e ): array {
+		$body   = self::body( $s, $e, [ 'sessionDefaultChannelGroup' ], [ 'totalUsers' ] );
+		$body  += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 20;
+		$result = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'channel' ], [ 'readers' ], 'breakdown' );
+	}
+
+	/**
+	 * Top Campaigns — sessionSource/Medium/CampaignName / totalUsers + sessions.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_campaigns_via_ga4( string $pid, string $s, string $e ): array {
+		$body          = self::body( $s, $e, [ 'sessionSource', 'sessionMedium', 'sessionCampaignName' ], [ 'totalUsers', 'sessions' ] );
+		$body         += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 50;
+		$result        = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'source', 'medium', 'campaign' ], [ 'readers', 'sessions' ], 'table' );
+	}
+
+	/**
+	 * Device Breakdown — deviceCategory / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function device_breakdown_via_ga4( string $pid, string $s, string $e ): array {
+		$body   = self::body( $s, $e, [ 'deviceCategory' ], [ 'totalUsers' ] );
+		$body  += self::order_by_metric_desc( 'totalUsers' );
+		$result = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'device' ], [ 'readers' ], 'breakdown' );
+	}
+
+	/**
+	 * Top Countries — country / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_countries_via_ga4( string $pid, string $s, string $e ): array {
+		$body          = self::body( $s, $e, [ 'country' ], [ 'totalUsers' ] );
+		$body         += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 25;
+		$result        = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'country' ], [ 'readers' ], 'table' );
+	}
+
+	/**
+	 * Top Regions/States — country, region / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_regions_via_ga4( string $pid, string $s, string $e ): array {
+		$body          = self::body( $s, $e, [ 'country', 'region' ], [ 'totalUsers' ] );
+		$body         += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 50;
+		$result        = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'country', 'region' ], [ 'readers' ], 'table' );
+	}
+
+	/**
+	 * Top Cities — country, region, city / totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_cities_via_ga4( string $pid, string $s, string $e ): array {
+		$body          = self::body( $s, $e, [ 'country', 'region', 'city' ], [ 'totalUsers' ] );
+		$body         += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 50;
+		$result        = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'country', 'region', 'city' ], [ 'readers' ], 'table' );
+	}
+
+	/**
+	 * Top DMAs (US-only) — metro / totalUsers, filtered to United States.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_dmas_via_ga4( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'metro' ], [ 'totalUsers' ] );
+		$body['dimensionFilter'] = [
+			'filter' => [
+				'fieldName'    => 'country',
+				'stringFilter' => [
+					'matchType' => 'EXACT',
+					'value'     => 'United States',
+				],
+			],
+		];
+		$body         += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 50;
+		$result        = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'dma' ], [ 'readers' ], 'table' );
+	}
+
+	/*
+	===================================================================
+	 * GA4-conditional metrics (custom dimensions)
+	 * ===================================================================
+	 */
+
+	/**
+	 * Newsletter Subscriber Rate — customEvent:is_newsletter_subscriber.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function newsletter_subscriber_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'customEvent:is_newsletter_subscriber' ], [ 'totalUsers' ] ) );
+		return self::yes_rate( $result );
+	}
+
+	/**
+	 * Newsletter Subscriber Composition — same query, two-slice pie.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function newsletter_subscriber_composition_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'customEvent:is_newsletter_subscriber' ], [ 'totalUsers' ] ) );
+		return self::yes_composition( $result, __( 'Newsletter subscriber', 'newspack-plugin' ), __( 'Not subscribed', 'newspack-plugin' ) );
+	}
+
+	/**
+	 * Logged-In Reader Rate — customEvent:logged_in.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function logged_in_reader_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'customEvent:logged_in' ], [ 'totalUsers' ] ) );
+		return self::yes_rate( $result );
+	}
+
+	/**
+	 * Logged-In vs Anonymous Composition — same query, two-slice pie.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function logged_in_vs_anonymous_composition_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'customEvent:logged_in' ], [ 'totalUsers' ] ) );
+		return self::yes_composition( $result, __( 'Logged in', 'newspack-plugin' ), __( 'Anonymous', 'newspack-plugin' ) );
+	}
+
+	/**
+	 * Top Pages by Pageviews — customEvent:post_id (degrade to all URLs if missing).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_pages_by_pageviews_via_ga4( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'customEvent:post_id', 'pagePath', 'pageTitle' ], [ 'screenPageViews' ] );
+		$body['dimensionFilter'] = self::custom_event_present_filter( 'post_id' );
+		$body                   += self::order_by_metric_desc( 'screenPageViews' );
+		$body['limit']           = 50;
+		$result                  = self::safe_run_report( $pid, $body );
+
+		if ( self::is_custom_dimension_missing( $result ) ) {
+			// Degrade rather than hide: drop the post_id dimension + filter.
+			$degraded          = self::body( $s, $e, [ 'pagePath', 'pageTitle' ], [ 'screenPageViews' ] );
+			$degraded         += self::order_by_metric_desc( 'screenPageViews' );
+			$degraded['limit'] = 50;
+			$out               = self::rows( self::safe_run_report( $pid, $degraded ), [ 'page_path', 'page_title' ], [ 'pageviews' ], 'table' );
+			return self::mark_degraded( $out, __( 'Singular content filter unavailable; showing all URLs.', 'newspack-plugin' ) );
+		}
+		return self::rows( $result, [ 'post_id', 'page_path', 'page_title' ], [ 'pageviews' ], 'table' );
+	}
+
+	/**
+	 * Top Pages by Reader Count — customEvent:post_id (degrade if missing).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_pages_by_reader_count_via_ga4( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'customEvent:post_id', 'pagePath', 'pageTitle' ], [ 'totalUsers', 'screenPageViews' ] );
+		$body['dimensionFilter'] = self::custom_event_present_filter( 'post_id' );
+		$body                   += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit']           = 50;
+		$result                  = self::safe_run_report( $pid, $body );
+
+		if ( self::is_custom_dimension_missing( $result ) ) {
+			$degraded          = self::body( $s, $e, [ 'pagePath', 'pageTitle' ], [ 'totalUsers', 'screenPageViews' ] );
+			$degraded         += self::order_by_metric_desc( 'totalUsers' );
+			$degraded['limit'] = 50;
+			$out               = self::rows( self::safe_run_report( $pid, $degraded ), [ 'page_path', 'page_title' ], [ 'unique_readers', 'pageviews' ], 'table' );
+			return self::mark_degraded( $out, __( 'Singular content filter unavailable; showing all URLs.', 'newspack-plugin' ) );
+		}
+		return self::rows( $result, [ 'post_id', 'page_path', 'page_title' ], [ 'unique_readers', 'pageviews' ], 'table' );
+	}
+
+	/**
+	 * Top Authors by Reader Count — customEvent:author + post_id (overlay if missing).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_authors_by_reader_count_via_ga4( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'customEvent:author' ], [ 'totalUsers', 'screenPageViews' ] );
+		$body['dimensionFilter'] = [
+			'andGroup' => [
+				'expressions' => [
+					self::custom_event_present_expression( 'post_id' ),
+					self::custom_event_present_expression( 'author' ),
+				],
+			],
+		];
+		$body         += self::order_by_metric_desc( 'totalUsers' );
+		$body['limit'] = 25;
+		$result        = self::safe_run_report( $pid, $body );
+		return self::rows( $result, [ 'author' ], [ 'unique_readers', 'pageviews' ], 'table' );
+	}
+
+	/**
+	 * Local Reader Rate — geo report merged in PHP against configured tuples.
+	 * Hidden (not_configured) when no coverage area is set.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function local_reader_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$filters = get_option( 'newspack_insights_local_geo_filters', [] );
+		if ( ! is_array( $filters ) || empty( $filters ) ) {
+			return [
+				'value'          => null,
+				'computable'     => false,
+				'type'           => 'rate',
+				'not_configured' => true,
+			];
+		}
+
+		$body          = self::body( $s, $e, [ 'country', 'region', 'city', 'metro' ], [ 'totalUsers' ] );
+		$body['limit'] = 100000;
+		$result        = self::safe_run_report( $pid, $body );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+
+		$total = 0;
+		$local = 0;
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$geo   = [
+				'country' => $row['dimensionValues'][0]['value'] ?? '',
+				'region'  => $row['dimensionValues'][1]['value'] ?? '',
+				'city'    => $row['dimensionValues'][2]['value'] ?? '',
+				'metro'   => $row['dimensionValues'][3]['value'] ?? '',
+			];
+			$users = (int) ( $row['metricValues'][0]['value'] ?? 0 );
+			$total += $users;
+			if ( self::geo_matches_any( $geo, $filters ) ) {
+				$local += $users;
+			}
+		}
+		return [
+			'value'       => $total > 0 ? $local / $total : 0,
+			'computable'  => $total > 0,
+			'type'        => 'rate',
+			'numerator'   => $local,
+			'denominator' => $total,
+		];
+	}
+
+	/**
+	 * Whether a geo row matches any configured filter tuple. Each tuple's
+	 * present (non-empty) fields must all equal the row's values.
+	 *
+	 * @param array $geo     Row geo [country, region, city, metro].
+	 * @param array $filters Array of partial geo tuples.
+	 * @return bool
+	 */
+	private static function geo_matches_any( array $geo, array $filters ): bool {
+		foreach ( $filters as $tuple ) {
+			if ( ! is_array( $tuple ) ) {
+				continue;
+			}
+			$match = true;
+			foreach ( [ 'country', 'region', 'city', 'metro' ] as $field ) {
+				if ( ! empty( $tuple[ $field ] ) && $tuple[ $field ] !== ( $geo[ $field ] ?? '' ) ) {
+					$match = false;
+					break;
+				}
+			}
+			if ( $match ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/*
+	===================================================================
+	 * Shared helpers
+	 * ===================================================================
+	 */
+
+	/**
+	 * Build a base runReport body.
+	 *
+	 * @param string   $s        Start date YYYY-MM-DD.
+	 * @param string   $e        End date YYYY-MM-DD.
+	 * @param string[] $dims     Dimension names.
+	 * @param string[] $metrics  Metric names.
+	 * @return array
+	 */
+	private static function body( string $s, string $e, array $dims, array $metrics ): array {
+		$body = [
+			'dateRanges' => [
+				[
+					'startDate' => $s,
+					'endDate'   => $e,
+				],
+			],
+			'metrics'    => array_map(
+				function ( $m ) {
+					return [ 'name' => $m ];
+				},
+				$metrics
+			),
+		];
+		if ( ! empty( $dims ) ) {
+			$body['dimensions'] = array_map(
+				function ( $d ) {
+					return [ 'name' => $d ];
+				},
+				$dims
+			);
+		}
+		return $body;
+	}
+
+	/**
+	 * Build an orderBys fragment: a single metric, descending.
+	 *
+	 * @param string $metric Metric name.
+	 * @return array
+	 */
+	private static function order_by_metric_desc( string $metric ): array {
+		return [
+			'orderBys' => [
+				[
+					'metric' => [ 'metricName' => $metric ],
+					'desc'   => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build a dimensionFilter asserting a customEvent dimension is present.
+	 *
+	 * @param string $param Event parameter name.
+	 * @return array
+	 */
+	private static function custom_event_present_filter( string $param ): array {
+		return [ 'filter' => self::custom_event_present_expression( $param )['filter'] ];
+	}
+
+	/**
+	 * A single FilterExpression asserting a customEvent dimension is present.
+	 *
+	 * @param string $param Event parameter name.
+	 * @return array
+	 */
+	private static function custom_event_present_expression( string $param ): array {
+		return [
+			'filter' => [
+				'fieldName'    => 'customEvent:' . $param,
+				'stringFilter' => [
+					'matchType' => 'FULL_REGEXP',
+					'value'     => '.+',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Run a report, normalizing WP_Error into payload-shaped failures.
+	 *
+	 * @param string $property_id Property ID.
+	 * @param array  $body        runReport body.
+	 * @return array { raw } on success, or { error } / { overlay } on failure.
+	 */
+	private static function safe_run_report( string $property_id, array $body ): array {
+		$result = Client::run_report( $property_id, $body );
+
+		if ( is_wp_error( $result ) ) {
+			if ( 'custom_dimension_missing' === $result->get_error_code() ) {
+				$data = $result->get_error_data();
+				return [
+					'value'      => null,
+					'computable' => false,
+					'overlay'    => [
+						'type'       => 'custom_dimension_missing',
+						'dimensions' => is_array( $data ) && isset( $data['dimensions'] ) ? $data['dimensions'] : [],
+					],
+				];
+			}
+			return [
+				'value'      => null,
+				'computable' => false,
+				'error'      => $result->get_error_message(),
+			];
+		}
+
+		return [ 'raw' => $result ];
+	}
+
+	/**
+	 * Whether a safe_run_report result is a custom_dimension_missing overlay.
+	 *
+	 * @param array $result safe_run_report result.
+	 * @return bool
+	 */
+	private static function is_custom_dimension_missing( array $result ): bool {
+		return isset( $result['overlay']['type'] ) && 'custom_dimension_missing' === $result['overlay']['type'];
+	}
+
+	/**
+	 * Transform a single scalar metric value.
+	 *
+	 * @param array  $result safe_run_report result.
+	 * @param string $type   'count' or 'decimal'.
+	 * @return array
+	 */
+	private static function scalar( array $result, string $type ): array {
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$raw   = $result['raw']['rows'][0]['metricValues'][0]['value'] ?? null;
+		$value = null === $raw
+			? ( 'decimal' === $type ? 0.0 : 0 )
+			: ( 'decimal' === $type ? (float) $raw : (int) $raw );
+		return [
+			'value'      => $value,
+			'computable' => true,
+			'type'       => $type,
+		];
+	}
+
+	/**
+	 * Transform report rows into a list of associative rows.
+	 *
+	 * @param array    $result      safe_run_report result.
+	 * @param string[] $dim_keys    Output keys for each dimension (in order).
+	 * @param string[] $metric_keys Output keys for each metric (in order).
+	 * @param string   $type        Payload type token.
+	 * @return array
+	 */
+	private static function rows( array $result, array $dim_keys, array $metric_keys, string $type ): array {
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$out = [];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$entry = [];
+			foreach ( $dim_keys as $i => $key ) {
+				$entry[ $key ] = $row['dimensionValues'][ $i ]['value'] ?? null;
+			}
+			foreach ( $metric_keys as $i => $key ) {
+				$raw           = $row['metricValues'][ $i ]['value'] ?? null;
+				$entry[ $key ] = null === $raw ? null : ( str_contains( (string) $raw, '.' ) ? (float) $raw : (int) $raw );
+			}
+			$out[] = $entry;
+		}
+		return [
+			'rows'       => $out,
+			'computable' => true,
+			'type'       => $type,
+		];
+	}
+
+	/**
+	 * Rate from a yes/no custom-dimension split (numerator = 'yes').
+	 *
+	 * @param array $result safe_run_report result.
+	 * @return array
+	 */
+	private static function yes_rate( array $result ): array {
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$num   = 0;
+		$total = 0;
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$dim   = $row['dimensionValues'][0]['value'] ?? '';
+			$users = (int) ( $row['metricValues'][0]['value'] ?? 0 );
+			$total += $users;
+			if ( 'yes' === $dim ) {
+				$num += $users;
+			}
+		}
+		return [
+			'value'       => $total > 0 ? $num / $total : 0,
+			'computable'  => $total > 0,
+			'type'        => 'rate',
+			'numerator'   => $num,
+			'denominator' => $total,
+		];
+	}
+
+	/**
+	 * Two-slice composition (yes vs everything else) for a pie.
+	 *
+	 * @param array  $result    safe_run_report result.
+	 * @param string $yes_label Label for the 'yes' slice.
+	 * @param string $no_label  Label for the remainder.
+	 * @return array
+	 */
+	private static function yes_composition( array $result, string $yes_label, string $no_label ): array {
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$yes = 0;
+		$no  = 0;
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$dim   = $row['dimensionValues'][0]['value'] ?? '';
+			$users = (int) ( $row['metricValues'][0]['value'] ?? 0 );
+			if ( 'yes' === $dim ) {
+				$yes += $users;
+			} else {
+				$no += $users;
+			}
+		}
+		return [
+			'rows'       => [
+				[
+					'label' => $yes_label,
+					'value' => $yes,
+				],
+				[
+					'label' => $no_label,
+					'value' => $no,
+				],
+			],
+			'computable' => ( $yes + $no ) > 0,
+			'type'       => 'breakdown',
+		];
+	}
+
+	/**
+	 * Attach a degraded-state overlay to an otherwise-successful rows payload.
+	 *
+	 * @param array  $payload rows() output.
+	 * @param string $message Overlay message.
+	 * @return array
+	 */
+	private static function mark_degraded( array $payload, string $message ): array {
+		if ( isset( $payload['error'] ) || isset( $payload['overlay'] ) ) {
+			return $payload;
+		}
+		$payload['degraded'] = true;
+		$payload['overlay']  = [
+			'type'    => 'degraded',
+			'message' => $message,
+		];
+		return $payload;
+	}
+
+	/**
+	 * Standard payload for BQ-only metrics: hidden in v1 (UI skips rendering).
+	 *
+	 * @return array
+	 */
+	private static function hidden_in_v1_payload(): array {
+		return [
+			'value'        => null,
+			'computable'   => false,
+			'hidden_in_v1' => true,
+		];
+	}
+
+	/**
+	 * Standard payload for the v1 BQ stub path.
+	 *
+	 * @return array
+	 */
+	private static function not_implemented_payload(): array {
+		return [
+			'value'      => null,
+			'computable' => false,
+			'error'      => 'BQ path not yet implemented. See NPPD-1630.',
+		];
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -535,6 +535,16 @@ final class Engagement_Metric {
 				'avg_engagement_seconds' => $readers > 0 ? self::num( $row, 1 ) / $readers : 0,
 			];
 		}
+		// The query orders by total userEngagementDuration to pull a strong
+		// candidate set (authors with real readership, not one-reader outliers);
+		// re-sort that set by the computed per-reader average so the ranking
+		// actually matches the metric — "Top Authors by Avg Engagement Time".
+		usort(
+			$out,
+			static function ( $a, $b ) {
+				return $b['avg_engagement_seconds'] <=> $a['avg_engagement_seconds'];
+			}
+		);
 		return [
 			'rows'       => $out,
 			'computable' => true,
@@ -883,7 +893,7 @@ final class Engagement_Metric {
 		return [
 			'value'      => null,
 			'computable' => false,
-			'error'      => 'BQ path not yet implemented. See NPPD-1630.',
+			'error'      => __( 'BQ path not yet implemented. See NPPD-1630.', 'newspack-plugin' ),
 		];
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -1,0 +1,889 @@
+<?php
+/**
+ * Newspack Insights — Engagement Metric orchestrator (Tab 2, NPPD-1648).
+ *
+ * Composes GA4 Data API `runReport` bodies (translated from
+ * `~/Sites/insights-docs/formulas/tab-2-engagement.md`) and returns
+ * MetricCard-ready payloads. Dispatches between GA4 (v1, default) and the
+ * BigQuery proxy (v1.1, NPPD-1630 — stubbed here) per the
+ * `NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4` constant (default true).
+ *
+ * The three box-plot distributions from the original Tab 2 design are cut
+ * from the spec entirely and intentionally absent here.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+use Newspack\Insights\GA4\Client;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Engagement (Tab 2) metric orchestrator.
+ */
+final class Engagement_Metric {
+
+	const CACHE_TTL        = 15 * MINUTE_IN_SECONDS;
+	const CACHE_KEY_PREFIX = 'newspack_insights_engagement_v1:';
+
+	const READER_THRESHOLD = 50;
+
+	/**
+	 * Whether this tab uses the GA4 path. Default true.
+	 *
+	 * @return bool
+	 */
+	private static function use_ga4(): bool {
+		return ! defined( 'NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4' ) || NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4;
+	}
+
+	/**
+	 * Resolve the GA4 property ID from Site Kit's stored settings.
+	 *
+	 * @return string
+	 */
+	private static function resolve_property_id(): string {
+		$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
+		return is_array( $settings ) && ! empty( $settings['propertyID'] ) ? (string) $settings['propertyID'] : '';
+	}
+
+	/**
+	 * Tab-level connection check (GA4 path only).
+	 *
+	 * @return array|null
+	 */
+	public static function connection_error(): ?array {
+		if ( ! self::use_ga4() ) {
+			return null;
+		}
+		$connected = class_exists( '\Newspack\Google_OAuth' )
+			&& \Newspack\Google_OAuth::is_oauth_configured()
+			&& '' !== self::resolve_property_id();
+		if ( $connected ) {
+			return null;
+		}
+		return [
+			'tab_error'   => 'oauth_not_connected',
+			'banner_text' => __( 'Connect Google Analytics in Newspack → Connections to see this tab.', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * Full tab payload for a window (+ optional prior-period under `compare`).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @param bool   $compare    Attach prior-period payload.
+	 * @return array
+	 */
+	public static function get_all( string $start_date, string $end_date, bool $compare = false ): array {
+		$error = self::connection_error();
+		if ( null !== $error ) {
+			return $error;
+		}
+
+		$payload = self::compute_window_cached( $start_date, $end_date );
+
+		if ( $compare ) {
+			[ $prior_start, $prior_end ] = self::prior_period( $start_date, $end_date );
+			$payload['compare']          = self::compute_window_cached( $prior_start, $prior_end );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Immediately-preceding window of equal length.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string[]
+	 */
+	private static function prior_period( string $start_date, string $end_date ): array {
+		$start       = new \DateTimeImmutable( $start_date );
+		$end         = new \DateTimeImmutable( $end_date );
+		$days        = (int) $start->diff( $end )->format( '%a' ) + 1;
+		$prior_end   = $start->modify( '-1 day' );
+		$prior_start = $prior_end->modify( '-' . ( $days - 1 ) . ' days' );
+		return [ $prior_start->format( 'Y-m-d' ), $prior_end->format( 'Y-m-d' ) ];
+	}
+
+	/**
+	 * Cached single-window computation.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_window_cached( string $start_date, string $end_date ): array {
+		$use_ga4   = self::use_ga4();
+		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date . '|' . $end_date . '|' . ( $use_ga4 ? 'ga4' : 'bq' ) );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+		$payload = $use_ga4
+			? self::compute_via_ga4( $start_date, $end_date )
+			: self::compute_via_bq( $start_date, $end_date );
+		set_transient( $cache_key, $payload, self::CACHE_TTL );
+		return $payload;
+	}
+
+	/**
+	 * GA4 path — every metric for the window.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_via_ga4( string $start_date, string $end_date ): array {
+		$pid = self::resolve_property_id();
+		return [
+			'window'                                => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			// Overall engagement quality.
+			'avg_pages_per_session'                 => self::avg_pages_per_session_via_ga4( $pid, $start_date, $end_date ),
+			'avg_engaged_session_duration'          => self::avg_engaged_session_duration_via_ga4( $pid, $start_date, $end_date ),
+			'bounce_rate'                           => self::bounce_rate_via_ga4( $pid, $start_date, $end_date ),
+			'scroll_depth_rate'                     => self::scroll_depth_rate_via_ga4( $pid, $start_date, $end_date ),
+			// Content engagement.
+			'most_engaged_articles'                 => self::most_engaged_articles_via_ga4( $pid, $start_date, $end_date ),
+			'articles_by_completion_rate'           => self::articles_by_completion_rate_via_ga4( $pid, $start_date, $end_date ),
+			'articles_by_avg_time_on_page'          => self::articles_by_avg_time_on_page_via_ga4( $pid, $start_date, $end_date ),
+			'top_authors_by_avg_engagement_time'    => self::top_authors_by_avg_engagement_time_via_ga4( $pid, $start_date, $end_date ),
+			// Reader segments.
+			'engagement_by_device_type'             => self::engagement_by_device_type_via_ga4( $pid, $start_date, $end_date ),
+			'engagement_by_newsletter_status'       => self::engagement_by_newsletter_status_via_ga4( $pid, $start_date, $end_date ),
+			'engagement_by_returning_vs_new'        => self::engagement_by_returning_vs_new_via_ga4( $pid, $start_date, $end_date ),
+			// Time patterns.
+			'engagement_by_day_of_week'             => self::engagement_by_day_of_week_via_ga4( $pid, $start_date, $end_date ),
+			// BQ-only (hidden in v1).
+			'top_categories_by_engagement'          => self::hidden_in_v1_payload(),
+			'mobile_vs_desktop_content_preferences' => self::hidden_in_v1_payload(),
+			'top_authors_by_repeat_reader_rate'     => self::hidden_in_v1_payload(),
+			'article_freshness_vs_engagement'       => self::hidden_in_v1_payload(),
+		];
+	}
+
+	/**
+	 * BQ path — v1 stub.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_via_bq( string $start_date, string $end_date ): array {
+		$keys = [
+			'avg_pages_per_session',
+			'avg_engaged_session_duration',
+			'bounce_rate',
+			'scroll_depth_rate',
+			'most_engaged_articles',
+			'articles_by_completion_rate',
+			'articles_by_avg_time_on_page',
+			'top_authors_by_avg_engagement_time',
+			'engagement_by_device_type',
+			'engagement_by_newsletter_status',
+			'engagement_by_returning_vs_new',
+			'engagement_by_day_of_week',
+		];
+		$payload = [
+			'window' => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+		];
+		foreach ( $keys as $key ) {
+			$payload[ $key ] = self::not_implemented_payload();
+		}
+		foreach ( [ 'top_categories_by_engagement', 'mobile_vs_desktop_content_preferences', 'top_authors_by_repeat_reader_rate', 'article_freshness_vs_engagement' ] as $hidden ) {
+			$payload[ $hidden ] = self::hidden_in_v1_payload();
+		}
+		return $payload;
+	}
+
+	/*
+	===================================================================
+	 * GA4-standard metrics
+	 * ===================================================================
+	 */
+
+	/**
+	 * Avg Pages per Session — screenPageViewsPerSession.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function avg_pages_per_session_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'screenPageViewsPerSession' ] ) );
+		return self::scalar( $result, 'decimal' );
+	}
+
+	/**
+	 * Avg Engaged Session Duration — averageSessionDuration (seconds).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function avg_engaged_session_duration_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'averageSessionDuration' ] ) );
+		return self::scalar( $result, 'duration' );
+	}
+
+	/**
+	 * Bounce Rate — bounceRate (0-1).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function bounce_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [], [ 'bounceRate' ] ) );
+		return self::scalar( $result, 'rate' );
+	}
+
+	/**
+	 * Engagement by Day of Week — dayOfWeekName / averageSessionDuration + totalUsers.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function engagement_by_day_of_week_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'dayOfWeekName' ], [ 'averageSessionDuration', 'totalUsers' ] ) );
+		return self::rows( $result, [ 'day_of_week' ], [ 'avg_session_duration', 'active_readers' ], 'breakdown' );
+	}
+
+	/**
+	 * Engagement by Device Type — deviceCategory / sessions, userEngagementDuration, screenPageViewsPerSession.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function engagement_by_device_type_via_ga4( string $pid, string $s, string $e ): array {
+		$body   = self::body( $s, $e, [ 'deviceCategory' ], [ 'sessions', 'userEngagementDuration', 'screenPageViewsPerSession' ] );
+		$body  += self::order_by_metric_desc( 'sessions' );
+		$result = self::safe_run_report( $pid, $body );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$out = [];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$sessions = self::num( $row, 0 );
+			$out[]    = [
+				'device'                 => $row['dimensionValues'][0]['value'] ?? null,
+				'sessions'               => (int) $sessions,
+				'avg_engagement_seconds' => $sessions > 0 ? self::num( $row, 1 ) / $sessions : 0,
+				'avg_pages_per_session'  => self::num( $row, 2 ),
+			];
+		}
+		return [
+			'rows'       => $out,
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Engagement by Returning vs New — newVsReturning / sessions, screenPageViewsPerSession, userEngagementDuration.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function engagement_by_returning_vs_new_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'newVsReturning' ], [ 'sessions', 'screenPageViewsPerSession', 'userEngagementDuration' ] ) );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$out = [];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$sessions = self::num( $row, 0 );
+			$out[]    = [
+				'reader_type'            => $row['dimensionValues'][0]['value'] ?? null,
+				'sessions'               => (int) $sessions,
+				'avg_pages_per_session'  => self::num( $row, 1 ),
+				'avg_engagement_seconds' => $sessions > 0 ? self::num( $row, 2 ) / $sessions : 0,
+			];
+		}
+		return [
+			'rows'       => $out,
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Articles by Avg Time on Page — customEvent:post_id (degrade if missing).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function articles_by_avg_time_on_page_via_ga4( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'customEvent:post_id', 'pagePath', 'pageTitle' ], [ 'totalUsers', 'averageEngagementTimePerSession' ] );
+		$body['dimensionFilter'] = self::custom_event_present_filter( 'post_id' );
+		$body                   += self::order_by_metric_desc( 'averageEngagementTimePerSession' );
+		$body['limit']           = 50;
+		$result                  = self::safe_run_report( $pid, $body );
+
+		if ( self::is_custom_dimension_missing( $result ) ) {
+			$degraded          = self::body( $s, $e, [ 'pagePath', 'pageTitle' ], [ 'totalUsers', 'averageEngagementTimePerSession' ] );
+			$degraded         += self::order_by_metric_desc( 'averageEngagementTimePerSession' );
+			$degraded['limit'] = 50;
+			$out               = self::rows( self::safe_run_report( $pid, $degraded ), [ 'page_path', 'page_title' ], [ 'unique_readers', 'avg_time_seconds' ], 'table' );
+			return self::mark_degraded( $out, __( 'Singular content filter unavailable; showing all pages.', 'newspack-plugin' ) );
+		}
+		return self::rows( $result, [ 'post_id', 'page_path', 'page_title' ], [ 'unique_readers', 'avg_time_seconds' ], 'table' );
+	}
+
+	/*
+	===================================================================
+	 * GA4-conditional metrics
+	 * ===================================================================
+	 */
+
+	/**
+	 * Scroll Depth Rate — article-scoped scroll events ÷ article reads.
+	 * Each `scroll` event is a 90% read under GA4 default enhanced measurement.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function scroll_depth_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$num_body                    = self::body( $s, $e, [], [ 'eventCount' ] );
+		$num_body['dimensionFilter'] = [
+			'andGroup' => [
+				'expressions' => [
+					self::event_name_expression( 'scroll' ),
+					self::custom_event_present_expression( 'post_id' ),
+				],
+			],
+		];
+		$num = self::safe_run_report( $pid, $num_body );
+		if ( isset( $num['error'] ) || isset( $num['overlay'] ) ) {
+			return $num;
+		}
+
+		$den_body                    = self::body( $s, $e, [], [ 'screenPageViews' ] );
+		$den_body['dimensionFilter'] = self::custom_event_present_filter( 'post_id' );
+		$den = self::safe_run_report( $pid, $den_body );
+		if ( isset( $den['error'] ) || isset( $den['overlay'] ) ) {
+			return $den;
+		}
+
+		$numerator   = (int) ( $num['raw']['rows'][0]['metricValues'][0]['value'] ?? 0 );
+		$denominator = (int) ( $den['raw']['rows'][0]['metricValues'][0]['value'] ?? 0 );
+		return [
+			'value'       => $denominator > 0 ? $numerator / $denominator : 0,
+			'computable'  => $denominator > 0,
+			'type'        => 'rate',
+			'numerator'   => $numerator,
+			'denominator' => $denominator,
+		];
+	}
+
+	/**
+	 * Most-Engaged Articles — composite of reach, scroll completion, and time.
+	 * Two reports joined and scored in PHP.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function most_engaged_articles_via_ga4( string $pid, string $s, string $e ): array {
+		$reach_body                    = self::body( $s, $e, [ 'customEvent:post_id', 'pagePath', 'pageTitle' ], [ 'totalUsers', 'userEngagementDuration' ] );
+		$reach_body['dimensionFilter'] = self::custom_event_present_filter( 'post_id' );
+		$reach_body                   += self::order_by_metric_desc( 'totalUsers' );
+		$reach_body['limit']           = 200;
+		$reach                         = self::safe_run_report( $pid, $reach_body );
+		if ( isset( $reach['error'] ) || isset( $reach['overlay'] ) ) {
+			return $reach;
+		}
+
+		$scroll_by_post = self::scroll_events_by_post( $pid, $s, $e );
+
+		$articles = [];
+		foreach ( $reach['raw']['rows'] ?? [] as $row ) {
+			$readers = (int) self::num( $row, 0 );
+			if ( $readers < self::READER_THRESHOLD ) {
+				continue;
+			}
+			$post_id    = $row['dimensionValues'][0]['value'] ?? '';
+			$avg_eng    = $readers > 0 ? self::num( $row, 1 ) / $readers : 0;
+			$scroll     = $scroll_by_post[ $post_id ] ?? 0;
+			$avg_scroll = $readers > 0 ? min( 1.0, $scroll / $readers ) : 0;
+			$articles[] = [
+				'post_id'                => $post_id,
+				'page_path'              => $row['dimensionValues'][1]['value'] ?? null,
+				'page_title'             => $row['dimensionValues'][2]['value'] ?? null,
+				'unique_readers'         => $readers,
+				'avg_scroll_depth'       => $avg_scroll,
+				'avg_engagement_seconds' => $avg_eng,
+				'engagement_score'       => $readers * max( $avg_scroll, 0.1 ) * ( 1 + log( $avg_eng + 1 ) ),
+			];
+		}
+		usort(
+			$articles,
+			function ( $a, $b ) {
+				return $b['engagement_score'] <=> $a['engagement_score'];
+			}
+		);
+		return [
+			'rows'       => array_slice( $articles, 0, 50 ),
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Articles by Completion Rate — scroll-to-90 events ÷ readers per article.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function articles_by_completion_rate_via_ga4( string $pid, string $s, string $e ): array {
+		$readers_body                    = self::body( $s, $e, [ 'customEvent:post_id', 'pagePath', 'pageTitle' ], [ 'totalUsers' ] );
+		$readers_body['dimensionFilter'] = self::custom_event_present_filter( 'post_id' );
+		$readers_body['limit']           = 1000;
+		$readers                         = self::safe_run_report( $pid, $readers_body );
+		if ( isset( $readers['error'] ) || isset( $readers['overlay'] ) ) {
+			return $readers;
+		}
+
+		$scroll_by_post = self::scroll_events_by_post( $pid, $s, $e );
+
+		$rows = [];
+		foreach ( $readers['raw']['rows'] ?? [] as $row ) {
+			$count = (int) self::num( $row, 0 );
+			if ( $count < self::READER_THRESHOLD ) {
+				continue;
+			}
+			$post_id = $row['dimensionValues'][0]['value'] ?? '';
+			$scroll  = $scroll_by_post[ $post_id ] ?? 0;
+			$rows[]  = [
+				'post_id'         => $post_id,
+				'page_path'       => $row['dimensionValues'][1]['value'] ?? null,
+				'page_title'      => $row['dimensionValues'][2]['value'] ?? null,
+				'readers'         => $count,
+				'completion_rate' => $count > 0 ? min( 1.0, $scroll / $count ) : 0,
+			];
+		}
+		usort(
+			$rows,
+			function ( $a, $b ) {
+				$by_rate = $b['completion_rate'] <=> $a['completion_rate'];
+				return 0 !== $by_rate ? $by_rate : ( $b['readers'] <=> $a['readers'] );
+			}
+		);
+		return [
+			'rows'       => array_slice( $rows, 0, 50 ),
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Top Authors by Avg Engagement Time — customEvent:author + post_id.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function top_authors_by_avg_engagement_time_via_ga4( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'customEvent:author' ], [ 'totalUsers', 'userEngagementDuration' ] );
+		$body['dimensionFilter'] = [
+			'andGroup' => [
+				'expressions' => [
+					self::custom_event_present_expression( 'post_id' ),
+					self::custom_event_present_expression( 'author' ),
+				],
+			],
+		];
+		$body         += self::order_by_metric_desc( 'userEngagementDuration' );
+		$body['limit'] = 25;
+		$result        = self::safe_run_report( $pid, $body );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$out = [];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$readers = (int) self::num( $row, 0 );
+			$out[]   = [
+				'author'                 => $row['dimensionValues'][0]['value'] ?? null,
+				'unique_readers'         => $readers,
+				'avg_engagement_seconds' => $readers > 0 ? self::num( $row, 1 ) / $readers : 0,
+			];
+		}
+		return [
+			'rows'       => $out,
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Engagement by Newsletter Status — customEvent:is_newsletter_subscriber.
+	 * Collapses non-'yes' dimension values into a single "not subscribed" bucket.
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array
+	 */
+	private static function engagement_by_newsletter_status_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'customEvent:is_newsletter_subscriber' ], [ 'sessions', 'screenPageViewsPerSession', 'userEngagementDuration' ] ) );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		// Aggregate into two buckets. screenPageViewsPerSession is a per-session
+		// average, so weight it by sessions before re-dividing.
+		$buckets = [
+			'subscriber'     => [
+				'sessions' => 0,
+				'pages'    => 0.0,
+				'eng'      => 0.0,
+			],
+			'not_subscribed' => [
+				'sessions' => 0,
+				'pages'    => 0.0,
+				'eng'      => 0.0,
+			],
+		];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$key      = ( ( $row['dimensionValues'][0]['value'] ?? '' ) === 'yes' ) ? 'subscriber' : 'not_subscribed';
+			$sessions = self::num( $row, 0 );
+			$buckets[ $key ]['sessions'] += (int) $sessions;
+			$buckets[ $key ]['pages']    += self::num( $row, 1 ) * $sessions;
+			$buckets[ $key ]['eng']      += self::num( $row, 2 );
+		}
+		$labels = [
+			'subscriber'     => __( 'Newsletter subscriber', 'newspack-plugin' ),
+			'not_subscribed' => __( 'Not subscribed', 'newspack-plugin' ),
+		];
+		$out = [];
+		foreach ( $buckets as $key => $b ) {
+			$out[] = [
+				'segment'                => $labels[ $key ],
+				'sessions'               => $b['sessions'],
+				'avg_pages_per_session'  => $b['sessions'] > 0 ? $b['pages'] / $b['sessions'] : 0,
+				'avg_engagement_seconds' => $b['sessions'] > 0 ? $b['eng'] / $b['sessions'] : 0,
+			];
+		}
+		return [
+			'rows'       => $out,
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Article-scoped scroll-event counts keyed by post_id. Empty array on
+	 * error/overlay (callers treat missing scroll data as zero completion).
+	 *
+	 * @param string $pid Property ID.
+	 * @param string $s   Start date.
+	 * @param string $e   End date.
+	 * @return array<string,int>
+	 */
+	private static function scroll_events_by_post( string $pid, string $s, string $e ): array {
+		$body                    = self::body( $s, $e, [ 'customEvent:post_id' ], [ 'eventCount' ] );
+		$body['dimensionFilter'] = [
+			'andGroup' => [
+				'expressions' => [
+					self::event_name_expression( 'scroll' ),
+					self::custom_event_present_expression( 'post_id' ),
+				],
+			],
+		];
+		$body['limit'] = 1000;
+		$result        = self::safe_run_report( $pid, $body );
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return [];
+		}
+		$map = [];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$key = $row['dimensionValues'][0]['value'] ?? '';
+			if ( '' !== $key ) {
+				$map[ $key ] = (int) ( $row['metricValues'][0]['value'] ?? 0 );
+			}
+		}
+		return $map;
+	}
+
+	/*
+	===================================================================
+	 * Shared helpers
+	 * ===================================================================
+	 */
+
+	/**
+	 * Build a base runReport body.
+	 *
+	 * @param string   $s       Start date.
+	 * @param string   $e       End date.
+	 * @param string[] $dims    Dimension names.
+	 * @param string[] $metrics Metric names.
+	 * @return array
+	 */
+	private static function body( string $s, string $e, array $dims, array $metrics ): array {
+		$body = [
+			'dateRanges' => [
+				[
+					'startDate' => $s,
+					'endDate'   => $e,
+				],
+			],
+			'metrics'    => array_map(
+				function ( $m ) {
+					return [ 'name' => $m ];
+				},
+				$metrics
+			),
+		];
+		if ( ! empty( $dims ) ) {
+			$body['dimensions'] = array_map(
+				function ( $d ) {
+					return [ 'name' => $d ];
+				},
+				$dims
+			);
+		}
+		return $body;
+	}
+
+	/**
+	 * Build an orderBys fragment: one metric, descending.
+	 *
+	 * @param string $metric Metric name.
+	 * @return array
+	 */
+	private static function order_by_metric_desc( string $metric ): array {
+		return [
+			'orderBys' => [
+				[
+					'metric' => [ 'metricName' => $metric ],
+					'desc'   => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * FilterExpression: eventName EXACT match.
+	 *
+	 * @param string $event_name Event name.
+	 * @return array
+	 */
+	private static function event_name_expression( string $event_name ): array {
+		return [
+			'filter' => [
+				'fieldName'    => 'eventName',
+				'stringFilter' => [
+					'matchType' => 'EXACT',
+					'value'     => $event_name,
+				],
+			],
+		];
+	}
+
+	/**
+	 * FilterExpression: a customEvent dimension is present (non-empty).
+	 *
+	 * @param string $param Event parameter name.
+	 * @return array
+	 */
+	private static function custom_event_present_expression( string $param ): array {
+		return [
+			'filter' => [
+				'fieldName'    => 'customEvent:' . $param,
+				'stringFilter' => [
+					'matchType' => 'FULL_REGEXP',
+					'value'     => '.+',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build a dimensionFilter asserting a customEvent dimension is present.
+	 *
+	 * @param string $param Event parameter name.
+	 * @return array
+	 */
+	private static function custom_event_present_filter( string $param ): array {
+		return [ 'filter' => self::custom_event_present_expression( $param )['filter'] ];
+	}
+
+	/**
+	 * Read a metric value from a report row as a number.
+	 *
+	 * @param array $row   Report row.
+	 * @param int   $index Metric index.
+	 * @return float
+	 */
+	private static function num( array $row, int $index ): float {
+		return (float) ( $row['metricValues'][ $index ]['value'] ?? 0 );
+	}
+
+	/**
+	 * Run a report, normalizing WP_Error into payload-shaped failures.
+	 *
+	 * @param string $property_id Property ID.
+	 * @param array  $body        runReport body.
+	 * @return array
+	 */
+	private static function safe_run_report( string $property_id, array $body ): array {
+		$result = Client::run_report( $property_id, $body );
+
+		if ( is_wp_error( $result ) ) {
+			if ( 'custom_dimension_missing' === $result->get_error_code() ) {
+				$data = $result->get_error_data();
+				return [
+					'value'      => null,
+					'computable' => false,
+					'overlay'    => [
+						'type'       => 'custom_dimension_missing',
+						'dimensions' => is_array( $data ) && isset( $data['dimensions'] ) ? $data['dimensions'] : [],
+					],
+				];
+			}
+			return [
+				'value'      => null,
+				'computable' => false,
+				'error'      => $result->get_error_message(),
+			];
+		}
+
+		return [ 'raw' => $result ];
+	}
+
+	/**
+	 * Whether a safe_run_report result is a custom_dimension_missing overlay.
+	 *
+	 * @param array $result safe_run_report result.
+	 * @return bool
+	 */
+	private static function is_custom_dimension_missing( array $result ): bool {
+		return isset( $result['overlay']['type'] ) && 'custom_dimension_missing' === $result['overlay']['type'];
+	}
+
+	/**
+	 * Transform a single scalar metric value.
+	 *
+	 * @param array  $result safe_run_report result.
+	 * @param string $type   'count' (int) or 'decimal'/'rate'/'duration' (float).
+	 * @return array
+	 */
+	private static function scalar( array $result, string $type ): array {
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$raw   = $result['raw']['rows'][0]['metricValues'][0]['value'] ?? null;
+		$value = null === $raw
+			? ( 'count' === $type ? 0 : 0.0 )
+			: ( 'count' === $type ? (int) $raw : (float) $raw );
+		return [
+			'value'      => $value,
+			'computable' => true,
+			'type'       => $type,
+		];
+	}
+
+	/**
+	 * Transform report rows into a list of associative rows.
+	 *
+	 * @param array    $result      safe_run_report result.
+	 * @param string[] $dim_keys    Output keys per dimension.
+	 * @param string[] $metric_keys Output keys per metric.
+	 * @param string   $type        Payload type token.
+	 * @return array
+	 */
+	private static function rows( array $result, array $dim_keys, array $metric_keys, string $type ): array {
+		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
+			return $result;
+		}
+		$out = [];
+		foreach ( $result['raw']['rows'] ?? [] as $row ) {
+			$entry = [];
+			foreach ( $dim_keys as $i => $key ) {
+				$entry[ $key ] = $row['dimensionValues'][ $i ]['value'] ?? null;
+			}
+			foreach ( $metric_keys as $i => $key ) {
+				$raw           = $row['metricValues'][ $i ]['value'] ?? null;
+				$entry[ $key ] = null === $raw ? null : ( str_contains( (string) $raw, '.' ) ? (float) $raw : (int) $raw );
+			}
+			$out[] = $entry;
+		}
+		return [
+			'rows'       => $out,
+			'computable' => true,
+			'type'       => $type,
+		];
+	}
+
+	/**
+	 * Attach a degraded-state overlay to a successful rows payload.
+	 *
+	 * @param array  $payload rows() output.
+	 * @param string $message Overlay message.
+	 * @return array
+	 */
+	private static function mark_degraded( array $payload, string $message ): array {
+		if ( isset( $payload['error'] ) || isset( $payload['overlay'] ) ) {
+			return $payload;
+		}
+		$payload['degraded'] = true;
+		$payload['overlay']  = [
+			'type'    => 'degraded',
+			'message' => $message,
+		];
+		return $payload;
+	}
+
+	/**
+	 * BQ-only metric payload: hidden in v1.
+	 *
+	 * @return array
+	 */
+	private static function hidden_in_v1_payload(): array {
+		return [
+			'value'        => null,
+			'computable'   => false,
+			'hidden_in_v1' => true,
+		];
+	}
+
+	/**
+	 * Standard v1 BQ stub payload.
+	 *
+	 * @return array
+	 */
+	private static function not_implemented_payload(): array {
+		return [
+			'value'      => null,
+			'computable' => false,
+			'error'      => 'BQ path not yet implemented. See NPPD-1630.',
+		];
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights-audience-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-audience-metric.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for the Insights Audience metric orchestrator (Tab 1, NPPD-1648).
+ *
+ * Covers the deterministic surface without a live GA4 connection: the
+ * tab-level OAuth short-circuit, the BQ stub path, hidden-in-v1 metrics, and
+ * the GA4 response → payload transform helpers (success, overlay and error
+ * propagation). Full GA4 round-trips are covered by manual verification.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Insights\Audience_Metric;
+
+/**
+ * Test \Newspack\Insights\Audience_Metric.
+ */
+class Newspack_Test_Insights_Audience_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private static method via reflection.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Arguments.
+	 * @return mixed
+	 */
+	private function invoke( $method, array $args = [] ) {
+		$ref = new ReflectionMethod( Audience_Metric::class, $method );
+		$ref->setAccessible( true );
+		return $ref->invoke( null, ...$args );
+	}
+
+	/**
+	 * With the GA4 path active (default) and no Google connection in the test
+	 * environment, get_all() short-circuits to a tab-level connection error.
+	 */
+	public function test_get_all_returns_tab_error_when_oauth_missing() {
+		$payload = Audience_Metric::get_all( '2026-05-09', '2026-06-08', false );
+		$this->assertArrayHasKey( 'tab_error', $payload );
+		$this->assertSame( 'oauth_not_connected', $payload['tab_error'] );
+		$this->assertArrayHasKey( 'banner_text', $payload );
+	}
+
+	/**
+	 * The BQ stub path returns a not_implemented error for every standard
+	 * metric, keyed identically to the GA4 path.
+	 */
+	public function test_bq_stub_returns_not_implemented() {
+		$payload = $this->invoke( 'compute_via_bq', [ '2026-05-09', '2026-06-08' ] );
+		$this->assertArrayHasKey( 'active_readers', $payload );
+		$this->assertFalse( $payload['active_readers']['computable'] );
+		$this->assertArrayHasKey( 'error', $payload['active_readers'] );
+		$this->assertStringContainsString( 'NPPD-1630', $payload['active_readers']['error'] );
+	}
+
+	/**
+	 * The strict returning-reader metric is BQ-only: hidden in v1 under both
+	 * the GA4 and BQ paths.
+	 */
+	public function test_returning_reader_rate_strict_hidden_in_both_paths() {
+		$bq  = $this->invoke( 'compute_via_bq', [ '2026-05-09', '2026-06-08' ] );
+		$ga4 = $this->invoke( 'compute_via_ga4', [ '2026-05-09', '2026-06-08' ] );
+		$this->assertTrue( $bq['returning_reader_rate_strict']['hidden_in_v1'] );
+		$this->assertTrue( $ga4['returning_reader_rate_strict']['hidden_in_v1'] );
+	}
+
+	/**
+	 * The scalar() helper transforms a GA4 single-value response into a count payload.
+	 */
+	public function test_scalar_transform_success() {
+		$raw     = [ 'raw' => [ 'rows' => [ [ 'metricValues' => [ [ 'value' => '1234' ] ] ] ] ] ];
+		$payload = $this->invoke( 'scalar', [ $raw, 'count' ] );
+		$this->assertSame( 1234, $payload['value'] );
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 'count', $payload['type'] );
+	}
+
+	/**
+	 * A custom_dimension_missing overlay propagates unchanged through transforms.
+	 */
+	public function test_overlay_propagates_through_transform() {
+		$overlay = [
+			'value'      => null,
+			'computable' => false,
+			'overlay'    => [
+				'type'       => 'custom_dimension_missing',
+				'dimensions' => [ 'is_newsletter_subscriber' ],
+			],
+		];
+		$payload = $this->invoke( 'yes_rate', [ $overlay ] );
+		$this->assertSame( 'custom_dimension_missing', $payload['overlay']['type'] );
+		$this->assertSame( [ 'is_newsletter_subscriber' ], $payload['overlay']['dimensions'] );
+		$this->assertFalse( $payload['computable'] );
+	}
+
+	/**
+	 * A generic error payload propagates unchanged through transforms.
+	 */
+	public function test_error_propagates_through_transform() {
+		$error   = [
+			'value'      => null,
+			'computable' => false,
+			'error'      => 'HTTP 500',
+		];
+		$payload = $this->invoke( 'scalar', [ $error, 'count' ] );
+		$this->assertSame( 'HTTP 500', $payload['error'] );
+		$this->assertFalse( $payload['computable'] );
+	}
+
+	/**
+	 * The yes_rate() helper computes numerator/denominator from a yes/no split.
+	 */
+	public function test_yes_rate_computes_from_split() {
+		$raw     = [
+			'raw' => [
+				'rows' => [
+					[
+						'dimensionValues' => [ [ 'value' => 'yes' ] ],
+						'metricValues'    => [ [ 'value' => '30' ] ],
+					],
+					[
+						'dimensionValues' => [ [ 'value' => 'no' ] ],
+						'metricValues'    => [ [ 'value' => '70' ] ],
+					],
+				],
+			],
+		];
+		$payload = $this->invoke( 'yes_rate', [ $raw ] );
+		$this->assertEqualsWithDelta( 0.3, $payload['value'], 0.0001 );
+		$this->assertSame( 30, $payload['numerator'] );
+		$this->assertSame( 100, $payload['denominator'] );
+		$this->assertTrue( $payload['computable'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for the Insights Engagement metric orchestrator (Tab 2, NPPD-1648).
+ *
+ * Covers the deterministic surface without a live GA4 connection: the
+ * tab-level OAuth short-circuit, the BQ stub path, the four BQ-only hidden
+ * metrics, and the GA4 response → payload transform helpers. Full GA4
+ * round-trips are covered by manual verification.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Insights\Engagement_Metric;
+
+/**
+ * Test \Newspack\Insights\Engagement_Metric.
+ */
+class Newspack_Test_Insights_Engagement_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private static method via reflection.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Arguments.
+	 * @return mixed
+	 */
+	private function invoke( $method, array $args = [] ) {
+		$ref = new ReflectionMethod( Engagement_Metric::class, $method );
+		$ref->setAccessible( true );
+		return $ref->invoke( null, ...$args );
+	}
+
+	/**
+	 * No Google connection in the test environment → tab-level error.
+	 */
+	public function test_get_all_returns_tab_error_when_oauth_missing() {
+		$payload = Engagement_Metric::get_all( '2026-05-09', '2026-06-08', false );
+		$this->assertArrayHasKey( 'tab_error', $payload );
+		$this->assertSame( 'oauth_not_connected', $payload['tab_error'] );
+	}
+
+	/**
+	 * BQ stub returns not_implemented for every standard metric.
+	 */
+	public function test_bq_stub_returns_not_implemented() {
+		$payload = $this->invoke( 'compute_via_bq', [ '2026-05-09', '2026-06-08' ] );
+		$this->assertFalse( $payload['avg_pages_per_session']['computable'] );
+		$this->assertStringContainsString( 'NPPD-1630', $payload['avg_pages_per_session']['error'] );
+	}
+
+	/**
+	 * The four BQ-only metrics are hidden in v1 under both paths.
+	 */
+	public function test_bq_only_metrics_hidden_in_both_paths() {
+		$bq_only = [
+			'top_categories_by_engagement',
+			'mobile_vs_desktop_content_preferences',
+			'top_authors_by_repeat_reader_rate',
+			'article_freshness_vs_engagement',
+		];
+		$bq  = $this->invoke( 'compute_via_bq', [ '2026-05-09', '2026-06-08' ] );
+		$ga4 = $this->invoke( 'compute_via_ga4', [ '2026-05-09', '2026-06-08' ] );
+		foreach ( $bq_only as $key ) {
+			$this->assertTrue( $bq[ $key ]['hidden_in_v1'], "$key hidden in BQ path" );
+			$this->assertTrue( $ga4[ $key ]['hidden_in_v1'], "$key hidden in GA4 path" );
+		}
+	}
+
+	/**
+	 * The cut box-plot metrics never appear in the orchestrator output.
+	 */
+	public function test_cut_box_plots_absent() {
+		$ga4 = $this->invoke( 'compute_via_ga4', [ '2026-05-09', '2026-06-08' ] );
+		$this->assertArrayNotHasKey( 'pages_per_session_distribution', $ga4 );
+		$this->assertArrayNotHasKey( 'scroll_depth_distribution', $ga4 );
+		$this->assertArrayNotHasKey( 'reader_author_affinity', $ga4 );
+	}
+
+	/**
+	 * The scalar() helper casts a decimal metric to float.
+	 */
+	public function test_scalar_decimal_transform() {
+		$raw     = [ 'raw' => [ 'rows' => [ [ 'metricValues' => [ [ 'value' => '2.5' ] ] ] ] ] ];
+		$payload = $this->invoke( 'scalar', [ $raw, 'decimal' ] );
+		$this->assertSame( 2.5, $payload['value'] );
+		$this->assertSame( 'decimal', $payload['type'] );
+		$this->assertTrue( $payload['computable'] );
+	}
+
+	/**
+	 * Overlay propagation through a transform helper.
+	 */
+	public function test_overlay_propagates_through_transform() {
+		$overlay = [
+			'value'      => null,
+			'computable' => false,
+			'overlay'    => [
+				'type'       => 'custom_dimension_missing',
+				'dimensions' => [ 'post_id' ],
+			],
+		];
+		$payload = $this->invoke( 'rows', [ $overlay, [ 'post_id' ], [ 'readers' ], 'table' ] );
+		$this->assertSame( 'custom_dimension_missing', $payload['overlay']['type'] );
+		$this->assertSame( [ 'post_id' ], $payload['overlay']['dimensions'] );
+	}
+}


### PR DESCRIPTION
## Summary

Lands the metric orchestrators powering the v1 Audience (Tab 1) and Engagement (Tab 2) Insights tabs: `\Newspack\Insights\Audience_Metric` and `\Newspack\Insights\Engagement_Metric`, with their REST controllers and the existing `Insights_Section_Audience` / `Insights_Section_Engagement` wired in.

Each orchestrator dispatches between GA4 Data API (v1, default) and BigQuery (v1.1 stub) per a per-tab constant — `NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4` and `NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4`, both defaulting true. Consumes the GA4 client from NPPD-1647 (`\Newspack\Insights\GA4\Client`) and its authoritative custom-dimension detection.

GA4 query bodies are translated directly from `formulas/tab-1-audience.md` and `tab-2-engagement.md`. BQ paths are stubs returning `not_implemented` until NPPD-1630 ships the catalog.

Unblocks NPPD-1649 (Audience and Engagement UI). Stacked on `nppd-1647` (#238, the GA4 client). Retargets to `nppd-1604` / `main` as the stack merges.

## What's in this PR

### Audience_Metric

Window-scoped orchestrator returning 25 GA4-implementable + 1 BQ-only-hidden metric across the spec's five sections (Reach, Audience Composition, Time Trends, Traffic Sources, Geographic, Content Performance).

- All Reach scorecards (Active Readers, Sessions, Pageviews, Avg Sessions per Reader, Engaged Session Rate)
- Composition pies (Newsletter Subscriber, Logged-In vs Anonymous, Device Breakdown) + their scorecards (Newsletter Subscriber Rate, Logged-In Reader Rate, Local Reader Rate)
- Time trends line/bar charts (Active Readers Over Time, New vs Returning Over Time, Day of Week, Hour of Day)
- Traffic Sources pie + Top Campaigns table
- Geographic tables (Countries, Regions/States, Cities, DMAs)
- Content Performance tables (Top Pages by Pageviews, Top Pages by Reader Count, Top Authors by Reader Count)
- GA4-conditional handling: `top_pages_*` degrade to all-URLs when `post_id` is unregistered; `top_authors_by_reader_count` returns the custom-dimension overlay; `local_reader_rate` merges geo rows in PHP against a configured coverage area (hidden until configured).
- BQ-only-hidden: `returning_reader_rate_strict`.

### Engagement_Metric

Window-scoped orchestrator returning 12 GA4-implementable + 4 BQ-only-hidden metric across four sections (Overall Engagement Quality, Content Engagement, Reader Segments, Time Patterns).

- Engagement Quality scorecards (Avg Pages per Session, Avg Engaged Session Duration, Bounce Rate, Scroll Depth Rate)
- Content Engagement tables (Most-Engaged Articles, Articles by Completion Rate, Articles by Avg Time on Page, Top Authors by Avg Engagement Time)
- Reader Segments tables (Engagement by Device Type, Engagement by Returning vs New, Engagement by Newsletter Status)
- Time Patterns chart (Engagement by Day of Week)
- Multi-call composites for scroll depth ratio and Most-Engaged Articles (score = unique_readers × scroll × engagement_time)
- BQ-only-hidden: `top_categories_by_engagement`, `mobile_vs_desktop_content_preferences`, `top_authors_by_repeat_reader_rate`, `article_freshness_vs_engagement`
- The three box plots cut from the spec (Pages per Session distribution, Scroll Depth Distribution, Reader-Author Affinity) are intentionally absent

### REST controllers

`GET /newspack-insights/v1/audience` and `GET /newspack-insights/v1/engagement` mirror the existing Gates controller's date-arg validation, permission check, 15-minute cache TTL, and `{ current, previous }` response shape. Tab-level OAuth check happens up front so a missing Google connection returns a single `tab_error: 'oauth_not_connected'` payload rather than 30+ rejected runReport calls.

### Section wiring

`Insights_Section_Audience` and `Insights_Section_Engagement` were already init'd from `class-wizards.php`; this PR fills them from stubs to load the data layer and register the routes.

### Tests

13 PHPUnit tests covering dispatch routing, tab-level OAuth error, custom_dimension_missing overlay, generic error, hidden_in_v1, and successful payload transformation.

## How to test

1. On a site without a Google connection:
```php
   $a = \Newspack\Insights\Audience_Metric::get_all( '2026-05-09', '2026-06-08', false );
   print_r( $a );
```
   Expect: `{ tab_error: 'oauth_not_connected', banner_text: ... }`.

2. On a site with a Newspack Google connection:
   - Run the same call. Expect 26 metric keys, each a real value or a graceful-failure payload (overlay / degraded / error).
   - Repeat with `Engagement_Metric::get_all(...)`. Expect 16 metric keys.

3. Backend dispatch:
   - `define( 'NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4', false )` in wp-config and re-run. Every metric returns a `not_implemented` error except BQ-only metrics which return `hidden_in_v1`.
   - Same for `NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4`.

4. Graceful degradation:
   - Confirm an unregistered custom dimension degrades (Top Pages → all URLs) or overlays (`custom_dimension_missing`) rather than throwing.

5. REST:
   - With `NEWSPACK_INSIGHTS_ENABLED` set, hit `GET /wp-json/newspack-insights/v1/audience?start=2026-05-09&end=2026-06-08&compare_start=2026-04-09&compare_end=2026-05-08`. Expect `{ current, previous }` (or `tab_error` when GA4 is unconnected).

6. Tests:
   - `n test-php --filter Newspack_Test_Insights_Audience_Metric` (7 tests)
   - `n test-php --filter Newspack_Test_Insights_Engagement_Metric` (6 tests)
   - PHPCS clean on all changed files.

## Out of scope

- The React UI for Audience and Engagement (NPPD-1649, depends on this PR)
- BQ path implementation (NPPD-1630, the v1.1 swap)
- Provisioning `post_id` as a GA4 custom dimension (NPPD-1652) — until then, article-scoped metrics degrade or overlay gracefully per spec
- Box plot visualizations (cut from spec entirely)
- v1.1 boot-time custom dimension probe (partially folded into v1 via the per-call check)