### PR TITLE
fix(block-theme): correcting comment list item styling

### DIFF
--- a/themes/newspack-block-theme/src/scss/blocks/_post-comments.scss
+++ b/themes/newspack-block-theme/src/scss/blocks/_post-comments.scss
@@ -68,12 +68,11 @@
 
 .wp-block-comment-template {
 	ol {
-		list-style: decimal;
+		list-style: none;
 		padding-left: var(--wp--preset--spacing--40);
 
 		&:has(.comment) {
 			border-left: 1px solid var(--wp--preset--color--base-3);
-			list-style: none;
 			margin: var(--wp--preset--spacing--50) 0 0;
 			padding-left: var(--wp--preset--spacing--50);
 		}
@@ -148,6 +147,11 @@
 	.comment-awaiting-moderation {
 		font-size: inherit;
 		line-height: inherit;
+	}
+
+	ol {
+		list-style: decimal;
+		margin-bottom: var(--wp--preset--spacing--30); // overriding some Core styles.
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a minor issue in the block theme: due to how the ordered list in comment styles were set up, the numbers would show up in the Site Editor because the `.comment` class doesn't live there. 

This PR works around that by explicitly removing the numbers from the top level of the comments block (the actual, individual comments), and reinstating it instead in the comment content, in case an `<ol>` has been added there.

### How to test the changes in this Pull Request:

1. Add the comments block to the block theme and observe the preview in the Site Editor - note the numbers.
2. Apply this PR and build.
3. Repeat step 1; confirm no numbers appear.
4. Test on the front end with a post with nested columns, and confirm all looks well.
5. Add an ordered list to a comment (you have to use markup) - confirm the number shows up as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
