### PR TITLE
fix(access-control): make email domain matching case-insensitive

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -426,6 +426,7 @@ class Access_Rules {
 		$domains = str_replace( PHP_EOL, ',', $domains );
 		$domains = explode( ',', $domains );
 		$domains = array_map( 'trim', $domains );
+		$domains = array_map( 'strtolower', $domains );
 		$user    = \get_userdata( $user_id );
 		if ( ! $user ) {
 			return false;
@@ -437,7 +438,7 @@ class Access_Rules {
 		if ( Reader_Activation::is_reader_verified( $user ) === false ) {
 			return false;
 		}
-		$email_domain = substr( $email, strrpos( $email, '@' ) + 1 );
+		$email_domain = strtolower( substr( $email, strrpos( $email, '@' ) + 1 ) );
 		return in_array( $email_domain, $domains, true );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -262,6 +262,25 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test user passing email domain rule with case insensitivity.
+	 */
+	public function test_email_domain_pass_case_insensitive() {
+		$rules = [
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'Example.com',
+				],
+			],
+		];
+		$this->create_gate_with_rules( 'Domain Gate', $rules );
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'User with matching domain but non-matching case should have access.' );
+	}
+
+	/**
 	 * Test user failing email domain rule.
 	 */
 	public function test_email_domain_fail() {

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -264,7 +264,20 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	/**
 	 * Test user passing email domain rule with case insensitivity.
 	 */
+	/**
+	 * Test user passing email domain rule with case insensitivity.
+	 */
 	public function test_email_domain_pass_case_insensitive() {
+		global $wpdb;
+
+		// Force a mixed-case email in the DB to ensure the domain comparison is truly case-insensitive.
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->users,
+			[ 'user_email' => 'reader@ExAmPlE.com' ],
+			[ 'ID' => self::$user_id ]
+		);
+		clean_user_cache( self::$user_id );
+
 		$rules = [
 			[
 				[

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -264,20 +264,7 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	/**
 	 * Test user passing email domain rule with case insensitivity.
 	 */
-	/**
-	 * Test user passing email domain rule with case insensitivity.
-	 */
 	public function test_email_domain_pass_case_insensitive() {
-		global $wpdb;
-
-		// Force a mixed-case email in the DB to ensure the domain comparison is truly case-insensitive.
-		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->users,
-			[ 'user_email' => 'reader@ExAmPlE.com' ],
-			[ 'ID' => self::$user_id ]
-		);
-		clean_user_cache( self::$user_id );
-
 		$rules = [
 			[
 				[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes the email domain whitelist check case-insensitive.

### How to test the changes in this Pull Request:

1. Register and verify a reader account with a mixed-case domain, and publish a content gate with an email domain whitelist rule specifying a domain that matches but case-insensitively (e.g. user@Domain.com vs. domain.com)
2. As the reader, confirm you can access content restricted by the gate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
