### PR TITLE
feat(insights): Tab 5 Prompts UI scaffold (Phase 1)

### DIFF
--- a/plugins/newspack-plugin/docs/insights/formulas/tab-5-prompts.md
+++ b/plugins/newspack-plugin/docs/insights/formulas/tab-5-prompts.md
@@ -413,9 +413,10 @@ Notes:
 
 ### Table: Performance by Prompt
 
-Row per prompt, with impressions and conversion rates by intent.
+Row per prompt: impressions, engagement rates, and per-intent **conversion** outcomes. The aggregate engagement query (1) runs in BQ; the donation/subscription **conversion** columns are completed-order counts produced by a PHP Woo join over the per-attempt rows from query (2) — the same completion pattern as `get_donation_revenue_direct` / `get_subscription_revenue_direct`, and aligned with the Gates v1.1 per-gate conversion decision (NPPD-1684). BQ alone only sees attempts; conversions require the Woo join.
 
 ```sql
+-- (1) Per-prompt engagement aggregate (BQ).
 WITH prompt_impressions AS (
   SELECT
     PARAM('newspack_popup_id') AS popup_id,
@@ -424,6 +425,7 @@ WITH prompt_impressions AS (
     PARAM('prompt_placement') AS placement,
     COUNT(*) AS impressions,
     COUNT(DISTINCT COALESCE(user_id, user_pseudo_id)) AS unique_viewers,
+    COUNT(DISTINCT IF(PARAM('action') = 'seen', PARAM('ga_session_id'), NULL)) AS sessions_with_impression,
     COUNTIF(PARAM('action') = 'clicked') AS clicks,
     COUNTIF(PARAM('action') = 'form_submission') AS form_submissions,
     COUNTIF(PARAM('action') = 'dismissed') AS dismissals
@@ -452,18 +454,6 @@ prompt_newsletter_signups AS (
     AND event_name = 'np_newsletter_subscribed'
     AND PARAM('newspack_popup_id') IS NOT NULL
   GROUP BY popup_id
-),
-prompt_checkout_attempts AS (
-  SELECT
-    PARAM('newspack_popup_id') AS popup_id,
-    PARAM('action_type') AS checkout_type,
-    COUNT(*) AS attempts
-  FROM `{project}.{dataset}.events_*`
-  WHERE _TABLE_SUFFIX BETWEEN @start_date AND @end_date
-    AND event_name = 'np_modal_checkout_interaction'
-    AND PARAM('action') = 'form_submission'
-    AND PARAM('newspack_popup_id') IS NOT NULL
-  GROUP BY popup_id, checkout_type
 )
 SELECT
   i.popup_id,
@@ -472,29 +462,47 @@ SELECT
   i.placement,
   i.impressions,
   i.unique_viewers,
+  i.sessions_with_impression,
   SAFE_DIVIDE(i.clicks, i.impressions) AS ctr,
   SAFE_DIVIDE(i.form_submissions, i.impressions) AS form_submission_rate,
   SAFE_DIVIDE(i.dismissals, i.impressions) AS dismissal_rate,
   COALESCE(r.registrations, 0) AS registrations,
-  COALESCE(n.newsletter_signups, 0) AS newsletter_signups,
-  COALESCE(SUM(IF(c.checkout_type = 'donation', c.attempts, 0)), 0) AS donation_attempts,
-  COALESCE(SUM(IF(c.checkout_type = 'checkout_button', c.attempts, 0)), 0) AS subscription_attempts
+  COALESCE(n.newsletter_signups, 0) AS newsletter_signups
 FROM prompt_impressions i
 LEFT JOIN prompt_registrations r USING (popup_id)
 LEFT JOIN prompt_newsletter_signups n USING (popup_id)
-LEFT JOIN prompt_checkout_attempts c USING (popup_id)
-GROUP BY
-  i.popup_id, i.prompt_title, i.intent, i.placement,
-  i.impressions, i.unique_viewers, i.clicks, i.form_submissions,
-  i.dismissals, r.registrations, n.newsletter_signups
 ORDER BY i.impressions DESC
 LIMIT 50
 ```
 
+```sql
+-- (2) Per-attempt rows for the Woo conversion join (BQ). One row per checkout
+-- form submission tagged to a prompt; PHP groups these by popup_id and matches
+-- completed Woo orders within the 30-min window, scoped by product type.
+SELECT
+  PARAM('newspack_popup_id') AS popup_id,
+  PARAM('action_type') AS checkout_type, -- 'donation' | 'checkout_button' (subscription)
+  COALESCE(user_id, user_pseudo_id) AS uid,
+  PARAM('ga_session_id') AS session_id,
+  event_timestamp
+FROM `{project}.{dataset}.events_*`
+WHERE _TABLE_SUFFIX BETWEEN @start_date AND @end_date
+  AND event_name = 'np_modal_checkout_interaction'
+  AND PARAM('action') = 'form_submission'
+  AND PARAM('newspack_popup_id') IS NOT NULL
+```
+
+Then in PHP, per prompt (`popup_id`):
+
+- Group the attempt rows from query (2) by `popup_id`, split by `checkout_type` (`donation` vs `checkout_button` → subscription).
+- Pass each group to `Woo_Order_Resolver::count_completed_orders()`, scoped to the matching Woo product type (donation products vs subscription products) — the same product-type scoping used by `get_donation_revenue_direct` / `get_subscription_revenue_direct`. The result is `donation_conversions` / `subscription_conversions`.
+- `donation_conversion_rate` = `donation_conversions ÷ sessions_with_impression`; `subscription_conversion_rate` likewise. `sessions_with_impression` (from query 1) is the count of distinct sessions with a `seen` impression of that prompt — the same denominator family the section-level Prompts rate metrics use.
+- A prompt with no donation (resp. subscription) intent returns `null` for that count + rate pair → the table renders a muted em-dash; a prompt with the intent but zero completions returns `0` / `0%`.
+
 Notes:
 - `prompt_title` is captured directly in the event params, no WP enrichment needed (unlike Gates which only have `gate_post_id`).
-- Donation and subscription columns show *attempts* — the table needs PHP post-processing to convert to *completions* via the Woo join. v1 may ship with the attempts column labeled explicitly and add the completion column in a follow-up.
-- `LIMIT 50` guardrail. Publishers with >50 prompts get the top 50 by impressions with a footnote noting truncation.
+- Donation and subscription columns report **conversions** (Woo-completed outcomes), not attempts — aligning with the Gates v1.1 decision (NPPD-1684). Phase 1 ships the final column set with placeholder zeros; Phase 2 (NPPD-1682) populates them via the Woo join above.
+- `LIMIT 50` guardrail on the aggregate query. The UI shows the top 10 by the sorted column with a "See more" toggle that reveals the rest (up to 50); publishers with >50 prompts get the top 50 by impressions with a footnote noting truncation.
 
 ### Table: Performance by Prompt Intent
 

--- a/plugins/newspack-plugin/docs/insights/specs/prompts.md
+++ b/plugins/newspack-plugin/docs/insights/specs/prompts.md
@@ -1,0 +1,324 @@
+# Tab 5: Prompts
+
+Behavioral funnel tab covering Newspack Campaigns (prompts). Sourced from GA4 `np_prompt_interaction` event data via BigQuery, with paid conversion completion via local Woo. Conceptually parallel to Tab 4 (Gates), with four conversion intents instead of two: donation, registration, subscription, and newsletter signup.
+
+Spec mirrors Tab 4's structure where possible. Where Prompts diverges, it's because the underlying data model differs: prompts carry richer intent + placement + title metadata in event params, and the conversion space is wider.
+
+Cross-reference: `formulas/tab-5-prompts.md` for the SQL, `tab-4-gates.md` for the parallel patterns.
+
+## Tab visibility
+
+Gated only by `NEWSPACK_INSIGHTS_ENABLED`. No separate preview flag — the Prompts tab work lands on `feat/insights-rsm` (the Insights v1 integration branch) and isn't visible to publishers until that branch merges to main as a single Insights v1 release event.
+
+## Top of tab
+
+### Direct vs Influenced explainer (lifted from Tab 4, with substitution)
+
+A dismissable callout sits between the tab header and Section 1. Body text — lifted from Tab 4 and substituting "gate" → "prompt":
+
+> **Direct** conversions happen in the same session as a prompt impression. The prompt is credited regardless of whether checkout happens on the same page (embedded checkout block) or after clicking through to a subscription page.
+>
+> **Influenced** conversions happen after a prompt impression but in a later session, within a lookback window (7 days for free conversions, 14 days for paid).
+>
+> Same-session is Direct. Later-session-within-lookback is Influenced. The two are mutually exclusive and together capture every prompt-touched conversion within the lookback period.
+
+Dismissal is session-only — reappears on page reload, matching Tab 4's treatment.
+
+## Section 1: Prompt exposure
+
+**Caption:** Top of the funnel. How many readers see prompts in this timeframe.
+
+Three scorecards in a row.
+
+### Card 1.1 — TOTAL PROMPT IMPRESSIONS
+
+- Value format: `count`
+- Subtitle: Every prompt view in this timeframe
+- Formula reference: `formulas/tab-5-prompts.md#total-prompt-impressions-selected-period`
+
+### Card 1.2 — UNIQUE READERS REACHED
+
+- Value format: `count`
+- Subtitle: Distinct readers who saw at least one prompt
+- Formula reference: `formulas/tab-5-prompts.md#unique-readers-who-saw-a-prompt`
+
+### Card 1.3 — AVG PROMPTS PER READER
+
+- Value format: `decimal` (one decimal place, e.g. `2.4`)
+- Subtitle: How many prompts a typical reader sees
+- Formula reference: `formulas/tab-5-prompts.md#avg-prompts-per-reader`
+
+## Section 2: Prompt engagement
+
+**Caption:** How readers respond to prompts they see. Engagement is any interaction beyond just seeing the prompt.
+
+Three scorecards in a row.
+
+### Card 2.1 — CLICK-THROUGH RATE
+
+- Value format: `rate` (percentage)
+- Subtitle: Clicks ÷ prompt impressions
+- Formula reference: `formulas/tab-5-prompts.md#click-through-rate`
+
+### Card 2.2 — FORM SUBMISSION RATE
+
+- Value format: `rate` (percentage)
+- Subtitle: Form submissions ÷ impressions on form-bearing prompts
+- Formula reference: `formulas/tab-5-prompts.md#form-submission-rate`
+
+### Card 2.3 — DISMISSAL RATE
+
+- Value format: `rate` (percentage)
+- Subtitle: Explicit dismissals ÷ prompt impressions
+- Formula reference: `formulas/tab-5-prompts.md#dismissal-rate`
+
+## Section 3: Free reader conversion
+
+**Caption:** How effectively prompts convert readers into registered readers and newsletter subscribers. Direct counts conversions in the same session as a prompt impression. Influenced counts conversions in a later session within 7 days of seeing a prompt.
+
+Four scorecards in a row.
+
+### Card 3.1 — REGISTRATION CONVERSION (DIRECT)
+
+- Value format: `rate`
+- Subtitle: Sessions with a registration after a registration-intent prompt impression ÷ sessions with a registration-intent prompt impression
+- Formula reference: `formulas/tab-5-prompts.md#registration-conversion-rate-direct`
+
+### Card 3.2 — REGISTRATION CONVERSION (INFLUENCED, 7D)
+
+- Value format: `rate`
+- Subtitle: Readers who registered in a later session within 7 days of seeing a registration-intent prompt ÷ readers who saw a registration-intent prompt
+- Formula reference: `formulas/tab-5-prompts.md#registration-conversion-rate-influenced-7d-lookback`
+
+### Card 3.3 — NEWSLETTER SIGNUP CONVERSION (DIRECT)
+
+- Value format: `rate`
+- Subtitle: Sessions with a newsletter signup after a newsletter-intent prompt impression ÷ sessions with a newsletter-intent prompt impression
+- Formula reference: `formulas/tab-5-prompts.md#newsletter-signup-conversion-rate-direct`
+
+### Card 3.4 — NEWSLETTER SIGNUP CONVERSION (INFLUENCED, 7D)
+
+- Value format: `rate`
+- Subtitle: Readers who signed up for a newsletter in a later session within 7 days of seeing a newsletter-intent prompt ÷ readers who saw a newsletter-intent prompt
+- Formula reference: `formulas/tab-5-prompts.md#newsletter-signup-conversion-rate-influenced-7d-lookback`
+
+## Section 4: Paid reader conversion
+
+**Caption:** How effectively prompts convert readers into donors and subscribers. Direct counts conversions in the same session as a prompt impression. Influenced counts conversions in a later session within 14 days of seeing a prompt.
+
+Four scorecards in a row.
+
+### Card 4.1 — DONATION CONVERSION (DIRECT)
+
+- Value format: `rate`
+- Subtitle: Sessions with a completed donation after a donation-intent prompt impression ÷ sessions with a donation-intent prompt impression
+- Formula reference: `formulas/tab-5-prompts.md#donation-conversion-rate-direct`
+
+### Card 4.2 — DONATION CONVERSION (INFLUENCED, 14D)
+
+- Value format: `rate`
+- Subtitle: Readers who completed a donation in a later session within 14 days of seeing a donation-intent prompt ÷ readers who saw a donation-intent prompt
+- Formula reference: `formulas/tab-5-prompts.md#donation-conversion-rate-influenced-14d-lookback`
+
+### Card 4.3 — SUBSCRIPTION CONVERSION (DIRECT)
+
+- Value format: `rate`
+- Subtitle: Sessions with a completed subscription after a subscription-intent prompt impression ÷ sessions with a subscription-intent prompt impression
+- Formula reference: `formulas/tab-5-prompts.md#subscription-conversion-rate-direct`
+
+### Card 4.4 — SUBSCRIPTION CONVERSION (INFLUENCED, 14D)
+
+- Value format: `rate`
+- Subtitle: Readers who completed a subscription in a later session within 14 days of seeing a subscription-intent prompt ÷ readers who saw a subscription-intent prompt
+- Formula reference: `formulas/tab-5-prompts.md#subscription-conversion-rate-influenced-14d-lookback`
+
+## Section 5: Revenue from prompts
+
+**Caption:** Sum of Woo order totals from donations and subscriptions completed after a prompt impression. Direct totals revenue from same-session completions. Influenced totals revenue from later-session completions within 14 days of seeing a prompt.
+
+Four scorecards in a row.
+
+### Card 5.1 — DONATION REVENUE (DIRECT)
+
+- Value format: `currency`
+- Subtitle: Sum of Woo donation order totals from same-session completions after a donation-intent prompt impression
+- Formula reference: `formulas/tab-5-prompts.md#total-donation-revenue-from-prompts-direct`
+
+### Card 5.2 — DONATION REVENUE (INFLUENCED, 14D)
+
+- Value format: `currency`
+- Subtitle: Sum of Woo donation order totals from later-session completions within 14 days of seeing a donation-intent prompt
+- Formula reference: `formulas/tab-5-prompts.md#total-donation-revenue-from-prompts-influenced-14d`
+
+### Card 5.3 — SUBSCRIPTION REVENUE (DIRECT)
+
+- Value format: `currency`
+- Subtitle: Sum of Woo subscription order totals from same-session completions after a subscription-intent prompt impression
+- Formula reference: `formulas/tab-5-prompts.md#total-subscription-revenue-from-prompts-direct`
+
+### Card 5.4 — SUBSCRIPTION REVENUE (INFLUENCED, 14D)
+
+- Value format: `currency`
+- Subtitle: Sum of Woo subscription order totals from later-session completions within 14 days of seeing a subscription-intent prompt
+- Formula reference: `formulas/tab-5-prompts.md#total-subscription-revenue-from-prompts-influenced-14d`
+
+## Section 6: How readers convert
+
+**Caption:** The journey from prompt impression to conversion. The funnel shows where readers drop off; the distribution shows how many touches it typically takes before conversion.
+
+Two-column layout: Funnel on the left, Distribution table on the right. Matches Tab 4's treatment.
+
+### Funnel
+
+Three stages, vertical SVG. Stage values are distinct user counts.
+
+| Stage | Label | Definition |
+|---|---|---|
+| 1 | Impression | Distinct readers with at least one `np_prompt_interaction(action=seen)` event |
+| 2 | Engagement | Distinct readers with at least one `np_prompt_interaction(action ∈ clicked, form_submission)` event |
+| 3 | Conversion | Distinct readers who registered, signed up for a newsletter, completed a donation, or completed a subscription, where any of those events is tagged with a `newspack_popup_id` |
+
+Stage 3 is a rollup across the four conversion types. The per-intent breakdowns live in Sections 3 / 4 / 5. The funnel is intentionally permissive (no time-window enforcement between impression and conversion) so it's readable at a glance — the per-prompt table below carries the rigor.
+
+Formula reference: `formulas/tab-5-prompts.md#funnel-prompt-impression-engagement-conversion-rolled-up`
+
+### Distribution table
+
+Bucketed exposure counts among readers who converted. Same shape as Tab 4.
+
+| Bucket label | Bucket condition |
+|---|---|
+| 1 exposure | Reader saw exactly 1 prompt impression before converting |
+| 2 exposures | Reader saw exactly 2 prompt impressions before converting |
+| 3–5 exposures | Reader saw 3 to 5 prompt impressions before converting |
+| 6+ exposures | Reader saw 6 or more prompt impressions before converting |
+
+Caption under the table: Of readers who converted, this is how many prompts they saw first.
+
+## Section 7: Performance breakdown
+
+**Caption:** Per-prompt, per-intent, and per-placement breakdowns for the selected timeframe. Click any column to re-sort.
+
+Three stacked tables. Same sortable table chrome as the Tab 4 Performance by gate table.
+
+### Table 7.1 — Performance by prompt
+
+One row per prompt, sorted by impressions descending by default.
+
+| Column | Format | Source |
+|---|---|---|
+| Prompt | text | `prompt_title` from event params (no WP enrichment needed) |
+| Intent | text | `action_type` value: `donation` / `registration` / `newsletters_subscription` |
+| Placement | text | `prompt_placement` value: e.g. `overlay`, `inline`, `above-header` |
+| Impressions | count | Total `action=seen` count |
+| Unique viewers | count | Distinct users with `action=seen` |
+| CTR | rate | Clicks ÷ impressions |
+| Form submission rate | rate | Form submissions ÷ impressions |
+| Dismissal rate | rate | Dismissals ÷ impressions |
+| Registrations | count | `np_reader_registered` events tagged with this `newspack_popup_id` |
+| Newsletter signups | count | `np_newsletter_subscribed` events tagged with this `newspack_popup_id` |
+| Donation conversions | count | Per-prompt Woo donation completions matched to attempts within 30 min (via `Woo_Order_Resolver`) |
+| Donation conversion rate | rate | `donation_conversions ÷ sessions_with_prompt_impression` |
+| Subscription conversions | count | Per-prompt Woo subscription completions matched to attempts within 30 min (via `Woo_Order_Resolver`) |
+| Subscription conversion rate | rate | `subscription_conversions ÷ sessions_with_prompt_impression` |
+
+The donation/subscription columns report **conversions** (Woo-completed outcomes), not attempts — aligning with the Gates v1.1 decision (NPPD-1684). Count + rate cells right-aligned. Em-dash for non-applicable cells (e.g. CTR on a button-less prompt, or donation conversions on a registration-intent prompt) in muted gray to distinguish from a real zero.
+
+Empty-state row when no data: "No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts."
+
+Truncated at LIMIT 50 (top by impressions). The UI shows the top 10 by the sorted column with a "See more" toggle that reveals the rest; caption note: "Showing the top 10 prompts by the sorted column; use 'See more' to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear."
+
+Formula reference: `formulas/tab-5-prompts.md#table-performance-by-prompt`
+
+### Table 7.2 — Performance by prompt intent
+
+One row per intent (donation / registration / newsletter signup). Aggregates across all prompts of that intent.
+
+| Column | Format | Source |
+|---|---|---|
+| Intent | text | `donation` / `registration` / `newsletters_subscription` (display: title case) |
+| Impressions | count | |
+| Unique viewers | count | |
+| CTR | rate | |
+| Form submission rate | rate | |
+| Dismissal rate | rate | |
+
+Caption note: "Answers 'are my donation prompts working better than my registration prompts?' at a glance."
+
+Formula reference: `formulas/tab-5-prompts.md#table-performance-by-prompt-intent`
+
+### Table 7.3 — Performance by prompt placement
+
+One row per placement (`overlay`, `inline`, `above-header`, etc.). Aggregates across all prompts at that placement.
+
+| Column | Format | Source |
+|---|---|---|
+| Placement | text | `prompt_placement` value (display: title case) |
+| Impressions | count | |
+| Unique viewers | count | |
+| CTR | rate | |
+| Dismissal rate | rate | |
+
+Caption note: "Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults."
+
+Formula reference: `formulas/tab-5-prompts.md#table-performance-by-prompt-placement`
+
+## Empty states
+
+When a section has data but zero of a specific category:
+
+- A specific scorecard with value zero renders the zero (e.g. "0%", "$0.00") — does not render as empty
+- Comparison delta on a card renders normally when comparison is on; suppresses when off (see MetricCard `pending` pattern from Tab 4)
+- Performance breakdown tables show their data — if a table has zero rows, the empty-state row above appears
+
+When the whole tab has zero data (no prompts active, no event data ingested yet):
+
+- Every scorecard shows zero per its format type
+- Funnel shows three stages with zero / zero / zero
+- Distribution shows four buckets with zero / 0%
+- Performance by prompt table shows the empty-state row above
+- Performance by intent table shows zero rows
+- Performance by placement table shows zero rows
+
+## Notes for implementation
+
+### Subscription-intent vs registration-intent prompts (v1 simplification)
+
+Subscription-intent prompts and pure-registration prompts share `action_type = 'registration'` in the data model. The actual distinction is the modal checkout product type at conversion time. v1 ships with both lumped under "registration" intent in the prompt breakdown table — the conversion metrics still distinguish them (Section 4 Subscription Conversion vs Section 3 Registration Conversion) because the completion side filters by Woo product type.
+
+v1.1 may add a "subscription-intent" badge to the per-prompt table by inferring intent from whether the prompt has ever converted to a subscription product. Out of scope for v1.
+
+### Newsletter conversion uses event-only attribution
+
+Newsletter signup conversions don't need a Woo join (signups complete in-event via `np_newsletter_subscribed`). Simplest of the four conversion types — the orchestrator can compute it from BQ alone with no PHP post-processing.
+
+### Donation and subscription conversions need Woo post-processing
+
+The BQ query returns attempts (form submissions). Completions require joining against `wp_wc_orders` with a 30-min window from the attempt event, scoped by Woo product type. Same pattern as Tab 4's paywall conversion. Lives in PHP, not the catalog query. This is what backs the per-prompt **Donation conversions / Subscription conversions** columns (count + rate) in Table 7.1 — the table reports conversions, not attempts.
+
+### A/B variant tracking (v2)
+
+`ab_test_id` and `ab_variant` are present on every prompt event. v1 ignores them; v2 may slice the per-prompt table by variant. File a follow-up ticket.
+
+### `prompt_frequency` parameter (v2)
+
+The help doc references a `prompt_frequency` event param. v1 ignores it; v2 may use it for "once-per-session prompts vs always-shown" comparison. File a follow-up ticket.
+
+## Open questions
+
+These remain to be decided. Defaults below are best-guess; document choices when settled.
+
+1. **Performance by prompt LIMIT.** Spec says 50 with a caption note. Acceptable for most publishers. If any publisher has >50 active prompts and the truncation becomes a real problem, consider pagination in v1.1.
+
+2. **Performance by prompt — completion column vs attempt column. (Resolved.)** The per-prompt table ships with **conversion** columns — `Donation conversions` / `Donation conversion rate` / `Subscription conversions` / `Subscription conversion rate` — not attempt columns, computed via the Woo join (`Woo_Order_Resolver`). This aligns with the Gates v1.1 decision (NPPD-1684): show outcomes, not engagement intent. Phase 1 ships the final column set with placeholder zeros; Phase 2 (NPPD-1682) populates real Woo-joined values. The cost is one Woo query per visible prompt, bounded by the top-50 cap.
+
+3. **Funnel rigor — time-window enforcement.** Spec funnel is permissive (no time window between impression and conversion). The Tab 4 funnel has the same caveat. If publishers ask "how can these add up?" we have an answer (rigor lives in the per-prompt table). If they don't ask, no change.
+
+4. **Sticky dismissal of the Direct vs Influenced explainer.** Currently session-only — reappears on page reload. Tab 4 has the same treatment. If publishers report it as repetitive, change to permanent dismissal stored in user meta. Defer until signal.
+
+## Cross-references
+
+- Formulas: `formulas/tab-5-prompts.md`
+- Tab 4 (Gates) spec for the parallel patterns: `specs/tab-4-gates.md`
+- Event reference: `event-reference.md`
+- Open questions (project-wide): `open-questions.md`

