### PR TITLE
fix(insights): GA4 client + orchestrator review fixes (NPPD-1669)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
@@ -165,8 +165,8 @@ final class Client {
 	 * indeterminate — we return no "missing" entries and let the Data API
 	 * respond, rather than blocking the metric on a transient state.
 	 *
-	 * @param string[]       $requested  Requested parameter names.
-	 * @param string[]|mixed $registered Registered names, or a WP_Error.
+	 * @param string[]           $requested  Requested parameter names.
+	 * @param string[]|\WP_Error $registered Registered names, or a WP_Error.
 	 * @return string[] Definitely-missing parameter names ([] if indeterminate).
 	 */
 	private static function missing_registered_dimensions( array $requested, $registered ): array {

--- a/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/ga4/class-client.php
@@ -88,23 +88,17 @@ final class Client {
 		$requested = self::extract_custom_dimensions( $body );
 		if ( ! empty( $requested ) ) {
 			$registered = self::get_registered_parameter_names_cached( $property_id );
-			// Only block on a definitive answer. If the registered list can't be
-			// resolved (WP_Error), fall through and let the Data API respond — a
-			// genuinely missing dimension surfaces as an API error rather than
-			// silently suppressing the metric.
-			if ( ! is_wp_error( $registered ) ) {
-				$missing = array_values( array_diff( $requested, $registered ) );
-				if ( ! empty( $missing ) ) {
-					return new \WP_Error(
-						'custom_dimension_missing',
-						sprintf(
-							/* translators: %s: comma-separated list of GA4 custom dimension parameter names. */
-							__( 'GA4 custom dimension(s) not registered on this property: %s', 'newspack-plugin' ),
-							implode( ', ', $missing )
-						),
-						[ 'dimensions' => $missing ]
-					);
-				}
+			$missing    = self::missing_registered_dimensions( $requested, $registered );
+			if ( ! empty( $missing ) ) {
+				return new \WP_Error(
+					'custom_dimension_missing',
+					sprintf(
+						/* translators: %s: comma-separated list of GA4 custom dimension parameter names. */
+						__( 'GA4 custom dimension(s) not registered on this property: %s', 'newspack-plugin' ),
+						implode( ', ', $missing )
+					),
+					[ 'dimensions' => $missing ]
+				);
 			}
 		}
 
@@ -159,6 +153,27 @@ final class Client {
 			$results[ $key ] = self::run_report( $property_id, $body );
 		}
 		return $results;
+	}
+
+	/**
+	 * Which requested custom-dimension parameter names are definitively NOT
+	 * registered on the property.
+	 *
+	 * Only a non-empty, non-error registered set is treated as authoritative.
+	 * A `WP_Error` (lookup failed) OR an empty array (e.g. a freshly connected
+	 * property whose async dimension provisioning has not run yet) is
+	 * indeterminate — we return no "missing" entries and let the Data API
+	 * respond, rather than blocking the metric on a transient state.
+	 *
+	 * @param string[]       $requested  Requested parameter names.
+	 * @param string[]|mixed $registered Registered names, or a WP_Error.
+	 * @return string[] Definitely-missing parameter names ([] if indeterminate).
+	 */
+	private static function missing_registered_dimensions( array $requested, $registered ): array {
+		if ( is_wp_error( $registered ) || ! is_array( $registered ) || empty( $registered ) ) {
+			return [];
+		}
+		return array_values( array_diff( $requested, $registered ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -59,6 +59,22 @@ final class Audience_Metric {
 	}
 
 	/**
+	 * Build the per-window transient cache key. Includes the GA4 property ID so
+	 * that a reconnect to a different property never serves the previous
+	 * property's cached payload within the TTL.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @param bool   $use_ga4    Whether the GA4 backend is active.
+	 * @return string
+	 */
+	private static function window_cache_key( string $start_date, string $end_date, bool $use_ga4 ): string {
+		return self::CACHE_KEY_PREFIX . md5(
+			self::resolve_property_id() . '|' . $start_date . '|' . $end_date . '|' . ( $use_ga4 ? 'ga4' : 'bq' )
+		);
+	}
+
+	/**
 	 * Tab-level connection check. Returns a tab_error payload when the GA4
 	 * path is active but no usable Google connection / property exists, else
 	 * null. Checking once up front avoids N rejected runReport calls.
@@ -142,7 +158,7 @@ final class Audience_Metric {
 	 */
 	private static function compute_window_cached( string $start_date, string $end_date ): array {
 		$use_ga4   = self::use_ga4();
-		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date . '|' . $end_date . '|' . ( $use_ga4 ? 'ga4' : 'bq' ) );
+		$cache_key = self::window_cache_key( $start_date, $end_date, $use_ga4 );
 		$cached    = get_transient( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -50,6 +50,22 @@ final class Engagement_Metric {
 	}
 
 	/**
+	 * Build the per-window transient cache key. Includes the GA4 property ID so
+	 * that a reconnect to a different property never serves the previous
+	 * property's cached payload within the TTL.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @param bool   $use_ga4    Whether the GA4 backend is active.
+	 * @return string
+	 */
+	private static function window_cache_key( string $start_date, string $end_date, bool $use_ga4 ): string {
+		return self::CACHE_KEY_PREFIX . md5(
+			self::resolve_property_id() . '|' . $start_date . '|' . $end_date . '|' . ( $use_ga4 ? 'ga4' : 'bq' )
+		);
+	}
+
+	/**
 	 * Tab-level connection check (GA4 path only).
 	 *
 	 * @return array|null
@@ -129,7 +145,7 @@ final class Engagement_Metric {
 	 */
 	private static function compute_window_cached( string $start_date, string $end_date ): array {
 		$use_ga4   = self::use_ga4();
-		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date . '|' . $end_date . '|' . ( $use_ga4 ? 'ga4' : 'bq' ) );
+		$cache_key = self::window_cache_key( $start_date, $end_date, $use_ga4 );
 		$cached    = get_transient( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
@@ -185,14 +185,8 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
 					<Route path="/groups" render={ () => <Groups { ...props } /> } />
-					<Route
-						path="/campaign"
-						render={ () => ( configLoaded && ! config.enabled ? <Redirect to="/" /> : <Campaign { ...props } /> ) }
-					/>
-					<Route
-						path="/complete"
-						render={ () => ( configLoaded && ! config.enabled ? <Redirect to="/" /> : <Complete { ...props } /> ) }
-					/>
+					<Route path="/campaign" render={ () => ( configLoaded && ! config.enabled ? <Redirect to="/" /> : <Campaign { ...props } /> ) } />
+					<Route path="/complete" render={ () => ( configLoaded && ! config.enabled ? <Redirect to="/" /> : <Complete { ...props } /> ) } />
 					<Redirect to="/" />
 				</Switch>
 			</HashRouter>

--- a/plugins/newspack-plugin/tests/unit-tests/insights-audience-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-audience-metric.php
@@ -36,19 +36,26 @@ class Newspack_Test_Insights_Audience_Metric extends WP_UnitTestCase {
 	 * the TTL.
 	 */
 	public function test_window_cache_key_varies_by_property() {
-		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
-		$key_a = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+		$previous = get_option( 'googlesitekit_analytics-4_settings' );
+		try {
+			update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+			$key_a = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
 
-		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '222222' ] );
-		$key_b = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+			update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '222222' ] );
+			$key_b = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
 
-		$this->assertNotSame( $key_a, $key_b, 'Different properties must produce different cache keys.' );
+			$this->assertNotSame( $key_a, $key_b, 'Different properties must produce different cache keys.' );
 
-		// Same property + window is stable.
-		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
-		$this->assertSame( $key_a, $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] ) );
-
-		delete_option( 'googlesitekit_analytics-4_settings' );
+			// Same property + window is stable.
+			update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+			$this->assertSame( $key_a, $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] ) );
+		} finally {
+			if ( false === $previous ) {
+				delete_option( 'googlesitekit_analytics-4_settings' );
+			} else {
+				update_option( 'googlesitekit_analytics-4_settings', $previous );
+			}
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights-audience-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-audience-metric.php
@@ -31,6 +31,27 @@ class Newspack_Test_Insights_Audience_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The per-window cache key incorporates the GA4 property ID, so a reconnect
+	 * to a different property never serves the previous property's cache within
+	 * the TTL.
+	 */
+	public function test_window_cache_key_varies_by_property() {
+		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+		$key_a = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+
+		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '222222' ] );
+		$key_b = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+
+		$this->assertNotSame( $key_a, $key_b, 'Different properties must produce different cache keys.' );
+
+		// Same property + window is stable.
+		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+		$this->assertSame( $key_a, $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] ) );
+
+		delete_option( 'googlesitekit_analytics-4_settings' );
+	}
+
+	/**
 	 * With the GA4 path active (default) and no Google connection in the test
 	 * environment, get_all() short-circuits to a tab-level connection error.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
@@ -36,19 +36,26 @@ class Newspack_Test_Insights_Engagement_Metric extends WP_UnitTestCase {
 	 * the TTL.
 	 */
 	public function test_window_cache_key_varies_by_property() {
-		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
-		$key_a = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+		$previous = get_option( 'googlesitekit_analytics-4_settings' );
+		try {
+			update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+			$key_a = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
 
-		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '222222' ] );
-		$key_b = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+			update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '222222' ] );
+			$key_b = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
 
