### PR TITLE
fix(insights): clamp Gates funnel trapezoid top edge to viewBox

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/viz/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/viz/Funnel.tsx
@@ -74,7 +74,7 @@ const stepHeightFor = ( stepCount: number ): number => Math.max( MIN_STEP_HEIGHT
  */
 const trapezoidPath = ( count: number, nextCount: number, topCount: number, yTop: number, yBottom: number ): string => {
 	const cx = VIEWBOX_WIDTH / 2;
-	const halfTop = ( count / topCount ) * ( VIEWBOX_WIDTH / 2 );
+	const halfTop = Math.min( VIEWBOX_WIDTH / 2, ( count / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
 	const halfBottom = Math.min( halfTop, ( nextCount / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
 	return [
 		`M ${ cx - halfTop } ${ yTop }`,


### PR DESCRIPTION
## What

One-line clamp in `trapezoidPath` so the Gates conversion funnel's top edge can never render outside the SVG viewBox.

```diff
-const halfTop = ( count / topCount ) * ( VIEWBOX_WIDTH / 2 );
+const halfTop = Math.min( VIEWBOX_WIDTH / 2, ( count / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
```

## Why

Funnel stages are independent aggregates, so a later stage can occasionally exceed the first (top) stage's count — "data drift", acknowledged by the file's own comments. `halfBottom` was already clamped (via the implicit `halfTop` ceiling), but `halfTop` itself was not. When `count > topCount`, `halfTop > VIEWBOX_WIDTH/2`, so the trapezoid's top points render at `x < 0` and `x > VIEWBOX_WIDTH` and the shape flares/overflows past the viewBox — the opposite of the "silhouette only ever narrows / never flares outward" invariant the code documents.

This is the same latent bug introduced with the SVG funnel in #267. The Prompts tab copied this funnel and the fix was already applied there in #271; this mirrors it one-for-one on the Gates copy.

## Testing

- `n build newspack-plugin` — compiles clean.
- ESLint on the changed file — clean.
- `npm test` — no new failures; the suite's pre-existing failures are unrelated `@wordpress/dataviews` import errors. The `Funnel.test.tsx` helper tests are not collected by the current `testMatch` (`.tsx` test gap, NPPD-1683).

Ref #267 · mirrors #271