--- a/plugins/newspack-plugin/docs/insights/specs/prompts.md
+++ b/plugins/newspack-plugin/docs/insights/specs/prompts.md
@@ -274,7 +274,7 @@ When a section has data but zero of a specific category:
 When the whole tab has zero data (no prompts active, no event data ingested yet):
 
 - Every scorecard shows zero per its format type
-- Funnel shows three stages with zero / zero / zero
+- Funnel shows its empty-state message ("Not enough data to chart the funnel.") — the SVG funnel needs a non-zero top stage to chart proportions, so an all-zero window renders the message rather than three zero-height bands (matches the Gates funnel)
 - Distribution shows four buckets with zero / 0%
 - Performance by prompt table shows the empty-state row above
 - Performance by intent table shows zero rows

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -1,0 +1,318 @@
+<?php
+/**
+ * Newspack Insights — Tab 5 Prompts REST controller (NPPD-1607, Phase 1).
+ *
+ * Single endpoint: `GET /newspack-insights/v1/prompts`. Same date-arg
+ * validation, permission check, and date parsing conventions as
+ * {@see Gates_REST_Controller} — Tab 5 mirrors Tab 4's request/response
+ * lifecycle exactly.
+ *
+ * Response shape:
+ *   tab_pending: bool        — true in Phase 1 (placeholder phase); React
+ *                              uses it to render the top-of-tab banner.
+ *   current:     PromptsWindow — scorecards + funnel + distribution + tables
+ *   previous:    PromptsWindow | null — only populated when the request
+ *                              passes `compare_start` + `compare_end`.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Prompts REST controller.
+ */
+class Prompts_REST_Controller extends WP_REST_Controller {
+
+	/**
+	 * Shared Tab 4–7 namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'prompts';
+
+	/**
+	 * Register the Tab 5 route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_prompts_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET handler.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function get_prompts_data( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
+
+		try {
+			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
+			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+		}
+		if ( $start > $end ) {
+			return new WP_Error(
+				'newspack_insights_invalid_window',
+				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$compare_start_param = $request->get_param( 'compare_start' );
+		$compare_end_param   = $request->get_param( 'compare_end' );
+		$compare_start       = null;
+		$compare_end         = null;
+		if ( $compare_start_param || $compare_end_param ) {
+			if ( ! $compare_start_param || ! $compare_end_param ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison',
+					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+			try {
+				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
+				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+			}
+			if ( $compare_start > $compare_end ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison_window',
+					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		$metric = new Prompts_Metric();
+		return rest_ensure_response( $this->build_response( $metric, $start, $end, $compare_start, $compare_end ) );
+	}
+
+	/**
+	 * Assemble the top-level response.
+	 *
+	 * `tab_pending` is true in Phase 1 (placeholder phase). React uses it
+	 * to render the top-of-tab banner; remove the flag (or have it return
+	 * false based on real data state) when Phase 2 wires up BigQuery.
+	 *
+	 * @param Prompts_Metric         $metric        Orchestrator.
+	 * @param DateTimeImmutable      $start         Current window start.
+	 * @param DateTimeImmutable      $end           Current window end.
+	 * @param DateTimeImmutable|null $compare_start Prior window start.
+	 * @param DateTimeImmutable|null $compare_end   Prior window end.
+	 * @return array
+	 */
+	private function build_response(
+		Prompts_Metric $metric,
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		?DateTimeImmutable $compare_start,
+		?DateTimeImmutable $compare_end
+	): array {
+		$response = [
+			'tab_pending' => true,
+			'current'     => $this->build_window( $metric, $start, $end ),
+			'previous'    => null,
+		];
+		if ( $compare_start && $compare_end ) {
+			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end );
+		}
+		return $response;
+	}
+
+	/**
+	 * Window-bound payload covering all seven sections.
+	 *
+	 * @param Prompts_Metric    $metric Orchestrator.
+	 * @param DateTimeImmutable $start  Start.
+	 * @param DateTimeImmutable $end    End.
+	 * @return array
+	 */
+	private function build_window( Prompts_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return [
+			'window'                                     => [
+				'start' => $start->format( 'Y-m-d' ),
+				'end'   => $end->format( 'Y-m-d' ),
+			],
+			// Section 1 — Prompt exposure.
+			'total_prompt_impressions'                   => $metric->get_total_prompt_impressions( $start, $end ),
+			'unique_readers_reached'                     => $metric->get_unique_readers_reached( $start, $end ),
+			'avg_prompts_per_reader'                     => $metric->get_avg_prompts_per_reader( $start, $end ),
+			// Section 2 — Prompt engagement.
+			'click_through_rate'                         => $metric->get_click_through_rate( $start, $end ),
+			'form_submission_rate'                       => $metric->get_form_submission_rate( $start, $end ),
+			'dismissal_rate'                             => $metric->get_dismissal_rate( $start, $end ),
+			// Section 3 — Free reader conversion.
+			'registration_conversion_direct'             => $metric->get_registration_conversion_direct( $start, $end ),
+			'registration_conversion_influenced_7d'      => $metric->get_registration_conversion_influenced_7d( $start, $end ),
+			'newsletter_signup_conversion_direct'        => $metric->get_newsletter_signup_conversion_direct( $start, $end ),
+			'newsletter_signup_conversion_influenced_7d' => $metric->get_newsletter_signup_conversion_influenced_7d( $start, $end ),
+			// Section 4 — Paid reader conversion.
+			'donation_conversion_direct'                 => $metric->get_donation_conversion_direct( $start, $end ),
+			'donation_conversion_influenced_14d'         => $metric->get_donation_conversion_influenced_14d( $start, $end ),
+			'subscription_conversion_direct'             => $metric->get_subscription_conversion_direct( $start, $end ),
+			'subscription_conversion_influenced_14d'     => $metric->get_subscription_conversion_influenced_14d( $start, $end ),
+			// Section 5 — Revenue from prompts.
+			'donation_revenue_direct'                    => $metric->get_donation_revenue_direct( $start, $end ),
+			'donation_revenue_influenced_14d'            => $metric->get_donation_revenue_influenced_14d( $start, $end ),
+			'subscription_revenue_direct'                => $metric->get_subscription_revenue_direct( $start, $end ),
+			'subscription_revenue_influenced_14d'        => $metric->get_subscription_revenue_influenced_14d( $start, $end ),
+			// Section 6 — How readers convert.
+			'conversion_funnel'                          => $metric->get_conversion_funnel( $start, $end ),
+			'exposures_distribution'                     => $metric->get_exposures_distribution( $start, $end ),
+			// Section 7 — Performance breakdown.
+			'performance_by_prompt'                      => $metric->get_performance_by_prompt( $start, $end ),
+			'performance_by_intent'                      => $metric->get_performance_by_intent( $start, $end ),
+			'performance_by_placement'                   => $metric->get_performance_by_placement( $start, $end ),
+		];
+	}
+
+	/**
+	 * Args spec.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$base = [
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+		];
+		return [
+			'start'         => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				]
+			),
+			'end'           => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				]
+			),
+			'compare_start' => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
+					'required'    => false,
+				]
+			),
+			'compare_end'   => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
+					'required'    => false,
+				]
+			),
+		];
+	}
+
+	/**
+	 * REST validate_callback.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool|WP_Error
+	 */
+	public function validate_date_string( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				/* translators: %s: the invalid date string */
+				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
+				[ 'status' => 400 ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Parse a Y-m-d string into a DateTimeImmutable.
+	 *
+	 * @param mixed        $value      Raw value.
+	 * @param DateTimeZone $tz         Timezone.
+	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
+	 * @return DateTimeImmutable
+	 * @throws Exception On parse failure.
+	 */
+	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			/* translators: %s: the invalid date string */
+			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
+		}
+		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
+	}
+
+	/**
+	 * Site timezone.
+	 *
+	 * @return DateTimeZone
+	 */
+	private function site_timezone(): DateTimeZone {
+		return wp_timezone();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
@@ -1,21 +1,27 @@
 <?php
 /**
- * Newspack Insights — Prompts section (NPPD-1602).
+ * Newspack Insights — Prompts section (NPPD-1607).
  *
- * Prompts tab scope: per-campaign / per-prompt performance from the
- * Campaigns surface. Impressions, click-throughs, gate fires attributed
- * to specific overlay / inline / popup prompts. Complements the Gates
- * tab — Gates is "what conversion surface fired"; Prompts is "what
- * editorial campaign drove the fire."
+ * Tab 5 scope: prompt exposure, engagement, free + paid reader
+ * conversion, revenue from prompts, the impression → engagement →
+ * conversion funnel, and per-prompt / per-intent / per-placement
+ * performance breakdowns. Sourced from Newspack Campaigns (prompt)
+ * GA4 events. Phase 1 ships the full UI with placeholder data;
+ * Phase 2 swaps the underlying metric implementations to BigQuery via
+ * the Newspack Manager query proxy.
  *
- * Future REST endpoints for the Prompts tab register from
- * {@see self::register_hooks()}. Currently a stub; the React side renders
- * a "Coming soon" placeholder for this tab.
+ * Unlike Gates, the Prompts tab has no separate preview flag — it is
+ * gated solely by {@see Insights_Wizard::is_enabled()}. The
+ * `feat/insights-rsm` integration branch is the staging area; the tab
+ * is not visible to publishers until that branch merges to main as a
+ * single Insights v1 release event.
  *
  * @package Newspack
  */
 
 namespace Newspack;
+
+use Newspack\Insights\Prompts_REST_Controller;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -32,18 +38,39 @@ class Insights_Section_Prompts {
 	const SECTION_NAME = 'Prompts';
 
 	/**
-	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1607).
+	 * Initialize. Bails early when the parent Insights feature flag is off.
 	 */
 	public static function init() {
 		if ( ! Insights_Wizard::is_enabled() ) {
 			return;
 		}
+		self::load_dependencies();
 		self::register_hooks();
 	}
 
 	/**
-	 * Register hooks for this section. Currently a stub.
+	 * Include Tab 5 PHP files.
+	 *
+	 * @return void
 	 */
-	public static function register_hooks() {}
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'metrics/class-prompts-metric.php';
+		include_once $base . 'api/class-prompts-rest-controller.php';
+	}
+
+	/**
+	 * Register the Tab 5 REST route.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new Prompts_REST_Controller();
+				$controller->register_routes();
+			}
+		);
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -383,8 +383,10 @@ final class Prompts_Metric {
 	 * when the array is empty. Phase 2 will populate this with real BQ
 	 * rows — `prompt_title` is captured directly in event params, so no
 	 * WP enrichment is needed (unlike Gates' `gate_post_id` → post_title
-	 * lookup). Donation/subscription columns ship as *attempts* in v1;
-	 * completion columns are a v1.1 candidate via the Woo join.
+	 * lookup). Donation/subscription columns report *conversions* (count
+	 * + rate), populated in Phase 2 by grouping per-prompt attempts and
+	 * matching Woo completions via `Woo_Order_Resolver` — mirroring the
+	 * Gates v1.1 decision (NPPD-1684).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -1,0 +1,434 @@
+<?php
+/**
+ * Newspack Insights — Prompts Metric orchestrator (NPPD-1607, Phase 1).
+ *
+ * Phase 1 placeholder layer. Every metric returns a `pending: true`
+ * payload with a zero value and a `placeholder_type` so the React
+ * layer can render the spec's empty-state value ("0", "0%", "$0.00",
+ * "0.0") without inferring type. No storage layer, no SQL — the data
+ * is intentionally synthetic until Phase 2 wires the BigQuery query
+ * proxy into the same method signatures.
+ *
+ * Mirrors {@see Gates_Metric} (Tab 4) one-for-one: same placeholder
+ * shape, same Phase 1 / Phase 2 split. Method names track the query
+ * names in `formulas/tab-5-prompts.md` so Phase 2 swaps each method
+ * body to a `query_name` dispatch against the Newspack Manager BQ
+ * catalog without touching signatures or the response envelope.
+ *
+ * Tab 5 carries four conversion intents (registration, newsletter
+ * signup, donation, subscription) versus Gates' two, so it has more
+ * scorecards and a three-table performance breakdown — but the
+ * per-metric envelope is identical.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeInterface;
+
+/**
+ * Tab 5 placeholder metric orchestrator.
+ *
+ * @phpstan-type ScalarMetric array{
+ *   value: int|float,
+ *   computable: bool,
+ *   pending: bool,
+ *   denominator: int|null,
+ *   placeholder_type: string,
+ * }
+ */
+final class Prompts_Metric {
+
+	/**
+	 * Cache key prefix. Bumped when the response shape changes so
+	 * cached payloads from a prior shape don't break a deploy.
+	 *
+	 * @var string
+	 */
+	const CACHE_PREFIX = 'newspack_insights_tab5_v1:';
+
+	/**
+	 * Build the standard placeholder shape for a single scorecard
+	 * metric. Type is encoded in `placeholder_type` so React can pick
+	 * the right format token ("0" vs "0%" vs "$0.00" vs "0.0") without
+	 * inferring from the field name.
+	 *
+	 * @param string $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @return array{value: int|float, computable: bool, pending: bool, denominator: null, placeholder_type: string}
+	 */
+	private function placeholder( string $placeholder_type ): array {
+		return [
+			'value'            => 'decimal' === $placeholder_type ? 0.0 : 0,
+			'computable'       => false,
+			'pending'          => true,
+			'denominator'      => null,
+			'placeholder_type' => $placeholder_type,
+		];
+	}
+
+	// --- Section 1: Prompt exposure -------------------------------------
+
+	/**
+	 * Total prompt impressions in window.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_total_prompt_impressions( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'count' );
+	}
+
+	/**
+	 * Unique readers who saw at least one prompt.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_unique_readers_reached( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'count' );
+	}
+
+	/**
+	 * Average prompt exposures per reader.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_avg_prompts_per_reader( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'decimal' );
+	}
+
+	// --- Section 2: Prompt engagement -----------------------------------
+
+	/**
+	 * Click-through rate (clicks ÷ impressions).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_click_through_rate( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Form submission rate (submissions ÷ form-bearing impressions).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_form_submission_rate( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Dismissal rate (explicit dismissals ÷ impressions).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_dismissal_rate( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	// --- Section 3: Free reader conversion ------------------------------
+
+	/**
+	 * Registration conversion rate, direct attribution.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_registration_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Registration conversion rate, influenced (7-day lookback).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_registration_conversion_influenced_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Newsletter signup conversion rate, direct attribution.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_newsletter_signup_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Newsletter signup conversion rate, influenced (7-day lookback).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_newsletter_signup_conversion_influenced_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	// --- Section 4: Paid reader conversion ------------------------------
+
+	/**
+	 * Donation conversion rate, direct attribution.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_donation_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Donation conversion rate, influenced (14-day lookback).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_donation_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Subscription conversion rate, direct attribution.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_subscription_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Subscription conversion rate, influenced (14-day lookback).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_subscription_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	// --- Section 5: Revenue from prompts --------------------------------
+
+	/**
+	 * Total donation revenue from prompts, direct attribution.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_donation_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'currency' );
+	}
+
+	/**
+	 * Total donation revenue from prompts, influenced (14-day lookback).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_donation_revenue_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'currency' );
+	}
+
+	/**
+	 * Total subscription revenue from prompts, direct attribution.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_subscription_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'currency' );
+	}
+
+	/**
+	 * Total subscription revenue from prompts, influenced (14-day lookback).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_subscription_revenue_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'currency' );
+	}
+
+	// --- Section 6: How readers convert ---------------------------------
+
+	/**
+	 * Conversion funnel — three stages (impression → engagement →
+	 * conversion) with zeros and a pending flag. Stage shape kept
+	 * stable so the React Funnel viz renders the same chrome regardless
+	 * of phase. Stage 3 (Conversion) is a rollup across the four
+	 * conversion intents; the per-intent breakdowns live in Sections
+	 * 3 / 4 / 5.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{
+	 *   pending: bool,
+	 *   stages: array<int, array{label: string, count: int, pct_of_top: float}>
+	 * }
+	 */
+	public function get_conversion_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'stages'  => [
+				[
+					'label'      => __( 'Impression', 'newspack-plugin' ),
+					'count'      => 0,
+					'pct_of_top' => 0.0,
+				],
+				[
+					'label'      => __( 'Engagement', 'newspack-plugin' ),
+					'count'      => 0,
+					'pct_of_top' => 0.0,
+				],
+				[
+					'label'      => __( 'Conversion', 'newspack-plugin' ),
+					'count'      => 0,
+					'pct_of_top' => 0.0,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Exposures-before-conversion distribution buckets.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{
+	 *   pending: bool,
+	 *   buckets: array<int, array{label: string, count: int, pct: float}>
+	 * }
+	 */
+	public function get_exposures_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'buckets' => [
+				[
+					'label' => __( '1 exposure', 'newspack-plugin' ),
+					'count' => 0,
+					'pct'   => 0.0,
+				],
+				[
+					'label' => __( '2 exposures', 'newspack-plugin' ),
+					'count' => 0,
+					'pct'   => 0.0,
+				],
+				[
+					'label' => __( '3–5 exposures', 'newspack-plugin' ),
+					'count' => 0,
+					'pct'   => 0.0,
+				],
+				[
+					'label' => __( '6+ exposures', 'newspack-plugin' ),
+					'count' => 0,
+					'pct'   => 0.0,
+				],
+			],
+		];
+	}
+
+	// --- Section 7: Performance breakdown -------------------------------
+
+	/**
+	 * Per-prompt breakdown. Phase 1 returns an empty `rows` array; the
+	 * React PerformanceByPromptTable renders the spec's empty-state copy
+	 * when the array is empty. Phase 2 will populate this with real BQ
+	 * rows — `prompt_title` is captured directly in event params, so no
+	 * WP enrichment is needed (unlike Gates' `gate_post_id` → post_title
+	 * lookup). Donation/subscription columns ship as *attempts* in v1;
+	 * completion columns are a v1.1 candidate via the Woo join.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, rows: array}
+	 */
+	public function get_performance_by_prompt( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'rows'    => [],
+		];
+	}
+
+	/**
+	 * Per-intent breakdown (donation / registration / newsletter signup),
+	 * aggregated across all prompts of that intent. Phase 1 returns an
+	 * empty `rows` array.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, rows: array}
+	 */
+	public function get_performance_by_intent( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'rows'    => [],
+		];
+	}
+
+	/**
+	 * Per-placement breakdown (overlay / inline / above-header / etc.),
+	 * aggregated across all prompts at that placement. Phase 1 returns an
+	 * empty `rows` array.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, rows: array}
+	 */
+	public function get_performance_by_placement( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'rows'    => [],
+		];
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
@@ -1,0 +1,198 @@
+/**
+ * Prompts API client (NPPD-1607, Phase 1).
+ *
+ * Thin wrapper around `@wordpress/api-fetch` for the single Tab 5
+ * endpoint: `GET /newspack-insights/v1/prompts`. Type definitions
+ * mirror the PHP response shape assembled by `Prompts_REST_Controller`.
+ *
+ * Phase 1: every metric carries `pending: true` and a zero value.
+ * Phase 2 keeps the same shape but flips `pending` to false and
+ * surfaces real BQ values; the React layer does not need to know
+ * which phase produced a payload — it reads `pending` and the
+ * `tab_pending` banner flag.
+ *
+ * Mirrors `api/gates.ts` (Tab 4) one-for-one. Tab 5 carries four
+ * conversion intents instead of two, so it has more scorecards and a
+ * three-table performance breakdown.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * The kind of placeholder a metric renders. Encoded server-side so
+ * the React format layer doesn't have to guess from the field name.
+ */
+export type PromptsPlaceholderType = 'count' | 'rate' | 'currency' | 'decimal';
+
+/**
+ * Standard scorecard metric payload. Carries the value plus the
+ * `pending` and `placeholder_type` markers the UI needs to render
+ * the Phase 1 zeros in the correct visual format.
+ */
+export interface PromptsScalarMetric {
+	value: number;
+	computable: boolean;
+	pending: boolean;
+	denominator: number | null;
+	placeholder_type: PromptsPlaceholderType;
+}
+
+export interface PromptsFunnelStage {
+	label: string;
+	count: number;
+	pct_of_top: number;
+}
+
+export interface PromptsFunnelData {
+	pending: boolean;
+	stages: PromptsFunnelStage[];
+}
+
+export interface PromptsDistributionBucket {
+	label: string;
+	count: number;
+	pct: number;
+}
+
+export interface PromptsDistributionData {
+	pending: boolean;
+	buckets: PromptsDistributionBucket[];
+}
+
+/**
+ * One row in the Performance by prompt table (Table 7.1). Phase 1
+ * returns no rows (the section renders the spec's empty-state copy).
+ * Phase 2 populates this from BQ — `prompt_title` comes straight from
+ * the event params, no WP enrichment needed. Donation / subscription
+ * columns are *attempts* in v1; completion columns are a v1.1
+ * candidate. Rate columns are nullable: a button-less prompt has no
+ * CTR, which renders as an em-dash (distinct from a real 0%).
+ */
+export interface PromptsPerformanceByPromptRow {
+	newspack_popup_id: number;
+	prompt_title: string;
+	intent: string;
+	placement: string;
+	impressions: number;
+	unique_viewers: number;
+	ctr: number | null;
+	form_submission_rate: number | null;
+	dismissal_rate: number | null;
+	registrations: number;
+	newsletter_signups: number;
+	donation_attempts: number;
+	subscription_attempts: number;
+}
+
+/**
+ * One row in the Performance by prompt intent table (Table 7.2).
+ * Aggregated across all prompts of a given intent.
+ */
+export interface PromptsPerformanceByIntentRow {
+	intent: string;
+	impressions: number;
+	unique_viewers: number;
+	ctr: number | null;
+	form_submission_rate: number | null;
+	dismissal_rate: number | null;
+}
+
+/**
+ * One row in the Performance by prompt placement table (Table 7.3).
+ * Aggregated across all prompts at a given placement.
+ */
+export interface PromptsPerformanceByPlacementRow {
+	placement: string;
+	impressions: number;
+	unique_viewers: number;
+	ctr: number | null;
+	dismissal_rate: number | null;
+}
+
+export interface PromptsPerformanceByPromptTable {
+	pending: boolean;
+	rows: PromptsPerformanceByPromptRow[];
+}
+
+export interface PromptsPerformanceByIntentTable {
+	pending: boolean;
+	rows: PromptsPerformanceByIntentRow[];
+}
+
+export interface PromptsPerformanceByPlacementTable {
+	pending: boolean;
+	rows: PromptsPerformanceByPlacementRow[];
+}
+
+export interface PromptsWindow {
+	window: { start: string; end: string };
+	// Section 1 — Prompt exposure.
+	total_prompt_impressions: PromptsScalarMetric;
+	unique_readers_reached: PromptsScalarMetric;
+	avg_prompts_per_reader: PromptsScalarMetric;
+	// Section 2 — Prompt engagement.
+	click_through_rate: PromptsScalarMetric;
+	form_submission_rate: PromptsScalarMetric;
+	dismissal_rate: PromptsScalarMetric;
+	// Section 3 — Free reader conversion.
+	registration_conversion_direct: PromptsScalarMetric;
+	registration_conversion_influenced_7d: PromptsScalarMetric;
+	newsletter_signup_conversion_direct: PromptsScalarMetric;
+	newsletter_signup_conversion_influenced_7d: PromptsScalarMetric;
+	// Section 4 — Paid reader conversion.
+	donation_conversion_direct: PromptsScalarMetric;
+	donation_conversion_influenced_14d: PromptsScalarMetric;
+	subscription_conversion_direct: PromptsScalarMetric;
+	subscription_conversion_influenced_14d: PromptsScalarMetric;
+	// Section 5 — Revenue from prompts.
+	donation_revenue_direct: PromptsScalarMetric;
+	donation_revenue_influenced_14d: PromptsScalarMetric;
+	subscription_revenue_direct: PromptsScalarMetric;
+	subscription_revenue_influenced_14d: PromptsScalarMetric;
+	// Section 6 — How readers convert.
+	conversion_funnel: PromptsFunnelData;
+	exposures_distribution: PromptsDistributionData;
+	// Section 7 — Performance breakdown.
+	performance_by_prompt: PromptsPerformanceByPromptTable;
+	performance_by_intent: PromptsPerformanceByIntentTable;
+	performance_by_placement: PromptsPerformanceByPlacementTable;
+}
+
+export interface PromptsResponse {
+	/**
+	 * True while Tab 5 is in the Phase 1 placeholder phase. React
+	 * uses this to render the top-of-tab banner.
+	 */
+	tab_pending: boolean;
+	current: PromptsWindow;
+	previous: PromptsWindow | null;
+}
+
+export interface PromptsQuery {
+	start: string;
+	end: string;
+	compare_start?: string;
+	compare_end?: string;
+}
+
+const ENDPOINT = '/newspack-insights/v1/prompts';
+
+/**
+ * Fetch Tab 5 data for the given window pair.
+ */
+export const fetchPromptsData = async ( query: PromptsQuery ): Promise< PromptsResponse > => {
+	const params = new URLSearchParams();
+	params.set( 'start', query.start );
+	params.set( 'end', query.end );
+	if ( query.compare_start && query.compare_end ) {
+		params.set( 'compare_start', query.compare_start );
+		params.set( 'compare_end', query.compare_end );
+	}
+	return apiFetch< PromptsResponse >( {
+		path: `${ ENDPOINT }?${ params.toString() }`,
+		method: 'GET',
+	} );
+};

