### PR TITLE
feat(insights): advertising metric orchestrator with GAM dispatch (NPPD-1663)

### DIFF
--- a/plugins/newspack-plugin/docs/insights/architecture.md
+++ b/plugins/newspack-plugin/docs/insights/architecture.md
@@ -88,6 +88,8 @@ Storage backend dispatch and multisite prefix handling are independent — a pub
 
 ## Caching strategy
 
+> **Updated 2026-06-09 — the custom-table design below was canceled (NPPD-1605).** It was scoped for the original architecture where publisher sites queried BigQuery directly. Under the NPPD-1630 (Manager BQ-proxy) direction it was retired in favor of caching the assembled JSON payload in **WP transients**. The shipped orchestrators cache per-window payloads in transients: Audience/Engagement (NPPD-1648) compute synchronously and cache; Advertising (NPPD-1663) caches and uses an Action Scheduler job to refresh out-of-band, since GAM reports are asynchronous (submit → poll → download). The original design is preserved below for reference.
+
 - **Custom table** `wp_newspack_insights_cache` with columns: `cache_key`, `query_hash`, `query_signature`, `tab`, `metric`, `payload JSON`, `computed_at`, `expires_at`, `last_accessed_at`. Rejected transients (wp_options bloat at scale, no observability).
 - **Action Scheduler pre-warm** — hourly job iterates registered metrics and refreshes the cache. newspack-plugin already depends on `woocommerce/action-scheduler` ^3.9, so no new infrastructure.
 - **Stale-while-revalidate** — admin UI reads only from cache. Served payload includes `computed_at` and a `stale` flag; if expired, an async refresh is fired and the stale payload is returned for the current request.
@@ -95,7 +97,7 @@ Storage backend dispatch and multisite prefix handling are independent — a pub
 - **Cost guardrail** — every query is dry-run first to estimate bytes; jobs over a configurable byte ceiling (default 10 GiB) are refused before execution. Audit log records `total_bytes_processed` for after-the-fact spend visibility.
 - **Expensive query refresh cadence** — cohort retention (Tab 3, Tab 7) and reader-author affinity (Tab 2) refresh weekly rather than hourly. The pre-warm job inspects each metric's `refresh_interval` annotation.
 
-See NPPD-1605 (cache table + read/write API + SWR logic) and NPPD-1606 (Action Scheduler pre-warm + cost guardrails) for implementation issues.
+NPPD-1605 (cache table + read/write API + SWR logic) was **canceled** — superseded by the NPPD-1630 proxy architecture; orchestrators now cache the assembled payload in WP transients. NPPD-1606 (Action Scheduler pre-warm + cost guardrails) tracked the BQ-proxy pre-warm side. The Advertising tab (NPPD-1663) does run an Action Scheduler refresh — but to populate a transient with async GAM report results, not the canceled custom table.
 
 ## Component approach
 

--- a/plugins/newspack-plugin/docs/insights/dev-notes.md
+++ b/plugins/newspack-plugin/docs/insights/dev-notes.md
@@ -65,3 +65,30 @@ The fixtures live at:
 They return the same `{ current, previous }` shape the live REST controllers
 assemble, and compute window/series dates relative to "today" so they never go
 stale. Edit them to change what the UI sees during smoke tests.