-		$this->assertNotSame( $key_a, $key_b, 'Different properties must produce different cache keys.' );
+			$this->assertNotSame( $key_a, $key_b, 'Different properties must produce different cache keys.' );
 
-		// Same property + window is stable.
-		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
-		$this->assertSame( $key_a, $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] ) );
-
-		delete_option( 'googlesitekit_analytics-4_settings' );
+			// Same property + window is stable.
+			update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+			$this->assertSame( $key_a, $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] ) );
+		} finally {
+			if ( false === $previous ) {
+				delete_option( 'googlesitekit_analytics-4_settings' );
+			} else {
+				update_option( 'googlesitekit_analytics-4_settings', $previous );
+			}
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
@@ -31,6 +31,27 @@ class Newspack_Test_Insights_Engagement_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The per-window cache key incorporates the GA4 property ID, so a reconnect
+	 * to a different property never serves the previous property's cache within
+	 * the TTL.
+	 */
+	public function test_window_cache_key_varies_by_property() {
+		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+		$key_a = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+
+		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '222222' ] );
+		$key_b = $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] );
+
+		$this->assertNotSame( $key_a, $key_b, 'Different properties must produce different cache keys.' );
+
+		// Same property + window is stable.
+		update_option( 'googlesitekit_analytics-4_settings', [ 'propertyID' => '111111' ] );
+		$this->assertSame( $key_a, $this->invoke( 'window_cache_key', [ '2026-01-01', '2026-01-31', true ] ) );
+
+		delete_option( 'googlesitekit_analytics-4_settings' );
+	}
+
+	/**
 	 * No Google connection in the test environment → tab-level error.
 	 */
 	public function test_get_all_returns_tab_error_when_oauth_missing() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights-ga4-client.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-ga4-client.php
