### PR TITLE
fix(insights): re-land orphaned wizard-chrome a11y + review fixes (NPPD-1602)

### DIFF
--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -69,7 +69,6 @@ class Wizards {
 			'audience-content-gates'  => new Audience_Content_Gates(),
 			'audience-donations'      => new Audience_Donations(),
 			'audience-integrations'   => new Audience_Integrations(),
-			'insights'                => new Insights_Wizard(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),
@@ -79,17 +78,24 @@ class Wizards {
 			self::$wizards['audience-subscriptions'] = new Audience_Subscriptions();
 		}
 
-		// Initialize Insights section classes. These are plain classes (not
-		// Wizard_Section subclasses) that hold the hook points for future
-		// per-tab REST endpoint registration as each tab's data layer lands.
-		Insights_Section_Audience::init();
-		Insights_Section_Engagement::init();
-		Insights_Section_Conversion::init();
-		Insights_Section_Gates::init();
-		Insights_Section_Prompts::init();
-		Insights_Section_Subscribers::init();
-		Insights_Section_Donors::init();
-		Insights_Section_Advertising::init();
+		// Insights wizard + section init are gated together. The wizard's
+		// own constructor short-circuits when the feature flag is off and
+		// each section's init() self-gates too, but registering the
+		// instance and firing eight no-op init()s leaves stale state in
+		// self::$wizards (which Wizards::get_url() and Wizards::menu_order()
+		// read from). Keeping the gate at this layer is the single source
+		// of truth.
+		if ( Insights_Wizard::is_enabled() ) {
+			self::$wizards['insights'] = new Insights_Wizard();
+			Insights_Section_Audience::init();
+			Insights_Section_Engagement::init();
+			Insights_Section_Conversion::init();
+			Insights_Section_Gates::init();
+			Insights_Section_Prompts::init();
+			Insights_Section_Subscribers::init();
+			Insights_Section_Donors::init();
+			Insights_Section_Advertising::init();
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ComparisonToggle.tsx
@@ -1,14 +1,19 @@
 /**
  * ComparisonToggle
  *
- * Checkbox to enable "compare to previous period". Component owns no
- * state — caller wires it to useComparisonMode.
+ * "Compare to previous period" checkbox. Uses @wordpress/components
+ * CheckboxControl per Newspack admin convention (built-in label
+ * association, focus ring, and a11y semantics — the previous raw
+ * <input type="checkbox"> had no styled focus state).
+ *
+ * Component owns no state — caller wires it to useComparisonMode.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
 
 export interface ComparisonToggleProps {
 	enabled: boolean;
@@ -16,14 +21,15 @@ export interface ComparisonToggleProps {
 	className?: string;
 }
 
-const ComparisonToggle = ( { enabled, onChange, className }: ComparisonToggleProps ) => {
-	const inputId = 'newspack-insights-comparison-toggle';
-	return (
-		<label className={ className ?? 'newspack-insights__comparison-toggle' } htmlFor={ inputId }>
-			<input id={ inputId } type="checkbox" checked={ enabled } onChange={ e => onChange( e.target.checked ) } />
-			<span className="newspack-insights__comparison-toggle-label">{ __( 'Compare to previous period', 'newspack-plugin' ) }</span>
-		</label>
-	);
-};
+const ComparisonToggle = ( { enabled, onChange, className }: ComparisonToggleProps ) => (
+	<div className={ className ?? 'newspack-insights__comparison-toggle' }>
+		<CheckboxControl
+			__nextHasNoMarginBottom
+			label={ __( 'Compare to previous period', 'newspack-plugin' ) }
+			checked={ enabled }
+			onChange={ onChange }
+		/>
+	</div>
+);
 
 export default ComparisonToggle;

--- a/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/DateRangePicker.tsx
@@ -5,6 +5,10 @@
  * last-90, this-month, last-month, custom). Custom mode reveals two date
  * inputs.
  *
+ * Uses @wordpress/components SelectControl for the preset dropdown per
+ * Newspack admin convention. The custom date inputs stay as
+ * <input type="date"> because WordPress doesn't ship a date control.
+ *
  * Component owns no state — caller wires it to useDateRange.
  */
 
@@ -12,6 +16,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -26,26 +31,21 @@ export interface DateRangePickerProps {
 }
 
 const DateRangePicker = ( { range, onPresetChange, onCustomChange, className }: DateRangePickerProps ) => {
-	const presetId = 'newspack-insights-date-range-preset';
 	const startId = 'newspack-insights-date-range-start';
 	const endId = 'newspack-insights-date-range-end';
+	const options = DATE_RANGE_PRESETS.map( p => ( { value: p.key, label: p.label } ) );
+
 	return (
 		<div className={ className ?? 'newspack-insights__date-range-picker' }>
-			<label className="newspack-insights__date-range-picker-label" htmlFor={ presetId }>
-				<span className="screen-reader-text">{ __( 'Date range', 'newspack-plugin' ) }</span>
-				<select
-					id={ presetId }
-					className="newspack-insights__date-range-picker-select"
-					value={ range.preset }
-					onChange={ e => onPresetChange( e.target.value as DateRangePreset ) }
-				>
-					{ DATE_RANGE_PRESETS.map( p => (
-						<option key={ p.key } value={ p.key }>
-							{ p.label }
-						</option>
-					) ) }
-				</select>
-			</label>
+			<SelectControl
+				className="newspack-insights__date-range-picker-select"
+				label={ __( 'Date range', 'newspack-plugin' ) }
+				hideLabelFromVision
+				__nextHasNoMarginBottom
+				value={ range.preset }
+				options={ options }
+				onChange={ value => onPresetChange( value as DateRangePreset ) }
+			/>
 
 			{ range.preset === 'custom' && (
 				<div className="newspack-insights__date-range-picker-custom">

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -19,8 +19,11 @@ export interface LastUpdatedProps {
 }
 
 const formatRelative = ( ts: Date, now: Date ): string => {
+	// Math.floor (not Math.round) so a 30-second-old timestamp stays in
+	// the "just now" branch instead of rounding up to "1 minute ago".
+	// Same reasoning applies to the hour / day branches below.
 	const diffMs = now.getTime() - ts.getTime();
-	const diffMin = Math.round( diffMs / ( 1000 * 60 ) );
+	const diffMin = Math.floor( diffMs / ( 1000 * 60 ) );
 	if ( diffMin < 1 ) {
 		return __( 'Updated just now', 'newspack-plugin' );
 	}
@@ -31,7 +34,7 @@ const formatRelative = ( ts: Date, now: Date ): string => {
 			diffMin
 		);
 	}
-	const diffHr = Math.round( diffMin / 60 );
+	const diffHr = Math.floor( diffMin / 60 );
 	if ( diffHr < 24 ) {
 		return sprintf(
 			/* translators: %d is number of hours */
@@ -39,7 +42,7 @@ const formatRelative = ( ts: Date, now: Date ): string => {
 			diffHr
 		);
 	}
-	const diffDay = Math.round( diffHr / 24 );
+	const diffDay = Math.floor( diffHr / 24 );
 	return sprintf(
 		/* translators: %d is number of days */
 		__( 'Updated %d days ago', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
@@ -3,14 +3,17 @@
  *
  * Lazy-loads the appropriate tab component based on activeTab and renders
  * it inside a Suspense boundary with a skeleton fallback. Each tab is
- * code-split via React.lazy.
+ * code-split via React.lazy. An ErrorBoundary wraps Suspense so a chunk
+ * load failure (deploy mid-session, ad blocker, transient network) shows
+ * a recoverable message instead of crashing the wizard.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lazy, Suspense } from '@wordpress/element';
+import { Component, lazy, Suspense } from '@wordpress/element';
+import type { ErrorInfo, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -27,10 +30,18 @@ const SubscribersTab = lazy( () => import( '../tabs/SubscribersTab' ) );
 const DonorsTab = lazy( () => import( '../tabs/DonorsTab' ) );
 const AdvertisingTab = lazy( () => import( '../tabs/AdvertisingTab' ) );
 
-export interface TabContentProps {
-	activeTab: TabKey;
+/**
+ * Props every tab component receives. Exported so each tab module can
+ * type its own props from the same source, satisfying strict-mode TS
+ * when TabContent passes range / previousRange via the spread below.
+ */
+export interface TabSectionProps {
 	range: DateRange;
 	previousRange: DateRange | null;
+}
+
+export interface TabContentProps extends TabSectionProps {
+	activeTab: TabKey;
 }
 
 const Fallback = () => (
@@ -39,26 +50,67 @@ const Fallback = () => (
 	</div>
 );
 
-const TabContent = ( props: TabContentProps ) => {
-	const { activeTab } = props;
+interface TabErrorBoundaryProps {
+	children: ReactNode;
+}
+
+interface TabErrorBoundaryState {
+	error: Error | null;
+}
+
+class TabErrorBoundary extends Component< TabErrorBoundaryProps, TabErrorBoundaryState > {
+	state: TabErrorBoundaryState = { error: null };
+
+	static getDerivedStateFromError( error: Error ): TabErrorBoundaryState {
+		return { error };
+	}
+
+	componentDidCatch( error: Error, info: ErrorInfo ): void {
+		// eslint-disable-next-line no-console
+		console.error( 'Insights tab failed to load', error, info );
+	}
+
+	handleReload = (): void => {
+		if ( typeof window !== 'undefined' ) {
+			window.location.reload();
+		}
+	};
+
+	render() {
+		if ( this.state.error ) {
+			return (
+				<div className="newspack-insights__tab-error" role="alert">
+					<p>{ __( 'This section could not be loaded.', 'newspack-plugin' ) }</p>
+					<button type="button" className="newspack-insights__tab-error-action" onClick={ this.handleReload }>
+						{ __( 'Reload the page', 'newspack-plugin' ) }
+					</button>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}
+
+const TabContent = ( { activeTab, range, previousRange }: TabContentProps ) => {
+	const sectionProps: TabSectionProps = { range, previousRange };
 	const renderTab = () => {
 		switch ( activeTab ) {
 			case 'audience':
-				return <AudienceTab { ...props } />;
+				return <AudienceTab { ...sectionProps } />;
 			case 'engagement':
-				return <EngagementTab { ...props } />;
+				return <EngagementTab { ...sectionProps } />;
 			case 'conversion':
-				return <ConversionTab { ...props } />;
+				return <ConversionTab { ...sectionProps } />;
 			case 'gates':
-				return <GatesTab { ...props } />;
+				return <GatesTab { ...sectionProps } />;
 			case 'prompts':
-				return <PromptsTab { ...props } />;
+				return <PromptsTab { ...sectionProps } />;
 			case 'subscribers':
-				return <SubscribersTab { ...props } />;
+				return <SubscribersTab { ...sectionProps } />;
 			case 'donors':
-				return <DonorsTab { ...props } />;
+				return <DonorsTab { ...sectionProps } />;
 			case 'advertising':
-				return <AdvertisingTab { ...props } />;
+				return <AdvertisingTab { ...sectionProps } />;
 			default:
 				return null;
 		}
@@ -70,7 +122,9 @@ const TabContent = ( props: TabContentProps ) => {
 			id={ `newspack-insights-panel-${ activeTab }` }
 			aria-labelledby={ `newspack-insights-tab-${ activeTab }` }
 		>
-			<Suspense fallback={ <Fallback /> }>{ renderTab() }</Suspense>
+			<TabErrorBoundary>
+				<Suspense fallback={ <Fallback /> }>{ renderTab() }</Suspense>
+			</TabErrorBoundary>
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabContent.tsx
@@ -122,7 +122,10 @@ const TabContent = ( { activeTab, range, previousRange }: TabContentProps ) => {
 			id={ `newspack-insights-panel-${ activeTab }` }
 			aria-labelledby={ `newspack-insights-tab-${ activeTab }` }
 		>
-			<TabErrorBoundary>
+			{ /* Keyed by activeTab so switching tabs remounts the boundary and
+			     clears any error from a failed chunk load — otherwise the error
+			     UI would persist across tabs and lock the content area. */ }
+			<TabErrorBoundary key={ activeTab }>
 				<Suspense fallback={ <Fallback /> }>{ renderTab() }</Suspense>
 			</TabErrorBoundary>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabNavigation.tsx
@@ -5,6 +5,10 @@
  * driven by props (computed at boot from feature detection — stubbed
  * all-on for now). Active tab highlighting per design spec.
  *
+ * Implements the WAI-ARIA tabs pattern: roving tabindex (only the
+ * active tab is in the tab order; others use tabIndex={-1}) and
+ * arrow / Home / End keyboard navigation between tabs.
+ *
  * Component owns no state — caller passes activeTab and onTabChange.
  */
 
@@ -12,6 +16,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useCallback, useRef } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -47,24 +52,67 @@ export interface TabNavigationProps {
 
 const TabNavigation = ( { activeTab, visibility, onTabChange, className }: TabNavigationProps ) => {
 	const visibleTabs = ALL_TABS.filter( t => visibility[ t.key ] );
+	const tabsRef = useRef< Record< TabKey, HTMLButtonElement | null > >( {} as Record< TabKey, HTMLButtonElement | null > );
+
+	const focusTab = useCallback(
+		( key: TabKey ) => {
+			tabsRef.current[ key ]?.focus();
+			onTabChange( key );
+		},
+		[ onTabChange ]
+	);
+
+	const handleKeyDown = useCallback(
+		( e: React.KeyboardEvent< HTMLButtonElement >, index: number ) => {
+			if ( visibleTabs.length === 0 ) {
+				return;
+			}
+			let nextIndex: number | null = null;
+			switch ( e.key ) {
+				case 'ArrowRight':
+					nextIndex = ( index + 1 ) % visibleTabs.length;
+					break;
+				case 'ArrowLeft':
+					nextIndex = ( index - 1 + visibleTabs.length ) % visibleTabs.length;
+					break;
+				case 'Home':
+					nextIndex = 0;
+					break;
+				case 'End':
+					nextIndex = visibleTabs.length - 1;
+					break;
+				default:
+					return;
+			}
+			e.preventDefault();
+			focusTab( visibleTabs[ nextIndex ].key );
+		},
+		[ visibleTabs, focusTab ]
+	);
+
 	return (
 		<div
 			className={ classnames( 'newspack-insights__tabs', className ) }
 			role="tablist"
 			aria-label={ __( 'Insights sections', 'newspack-plugin' ) }
 		>
-			{ visibleTabs.map( tab => {
+			{ visibleTabs.map( ( tab, index ) => {
 				const isActive = tab.key === activeTab;
 				return (
 					<button
 						key={ tab.key }
+						ref={ el => {
+							tabsRef.current[ tab.key ] = el;
+						} }
 						type="button"
 						role="tab"
 						aria-selected={ isActive }
 						aria-controls={ `newspack-insights-panel-${ tab.key }` }
 						id={ `newspack-insights-tab-${ tab.key }` }
+						tabIndex={ isActive ? 0 : -1 }
 						className={ classnames( 'newspack-insights__tab', isActive && 'is-active' ) }
 						onClick={ () => onTabChange( tab.key ) }
+						onKeyDown={ e => handleKeyDown( e, index ) }
 					>
 						{ tab.label }
 					</button>

--- a/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
@@ -82,11 +82,12 @@ const writeUrl = ( enabled: boolean ) => {
 		return;
 	}
 	const params = new URLSearchParams( window.location.search );
-	if ( enabled ) {
-		params.set( 'compare', '1' );
-	} else {
-		params.delete( 'compare' );
-	}
+	// Persist both states explicitly. Previously the disabled state
+	// deleted the param, which meant an explicit user choice of
+	// "disabled" would silently revert to the boot config default on
+	// refresh whenever that default is true. `readUrl` already accepts
+	// '0' so this round-trips cleanly.
+	params.set( 'compare', enabled ? '1' : '0' );
 	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
 	window.history.replaceState( window.history.state, '', next );
 };

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -37,7 +37,20 @@ export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-const isValidISODate = ( s: unknown ): s is string => typeof s === 'string' && ISO_DATE_RE.test( s );
+/**
+ * Validate a YYYY-MM-DD string. Checks both the shape AND that the parsed
+ * date round-trips back to the same string — otherwise inputs like
+ * '2026-99-99' would pass the regex and silently roll over to a future
+ * month when used as a Date.
+ */
+const isValidISODate = ( s: unknown ): s is string => {
+	if ( typeof s !== 'string' || ! ISO_DATE_RE.test( s ) ) {
+		return false;
+	}
+	const [ y, m, d ] = s.split( '-' ).map( Number );
+	const parsed = new Date( y, m - 1, d );
+	return parsed.getFullYear() === y && parsed.getMonth() === m - 1 && parsed.getDate() === d;
+};
 
 const isPreset = ( v: unknown ): v is DateRangePreset => typeof v === 'string' && DATE_RANGE_PRESETS.some( p => p.key === v );
 
@@ -187,7 +200,13 @@ const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeRetu
 		if ( ! isValidISODate( start ) || ! isValidISODate( end ) ) {
 			return;
 		}
-		setRange( { preset: 'custom', start, end } );
+		// Normalize so the earlier date is always start. The picker has
+		// two independent <input type="date"> fields and editing one
+		// before the other can transiently produce start > end, which
+		// otherwise propagates a nonsensical range into the URL and
+		// breaks computePreviousRange.
+		const [ s, e ] = start <= end ? [ start, end ] : [ end, start ];
+		setRange( { preset: 'custom', start: s, end: e } );
 	}, [] );
 
 	return { range, setPreset, setCustom };

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -4,18 +4,11 @@
  * Per spec at ~/Sites/insights-docs/component-design-spec.md. Owns
  * page-level layout (header, tab nav, tab content area) plus styles for
  * the chrome-only components (DateRangePicker, ComparisonToggle,
- * LastUpdated, tab stub).
- *
- * Also forwards the shared cross-tab chrome — sections, metric cards,
- * tables, tab loading/error — from `tabs/components/sections.scss` so
- * every tab inherits them without having to import on its own.
- *
- * Per-component metric viz styles live in
+ * LastUpdated, tab stub). Per-component metric viz styles live in
  * packages/components/src/<component>/ and don't belong here.
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "tabs/components/sections";
 
 .newspack-insights {
 	max-width: 1200px;
@@ -116,19 +109,13 @@
 		gap: 8px;
 	}
 
+	// SelectControl + CheckboxControl from @wordpress/components carry
+	// their own admin-pattern styles, focus rings, and a11y. We only
+	// keep a wrapper override here for the SelectControl so it sits
+	// flush with the picker row (the component's default margin-bottom
+	// is opted out via __nextHasNoMarginBottom on the JS side).
 	&__date-range-picker-select {
-		font-size: 13px;
-		padding: 6px 10px;
-		border: 1px solid wp-colors.$gray-300;
-		border-radius: 4px;
-		background: #fff;
-		color: wp-colors.$gray-900;
-		cursor: pointer;
-
-		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color);
-			outline-offset: -2px;
-		}
+		width: auto;
 	}
 
 	&__date-range-picker-custom {
@@ -143,28 +130,17 @@
 			border-radius: 4px;
 			background: #fff;
 			color: wp-colors.$gray-900;
+
+			&:focus-visible {
+				outline: 2px solid var(--wp-admin-theme-color);
+				outline-offset: 1px;
+			}
 		}
 	}
 
 	&__date-range-picker-sep {
 		color: wp-colors.$gray-600;
 		font-size: 13px;
-	}
-
-	// Comparison toggle
-
-	&__comparison-toggle {
-		display: inline-flex;
-		align-items: center;
-		gap: 6px;
-		font-size: 13px;
-		font-weight: 400;
-		color: wp-colors.$gray-700;
-		cursor: pointer;
-
-		input[type="checkbox"] {
-			margin: 0;
-		}
 	}
 
 	// Tab navigation

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -4,11 +4,18 @@
  * Per spec at ~/Sites/insights-docs/component-design-spec.md. Owns
  * page-level layout (header, tab nav, tab content area) plus styles for
  * the chrome-only components (DateRangePicker, ComparisonToggle,
- * LastUpdated, tab stub). Per-component metric viz styles live in
+ * LastUpdated, tab stub).
+ *
+ * Also forwards the shared cross-tab chrome — sections, metric cards,
+ * tables, tab loading/error — from `tabs/components/sections.scss` so
+ * every tab inherits them without having to import on its own.
+ *
+ * Per-component metric viz styles live in
  * packages/components/src/<component>/ and don't belong here.
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "tabs/components/sections";
 
 .newspack-insights {
 	max-width: 1200px;


### PR DESCRIPTION
## Summary

Re-lands review/accessibility fixes for the Insights **wizard chrome** that were orphaned when the original chrome PR (#211, `nppd-1602`) was closed instead of merged. The chrome reached `main` via a different PR based on the *pre-fix* commit, so this commit (`622198a577`) never shipped. Verified: `main`'s chrome files are byte-identical to the fix's parent, i.e. these changes are genuinely absent.

## What's included (9 chrome files)

- **`TabNavigation`** — WAI-ARIA tabs pattern: roving tabindex + arrow-key keyboard navigation (the main accessibility gap).
- **`TabContent`**, **`DateRangePicker`**, **`ComparisonToggle`**, **`LastUpdated`** — Copilot + design + code-review fixes.
- **`useDateRange`**, **`useComparisonMode`** — state-hook review fixes.
- **`class-wizards.php`**, **`style.scss`** — chrome wiring + style cleanup.

## Scope note

The original commit also touched the per-tab files (`AudienceTab`, `EngagementTab`, etc.), but those were **stubs at the time and have since been fully rewritten** (NPPD-1608/1624/1649). Those hunks are obsolete and intentionally dropped — only the still-current chrome files are applied here, cleanly (each was still at the pre-fix state on `main`).

## Testing

- tsc clean (0 errors) — confirms the chrome still integrates with the now-built tabs.
- ESLint, stylelint, PHPCS clean.
- `npm run build` green.
- Manual: tab bar is keyboard-navigable (arrow keys move focus, roving tabindex), date picker / comparison toggle behave per the review fixes.