+
+## Advertising (Tab 8) fixture & render-path toggles
+
+Tab 8 reads Google Ad Manager via the async SOAP ReportService, so its fixture
+lives at
+`plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php`
+and is served by the Advertising REST controller when
+`NEWSPACK_INSIGHTS_FIXTURE_MODE` is on. Note the tab only registers when
+`NEWSPACK_INSIGHTS_ADVERTISING_ENABLED` is also defined and true.
+
+The fixture returns the live `get_all()` envelope shape (`is_tab_visible`,
+`is_report_ready`, `readiness_issues`, `metrics`, `data_as_of`,
+`has_estimated_data`, `estimated_window_start_date`, plus `compare` when
+comparison mode is on). All dates are computed at runtime.
+
+Exercise each render path with the `_fixture_state` query param on
+`/wp-json/newspack-insights/v1/advertising?start=…&end=…&_fixture_state=…`:
+
+- **`populated`** (default) — full scorecards (~2.4M impressions, $4,200
+  revenue, ~$1.75 eCPM, 87% fill, 64% viewability), 10 ad units, 8 advertisers,
+  5 countries, 3 device categories, and a 60/40 direct/programmatic split. Add
+  `compare_start`/`compare_end` to get the comparison payload (mixed +/- deltas).
+- **`not_ready`** — `is_report_ready: false` with both `oauth_scope_missing`
+  and `network_code_missing` in `readiness_issues`.
+- **`zero`** — a zero-impression window: scorecards read 0, tables are empty.
+- **`no_viewability`** — the viewability scorecard renders as an
+  `overlay: { type: 'data_unavailable' }` (publisher without Active View).

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Newspack Insights — Tab 8 Advertising REST controller (NPPD-1663).
+ *
+ * Single endpoint: `GET /newspack-insights/v1/advertising`. Same date-arg
+ * validation, permission check, and date parsing conventions as the Audience
+ * controller (NPPD-1648).
+ *
+ * Response shape:
+ *   current  — Advertising envelope for the requested window (is_tab_visible,
+ *              is_report_ready, readiness_issues, data_as_of, has_estimated_data,
+ *              estimated_window_start_date, metrics, plus is_loading/is_stale).
+ *   previous — same for the comparison window, or null.
+ *
+ * Data comes from {@see Advertising_Metric}, which reads a transient cache and
+ * schedules a background GAM refresh (Action Scheduler) on a miss/stale entry.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Advertising REST controller.
+ */
+class Advertising_REST_Controller extends WP_REST_Controller {
+
+	/**
+	 * Shared Insights namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'advertising';
+
+	/**
+	 * Register the Tab 8 route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_advertising_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET handler.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function get_advertising_data( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
+
+		try {
+			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
+			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+		}
+		if ( $start > $end ) {
+			return new WP_Error(
+				'newspack_insights_invalid_window',
+				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$compare_start_param = $request->get_param( 'compare_start' );
+		$compare_end_param   = $request->get_param( 'compare_end' );
+		$compare_start       = null;
+		$compare_end         = null;
+		if ( $compare_start_param || $compare_end_param ) {
+			if ( ! $compare_start_param || ! $compare_end_param ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison',
+					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+			try {
+				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
+				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+			}
+			if ( $compare_start > $compare_end ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison_window',
+					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		$compare = $compare_start && $compare_end;
+
+		// Dev smoke-test path: serve canned fixture data so the UI renders without
+		// a GAM connection. The optional _fixture_state param selects a render
+		// path (see dev-notes.md). Never enable in production.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			$variant = (string) ( $request->get_param( '_fixture_state' ) ?? 'populated' );
+			return rest_ensure_response(
+				Advertising_Metric::get_fixture( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), $compare, $variant )
+			);
+		}
+
+		return rest_ensure_response( $this->build_response( $start, $end, $compare_start, $compare_end ) );
+	}
+
+	/**
+	 * Assemble the top-level response.
+	 *
+	 * @param DateTimeImmutable      $start         Current window start.
+	 * @param DateTimeImmutable      $end           Current window end.
+	 * @param DateTimeImmutable|null $compare_start Prior window start.
+	 * @param DateTimeImmutable|null $compare_end   Prior window end.
+	 * @return array
+	 */
+	private function build_response(
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		?DateTimeImmutable $compare_start,
+		?DateTimeImmutable $compare_end
+	): array {
+		$response = [
+			'current'  => Advertising_Metric::get_all( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), false ),
+			'previous' => null,
+		];
+		if ( $compare_start && $compare_end ) {
+			$response['previous'] = Advertising_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );
+		}
+		return $response;
+	}
+
+	/**
+	 * Args spec.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$base = [
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+		];
+		return [
+			'start'         => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				]
+			),
+			'end'           => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				]
+			),
+			'compare_start' => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
+					'required'    => false,
+				]
+			),
+			'compare_end'   => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
+					'required'    => false,
+				]
+			),
+		];
+	}
+
+	/**
+	 * REST validate_callback.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool|WP_Error
+	 */
+	public function validate_date_string( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				/* translators: %s: the invalid date string */
+				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
+				[ 'status' => 400 ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Parse a Y-m-d string into a DateTimeImmutable.
+	 *
+	 * @param mixed        $value      Raw value.
+	 * @param DateTimeZone $tz         Timezone.
+	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
+	 * @return DateTimeImmutable
+	 * @throws Exception On parse failure.
+	 */
+	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			/* translators: %s: the invalid date string */
+			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
+		}
+		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
+	}
+
+	/**
+	 * Site timezone.
+	 *
+	 * @return DateTimeZone
+	 */
+	private function site_timezone(): DateTimeZone {
+		return wp_timezone();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -1,20 +1,25 @@
 <?php
 /**
- * Newspack Insights — Advertising section (NPPD-1602).
+ * Newspack Insights — Advertising section (NPPD-1602, data layer NPPD-1663).
  *
- * Advertising tab scope: GAM-driven ad performance. Impressions, fill
- * rate, eCPM, revenue by placement / ad unit. Requires GA4 to be
- * receiving GAM event data; visibility gated on GAM dataset presence
- * in the publisher's BigQuery export.
+ * Advertising tab scope: GAM-driven ad performance — impressions, revenue,
+ * eCPM, fill rate, viewability, and revenue/performance breakdowns. Reads
+ * Google Ad Manager live via the SOAP ReportService client (NPPD-1662), not
+ * BigQuery.
  *
- * Future REST endpoints for the Advertising tab register from
- * {@see self::register_hooks()}. Currently a stub; the React side renders
- * a "Coming soon" placeholder for this tab.
+ * The data layer (REST route + Action Scheduler refresh) registers from
+ * {@see self::register_hooks()} via {@see \Newspack\Insights\Advertising_REST_Controller}
+ * and {@see \Newspack\Insights\Advertising_Metric}. It is gated behind both the
+ * Insights flag and {@see Insights_Wizard::is_advertising_enabled()}, so the
+ * entire stack stays dormant (and Tab 8 invisible) unless explicitly enabled.
  *
  * @package Newspack
  */
 
 namespace Newspack;
+
+use Newspack\Insights\Advertising_REST_Controller;
+use Newspack\Insights\Advertising_Metric;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -31,18 +36,46 @@ class Insights_Section_Advertising {
 	const SECTION_NAME = 'Advertising';
 
 	/**
-	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1618).
+	 * Initialize. Loads the Tab 8 data layer and registers its REST route +
+	 * Action Scheduler refresh handler (NPPD-1663). No-op unless both the
+	 * Insights flag and the Advertising feature constant are enabled.
 	 */
 	public static function init() {
-		if ( ! Insights_Wizard::is_enabled() ) {
+		if ( ! Insights_Wizard::is_enabled() || ! Insights_Wizard::is_advertising_enabled() ) {
 			return;
 		}
+		self::load_dependencies();
 		self::register_hooks();
 	}
 
 	/**
-	 * Register hooks for this section. Currently a stub.
+	 * Include Tab 8 PHP files (metric orchestrator + REST controller), matching
+	 * the per-section include convention.
+	 *
+	 * @return void
 	 */
-	public static function register_hooks() {}
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'metrics/class-advertising-metric.php';
+		include_once $base . 'api/class-advertising-rest-controller.php';
+	}
+
+	/**
+	 * Register the Tab 8 REST route and the background refresh handler.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new Advertising_REST_Controller();
+				$controller->register_routes();
+			}
+		);
+		add_action(
+			Advertising_Metric::REFRESH_ACTION,
+			[ Advertising_Metric::class, 'run_scheduled_refresh' ]
+		);
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -99,6 +99,30 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
+	 * Whether the Advertising tab (Tab 8 / NPPD-1663) is enabled for this
+	 * environment.
+	 *
+	 * Independent from {@see self::is_enabled()} so the GAM-backed Advertising
+	 * orchestrator (its REST route and Action Scheduler refresh) only registers
+	 * where wanted, separately from the broader Insights rollout.
+	 *
+	 * @return bool True when Tab 8's data layer should be active.
+	 */
+	public static function is_advertising_enabled(): bool {
+		/**
+		 * Enables the Advertising tab (Tab 8) GAM orchestrator.
+		 *
+		 * @constant NEWSPACK_INSIGHTS_ADVERTISING_ENABLED
+		 * @type     bool
+		 * @default  Advertising tab disabled
+		 * @status   draft
+		 *
+		 * @example define( 'NEWSPACK_INSIGHTS_ADVERTISING_ENABLED', true );
+		 */
+		return defined( 'NEWSPACK_INSIGHTS_ADVERTISING_ENABLED' ) && NEWSPACK_INSIGHTS_ADVERTISING_ENABLED;
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * Bails before parent registration when the feature flag is disabled,

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -3,8 +3,10 @@
  * Newspack Insights — Advertising (Tab 8) fixture.
  *
  * Returns a callable that produces a realistic, date-relative Advertising
- * payload matching {@see \Newspack\Insights\Advertising_Metric::get_all()} for
- * UI smoke testing without a GAM connection. Served by the REST controller when
+ * payload for UI smoke testing without a GAM connection. The shape matches the
+ * live REST response — `{ current, previous }`, where each is the
+ * {@see \Newspack\Insights\Advertising_Metric::get_all()} envelope (and
+ * `previous` is null without comparison). Served by the REST controller when
  * NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
  *
  * Variants (via the `_fixture_state` query param — see dev-notes.md):
@@ -282,7 +284,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 
 	// Not-ready render path: tab visible, reporting not ready, both issues.
 	if ( 'not_ready' === $variant ) {
-		return [
+		$not_ready = [
 			'window'                      => [
 				'start' => $start_date,
 				'end'   => $end_date,
@@ -306,6 +308,11 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 			'has_estimated_data'          => false,
 			'estimated_window_start_date' => null,
 		];
+
+		return [
+			'current'  => $not_ready,
+			'previous' => null,
+		];
 	}
 
 	$envelope = [
@@ -322,6 +329,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		'estimated_window_start_date' => $est_start,
 	];
 
+	$previous = null;
 	if ( $compare ) {
 		// Comparison window = the immediately-preceding window of equal length.
 		try {
@@ -337,14 +345,23 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 
 		// 0.85 scale → current is higher on volume (positive deltas) while a few
 		// per-row figures land lower, exercising both delta directions.
-		$envelope['compare'] = [
-			'window'  => [
+		$previous = [
+			'window'                      => [
 				'start' => $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start,
 				'end'   => $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end,
 			],
-			'metrics' => $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant ),
+			'is_tab_visible'              => true,
+			'is_report_ready'             => true,
+			'readiness_issues'            => [],
+			'metrics'                     => $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant ),
+			'data_as_of'                  => $data_as_of,
+			'has_estimated_data'          => true,
+			'estimated_window_start_date' => $est_start,
 		];
 	}
 
-	return $envelope;
+	return [
+		'current'  => $envelope,
+		'previous' => $previous,
+	];
 };

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -323,12 +323,24 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 	];
 
 	if ( $compare ) {
+		// Comparison window = the immediately-preceding window of equal length.
+		try {
+			$start       = new DateTimeImmutable( $start_date, $tz );
+			$end         = new DateTimeImmutable( $end_date, $tz );
+			$length_days = (int) $start->diff( $end )->format( '%a' ) + 1;
+			$prior_end   = $start->modify( '-1 day' );
+			$prior_start = $prior_end->modify( '-' . ( $length_days - 1 ) . ' days' );
+		} catch ( Exception $e ) {
+			$prior_start = $start_date;
+			$prior_end   = $end_date;
+		}
+
 		// 0.85 scale → current is higher on volume (positive deltas) while a few
 		// per-row figures land lower, exercising both delta directions.
 		$envelope['compare'] = [
 			'window'  => [
-				'start' => $start_date,
-				'end'   => $end_date,
+				'start' => $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start,
+				'end'   => $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end,
 			],
 			'metrics' => $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant ),
 		];

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * Newspack Insights — Advertising (Tab 8) fixture.
+ *
+ * Returns a callable that produces a realistic, date-relative Advertising
+ * payload matching {@see \Newspack\Insights\Advertising_Metric::get_all()} for
+ * UI smoke testing without a GAM connection. Served by the REST controller when
+ * NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
+ *
+ * Variants (via the `_fixture_state` query param — see dev-notes.md):
+ *   populated       — full scorecards + tables + direct/programmatic split.
+ *   not_ready       — is_report_ready false; both readiness issues present.
+ *   zero            — zero-impression window: scorecards 0, tables empty.
+ *   no_viewability  — viewability scorecard as a data_unavailable overlay.
+ *
+ * All dates are computed at runtime so the fixture never goes stale.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return function ( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated' ): array {
+	$tz         = wp_timezone();
+	$today      = new DateTimeImmutable( 'today', $tz );
+	$data_as_of = $today->modify( '-7 days' )->format( 'Y-m-d' );
+	$est_start  = $today->modify( '-7 days' )->format( 'Y-m-d' );
+
+	/**
+	 * Build a single window's metric set, scaled so comparison windows can
+	 * differ and produce both positive and negative deltas.
+	 *
+	 * @param float $scale Multiplier applied to the baseline numbers.
+	 * @param string $window_variant Variant for this window.
+	 * @return array
+	 */
+	$metrics = function ( float $scale, string $window_variant ): array {
+		if ( 'zero' === $window_variant ) {
+			return [
+				'total_impressions'      => [
+					'value'      => 0,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'total_revenue'          => [
+					'value'      => 0.0,
+					'computable' => true,
+					'type'       => 'currency',
+				],
+				'avg_ecpm'               => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'currency',
+					'numerator'   => 0.0,
+					'denominator' => 0,
+				],
+				'fill_rate'              => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'rate',
+					'numerator'   => 0,
+					'denominator' => 0,
+				],
+				'viewability_rate'       => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'rate',
+					'numerator'   => 0,
+					'denominator' => 0,
+				],
+				'direct_vs_programmatic' => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'breakdown',
+				],
+				'top_ad_units'           => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+				'top_advertisers'        => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+				'performance_by_device'  => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+				'top_countries'          => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+			];
+		}
+
+		$impressions = (int) round( 2400000 * $scale );
+		$coded       = (int) round( $impressions * 0.87 );
+		$revenue     = round( 4200.0 * $scale, 2 );
+		$ecpm        = $coded > 0 ? round( ( $revenue / $coded ) * 1000, 2 ) : 0.0;
+
+		$viewability = 'no_viewability' === $window_variant
+			? [
+				'value'      => null,
+				'computable' => false,
+				'overlay'    => [ 'type' => 'data_unavailable' ],
+			]
+			: [
+				'value'       => 0.64,
+				'computable'  => true,
+				'type'        => 'rate',
+				'numerator'   => (int) round( $coded * 0.64 ),
+				'denominator' => $coded,
+			];
+
+		$ad_units = [];
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$unit_rev = round( ( $revenue / 14 ) * ( 11 - $i ), 2 );
+			$unit_imp = (int) round( ( $impressions / 14 ) * ( 11 - $i ) );
+			$ad_units[] = [
+				'ad_unit'     => sprintf( 'Ad Unit %02d', $i ),
+				'impressions' => $unit_imp,
+				'revenue'     => $unit_rev,
+				'ecpm'        => $unit_imp > 0 ? round( ( $unit_rev / $unit_imp ) * 1000, 2 ) : 0.0,
+				'ctr'         => round( 0.004 - ( $i * 0.0002 ), 4 ),
+			];
+		}
+
+		$advertisers = [];
+		for ( $i = 1; $i <= 8; $i++ ) {
+			$adv_rev = round( ( $revenue * 0.6 / 9 ) * ( 9 - $i ), 2 );
+			$advertisers[] = [
+				'advertiser'  => sprintf( 'Advertiser %d', $i ),
+				'impressions' => (int) round( ( $impressions * 0.6 / 9 ) * ( 9 - $i ) ),
+				'revenue'     => $adv_rev,
+			];
+		}
+
+		$devices = [
+			[
+				'device' => 'Smartphone',
+				'share'  => 0.58,
+			],
+			[
+				'device' => 'Desktop',
+				'share'  => 0.34,
+			],
+			[
+				'device' => 'Tablet',
+				'share'  => 0.08,
+			],
+		];
+		$device_rows = array_map(
+			function ( $d ) use ( $impressions, $revenue, $coded ) {
+				$imp = (int) round( $impressions * $d['share'] );
+				$rev = round( $revenue * $d['share'], 2 );
+				$cod = (int) round( $coded * $d['share'] );
+				return [
+					'device'      => $d['device'],
+					'impressions' => $imp,
+					'revenue'     => $rev,
+					'ecpm'        => $cod > 0 ? round( ( $rev / $cod ) * 1000, 2 ) : 0.0,
+					'ctr'         => 0.003,
+				];
+			},
+			$devices
+		);
+
+		$countries = [
+			[
+				'country' => 'United States',
+				'share'   => 0.82,
+			],
+			[
+				'country' => 'Canada',
+				'share'   => 0.07,
+			],
+			[
+				'country' => 'United Kingdom',
+				'share'   => 0.05,
+			],
+			[
+				'country' => 'Mexico',
+				'share'   => 0.04,
+			],
+			[
+				'country' => 'Germany',
+				'share'   => 0.02,
+			],
+		];
+		$country_rows = array_map(
+			function ( $c ) use ( $impressions, $revenue, $coded ) {
+				$imp = (int) round( $impressions * $c['share'] );
+				$rev = round( $revenue * $c['share'], 2 );
+				$cod = (int) round( $coded * $c['share'] );
+				return [
+					'country'     => $c['country'],
+					'impressions' => $imp,
+					'revenue'     => $rev,
+					'ecpm'        => $cod > 0 ? round( ( $rev / $cod ) * 1000, 2 ) : 0.0,
+				];
+			},
+			$countries
+		);
+
+		return [
+			'total_impressions'      => [
+				'value'      => $impressions,
+				'computable' => true,
+				'type'       => 'count',
+			],
+			'total_revenue'          => [
+				'value'      => $revenue,
+				'computable' => true,
+				'type'       => 'currency',
+			],
+			'avg_ecpm'               => [
+				'value'       => $ecpm,
+				'computable'  => true,
+				'type'        => 'currency',
+				'numerator'   => $revenue,
+				'denominator' => $coded,
+			],
+			'fill_rate'              => [
+				'value'       => 0.87,
+				'computable'  => true,
+				'type'        => 'rate',
+				'numerator'   => $coded,
+				'denominator' => $impressions,
+			],
+			'viewability_rate'       => $viewability,
+			'direct_vs_programmatic' => [
+				'rows'       => [
+					[
+						'label'       => 'direct',
+						'revenue'     => round( $revenue * 0.6, 2 ),
+						'impressions' => (int) round( $impressions * 0.55 ),
+					],
+					[
+						'label'       => 'programmatic',
+						'revenue'     => round( $revenue * 0.4, 2 ),
+						'impressions' => (int) round( $impressions * 0.45 ),
+					],
+					[
+						'label'       => 'house',
+						'revenue'     => 0.0,
+						'impressions' => (int) round( $impressions * 0.02 ),
+					],
+					[
+						'label'       => 'other',
+						'revenue'     => 0.0,
+						'impressions' => 0,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			'top_ad_units'           => [
+				'rows'       => $ad_units,
+				'computable' => true,
+				'type'       => 'table',
+			],
+			'top_advertisers'        => [
+				'rows'       => $advertisers,
+				'computable' => true,
+				'type'       => 'table',
+			],
+			'performance_by_device'  => [
+				'rows'       => $device_rows,
+				'computable' => true,
+				'type'       => 'table',
+			],
+			'top_countries'          => [
+				'rows'       => $country_rows,
+				'computable' => true,
+				'type'       => 'table',
+			],
+		];
+	};
+
+	// Not-ready render path: tab visible, reporting not ready, both issues.
+	if ( 'not_ready' === $variant ) {
+		return [
+			'window'                      => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			'is_tab_visible'              => true,
+			'is_report_ready'             => false,
+			'readiness_issues'            => [
+				[
+					'code'            => 'oauth_scope_missing',
+					'message'         => __( 'Your Google connection is missing the Ad Manager scope. Reconnect Google to grant it.', 'newspack-plugin' ),
+					'remediation_url' => admin_url( 'admin.php?page=newspack-settings' ),
+				],
+				[
+					'code'            => 'network_code_missing',
+					'message'         => __( 'No Google Ad Manager network is configured.', 'newspack-plugin' ),
+					'remediation_url' => admin_url( 'admin.php?page=newspack-advertising' ),
+				],
+			],
+			'metrics'                     => [],
+			'data_as_of'                  => $data_as_of,
+			'has_estimated_data'          => false,
+			'estimated_window_start_date' => null,
+		];
+	}
+
+	$envelope = [
+		'window'                      => [
+			'start' => $start_date,
+			'end'   => $end_date,
+		],
+		'is_tab_visible'              => true,
+		'is_report_ready'             => true,
+		'readiness_issues'            => [],
+		'metrics'                     => $metrics( 1.0, $variant ),
+		'data_as_of'                  => $data_as_of,
+		'has_estimated_data'          => true,
+		'estimated_window_start_date' => $est_start,
+	];
+
+	if ( $compare ) {
+		// 0.85 scale → current is higher on volume (positive deltas) while a few
+		// per-row figures land lower, exercising both delta directions.
+		$envelope['compare'] = [
+			'window'  => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			'metrics' => $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant ),
+		];
+	}
+
+	return $envelope;
+};

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -1,0 +1,1081 @@
+<?php
+/**
+ * Newspack Insights — Advertising Metric orchestrator (Tab 8, NPPD-1663).
+ *
+ * Publisher-side equivalent of the Audience/Engagement orchestrators
+ * (NPPD-1648), but the data source is Google Ad Manager via the SOAP
+ * ReportService client landed in NPPD-1662 ({@see \Newspack\Insights\GAM\Client}).
+ *
+ * Unlike GA4 (fast, synchronous), GAM reports are asynchronous jobs that can
+ * take seconds to minutes (submit -> poll -> download -> parse). They therefore
+ * never run inside a web request. Instead:
+ *   - {@see self::get_all()} reads a transient cache and, on a missing/stale
+ *     entry, schedules the {@see self::REFRESH_ACTION} Action Scheduler job and
+ *     returns the (stale or loading) payload immediately (stale-while-revalidate).
+ *   - {@see self::run_scheduled_refresh()} (the Action Scheduler handler) runs
+ *     every metric's report end-to-end and writes the window payload to cache.
+ *
+ * Caching uses WP transients to match the NPPD-1648 orchestrators. (The original
+ * architecture's custom `wp_newspack_insights_cache` SWR table — NPPD-1605 — was
+ * canceled; see architecture.md.)
+ *
+ * GAM revenue columns are micro-currency; normalization to standard currency
+ * happens at this layer's boundary so the UI never receives micros.
+ *
+ * Enum names (columns/dimensions/line-item types) are the documented v202602
+ * ReportService names and remain pending verification against a real publisher
+ * network (NPPD-1666).
+ *
+ * Payload shapes mirror the Audience orchestrator:
+ *   scalar  : { value, computable, type: count|currency|decimal }
+ *   rate    : { value (0-1), computable, type: rate, numerator, denominator }
+ *   rows    : { rows: [...], computable, type: breakdown|table|timeseries }
+ *   overlay : { value: null, computable: false, overlay: { type } }
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+use Newspack\Insights\GAM\Client;
+use Newspack\Insights\GAM\Report_Query;
+use Newspack\Insights\GAM\Report_Job_Status;
+use Newspack\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Advertising (Tab 8) metric orchestrator.
+ *
+ * Not `final` (unlike the Audience/Engagement orchestrators): the GAM-touching
+ * {@see self::run_gam_report()} seam is `protected` and called via `static::`
+ * so unit tests can subclass and inject canned report rows per metric (the GAM
+ * Client is `final` + static and cannot otherwise be mocked).
+ */
+class Advertising_Metric {
+
+	const CACHE_KEY_PREFIX = 'newspack_insights_advertising_v1:';
+	const CACHE_FRESH_TTL  = 30 * MINUTE_IN_SECONDS;
+	const CACHE_HARD_TTL   = DAY_IN_SECONDS;
+
+	const REFRESH_ACTION = 'newspack_insights_advertising_refresh';
+	const REFRESH_GROUP  = 'newspack-insights';
+
+	const AUDIT_LOG_OPTION = 'newspack_insights_advertising_audit_log';
+	const AUDIT_LOG_MAX    = 500;
+	const LOGGER_HEADER    = 'NEWSPACK-INSIGHTS-ADVERTISING';
+
+	/**
+	 * Per-report poll backoff (seconds) and overall ceiling per report job.
+	 */
+	const POLL_BACKOFF_SECONDS = [ 1, 2, 4, 8, 16, 30 ];
+	const POLL_MAX_SECONDS     = 300;
+
+	/**
+	 * GAM data lag: figures for the most recent N days are estimated until AdX
+	 * clears. Drives the "data as of" / estimated-window indicators.
+	 */
+	const ESTIMATED_LAG_DAYS = 7;
+
+	/*
+	 * GAM v202602 ReportService column/dimension enum names. Pending NPPD-1666
+	 * verification against a real publisher network.
+	 */
+	const COL_IMPRESSIONS   = 'TOTAL_IMPRESSIONS';
+	const COL_REVENUE       = 'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE';
+	const COL_CODED         = 'TOTAL_CODE_SERVED_COUNT';
+	const COL_CLICKS        = 'TOTAL_LINE_ITEM_LEVEL_CLICKS';
+	const COL_AV_VIEWABLE   = 'TOTAL_ACTIVE_VIEW_VIEWABLE_IMPRESSIONS';
+	const COL_AV_MEASURABLE = 'TOTAL_ACTIVE_VIEW_MEASURABLE_IMPRESSIONS';
+
+	const DIM_LINE_ITEM_TYPE  = 'LINE_ITEM_TYPE';
+	const DIM_AD_UNIT_NAME    = 'AD_UNIT_NAME';
+	const DIM_ADVERTISER_NAME = 'ADVERTISER_NAME';
+	const DIM_DEVICE          = 'DEVICE_CATEGORY_NAME';
+	const DIM_COUNTRY         = 'COUNTRY_NAME';
+
+	const DIRECT_LINE_ITEM_TYPES       = [ 'SPONSORSHIP', 'STANDARD', 'BULK', 'PRICE_PRIORITY' ];
+	const PROGRAMMATIC_LINE_ITEM_TYPES = [ 'NETWORK', 'AD_EXCHANGE' ];
+
+	/*
+	 * Visibility / readiness
+	 */
+
+	/**
+	 * Whether Tab 8 should be visible: Google Ad Manager active on the site.
+	 *
+	 * @return bool
+	 */
+	public static function is_tab_visible(): bool {
+		return Client::is_gam_active();
+	}
+
+	/**
+	 * Whether a report can actually be run (GAM active + OAuth scope + network
+	 * code). Performs the OAuth scope check; call deliberately, not in a loop.
+	 *
+	 * @return bool
+	 */
+	public static function is_report_ready(): bool {
+		return Client::can_run_reports();
+	}
+
+	/**
+	 * Specific reasons reporting isn't ready, for the UI to render guidance.
+	 * Empty array when ready. Both issues can be present simultaneously.
+	 *
+	 * @return array<int,array<string,string>>
+	 */
+	public static function readiness_issues(): array {
+		if ( self::is_report_ready() ) {
+			return [];
+		}
+		$issues = [];
+		if ( ! self::has_admanager_scope() ) {
+			$issues[] = [
+				'code'            => 'oauth_scope_missing',
+				'message'         => __( 'Your Google connection is missing the Ad Manager scope. Reconnect Google to grant it.', 'newspack-plugin' ),
+				'remediation_url' => admin_url( 'admin.php?page=newspack-settings' ),
+			];
+		}
+		if ( '' === self::resolve_network_code() ) {
+			$issues[] = [
+				'code'            => 'network_code_missing',
+				'message'         => __( 'No Google Ad Manager network is configured.', 'newspack-plugin' ),
+				'remediation_url' => admin_url( 'admin.php?page=newspack-advertising' ),
+			];
+		}
+		return $issues;
+	}
+
+	/**
+	 * Whether the saved Google OAuth token carries the GAM scope.
+	 *
+	 * Resolved here (rather than on the Client, whose accessor is protected) so
+	 * this PR stays scoped to new files; mirrors Client::has_gam_scope().
+	 *
+	 * @return bool
+	 */
+	private static function has_admanager_scope(): bool {
+		return class_exists( '\Newspack\Google_OAuth' )
+			&& \Newspack\Google_OAuth::token_has_scope( Client::GAM_SCOPE );
+	}
+
+	/**
+	 * Resolve the publisher's GAM network code, server-side. Mirrors the
+	 * Client's resolution (its accessor is protected).
+	 *
+	 * @return string Network code, or '' if none.
+	 */
+	private static function resolve_network_code(): string {
+		if ( class_exists( '\Newspack_Ads\Providers\GAM_Model' ) ) {
+			$code = \Newspack_Ads\Providers\GAM_Model::get_active_network_code();
+		} else {
+			$code = get_option( '_newspack_ads_gam_network_code', '' );
+		}
+		if ( is_string( $code ) && false !== strpos( $code, ',' ) ) {
+			$parts = explode( ',', $code );
+			$code  = trim( $parts[0] );
+		}
+		return (string) $code;
+	}
+
+	/*
+	 * Public tab payload
+	 */
+
+	/**
+	 * Full Tab 8 payload for a window. Reads cache; schedules a background
+	 * refresh on a missing/stale entry (stale-while-revalidate). Never runs GAM
+	 * reports synchronously.
+	 *
+	 * @param string $start_date YYYY-MM-DD (site timezone).
+	 * @param string $end_date   YYYY-MM-DD (site timezone).
+	 * @param bool   $compare    Whether to attach the prior-period payload.
+	 * @return array
+	 */
+	public static function get_all( string $start_date, string $end_date, bool $compare = false ): array {
+		$envelope = [
+			'window'           => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			'is_tab_visible'   => self::is_tab_visible(),
+			'is_report_ready'  => self::is_report_ready(),
+			'readiness_issues' => self::readiness_issues(),
+		];
+
+		// Not connected enough to report: return the envelope so the UI can show
+		// the tab (if visible) with a "finish connecting" diagnostic. Don't
+		// schedule a refresh that would just be skipped.
+		if ( ! $envelope['is_tab_visible'] || ! $envelope['is_report_ready'] ) {
+			return array_merge( $envelope, self::empty_window( $start_date, $end_date ), [ 'is_report_ready' => $envelope['is_report_ready'] ] );
+		}
+
+		$window = self::read_window( $start_date, $end_date );
+		$envelope = array_merge( $envelope, $window );
+
+		if ( $compare ) {
+			[ $prior_start, $prior_end ] = self::prior_period( $start_date, $end_date );
+			$compare_window              = self::read_window( $prior_start, $prior_end );
+			$envelope['compare']         = $compare_window;
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Realistic fixture payload for UI smoke testing without a GAM connection.
+	 * Served by the REST controller when NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @param bool   $compare    Whether to attach the comparison payload.
+	 * @param string $variant    Render-path variant: populated|not_ready|zero|no_viewability.
+	 * @return array
+	 */
+	public static function get_fixture( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated' ): array {
+		$fixture = require NEWSPACK_ABSPATH . 'includes/wizards/insights/fixtures/advertising-fixture.php';
+		return $fixture( $start_date, $end_date, $compare, $variant );
+	}
+
+	/*
+	 * Cache (transient SWR) + Action Scheduler refresh
+	 */
+
+	/**
+	 * Read a window's cached payload, scheduling a background refresh when the
+	 * entry is missing (loading) or stale (stale-while-revalidate).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array Window payload with `is_loading` / `is_stale` flags as relevant.
+	 */
+	private static function read_window( string $start_date, string $end_date ): array {
+		$cached = get_transient( self::cache_key( $start_date, $end_date ) );
+
+		if ( ! is_array( $cached ) || ! isset( $cached['payload'], $cached['computed_at'] ) ) {
+			self::schedule_refresh( $start_date, $end_date );
+			$window               = self::empty_window( $start_date, $end_date );
+			$window['is_loading'] = true;
+			return $window;
+		}
+
+		$window = $cached['payload'];
+		if ( ( time() - (int) $cached['computed_at'] ) > self::CACHE_FRESH_TTL ) {
+			self::schedule_refresh( $start_date, $end_date );
+			$window['is_stale'] = true;
+		}
+		return $window;
+	}
+
+	/**
+	 * Window cache key, scoped to the network code so a reconnect to a different
+	 * network never serves the previous network's cached payload.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string
+	 */
+	private static function cache_key( string $start_date, string $end_date ): string {
+		return self::CACHE_KEY_PREFIX . md5( self::resolve_network_code() . '|' . $start_date . '|' . $end_date );
+	}
+
+	/**
+	 * Schedule a one-off background refresh for a window if one isn't already
+	 * pending. No-op if Action Scheduler isn't available.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return void
+	 */
+	private static function schedule_refresh( string $start_date, string $end_date ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		$args = [
+			'start' => $start_date,
+			'end'   => $end_date,
+		];
+		if ( as_has_scheduled_action( self::REFRESH_ACTION, [ $args ], self::REFRESH_GROUP ) ) {
+			return;
+		}
+		as_schedule_single_action( time(), self::REFRESH_ACTION, [ $args ], self::REFRESH_GROUP );
+	}
+
+	/**
+	 * Action Scheduler handler: run every metric's report for the window and
+	 * write the result to cache. Skips cleanly (leaving any existing cache in
+	 * place) when reporting isn't ready.
+	 *
+	 * @param array $args [ 'start' => YYYY-MM-DD, 'end' => YYYY-MM-DD ].
+	 * @return void
+	 */
+	public static function run_scheduled_refresh( $args ): void {
+		$start_date = is_array( $args ) ? (string) ( $args['start'] ?? '' ) : '';
+		$end_date   = is_array( $args ) ? (string) ( $args['end'] ?? '' ) : '';
+		if ( '' === $start_date || '' === $end_date ) {
+			return;
+		}
+
+		// Never run GAM reports when not ready; leave previous cache untouched.
+		if ( ! self::is_report_ready() ) {
+			return;
+		}
+
+		$metrics = self::compute_window( $start_date, $end_date );
+
+		// If every metric failed (e.g. transient GAM/network outage), keep the
+		// previous payload rather than overwriting good data with errors.
+		if ( self::all_failed( $metrics ) && false !== get_transient( self::cache_key( $start_date, $end_date ) ) ) {
+			return;
+		}
+
+		$lag    = self::data_lag_info( $end_date );
+		$window = array_merge(
+			[
+				'window'      => [
+					'start' => $start_date,
+					'end'   => $end_date,
+				],
+				'metrics'     => $metrics,
+				'computed_at' => gmdate( 'c' ),
+			],
+			$lag
+		);
+
+		set_transient(
+			self::cache_key( $start_date, $end_date ),
+			[
+				'computed_at' => time(),
+				'payload'     => $window,
+			],
+			self::CACHE_HARD_TTL
+		);
+	}
+
+	/**
+	 * Compute every Tab 8 metric for a window (the expensive, GAM-touching path
+	 * run from the background job).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array<string,array> Keyed metric payloads.
+	 */
+	private static function compute_window( string $start_date, string $end_date ): array {
+		return [
+			'total_impressions'      => self::total_impressions( $start_date, $end_date ),
+			'total_revenue'          => self::total_revenue( $start_date, $end_date ),
+			'avg_ecpm'               => self::avg_ecpm( $start_date, $end_date ),
+			'fill_rate'              => self::fill_rate( $start_date, $end_date ),
+			'viewability_rate'       => self::viewability_rate( $start_date, $end_date ),
+			'direct_vs_programmatic' => self::direct_vs_programmatic( $start_date, $end_date ),
+			'top_ad_units'           => self::top_ad_units( $start_date, $end_date ),
+			'top_advertisers'        => self::top_advertisers( $start_date, $end_date ),
+			'performance_by_device'  => self::performance_by_device( $start_date, $end_date ),
+			'top_countries'          => self::top_countries( $start_date, $end_date ),
+		];
+	}
+
+	/*
+	 * Metric methods (one per formula-doc metric). Each runs a GAM report
+	 * end-to-end and returns a MetricCard-shaped payload. Invoked from the
+	 * background refresh, never synchronously in a request.
+	 */
+
+	/**
+	 * Total Impressions (window).
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function total_impressions( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'columns'    => [ self::COL_IMPRESSIONS ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				] 
+			) 
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		return self::scalar_count( self::sum_column( $rows['rows'], self::COL_IMPRESSIONS ) );
+	}
+
+	/**
+	 * Total Revenue (window), normalized from micros.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function total_revenue( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'columns'    => [ self::COL_REVENUE ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				] 
+			) 
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$revenue = Client::normalize_currency_micros( self::sum_column( $rows['rows'], self::COL_REVENUE ) );
+		return [
+			'value'      => $revenue,
+			'computable' => true,
+			'type'       => 'currency',
+		];
+	}
+
+	/**
+	 * Average eCPM — revenue (normalized) / coded impressions * 1000.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function avg_ecpm( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'columns'    => [ self::COL_REVENUE, self::COL_CODED ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				] 
+			) 
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$revenue = Client::normalize_currency_micros( self::sum_column( $rows['rows'], self::COL_REVENUE ) );
+		$coded   = self::sum_column( $rows['rows'], self::COL_CODED );
+		return [
+			'value'       => $coded > 0 ? ( $revenue / $coded ) * 1000 : 0.0,
+			'computable'  => $coded > 0,
+			'type'        => 'currency',
+			'numerator'   => $revenue,
+			'denominator' => $coded,
+		];
+	}
+
+	/**
+	 * Fill Rate — coded impressions / total impressions.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function fill_rate( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'columns'    => [ self::COL_CODED, self::COL_IMPRESSIONS ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				] 
+			) 
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$coded = self::sum_column( $rows['rows'], self::COL_CODED );
+		$total = self::sum_column( $rows['rows'], self::COL_IMPRESSIONS );
+		return [
+			'value'       => $total > 0 ? min( 1.0, $coded / $total ) : 0.0,
+			'computable'  => $total > 0,
+			'type'        => 'rate',
+			'numerator'   => $coded,
+			'denominator' => $total,
+		];
+	}
+
+	/**
+	 * Viewability Rate — Active View viewable / measurable. Degrades to a
+	 * data_unavailable overlay when the network has no Active View data.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function viewability_rate( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'columns'    => [ self::COL_AV_VIEWABLE, self::COL_AV_MEASURABLE ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				] 
+			) 
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$measurable = self::sum_column( $rows['rows'], self::COL_AV_MEASURABLE );
+		if ( $measurable <= 0 ) {
+			return [
+				'value'      => null,
+				'computable' => false,
+				'overlay'    => [ 'type' => 'data_unavailable' ],
+			];
+		}
+		$viewable = self::sum_column( $rows['rows'], self::COL_AV_VIEWABLE );
+		return [
+			'value'       => min( 1.0, $viewable / $measurable ),
+			'computable'  => true,
+			'type'        => 'rate',
+			'numerator'   => $viewable,
+			'denominator' => $measurable,
+		];
+	}
+
+	/**
+	 * Direct vs Programmatic split — bucket LINE_ITEM_TYPE into direct / house /
+	 * programmatic / other, by revenue and impressions.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function direct_vs_programmatic( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions' => [ self::DIM_LINE_ITEM_TYPE ],
+					'columns'    => [ self::COL_REVENUE, self::COL_IMPRESSIONS ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$buckets = [
+			'direct'       => [
+				'revenue'     => 0.0,
+				'impressions' => 0,
+			],
+			'house'        => [
+				'revenue'     => 0.0,
+				'impressions' => 0,
+			],
+			'programmatic' => [
+				'revenue'     => 0.0,
+				'impressions' => 0,
+			],
+			'other'        => [
+				'revenue'     => 0.0,
+				'impressions' => 0,
+			],
+		];
+		foreach ( $rows['rows'] as $row ) {
+			$type    = strtoupper( (string) self::cell( $row, self::DIM_LINE_ITEM_TYPE ) );
+			$bucket  = self::line_item_bucket( $type );
+			$buckets[ $bucket ]['revenue']     += Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) );
+			$buckets[ $bucket ]['impressions'] += (int) self::cell_number( $row, self::COL_IMPRESSIONS );
+		}
+		$out = [];
+		foreach ( $buckets as $label => $vals ) {
+			$out[] = [
+				'label'       => $label,
+				'revenue'     => $vals['revenue'],
+				'impressions' => $vals['impressions'],
+			];
+		}
+		$total = array_sum( array_column( $out, 'revenue' ) );
+		return [
+			'rows'       => $out,
+			'computable' => $total > 0,
+			'type'       => 'breakdown',
+		];
+	}
+
+	/**
+	 * Top Ad Units by revenue.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function top_ad_units( string $s, string $e, int $limit = 25 ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions' => [ self::DIM_AD_UNIT_NAME ],
+					'columns'    => [ self::COL_IMPRESSIONS, self::COL_REVENUE, self::COL_CODED, self::COL_CLICKS ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$out = [];
+		foreach ( $rows['rows'] as $row ) {
+			$impressions = (int) self::cell_number( $row, self::COL_IMPRESSIONS );
+			$revenue     = Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) );
+			$coded       = (int) self::cell_number( $row, self::COL_CODED );
+			$clicks      = (int) self::cell_number( $row, self::COL_CLICKS );
+			$out[]       = [
+				'ad_unit'     => (string) self::cell( $row, self::DIM_AD_UNIT_NAME ),
+				'impressions' => $impressions,
+				'revenue'     => $revenue,
+				'ecpm'        => $coded > 0 ? ( $revenue / $coded ) * 1000 : 0.0,
+				'ctr'         => $coded > 0 ? $clicks / $coded : 0.0,
+			];
+		}
+		return self::rank_table( $out, 'revenue', $limit );
+	}
+
+	/**
+	 * Top Advertisers by revenue — direct-sold line item types only.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function top_advertisers( string $s, string $e, int $limit = 25 ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions' => [ self::DIM_ADVERTISER_NAME ],
+					'columns'    => [ self::COL_IMPRESSIONS, self::COL_REVENUE ],
+					'pql_filter' => self::direct_sold_pql_filter(),
+					'start_date' => $s,
+					'end_date'   => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$out = [];
+		foreach ( $rows['rows'] as $row ) {
+			$out[] = [
+				'advertiser'  => (string) self::cell( $row, self::DIM_ADVERTISER_NAME ),
+				'impressions' => (int) self::cell_number( $row, self::COL_IMPRESSIONS ),
+				'revenue'     => Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) ),
+			];
+		}
+		return self::rank_table( $out, 'revenue', $limit );
+	}
+
+	/**
+	 * Performance by Device.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function performance_by_device( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions' => [ self::DIM_DEVICE ],
+					'columns'    => [ self::COL_IMPRESSIONS, self::COL_REVENUE, self::COL_CODED, self::COL_CLICKS ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$out = [];
+		foreach ( $rows['rows'] as $row ) {
+			$revenue = Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) );
+			$coded   = (int) self::cell_number( $row, self::COL_CODED );
+			$clicks  = (int) self::cell_number( $row, self::COL_CLICKS );
+			$out[]   = [
+				'device'      => (string) self::cell( $row, self::DIM_DEVICE ),
+				'impressions' => (int) self::cell_number( $row, self::COL_IMPRESSIONS ),
+				'revenue'     => $revenue,
+				'ecpm'        => $coded > 0 ? ( $revenue / $coded ) * 1000 : 0.0,
+				'ctr'         => $coded > 0 ? $clicks / $coded : 0.0,
+			];
+		}
+		return self::rank_table( $out, 'revenue', count( $out ) );
+	}
+
+	/**
+	 * Top Countries by revenue.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function top_countries( string $s, string $e, int $limit = 25 ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions' => [ self::DIM_COUNTRY ],
+					'columns'    => [ self::COL_IMPRESSIONS, self::COL_REVENUE, self::COL_CODED ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$out = [];
+		foreach ( $rows['rows'] as $row ) {
+			$revenue = Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) );
+			$coded   = (int) self::cell_number( $row, self::COL_CODED );
+			$out[]   = [
+				'country'     => (string) self::cell( $row, self::DIM_COUNTRY ),
+				'impressions' => (int) self::cell_number( $row, self::COL_IMPRESSIONS ),
+				'revenue'     => $revenue,
+				'ecpm'        => $coded > 0 ? ( $revenue / $coded ) * 1000 : 0.0,
+			];
+		}
+		return self::rank_table( $out, 'revenue', $limit );
+	}
+
+	/*
+	 * GAM report execution + parsing helpers
+	 */
+
+	/**
+	 * Run a GAM report end-to-end: submit -> poll (backoff) -> download -> parse.
+	 * Returns `{ rows: array }` on success, or a `{ error }` / `{ overlay }`
+	 * payload-shaped failure. Audit-logs the submission with metric context.
+	 *
+	 * @param Report_Query $query The report query.
+	 * @return array
+	 */
+	protected static function run_gam_report( Report_Query $query ): array {
+		$network_code = self::resolve_network_code();
+		if ( '' === $network_code ) {
+			return self::error_payload( __( 'No Google Ad Manager network is configured.', 'newspack-plugin' ) );
+		}
+
+		try {
+			$job_id = Client::run_report_job( $network_code, $query );
+			self::audit( $network_code, $query, $job_id, true );
+
+			$status = self::poll_until_terminal( $network_code, $job_id );
+			if ( Report_Job_Status::COMPLETED !== $status ) {
+				return self::error_payload(
+					sprintf(
+						/* translators: %s: report job status. */
+						__( 'GAM report did not complete (status: %s).', 'newspack-plugin' ),
+						$status
+					)
+				);
+			}
+
+			$url  = Client::get_report_download_url( $network_code, $job_id );
+			$rows = Client::fetch_and_parse_csv( $url );
+			return [ 'rows' => $rows ];
+		} catch ( \Exception $e ) {
+			self::audit( $network_code, $query, '', false );
+			Logger::error( $e->getMessage(), self::LOGGER_HEADER );
+			return self::error_payload( $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Poll a report job until it reaches a terminal status or the time ceiling,
+	 * with capped exponential backoff.
+	 *
+	 * @param string $network_code Network code.
+	 * @param string $job_id       Job ID.
+	 * @return string A {@see Report_Job_Status} value (UNKNOWN on timeout).
+	 */
+	private static function poll_until_terminal( string $network_code, string $job_id ): string {
+		$elapsed = 0;
+		$attempt = 0;
+		while ( $elapsed < self::POLL_MAX_SECONDS ) {
+			$status = Client::get_report_job_status( $network_code, $job_id );
+			if ( Report_Job_Status::is_terminal( $status ) ) {
+				return $status;
+			}
+			$wait     = self::POLL_BACKOFF_SECONDS[ min( $attempt, count( self::POLL_BACKOFF_SECONDS ) - 1 ) ];
+			$wait     = (int) min( $wait, self::POLL_MAX_SECONDS - $elapsed );
+			self::sleep( $wait );
+			$elapsed += $wait;
+			++$attempt;
+		}
+		return Report_Job_Status::UNKNOWN;
+	}
+
+	/**
+	 * Sleep wrapper (overridable in tests to avoid real waits).
+	 *
+	 * @param int $seconds Seconds to sleep.
+	 * @return void
+	 */
+	protected static function sleep( int $seconds ): void {
+		if ( $seconds > 0 ) {
+			sleep( $seconds );
+		}
+	}
+
+	/**
+	 * Bucket a LINE_ITEM_TYPE value into direct / house / programmatic / other.
+	 *
+	 * @param string $type Upper-cased line item type.
+	 * @return string
+	 */
+	private static function line_item_bucket( string $type ): string {
+		if ( in_array( $type, self::DIRECT_LINE_ITEM_TYPES, true ) ) {
+			return 'direct';
+		}
+		if ( 'HOUSE' === $type ) {
+			return 'house';
+		}
+		if ( in_array( $type, self::PROGRAMMATIC_LINE_ITEM_TYPES, true ) ) {
+			return 'programmatic';
+		}
+		return 'other';
+	}
+
+	/**
+	 * PQL filter clause restricting to direct-sold line item types.
+	 *
+	 * @return string
+	 */
+	private static function direct_sold_pql_filter(): string {
+		$types = array_map(
+			function ( $type ) {
+				return "'" . $type . "'";
+			},
+			self::DIRECT_LINE_ITEM_TYPES
+		);
+		return self::DIM_LINE_ITEM_TYPE . ' IN (' . implode( ',', $types ) . ')';
+	}
+
+	/**
+	 * Sum a numeric column across parsed CSV rows.
+	 *
+	 * @param array  $rows   Parsed rows.
+	 * @param string $column Column key.
+	 * @return float
+	 */
+	private static function sum_column( array $rows, string $column ): float {
+		$sum = 0.0;
+		foreach ( $rows as $row ) {
+			$sum += self::cell_number( $row, $column );
+		}
+		return $sum;
+	}
+
+	/**
+	 * Read a raw cell from a parsed CSV row. GAM CSV headers may be qualified
+	 * (e.g. `Column.TOTAL_IMPRESSIONS`); match the bare enum name as a suffix.
+	 *
+	 * @param array  $row Parsed row (assoc).
+	 * @param string $key Column/dimension enum name.
+	 * @return string
+	 */
+	private static function cell( array $row, string $key ): string {
+		if ( array_key_exists( $key, $row ) ) {
+			return (string) $row[ $key ];
+		}
+		foreach ( $row as $header => $value ) {
+			// Match a dotted-qualified header ending in the enum name.
+			if ( $header === $key || ( is_string( $header ) && str_ends_with( $header, '.' . $key ) ) ) {
+				return (string) $value;
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Read a numeric cell from a parsed CSV row.
+	 *
+	 * @param array  $row Parsed row.
+	 * @param string $key Column enum name.
+	 * @return float
+	 */
+	private static function cell_number( array $row, string $key ): float {
+		$raw = self::cell( $row, $key );
+		return is_numeric( $raw ) ? (float) $raw : 0.0;
+	}
+
+	/*
+	 * Payload helpers
+	 */
+
+	/**
+	 * Scalar count payload.
+	 *
+	 * @param float $value Value.
+	 * @return array
+	 */
+	private static function scalar_count( float $value ): array {
+		return [
+			'value'      => (int) $value,
+			'computable' => true,
+			'type'       => 'count',
+		];
+	}
+
+	/**
+	 * Rank a table by a numeric column (desc) and cap to a limit.
+	 *
+	 * @param array  $rows  Rows.
+	 * @param string $by    Column to sort by.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	private static function rank_table( array $rows, string $by, int $limit ): array {
+		usort(
+			$rows,
+			function ( $a, $b ) use ( $by ) {
+				return ( $b[ $by ] ?? 0 ) <=> ( $a[ $by ] ?? 0 );
+			}
+		);
+		if ( $limit > 0 ) {
+			$rows = array_slice( $rows, 0, $limit );
+		}
+		return [
+			'rows'       => $rows,
+			'computable' => ! empty( $rows ),
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Standard error payload.
+	 *
+	 * @param string $message Error message.
+	 * @return array
+	 */
+	private static function error_payload( string $message ): array {
+		return [
+			'value'      => null,
+			'computable' => false,
+			'error'      => $message,
+		];
+	}
+
+	/**
+	 * Whether every metric in a computed window is a failure payload.
+	 *
+	 * @param array $metrics Keyed metric payloads.
+	 * @return bool
+	 */
+	private static function all_failed( array $metrics ): bool {
+		foreach ( $metrics as $payload ) {
+			if ( ! isset( $payload['error'] ) ) {
+				return false;
+			}
+		}
+		return ! empty( $metrics );
+	}
+
+	/**
+	 * Empty/loading window scaffold (no metric data yet).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function empty_window( string $start_date, string $end_date ): array {
+		return array_merge(
+			[
+				'window'  => [
+					'start' => $start_date,
+					'end'   => $end_date,
+				],
+				'metrics' => [],
+			],
+			self::data_lag_info( $end_date )
+		);
+	}
+
+	/**
+	 * GAM data-lag indicators for a window end date. GAM figures for the most
+	 * recent {@see self::ESTIMATED_LAG_DAYS} days are estimated until AdX clears.
+	 *
+	 * @param string $end_date YYYY-MM-DD.
+	 * @return array{data_as_of:string,has_estimated_data:bool,estimated_window_start_date:?string}
+	 */
+	private static function data_lag_info( string $end_date ): array {
+		$today      = new \DateTimeImmutable( 'today', wp_timezone() );
+		$data_as_of = $today->modify( '-1 day' );
+		$estimated_boundary = $today->modify( '-' . self::ESTIMATED_LAG_DAYS . ' days' );
+
+		try {
+			$end = new \DateTimeImmutable( $end_date, wp_timezone() );
+		} catch ( \Exception $e ) {
+			$end = $today;
+		}
+
+		$has_estimated = $end >= $estimated_boundary;
+		return [
+			'data_as_of'                  => $data_as_of->format( 'Y-m-d' ),
+			'has_estimated_data'          => $has_estimated,
+			'estimated_window_start_date' => $has_estimated ? $estimated_boundary->format( 'Y-m-d' ) : null,
+		];
+	}
+
+	/**
+	 * Immediately-preceding window of equal length.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string[] [ prior_start, prior_end ].
+	 */
+	private static function prior_period( string $start_date, string $end_date ): array {
+		$start       = new \DateTimeImmutable( $start_date );
+		$end         = new \DateTimeImmutable( $end_date );
+		$days        = (int) $start->diff( $end )->format( '%a' ) + 1;
+		$prior_end   = $start->modify( '-1 day' );
+		$prior_start = $prior_end->modify( '-' . ( $days - 1 ) . ' days' );
+		return [ $prior_start->format( 'Y-m-d' ), $prior_end->format( 'Y-m-d' ) ];
+	}
+
+	/*
+	 * Audit log (extends the GAM client's per-submission log with metric context)
+	 */
+
+	/**
+	 * Append a metric-context audit entry for a report job submission.
+	 *
+	 * @param string       $network_code Network code.
+	 * @param Report_Query $query        The query.
+	 * @param string       $job_id       Returned job ID (empty on failure).
+	 * @param bool         $success      Whether submission succeeded.
+	 * @return void
+	 */
+	private static function audit( string $network_code, Report_Query $query, string $job_id, bool $success ): void {
+		$entry = [
+			'time'         => gmdate( 'c' ),
+			'tab'          => 'advertising',
+			'network_code' => $network_code,
+			'dimensions'   => $query->dimensions,
+			'columns'      => $query->columns,
+			'date_range'   => $query->start_date . '..' . $query->end_date,
+			'query_hash'   => $query->hash(),
+			'user_id'      => function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0,
+			'success'      => $success,
+			'job_id'       => $job_id,
+		];
+		if ( class_exists( '\Newspack\Logger' ) ) {
+			Logger::log( $entry, self::LOGGER_HEADER, $success ? 'info' : 'error' );
+		}
+		$log = get_option( self::AUDIT_LOG_OPTION, [] );
+		if ( ! is_array( $log ) ) {
+			$log = [];
+		}
+		$log[] = $entry;
+		if ( count( $log ) > self::AUDIT_LOG_MAX ) {
+			$log = array_slice( $log, - self::AUDIT_LOG_MAX );
+		}
+		update_option( self::AUDIT_LOG_OPTION, $log, false );
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -55,7 +55,7 @@ defined( 'ABSPATH' ) || exit;
 class Advertising_Metric {
 
 	const CACHE_KEY_PREFIX = 'newspack_insights_advertising_v1:';
-	const CACHE_FRESH_TTL  = 30 * MINUTE_IN_SECONDS;
+	const CACHE_FRESH_TTL  = 15 * MINUTE_IN_SECONDS;
 	const CACHE_HARD_TTL   = DAY_IN_SECONDS;
 	const CACHE_RETRY_TTL  = 5 * MINUTE_IN_SECONDS;
 
@@ -160,7 +160,9 @@ class Advertising_Metric {
 	 * @return array<int,array<string,string>>
 	 */
 	public static function readiness_issues(): array {
-		if ( self::is_report_ready() ) {
+		// When GAM isn't even active the tab is hidden; skip the remote scope
+		// check entirely (is_tab_visible is a cheap, local-only signal).
+		if ( ! self::is_tab_visible() || self::is_report_ready() ) {
 			return [];
 		}
 		$issues = [];
@@ -455,8 +457,8 @@ class Advertising_Metric {
 					'columns'    => [ self::COL_IMPRESSIONS ],
 					'start_date' => $s,
 					'end_date'   => $e,
-				] 
-			) 
+				]
+			)
 		);
 		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
 			return $rows;
@@ -478,8 +480,8 @@ class Advertising_Metric {
 					'columns'    => [ self::COL_REVENUE ],
 					'start_date' => $s,
 					'end_date'   => $e,
-				] 
-			) 
+				]
+			)
 		);
 		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
 			return $rows;
@@ -506,8 +508,8 @@ class Advertising_Metric {
 					'columns'    => [ self::COL_REVENUE, self::COL_CODED ],
 					'start_date' => $s,
 					'end_date'   => $e,
-				] 
-			) 
+				]
+			)
 		);
 		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
 			return $rows;
@@ -537,8 +539,8 @@ class Advertising_Metric {
 					'columns'    => [ self::COL_CODED, self::COL_IMPRESSIONS ],
 					'start_date' => $s,
 					'end_date'   => $e,
-				] 
-			) 
+				]
+			)
 		);
 		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
 			return $rows;