--- a/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
@@ -67,9 +67,11 @@ export interface PromptsDistributionData {
  * returns no rows (the section renders the spec's empty-state copy).
  * Phase 2 populates this from BQ — `prompt_title` comes straight from
  * the event params, no WP enrichment needed. Donation / subscription
- * columns are *attempts* in v1; completion columns are a v1.1
- * candidate. Rate columns are nullable: a button-less prompt has no
- * CTR, which renders as an em-dash (distinct from a real 0%).
+ * columns report *conversions* (Woo-completed outcomes), not attempts,
+ * matching the Gates v1.1 decision (NPPD-1684). Count and rate columns
+ * are nullable: a non-applicable cell (e.g. CTR on a button-less
+ * prompt, or donation conversions on a registration prompt) renders as
+ * an em-dash, distinct from a real 0 / 0%.
  */
 export interface PromptsPerformanceByPromptRow {
 	newspack_popup_id: number;
@@ -83,8 +85,10 @@ export interface PromptsPerformanceByPromptRow {
 	dismissal_rate: number | null;
 	registrations: number;
 	newsletter_signups: number;
-	donation_attempts: number;
-	subscription_attempts: number;
+	donation_conversions: number | null;
+	donation_conversion_rate: number | null;
+	subscription_conversions: number | null;
+	subscription_conversion_rate: number | null;
 }
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/usePromptsData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/usePromptsData.ts
@@ -1,0 +1,76 @@
+/**
+ * usePromptsData (NPPD-1607).
+ *
+ * Tab 5's data fetch lifecycle. Mirrors {@see useGatesData}: a
+ * request-id guard serializes overlapping calls so the latest range
+ * change wins, and idle / loading / success / error state is local to
+ * the tab.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+import { fetchPromptsData, type PromptsResponse } from '../api/prompts';
+
+export type PromptsFetchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UsePromptsDataResult {
+	status: PromptsFetchStatus;
+	data: PromptsResponse | null;
+	error: string | null;
+	refetch: () => void;
+}
+
+const errorMessage = ( e: unknown ): string => {
+	if ( e && typeof e === 'object' && 'message' in e && typeof ( e as { message: unknown } ).message === 'string' ) {
+		return ( e as { message: string } ).message;
+	}
+	return String( e );
+};
+
+const usePromptsData = ( range: DateRange, previousRange: DateRange | null ): UsePromptsDataResult => {
+	const [ status, setStatus ] = useState< PromptsFetchStatus >( 'idle' );
+	const [ data, setData ] = useState< PromptsResponse | null >( null );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const requestIdRef = useRef( 0 );
+	const [ refetchTick, setRefetchTick ] = useState( 0 );
+	const refetch = useCallback( () => setRefetchTick( t => t + 1 ), [] );
+
+	useEffect( () => {
+		const myId = ++requestIdRef.current;
+		setStatus( 'loading' );
+		setError( null );
+
+		fetchPromptsData( {
+			start: range.start,
+			end: range.end,
+			compare_start: previousRange?.start,
+			compare_end: previousRange?.end,
+		} )
+			.then( response => {
+				if ( requestIdRef.current !== myId ) {
+					return;
+				}
+				setData( response );
+				setStatus( 'success' );
+			} )
+			.catch( e => {
+				if ( requestIdRef.current !== myId ) {
+					return;
+				}
+				setError( errorMessage( e ) );
+				setStatus( 'error' );
+			} );
+	}, [ range.start, range.end, previousRange?.start, previousRange?.end, refetchTick ] );
+
+	return { status, data, error, refetch };
+};
+
+export default usePromptsData;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
@@ -134,13 +134,16 @@ describe( 'PromptsTab', () => {
 		expect( screen.getByText( 'Donation Revenue (Direct)' ) ).toBeInTheDocument(); // currency
 	} );
 
-	it( 'renders the funnel three stages and the distribution four buckets at zero', () => {
+	it( 'renders the funnel empty state and the distribution four buckets when all-zero', () => {
 		mockSuccess();
 		render( <PromptsTab range={ range } previousRange={ null } /> );
 
-		expect( screen.getByText( 'Impression' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Engagement' ) ).toBeInTheDocument();
-		// "Conversion" is also a funnel stage; the distribution buckets each render once.
+		// Phase 1 funnel data is all-zero; the SVG funnel needs a non-zero top step
+		// to chart proportions, so it shows its empty-state copy (matching Gates).
+		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Impression' ) ).not.toBeInTheDocument();
+
+		// The distribution still renders its four buckets at 0 / 0%.
 		expect( screen.getByText( '1 exposure' ) ).toBeInTheDocument();
 		expect( screen.getByText( '2 exposures' ) ).toBeInTheDocument();
 		expect( screen.getByText( '3–5 exposures' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Tab-level tests for PromptsTab (NPPD-1607, Phase 1).
+ *
+ * Phase 1 ships the whole tab against placeholder (`pending: true`)
+ * data. These tests confirm the tab renders the full section
+ * structure without crashing when every metric is pending, that the
+ * funnel / distribution / performance tables render their zero / empty
+ * states, and that loading + error states are handled. A snapshot pins
+ * the section structure, card titles, table headers, and explainer
+ * copy against the spec.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PromptsTab from './PromptsTab';
+import usePromptsData from '../hooks/usePromptsData';
+import type { PromptsPlaceholderType, PromptsResponse, PromptsScalarMetric, PromptsWindow } from '../api/prompts';
+import type { DateRange } from '../state/useDateRange';
+
+jest.mock( '../hooks/usePromptsData' );
+
+// `@wordpress/icons` ships pre-built SVG element trees created against its own
+// bundled React copy; under the test runner's React they trip React's
+// "element from an older version of React" guard. The icons are decorative
+// here (no assertion depends on them), so stub the module.
+jest.mock( '@wordpress/icons', () => ( {
+	__esModule: true,
+	Icon: () => null,
+	info: 'info',
+	closeSmall: 'closeSmall',
+	chevronUp: 'chevronUp',
+	chevronDown: 'chevronDown',
+} ) );
+
+const mockHook = usePromptsData as jest.Mock;
+const range = { start: '2026-05-09', end: '2026-06-08', preset: 'last-30' } as unknown as DateRange;
+
+const scalar = ( placeholder_type: PromptsPlaceholderType ): PromptsScalarMetric => ( {
+	value: 'decimal' === placeholder_type ? 0.0 : 0,
+	computable: false,
+	pending: true,
+	denominator: null,
+	placeholder_type,
+} );
+
+const makeWindow = (): PromptsWindow => ( {
+	window: { start: '2026-05-09', end: '2026-06-08' },
+	total_prompt_impressions: scalar( 'count' ),
+	unique_readers_reached: scalar( 'count' ),
+	avg_prompts_per_reader: scalar( 'decimal' ),
+	click_through_rate: scalar( 'rate' ),
+	form_submission_rate: scalar( 'rate' ),
+	dismissal_rate: scalar( 'rate' ),
+	registration_conversion_direct: scalar( 'rate' ),
+	registration_conversion_influenced_7d: scalar( 'rate' ),
+	newsletter_signup_conversion_direct: scalar( 'rate' ),
+	newsletter_signup_conversion_influenced_7d: scalar( 'rate' ),
+	donation_conversion_direct: scalar( 'rate' ),
+	donation_conversion_influenced_14d: scalar( 'rate' ),
+	subscription_conversion_direct: scalar( 'rate' ),
+	subscription_conversion_influenced_14d: scalar( 'rate' ),
+	donation_revenue_direct: scalar( 'currency' ),
+	donation_revenue_influenced_14d: scalar( 'currency' ),
+	subscription_revenue_direct: scalar( 'currency' ),
+	subscription_revenue_influenced_14d: scalar( 'currency' ),
+	conversion_funnel: {
+		pending: true,
+		stages: [
+			{ label: 'Impression', count: 0, pct_of_top: 0 },
+			{ label: 'Engagement', count: 0, pct_of_top: 0 },
+			{ label: 'Conversion', count: 0, pct_of_top: 0 },
+		],
+	},
+	exposures_distribution: {
+		pending: true,
+		buckets: [
+			{ label: '1 exposure', count: 0, pct: 0 },
+			{ label: '2 exposures', count: 0, pct: 0 },
+			{ label: '3–5 exposures', count: 0, pct: 0 },
+			{ label: '6+ exposures', count: 0, pct: 0 },
+		],
+	},
+	performance_by_prompt: { pending: true, rows: [] },
+	performance_by_intent: { pending: true, rows: [] },
+	performance_by_placement: { pending: true, rows: [] },
+} );
+
+const makeResponse = (): PromptsResponse => ( {
+	tab_pending: true,
+	current: makeWindow(),
+	previous: null,
+} );
+
+const mockSuccess = () =>
+	mockHook.mockReturnValue( {
+		status: 'success',
+		error: null,
+		refetch: () => {},
+		data: makeResponse(),
+	} );
+
+describe( 'PromptsTab', () => {
+	afterEach( () => {
+		mockHook.mockReset();
+	} );
+
+	it( 'renders all seven section headings + the explainer when every metric is pending', () => {
+		mockSuccess();
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'About Direct vs Influenced conversion' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Prompt exposure' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Prompt engagement' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Free reader conversion' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Paid reader conversion' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Revenue from prompts' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'How readers convert' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance breakdown' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders scorecard titles across the four format types', () => {
+		mockSuccess();
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'Total Prompt Impressions' ) ).toBeInTheDocument(); // count
+		expect( screen.getByText( 'Avg Prompts per Reader' ) ).toBeInTheDocument(); // decimal
+		expect( screen.getByText( 'Click-Through Rate' ) ).toBeInTheDocument(); // rate
+		expect( screen.getByText( 'Donation Revenue (Direct)' ) ).toBeInTheDocument(); // currency
+	} );
+
+	it( 'renders the funnel three stages and the distribution four buckets at zero', () => {
+		mockSuccess();
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'Impression' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Engagement' ) ).toBeInTheDocument();
+		// "Conversion" is also a funnel stage; the distribution buckets each render once.
+		expect( screen.getByText( '1 exposure' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2 exposures' ) ).toBeInTheDocument();
+		expect( screen.getByText( '3–5 exposures' ) ).toBeInTheDocument();
+		expect( screen.getByText( '6+ exposures' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the three performance tables empty-state rows when rows are empty', () => {
+		mockSuccess();
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+
+		expect(
+			screen.getByText( 'No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the loading state', () => {
+		mockHook.mockReturnValue( { status: 'loading', data: null, error: null, refetch: () => {} } );
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+		expect( screen.getByText( 'Loading prompt data…' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the error state', () => {
+		mockHook.mockReturnValue( { status: 'error', data: null, error: 'Boom', refetch: () => {} } );
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+		expect( screen.getByText( 'Could not load prompt data.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'matches the full-tab placeholder snapshot', () => {
+		mockSuccess();
+		const { container } = render( <PromptsTab range={ range } previousRange={ null } /> );
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -1,7 +1,19 @@
 /**
- * PromptsTab
+ * PromptsTab (NPPD-1607).
  *
- * Stub. Real content lands in NPPD-1607.
+ * Tab 5 orchestrator. Mirrors the GatesTab loading / error / success
+ * lifecycle and composes the seven Prompts sections.
+ *
+ * Date range picker affects every metric — there are no current-state
+ * metrics on this tab, only window-scoped ones. Comparison toggle is
+ * forwarded by the wizard chrome via the standard `previousRange`
+ * prop; when set, the response carries a `previous` window that the
+ * sections thread into their per-card MetricCards.
+ *
+ * Note: unlike Gates, Prompts renders no top-of-tab "preview" banner —
+ * the tab is not behind a preview flag, and the spec calls for none.
+ * The `tab_pending` flag stays in the response envelope for parity
+ * with the other Insights tabs and for Phase 2.
  */
 
 /**
@@ -9,11 +21,62 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const PromptsTab = () => (
-	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">{ __( 'Prompts', 'newspack-plugin' ) }</h2>
-		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
-	</div>
-);
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+import usePromptsData from '../hooks/usePromptsData';
+import DirectVsInfluencedCallout from './prompts/DirectVsInfluencedCallout';
+import PromptExposureSection from './prompts/PromptExposureSection';
+import PromptEngagementSection from './prompts/PromptEngagementSection';
+import FreeReaderConversionSection from './prompts/FreeReaderConversionSection';
+import PaidReaderConversionSection from './prompts/PaidReaderConversionSection';
+import RevenueFromPromptsSection from './prompts/RevenueFromPromptsSection';
+import HowReadersConvertSection from './prompts/HowReadersConvertSection';
+import PerformanceBreakdownSection from './prompts/PerformanceBreakdownSection';
+import './prompts/prompts.scss';
+
+export interface PromptsTabProps {
+	range: DateRange;
+	previousRange: DateRange | null;
+}
+
+const PromptsTab = ( { range, previousRange }: PromptsTabProps ) => {
+	const { status, data, error } = usePromptsData( range, previousRange );
+
+	if ( status === 'loading' && ! data ) {
+		return (
+			<div className="newspack-insights__tab-loading" role="status" aria-live="polite">
+				{ __( 'Loading prompt data…', 'newspack-plugin' ) }
+			</div>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div className="newspack-insights__tab-error" role="alert">
+				<p>{ __( 'Could not load prompt data.', 'newspack-plugin' ) }</p>
+				{ error && <p className="newspack-insights__tab-error-detail">{ error }</p> }
+			</div>
+		);
+	}
+
+	if ( ! data ) {
+		return null;
+	}
+
+	return (
+		<div className="newspack-insights__prompts-tab">
+			<DirectVsInfluencedCallout />
+			<PromptExposureSection current={ data.current } previous={ data.previous } />
+			<PromptEngagementSection current={ data.current } previous={ data.previous } />
+			<FreeReaderConversionSection current={ data.current } previous={ data.previous } />
+			<PaidReaderConversionSection current={ data.current } previous={ data.previous } />
+			<RevenueFromPromptsSection current={ data.current } previous={ data.previous } />
+			<HowReadersConvertSection current={ data.current } />
+			<PerformanceBreakdownSection current={ data.current } />
+		</div>
+	);
+};
 
 export default PromptsTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/DirectVsInfluencedCallout.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/DirectVsInfluencedCallout.tsx
@@ -1,0 +1,68 @@
+/**
+ * DirectVsInfluencedCallout (NPPD-1607).
+ *
+ * Small dismissable info callout rendered at the top of the Prompts
+ * tab, above Section 1's heading. The Direct vs Influenced framing is
+ * foundational to Sections 3, 4 and 5, so publishers should see it
+ * before reading any section that uses the terms. Per spec, dismissal
+ * is session-only (no persisted "don't show again" — the callout
+ * reappears on page reload).
+ *
+ * Mirrors the Gates DirectVsInfluencedCallout (session-only,
+ * self-contained), substituting "gate" → "prompt" in the copy per
+ * `specs/prompts.md`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Icon, closeSmall, info } from '@wordpress/icons';
+
+const DirectVsInfluencedCallout = () => {
+	const [ visible, setVisible ] = useState( true );
+	if ( ! visible ) {
+		return null;
+	}
+	return (
+		<div className="newspack-insights__prompts-callout" role="note">
+			<Icon icon={ info } className="newspack-insights__prompts-callout-icon" />
+			<div className="newspack-insights__prompts-callout-body">
+				<p className="newspack-insights__prompts-callout-title">
+					<strong>{ __( 'About Direct vs Influenced conversion', 'newspack-plugin' ) }</strong>
+				</p>
+				<p>
+					<strong>{ __( 'Direct', 'newspack-plugin' ) }</strong>{ ' ' }
+					{ __(
+						'conversions happen in the same session as a prompt impression. The prompt is credited regardless of whether checkout happens on the same page (embedded checkout block) or after clicking through to a subscription page.',
+						'newspack-plugin'
+					) }
+				</p>
+				<p>
+					<strong>{ __( 'Influenced', 'newspack-plugin' ) }</strong>{ ' ' }
+					{ __(
+						'conversions happen after a prompt impression but in a later session, within a lookback window (7 days for free conversions, 14 days for paid).',
+						'newspack-plugin'
+					) }
+				</p>
+				<p>
+					{ __(
+						'Same-session is Direct. Later-session-within-lookback is Influenced. The two are mutually exclusive and together capture every prompt-touched conversion within the lookback period.',
+						'newspack-plugin'
+					) }
+				</p>
+			</div>
+			<button
+				type="button"
+				className="newspack-insights__prompts-callout-dismiss"
+				onClick={ () => setVisible( false ) }
+				aria-label={ __( 'Dismiss callout', 'newspack-plugin' ) }
+			>
+				<Icon icon={ closeSmall } />
+			</button>
+		</div>
+	);
+};
+
+export default DirectVsInfluencedCallout;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -1,0 +1,86 @@
+/**
+ * FreeReaderConversionSection (NPPD-1607, Section 3).
+ *
+ * Four scorecards covering free-conversion intents — registration and
+ * newsletter signup — each in Direct and Influenced (7-day lookback)
+ * attribution.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface FreeReaderConversionSectionProps {
+	current: PromptsWindow;
+	previous: PromptsWindow | null;
+}
+
+const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversionSectionProps ) => (
+	<section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby="newspack-insights-prompts-free-heading">
+		<h2 id="newspack-insights-prompts-free-heading" className="newspack-insights__section-heading">
+			{ __( 'Free reader conversion', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'How effectively prompts convert readers into registered readers and newsletter subscribers. Direct counts conversions in the same session as a prompt impression. Influenced counts conversions in a later session within 7 days of seeing a prompt.',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Registration Conversion (Direct)', 'newspack-plugin' ),
+					description: __(
+						'Sessions with a registration after a registration-intent prompt impression ÷ sessions with a registration-intent prompt impression',
+						'newspack-plugin'
+					),
+					current: current.registration_conversion_direct,
+					previous: previous?.registration_conversion_direct,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Registration Conversion (Influenced, 7d)', 'newspack-plugin' ),
+					description: __(
+						'Readers who registered in a later session within 7 days of seeing a registration-intent prompt ÷ readers who saw a registration-intent prompt',
+						'newspack-plugin'
+					),
+					current: current.registration_conversion_influenced_7d,
+					previous: previous?.registration_conversion_influenced_7d,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Newsletter Signup Conversion (Direct)', 'newspack-plugin' ),
+					description: __(
+						'Sessions with a newsletter signup after a newsletter-intent prompt impression ÷ sessions with a newsletter-intent prompt impression',
+						'newspack-plugin'
+					),
+					current: current.newsletter_signup_conversion_direct,
+					previous: previous?.newsletter_signup_conversion_direct,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Newsletter Signup Conversion (Influenced, 7d)', 'newspack-plugin' ),
+					description: __(
+						'Readers who signed up for a newsletter in a later session within 7 days of seeing a newsletter-intent prompt ÷ readers who saw a newsletter-intent prompt',
+						'newspack-plugin'
+					),
+					current: current.newsletter_signup_conversion_influenced_7d,
+					previous: previous?.newsletter_signup_conversion_influenced_7d,
+				} ) }
+			/>
+		</div>
+	</section>
+);
+
+export default FreeReaderConversionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
@@ -37,7 +37,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 		</p>
 		<div className="newspack-insights__prompts-convert-grid">
 			<div className="newspack-insights__prompts-convert-col">
-				<Funnel data={ current.conversion_funnel } />
+				<Funnel stages={ current.conversion_funnel.stages } />
 			</div>
 			<div className="newspack-insights__prompts-convert-col">
 				<DistributionTable data={ current.exposures_distribution } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
@@ -1,0 +1,49 @@
+/**
+ * HowReadersConvertSection (NPPD-1607, Section 6).
+ *
+ * Funnel (left) + Distribution (right), side-by-side at equal width,
+ * matching the Gates treatment. Both viz components are tab-local.
+ *
+ * Per spec, comparison overlays on these visualizations are deferred
+ * — no `previous` consumption here.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import Funnel from './viz/Funnel';
+import DistributionTable from './viz/DistributionTable';
+
+export interface HowReadersConvertSectionProps {
+	current: PromptsWindow;
+}
+
+const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) => (
+	<section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-prompts-convert-heading">
+		<h2 id="newspack-insights-prompts-convert-heading" className="newspack-insights__section-heading">
+			{ __( 'How readers convert', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'The journey from prompt impression to conversion. The funnel shows where readers drop off; the distribution shows how many touches it typically takes before conversion.',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__prompts-convert-grid">
+			<div className="newspack-insights__prompts-convert-col">
+				<Funnel data={ current.conversion_funnel } />
+			</div>
+			<div className="newspack-insights__prompts-convert-col">
+				<DistributionTable data={ current.exposures_distribution } />
+			</div>
+		</div>
+	</section>
+);
+
+export default HowReadersConvertSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -1,0 +1,87 @@
+/**
+ * PaidReaderConversionSection (NPPD-1607, Section 4).
+ *
+ * Four scorecards covering paid-conversion intents — donation and
+ * subscription — each in Direct and Influenced (14-day lookback)
+ * attribution. Completion (not just attempt) is established via the
+ * Woo join in Phase 2.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface PaidReaderConversionSectionProps {
+	current: PromptsWindow;
+	previous: PromptsWindow | null;
+}
+
+const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversionSectionProps ) => (
+	<section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby="newspack-insights-prompts-paid-heading">
+		<h2 id="newspack-insights-prompts-paid-heading" className="newspack-insights__section-heading">
+			{ __( 'Paid reader conversion', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'How effectively prompts convert readers into donors and subscribers. Direct counts conversions in the same session as a prompt impression. Influenced counts conversions in a later session within 14 days of seeing a prompt.',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Donation Conversion (Direct)', 'newspack-plugin' ),
+					description: __(
+						'Sessions with a completed donation after a donation-intent prompt impression ÷ sessions with a donation-intent prompt impression',
+						'newspack-plugin'
+					),
+					current: current.donation_conversion_direct,
+					previous: previous?.donation_conversion_direct,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Donation Conversion (Influenced, 14d)', 'newspack-plugin' ),
+					description: __(
+						'Readers who completed a donation in a later session within 14 days of seeing a donation-intent prompt ÷ readers who saw a donation-intent prompt',
+						'newspack-plugin'
+					),
+					current: current.donation_conversion_influenced_14d,
+					previous: previous?.donation_conversion_influenced_14d,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Subscription Conversion (Direct)', 'newspack-plugin' ),
+					description: __(
+						'Sessions with a completed subscription after a subscription-intent prompt impression ÷ sessions with a subscription-intent prompt impression',
+						'newspack-plugin'
+					),
+					current: current.subscription_conversion_direct,
+					previous: previous?.subscription_conversion_direct,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Subscription Conversion (Influenced, 14d)', 'newspack-plugin' ),
+					description: __(
+						'Readers who completed a subscription in a later session within 14 days of seeing a subscription-intent prompt ÷ readers who saw a subscription-intent prompt',
+						'newspack-plugin'
+					),
+					current: current.subscription_conversion_influenced_14d,
+					previous: previous?.subscription_conversion_influenced_14d,
+				} ) }
+			/>
+		</div>
+	</section>
+);
+
+export default PaidReaderConversionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
@@ -1,0 +1,47 @@
+/**
+ * PerformanceBreakdownSection (NPPD-1607, Section 7).
+ *
+ * Three stacked sortable tables: by prompt, by intent, by placement.
+ * Each is a thin wrapper over the tab-local SortableTable primitive.
+ * Phase 1 renders each table's empty-state row; the sort chrome stays
+ * visible so it's identical between phases.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import PerformanceByPromptTable from './viz/PerformanceByPromptTable';
+import PerformanceByIntentTable from './viz/PerformanceByIntentTable';
+import PerformanceByPlacementTable from './viz/PerformanceByPlacementTable';
+
+export interface PerformanceBreakdownSectionProps {
+	current: PromptsWindow;
+}
+
+const PerformanceBreakdownSection = ( { current }: PerformanceBreakdownSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--performance"
+		aria-labelledby="newspack-insights-prompts-performance-heading"
+	>
+		<h2 id="newspack-insights-prompts-performance-heading" className="newspack-insights__section-heading">
+			{ __( 'Performance breakdown', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Per-prompt, per-intent, and per-placement breakdowns for the selected timeframe. Click any column to re-sort.',
+				'newspack-plugin'
+			) }
+		</p>
+		<PerformanceByPromptTable data={ current.performance_by_prompt } />
+		<PerformanceByIntentTable data={ current.performance_by_intent } />
+		<PerformanceByPlacementTable data={ current.performance_by_placement } />
+	</section>
+);
+
+export default PerformanceBreakdownSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
@@ -1,0 +1,65 @@
+/**
+ * PromptEngagementSection (NPPD-1607, Section 2).
+ *
+ * Three scorecards in a single row covering how readers respond to
+ * prompts they see (click-through, form submission, dismissal).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface PromptEngagementSectionProps {
+	current: PromptsWindow;
+	previous: PromptsWindow | null;
+}
+
+const PromptEngagementSection = ( { current, previous }: PromptEngagementSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--engagement"
+		aria-labelledby="newspack-insights-prompts-engagement-heading"
+	>
+		<h2 id="newspack-insights-prompts-engagement-heading" className="newspack-insights__section-heading">
+			{ __( 'Prompt engagement', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __( 'How readers respond to prompts they see. Engagement is any interaction beyond just seeing the prompt.', 'newspack-plugin' ) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Click-Through Rate', 'newspack-plugin' ),
+					description: __( 'Clicks ÷ prompt impressions', 'newspack-plugin' ),
+					current: current.click_through_rate,
+					previous: previous?.click_through_rate,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Form Submission Rate', 'newspack-plugin' ),
+					description: __( 'Form submissions ÷ impressions on form-bearing prompts', 'newspack-plugin' ),
+					current: current.form_submission_rate,
+					previous: previous?.form_submission_rate,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Dismissal Rate', 'newspack-plugin' ),
+					description: __( 'Explicit dismissals ÷ prompt impressions', 'newspack-plugin' ),
+					current: current.dismissal_rate,
+					previous: previous?.dismissal_rate,
+				} ) }
+			/>
+		</div>
+	</section>
+);
+
+export default PromptEngagementSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
@@ -1,0 +1,64 @@
+/**
+ * PromptExposureSection (NPPD-1607, Section 1).
+ *
+ * Top-of-funnel exposure scorecards. Three cards in a single row.
+ * The Direct vs Influenced explainer lives at the tab top (above this
+ * section) so publishers encounter the framing before any section
+ * that uses the terms — see {@see PromptsTab}.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface PromptExposureSectionProps {
+	current: PromptsWindow;
+	previous: PromptsWindow | null;
+}
+
+const PromptExposureSection = ( { current, previous }: PromptExposureSectionProps ) => (
+	<section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-prompts-exposure-heading">
+		<h2 id="newspack-insights-prompts-exposure-heading" className="newspack-insights__section-heading">
+			{ __( 'Prompt exposure', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Total Prompt Impressions', 'newspack-plugin' ),
+					description: __( 'Every prompt view in this timeframe', 'newspack-plugin' ),
+					current: current.total_prompt_impressions,
+					previous: previous?.total_prompt_impressions,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Unique Readers Reached', 'newspack-plugin' ),
+					description: __( 'Distinct readers who saw at least one prompt', 'newspack-plugin' ),
+					current: current.unique_readers_reached,
+					previous: previous?.unique_readers_reached,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Avg Prompts per Reader', 'newspack-plugin' ),
+					description: __( 'How many prompts a typical reader sees', 'newspack-plugin' ),
+					current: current.avg_prompts_per_reader,
+					previous: previous?.avg_prompts_per_reader,
+				} ) }
+			/>
+		</div>
+	</section>
+);
+
+export default PromptExposureSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
@@ -1,0 +1,87 @@
+/**
+ * RevenueFromPromptsSection (NPPD-1607, Section 5).
+ *
+ * Four scorecards summing Woo order totals from donations and
+ * subscriptions completed after a prompt impression, in Direct and
+ * Influenced (14-day lookback) attribution. Revenue is computed from
+ * actual Woo orders, not prompt-event amounts.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsWindow } from '../../api/prompts';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface RevenueFromPromptsSectionProps {
+	current: PromptsWindow;
+	previous: PromptsWindow | null;
+}
+
+const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSectionProps ) => (
+	<section className="newspack-insights__section newspack-insights__section--revenue" aria-labelledby="newspack-insights-prompts-revenue-heading">
+		<h2 id="newspack-insights-prompts-revenue-heading" className="newspack-insights__section-heading">
+			{ __( 'Revenue from prompts', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Sum of Woo order totals from donations and subscriptions completed after a prompt impression. Direct totals revenue from same-session completions. Influenced totals revenue from later-session completions within 14 days of seeing a prompt.',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Donation Revenue (Direct)', 'newspack-plugin' ),
+					description: __(
+						'Sum of Woo donation order totals from same-session completions after a donation-intent prompt impression',
+						'newspack-plugin'
+					),
+					current: current.donation_revenue_direct,
+					previous: previous?.donation_revenue_direct,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Donation Revenue (Influenced, 14d)', 'newspack-plugin' ),
+					description: __(
+						'Sum of Woo donation order totals from later-session completions within 14 days of seeing a donation-intent prompt',
+						'newspack-plugin'
+					),
+					current: current.donation_revenue_influenced_14d,
+					previous: previous?.donation_revenue_influenced_14d,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Subscription Revenue (Direct)', 'newspack-plugin' ),
+					description: __(
+						'Sum of Woo subscription order totals from same-session completions after a subscription-intent prompt impression',
+						'newspack-plugin'
+					),
+					current: current.subscription_revenue_direct,
+					previous: previous?.subscription_revenue_direct,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Subscription Revenue (Influenced, 14d)', 'newspack-plugin' ),
+					description: __(
+						'Sum of Woo subscription order totals from later-session completions within 14 days of seeing a subscription-intent prompt',
+						'newspack-plugin'
+					),
+					current: current.subscription_revenue_influenced_14d,
+					previous: previous?.subscription_revenue_influenced_14d,
+				} ) }
+			/>
+		</div>
+	</section>
+);
+
+export default RevenueFromPromptsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
@@ -14,6 +14,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "../../../../../packages/colors/colors.module" as colors;
 
 .newspack-insights {
 	&__prompts-tab {
@@ -85,78 +86,140 @@
 		min-width: 0; // allow the column to shrink within the grid
 	}
 
-	// Funnel viz — tab-local. Vertical trapezoids approximated as
-	// centered, width-scaled rounded rectangles.
+	// Funnel viz — tab-local. Stacked SVG trapezoids in a single anchor color
+	// (primary-500) fading to 0.6 opacity at the tail. Side-label mode puts the
+	// step name/count/deltas in a fixed column beside the equal-height bands;
+	// compact mode renders the count inside each band and moves labels to a
+	// legend below.
 	&__prompts-funnel {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 16px;
 		padding: 20px;
 		background-color: #fff;
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 4px;
 
-		&-row {
+		&--side {
+			display: flex;
+			align-items: stretch;
+			gap: 16px;
+		}
+
+		&--compact {
+			display: flex;
+			flex-direction: column;
+			gap: 16px;
+		}
+
+		&-svg {
+			min-width: 0;
 			width: 100%;
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			gap: 6px;
+			height: auto;
+			display: block;
 		}
 
-		&-dropoff {
-			font-size: 12px;
+		// Side mode: cap the SVG WIDTH (not height) so it keeps its exact viewBox
+		// aspect ratio — no letterboxing — and the equal-height trapezoid bands
+		// stay aligned with the equal-flex label column beside them.
+		&--side &-svg {
+			flex: 0 1 auto;
+			max-width: 320px;
+		}
+
+		// Compact mode: fill the width; the count sits inside each band, so there's
+		// no side column to align against and a height cap is fine.
+		&--compact &-svg {
+			max-height: 480px;
+		}
+
+		// Single anchor color; the 1.0 → 0.6 opacity interpolation gives each band
+		// its own weight while staying within one hue.
+		&-trapezoid {
+			fill: colors.$primary-500;
+		}
+
+		// In-band count (compact mode): white on the darker top bands, dark on the
+		// faded tail bands — see DARK_TEXT_OPACITY_THRESHOLD in Funnel.tsx.
+		&-count-text {
+			font-size: 16px;
 			font-weight: 600;
-			letter-spacing: 0.04em;
-			text-transform: uppercase;
-			color: wp-colors.$gray-700;
+			font-variant-numeric: tabular-nums;
+
+			&.is-on-dark {
+				fill: #fff;
+			}
+
+			&.is-on-light {
+				fill: wp-colors.$gray-900;
+			}
 		}
 
-		&-stage {
-			width: 40%;
-			min-height: 72px;
-			padding: 12px 16px;
+		// Side-label column: equal-flex blocks align to the equal-height bands.
+		&-labels {
+			flex: 0 0 200px;
 			display: flex;
 			flex-direction: column;
-			align-items: center;
+		}
+
+		&-label {
+			flex: 1 1 0;
+			display: flex;
+			flex-direction: column;
 			justify-content: center;
-			gap: 4px;
-			background-color: var(--wp-admin-theme-color);
-			color: #fff;
-			border-radius: 6px;
+		}
 
-			&[data-stage-index="0"] {
-				opacity: 1;
-			}
+		&-legend {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-direction: column;
+			gap: 12px;
+		}
 
-			&[data-stage-index="1"] {
-				opacity: 0.8;
-			}
+		&-legend-item {
+			display: flex;
+			flex-direction: column;
+		}
 
-			&[data-stage-index="2"] {
-				opacity: 0.6;
-			}
+		&-label-name {
+			font-size: 13px;
+			font-weight: 600;
+			color: wp-colors.$gray-900;
+		}
 
-			&-label {
-				font-size: 13px;
-				font-weight: 600;
-				letter-spacing: 0.04em;
-				text-transform: uppercase;
-			}
+		&-label-count {
+			font-size: 20px;
+			font-weight: 600;
+			font-variant-numeric: tabular-nums;
+			line-height: 1.2;
+			color: wp-colors.$gray-900;
+		}
 
-			&-count {
-				font-size: 24px;
-				font-weight: 600;
-				font-variant-numeric: tabular-nums;
-				line-height: 1.1;
-			}
+		// Stage descriptors: both muted gray. The drop-off is funnel context, not
+		// an alarm, and deliberately NOT red/green — red/green is reserved for the
+		// period-over-period scorecard deltas elsewhere on the page.
+		&-label-pct {
+			font-size: 13px;
+			font-weight: 400;
+			color: wp-colors.$gray-600;
+		}
 
-			&-pct {
-				font-size: 12px;
-				font-weight: 400;
-				opacity: 0.9;
+		&-label-drop {
+			font-size: 13px;
+			font-weight: 400;
+			font-variant-numeric: tabular-nums;
+			color: wp-colors.$gray-600;
+
+			&-arrow {
+				color: wp-colors.$gray-600;
 			}
+		}
+
+		&-empty {
+			margin: 0;
+			padding: 32px 20px;
+			text-align: center;
+			font-size: 13px;
+			color: wp-colors.$gray-600;
 		}
 	}
 
@@ -209,16 +272,9 @@
 		color: wp-colors.$gray-700;
 	}
 
-	// Right-aligned numeric cells (header + body), tabular figures.
-	&__prompts-table-num {
-		text-align: right;
-		font-variant-numeric: tabular-nums;
-	}
-
-	// Em-dash for non-applicable cells, muted to distinguish from a real zero.
-	&__prompts-table-na {
-		color: wp-colors.$gray-600;
-	}
+	// Numeric right-alignment (`__table-num`) and the muted em-dash
+	// (`__table-na`) come from the shared sections.scss table chrome — Prompts
+	// reuses them so the #267 specificity fix applies here too.
 
 	// Sortable table affordances (Tab 5 Performance breakdown). A
 	// tab-local copy of the Gates sortable chrome.
@@ -257,9 +313,9 @@
 			}
 		}
 
-		// Numeric columns are right-aligned, so pin the indicator to the
-		// right edge.
-		.newspack-insights__prompts-table-num .newspack-insights__prompts-table-sort {
+		// Numeric columns are right-aligned (shared `__table-num`), so pin the
+		// indicator to the right edge.
+		.newspack-insights__table-num .newspack-insights__prompts-table-sort {
 			justify-content: flex-end;
 			text-align: right;
 		}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
@@ -1,0 +1,288 @@
+/**
+ * Newspack Insights — Tab 5 (Prompts) styles (NPPD-1607, Phase 1)
+ *
+ * Tab 5-specific layout only. The shared Insights chrome (sections,
+ * metric cards, table base + wrap, tab loading/error) lives in
+ * `tabs/components/sections.scss` and is loaded by the wizard's main
+ * `style.scss`. Visualization + callout + sortable-table styles live
+ * here because those components are tab-local for Phase 1.
+ *
+ * These classes are prompts-scoped (`__prompts-*`) rather than reusing
+ * the generic Gates names so the two tabs stay fully decoupled — no
+ * shared-stylesheet edits, no cross-tab selector collisions. The
+ * visual language is intentionally identical to Gates.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+.newspack-insights {
+	&__prompts-tab {
+		display: flex;
+		flex-direction: column;
+		gap: 32px;
+	}
+
+	// Direct vs Influenced explainer — light gray chrome, info icon, X to
+	// dismiss (session-only). Mirrors the Gates callout.
+	&__prompts-callout {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		padding: 16px 20px;
+		background-color: wp-colors.$gray-100;
+		border: 1px solid wp-colors.$gray-200;
+		border-radius: 4px;
+
+		&-icon {
+			flex: 0 0 20px;
+			width: 20px;
+			height: 20px;
+			color: wp-colors.$gray-700;
+		}
+
+		&-body {
+			flex: 1 1 auto;
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+			font-size: 13px;
+			line-height: 1.5;
+			color: wp-colors.$gray-900;
+
+			p {
+				margin: 0;
+			}
+		}
+
+		&-title {
+			font-size: 14px;
+		}
+
+		&-dismiss {
+			flex: 0 0 auto;
+			background: transparent;
+			border: 0;
+			cursor: pointer;
+			padding: 4px;
+			color: wp-colors.$gray-700;
+
+			&:hover {
+				color: wp-colors.$gray-900;
+			}
+		}
+	}
+
+	// Section 6 — funnel + distribution side-by-side at equal width,
+	// stacking under ~720px container width.
+	&__prompts-convert-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+		gap: 24px;
+		align-items: start;
+	}
+
+	&__prompts-convert-col {
+		min-width: 0; // allow the column to shrink within the grid
+	}
+
+	// Funnel viz — tab-local. Vertical trapezoids approximated as
+	// centered, width-scaled rounded rectangles.
+	&__prompts-funnel {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 16px;
+		padding: 20px;
+		background-color: #fff;
+		border: 1px solid wp-colors.$gray-200;
+		border-radius: 4px;
+
+		&-row {
+			width: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 6px;
+		}
+
+		&-dropoff {
+			font-size: 12px;
+			font-weight: 600;
+			letter-spacing: 0.04em;
+			text-transform: uppercase;
+			color: wp-colors.$gray-700;
+		}
+
+		&-stage {
+			width: 40%;
+			min-height: 72px;
+			padding: 12px 16px;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			gap: 4px;
+			background-color: var(--wp-admin-theme-color);
+			color: #fff;
+			border-radius: 6px;
+
+			&[data-stage-index="0"] {
+				opacity: 1;
+			}
+
+			&[data-stage-index="1"] {
+				opacity: 0.8;
+			}
+
+			&[data-stage-index="2"] {
+				opacity: 0.6;
+			}
+
+			&-label {
+				font-size: 13px;
+				font-weight: 600;
+				letter-spacing: 0.04em;
+				text-transform: uppercase;
+			}
+
+			&-count {
+				font-size: 24px;
+				font-weight: 600;
+				font-variant-numeric: tabular-nums;
+				line-height: 1.1;
+			}
+
+			&-pct {
+				font-size: 12px;
+				font-weight: 400;
+				opacity: 0.9;
+			}
+		}
+	}
+
+	// Distribution viz — tab-local. Reuses the shared table chrome.
+	&__prompts-distribution {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		&-caption {
+			margin: 0;
+			font-size: 13px;
+			font-weight: 400;
+			line-height: 1.5;
+			color: wp-colors.$gray-700;
+		}
+	}
+
+	// Section 7 — stacked breakdown sub-blocks.
+	&__prompts-subsection {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		& + & {
+			margin-top: 24px;
+		}
+
+		&-heading {
+			margin: 0;
+			font-size: 15px;
+			font-weight: 600;
+			color: wp-colors.$gray-900;
+		}
+
+		&-note {
+			margin: 0;
+			font-size: 13px;
+			font-weight: 400;
+			line-height: 1.5;
+			color: wp-colors.$gray-700;
+		}
+	}
+
+	// Empty state row inside a Performance breakdown table.
+	&__prompts-performance-empty {
+		padding: 32px 20px;
+		text-align: center;
+		font-style: italic;
+		color: wp-colors.$gray-700;
+	}
+
+	// Right-aligned numeric cells (header + body), tabular figures.
+	&__prompts-table-num {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	// Em-dash for non-applicable cells, muted to distinguish from a real zero.
+	&__prompts-table-na {
+		color: wp-colors.$gray-600;
+	}
+
+	// Sortable table affordances (Tab 5 Performance breakdown). A
+	// tab-local copy of the Gates sortable chrome.
+	&__prompts-table--sortable {
+		.newspack-insights__prompts-table-sort-cell {
+			// Eliminate the th's default padding because the button
+			// inside owns the click target and re-paints the padding
+			// itself; without this, half the cell isn't clickable.
+			padding: 0;
+		}
+
+		.newspack-insights__prompts-table-sort {
+			// Button fills the cell so any click anywhere in the th
+			// triggers the sort.
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			width: 100%;
+			padding: 12px 20px;
+			background: transparent;
+			border: 0;
+			cursor: pointer;
+			text-align: inherit;
+			font: inherit;
+			color: inherit;
+			letter-spacing: inherit;
+			text-transform: inherit;
+
+			&:hover {
+				background-color: wp-colors.$gray-200;
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--wp-admin-theme-color);
+				outline-offset: -2px;
+			}
+		}
+
+		// Numeric columns are right-aligned, so pin the indicator to the
+		// right edge.
+		.newspack-insights__prompts-table-num .newspack-insights__prompts-table-sort {
+			justify-content: flex-end;
+			text-align: right;
+		}
+
+		.newspack-insights__prompts-table-sort-label {
+			flex: 1 1 auto;
+		}
+
+		.newspack-insights__prompts-table-sort-indicator {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			opacity: 0.3;
+			color: wp-colors.$gray-700;
+		}
+
+		.newspack-insights__prompts-table-sort:hover .newspack-insights__prompts-table-sort-indicator {
+			opacity: 0.7;
+		}
+
+		.newspack-insights__prompts-table-sort.is-active .newspack-insights__prompts-table-sort-indicator {
+			opacity: 1;
+			color: wp-colors.$gray-900;
+		}
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
@@ -264,6 +264,27 @@
 		}
 	}
 
+	// "See more" / "See less" toggle under a row-capped breakdown table.
+	&__prompts-table-more {
+		align-self: flex-start;
+		padding: 4px 0;
+		background: transparent;
+		border: 0;
+		cursor: pointer;
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--wp-admin-theme-color);
+
+		&:hover {
+			text-decoration: underline;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: 2px;
+		}
+	}
+
 	// Empty state row inside a Performance breakdown table.
 	&__prompts-performance-empty {
 		padding: 32px 20px;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
@@ -1,0 +1,45 @@
+/**
+ * Small helper that maps a `PromptsScalarMetric` payload + section
+ * copy into the MetricCard props used by every Tab 5 scorecard.
+ *
+ * Centralises the `placeholder_type` → `MetricFormat` mapping so the
+ * section components stay declarative. Mirrors the Gates tab-local
+ * `scalarToCard.ts`; Tab 5 is the first tab to use the `decimal`
+ * placeholder type (Card 1.3 — Avg Prompts per Reader).
+ */
+
+import type { PromptsScalarMetric } from '../../api/prompts';
+import type { MetricFormat } from '../components/MetricCard';
+
+const formatFor = ( m: PromptsScalarMetric ): MetricFormat => {
+	switch ( m.placeholder_type ) {
+		case 'rate':
+			return 'percent';
+		case 'currency':
+			return 'currency';
+		case 'decimal':
+			return 'decimal';
+		case 'count':
+		default:
+			return 'number';
+	}
+};
+
+export interface ScalarCardProps {
+	label: string;
+	description: string;
+	current: PromptsScalarMetric;
+	previous?: PromptsScalarMetric | null;
+}
+
+export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
+	const { label, description, current, previous } = props;
+	return {
+		label,
+		description,
+		value: current.value,
+		format: formatFor( current ),
+		previousValue: previous?.computable ? previous.value : null,
+		pending: current.pending,
+	};
+};

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/DistributionTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/DistributionTable.tsx
@@ -33,10 +33,10 @@ const DistributionTable = ( { data }: DistributionTableProps ) => (
 				<thead>
 					<tr>
 						<th scope="col">{ __( 'Exposures before conversion', 'newspack-plugin' ) }</th>
-						<th scope="col" className="newspack-insights__prompts-table-num">
+						<th scope="col" className="newspack-insights__table-num">
 							{ __( 'Converters', 'newspack-plugin' ) }
 						</th>
-						<th scope="col" className="newspack-insights__prompts-table-num">
+						<th scope="col" className="newspack-insights__table-num">
 							{ __( '% of total', 'newspack-plugin' ) }
 						</th>
 					</tr>
@@ -45,8 +45,8 @@ const DistributionTable = ( { data }: DistributionTableProps ) => (
 					{ data.buckets.map( bucket => (
 						<tr key={ bucket.label }>
 							<td>{ bucket.label }</td>
-							<td className="newspack-insights__prompts-table-num">{ formatNumber( bucket.count ) }</td>
-							<td className="newspack-insights__prompts-table-num">{ formatPercent( bucket.pct ) }</td>
+							<td className="newspack-insights__table-num">{ formatNumber( bucket.count ) }</td>
+							<td className="newspack-insights__table-num">{ formatPercent( bucket.pct ) }</td>
 						</tr>
 					) ) }
 				</tbody>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/DistributionTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/DistributionTable.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tab-local Distribution table viz (NPPD-1607, Phase 1).
+ *
+ * Bucket distribution table used inside Tab 5 only. A tab-local copy
+ * of the Gates DistributionTable; reuses the shared table chrome
+ * (`__table-wrap` / `__table`) and adds the tab-local
+ * `__prompts-distribution` wrapper + caption.
+ *
+ * Phase 1 behavior: every bucket renders 0 / 0% in the standard table
+ * chrome; the caption below the table explains the cohort definition
+ * regardless of phase.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsDistributionData } from '../../../api/prompts';
+import { formatNumber, formatPercent } from '../../components/format';
+
+export interface DistributionTableProps {
+	data: PromptsDistributionData;
+}
+
+const DistributionTable = ( { data }: DistributionTableProps ) => (
+	<div className="newspack-insights__prompts-distribution">
+		<div className="newspack-insights__table-wrap">
+			<table className="newspack-insights__table">
+				<thead>
+					<tr>
+						<th scope="col">{ __( 'Exposures before conversion', 'newspack-plugin' ) }</th>
+						<th scope="col" className="newspack-insights__prompts-table-num">
+							{ __( 'Converters', 'newspack-plugin' ) }
+						</th>
+						<th scope="col" className="newspack-insights__prompts-table-num">
+							{ __( '% of total', 'newspack-plugin' ) }
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ data.buckets.map( bucket => (
+						<tr key={ bucket.label }>
+							<td>{ bucket.label }</td>
+							<td className="newspack-insights__prompts-table-num">{ formatNumber( bucket.count ) }</td>
+							<td className="newspack-insights__prompts-table-num">{ formatPercent( bucket.pct ) }</td>
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+		</div>
+		<p className="newspack-insights__prompts-distribution-caption">
+			{ __( 'Of readers who converted, this is how many prompts they saw first.', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default DistributionTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/Funnel.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tab-local Funnel viz (NPPD-1607, Phase 1).
+ *
+ * Minimal vertical three-stage funnel used inside Tab 5 only. A
+ * tab-local copy of the Gates Funnel (the two tabs render the same
+ * three-stage chrome); kept separate so the two tabs stay decoupled
+ * until a canonical Funnel component lands in
+ * `packages/components/src/`. Keeping the API surface narrow on
+ * purpose: a `stages` array, a `pending` flag, and CSS classes the
+ * tab-local prompts.scss styles.
+ *
+ * Phase 1 behavior:
+ *   - All stages render at zero
+ *   - Drop-off labels are hidden when every stage is 0 (per spec)
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsFunnelData, PromptsFunnelStage } from '../../../api/prompts';
+import { formatNumber, formatPercent } from '../../components/format';
+
+export interface FunnelProps {
+	data: PromptsFunnelData;
+}
+
+const stageWidthPct = ( stage: PromptsFunnelStage, topCount: number ): number => {
+	if ( topCount <= 0 ) {
+		// Phase 1 / no data: each stage renders at a fixed minimum so
+		// the funnel chrome stays visible without implying a value.
+		return 40;
+	}
+	const ratio = stage.count / topCount;
+	return Math.max( 12, Math.round( ratio * 100 ) );
+};
+
+const Funnel = ( { data }: FunnelProps ) => {
+	const { stages } = data;
+	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
+	const allZero = stages.every( s => s.count === 0 );
+
+	return (
+		<div className="newspack-insights__prompts-funnel" role="figure" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
+			{ stages.map( ( stage, idx ) => {
+				const prev = idx > 0 ? stages[ idx - 1 ] : null;
+				const dropOffPct = prev && prev.count > 0 ? 1 - stage.count / prev.count : 0;
+				const widthPct = stageWidthPct( stage, topCount );
+				return (
+					<div key={ stage.label } className="newspack-insights__prompts-funnel-row">
+						{ idx > 0 && ! allZero && (
+							<div className="newspack-insights__prompts-funnel-dropoff">
+								{ sprintf(
+									/* translators: %s: percentage of readers dropped off between two funnel stages */
+									__( '%s drop-off', 'newspack-plugin' ),
+									formatPercent( dropOffPct )
+								) }
+							</div>
+						) }
+						<div className="newspack-insights__prompts-funnel-stage" style={ { width: `${ widthPct }%` } } data-stage-index={ idx }>
+							<div className="newspack-insights__prompts-funnel-stage-label">{ stage.label }</div>
+							<div className="newspack-insights__prompts-funnel-stage-count">{ formatNumber( stage.count ) }</div>
+							{ idx > 0 && ! allZero && (
+								<div className="newspack-insights__prompts-funnel-stage-pct">
+									{ sprintf(
+										/* translators: %s: percentage of stage-1 readers reaching this stage */
+										__( '%s of top', 'newspack-plugin' ),
+										formatPercent( stage.pct_of_top )
+									) }
+								</div>
+							) }
+						</div>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+};
+
+export default Funnel;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/Funnel.tsx
@@ -79,7 +79,11 @@ const stepHeightFor = ( stepCount: number ): number => Math.max( MIN_STEP_HEIGHT
  */
 const trapezoidPath = ( count: number, nextCount: number, topCount: number, yTop: number, yBottom: number ): string => {
 	const cx = VIEWBOX_WIDTH / 2;
-	const halfTop = ( count / topCount ) * ( VIEWBOX_WIDTH / 2 );
+	// Clamp the top edge to the viewBox half-width too (not just the bottom):
+	// funnel stages are independent aggregates, so a later stage can exceed the
+	// top stage (data drift). Without this the trapezoid would flare past the
+	// viewBox edge — the opposite of the "only ever narrows" invariant below.
+	const halfTop = Math.min( VIEWBOX_WIDTH / 2, ( count / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
 	const halfBottom = Math.min( halfTop, ( nextCount / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
 	return [
 		`M ${ cx - halfTop } ${ yTop }`,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/Funnel.tsx
@@ -1,82 +1,256 @@
 /**
- * Tab-local Funnel viz (NPPD-1607, Phase 1).
+ * Funnel viz (NPPD-1607) — tab-local to Prompts.
  *
- * Minimal vertical three-stage funnel used inside Tab 5 only. A
- * tab-local copy of the Gates Funnel (the two tabs render the same
- * three-stage chrome); kept separate so the two tabs stay decoupled
- * until a canonical Funnel component lands in
- * `packages/components/src/`. Keeping the API surface narrow on
- * purpose: a `stages` array, a `pending` flag, and CSS classes the
- * tab-local prompts.scss styles.
+ * Multi-step conversion funnel rendered as stacked SVG trapezoids. Each
+ * trapezoid's top edge is proportional to its own count and its bottom edge to
+ * the next step's count, so the silhouette narrows with drop-off; the last step
+ * is a rectangle. A single anchor color (primary-500) fades from full opacity at
+ * the top to 0.6 at the bottom, so each stage carries its own weight.
  *
- * Phase 1 behavior:
- *   - All stages render at zero
- *   - Drop-off labels are hidden when every stage is 0 (per spec)
+ * A tab-local copy of the Gates funnel (adopted from PR #267): the two tabs
+ * render the same three-stage chrome. Kept separate so the tabs stay decoupled
+ * until a canonical Funnel lands in packages/components/src/.
+ *
+ * Two layouts, auto-selected from container width + step count:
+ *   - Side-label (default): step name / count / labels in a fixed column to the
+ *     right of each trapezoid. Used when stepCount < 5 AND width >= 480px.
+ *   - Compact: the count renders inside each trapezoid and the full
+ *     names/counts/labels move to a legend below. Used when stepCount >= 5 OR
+ *     width < 480px.
+ *
+ * Phase 1: every stage count is zero, so the first-step-zero guard renders the
+ * empty state ("Not enough data to chart the funnel.") — the same treatment
+ * Gates shows for a zero-data window.
  */
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import type { PromptsFunnelData, PromptsFunnelStage } from '../../../api/prompts';
+import type { PromptsFunnelStage } from '../../../api/prompts';
 import { formatNumber, formatPercent } from '../../components/format';
 
+const COMPACT_MIN_STEPS = 5;
+const COMPACT_MAX_WIDTH = 480; // Below this container width, force compact mode.
+const MIN_STEP_HEIGHT = 32;
+const MAX_CHART_HEIGHT = 480;
+const VIEWBOX_WIDTH = 320;
+const FULL_OPACITY = 1;
+const TAIL_OPACITY = 0.6;
+// Above this band opacity the fill is dark enough for white text; below it, the
+// faded band needs dark text. Only affects compact mode (count rendered inside).
+const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
+
 export interface FunnelProps {
-	data: PromptsFunnelData;
+	stages: PromptsFunnelStage[];
 }
 
-const stageWidthPct = ( stage: PromptsFunnelStage, topCount: number ): number => {
-	if ( topCount <= 0 ) {
-		// Phase 1 / no data: each stage renders at a fixed minimum so
-		// the funnel chrome stays visible without implying a value.
-		return 40;
+/** Compact when there are many steps OR the container is narrow. */
+export const isCompactMode = ( stepCount: number, containerWidth: number ): boolean =>
+	stepCount >= COMPACT_MIN_STEPS || containerWidth < COMPACT_MAX_WIDTH;
+
+/** Linear opacity from 1.0 at the first step to 0.6 at the last. */
+export const stepOpacity = ( index: number, stepCount: number ): number => {
+	if ( stepCount <= 1 ) {
+		return FULL_OPACITY;
 	}
-	const ratio = stage.count / topCount;
-	return Math.max( 12, Math.round( ratio * 100 ) );
+	return FULL_OPACITY + ( TAIL_OPACITY - FULL_OPACITY ) * ( index / ( stepCount - 1 ) );
 };
 
-const Funnel = ( { data }: FunnelProps ) => {
-	const { stages } = data;
-	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
-	const allZero = stages.every( s => s.count === 0 );
+/**
+ * Drop-off from the previous step as a fraction in [0, 1]. Clamped at 0: funnel
+ * stages are independent aggregates, so a later stage can occasionally exceed
+ * the prior one (data drift) — a negative "drop-off" is meaningless, so show 0%.
+ */
+export const dropFromPrevious = ( count: number, prevCount: number ): number => ( prevCount > 0 ? Math.max( 0, 1 - count / prevCount ) : 0 );
 
+/** Equal band height per step, capped so the whole chart fits ~480px. */
+const stepHeightFor = ( stepCount: number ): number => Math.max( MIN_STEP_HEIGHT, Math.floor( MAX_CHART_HEIGHT / stepCount ) );
+
+/**
+ * SVG path for one trapezoid: top edge sized to `count`, bottom to `nextCount`,
+ * centered. The bottom is clamped to never exceed the top so the silhouette only
+ * ever narrows (a funnel never flares outward, even on anomalous data).
+ */
+const trapezoidPath = ( count: number, nextCount: number, topCount: number, yTop: number, yBottom: number ): string => {
+	const cx = VIEWBOX_WIDTH / 2;
+	const halfTop = ( count / topCount ) * ( VIEWBOX_WIDTH / 2 );
+	const halfBottom = Math.min( halfTop, ( nextCount / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
+	return [
+		`M ${ cx - halfTop } ${ yTop }`,
+		`L ${ cx + halfTop } ${ yTop }`,
+		`L ${ cx + halfBottom } ${ yBottom }`,
+		`L ${ cx - halfBottom } ${ yBottom }`,
+		'Z',
+	].join( ' ' );
+};
+
+interface StepView {
+	stage: PromptsFunnelStage;
+	index: number;
+	opacity: number;
+	pctOfTop: number;
+	drop: number | null;
+}
+
+/** Build the per-step view model shared by both layouts. */
+const buildSteps = ( stages: PromptsFunnelStage[], topCount: number ): StepView[] =>
+	stages.map( ( stage, index ) => {
+		const prevCount = index > 0 ? stages[ index - 1 ].count : 0;
+		return {
+			stage,
+			index,
+			opacity: stepOpacity( index, stages.length ),
+			pctOfTop: topCount > 0 ? stage.count / topCount : 0,
+			drop: index > 0 ? dropFromPrevious( stage.count, prevCount ) : null,
+		};
+	} );
+
+/**
+ * The two descriptive labels shown for every step beyond the first: what share
+ * of the top stage reached here, and the stage-to-stage drop-off. Both are muted
+ * (not red/green) — they describe funnel progression, not a period comparison.
+ */
+const StepLabels = ( { step, topLabel }: { step: StepView; topLabel: string } ) => {
+	if ( step.drop === null ) {
+		return null;
+	}
 	return (
-		<div className="newspack-insights__prompts-funnel" role="figure" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
-			{ stages.map( ( stage, idx ) => {
-				const prev = idx > 0 ? stages[ idx - 1 ] : null;
-				const dropOffPct = prev && prev.count > 0 ? 1 - stage.count / prev.count : 0;
-				const widthPct = stageWidthPct( stage, topCount );
+		<>
+			<span className="newspack-insights__prompts-funnel-label-pct">
+				{ sprintf(
+					/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
+					__( '%1$s of %2$s', 'newspack-plugin' ),
+					formatPercent( step.pctOfTop ),
+					topLabel
+				) }
+			</span>
+			<span className="newspack-insights__prompts-funnel-label-drop">
+				<span aria-hidden="true" className="newspack-insights__prompts-funnel-label-drop-arrow">
+					↓
+				</span>{ ' ' }
+				{ sprintf(
+					/* translators: %s: percentage drop-off from the previous stage. */
+					__( '%s drop-off', 'newspack-plugin' ),
+					formatPercent( step.drop )
+				) }
+			</span>
+		</>
+	);
+};
+
+const Funnel = ( { stages }: FunnelProps ) => {
+	const containerRef = useRef< HTMLDivElement >( null );
+	// Default to a desktop width so the common 3-step funnel renders in
+	// side-label mode on first paint (the observer corrects narrow containers).
+	const [ width, setWidth ] = useState( COMPACT_MAX_WIDTH );
+
+	useEffect( () => {
+		const el = containerRef.current;
+		if ( ! el || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+		setWidth( el.getBoundingClientRect().width );
+		const observer = new ResizeObserver( entries => {
+			for ( const entry of entries ) {
+				setWidth( entry.contentRect.width );
+			}
+		} );
+		observer.observe( el );
+		return () => observer.disconnect();
+	}, [] );
+
+	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
+	const topLabel = stages.length > 0 ? stages[ 0 ].label : '';
+	const steps = useMemo( () => buildSteps( stages, topCount ), [ stages, topCount ] );
+
+	// Proportions can't be computed without a non-zero first step.
+	if ( stages.length === 0 || topCount <= 0 ) {
+		return (
+			<div ref={ containerRef } className="newspack-insights__prompts-funnel">
+				<p className="newspack-insights__prompts-funnel-empty">{ __( 'Not enough data to chart the funnel.', 'newspack-plugin' ) }</p>
+			</div>
+		);
+	}
+
+	const stepCount = stages.length;
+	const compact = isCompactMode( stepCount, width );
+	const stepHeight = stepHeightFor( stepCount );
+	const chartHeight = stepHeight * stepCount;
+
+	const svg = (
+		<svg
+			className="newspack-insights__prompts-funnel-svg"
+			viewBox={ `0 0 ${ VIEWBOX_WIDTH } ${ chartHeight }` }
+			preserveAspectRatio="xMidYMid meet"
+			role="img"
+			aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }
+		>
+			{ steps.map( step => {
+				const nextCount = step.index < stepCount - 1 ? stages[ step.index + 1 ].count : step.stage.count;
+				const yTop = step.index * stepHeight;
 				return (
-					<div key={ stage.label } className="newspack-insights__prompts-funnel-row">
-						{ idx > 0 && ! allZero && (
-							<div className="newspack-insights__prompts-funnel-dropoff">
-								{ sprintf(
-									/* translators: %s: percentage of readers dropped off between two funnel stages */
-									__( '%s drop-off', 'newspack-plugin' ),
-									formatPercent( dropOffPct )
-								) }
-							</div>
-						) }
-						<div className="newspack-insights__prompts-funnel-stage" style={ { width: `${ widthPct }%` } } data-stage-index={ idx }>
-							<div className="newspack-insights__prompts-funnel-stage-label">{ stage.label }</div>
-							<div className="newspack-insights__prompts-funnel-stage-count">{ formatNumber( stage.count ) }</div>
-							{ idx > 0 && ! allZero && (
-								<div className="newspack-insights__prompts-funnel-stage-pct">
-									{ sprintf(
-										/* translators: %s: percentage of stage-1 readers reaching this stage */
-										__( '%s of top', 'newspack-plugin' ),
-										formatPercent( stage.pct_of_top )
-									) }
-								</div>
-							) }
-						</div>
-					</div>
+					<path
+						key={ step.index }
+						className="newspack-insights__prompts-funnel-trapezoid"
+						d={ trapezoidPath( step.stage.count, nextCount, topCount, yTop, yTop + stepHeight ) }
+						fillOpacity={ step.opacity }
+					/>
 				);
 			} ) }
+			{ compact &&
+				steps.map( step => (
+					<text
+						key={ step.index }
+						className={
+							'newspack-insights__prompts-funnel-count-text ' +
+							( step.opacity > DARK_TEXT_OPACITY_THRESHOLD ? 'is-on-dark' : 'is-on-light' )
+						}
+						x={ VIEWBOX_WIDTH / 2 }
+						y={ step.index * stepHeight + stepHeight / 2 }
+						textAnchor="middle"
+						dominantBaseline="central"
+					>
+						{ formatNumber( step.stage.count ) }
+					</text>
+				) ) }
+		</svg>
+	);
+
+	if ( compact ) {
+		return (
+			<div ref={ containerRef } className="newspack-insights__prompts-funnel newspack-insights__prompts-funnel--compact" role="figure">
+				{ svg }
+				<ol className="newspack-insights__prompts-funnel-legend">
+					{ steps.map( step => (
+						<li key={ step.index } className="newspack-insights__prompts-funnel-legend-item">
+							<span className="newspack-insights__prompts-funnel-label-name">{ step.stage.label }</span>
+							<span className="newspack-insights__prompts-funnel-label-count">{ formatNumber( step.stage.count ) }</span>
+							<StepLabels step={ step } topLabel={ topLabel } />
+						</li>
+					) ) }
+				</ol>
+			</div>
+		);
+	}
+
+	return (
+		<div ref={ containerRef } className="newspack-insights__prompts-funnel newspack-insights__prompts-funnel--side" role="figure">
+			{ svg }
+			<div className="newspack-insights__prompts-funnel-labels">
+				{ steps.map( step => (
+					<div key={ step.index } className="newspack-insights__prompts-funnel-label">
+						<span className="newspack-insights__prompts-funnel-label-name">{ step.stage.label }</span>
+						<span className="newspack-insights__prompts-funnel-label-count">{ formatNumber( step.stage.count ) }</span>
+						<StepLabels step={ step } topLabel={ topLabel } />
+					</div>
+				) ) }
+			</div>
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
@@ -1,0 +1,82 @@
+/**
+ * PerformanceByIntentTable (NPPD-1607, Table 7.2).
+ *
+ * One row per intent (donation / registration / newsletter signup),
+ * aggregated across all prompts of that intent. Thin wrapper over the
+ * tab-local {@see SortableTable}, sorted by impressions descending.
+ *
+ * Phase 1 renders an empty-state row; the sort chrome stays visible.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsPerformanceByIntentRow, PromptsPerformanceByIntentTable as TableData } from '../../../api/prompts';
+import { formatNumber, formatPercent } from '../../components/format';
+import SortableTable, { NotApplicable, type SortableColumn } from './SortableTable';
+import { humanizeTerm } from './humanize';
+
+export interface PerformanceByIntentTableProps {
+	data: TableData;
+}
+
+const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
+
+const columns: SortableColumn< PromptsPerformanceByIntentRow >[] = [
+	{ key: 'intent', label: __( 'Intent', 'newspack-plugin' ), numeric: false, render: r => humanizeTerm( r.intent ), sortValue: r => r.intent },
+	{
+		key: 'impressions',
+		label: __( 'Impressions', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.impressions ),
+		sortValue: r => r.impressions,
+	},
+	{
+		key: 'unique_viewers',
+		label: __( 'Unique viewers', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.unique_viewers ),
+		sortValue: r => r.unique_viewers,
+	},
+	{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), numeric: true, render: r => renderRate( r.ctr ), sortValue: r => r.ctr },
+	{
+		key: 'form_submission_rate',
+		label: __( 'Form submission rate', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderRate( r.form_submission_rate ),
+		sortValue: r => r.form_submission_rate,
+	},
+	{
+		key: 'dismissal_rate',
+		label: __( 'Dismissal rate', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderRate( r.dismissal_rate ),
+		sortValue: r => r.dismissal_rate,
+	},
+];
+
+const PerformanceByIntentTable = ( { data }: PerformanceByIntentTableProps ) => (
+	<div className="newspack-insights__prompts-subsection">
+		<h3 className="newspack-insights__prompts-subsection-heading">{ __( 'Performance by prompt intent', 'newspack-plugin' ) }</h3>
+		<SortableTable
+			columns={ columns }
+			rows={ data.rows }
+			getRowKey={ row => row.intent }
+			defaultSortKey="impressions"
+			emptyMessage={ __(
+				'No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.',
+				'newspack-plugin'
+			) }
+		/>
+		<p className="newspack-insights__prompts-subsection-note">
+			{ __( "Answers 'are my donation prompts working better than my registration prompts?' at a glance.", 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default PerformanceByIntentTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
@@ -17,15 +17,13 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { PromptsPerformanceByIntentRow, PromptsPerformanceByIntentTable as TableData } from '../../../api/prompts';
-import { formatNumber, formatPercent } from '../../components/format';
-import SortableTable, { NotApplicable, type SortableColumn } from './SortableTable';
+import { formatNumber } from '../../components/format';
+import SortableTable, { renderRate, type SortableColumn } from './SortableTable';
 import { humanizeTerm } from './humanize';
 
 export interface PerformanceByIntentTableProps {
 	data: TableData;
 }
-
-const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
 
 const columns: SortableColumn< PromptsPerformanceByIntentRow >[] = [
 	{ key: 'intent', label: __( 'Intent', 'newspack-plugin' ), numeric: false, render: r => humanizeTerm( r.intent ), sortValue: r => r.intent },

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
@@ -1,0 +1,81 @@
+/**
+ * PerformanceByPlacementTable (NPPD-1607, Table 7.3).
+ *
+ * One row per placement (overlay / inline / above-header / etc.),
+ * aggregated across all prompts at that placement. Thin wrapper over
+ * the tab-local {@see SortableTable}, sorted by impressions descending.
+ *
+ * Phase 1 renders an empty-state row; the sort chrome stays visible.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsPerformanceByPlacementRow, PromptsPerformanceByPlacementTable as TableData } from '../../../api/prompts';
+import { formatNumber, formatPercent } from '../../components/format';
+import SortableTable, { NotApplicable, type SortableColumn } from './SortableTable';
+import { humanizeTerm } from './humanize';
+
+export interface PerformanceByPlacementTableProps {
+	data: TableData;
+}
+
+const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
+
+const columns: SortableColumn< PromptsPerformanceByPlacementRow >[] = [
+	{
+		key: 'placement',
+		label: __( 'Placement', 'newspack-plugin' ),
+		numeric: false,
+		render: r => humanizeTerm( r.placement ),
+		sortValue: r => r.placement,
+	},
+	{
+		key: 'impressions',
+		label: __( 'Impressions', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.impressions ),
+		sortValue: r => r.impressions,
+	},
+	{
+		key: 'unique_viewers',
+		label: __( 'Unique viewers', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.unique_viewers ),
+		sortValue: r => r.unique_viewers,
+	},
+	{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), numeric: true, render: r => renderRate( r.ctr ), sortValue: r => r.ctr },
+	{
+		key: 'dismissal_rate',
+		label: __( 'Dismissal rate', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderRate( r.dismissal_rate ),
+		sortValue: r => r.dismissal_rate,
+	},
+];
+
+const PerformanceByPlacementTable = ( { data }: PerformanceByPlacementTableProps ) => (
+	<div className="newspack-insights__prompts-subsection">
+		<h3 className="newspack-insights__prompts-subsection-heading">{ __( 'Performance by prompt placement', 'newspack-plugin' ) }</h3>
+		<SortableTable
+			columns={ columns }
+			rows={ data.rows }
+			getRowKey={ row => row.placement }
+			defaultSortKey="impressions"
+			emptyMessage={ __(
+				'No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.',
+				'newspack-plugin'
+			) }
+		/>
+		<p className="newspack-insights__prompts-subsection-note">
+			{ __( "Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.", 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default PerformanceByPlacementTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
@@ -17,15 +17,13 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { PromptsPerformanceByPlacementRow, PromptsPerformanceByPlacementTable as TableData } from '../../../api/prompts';
-import { formatNumber, formatPercent } from '../../components/format';
-import SortableTable, { NotApplicable, type SortableColumn } from './SortableTable';
+import { formatNumber } from '../../components/format';
+import SortableTable, { renderRate, type SortableColumn } from './SortableTable';
 import { humanizeTerm } from './humanize';
 
 export interface PerformanceByPlacementTableProps {
 	data: TableData;
 }
-
-const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
 
 const columns: SortableColumn< PromptsPerformanceByPlacementRow >[] = [
 	{

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -108,6 +108,7 @@ const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => 
 			rows={ data.rows }
 			getRowKey={ row => row.newspack_popup_id }
 			defaultSortKey="impressions"
+			initialRowLimit={ 10 }
 			emptyMessage={ __(
 				'No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.',
 				'newspack-plugin'
@@ -115,7 +116,7 @@ const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => 
 		/>
 		<p className="newspack-insights__prompts-subsection-note">
 			{ __(
-				'Showing top 50 prompts by impressions. If you have more than 50 active prompts, lower-traffic prompts may not appear.',
+				'Showing the top 10 prompts by the sorted column; use “See more” to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear.',
 				'newspack-plugin'
 			) }
 		</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -1,0 +1,125 @@
+/**
+ * PerformanceByPromptTable (NPPD-1607, Table 7.1).
+ *
+ * One row per prompt, sorted by impressions descending by default.
+ * Thin wrapper over the tab-local {@see SortableTable}. Donation and
+ * subscription columns show *attempts* in v1 (completions are a v1.1
+ * candidate via the Woo join). Rate cells render an em-dash for
+ * non-applicable prompts (e.g. CTR on a button-less prompt), distinct
+ * from a real 0%.
+ *
+ * Phase 1 renders the spec's empty-state row; the sort chrome stays
+ * visible so it's identical between phases.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as TableData } from '../../../api/prompts';
+import { formatNumber, formatPercent } from '../../components/format';
+import SortableTable, { NotApplicable, type SortableColumn } from './SortableTable';
+import { humanizeTerm } from './humanize';
+
+export interface PerformanceByPromptTableProps {
+	data: TableData;
+}
+
+const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
+
+const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
+	{ key: 'prompt_title', label: __( 'Prompt', 'newspack-plugin' ), numeric: false, render: r => r.prompt_title, sortValue: r => r.prompt_title },
+	{ key: 'intent', label: __( 'Intent', 'newspack-plugin' ), numeric: false, render: r => humanizeTerm( r.intent ), sortValue: r => r.intent },
+	{
+		key: 'placement',
+		label: __( 'Placement', 'newspack-plugin' ),
+		numeric: false,
+		render: r => humanizeTerm( r.placement ),
+		sortValue: r => r.placement,
+	},
+	{
+		key: 'impressions',
+		label: __( 'Impressions', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.impressions ),
+		sortValue: r => r.impressions,
+	},
+	{
+		key: 'unique_viewers',
+		label: __( 'Unique viewers', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.unique_viewers ),
+		sortValue: r => r.unique_viewers,
+	},
+	{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), numeric: true, render: r => renderRate( r.ctr ), sortValue: r => r.ctr },
+	{
+		key: 'form_submission_rate',
+		label: __( 'Form submission rate', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderRate( r.form_submission_rate ),
+		sortValue: r => r.form_submission_rate,
+	},
+	{
+		key: 'dismissal_rate',
+		label: __( 'Dismissal rate', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderRate( r.dismissal_rate ),
+		sortValue: r => r.dismissal_rate,
+	},
+	{
+		key: 'registrations',
+		label: __( 'Registrations', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.registrations ),
+		sortValue: r => r.registrations,
+	},
+	{
+		key: 'newsletter_signups',
+		label: __( 'Newsletter signups', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.newsletter_signups ),
+		sortValue: r => r.newsletter_signups,
+	},
+	{
+		key: 'donation_attempts',
+		label: __( 'Donation attempts', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.donation_attempts ),
+		sortValue: r => r.donation_attempts,
+	},
+	{
+		key: 'subscription_attempts',
+		label: __( 'Subscription attempts', 'newspack-plugin' ),
+		numeric: true,
+		render: r => formatNumber( r.subscription_attempts ),
+		sortValue: r => r.subscription_attempts,
+	},
+];
+
+const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => (
+	<div className="newspack-insights__prompts-subsection">
+		<h3 className="newspack-insights__prompts-subsection-heading">{ __( 'Performance by prompt', 'newspack-plugin' ) }</h3>
+		<SortableTable
+			columns={ columns }
+			rows={ data.rows }
+			getRowKey={ row => row.newspack_popup_id }
+			defaultSortKey="impressions"
+			emptyMessage={ __(
+				'No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.',
+				'newspack-plugin'
+			) }
+		/>
+		<p className="newspack-insights__prompts-subsection-note">
+			{ __(
+				'Showing top 50 prompts by impressions. If you have more than 50 active prompts, lower-traffic prompts may not appear.',
+				'newspack-plugin'
+			) }
+		</p>
+	</div>
+);
+
+export default PerformanceByPromptTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -22,16 +22,13 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as TableData } from '../../../api/prompts';
-import { formatNumber, formatPercent } from '../../components/format';
-import SortableTable, { NotApplicable, type SortableColumn } from './SortableTable';
+import { formatNumber } from '../../components/format';
+import SortableTable, { renderCount, renderRate, type SortableColumn } from './SortableTable';
 import { humanizeTerm } from './humanize';
 
 export interface PerformanceByPromptTableProps {
 	data: TableData;
 }
-
-const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
-const renderCount = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatNumber( v ) }</> );
 
 const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 	{ key: 'prompt_title', label: __( 'Prompt', 'newspack-plugin' ), numeric: false, render: r => r.prompt_title, sortValue: r => r.prompt_title },

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -3,10 +3,11 @@
  *
  * One row per prompt, sorted by impressions descending by default.
  * Thin wrapper over the tab-local {@see SortableTable}. Donation and
- * subscription columns show *attempts* in v1 (completions are a v1.1
- * candidate via the Woo join). Rate cells render an em-dash for
- * non-applicable prompts (e.g. CTR on a button-less prompt), distinct
- * from a real 0%.
+ * subscription columns report *conversions* (Woo-completed outcomes) —
+ * count + rate for each — matching the Gates v1.1 decision (NPPD-1684).
+ * Count and rate cells render a muted em-dash for non-applicable
+ * prompts (e.g. donation conversions on a registration prompt),
+ * distinct from a real 0 / 0%.
  *
  * Phase 1 renders the spec's empty-state row; the sort chrome stays
  * visible so it's identical between phases.
@@ -30,6 +31,7 @@ export interface PerformanceByPromptTableProps {
 }
 
 const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
+const renderCount = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatNumber( v ) }</> );
 
 const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 	{ key: 'prompt_title', label: __( 'Prompt', 'newspack-plugin' ), numeric: false, render: r => r.prompt_title, sortValue: r => r.prompt_title },
@@ -85,18 +87,32 @@ const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 		sortValue: r => r.newsletter_signups,
 	},
 	{
-		key: 'donation_attempts',
-		label: __( 'Donation attempts', 'newspack-plugin' ),
+		key: 'donation_conversions',
+		label: __( 'Donation conversions', 'newspack-plugin' ),
 		numeric: true,
-		render: r => formatNumber( r.donation_attempts ),
-		sortValue: r => r.donation_attempts,
+		render: r => renderCount( r.donation_conversions ),
+		sortValue: r => r.donation_conversions,
 	},
 	{
-		key: 'subscription_attempts',
-		label: __( 'Subscription attempts', 'newspack-plugin' ),
+		key: 'donation_conversion_rate',
+		label: __( 'Donation conversion rate', 'newspack-plugin' ),
 		numeric: true,
-		render: r => formatNumber( r.subscription_attempts ),
-		sortValue: r => r.subscription_attempts,
+		render: r => renderRate( r.donation_conversion_rate ),
+		sortValue: r => r.donation_conversion_rate,
+	},
+	{
+		key: 'subscription_conversions',
+		label: __( 'Subscription conversions', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderCount( r.subscription_conversions ),
+		sortValue: r => r.subscription_conversions,
+	},
+	{
+		key: 'subscription_conversion_rate',
+		label: __( 'Subscription conversion rate', 'newspack-plugin' ),
+		numeric: true,
+		render: r => renderRate( r.subscription_conversion_rate ),
+		sortValue: r => r.subscription_conversion_rate,
 	},
 ];
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tab-local SortableTable primitive (NPPD-1607, Phase 1).
+ *
+ * Generic click-to-sort table used by the three Performance breakdown
+ * tables on Tab 5 (by prompt, by intent, by placement). Factors the
+ * sort behavior that the Gates tab inlines in its single
+ * PerformanceByGateSection — Tab 5 has three such tables, so a shared
+ * primitive is warranted rather than triplicating the logic.
+ *
+ * Behavior matches the Gates table chrome exactly:
+ *   - Click a column header to sort; numeric columns open DESC, string
+ *     columns open ASC; clicking the active column toggles direction.
+ *   - Null cells (em-dash) always sort to the bottom regardless of
+ *     direction — a non-applicable metric should never claim the top
+ *     of an ascending sort.
+ *   - When `rows` is empty (Phase 1, always), the empty-state row is
+ *     shown but the sort affordances stay visible so the chrome is
+ *     identical between phases.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
+
+export type SortDir = 'asc' | 'desc';
+
+export interface SortableColumn< Row > {
+	/** Stable key; also the default sort target when it matches `defaultSortKey`. */
+	key: string;
+	label: string;
+	numeric: boolean;
+	/** Cell content. */
+	render: ( row: Row ) => React.ReactNode;
+	/** Value used for sorting. `null` always sorts last. */
+	sortValue: ( row: Row ) => number | string | null;
+}
+
+export interface SortableTableProps< Row > {
+	columns: SortableColumn< Row >[];
+	rows: Row[];
+	getRowKey: ( row: Row ) => string | number;
+	defaultSortKey: string;
+	emptyMessage: string;
+}
+
+const ariaSortFor = ( isActive: boolean, activeDir: SortDir ): 'ascending' | 'descending' | 'none' => {
+	if ( ! isActive ) {
+		return 'none';
+	}
+	return activeDir === 'asc' ? 'ascending' : 'descending';
+};
+
+interface SortableHeaderProps< Row > {
+	column: SortableColumn< Row >;
+	activeKey: string;
+	activeDir: SortDir;
+	onSort: ( key: string ) => void;
+}
+
+function SortableHeader< Row >( { column, activeKey, activeDir, onSort }: SortableHeaderProps< Row > ) {
+	const isActive = column.key === activeKey;
+	const ariaSort = ariaSortFor( isActive, activeDir );
+	const className = column.numeric
+		? 'newspack-insights__prompts-table-num newspack-insights__prompts-table-sort-cell'
+		: 'newspack-insights__prompts-table-sort-cell';
+	return (
+		<th scope="col" className={ className } aria-sort={ ariaSort }>
+			<button
+				type="button"
+				className={ `newspack-insights__prompts-table-sort${ isActive ? ' is-active' : '' }` }
+				onClick={ () => onSort( column.key ) }
+			>
+				<span className="newspack-insights__prompts-table-sort-label">{ column.label }</span>
+				<span className="newspack-insights__prompts-table-sort-indicator" aria-hidden="true">
+					<Icon icon={ isActive && activeDir === 'asc' ? chevronUp : chevronDown } size={ 14 } />
+				</span>
+			</button>
+		</th>
+	);
+}
+
+function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, emptyMessage }: SortableTableProps< Row > ) {
+	const [ sortKey, setSortKey ] = useState< string >( defaultSortKey );
+	const [ sortDir, setSortDir ] = useState< SortDir >( () => {
+		const def = columns.find( c => c.key === defaultSortKey );
+		return def?.numeric ? 'desc' : 'asc';
+	} );
+
+	const handleSort = ( key: string ) => {
+		if ( key === sortKey ) {
+			setSortDir( prev => ( prev === 'asc' ? 'desc' : 'asc' ) );
+			return;
+		}
+		setSortKey( key );
+		// Default direction depends on column type: numeric columns open
+		// DESC (biggest first), string columns open ASC.
+		const def = columns.find( c => c.key === key );
+		setSortDir( def?.numeric ? 'desc' : 'asc' );
+	};
+
+	const sortedRows = useMemo( () => {
+		const column = columns.find( c => c.key === sortKey );
+		if ( ! column ) {
+			return rows;
+		}
+		return [ ...rows ].sort( ( a, b ) => {
+			const av = column.sortValue( a );
+			const bv = column.sortValue( b );
+			// Nulls last (regardless of direction).
+			if ( av === null && bv === null ) {
+				return 0;
+			}
+			if ( av === null ) {
+				return 1;
+			}
+			if ( bv === null ) {
+				return -1;
+			}
+			let cmp: number;
+			if ( typeof av === 'string' && typeof bv === 'string' ) {
+				cmp = av.localeCompare( bv );
+			} else {
+				cmp = ( av as number ) - ( bv as number );
+			}
+			return sortDir === 'asc' ? cmp : -cmp;
+		} );
+	}, [ rows, columns, sortKey, sortDir ] );
+
+	const isEmpty = sortedRows.length === 0;
+
+	return (
+		<div className="newspack-insights__table-wrap">
+			<table className="newspack-insights__table newspack-insights__prompts-table--sortable">
+				<thead>
+					<tr>
+						{ columns.map( col => (
+							<SortableHeader key={ col.key } column={ col } activeKey={ sortKey } activeDir={ sortDir } onSort={ handleSort } />
+						) ) }
+					</tr>
+				</thead>
+				<tbody>
+					{ isEmpty ? (
+						<tr>
+							<td colSpan={ columns.length } className="newspack-insights__prompts-performance-empty">
+								{ emptyMessage }
+							</td>
+						</tr>
+					) : (
+						sortedRows.map( row => (
+							<tr key={ getRowKey( row ) }>
+								{ columns.map( col => (
+									<td key={ col.key } className={ col.numeric ? 'newspack-insights__prompts-table-num' : undefined }>
+										{ col.render( row ) }
+									</td>
+								) ) }
+							</tr>
+						) )
+					) }
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+/** Renders an em-dash for non-applicable numeric cells, distinct from a real zero. */
+export const NotApplicable = () => (
+	<span className="newspack-insights__prompts-table-na" aria-label={ __( 'Not applicable', 'newspack-plugin' ) }>
+		—
+	</span>
+);
+
+export default SortableTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
@@ -64,7 +64,7 @@ function SortableHeader< Row >( { column, activeKey, activeDir, onSort }: Sortab
 	const isActive = column.key === activeKey;
 	const ariaSort = ariaSortFor( isActive, activeDir );
 	const className = column.numeric
-		? 'newspack-insights__prompts-table-num newspack-insights__prompts-table-sort-cell'
+		? 'newspack-insights__table-num newspack-insights__prompts-table-sort-cell'
 		: 'newspack-insights__prompts-table-sort-cell';
 	return (
 		<th scope="col" className={ className } aria-sort={ ariaSort }>
@@ -152,7 +152,7 @@ function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, empty
 						sortedRows.map( row => (
 							<tr key={ getRowKey( row ) }>
 								{ columns.map( col => (
-									<td key={ col.key } className={ col.numeric ? 'newspack-insights__prompts-table-num' : undefined }>
+									<td key={ col.key } className={ col.numeric ? 'newspack-insights__table-num' : undefined }>
 										{ col.render( row ) }
 									</td>
 								) ) }
@@ -167,7 +167,7 @@ function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, empty
 
 /** Renders an em-dash for non-applicable numeric cells, distinct from a real zero. */
 export const NotApplicable = () => (
-	<span className="newspack-insights__prompts-table-na" aria-label={ __( 'Not applicable', 'newspack-plugin' ) }>
+	<span className="newspack-insights__table-na" aria-label={ __( 'Not applicable', 'newspack-plugin' ) }>
 		—
 	</span>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
@@ -21,7 +21,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 
@@ -44,6 +44,12 @@ export interface SortableTableProps< Row > {
 	getRowKey: ( row: Row ) => string | number;
 	defaultSortKey: string;
 	emptyMessage: string;
+	/**
+	 * When set and the table has more rows than this, only the first N (by the
+	 * active sort) render, with a "See more" toggle that reveals the rest. The
+	 * cap is applied after sorting, so collapsing always shows the current top N.
+	 */
+	initialRowLimit?: number;
 }
 
 const ariaSortFor = ( isActive: boolean, activeDir: SortDir ): 'ascending' | 'descending' | 'none' => {
@@ -82,12 +88,13 @@ function SortableHeader< Row >( { column, activeKey, activeDir, onSort }: Sortab
 	);
 }
 
-function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, emptyMessage }: SortableTableProps< Row > ) {
+function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, emptyMessage, initialRowLimit }: SortableTableProps< Row > ) {
 	const [ sortKey, setSortKey ] = useState< string >( defaultSortKey );
 	const [ sortDir, setSortDir ] = useState< SortDir >( () => {
 		const def = columns.find( c => c.key === defaultSortKey );
 		return def?.numeric ? 'desc' : 'asc';
 	} );
+	const [ expanded, setExpanded ] = useState( false );
 
 	const handleSort = ( key: string ) => {
 		if ( key === sortKey ) {
@@ -131,37 +138,62 @@ function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, empty
 
 	const isEmpty = sortedRows.length === 0;
 
+	// Row cap + "See more" toggle (only when a limit is set and exceeded). The
+	// cap is applied to the already-sorted rows, so collapsing shows the current
+	// top N; the toggle persists across re-sorts.
+	const isCollapsible = typeof initialRowLimit === 'number' && sortedRows.length > initialRowLimit;
+	const visibleRows = isCollapsible && ! expanded ? sortedRows.slice( 0, initialRowLimit ) : sortedRows;
+	const hiddenCount = sortedRows.length - ( initialRowLimit ?? 0 );
+
 	return (
-		<div className="newspack-insights__table-wrap">
-			<table className="newspack-insights__table newspack-insights__prompts-table--sortable">
-				<thead>
-					<tr>
-						{ columns.map( col => (
-							<SortableHeader key={ col.key } column={ col } activeKey={ sortKey } activeDir={ sortDir } onSort={ handleSort } />
-						) ) }
-					</tr>
-				</thead>
-				<tbody>
-					{ isEmpty ? (
+		<>
+			<div className="newspack-insights__table-wrap">
+				<table className="newspack-insights__table newspack-insights__prompts-table--sortable">
+					<thead>
 						<tr>
-							<td colSpan={ columns.length } className="newspack-insights__prompts-performance-empty">
-								{ emptyMessage }
-							</td>
+							{ columns.map( col => (
+								<SortableHeader key={ col.key } column={ col } activeKey={ sortKey } activeDir={ sortDir } onSort={ handleSort } />
+							) ) }
 						</tr>
-					) : (
-						sortedRows.map( row => (
-							<tr key={ getRowKey( row ) }>
-								{ columns.map( col => (
-									<td key={ col.key } className={ col.numeric ? 'newspack-insights__table-num' : undefined }>
-										{ col.render( row ) }
-									</td>
-								) ) }
+					</thead>
+					<tbody>
+						{ isEmpty ? (
+							<tr>
+								<td colSpan={ columns.length } className="newspack-insights__prompts-performance-empty">
+									{ emptyMessage }
+								</td>
 							</tr>
-						) )
-					) }
-				</tbody>
-			</table>
-		</div>
+						) : (
+							visibleRows.map( row => (
+								<tr key={ getRowKey( row ) }>
+									{ columns.map( col => (
+										<td key={ col.key } className={ col.numeric ? 'newspack-insights__table-num' : undefined }>
+											{ col.render( row ) }
+										</td>
+									) ) }
+								</tr>
+							) )
+						) }
+					</tbody>
+				</table>
+			</div>
+			{ isCollapsible && (
+				<button
+					type="button"
+					className="newspack-insights__prompts-table-more"
+					aria-expanded={ expanded }
+					onClick={ () => setExpanded( prev => ! prev ) }
+				>
+					{ expanded
+						? __( 'See less', 'newspack-plugin' )
+						: sprintf(
+								/* translators: %d: number of additional rows revealed by expanding the table. */
+								__( 'See more (%d)', 'newspack-plugin' ),
+								hiddenCount
+						  ) }
+				</button>
+			) }
+		</>
 	);
 }
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
@@ -25,6 +25,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { formatNumber, formatPercent } from '../../components/format';
+
 export type SortDir = 'asc' | 'desc';
 
 export interface SortableColumn< Row > {
@@ -203,5 +208,11 @@ export const NotApplicable = () => (
 		—
 	</span>
 );
+
+/** Cell renderer: a percentage, or a muted em-dash when the metric is not applicable (null). */
+export const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
+
+/** Cell renderer: a formatted count, or a muted em-dash when the metric is not applicable (null). */
+export const renderCount = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatNumber( v ) }</> );
 
 export default SortableTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/humanize.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/humanize.ts
@@ -1,0 +1,16 @@
+/**
+ * humanizeTerm — display helper for raw event-param enum values.
+ *
+ * Turns snake_case / lowercase event values (`newsletters_subscription`,
+ * `above-header`) into title-cased display strings
+ * (`Newsletters Subscription`, `Above Header`) for the Performance
+ * breakdown tables. Phase 1 tables have no rows, but the per-cell
+ * renderers carry this through to Phase 2 unchanged.
+ */
+
+export const humanizeTerm = ( value: string ): string =>
+	value
+		.split( /[_-]+/ )
+		.filter( Boolean )
+		.map( word => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+		.join( ' ' );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Test Prompts_Metric (NPPD-1607, Phase 1).
+ *
+ * Phase 1 orchestrator returns placeholder envelopes only — no proxy,
+ * no SQL. These tests pin the envelope shape every Phase 2 swap must
+ * preserve: scalar scorecards carry `value` / `pending` / `computable`
+ * / `placeholder_type`, the funnel/distribution carry `pending` + an
+ * ordered collection, and the three performance tables carry `pending`
+ * + an empty `rows` array.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Newspack\Insights\Prompts_Metric;
+use WP_UnitTestCase;
+
+/**
+ * Prompts_Metric test class.
+ *
+ * @group insights
+ */
+class Test_Prompts_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Subject under test.
+	 *
+	 * @var Prompts_Metric
+	 */
+	private $metric;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->metric = new Prompts_Metric();
+	}
+
+	/**
+	 * Make a UTC DateTimeImmutable from a YYYY-MM-DD string.
+	 *
+	 * @param string $ymd Date string.
+	 * @return DateTimeImmutable
+	 */
+	private function make_date( string $ymd ): DateTimeImmutable {
+		return new DateTimeImmutable( $ymd, new DateTimeZone( 'UTC' ) );
+	}
+
+	/**
+	 * Every scalar scorecard returns the Phase 1 placeholder envelope:
+	 * a non-computable, pending, zero value of the documented type.
+	 *
+	 * @dataProvider provide_scalar_methods
+	 * @param string $method           Method on Prompts_Metric to call.
+	 * @param string $placeholder_type Expected `placeholder_type`.
+	 */
+	public function test_scalar_returns_placeholder_envelope( string $method, string $placeholder_type ) {
+		$result = $this->metric->$method( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'value', $result );
+		$this->assertArrayHasKey( 'computable', $result );
+		$this->assertArrayHasKey( 'pending', $result );
+		$this->assertArrayHasKey( 'denominator', $result );
+		$this->assertArrayHasKey( 'placeholder_type', $result );
+
+		$this->assertTrue( $result['pending'], "$method should be pending in Phase 1" );
+		$this->assertFalse( $result['computable'], "$method should be non-computable in Phase 1" );
+		$this->assertNull( $result['denominator'] );
+		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
+
+		// Decimal placeholders are floats; everything else is an integer zero.
+		if ( 'decimal' === $placeholder_type ) {
+			$this->assertSame( 0.0, $result['value'] );
+		} else {
+			$this->assertSame( 0, $result['value'] );
+		}
+	}
+
+	/**
+	 * Every scalar scorecard method, mapped to its expected placeholder type.
+	 * Mirrors the formulas-doc query set for Tab 5 Sections 1–5.
+	 *
+	 * @return array<string, array{0:string,1:string}>
+	 */
+	public function provide_scalar_methods(): array {
+		return [
+			// Section 1 — exposure.
+			'total_prompt_impressions'                   => [ 'get_total_prompt_impressions', 'count' ],
+			'unique_readers_reached'                     => [ 'get_unique_readers_reached', 'count' ],
+			'avg_prompts_per_reader'                     => [ 'get_avg_prompts_per_reader', 'decimal' ],
+			// Section 2 — engagement.
+			'click_through_rate'                         => [ 'get_click_through_rate', 'rate' ],
+			'form_submission_rate'                       => [ 'get_form_submission_rate', 'rate' ],
+			'dismissal_rate'                             => [ 'get_dismissal_rate', 'rate' ],
+			// Section 3 — free reader conversion.
+			'registration_conversion_direct'             => [ 'get_registration_conversion_direct', 'rate' ],
+			'registration_conversion_influenced_7d'      => [ 'get_registration_conversion_influenced_7d', 'rate' ],
+			'newsletter_signup_conversion_direct'        => [ 'get_newsletter_signup_conversion_direct', 'rate' ],
+			'newsletter_signup_conversion_influenced_7d' => [ 'get_newsletter_signup_conversion_influenced_7d', 'rate' ],
+			// Section 4 — paid reader conversion.
+			'donation_conversion_direct'                 => [ 'get_donation_conversion_direct', 'rate' ],
+			'donation_conversion_influenced_14d'         => [ 'get_donation_conversion_influenced_14d', 'rate' ],
+			'subscription_conversion_direct'             => [ 'get_subscription_conversion_direct', 'rate' ],
+			'subscription_conversion_influenced_14d'     => [ 'get_subscription_conversion_influenced_14d', 'rate' ],
+			// Section 5 — revenue.
+			'donation_revenue_direct'                    => [ 'get_donation_revenue_direct', 'currency' ],
+			'donation_revenue_influenced_14d'            => [ 'get_donation_revenue_influenced_14d', 'currency' ],
+			'subscription_revenue_direct'                => [ 'get_subscription_revenue_direct', 'currency' ],
+			'subscription_revenue_influenced_14d'        => [ 'get_subscription_revenue_influenced_14d', 'currency' ],
+		];
+	}
+
+	/**
+	 * The funnel returns a pending envelope with three ordered, zeroed stages.
+	 */
+	public function test_funnel_returns_three_zero_stages() {
+		$result = $this->metric->get_conversion_funnel( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertCount( 3, $result['stages'] );
+		foreach ( $result['stages'] as $stage ) {
+			$this->assertArrayHasKey( 'label', $stage );
+			$this->assertNotSame( '', $stage['label'] );
+			$this->assertSame( 0, $stage['count'] );
+			$this->assertSame( 0.0, $stage['pct_of_top'] );
+		}
+	}
+
+	/**
+	 * The distribution returns a pending envelope with four zeroed buckets.
+	 */
+	public function test_distribution_returns_four_zero_buckets() {
+		$result = $this->metric->get_exposures_distribution( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertCount( 4, $result['buckets'] );
+		foreach ( $result['buckets'] as $bucket ) {
+			$this->assertArrayHasKey( 'label', $bucket );
+			$this->assertNotSame( '', $bucket['label'] );
+			$this->assertSame( 0, $bucket['count'] );
+			$this->assertSame( 0.0, $bucket['pct'] );
+		}
+	}
+
+	/**
+	 * Each performance table returns a pending envelope with an empty
+	 * `rows` array, so the React layer renders the spec's empty-state row.
+	 *
+	 * @dataProvider provide_table_methods
+	 * @param string $method Method on Prompts_Metric to call.
+	 */
+	public function test_performance_table_returns_empty_rows( string $method ) {
+		$result = $this->metric->$method( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertArrayHasKey( 'rows', $result );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * The three Section 7 performance tables.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_table_methods(): array {
+		return [
+			'by_prompt'    => [ 'get_performance_by_prompt' ],
+			'by_intent'    => [ 'get_performance_by_intent' ],
+			'by_placement' => [ 'get_performance_by_placement' ],
+		];
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Test Prompts_REST_Controller (NPPD-1607, Phase 1).
+ *
+ * Exercises the Tab 5 endpoint's request lifecycle: a valid window
+ * returns 200 with the placeholder envelope; comparison mode adds a
+ * `previous` window; invalid / mismatched date params return 400.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Prompts_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * Prompts_REST_Controller test class.
+ *
+ * @group insights
+ */
+class Test_Prompts_REST_Controller extends WP_UnitTestCase {
+
+	const ROUTE = '/newspack-insights/v1/prompts';
+
+	/**
+	 * REST server.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up: an admin user + a registered Prompts route on a fresh server.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// Register on the rest_api_init action (as production does) — calling
+		// register_rest_route outside that action triggers a _doing_it_wrong notice.
+		add_action( 'rest_api_init', [ $this, 'register_prompts_route' ] );
+
+		global $wp_rest_server;
+		$this->server   = new WP_REST_Server();
+		$wp_rest_server = $this->server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Register the Prompts route. Hooked to rest_api_init in set_up().
+	 *
+	 * @return void
+	 */
+	public function register_prompts_route() {
+		( new Prompts_REST_Controller() )->register_routes();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_action( 'rest_api_init', [ $this, 'register_prompts_route' ] );
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Build + dispatch a GET request to the Prompts route.
+	 *
+	 * @param array $params Query params.
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch( array $params ) {
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * A valid window returns 200 with the full placeholder envelope and a
+	 * null `previous` (no comparison requested).
+	 */
+	public function test_valid_window_returns_200_envelope() {
+		$response = $this->dispatch(
+			[
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'tab_pending', $data );
+		$this->assertTrue( $data['tab_pending'] );
+		$this->assertArrayHasKey( 'current', $data );
+		$this->assertNull( $data['previous'] );
+
+		// Window echo + one representative metric per section is present.
+		$current = $data['current'];
+		$this->assertSame( '2026-03-22', $current['window']['start'] );
+		$this->assertSame( '2026-04-21', $current['window']['end'] );
+		foreach (
+			[
+				'total_prompt_impressions',
+				'click_through_rate',
+				'registration_conversion_direct',
+				'donation_conversion_direct',
+				'donation_revenue_direct',
+				'conversion_funnel',
+				'exposures_distribution',
+				'performance_by_prompt',
+				'performance_by_intent',
+				'performance_by_placement',
+			] as $key
+		) {
+			$this->assertArrayHasKey( $key, $current, "Missing window key: $key" );
+		}
+
+		// A scalar carries the placeholder envelope.
+		$this->assertTrue( $current['total_prompt_impressions']['pending'] );
+		$this->assertSame( 'count', $current['total_prompt_impressions']['placeholder_type'] );
+		// Tables ship empty rows for the empty-state UI.
+		$this->assertSame( [], $current['performance_by_prompt']['rows'] );
+	}
+
+	/**
+	 * Comparison mode (both compare params) adds a populated `previous`
+	 * window with the same shape.
+	 */
+	public function test_comparison_mode_populates_previous() {
+		$response = $this->dispatch(
+			[
+				'start'         => '2026-03-22',
+				'end'           => '2026-04-21',
+				'compare_start' => '2026-02-20',
+				'compare_end'   => '2026-03-21',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data['previous'] );
+		$this->assertSame( '2026-02-20', $data['previous']['window']['start'] );
+		$this->assertSame( '2026-03-21', $data['previous']['window']['end'] );
+		$this->assertArrayHasKey( 'total_prompt_impressions', $data['previous'] );
+	}
+
+	/**
+	 * An unparseable date is rejected by the route's validate_callback.
+	 */
+	public function test_invalid_date_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start' => 'not-a-date',
+				'end'   => '2026-04-21',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Start after end is rejected by the handler.
+	 */
+	public function test_start_after_end_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start' => '2026-04-21',
+				'end'   => '2026-03-22',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * A lone comparison bound (start without end) is rejected.
+	 */
+	public function test_partial_comparison_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start'         => '2026-03-22',
+				'end'           => '2026-04-21',
+				'compare_start' => '2026-02-20',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -193,4 +193,33 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		);
 		$this->assertSame( 400, $response->get_status() );
 	}
+
+	/**
+	 * The mirror of the above: a lone comparison end (no start) is rejected.
+	 */
+	public function test_partial_comparison_end_only_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start'       => '2026-03-22',
+				'end'         => '2026-04-21',
+				'compare_end' => '2026-03-21',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * An inverted comparison window (compare_start after compare_end) is rejected.
+	 */
+	public function test_inverted_comparison_window_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start'         => '2026-03-22',
+				'end'           => '2026-04-21',
+				'compare_start' => '2026-03-21',
+				'compare_end'   => '2026-02-20',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
 }


### PR DESCRIPTION
## Summary

Phase 1 of the Insights **Prompts** tab (Tab 5) — ships the complete UI behind `pending: true` placeholders so it can be reviewed independently of BigQuery. Every section, scorecard, table, viz component, and string is final; only the numbers are synthetic. Mirrors the two-phase pattern that worked for Gates: Phase 2 (NPPD-1682) swaps the orchestrator stubs to real BigQuery dispatch via the Newspack Manager proxy without touching the UI, the REST shape, or any method signatures.

Targets `feat/insights-rsm` but mirrors **Gates as it currently exists on `main`** (the shipped Phase 1 `pending: true` layer) rather than the in-flight state-envelope work on rsm — so when rsm merges to main, the diff resolves cleanly because Prompts was built against the same Gates contract already there.

The tab is gated only by `NEWSPACK_INSIGHTS_ENABLED` — no separate preview flag (rsm is itself the staging area until the v1 release event).

Closes NPPD-1607. Unblocks NPPD-1682 (Phase 2, BigQuery wiring). Separately tracked: NPPD-1683 (Insights `.tsx` test files not collected by `npm test`).

<img width="3294" height="6564" alt="image" src="https://github.com/user-attachments/assets/47ce778f-e3b1-4b4d-96a7-a338ae6a0bf7" />

### Pre-flight decisions

- **Base off `feat/insights-rsm`, but mirror Gates from `main`** — rsm's Gates is the unmerged state-envelope version (Phase 2 of the Gates pattern); main's Gates is the shipped `pending: true` Phase 1. Built against main to keep the eventual rsm → main reconciliation clean.
- **File layout follows actual Gates pattern** — `tabs/PromptsTab.tsx` + `tabs/prompts/` for sections, not `tabs/prompts/Tab.tsx`. Stubs were already in place in the expected locations.
- **Callout is the session-only, self-contained variant** — mirrors rsm's `DirectVsInfluencedCallout`. Main's version wraps a shared `InfoCallout` that was removed on rsm and wouldn't compile here.
- **Tab-local viz, scoped CSS** — `tabs/prompts/viz/` and `prompts.scss` with prompts-scoped classes. Zero coupling to `gates.scss`, no shared-stylesheet edits.
- **No preview banner** — Gates renders one on `tab_pending`; Prompts omits it (no separate preview flag for this tab). `tab_pending` stays in the envelope for parity and Phase 2 reuse.

## What's in this PR

### `Prompts_Metric` orchestrator

`plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php`. One method per scorecard, funnel stage, distribution, and breakdown table, named to the `formulas/tab-5-prompts.md` query set — 18 scalar methods plus `get_conversion_funnel()`, `get_exposures_distribution()`, and three table methods (`get_performance_by_prompt`, `_by_intent`, `_by_placement`). Each returns the placeholder envelope (`value`, `pending`, `computable`, `denominator`, `placeholder_type`). Signatures and return shapes match what Phase 2 will populate from the BigQuery proxy, so Phase 2 is a pure body swap.

### REST controller

`plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php` registering `GET /newspack-insights/v1/prompts` — same date-validation / comparison-window lifecycle / response envelope as the Gates endpoint. `Insights_Section_Prompts` wires the controller into the section registry. `tab_pending` is computed from per-metric `pending` flags (currently always `true`); kept in the envelope for parity with Gates and to keep the Phase 2 wiring path identical.

### UI

`PromptsTab` + seven sections under `tabs/prompts/`. All copy lifted verbatim from `specs/prompts.md`. Layout matches Gates: scorecard sections at top, viz mid-page, breakdown tables at bottom. The Direct vs Influenced explainer sits between the tab header and Section 1, session-dismissable.

The seven sections, in render order:

1. **Prompt exposure** (3 cards) — Total Prompt Impressions, Unique Readers Reached, Avg Prompts per Reader
2. **Prompt engagement** (3 cards) — Click-Through Rate, Form Submission Rate, Dismissal Rate
3. **Free reader conversion** (4 cards) — Registration + Newsletter Signup, each Direct + Influenced 7d
4. **Paid reader conversion** (4 cards) — Donation + Subscription, each Direct + Influenced 14d
5. **Revenue from prompts** (4 cards) — Donation + Subscription Revenue, each Direct + Influenced 14d
6. **How readers convert** — funnel (Impression → Engagement → Conversion) + distribution (1 / 2 / 3-5 / 6+ exposure buckets)
7. **Performance breakdown** — three sortable tables (by prompt, by intent, by placement)

### Tab-local viz

`tabs/prompts/viz/`: `Funnel.tsx`, `DistributionTable.tsx`, and three sortable performance tables (`PerformanceByPromptTable`, `_ByIntentTable`, `_ByPlacementTable`) consuming a shared **`SortableTable.tsx`** primitive — factored locally because Prompts has three sortable tables vs Gates' one, and triplicating the sort logic across three sibling files would be worse than a tab-local primitive. Promote to `packages/components/src/viz/` when a second tab needs it.

### `scalarToCard` wrapper

`tabs/prompts/scalarToCard.ts` mapping placeholder envelopes to `MetricCard` props — handles all four placeholder types (`count`, `rate`, `currency`, `decimal`). This is the first Insights tab to use `decimal` (for Card 1.3, Avg Prompts per Reader).

### Tests

28 PHPUnit tests (267 assertions) covering orchestrator envelope shape, every method's placeholder type, and REST controller behavior (200 on valid date ranges, 400 on invalid / reversed / partial-comparison input, `previousValue` omitted when comparison is off, full envelope structure). PHPCS clean. ESLint, Prettier, and `tsc` clean on source. `n build newspack-plugin` compiles with only generic asset-size warnings.

`PromptsTab.test.tsx` exists on disk following the established sibling convention (mirrors `AudienceTab.test.tsx`) but isn't collected by `npm test` — see **Known gaps** below.

## How to test

1. Check out `feat/insights-prompts-phase-1`, run `n build newspack-plugin`, and ensure `NEWSPACK_INSIGHTS_ENABLED` is on.
2. Open **Newspack → Insights** and select the **Prompts** tab (between Gates and Subscribers in the nav).
3. Confirm all seven sections render with placeholder zeros in the correct format per type — counts as `0`, rates as `0%`, currency as `$0.00`, and Avg Prompts per Reader as `0.0` (the first use of the `decimal` placeholder type).
4. Confirm the **Direct vs Influenced** explainer renders above Section 1, dismisses on click, and reappears after a page reload (session-only).
5. In **How readers convert**, confirm the funnel renders three stages (Impression / Engagement / Conversion) at zero, and the distribution renders four buckets (1, 2, 3-5, 6+) at 0 / 0%.
6. In **Performance breakdown**, confirm the three tables (by prompt, by intent, by placement) each render their empty-state row, that column headers are clickable (sort affordances visible), and that the by-prompt table shows the "top 50" footnote.
7. Exercise the endpoint directly: `GET /newspack-insights/v1/prompts?start=YYYY-MM-DD&end=YYYY-MM-DD` returns `200` with `tab_pending: true` and a `current` window; adding `compare_start` / `compare_end` populates `previous`; an invalid date, a reversed window, or a lone comparison bound returns `400`.
8. Run the PHP suite: `cd plugins/newspack-plugin && n test-php --filter Prompts` — 28 tests pass.

## Known gaps

**Insights `.tsx` test files are not collected by `npm test`.** The runner's `testMatch` is `*test.js?(x)`, which excludes `.tsx`; and when forced to run, `.tsx` tab tests fail on a pre-existing React-19 / jsx-runtime issue. This affects `AudienceTab.test.tsx` today and now `PromptsTab.test.tsx` — and every future Insights tab test. The `PromptsTab.test.tsx` file is included here per the established sibling convention; the gap is the bug, not the test. The Phase 1 data contract is fully covered by the passing PHP suite. Tracked separately as **NPPD-1683**.

## Out of scope

- BigQuery query dispatch and Woo joins for paid conversion completion — NPPD-1682 (Phase 2).
- Subscription-vs-registration intent splitting in the Performance by prompt table — v1 lumps both under "registration" per spec; v1.1 candidate.
- A/B variant slicing of the per-prompt table — v2 per spec (`ab_test_id` / `ab_variant` already in event payload but unused).
- `prompt_frequency` parameter usage — v2 per spec.
- Test harness fix — NPPD-1683.