### PR TITLE
fix(access-control): populate GA4 group metadata for anonymous readers

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -297,22 +297,22 @@ class GoogleSiteKit {
 	 * @return string[] Sorted, deduplicated anonymized labels.
 	 */
 	private static function get_user_group_labels( $user ) {
+		$labels = [];
+		// Non-logged-in users can still match institutions via IP-based access rules.
+		foreach ( Institution::get_matching_ids_for_user( $user->ID ?? 0 ) as $inst_id ) {
+			$labels[] = 'Institution ' . $inst_id;
+		}
 		if ( ! $user || ! $user->ID ) {
-			return [];
+			return $labels;
 		}
 		// Match the framing of the surrounding params (`is_reader`, `is_subscriber`):
 		// only attribute groups to actual readers, not admins/editors.
 		if ( ! Reader_Activation::is_user_reader( $user ) ) {
-			return [];
+			return $labels;
 		}
 		$user_id = (int) $user->ID;
-
-		$labels = [];
 		foreach ( Group_Subscription::get_group_ids_for_user( $user_id ) as $sub_id ) {
 			$labels[] = 'Group ' . $sub_id;
-		}
-		foreach ( Institution::get_matching_ids_for_user( $user_id ) as $inst_id ) {
-			$labels[] = 'Institution ' . $inst_id;
 		}
 		sort( $labels, SORT_NATURAL | SORT_FLAG_CASE );
 		return $labels;

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
@@ -190,8 +190,8 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Matching institution (via verified email domain) contributes the anonymized ID label
-	 * for logged-out users who match via IP-based access rules, too.
+	 * Matching institution (via IP-based access rules) contributes the anonymized ID label
+	 * for logged-out users, too.
 	 */
 	public function test_group_includes_matching_institution_while_logged_out() {
 		// Ensure logged-out user.

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
@@ -10,6 +10,7 @@ use Newspack\Group_Subscription;
 use Newspack\Group_Subscription_Settings;
 use Newspack\Institution;
 use Newspack\Reader_Activation;
+use Newspack\Content_Gate\IP_Access_Rule;
 
 /**
  * Test the `group` GA4 custom event parameter.
@@ -186,6 +187,30 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 		$params = GoogleSiteKit::get_custom_event_parameters();
 
 		$this->assertEquals( 'Institution ' . $inst_id, $params['group'] );
+	}
+
+	/**
+	 * Matching institution (via verified email domain) contributes the anonymized ID label
+	 * for logged-out users who match via IP-based access rules, too.
+	 */
+	public function test_group_includes_matching_institution_while_logged_out() {
+		// Ensure logged-out user.
+		wp_set_current_user( 0 );
+		$inst_id = $this->create_institution( 'Test University', [ 'ip_range' => '192.168.1.0/24' ] );
+
+		// Mock a session in the whitelisted IP range.
+		$_SERVER['REMOTE_ADDR'] = '192.168.1.50'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$_COOKIE[ IP_Access_Rule::COOKIE_NAME ] = '1'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		$this->assertTrue( IP_Access_Rule::is_cookie_set() );
+
+		$params = GoogleSiteKit::get_custom_event_parameters();
+
+		$this->assertEquals( 'Institution ' . $inst_id, $params['group'] );
+
+		// Unset whitelisted IP and cookie.
+		unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Porting the diff from [#4751](https://github.com/Automattic/newspack-plugin/pull/4751) to the monorepo. Description copied directly from the legacy repo's PR.

Follow-up to https://github.com/Automattic/newspack-plugin/pull/4697 and https://github.com/Automattic/newspack-plugin/pull/4746. Allows the GA4 group param to populate for non-logged-in readers who match an institution via IP access rules.

### How to test the changes in this Pull Request:

Prerequisites: 

- `NEWSPACK_CONTENT_GATES` defined in wp-config.php
- WooCommerce Memberships plugin deactivated
- A published Institution (**Audience > Access Control > [kebab menu] Institutions**) with an IP whitelist access rule
- Google Site Kit connected with Google Analytics enabled

1. In an incognito session, without registering or logging in, visit the institution's access URL using an IP that falls in the institution's whitelisted IP range and wait until you get redirected to the homepage with the "Connected to..." success message.
2. View the page source and confirm that you see the `"group": "Institution #####"` param appended to the `gtag("config")` call.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->