@@ -569,8 +571,8 @@ class Advertising_Metric {
 					'columns'    => [ self::COL_AV_VIEWABLE, self::COL_AV_MEASURABLE ],
 					'start_date' => $s,
 					'end_date'   => $e,
-				] 
-			) 
+				]
+			)
 		);
 		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
 			return $rows;
@@ -1121,7 +1123,7 @@ class Advertising_Metric {
 	}
 
 	/*
-	 * Audit log (extends the GAM client's per-submission log with metric context)
+	 * Audit log (a parallel metric-context log, separate from the GAM client's own per-submission log)
 	 */
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -57,6 +57,7 @@ class Advertising_Metric {
 	const CACHE_KEY_PREFIX = 'newspack_insights_advertising_v1:';
 	const CACHE_FRESH_TTL  = 30 * MINUTE_IN_SECONDS;
 	const CACHE_HARD_TTL   = DAY_IN_SECONDS;
+	const CACHE_RETRY_TTL  = 5 * MINUTE_IN_SECONDS;
 
 	const REFRESH_ACTION = 'newspack_insights_advertising_refresh';
 	const REFRESH_GROUP  = 'newspack-insights';
@@ -97,6 +98,22 @@ class Advertising_Metric {
 	const DIRECT_LINE_ITEM_TYPES       = [ 'SPONSORSHIP', 'STANDARD', 'BULK', 'PRICE_PRIORITY' ];
 	const PROGRAMMATIC_LINE_ITEM_TYPES = [ 'NETWORK', 'AD_EXCHANGE' ];
 
+	/**
+	 * Per-request memo of Client::can_run_reports() (which makes a remote OAuth
+	 * scope call), so a single request — including the current + comparison
+	 * windows and readiness_issues() — performs it at most once.
+	 *
+	 * @var bool|null
+	 */
+	private static $can_run_memo = null;
+
+	/**
+	 * Per-request memo of the GAM-scope check (remote tokeninfo call).
+	 *
+	 * @var bool|null
+	 */
+	private static $has_scope_memo = null;
+
 	/*
 	 * Visibility / readiness
 	 */
@@ -112,12 +129,28 @@ class Advertising_Metric {
 
 	/**
 	 * Whether a report can actually be run (GAM active + OAuth scope + network
-	 * code). Performs the OAuth scope check; call deliberately, not in a loop.
+	 * code). Memoized per request: the underlying Client::can_run_reports()
+	 * makes a remote OAuth scope call, so this is computed once even though
+	 * get_all() (current + previous windows) and readiness_issues() all consult it.
 	 *
 	 * @return bool
 	 */
 	public static function is_report_ready(): bool {
-		return Client::can_run_reports();
+		if ( null === self::$can_run_memo ) {
+			self::$can_run_memo = Client::can_run_reports();
+		}
+		return self::$can_run_memo;
+	}
+
+	/**
+	 * Reset the per-request readiness memos. Mainly for tests; harmless in
+	 * production (each request starts fresh).
+	 *
+	 * @return void
+	 */
+	public static function reset_readiness_cache(): void {
+		self::$can_run_memo   = null;
+		self::$has_scope_memo = null;
 	}
 
 	/**
@@ -157,8 +190,11 @@ class Advertising_Metric {
 	 * @return bool
 	 */
 	private static function has_admanager_scope(): bool {
-		return class_exists( '\Newspack\Google_OAuth' )
-			&& \Newspack\Google_OAuth::token_has_scope( Client::GAM_SCOPE );
+		if ( null === self::$has_scope_memo ) {
+			self::$has_scope_memo = class_exists( '\Newspack\Google_OAuth' )
+				&& \Newspack\Google_OAuth::token_has_scope( Client::GAM_SCOPE );
+		}
+		return self::$has_scope_memo;
 	}
 
 	/**
@@ -252,9 +288,9 @@ class Advertising_Metric {
 	 * @return array Window payload with `is_loading` / `is_stale` flags as relevant.
 	 */
 	private static function read_window( string $start_date, string $end_date ): array {
-		$cached = get_transient( self::cache_key( $start_date, $end_date ) );
+		$cached = self::read_cache_entry( $start_date, $end_date );
 
-		if ( ! is_array( $cached ) || ! isset( $cached['payload'], $cached['computed_at'] ) ) {
+		if ( null === $cached ) {
 			self::schedule_refresh( $start_date, $end_date );
 			$window               = self::empty_window( $start_date, $end_date );
 			$window['is_loading'] = true;
@@ -267,6 +303,24 @@ class Advertising_Metric {
 			$window['is_stale'] = true;
 		}
 		return $window;
+	}
+
+	/**
+	 * Read and validate a window's cache entry. Returns the
+	 * `[ computed_at, payload ]` wrapper only when well-formed, else null. The
+	 * single source of truth for "a usable cache entry exists", shared by
+	 * read_window() and the refresh guard.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array|null
+	 */
+	private static function read_cache_entry( string $start_date, string $end_date ): ?array {
+		$cached = get_transient( self::cache_key( $start_date, $end_date ) );
+		if ( is_array( $cached ) && isset( $cached['payload'], $cached['computed_at'] ) && is_array( $cached['payload'] ) ) {
+			return $cached;
+		}
+		return null;
 	}
 
 	/**
@@ -323,11 +377,12 @@ class Advertising_Metric {
 			return;
 		}
 
-		$metrics = self::compute_window( $start_date, $end_date );
+		$metrics      = self::compute_window( $start_date, $end_date );
+		$had_failures = self::any_failed( $metrics );
 
-		// If every metric failed (e.g. transient GAM/network outage), keep the
-		// previous payload rather than overwriting good data with errors.
-		if ( self::all_failed( $metrics ) && false !== get_transient( self::cache_key( $start_date, $end_date ) ) ) {
+		// If this refresh hit ANY failure and a valid prior payload exists, keep
+		// the prior payload rather than overwriting good data with errors.
+		if ( $had_failures && null !== self::read_cache_entry( $start_date, $end_date ) ) {
 			return;
 		}
 
@@ -344,13 +399,16 @@ class Advertising_Metric {
 			$lag
 		);
 
+		// A failure-containing payload (only written when there's no prior good
+		// entry) gets a short TTL so it self-expires and retries soon, instead of
+		// being served as "fresh" for the full hard TTL.
 		set_transient(
 			self::cache_key( $start_date, $end_date ),
 			[
 				'computed_at' => time(),
 				'payload'     => $window,
 			],
-			self::CACHE_HARD_TTL
+			$had_failures ? self::CACHE_RETRY_TTL : self::CACHE_HARD_TTL
 		);
 	}
 
@@ -589,10 +647,14 @@ class Advertising_Metric {
 				'impressions' => $vals['impressions'],
 			];
 		}
-		$total = array_sum( array_column( $out, 'revenue' ) );
+		// Computable when there's anything to show — revenue OR impressions.
+		// House/unsold inventory has real impressions at $0 revenue and should
+		// still render rather than being treated as "no data".
+		$total_revenue     = array_sum( array_column( $out, 'revenue' ) );
+		$total_impressions = array_sum( array_column( $out, 'impressions' ) );
 		return [
 			'rows'       => $out,
-			'computable' => $total > 0,
+			'computable' => $total_revenue > 0 || $total_impressions > 0,
 			'type'       => 'breakdown',
 		];
 	}
@@ -787,20 +849,39 @@ class Advertising_Metric {
 	}
 
 	/**
+	 * Maximum consecutive status-check errors tolerated before giving up on a
+	 * job (a single transient SOAP/OAuth hiccup must not kill a healthy job).
+	 */
+	const POLL_MAX_CONSECUTIVE_ERRORS = 3;
+
+	/**
 	 * Poll a report job until it reaches a terminal status or the time ceiling,
-	 * with capped exponential backoff.
+	 * with capped exponential backoff. Tolerates a few consecutive transient
+	 * status-check errors before re-throwing.
 	 *
 	 * @param string $network_code Network code.
 	 * @param string $job_id       Job ID.
 	 * @return string A {@see Report_Job_Status} value (UNKNOWN on timeout).
+	 *
+	 * @throws \Exception If status checks fail repeatedly in a row.
 	 */
 	private static function poll_until_terminal( string $network_code, string $job_id ): string {
-		$elapsed = 0;
-		$attempt = 0;
+		$elapsed             = 0;
+		$attempt             = 0;
+		$consecutive_errors  = 0;
 		while ( $elapsed < self::POLL_MAX_SECONDS ) {
-			$status = Client::get_report_job_status( $network_code, $job_id );
-			if ( Report_Job_Status::is_terminal( $status ) ) {
-				return $status;
+			try {
+				$status             = Client::get_report_job_status( $network_code, $job_id );
+				$consecutive_errors = 0;
+				if ( Report_Job_Status::is_terminal( $status ) ) {
+					return $status;
+				}
+			} catch ( \Exception $e ) {
+				// A transient blip shouldn't abort a healthy job; retry a few
+				// times before surfacing the error to the caller.
+				if ( ++$consecutive_errors >= self::POLL_MAX_CONSECUTIVE_ERRORS ) {
+					throw $e;
+				}
 			}
 			$wait     = self::POLL_BACKOFF_SECONDS[ min( $attempt, count( self::POLL_BACKOFF_SECONDS ) - 1 ) ];
 			$wait     = (int) min( $wait, self::POLL_MAX_SECONDS - $elapsed );
@@ -963,18 +1044,18 @@ class Advertising_Metric {
 	}
 
 	/**
-	 * Whether every metric in a computed window is a failure payload.
+	 * Whether any metric in a computed window is a failure (error) payload.
 	 *
 	 * @param array $metrics Keyed metric payloads.
 	 * @return bool
 	 */
-	private static function all_failed( array $metrics ): bool {
+	private static function any_failed( array $metrics ): bool {
 		foreach ( $metrics as $payload ) {
-			if ( ! isset( $payload['error'] ) ) {
-				return false;
+			if ( isset( $payload['error'] ) ) {
+				return true;
 			}
 		}
-		return ! empty( $metrics );
+		return false;
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -60,6 +60,7 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		Insights_Advertising_Test_Metric::$next_report = [ 'rows' => [] ];
+		Advertising_Metric::reset_readiness_cache();
 		parent::tear_down();
 	}
 
@@ -361,5 +362,90 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 		$info = $this->invoke( 'data_lag_info', [ '2020-01-31' ] );
 		$this->assertFalse( $info['has_estimated_data'] );
 		$this->assertNull( $info['estimated_window_start_date'] );
+	}
+
+	/**
+	 * Only a structurally valid cache wrapper is returned, else null — the
+	 * single validity definition shared with the refresh guard.
+	 */
+	public function test_read_cache_entry_validates_structure() {
+		$key_ref = new ReflectionMethod( Advertising_Metric::class, 'cache_key' );
+		$key_ref->setAccessible( true );
+		$key = $key_ref->invoke( null, '2026-03-01', '2026-03-31' );
+
+		set_transient( $key, 'not-an-array', 60 );
+		$this->assertNull( $this->invoke( 'read_cache_entry', [ '2026-03-01', '2026-03-31' ] ) );
+
+		set_transient( $key, [ 'payload' => 'not-an-array' ], 60 );
+		$this->assertNull( $this->invoke( 'read_cache_entry', [ '2026-03-01', '2026-03-31' ] ) );
+
+		$valid = [
+			'computed_at' => time(),
+			'payload'     => [ 'metrics' => [] ],
+		];
+		set_transient( $key, $valid, 60 );
+		$got = $this->invoke( 'read_cache_entry', [ '2026-03-01', '2026-03-31' ] );
+		$this->assertIsArray( $got );
+		$this->assertSame( $valid['computed_at'], $got['computed_at'] );
+
+		delete_transient( $key );
+	}
+
+	/**
+	 * Reports a failure when at least one metric errored.
+	 */
+	public function test_any_failed() {
+		$this->assertTrue(
+			$this->invoke(
+				'any_failed',
+				[
+					[
+						'a' => [ 'value' => 1 ],
+						'b' => [ 'error' => 'x' ],
+					],
+				]
+			)
+		);
+		$this->assertFalse(
+			$this->invoke(
+				'any_failed',
+				[
+					[
+						'a' => [ 'value' => 1 ],
+						'b' => [ 'value' => 2 ],
+					],
+				]
+			)
+		);
+		$this->assertFalse( $this->invoke( 'any_failed', [ [] ] ) );
+	}
+
+	/**
+	 * Direct vs programmatic is computable with impressions but zero revenue
+	 * (house/unsold inventory must still render).
+	 */
+	public function test_direct_vs_programmatic_computable_with_impressions_no_revenue() {
+		$this->with_rows(
+			[
+				[
+					'LINE_ITEM_TYPE'                    => 'HOUSE',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '0',
+					'TOTAL_IMPRESSIONS'                 => '5000',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::direct_vs_programmatic( '2026-01-01', '2026-01-31' );
+		$this->assertTrue( $payload['computable'] );
+	}
+
+	/**
+	 * The fixture comparison window is the immediately-preceding period, not a
+	 * copy of the current window.
+	 */
+	public function test_fixture_compare_window_is_prior_period() {
+		$payload = Advertising_Metric::get_fixture( '2026-02-01', '2026-02-28', true, 'populated' );
+		$this->assertArrayHasKey( 'compare', $payload );
+		$this->assertSame( '2026-01-31', $payload['compare']['window']['end'] );
+		$this->assertNotSame( $payload['window']['start'], $payload['compare']['window']['start'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -303,12 +303,14 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Lists both the scope and network-code problems.
+	 * Short-circuits to empty readiness issues when GAM is inactive (tab hidden),
+	 * so it never makes the remote scope check for the common not-configured case.
 	 */
-	public function test_readiness_issues_lists_missing_scope_and_network() {
-		$codes = array_column( Advertising_Metric::readiness_issues(), 'code' );
-		$this->assertContains( 'oauth_scope_missing', $codes );
-		$this->assertContains( 'network_code_missing', $codes );
+	public function test_readiness_issues_empty_when_gam_inactive() {
+		// GAM is inactive in the test environment (newspack-ads absent), so the
+		// tab is hidden and there are no actionable readiness issues to surface.
+		$this->assertFalse( Advertising_Metric::is_tab_visible() );
+		$this->assertSame( [], Advertising_Metric::readiness_issues() );
 	}
 
 	/**
@@ -444,8 +446,9 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	 */
 	public function test_fixture_compare_window_is_prior_period() {
 		$payload = Advertising_Metric::get_fixture( '2026-02-01', '2026-02-28', true, 'populated' );
-		$this->assertArrayHasKey( 'compare', $payload );
-		$this->assertSame( '2026-01-31', $payload['compare']['window']['end'] );
-		$this->assertNotSame( $payload['window']['start'], $payload['compare']['window']['start'] );
+		$this->assertArrayHasKey( 'current', $payload );
+		$this->assertArrayHasKey( 'previous', $payload );
+		$this->assertSame( '2026-01-31', $payload['previous']['window']['end'] );
+		$this->assertNotSame( $payload['current']['window']['start'], $payload['previous']['window']['start'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -1,0 +1,365 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound -- Test file defines a test-double subclass alongside the main test class.
+/**
+ * Tests the Advertising (Tab 8) metric orchestrator (NPPD-1663).
+ *
+ * The GAM Client is final + static and can't be mocked, so per-metric tests use
+ * a subclass that overrides the protected run_gam_report() seam to inject canned
+ * parsed rows. Envelope / readiness / runner-skip behavior is exercised against
+ * the real (disconnected) test environment.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Insights\Advertising_Metric;
+use Newspack\Insights\GAM\Report_Query;
+
+/**
+ * Test double: injects a canned run_gam_report() result.
+ */
+class Insights_Advertising_Test_Metric extends Advertising_Metric {
+	/**
+	 * The next run_gam_report() result to return.
+	 *
+	 * @var array
+	 */
+	public static $next_report = [ 'rows' => [] ];
+
+	/**
+	 * Override the GAM-touching seam with the injected result.
+	 *
+	 * @param Report_Query $query The query (ignored).
+	 * @return array
+	 */
+	protected static function run_gam_report( Report_Query $query ): array {
+		return self::$next_report;
+	}
+}
+
+/**
+ * Test the Advertising metric orchestrator.
+ *
+ * @group insights_advertising
+ */
+class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private/protected static method on Advertising_Metric.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Arguments.
+	 * @return mixed
+	 */
+	private function invoke( $method, array $args = [] ) {
+		$ref = new ReflectionMethod( Advertising_Metric::class, $method );
+		$ref->setAccessible( true );
+		return $ref->invoke( null, ...$args );
+	}
+
+	/**
+	 * Reset the double between tests.
+	 */
+	public function tear_down() {
+		Insights_Advertising_Test_Metric::$next_report = [ 'rows' => [] ];
+		parent::tear_down();
+	}
+
+	/**
+	 * Inject canned rows for the next metric call.
+	 *
+	 * @param array $rows Parsed CSV rows.
+	 */
+	private function with_rows( array $rows ) {
+		Insights_Advertising_Test_Metric::$next_report = [ 'rows' => $rows ];
+	}
+
+	/**
+	 * Total impressions sums the column and returns a count.
+	 */
+	public function test_total_impressions() {
+		$this->with_rows( [ [ 'TOTAL_IMPRESSIONS' => '2400000' ] ] );
+		$payload = Insights_Advertising_Test_Metric::total_impressions( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 2400000, $payload['value'] );
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 'count', $payload['type'] );
+	}
+
+	/**
+	 * Total revenue normalizes micro-currency to standard currency.
+	 */
+	public function test_total_revenue_normalizes_micros() {
+		$this->with_rows( [ [ 'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '4200000000' ] ] );
+		$payload = Insights_Advertising_Test_Metric::total_revenue( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 4200.0, $payload['value'] );
+		$this->assertSame( 'currency', $payload['type'] );
+	}
+
+	/**
+	 * Average eCPM derives from normalized revenue and coded impressions.
+	 */
+	public function test_avg_ecpm() {
+		$this->with_rows(
+			[
+				[
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '4200000000',
+					'TOTAL_CODE_SERVED_COUNT'           => '2400000',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::avg_ecpm( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 1.75, round( $payload['value'], 2 ) );
+		$this->assertTrue( $payload['computable'] );
+	}
+
+	/**
+	 * Average eCPM is not computable with zero coded impressions.
+	 */
+	public function test_avg_ecpm_zero_coded_not_computable() {
+		$this->with_rows(
+			[
+				[
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '4200000000',
+					'TOTAL_CODE_SERVED_COUNT'           => '0',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::avg_ecpm( '2026-01-01', '2026-01-31' );
+		$this->assertFalse( $payload['computable'] );
+		$this->assertSame( 0.0, $payload['value'] );
+	}
+
+	/**
+	 * Fill rate is coded / total impressions, capped at 1.
+	 */
+	public function test_fill_rate_capped_at_one() {
+		$this->with_rows(
+			[
+				[
+					'TOTAL_CODE_SERVED_COUNT' => '2088000',
+					'TOTAL_IMPRESSIONS'       => '2400000',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::fill_rate( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 0.87, round( $payload['value'], 2 ) );
+		$this->assertSame( 'rate', $payload['type'] );
+	}
+
+	/**
+	 * Viewability rate is viewable / measurable Active View impressions.
+	 */
+	public function test_viewability_rate() {
+		$this->with_rows(
+			[
+				[
+					'TOTAL_ACTIVE_VIEW_VIEWABLE_IMPRESSIONS'   => '640',
+					'TOTAL_ACTIVE_VIEW_MEASURABLE_IMPRESSIONS' => '1000',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::viewability_rate( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 0.64, round( $payload['value'], 2 ) );
+	}
+
+	/**
+	 * Viewability degrades to a data_unavailable overlay without Active View.
+	 */
+	public function test_viewability_rate_overlay_when_no_active_view() {
+		$this->with_rows(
+			[
+				[
+					'TOTAL_ACTIVE_VIEW_VIEWABLE_IMPRESSIONS'   => '0',
+					'TOTAL_ACTIVE_VIEW_MEASURABLE_IMPRESSIONS' => '0',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::viewability_rate( '2026-01-01', '2026-01-31' );
+		$this->assertFalse( $payload['computable'] );
+		$this->assertSame( 'data_unavailable', $payload['overlay']['type'] );
+	}
+
+	/**
+	 * Direct vs programmatic buckets LINE_ITEM_TYPE values correctly.
+	 */
+	public function test_direct_vs_programmatic_buckets_line_item_types() {
+		$this->with_rows(
+			[
+				[
+					'LINE_ITEM_TYPE'                    => 'STANDARD',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '3000000000',
+					'TOTAL_IMPRESSIONS'                 => '100',
+				],
+				[
+					'LINE_ITEM_TYPE'                    => 'AD_EXCHANGE',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '2000000000',
+					'TOTAL_IMPRESSIONS'                 => '200',
+				],
+				[
+					'LINE_ITEM_TYPE'                    => 'HOUSE',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '0',
+					'TOTAL_IMPRESSIONS'                 => '50',
+				],
+			]
+		);
+		$payload  = Insights_Advertising_Test_Metric::direct_vs_programmatic( '2026-01-01', '2026-01-31' );
+		$by_label = array_column( $payload['rows'], null, 'label' );
+		$this->assertSame( 3000.0, $by_label['direct']['revenue'] );
+		$this->assertSame( 2000.0, $by_label['programmatic']['revenue'] );
+		$this->assertSame( 50, $by_label['house']['impressions'] );
+		$this->assertTrue( $payload['computable'] );
+	}
+
+	/**
+	 * Top ad units rank by revenue and derive eCPM from coded impressions.
+	 */
+	public function test_top_ad_units_ranks_by_revenue_and_derives_ecpm() {
+		$this->with_rows(
+			[
+				[
+					'AD_UNIT_NAME'                      => 'Low',
+					'TOTAL_IMPRESSIONS'                 => '100',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '1000000',
+					'TOTAL_CODE_SERVED_COUNT'           => '100',
+					'TOTAL_LINE_ITEM_LEVEL_CLICKS'      => '1',
+				],
+				[
+					'AD_UNIT_NAME'                      => 'High',
+					'TOTAL_IMPRESSIONS'                 => '500',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '5000000',
+					'TOTAL_CODE_SERVED_COUNT'           => '500',
+					'TOTAL_LINE_ITEM_LEVEL_CLICKS'      => '5',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::top_ad_units( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 'High', $payload['rows'][0]['ad_unit'] );
+		$this->assertSame( 5.0, $payload['rows'][0]['revenue'] );
+		$this->assertSame( 10.0, round( $payload['rows'][0]['ecpm'], 2 ) ); // 5.0 / 500 * 1000.
+		$this->assertSame( 'table', $payload['type'] );
+	}
+
+	/**
+	 * Top ad units respect the row limit.
+	 */
+	public function test_top_ad_units_respects_limit() {
+		$rows = [];
+		for ( $i = 1; $i <= 30; $i++ ) {
+			$rows[] = [
+				'AD_UNIT_NAME'                      => "U$i",
+				'TOTAL_IMPRESSIONS'                 => (string) $i,
+				'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => (string) ( $i * 1000000 ),
+				'TOTAL_CODE_SERVED_COUNT'           => (string) $i,
+				'TOTAL_LINE_ITEM_LEVEL_CLICKS'      => '0',
+			];
+		}
+		$this->with_rows( $rows );
+		$payload = Insights_Advertising_Test_Metric::top_ad_units( '2026-01-01', '2026-01-31', 25 );
+		$this->assertCount( 25, $payload['rows'] );
+	}
+
+	/**
+	 * Dotted-qualified GAM CSV headers are matched by their enum suffix.
+	 */
+	public function test_top_countries_qualified_csv_headers() {
+		$this->with_rows(
+			[
+				[
+					'Dimension.COUNTRY_NAME'         => 'United States',
+					'Column.TOTAL_IMPRESSIONS'       => '1000',
+					'Column.TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => '2000000',
+					'Column.TOTAL_CODE_SERVED_COUNT' => '1000',
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::top_countries( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 'United States', $payload['rows'][0]['country'] );
+		$this->assertSame( 1000, $payload['rows'][0]['impressions'] );
+		$this->assertSame( 2.0, $payload['rows'][0]['revenue'] );
+	}
+
+	/**
+	 * A report error payload passes through unchanged.
+	 */
+	public function test_metric_passes_through_report_error() {
+		Insights_Advertising_Test_Metric::$next_report = [
+			'value'      => null,
+			'computable' => false,
+			'error'      => 'boom',
+		];
+		$payload = Insights_Advertising_Test_Metric::total_revenue( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 'boom', $payload['error'] );
+		$this->assertFalse( $payload['computable'] );
+	}
+
+	/**
+	 * Returns the envelope (no metrics) when GAM is inactive.
+	 */
+	public function test_get_all_envelope_when_gam_inactive() {
+		$payload = Advertising_Metric::get_all( '2026-01-01', '2026-01-31' );
+		$this->assertFalse( $payload['is_tab_visible'] );
+		$this->assertFalse( $payload['is_report_ready'] );
+		$this->assertSame( [], $payload['metrics'] );
+		$this->assertArrayHasKey( 'data_as_of', $payload );
+	}
+
+	/**
+	 * Lists both the scope and network-code problems.
+	 */
+	public function test_readiness_issues_lists_missing_scope_and_network() {
+		$codes = array_column( Advertising_Metric::readiness_issues(), 'code' );
+		$this->assertContains( 'oauth_scope_missing', $codes );
+		$this->assertContains( 'network_code_missing', $codes );
+	}
+
+	/**
+	 * The Action Scheduler runner skips (no cache write) when not ready.
+	 */
+	public function test_run_scheduled_refresh_skips_when_not_ready() {
+		$ref = new ReflectionMethod( Advertising_Metric::class, 'cache_key' );
+		$ref->setAccessible( true );
+		$key = $ref->invoke( null, '2026-01-01', '2026-01-31' );
+
+		Advertising_Metric::run_scheduled_refresh(
+			[
+				'start' => '2026-01-01',
+				'end'   => '2026-01-31',
+			]
+		);
+		$this->assertFalse( get_transient( $key ) );
+	}
+
+	/**
+	 * Prior period is the contiguous, equal-length preceding window.
+	 */
+	public function test_prior_period() {
+		$result = $this->invoke( 'prior_period', [ '2026-02-01', '2026-02-28' ] );
+		$this->assertSame( [ '2026-01-04', '2026-01-31' ], $result );
+	}
+
+	/**
+	 * The direct-sold PQL filter lists the direct line item types.
+	 */
+	public function test_direct_sold_pql_filter() {
+		$filter = $this->invoke( 'direct_sold_pql_filter' );
+		$this->assertStringContainsString( "LINE_ITEM_TYPE IN ('SPONSORSHIP','STANDARD','BULK','PRICE_PRIORITY')", $filter );
+	}
+
+	/**
+	 * A recent window is flagged as carrying estimated data.
+	 */
+	public function test_data_lag_info_recent_window_is_estimated() {
+		$tz    = wp_timezone();
+		$today = ( new DateTimeImmutable( 'today', $tz ) )->format( 'Y-m-d' );
+		$info  = $this->invoke( 'data_lag_info', [ $today ] );
+		$this->assertTrue( $info['has_estimated_data'] );
+		$this->assertNotNull( $info['estimated_window_start_date'] );
+	}
+
+	/**
+	 * An old window is not flagged as estimated.
+	 */
+	public function test_data_lag_info_old_window_not_estimated() {
+		$info = $this->invoke( 'data_lag_info', [ '2020-01-31' ] );
+		$this->assertFalse( $info['has_estimated_data'] );
+		$this->assertNull( $info['estimated_window_start_date'] );
+	}
+}


### PR DESCRIPTION
## Summary

Builds the **Advertising metric orchestrator** for Insights Tab 8 ([NPPD-1663](https://linear.app/a8c/issue/NPPD-1663)) — the publisher-side equivalent of the Audience/Engagement orchestrators ([NPPD-1648](https://linear.app/a8c/issue/NPPD-1648)), consuming the GAM SOAP `ReportService` client from [#256](https://github.com/Automattic/newspack-workspace/pull/256) ([NPPD-1662](https://linear.app/a8c/issue/NPPD-1662)). Section → REST controller → Metric, same shape, GAM data source.

GAM reports are genuinely asynchronous (submit → poll → download → parse, up to minutes), so they never run in a request. `get_all()` reads a transient cache and schedules an Action Scheduler refresh on a miss or stale entry; the background runner executes the reports and writes the cache. Matches the transient pattern from [NPPD-1648](https://linear.app/a8c/issue/NPPD-1648).

Closes [NPPD-1663](https://linear.app/a8c/issue/NPPD-1663).

## What's in this PR

### Advertising_Metric orchestrator

`plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php`. All 10 metrics from `formulas/tab-8-advertising.md`, each building a `Report_Query` and running it end-to-end via the client, normalizing micros at the boundary:

- Headline scorecards: `total_impressions`, `total_revenue`, `avg_ecpm`, `fill_rate`, `viewability_rate`
- Revenue breakdown: `direct_vs_programmatic`, `top_ad_units`, `top_advertisers`
- Performance: `performance_by_device`, `top_countries`

`get_all()` returns the envelope: `is_tab_visible` (wraps `Client::is_gam_active()`), `is_report_ready` (wraps `Client::can_run_reports()`), `readiness_issues` (describes what's missing when not ready so the UI can render specific guidance), `data_as_of`, `has_estimated_data`, `estimated_window_start_date`, `metrics`, plus `is_loading` / `is_stale`.

`Advertising_Metric` is not `final` (unlike the Audience/Engagement classes) so tests can subclass and inject canned report rows through a `protected static run_gam_report()` seam — the GAM client is `final` + static and otherwise unmockable.

### REST controller

`plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php`. Exposes `GET /newspack-insights/v1/advertising` with `manage_options` permission and `Y-m-d` date validation, mirroring the Audience controller. Branches to fixture mode when `NEWSPACK_INSIGHTS_FIXTURE_MODE` is set.

### Section registration

`plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php`. Fleshed out from the prior stub. Registers the REST route and Action Scheduler handler, gated behind `NEWSPACK_INSIGHTS_ADVERTISING_ENABLED` (with an `Insights_Wizard::is_advertising_enabled()` helper).

### Transient cache and Action Scheduler runner

Custom `wp_newspack_insights_cache` table is NOT used — that infrastructure ([NPPD-1605](https://linear.app/a8c/issue/NPPD-1605) / [NPPD-1606](https://linear.app/a8c/issue/NPPD-1606)) was canceled on 2026-06-08 in favor of the Manager BQ-proxy direction ([NPPD-1630](https://linear.app/a8c/issue/NPPD-1630)). This orchestrator uses WP transients, matching [NPPD-1648](https://linear.app/a8c/issue/NPPD-1648).

- `get_all()` reads from a 15-min transient; fresh hit returns immediately
- Miss / stale entry → schedules `newspack_insights_advertising_refresh` via Action Scheduler, returns the loading/stale envelope so the UI can render appropriately
- The runner submits each metric's report via the client, polls with capped backoff, parses the CSV, writes the payload to the transient
- Runner skips cleanly when `Client::can_run_reports()` is false — previously-cached payloads remain visible to the UI
- Failure handling: log error, leave prior cached payload in place (don't overwrite with empty)

`architecture.md` updated to remove the stale custom-cache-table references and reflect the transient pattern actually in use.

### Audit log

The GAM client (NPPD-1662 / #256) writes a capped `wp_option` audit log on each report job submission. The orchestrator extends each entry with metric-level context (which metric, dimensions, columns, date range) rather than introducing a parallel logger.

### Fixture mode

`plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php`. Reuses the existing `NEWSPACK_INSIGHTS_FIXTURE_MODE` constant; the REST controller branches to canned data when set.

Fixture is date-relative (never stale) and exercises every render path via a `_fixture_state` query parameter:

- `populated` — realistic scorecards (impressions, revenue, eCPM, fill rate, viewability), all tables populated, direct vs programmatic split, comparison deltas in both directions
- `not_ready` — `is_report_ready: false` with both `oauth_scope_missing` and `network_code_missing` in `readiness_issues`, so the UI can render the "finish connecting" diagnostic in dev without needing OAuth-incomplete real state
- `zero` — zero-impressions period (publisher had no ad activity in the date range)
- `no_viewability` — publisher without Active View enabled; viewability scorecard renders as `data_unavailable`

Usage documented in `dev-notes.md`.

### Tests

19 unit tests covering each metric (mocked report rows via the `run_gam_report` seam) plus envelope shape, readiness logic, runner-skip behavior, and data-lag fields. Full Insights suite: 59 tests / 157 assertions. PHPCS clean.

## How to test

1. Set `define( 'NEWSPACK_INSIGHTS_ENABLED', true );` and `define( 'NEWSPACK_INSIGHTS_ADVERTISING_ENABLED', true );` in `wp-config.php`.
2. With `define( 'NEWSPACK_INSIGHTS_FIXTURE_MODE', true );` set, hit `/wp-json/newspack-insights/v1/advertising?start=YYYY-MM-DD&end=YYYY-MM-DD&_fixture_state=populated` — confirm the envelope returns with realistic data across all 10 metrics.
3. Repeat with `_fixture_state=not_ready` — confirm `is_report_ready: false` and the `readiness_issues` array describes both `oauth_scope_missing` and `network_code_missing`.
4. Repeat with `_fixture_state=zero` — confirm scorecards return zero values and tables come back empty without erroring.
5. Repeat with `_fixture_state=no_viewability` — confirm the viewability scorecard returns the `data_unavailable` overlay.
6. With fixture mode off and no GAM connection, hit the endpoint — confirm `is_tab_visible: false` and `is_report_ready: false`.
7. With fixture mode off and a configured GAM site, confirm the Action Scheduler runner picks up the refresh job (check `wp-admin → Tools → Scheduled Actions`).
8. Run `./n test-php --group insights_advertising` (19 tests) or `--filter Insights` (full 59).
9. Confirm `composer run-script lint -- includes/wizards/insights/` is clean.

## Out of scope

- Tab 8 UI including the "finish connecting" diagnostic — [NPPD-1618](https://linear.app/a8c/issue/NPPD-1618)
- Real-publisher GAM enum verification and SOAP integration test (enum names built against documented v202602; corrections from verification land in the `Report_Query` builders here) — [NPPD-1666](https://linear.app/a8c/issue/NPPD-1666)
- Broadstreet support (separate ad server, separate API) — [NPPD-1665](https://linear.app/a8c/issue/NPPD-1665) (discovery)
- Header bidding / Prebid data — out of v1 per formula doc
- Content category × revenue cross-system join — v1.1 per formula doc
- Configurable GAM timezone setting — v1.1