### PR TITLE
fix(deps): sync @typescript-eslint/parser override with lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	"pnpm": {
 		"overrides": {
 			"basic-ftp": "5.3.1",
-			"@typescript-eslint/parser": "8.58.2",
+			"@typescript-eslint/parser": "8.61.0",
 			"prettier": "npm:wp-prettier@^3.0.3"
 		},
 		"patchedDependencies": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Bumps `pnpm.overrides.@typescript-eslint/parser` in `package.json` from `8.58.2` to `8.61.0` to match the value already in `pnpm-lock.yaml`.

`main` is currently red: the `Install deps` job fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because Dependabot PR #249 bumped the override only in the lockfile while `package.json` still pinned the previous version. The mismatch was not caught on #249 itself because the `Install deps` job was skipped by the change detector when only `pnpm-lock.yaml` changed — it first ran on the next PR with broader code changes (#196 / commit ` 71d2165`), which is the run that turned `main` red:

https://github.com/Automattic/newspack-workspace/actions/runs/27210804365/job/80339154690

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `pnpm install --frozen-lockfile`.
3. Confirm the install completes without `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
4. Confirm the `Install deps` job in CI passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — N/A, dependency config sync.
* [x] Have you successfully run tests with your changes locally? — verified `pnpm install --frozen-lockfile` succeeds.

Follow-ups worth considering (out of scope here):

* Teach Dependabot to update `pnpm.overrides` in `package.json` alongside `pnpm-lock.yaml`, or
* Always run the `Install deps` job when `pnpm-lock.yaml` changes, so this kind of mismatch is caught on the originating PR rather than after it merges.