### PR TITLE
fix(components): restore className and disabled props on CardSettingsGroup

### DIFF
--- a/packages/components/src/card-settings-group/index.tsx
+++ b/packages/components/src/card-settings-group/index.tsx
@@ -3,6 +3,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import { Card } from '../';
@@ -11,6 +16,8 @@ import './style.scss';
 const CardSettingsGroup = ( {
 	actionType = 'none',
 	children,
+	className,
+	disabled = false,
 	icon = null,
 	headerAction,
 	title = '',
@@ -21,6 +28,8 @@ const CardSettingsGroup = ( {
 }: {
 	actionType?: 'chevron' | 'toggle' | 'button' | 'link' | 'none';
 	children?: React.ReactNode;
+	className?: string;
+	disabled?: boolean;
 	icon?: React.ReactNode;
 	title: string;
 	headerAction?: {
@@ -40,7 +49,7 @@ const CardSettingsGroup = ( {
 } ) => {
 	return (
 		<Card
-			className="newspack-card--core--settings-group"
+			className={ classNames( 'newspack-card--core--settings-group', className ) }
 			actionType={ actionType }
 			isSmall
 			__experimentalCoreCard
@@ -54,6 +63,7 @@ const CardSettingsGroup = ( {
 				headerAction,
 				onHeaderClick,
 				onToggle: onEnable,
+				disabled,
 				icon,
 				iconBackgroundColor: true,
 				isActive,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Restores the `className` and `disabled` props on `CardSettingsGroup`, which were dropped when [newspack-plugin#4735](https://github.com/Automattic/newspack-plugin/pull/4735) was merged into the monorepo. The monorepo copy of the component never accepted either prop, so:

- The per-provider modifier class (e.g. `newspack-newsletters-esp-card--mailchimp`) never reached the DOM, so the ESP card brand backgrounds on the Newsletters Settings page never rendered (Mailchimp `#FFE01B` yellow, Active Campaign blue, Constant Contact gray).
- Cards and credential inputs no longer went disabled during an in-flight save.

`className` is now merged onto the underlying card via the `classnames` library, and `disabled` is forwarded to the core card props. This brings the monorepo component back in line with the reference implementation in `newspack-plugin`.

### How to test the changes in this Pull Request:

1. Build the components package and the plugin (`pnpm --filter "*components*" build`, then build `newspack-plugin`).
2. Go to the Newsletters Settings page (the Email service provider 2x2 card grid).
3. Confirm each ESP card renders its brand background behind the icon: Mailchimp `#FFE01B` yellow, Active Campaign blue, Constant Contact gray.
4. Click Save and confirm the ESP cards and credential inputs go disabled while the request is in flight.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?