@@ -161,11 +161,36 @@ class Newspack_Test_Insights_GA4_Client extends WP_UnitTestCase {
 			],
 		];
 
-		$requested  = $this->invoke_private( 'extract_custom_dimensions', [ $body ] );
-		$registered = [ 'post_id' ];
-		$missing    = array_values( array_diff( $requested, $registered ) );
+		$requested = $this->invoke_private( 'extract_custom_dimensions', [ $body ] );
+		$missing   = $this->invoke_private( 'missing_registered_dimensions', [ $requested, [ 'post_id' ] ] );
 
 		$this->assertSame( [ 'author' ], $missing );
+	}
+
+	/**
+	 * The pre-check only blocks on a definitive registered set. An empty list
+	 * (e.g. a freshly connected property before async dimension provisioning
+	 * runs) or a WP_Error is indeterminate and must NOT report anything missing,
+	 * so the metric is not falsely suppressed.
+	 */
+	public function test_missing_registered_dimensions_indeterminate_cases() {
+		$requested = [ 'post_id', 'author' ];
+
+		$this->assertSame(
+			[],
+			$this->invoke_private( 'missing_registered_dimensions', [ $requested, [] ] ),
+			'Empty registered set must be treated as indeterminate.'
+		);
+		$this->assertSame(
+			[],
+			$this->invoke_private( 'missing_registered_dimensions', [ $requested, new WP_Error( 'lookup_failed', 'x' ) ] ),
+			'A WP_Error registered set must be treated as indeterminate.'
+		);
+		$this->assertSame(
+			[],
+			$this->invoke_private( 'missing_registered_dimensions', [ $requested, [ 'post_id', 'author' ] ] ),
+			'A fully registered set reports nothing missing.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Post-merge code review of the merged Insights GA4 work (#238 / NPPD-1647 and #239 / NPPD-1648) surfaced two **HIGH**-severity bugs now live in `main`. This PR fixes both, with unit coverage. The remaining MED/LOW findings are tracked in [NPPD-1669](https://linear.app/a8c/issue/NPPD-1669).

## Fixes

### 1. Freshly-connected GA4 properties falsely report custom dimensions as missing
`ga4/class-client.php`'s pre-check treated an **empty (non-`WP_Error`) registered-dimension list** as definitive. Before a newly connected property's async dimension provisioning runs, `get_registered_parameter_names()` legitimately returns `[]`, and `array_diff($requested, [])` then flagged **every** `customEvent:` dimension as missing — so the metric rendered the "dimension not registered" overlay even though the data would arrive shortly.

Fix: extracted `missing_registered_dimensions()`, which treats an empty **or** `WP_Error` registered set as *indeterminate* (returns `[]`, lets the Data API respond) and only blocks on a definitive non-empty set.

### 2. Per-window cache key omitted the GA4 property ID
`metrics/class-audience-metric.php` and `class-engagement-metric.php` keyed the 15-minute transient on `md5(start|end|backend)` only. After a reconnect to a **different GA4 property** within the TTL, the previous property's analytics were served under the new property.

Fix: extracted `window_cache_key()`, which includes the resolved property ID. (Transients are already per-blog, so multisite isolation was intact; the property ID was the missing input.)

## Tests
- `missing_registered_dimensions()` — empty / `WP_Error` / definitive sets.
- `window_cache_key()` — varies by property, stable for the same property+window (both metric classes).
- Full Insights suite green: 24 tests / 59 assertions; PHPCS clean.

## Context
This is a post-merge follow-up; the source PRs are already merged. Auth & injection were reviewed and found clean (real `manage_options` callbacks; strict `Y-m-d` validation; server-side property ID). Findings are recall-biased — see NPPD-1669 for the full list and severities.