### PR TITLE
feat(insights): swap newsletter-status card for traffic source

### DIFF
--- a/plugins/newspack-plugin/docs/insights/dev-notes.md
+++ b/plugins/newspack-plugin/docs/insights/dev-notes.md
@@ -29,9 +29,9 @@ verified at once:
 
 - **Realistic values** across scorecards, tables, pie charts, the time-series
   line chart, and the day-of-week / hour-of-day bar charts.
-- **`custom_dimension_missing` overlay** — one card per tab:
+- **`custom_dimension_missing` overlay** — Audience only:
   - Audience: Newsletter Subscriber Rate (and its composition pie)
-  - Engagement: Engagement by Newsletter Status
+  - (Engagement's traffic-source card uses the standard `sessionMedium` dimension — no custom-dimension overlay.)
 - **`hidden_in_v1` skips** — BQ-only metrics render nothing (no card, no empty
   space): Audience's Returning Reader Rate (strict); Engagement's Top Categories,
   Mobile vs Desktop, Repeat Reader Rate, Article Freshness.

--- a/plugins/newspack-plugin/docs/insights/formulas/tab-2-engagement.md
+++ b/plugins/newspack-plugin/docs/insights/formulas/tab-2-engagement.md
@@ -559,54 +559,67 @@ Notes:
 - **Why BQ-only:** same `SPLIT` + `UNNEST` on the comma-separated `categories` param that GA4 Data API can't perform.
 - Useful for editorial placement decisions — categories with high mobile share might benefit from mobile-first formatting; desktop-heavy categories may be lunchtime/work-hour reads.
 
-### Engagement by Newsletter Status
+### Engagement by traffic source
 
 **v1 backend**: GA4 Data API
-**Custom dimension dependency**: `is_newsletter_subscriber`
-**Overlay if missing**: "Newsletter status custom dimension not detected — see [setup docs]"
+**Custom dimension dependency**: none (`sessionMedium` is a GA4 standard dimension, always present)
+**Minimum-sessions floor**: 100 newsletter sessions in the window. Below the floor the card renders "Not enough data in this timeframe." instead of a comparison.
 
-**GA4 Data API query (v1, active):**
+Sessions are partitioned into two cohorts by traffic medium:
+
+- **Newsletter:** sessions whose medium is `email` or `newsletter`.
+- **Other:** all other sessions, including direct, organic, referral, social, paid, etc.
+
+For each cohort, compute average engagement time per session.
+
+#### GA4 Data API (v1, active)
+
+Dimensions: `sessionMedium`
+Metrics: `userEngagementDuration`, `sessions`
+
+Per cohort: `SUM(userEngagementDuration) / SUM(sessions)`, partitioned by the IN-list above.
 
 ```json
 {
   "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
-  "dimensions": [{"name": "customEvent:is_newsletter_subscriber"}],
+  "dimensions": [{"name": "sessionMedium"}],
   "metrics": [
-    {"name": "sessions"},
-    {"name": "screenPageViewsPerSession"},
-    {"name": "userEngagementDuration"}
+    {"name": "userEngagementDuration"},
+    {"name": "sessions"}
   ]
 }
 ```
 
-PHP collapses non-`yes` dimension values into "not subscribed" and derives per-session averages.
+PHP buckets rows where `sessionMedium IN ('email', 'newsletter')` into `newsletter` and all other rows into `other`, summing `sessions` and `userEngagementDuration` per bucket, then `avg_engagement_sec = userEngagementDuration / sessions` per bucket.
 
-**BigQuery query (v1.1 swap target):**
+#### BigQuery (post-migration)
+
+Per session, sum `engagement_time_msec` event params (from `events_*`). Identify session medium from `COALESCE(NULLIF(collected_traffic_source.manual_medium, ''), NULLIF(traffic_source.medium, ''))`. Per cohort: average per-session engagement seconds.
 
 ```sql
 WITH session_engagement AS (
   SELECT
-    CONCAT(user_pseudo_id, '|', CAST(PARAM_INT('ga_session_id') AS STRING)) AS session_key,
-    MAX(IF(PARAM('is_newsletter_subscriber') = 'yes', 1, 0)) AS is_newsletter_subscriber,
-    SUM(IF(event_name = 'page_view', 1, 0)) AS pages_in_session,
-    SUM(PARAM_INT('engagement_time_msec')) / 1000 AS engagement_seconds
+    CONCAT(user_pseudo_id, '|', CAST((SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') AS STRING)) AS session_key,
+    ANY_VALUE(COALESCE(NULLIF(collected_traffic_source.manual_medium, ''), NULLIF(traffic_source.medium, ''))) AS medium,
+    SUM((SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'engagement_time_msec')) / 1000 AS engagement_seconds
   FROM `{project}.{dataset}.events_*`
   WHERE _TABLE_SUFFIX BETWEEN @start_date AND @end_date
-    AND PARAM_INT('ga_session_id') IS NOT NULL
+    AND (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') IS NOT NULL
   GROUP BY session_key
 )
 SELECT
-  CASE WHEN is_newsletter_subscriber = 1 THEN 'newsletter subscriber' ELSE 'not subscribed' END AS segment,
+  CASE WHEN medium IN ('email', 'newsletter') THEN 'newsletter' ELSE 'other' END AS segment,
   COUNT(*) AS sessions,
-  AVG(pages_in_session) AS avg_pages_per_session,
   AVG(engagement_seconds) AS avg_engagement_seconds
 FROM session_engagement
 GROUP BY segment;
 ```
 
 Notes:
-- Empty result for `customEvent:is_newsletter_subscriber` → overlay, not 0.
-- Expected pattern: newsletter subscribers engage substantially more per session. If they DON'T, that's a publisher diagnostic — the newsletter audience isn't converting to deeper site engagement.
+- The data contract returned to the React layer is source-agnostic: `rows: [{ segment: 'newsletter'|'other', sessions, avg_engagement_seconds }]`. The GA4 and BigQuery formulas above must produce the same shape so the migration is a mechanical backend swap.
+- Below the 100-session newsletter floor → "needs data" state, not a 0 comparison.
+- Expected pattern: newsletter traffic engages substantially more per session (validation on Richland Source showed ~2× — newsletter 97.6s vs other 47.4s over a 28-day window). If it DOESN'T, that's a publisher diagnostic — the newsletter audience isn't converting to deeper site engagement.
+- **Known limitations:** UTM-stripping email clients (Apple Mail Privacy Protection) push some email opens into the direct bucket, so the newsletter share is a floor; publishers using non-standard medium tags (e.g. `newsletter-weekly`) land in "other". The `email`/`newsletter` convention is required.
 
 ### Engagement by Returning vs New Readers
 

--- a/plugins/newspack-plugin/docs/insights/information-architecture.md
+++ b/plugins/newspack-plugin/docs/insights/information-architecture.md
@@ -78,7 +78,7 @@ The engagement-quality deep dive. Picks up where Tab 1 leaves off. Powered by th
 - Overall quality (avg pages per session, engaged session duration, bounce rate, scroll depth rate)
 - Distributions (pages per session BoxPlot, scroll depth BoxPlot)
 - Content engagement (most-engaged articles via composite score, articles by completion rate, by avg time, top categories/authors)
-- Reader segments (engagement by device, by newsletter status, returning vs new)
+- Reader segments (engagement by device, by traffic source, returning vs new)
 - Author loyalty (reader-author affinity BoxPlot, top authors by repeat reader rate)
 - Time patterns (engagement by day of week)
 

--- a/plugins/newspack-plugin/docs/insights/specs/engagement.md
+++ b/plugins/newspack-plugin/docs/insights/specs/engagement.md
@@ -8,7 +8,7 @@ This tab ships **v1 powered by the GA4 Data API** and swaps to **BigQuery in v1.
 
 ## Summary
 
-The Engagement tab answers "Are readers engaging?" It's the quality deep-dive after Tab 1's reach summary: pages per session, time on article, scroll completion, which articles and authors hold attention, and how engagement differs by device, newsletter status, and new-vs-returning. There is no attribution or entity-state concept here; every metric is window-scoped engagement quality.
+The Engagement tab answers "Are readers engaging?" It's the quality deep-dive after Tab 1's reach summary: pages per session, time on article, scroll completion, which articles and authors hold attention, and how engagement differs by device, traffic source, and new-vs-returning. There is no attribution or entity-state concept here; every metric is window-scoped engagement quality.
 
 ## Visibility heuristic
 
@@ -34,7 +34,7 @@ Scroll-dependent cards use a scroll-specific variant of this overlay ("Scroll tr
 
 1. **Overall engagement quality** — scorecards
 2. **Content engagement** — most-read articles, completion, top authors
-3. **Reader segments** — engagement by device, newsletter status, new vs returning
+3. **Reader segments** — engagement by device, traffic source, new vs returning
 4. **Author loyalty** — repeat-reader performance (BQ-only, hidden in v1)
 
 Three sections render in v1 (Overall engagement quality, Content engagement,
@@ -156,13 +156,20 @@ previously rendered as tables; the dense tables were unscannable.
 - **Footnote:** "Returning" uses GA4's standard 540-day definition.
 - **Formula:** `formulas/tab-2-engagement.md` → "Engagement by Returning vs New Readers"
 
-### Viz 3.3: Newsletter status (Takeaway card)
+### Viz 3.3: Traffic source (Takeaway card)
 
-- **Headline:** "Subscribers engage {X}% longer than non-subscribers" (flips if non-subscribers lead).
-- **Sub:** "{subscriber time} per session vs {non-subscriber time}"
-- **Mini chart:** bars for subscriber / non-subscriber, heights ∝ avg engaged session duration.
-- **Custom dimension:** `is_newsletter_subscriber` — if missing, the card shows the custom-dimension overlay.
-- **Formula:** `formulas/tab-2-engagement.md` → "Engagement by Newsletter Status"
+- **Headline:** "Newsletter traffic engages {X}% longer than other sources" (flips to "…{X}% shorter…" if other sources lead).
+- **Sub:** "{newsletter time} per session vs {other time}"
+- **Mini chart:** bars for newsletter / other, heights ∝ avg engaged session duration.
+- **Newsletter definition:** a session is "newsletter" when its `sessionMedium` is `email` or `newsletter`; everything else (direct, organic, referral, social, paid, etc.) is "other".
+- **Minimum-sessions floor:** if the newsletter cohort has fewer than 100 sessions in the window, the card renders the standard "Not enough data in this timeframe." state instead of a comparison. Below ~100 newsletter sessions a handful of unusually engaged or bouncy readers can swing the average enough to flip the headline, so the comparison stops being informative.
+- **Formula:** `formulas/tab-2-engagement.md` → "Engagement by traffic source"
+
+#### Known limitations
+
+- **UTM-stripping email clients.** Apple Mail Privacy Protection and similar privacy features strip UTM parameters, landing some email opens in the `(none)` / direct bucket. The newsletter share shown here is therefore a floor — real newsletter traffic share is typically higher (often 12–15% on an active publisher).
+- **Non-standard medium tags.** Most ESPs default to `utm_medium=email`; some use `newsletter`. Publishers tagging with bespoke mediums (e.g. `newsletter-weekly`) fall into the "other" bucket and will see depressed newsletter numbers. The `email`/`newsletter` convention is required for accurate attribution.
+- **Small newsletter programs.** Cohorts below the 100-session floor get the "needs data" state rather than a noisy comparison.
 
 ---
 

--- a/plugins/newspack-plugin/docs/insights/specs/engagement.md
+++ b/plugins/newspack-plugin/docs/insights/specs/engagement.md
@@ -158,8 +158,8 @@ previously rendered as tables; the dense tables were unscannable.
 
 ### Viz 3.3: Traffic source (Takeaway card)
 
-- **Headline:** "Newsletter traffic engages {X}% longer than other sources" (flips to "…{X}% shorter…" if other sources lead).
-- **Sub:** "{newsletter time} per session vs {other time}"
+- **Headline:** "Newsletter traffic engages {X}% longer than other sources" (when other sources lead, the subject flips: "Other sources engage {X}% longer than newsletter traffic" — same as the device / new-vs-returning cards, so the percentage is always computed against the leader and never reads as a misleading "X% shorter").
+- **Sub:** "{leader time} per session vs {other time}" (leads with the headline's subject).
 - **Mini chart:** bars for newsletter / other, heights ∝ avg engaged session duration.
 - **Newsletter definition:** a session is "newsletter" when its `sessionMedium` is `email` or `newsletter`; everything else (direct, organic, referral, social, paid, etc.) is "other".
 - **Minimum-sessions floor:** if the newsletter cohort has fewer than 100 sessions in the window, the card renders the standard "Not enough data in this timeframe." state instead of a comparison. Below ~100 newsletter sessions a handful of unusually engaged or bouncy readers can swing the average enough to flip the headline, so the comparison stops being informative.

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/engagement-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/engagement-fixture.php
@@ -266,19 +266,17 @@ $build = function ( float $f ) use ( $scalar, $rate, $table, $hidden, $start, $e
 				],
 			]
 		),
-		'engagement_by_newsletter_status'       => $table(
+		'engagement_by_traffic_source'          => $table(
 			[
 				[
-					'segment'                => 'subscriber',
-					'sessions'               => (int) round( 61200 * $f ),
-					'avg_pages_per_session'  => round( 3.4 * $f, 2 ),
-					'avg_engagement_seconds' => round( 224 * $f ),
+					'segment'                => 'newsletter',
+					'sessions'               => (int) round( 38200 * $f ),
+					'avg_engagement_seconds' => round( 98 * $f ),
 				],
 				[
-					'segment'                => 'not_subscribed',
-					'sessions'               => (int) round( 219800 * $f ),
-					'avg_pages_per_session'  => round( 2.0 * $f, 2 ),
-					'avg_engagement_seconds' => round( 121 * $f ),
+					'segment'                => 'other',
+					'sessions'               => (int) round( 243600 * $f ),
+					'avg_engagement_seconds' => round( 47 * $f ),
 				],
 			]
 		),

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -31,6 +31,20 @@ final class Engagement_Metric {
 	const READER_THRESHOLD = 50;
 
 	/**
+	 * Minimum newsletter sessions in the window before the "Engagement by traffic
+	 * source" card renders a comparison. Below this the newsletter average is too
+	 * noisy — a few unusually engaged or bouncy readers can flip the headline — so
+	 * the card shows its "needs data" state instead. Sessions, not readers, so this
+	 * is a distinct unit from READER_THRESHOLD.
+	 */
+	const NEWSLETTER_SESSION_FLOOR = 100;
+
+	/**
+	 * Session mediums that count as newsletter traffic. Everything else is "other".
+	 */
+	const NEWSLETTER_MEDIUMS = [ 'email', 'newsletter' ];
+
+	/**
 	 * Whether this tab uses the GA4 path. Default true.
 	 *
 	 * @return bool
@@ -182,7 +196,7 @@ final class Engagement_Metric {
 			'top_authors_by_avg_engagement_time'    => self::top_authors_by_avg_engagement_time_via_ga4( $pid, $start_date, $end_date ),
 			// Reader segments.
 			'engagement_by_device_type'             => self::engagement_by_device_type_via_ga4( $pid, $start_date, $end_date ),
-			'engagement_by_newsletter_status'       => self::engagement_by_newsletter_status_via_ga4( $pid, $start_date, $end_date ),
+			'engagement_by_traffic_source'          => self::engagement_by_traffic_source_via_ga4( $pid, $start_date, $end_date ),
 			'engagement_by_returning_vs_new'        => self::engagement_by_returning_vs_new_via_ga4( $pid, $start_date, $end_date ),
 			// BQ-only (hidden in v1).
 			'top_categories_by_engagement'          => self::hidden_in_v1_payload(),
@@ -209,7 +223,7 @@ final class Engagement_Metric {
 			'articles_by_completion_rate',
 			'top_authors_by_avg_engagement_time',
 			'engagement_by_device_type',
-			'engagement_by_newsletter_status',
+			'engagement_by_traffic_source',
 			'engagement_by_returning_vs_new',
 		];
 		$payload = [
@@ -530,39 +544,58 @@ final class Engagement_Metric {
 	}
 
 	/**
-	 * Engagement by Newsletter Status — customEvent:is_newsletter_subscriber.
-	 * Collapses non-'yes' dimension values into a single "not subscribed" bucket.
+	 * Engagement by traffic source — sessionMedium.
+	 *
+	 * Partitions sessions into two cohorts by traffic medium: "newsletter"
+	 * (sessionMedium IN 'email', 'newsletter') vs "other" (everything else), and
+	 * reports average engagement seconds per session for each. sessionMedium is a
+	 * GA4 standard dimension, so unlike the previous newsletter-status cut this has
+	 * no custom-dimension dependency. The returned shape is source-agnostic so the
+	 * BigQuery migration is a mechanical backend swap.
 	 *
 	 * @param string $pid Property ID.
 	 * @param string $s   Start date.
 	 * @param string $e   End date.
 	 * @return array
 	 */
-	private static function engagement_by_newsletter_status_via_ga4( string $pid, string $s, string $e ): array {
-		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'customEvent:is_newsletter_subscriber' ], [ 'sessions', 'screenPageViewsPerSession', 'userEngagementDuration' ] ) );
+	private static function engagement_by_traffic_source_via_ga4( string $pid, string $s, string $e ): array {
+		$result = self::safe_run_report( $pid, self::body( $s, $e, [ 'sessionMedium' ], [ 'userEngagementDuration', 'sessions' ] ) );
 		if ( isset( $result['error'] ) || isset( $result['overlay'] ) ) {
 			return $result;
 		}
-		// Aggregate into two buckets. screenPageViewsPerSession is a per-session
-		// average, so weight it by sessions before re-dividing.
+		return self::bucket_by_traffic_source( $result['raw']['rows'] ?? [] );
+	}
+
+	/**
+	 * Bucket raw GA4 sessionMedium rows into the newsletter/other cohorts.
+	 *
+	 * Pure transform (no GA4 client) so the cohort math and the minimum-sessions
+	 * floor are unit-testable in isolation. Each input row is
+	 * `{ dimensionValues: [ { value: <medium> } ], metricValues: [ <eng>, <sessions> ] }`.
+	 *
+	 * Below NEWSLETTER_SESSION_FLOOR newsletter sessions the comparison is too
+	 * noisy to render, so the payload carries `needs_data` and the card falls back
+	 * to its "Not enough data in this timeframe." state.
+	 *
+	 * @param array $rows GA4 report rows (userEngagementDuration, sessions).
+	 * @return array
+	 */
+	private static function bucket_by_traffic_source( array $rows ): array {
 		$buckets = [
-			'subscriber'     => [
+			'newsletter' => [
 				'sessions' => 0,
-				'pages'    => 0.0,
 				'eng'      => 0.0,
 			],
-			'not_subscribed' => [
+			'other'      => [
 				'sessions' => 0,
-				'pages'    => 0.0,
 				'eng'      => 0.0,
 			],
 		];
-		foreach ( $result['raw']['rows'] ?? [] as $row ) {
-			$key      = ( ( $row['dimensionValues'][0]['value'] ?? '' ) === 'yes' ) ? 'subscriber' : 'not_subscribed';
-			$sessions = self::num( $row, 0 );
-			$buckets[ $key ]['sessions'] += (int) $sessions;
-			$buckets[ $key ]['pages']    += self::num( $row, 1 ) * $sessions;
-			$buckets[ $key ]['eng']      += self::num( $row, 2 );
+		foreach ( $rows as $row ) {
+			$medium = strtolower( (string) ( $row['dimensionValues'][0]['value'] ?? '' ) );
+			$key    = in_array( $medium, self::NEWSLETTER_MEDIUMS, true ) ? 'newsletter' : 'other';
+			$buckets[ $key ]['eng']      += self::num( $row, 0 );
+			$buckets[ $key ]['sessions'] += (int) self::num( $row, 1 );
 		}
 		$out = [];
 		foreach ( $buckets as $key => $b ) {
@@ -571,7 +604,6 @@ final class Engagement_Metric {
 			$out[] = [
 				'segment'                => $key,
 				'sessions'               => $b['sessions'],
-				'avg_pages_per_session'  => $b['sessions'] > 0 ? $b['pages'] / $b['sessions'] : 0,
 				'avg_engagement_seconds' => $b['sessions'] > 0 ? $b['eng'] / $b['sessions'] : 0,
 			];
 		}
@@ -579,6 +611,7 @@ final class Engagement_Metric {
 			'rows'       => $out,
 			'computable' => true,
 			'type'       => 'table',
+			'needs_data' => $buckets['newsletter']['sessions'] < self::NEWSLETTER_SESSION_FLOOR,
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/viz/BarChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/viz/BarChart.tsx
@@ -22,9 +22,11 @@ export interface Bar {
 
 export interface BarChartProps {
 	bars: Bar[];
+	/** Render the hover value, e.g. "98 seconds". Defaults to a plain number. */
+	formatValue?: ( value: number ) => string;
 }
 
-const BarChart = ( { bars }: BarChartProps ) => {
+const BarChart = ( { bars, formatValue = formatNumber }: BarChartProps ) => {
 	if ( bars.length === 0 ) {
 		return <p className="newspack-insights__chart-empty">{ __( 'No data in this timeframe.', 'newspack-plugin' ) }</p>;
 	}
@@ -37,7 +39,7 @@ const BarChart = ( { bars }: BarChartProps ) => {
 					{ /* Dark hover panel (NPPD-1649 fix #5), shown on column hover via CSS. */ }
 					<div className="newspack-insights__chart-tooltip newspack-insights__chart-tooltip--bar">
 						<span className="newspack-insights__chart-tooltip-label">{ bar.label }</span>
-						<span className="newspack-insights__chart-tooltip-value">{ formatNumber( bar.value ) }</span>
+						<span className="newspack-insights__chart-tooltip-value">{ formatValue( bar.value ) }</span>
 					</div>
 					<div className="newspack-insights__bar-track">
 						<div

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
@@ -67,6 +67,8 @@ export interface MetricPayload {
 	error?: string;
 	hidden_in_v1?: boolean;
 	not_configured?: boolean;
+	/** Cohort below its minimum-sessions floor: render the "needs data" state instead of a comparison. */
+	needs_data?: boolean;
 }
 
 const typeToFormat = ( type?: MetricPayloadType ): MetricFormat => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
@@ -48,12 +48,13 @@ describe( 'ReaderSegmentsSection — traffic source card', () => {
 		expect( within( card ).getByText( '49 seconds' ) ).toBeInTheDocument();
 	} );
 
-	it( 'inverts the headline when other sources lead', () => {
+	it( 'flips the subject (not the adjective) when other sources lead', () => {
 		render( <ReaderSegmentsSection current={ windowOf( trafficSource( [ 'newsletter', 'other' ], [ 49, 98 ] ) ) } previous={ null } /> );
 		const card = trafficSourceCard();
-		// 49s vs 98s → other leads, so newsletter engages 100% shorter.
-		expect( within( card ).getByText( 'Newsletter traffic engages 100% shorter than other sources' ) ).toBeInTheDocument();
-		expect( within( card ).getByText( '0:49 per session vs 1:38' ) ).toBeInTheDocument();
+		// 98s vs 49s → other leads by 100%; phrased as "longer" with other as the subject.
+		expect( within( card ).getByText( 'Other sources engage 100% longer than newsletter traffic' ) ).toBeInTheDocument();
+		// Sub leads with the subject (other) too.
+		expect( within( card ).getByText( '1:38 per session vs 0:49' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the needs-data state when the newsletter cohort is below the floor', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Tests for ReaderSegmentsSection — specifically the "Engagement by newsletter
- * status" card, which matches orchestrator rows on the stable, non-translated
- * segment keys ('subscriber' / 'not_subscribed'). A regression guard: when the
- * keys don't line up, the card falls through to its empty state.
+ * Tests for ReaderSegmentsSection — specifically the "Engagement by traffic
+ * source" card, which matches orchestrator rows on the stable, non-translated
+ * segment keys ('newsletter' / 'other'). A regression guard: when the keys don't
+ * line up, the card falls through to its empty state.
  */
 
 /**
@@ -16,38 +16,59 @@ import { render, screen, within } from '@testing-library/react';
 import ReaderSegmentsSection from './ReaderSegmentsSection';
 import type { InsightsWindow } from '../../../api/audience';
 
-const table = ( rows: unknown[] ) => ( { computable: true, type: 'table', rows } );
+const table = ( rows: unknown[], extra: Record< string, unknown > = {} ) => ( { computable: true, type: 'table', rows, ...extra } );
 
-const newsletterStatus = ( segmentKeys: [ string, string ] ) =>
-	table( [
-		{ segment: segmentKeys[ 0 ], sessions: 61200, avg_pages_per_session: 3.4, avg_engagement_seconds: 224 },
-		{ segment: segmentKeys[ 1 ], sessions: 219800, avg_pages_per_session: 2.0, avg_engagement_seconds: 121 },
-	] );
+const trafficSource = ( segmentKeys: [ string, string ], [ newsletterSec, otherSec ]: [ number, number ], extra: Record< string, unknown > = {} ) =>
+	table(
+		[
+			{ segment: segmentKeys[ 0 ], sessions: 38200, avg_engagement_seconds: newsletterSec },
+			{ segment: segmentKeys[ 1 ], sessions: 243600, avg_engagement_seconds: otherSec },
+		],
+		extra
+	);
 
-const windowOf = ( engagement_by_newsletter_status: unknown ): InsightsWindow => ( { engagement_by_newsletter_status } ) as unknown as InsightsWindow;
+const windowOf = ( engagement_by_traffic_source: unknown ): InsightsWindow => ( { engagement_by_traffic_source } ) as unknown as InsightsWindow;
 
 /** The card body is a sibling of the title within the same takeaway card. */
-const newsletterCard = (): HTMLElement => {
-	const title = screen.getByText( 'Engagement by newsletter status' );
+const trafficSourceCard = (): HTMLElement => {
+	const title = screen.getByText( 'Engagement by traffic source' );
 	return title.closest( '.newspack-insights__takeaway-card' ) as HTMLElement;
 };
 
-describe( 'ReaderSegmentsSection — newsletter status card', () => {
-	it( 'renders the populated takeaway when rows use the stable segment keys', () => {
-		render( <ReaderSegmentsSection current={ windowOf( newsletterStatus( [ 'subscriber', 'not_subscribed' ] ) ) } previous={ null } /> );
-		const card = newsletterCard();
-		// 224s vs 121s → subscribers lead by 85%.
-		expect( within( card ).getByText( 'Subscribers engage 85% longer than non-subscribers' ) ).toBeInTheDocument();
-		expect( within( card ).getByText( '3:44 per session vs 2:01' ) ).toBeInTheDocument();
+describe( 'ReaderSegmentsSection — traffic source card', () => {
+	it( 'renders the populated takeaway when newsletter traffic leads', () => {
+		render( <ReaderSegmentsSection current={ windowOf( trafficSource( [ 'newsletter', 'other' ], [ 98, 49 ] ) ) } previous={ null } /> );
+		const card = trafficSourceCard();
+		// 98s vs 49s → newsletter leads by 100%.
+		expect( within( card ).getByText( 'Newsletter traffic engages 100% longer than other sources' ) ).toBeInTheDocument();
+		expect( within( card ).getByText( '1:38 per session vs 0:49' ) ).toBeInTheDocument();
 		expect( within( card ).queryByText( 'Not enough data in this timeframe.' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'falls through to the empty state when segment keys do not match (regression guard)', () => {
-		// The translated labels the orchestrator used to emit no longer match.
+	it( 'inverts the headline when other sources lead', () => {
+		render( <ReaderSegmentsSection current={ windowOf( trafficSource( [ 'newsletter', 'other' ], [ 49, 98 ] ) ) } previous={ null } /> );
+		const card = trafficSourceCard();
+		// 49s vs 98s → other leads, so newsletter engages 100% shorter.
+		expect( within( card ).getByText( 'Newsletter traffic engages 100% shorter than other sources' ) ).toBeInTheDocument();
+		expect( within( card ).getByText( '0:49 per session vs 1:38' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the needs-data state when the newsletter cohort is below the floor', () => {
 		render(
-			<ReaderSegmentsSection current={ windowOf( newsletterStatus( [ 'Newsletter subscriber', 'Not subscribed' ] ) ) } previous={ null } />
+			<ReaderSegmentsSection
+				current={ windowOf( trafficSource( [ 'newsletter', 'other' ], [ 98, 49 ], { needs_data: true } ) ) }
+				previous={ null }
+			/>
 		);
-		const card = newsletterCard();
+		const card = trafficSourceCard();
+		expect( within( card ).getByText( 'Not enough data in this timeframe.' ) ).toBeInTheDocument();
+		expect( within( card ).queryByText( /Newsletter traffic engages/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'falls through to the empty state when segment keys do not match (regression guard)', () => {
+		// The orchestrator's stable keys no longer line up.
+		render( <ReaderSegmentsSection current={ windowOf( trafficSource( [ 'Newsletter', 'Other' ], [ 98, 49 ] ) ) } previous={ null } /> );
+		const card = trafficSourceCard();
 		expect( within( card ).getByText( 'Not enough data in this timeframe.' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
@@ -43,6 +43,9 @@ describe( 'ReaderSegmentsSection — traffic source card', () => {
 		expect( within( card ).getByText( 'Newsletter traffic engages 100% longer than other sources' ) ).toBeInTheDocument();
 		expect( within( card ).getByText( '1:38 per session vs 0:49' ) ).toBeInTheDocument();
 		expect( within( card ).queryByText( 'Not enough data in this timeframe.' ) ).not.toBeInTheDocument();
+		// Bar-hover values carry the "seconds" unit.
+		expect( within( card ).getByText( '98 seconds' ) ).toBeInTheDocument();
+		expect( within( card ).getByText( '49 seconds' ) ).toBeInTheDocument();
 	} );
 
 	it( 'inverts the headline when other sources lead', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
@@ -151,26 +151,38 @@ const trafficSourceTakeaway = ( payload?: MetricPayload ): Takeaway => {
 	}
 	const newsletterTime = num( newsletterRow, 'avg_engagement_seconds' );
 	const otherTime = num( otherRow, 'avg_engagement_seconds' );
+	const newsletterLeads = newsletterTime >= otherTime;
+	// Always phrase the comparison as "<leader> engages X% longer than <other>",
+	// flipping the subject rather than inverting to "shorter" — matching the
+	// device / new-vs-returning takeaways. "X% shorter" would divide by the
+	// smaller value and overstate the gap (e.g. 49s vs 98s reads as "100% shorter"
+	// when newsletter is only half as long).
 	return {
 		bars,
-		headline:
-			newsletterTime >= otherTime
-				? sprintf(
-						/* translators: %d: percentage. */
-						__( 'Newsletter traffic engages %d%% longer than other sources', 'newspack-plugin' ),
-						pctMore( newsletterTime, otherTime )
-				  )
-				: sprintf(
-						/* translators: %d: percentage. */
-						__( 'Newsletter traffic engages %d%% shorter than other sources', 'newspack-plugin' ),
-						pctMore( otherTime, newsletterTime )
-				  ),
-		sub: sprintf(
-			/* translators: 1: newsletter avg time, 2: other avg time. */
-			__( '%1$s per session vs %2$s', 'newspack-plugin' ),
-			formatDuration( newsletterTime ),
-			formatDuration( otherTime )
-		),
+		headline: newsletterLeads
+			? sprintf(
+					/* translators: %d: percentage. */
+					__( 'Newsletter traffic engages %d%% longer than other sources', 'newspack-plugin' ),
+					pctMore( newsletterTime, otherTime )
+			  )
+			: sprintf(
+					/* translators: %d: percentage. */
+					__( 'Other sources engage %d%% longer than newsletter traffic', 'newspack-plugin' ),
+					pctMore( otherTime, newsletterTime )
+			  ),
+		sub: newsletterLeads
+			? sprintf(
+					/* translators: 1: newsletter avg time, 2: other avg time. */
+					__( '%1$s per session vs %2$s', 'newspack-plugin' ),
+					formatDuration( newsletterTime ),
+					formatDuration( otherTime )
+			  )
+			: sprintf(
+					/* translators: 1: other avg time, 2: newsletter avg time. */
+					__( '%1$s per session vs %2$s', 'newspack-plugin' ),
+					formatDuration( otherTime ),
+					formatDuration( newsletterTime )
+			  ),
 	};
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
@@ -16,7 +16,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/audience';
 import type { MetricPayload, MetricRow } from '../../components/metrics';
-import { formatDecimal, formatDuration } from '../../components/format';
+import { formatDecimal, formatDuration, formatNumber } from '../../components/format';
 import TakeawayCard from '../viz/TakeawayCard';
 
 export interface SectionProps {
@@ -38,6 +38,16 @@ const num = ( row: MetricRow | undefined, key: string ): number => ( typeof row?
 const findRow = ( rows: MetricRow[], key: string, value: string ): MetricRow | undefined => rows.find( row => row[ key ] === value );
 const pctMore = ( a: number, b: number ): number => ( b > 0 ? Math.round( ( ( a - b ) / b ) * 100 ) : 0 );
 const cap = ( s: string ): string => s.charAt( 0 ).toUpperCase() + s.slice( 1 );
+
+// Bar-hover value formatters: append the unit so a hovered bar reads "98 seconds"
+// or "2.4 pages" rather than a bare number. Engagement values are aggregate
+// averages (always well above 1), so a single plural form is sufficient.
+const formatSeconds = ( value: number ): string =>
+	/* translators: %s: a number of seconds. */
+	sprintf( __( '%s seconds', 'newspack-plugin' ), formatNumber( value ) );
+const formatPages = ( value: number ): string =>
+	/* translators: %s: a number of pages. */
+	sprintf( __( '%s pages', 'newspack-plugin' ), formatDecimal( value ) );
 
 interface Takeaway {
 	headline?: string;
@@ -182,6 +192,7 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					headline={ device.headline }
 					sub={ device.sub }
 					bars={ device.bars }
+					formatValue={ formatSeconds }
 				/>
 				<TakeawayCard
 					title={ __( 'New vs returning readers', 'newspack-plugin' ) }
@@ -189,6 +200,7 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					headline={ returning.headline }
 					sub={ returning.sub }
 					bars={ returning.bars }
+					formatValue={ formatPages }
 				/>
 				<TakeawayCard
 					title={ __( 'Engagement by traffic source', 'newspack-plugin' ) }
@@ -196,6 +208,7 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					headline={ trafficSource.headline }
 					sub={ trafficSource.sub }
 					bars={ trafficSource.bars }
+					formatValue={ formatSeconds }
 				/>
 			</div>
 		</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
@@ -1,7 +1,7 @@
 /**
  * Engagement › Reader segments (NPPD-1649, Section 3).
  *
- * Three takeaway cards (device, returning-vs-new, newsletter status): each a
+ * Three takeaway cards (device, returning-vs-new, traffic source): each a
  * one-line comparison + an inline mini bar chart, derived from the same
  * orchestrator metrics that previously rendered as dense tables.
  */
@@ -25,12 +25,12 @@ export interface SectionProps {
 }
 
 // Stable segment keys emitted by the orchestrator
-// (Engagement_Metric::engagement_by_newsletter_status_via_ga4). Kept here as the
+// (Engagement_Metric::engagement_by_traffic_source_via_ga4). Kept here as the
 // single JS-side reference for the PHP↔JS contract; a regression test
 // (ReaderSegmentsSection.test.tsx) guards the match.
-const NEWSLETTER_SEGMENT = {
-	subscriber: 'subscriber',
-	notSubscribed: 'not_subscribed',
+const TRAFFIC_SEGMENT = {
+	newsletter: 'newsletter',
+	other: 'other',
 } as const;
 
 const rowsOf = ( payload?: MetricPayload ): MetricRow[] => ( Array.isArray( payload?.rows ) ? ( payload as MetricPayload ).rows ?? [] : [] );
@@ -123,41 +123,43 @@ const returningTakeaway = ( payload?: MetricPayload ): Takeaway => {
 	};
 };
 
-/** Newsletter status: subscriber vs non-subscriber avg engaged time. */
-const newsletterTakeaway = ( payload?: MetricPayload ): Takeaway => {
+/** Traffic source: newsletter vs other avg engaged time per session. */
+const trafficSourceTakeaway = ( payload?: MetricPayload ): Takeaway => {
 	const rows = rowsOf( payload );
 	// Match on the orchestrator's stable, non-translated segment keys; the bar
 	// labels below carry the user-facing translated strings.
-	const subRow = findRow( rows, 'segment', NEWSLETTER_SEGMENT.subscriber );
-	const nonRow = findRow( rows, 'segment', NEWSLETTER_SEGMENT.notSubscribed );
+	const newsletterRow = findRow( rows, 'segment', TRAFFIC_SEGMENT.newsletter );
+	const otherRow = findRow( rows, 'segment', TRAFFIC_SEGMENT.other );
 	const bars = [
-		{ label: __( 'Subscriber', 'newspack-plugin' ), value: num( subRow, 'avg_engagement_seconds' ) },
-		{ label: __( 'Non-subscriber', 'newspack-plugin' ), value: num( nonRow, 'avg_engagement_seconds' ) },
+		{ label: __( 'Newsletter traffic', 'newspack-plugin' ), value: num( newsletterRow, 'avg_engagement_seconds' ) },
+		{ label: __( 'Other traffic', 'newspack-plugin' ), value: num( otherRow, 'avg_engagement_seconds' ) },
 	];
-	if ( ! subRow || ! nonRow ) {
+	// Below the orchestrator's minimum-sessions floor the comparison is too noisy
+	// to render; suppress the headline so the card shows its "needs data" state.
+	if ( ! newsletterRow || ! otherRow || payload?.needs_data ) {
 		return { bars };
 	}
-	const subTime = num( subRow, 'avg_engagement_seconds' );
-	const nonTime = num( nonRow, 'avg_engagement_seconds' );
+	const newsletterTime = num( newsletterRow, 'avg_engagement_seconds' );
+	const otherTime = num( otherRow, 'avg_engagement_seconds' );
 	return {
 		bars,
 		headline:
-			subTime >= nonTime
+			newsletterTime >= otherTime
 				? sprintf(
 						/* translators: %d: percentage. */
-						__( 'Subscribers engage %d%% longer than non-subscribers', 'newspack-plugin' ),
-						pctMore( subTime, nonTime )
+						__( 'Newsletter traffic engages %d%% longer than other sources', 'newspack-plugin' ),
+						pctMore( newsletterTime, otherTime )
 				  )
 				: sprintf(
 						/* translators: %d: percentage. */
-						__( 'Non-subscribers engage %d%% longer than subscribers', 'newspack-plugin' ),
-						pctMore( nonTime, subTime )
+						__( 'Newsletter traffic engages %d%% shorter than other sources', 'newspack-plugin' ),
+						pctMore( otherTime, newsletterTime )
 				  ),
 		sub: sprintf(
-			/* translators: 1: subscriber avg time, 2: non-subscriber avg time. */
+			/* translators: 1: newsletter avg time, 2: other avg time. */
 			__( '%1$s per session vs %2$s', 'newspack-plugin' ),
-			formatDuration( subTime ),
-			formatDuration( nonTime )
+			formatDuration( newsletterTime ),
+			formatDuration( otherTime )
 		),
 	};
 };
@@ -165,7 +167,7 @@ const newsletterTakeaway = ( payload?: MetricPayload ): Takeaway => {
 const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 	const device = deviceTakeaway( current.engagement_by_device_type );
 	const returning = returningTakeaway( current.engagement_by_returning_vs_new );
-	const newsletter = newsletterTakeaway( current.engagement_by_newsletter_status );
+	const trafficSource = trafficSourceTakeaway( current.engagement_by_traffic_source );
 
 	return (
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-segments">
@@ -189,11 +191,11 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					bars={ returning.bars }
 				/>
 				<TakeawayCard
-					title={ __( 'Engagement by newsletter status', 'newspack-plugin' ) }
-					payload={ current.engagement_by_newsletter_status }
-					headline={ newsletter.headline }
-					sub={ newsletter.sub }
-					bars={ newsletter.bars }
+					title={ __( 'Engagement by traffic source', 'newspack-plugin' ) }
+					payload={ current.engagement_by_traffic_source }
+					headline={ trafficSource.headline }
+					sub={ trafficSource.sub }
+					bars={ trafficSource.bars }
 				/>
 			</div>
 		</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/viz/TakeawayCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/viz/TakeawayCard.test.tsx
@@ -35,8 +35,8 @@ describe( 'TakeawayCard', () => {
 	} );
 
 	it( 'renders the title even in the empty state (no headline / no bars)', () => {
-		render( <TakeawayCard title="Engagement by newsletter status" payload={ { computable: true, type: 'table', rows: [] } } bars={ [] } /> );
-		expect( screen.getByText( 'Engagement by newsletter status' ) ).toBeInTheDocument();
+		render( <TakeawayCard title="Engagement by traffic source" payload={ { computable: true, type: 'table', rows: [] } } bars={ [] } /> );
+		expect( screen.getByText( 'Engagement by traffic source' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough data in this timeframe.' ) ).toBeInTheDocument();
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/viz/TakeawayCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/viz/TakeawayCard.tsx
@@ -30,9 +30,11 @@ export interface TakeawayCardProps {
 	sub?: string;
 	/** Bars for the inline mini chart. */
 	bars: { label: string; value: number }[];
+	/** Render the bar hover value with its unit, e.g. "98 seconds". */
+	formatValue?: ( value: number ) => string;
 }
 
-const TakeawayCard = ( { title, payload, headline, sub, bars }: TakeawayCardProps ) => {
+const TakeawayCard = ( { title, payload, headline, sub, bars, formatValue }: TakeawayCardProps ) => {
 	if ( ! payload || payload.hidden_in_v1 ) {
 		return null;
 	}
@@ -52,7 +54,7 @@ const TakeawayCard = ( { title, payload, headline, sub, bars }: TakeawayCardProp
 				<p className="newspack-insights__takeaway-headline">{ headline }</p>
 				{ sub && <p className="newspack-insights__takeaway-sub">{ sub }</p> }
 				<div className="newspack-insights__takeaway-chart">
-					<BarChart bars={ bars } />
+					<BarChart bars={ bars } formatValue={ formatValue } />
 				</div>
 			</>
 		);

--- a/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
@@ -116,6 +116,134 @@ class Newspack_Test_Insights_Engagement_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Build a GA4 sessionMedium report row: medium dimension + userEngagementDuration, sessions.
+	 *
+	 * @param string $medium   Session medium dimension value.
+	 * @param float  $eng       Total userEngagementDuration (seconds).
+	 * @param int    $sessions  Session count.
+	 * @return array
+	 */
+	private function medium_row( string $medium, float $eng, int $sessions ): array {
+		return [
+			'dimensionValues' => [ [ 'value' => $medium ] ],
+			'metricValues'    => [ [ 'value' => (string) $eng ], [ 'value' => (string) $sessions ] ],
+		];
+	}
+
+	/**
+	 * Pull a cohort row out of a bucket_by_traffic_source payload by segment key.
+	 *
+	 * @param array  $payload bucket_by_traffic_source result.
+	 * @param string $segment 'newsletter' or 'other'.
+	 * @return array
+	 */
+	private function cohort( array $payload, string $segment ): array {
+		foreach ( $payload['rows'] as $row ) {
+			if ( $row['segment'] === $segment ) {
+				return $row;
+			}
+		}
+		return [];
+	}
+
+	/**
+	 * Normal case: email + newsletter mediums aggregate into the newsletter cohort,
+	 * everything else into other, and per-session averages are sum(eng)/sum(sessions).
+	 */
+	public function test_bucket_by_traffic_source_aggregates_cohorts() {
+		$rows    = [
+			$this->medium_row( 'email', 9760.0, 100 ),       // newsletter.
+			$this->medium_row( 'newsletter', 1490.0, 20 ),   // newsletter.
+			$this->medium_row( 'organic', 6870.0, 100 ),     // other.
+			$this->medium_row( 'referral', 1330.0, 100 ),    // other.
+		];
+		$payload = $this->invoke( 'bucket_by_traffic_source', [ $rows ] );
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 'table', $payload['type'] );
+
+		$newsletter = $this->cohort( $payload, 'newsletter' );
+		$other      = $this->cohort( $payload, 'other' );
+
+		// Newsletter: (9760 + 1490) / (100 + 20) = 11250 / 120 = 93.75.
+		$this->assertSame( 120, $newsletter['sessions'] );
+		$this->assertEqualsWithDelta( 93.75, $newsletter['avg_engagement_seconds'], 0.001 );
+		// Other: (6870 + 1330) / (100 + 100) = 8200 / 200 = 41.0.
+		$this->assertSame( 200, $other['sessions'] );
+		$this->assertEqualsWithDelta( 41.0, $other['avg_engagement_seconds'], 0.001 );
+
+		// Above the 100-session floor → comparison renders.
+		$this->assertFalse( $payload['needs_data'] );
+		// avg_pages_per_session is no longer part of the contract.
+		$this->assertArrayNotHasKey( 'avg_pages_per_session', $newsletter );
+	}
+
+	/**
+	 * Inverted case: when other sources out-engage newsletter, the cohorts still
+	 * compute correctly — the headline inversion lives in the React layer.
+	 */
+	public function test_bucket_by_traffic_source_inverted() {
+		$rows    = [
+			$this->medium_row( 'email', 4900.0, 100 ),   // newsletter: 49s/session.
+			$this->medium_row( 'organic', 9800.0, 100 ), // other: 98s/session.
+		];
+		$payload = $this->invoke( 'bucket_by_traffic_source', [ $rows ] );
+
+		$newsletter = $this->cohort( $payload, 'newsletter' );
+		$other      = $this->cohort( $payload, 'other' );
+		$this->assertEqualsWithDelta( 49.0, $newsletter['avg_engagement_seconds'], 0.001 );
+		$this->assertEqualsWithDelta( 98.0, $other['avg_engagement_seconds'], 0.001 );
+		$this->assertFalse( $payload['needs_data'] );
+	}
+
+	/**
+	 * Empty case: zero newsletter sessions yields a 0 average (no divide-by-zero)
+	 * and the needs-data floor trips.
+	 */
+	public function test_bucket_by_traffic_source_empty_newsletter() {
+		$rows    = [
+			$this->medium_row( 'organic', 6870.0, 100 ),
+			$this->medium_row( '(none)', 5860.0, 100 ),
+		];
+		$payload = $this->invoke( 'bucket_by_traffic_source', [ $rows ] );
+
+		$newsletter = $this->cohort( $payload, 'newsletter' );
+		$this->assertSame( 0, $newsletter['sessions'] );
+		$this->assertSame( 0.0, (float) $newsletter['avg_engagement_seconds'] );
+		$this->assertTrue( $payload['needs_data'] );
+	}
+
+	/**
+	 * Below-floor case: a newsletter cohort with some sessions but under
+	 * NEWSLETTER_SESSION_FLOOR still trips needs_data while computing its average.
+	 */
+	public function test_bucket_by_traffic_source_below_floor() {
+		$rows    = [
+			$this->medium_row( 'email', 4500.0, 50 ),     // 50 < 100 floor
+			$this->medium_row( 'organic', 9800.0, 1000 ),
+		];
+		$payload = $this->invoke( 'bucket_by_traffic_source', [ $rows ] );
+
+		$newsletter = $this->cohort( $payload, 'newsletter' );
+		$this->assertSame( 50, $newsletter['sessions'] );
+		$this->assertEqualsWithDelta( 90.0, $newsletter['avg_engagement_seconds'], 0.001 );
+		$this->assertTrue( $payload['needs_data'] );
+	}
+
+	/**
+	 * The orchestrator exposes the metric under the traffic-source key, and the old
+	 * newsletter-status key is gone from both paths.
+	 */
+	public function test_traffic_source_key_replaces_newsletter_status() {
+		$ga4 = $this->invoke( 'compute_via_ga4', [ '2026-05-09', '2026-06-08' ] );
+		$bq  = $this->invoke( 'compute_via_bq', [ '2026-05-09', '2026-06-08' ] );
+		$this->assertArrayHasKey( 'engagement_by_traffic_source', $ga4 );
+		$this->assertArrayHasKey( 'engagement_by_traffic_source', $bq );
+		$this->assertArrayNotHasKey( 'engagement_by_newsletter_status', $ga4 );
+		$this->assertArrayNotHasKey( 'engagement_by_newsletter_status', $bq );
+	}
+
+	/**
 	 * Overlay propagation through a transform helper.
 	 */
 	public function test_overlay_propagates_through_transform() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-engagement-metric.php
@@ -244,6 +244,21 @@ class Newspack_Test_Insights_Engagement_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When the GA4 report fails (no connection in tests), the traffic-source method
+	 * must propagate the error/overlay payload and NOT run the bucketing helper —
+	 * otherwise a failed report would render as a zeroed, needs-data comparison.
+	 */
+	public function test_traffic_source_short_circuits_on_failed_report() {
+		$payload = $this->invoke( 'engagement_by_traffic_source_via_ga4', [ '123456', '2026-05-09', '2026-06-08' ] );
+		// safe_run_report returns an error (or overlay) payload; it must pass through.
+		$this->assertTrue( isset( $payload['error'] ) || isset( $payload['overlay'] ), 'Failed report should propagate error/overlay.' );
+		$this->assertFalse( $payload['computable'] ?? true );
+		// The bucketing helper never ran, so no rows / needs_data leaked in.
+		$this->assertArrayNotHasKey( 'rows', $payload );
+		$this->assertArrayNotHasKey( 'needs_data', $payload );
+	}
+
+	/**
 	 * Overlay propagation through a transform helper.
 	 */
 	public function test_overlay_propagates_through_transform() {


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Replaces the "Engagement by newsletter status" takeaway card on Tab 2 (Engagement → Reader segments) with "Engagement by traffic source." Closes NPPD-1687.</p>
<p>The underlying metric is unchanged — average engagement time per session. Only the dimensional cut changes: sessions are now partitioned by traffic medium (<code>sessionMedium</code>) instead of subscriber status. Newsletter traffic = sessions whose medium is <code>email</code> or <code>newsletter</code>; Other = everything else (direct, organic, referral, social, paid). The card headline becomes "Newsletter traffic engages X% longer than other sources" (inverts to "shorter" when other sources lead), with bars labeled Newsletter traffic / Other traffic.</p>
<p>The reframe lands a much stronger story than the original card: on test publisher, newsletter traffic engages ~106% longer than other sources — effectively 2×. The original card on the same publisher was rendering a "0% / 0:00" failure-mode headline because subscriber identification wasn't reliably lit up; the new card is grounded in 9.4% of total sessions and works without that signal.</p>
<p>This PR ships the GA4 Data API implementation now and documents the BigQuery formula so the upcoming BQ migration is a mechanical backend swap. The PHP orchestrator returns a source-agnostic shape (<code>rows: [{ segment, sessions, avg_engagement_seconds }]</code>) that the React layer consumes without caring which backend produced it.</p>

<img width="786" height="532" alt="image" src="https://github.com/user-attachments/assets/a173ca56-7158-4dc7-b822-94f793a7b822" />

<h3>Pre-flight decisions</h3>
<ul>
<li><strong>Minimum-sessions floor — <code>NEWSLETTER_SESSION_FLOOR = 100</code>.</strong> Below ~100 newsletter sessions in the window the comparison is too noisy — a handful of unusually engaged or bouncy readers can flip the headline or produce a misleadingly large delta. Below the floor, the card renders its existing "Not enough data in this timeframe." state. This is a distinct unit from the existing <code>READER_THRESHOLD = 50</code>, which is readers-per-row in other breakdowns; the precedent doesn't transfer. Validation evidence on test publisher shows real newsletter programs are at 38K+ sessions, so 100 only catches the cases where the comparison genuinely shouldn't render.</li>
<li><strong>Envelope key renamed</strong> <code>engagement_by_newsletter_status</code> → <code>engagement_by_traffic_source</code>. The key is an internal contract describing the question being answered; the new metric answers a different question with different bucket semantics. Carrying forward the old name would lie about what the data contains, and the BQ migration will use this key as its contract.</li>
<li><strong>Subscriber dimension left intact.</strong> <code>is_newsletter_subscriber</code> has 6+ consumers (Audience tab metric, reader-activation, Site Kit custom-dimension provisioning). Only this one card stops using it; the mechanism itself stays.</li>
</ul>
<h2>What's in this PR</h2>
<h3>Spec and formula docs</h3>
<ul>
<li><code>specs/engagement.md</code> — Viz 3.3 rewritten for traffic source (headline shape, inversion logic, bar labels, the <code>email</code> / <code>newsletter</code> definition, known limitations subsection, minimum-sessions floor).</li>
<li><code>formulas/tab-2-engagement.md</code> — replaces the newsletter-status formula with the dual GA4 + BigQuery formula. The canonical BQ feasibility SQL (preserved from the Linear ticket) lives here.</li>
<li><code>information-architecture.md</code> and <code>dev-notes.md</code> — references updated to match.</li>
</ul>
<h3>PHP orchestrator</h3>
<p><code>includes/wizards/insights/metrics/class-engagement-metric.php</code>:</p>
<ul>
<li>New <code>engagement_by_traffic_source_via_ga4()</code> — dimension <code>sessionMedium</code>, metrics <code>userEngagementDuration</code> + <code>sessions</code>.</li>
<li>Extracted pure <code>bucket_by_traffic_source()</code> helper so the cohort math + floor are unit-testable in isolation (the current method can't be tested without mocking the GA4 client).</li>
<li><code>NEWSLETTER_SESSION_FLOOR</code> + <code>NEWSLETTER_MEDIUMS</code> constants.</li>
<li>Envelope key rename in <code>compute_via_ga4()</code> and the BQ-stub key list.</li>
<li>Old <code>engagement_by_newsletter_status_via_ga4()</code> removed; the <code>is_newsletter_subscriber</code> dimension reads from <code>class-engagement-metric.php</code> are gone, but the dimension itself remains in the codebase (Audience tab still uses it).</li>
</ul>
<h3>Fixture</h3>
<p><code>engagement-fixture.php</code> updated to the traffic-source shape with a representative ~2× demo (newsletter 98s vs other 47s) so local fixture-mode rendering matches what publishers will see.</p>
<h3>React</h3>
<p>In-place card replacement — no component rename, no file rename, no <code>EngagementTab.tsx</code> change:</p>
<ul>
<li><code>metrics.ts</code> — <code>needs_data</code> payload field added so the card knows when to render the floor-triggered empty state.</li>
<li><code>ReaderSegmentsSection.tsx</code> — <code>trafficSourceTakeaway</code> (replaces <code>newsletterTakeaway</code>); segment keys <code>newsletter</code> / <code>other</code>; new headline with longer/shorter inversion; bars labeled Newsletter traffic / Other traffic; needs-data branch.</li>
<li><code>TakeawayCard.test.tsx</code> — title string updated.</li>
</ul>
<h3>Tests</h3>
<ul>
<li><code>insights-engagement-metric.php</code> — five new PHPUnit tests against the extracted helper: normal (newsletter &gt; other), inverted (other &gt; newsletter), empty cohort, below-floor → needs-data, key rename in the envelope. All 12 tests in the file pass.</li>
<li><code>ReaderSegmentsSection.test.tsx</code> — four cases rewritten for traffic source (normal / inverted / below-floor / empty).</li>
</ul>
<h2>Validation evidence</h2>
<p>BigQuery feasibility check on test publisher, 28-day window (2026-03-24 → 2026-04-20):</p>

Medium | Sessions | % of total | Avg engagement / session
-- | -- | -- | --
organic | 134,271 | 33.0% | 68.7s
referral | 119,180 | 29.3% | 13.3s
(none) / direct | 112,245 | 27.6% | 58.6s
email | 38,105 | 9.4% | 97.6s
social | 1,653 | 0.4% | 28.5s
gnews | 1,144 | 0.3% | 37.6s
paid | 429 | 0.1% | 2.6s
newsletter | 80 | 0.02% | 74.5s


<p>Newsletter (<code>email</code> + <code>newsletter</code>) avg 97.6s vs all non-newsletter mediums weighted avg 47.4s → newsletter engages ~106% longer (≈2×). Local fixture-mode smoketest renders a headline in the same shape.</p>
<h2>How to test</h2>
<ol>
<li>From <code>plugins/newspack-plugin</code>, run <code>n build newspack-plugin</code> to rebuild the JS bundle.</li>
<li>In <code>wp-config.php</code>, confirm both <code>NEWSPACK_INSIGHTS_ENABLED</code> and <code>NEWSPACK_INSIGHTS_FIXTURE_MODE</code> are defined <code>true</code>.</li>
<li>Open wp-admin → Newspack → Insights → Engagement. Hard-reload (<code>Cmd+Shift+R</code>) to bust cached JS.</li>
<li>Under Reader segments, confirm the third card is titled "Engagement by traffic source" with the headline <code>Newsletter traffic engages ~109% longer than other sources</code>, bars labeled <code>Newsletter traffic</code> / <code>Other traffic</code>, and a sub-line like <code>1:38 per session vs 0:47</code>. The old "Engagement by newsletter status" card should be gone.</li>
<li><strong>Inverted headline:</strong> in <code>engagement-fixture.php</code>, set the <code>other</code> row's <code>avg_engagement_seconds</code> higher than the <code>newsletter</code> row's. Reload (no rebuild needed for fixture edits) and confirm the headline reads "Newsletter traffic engages X% shorter than other sources."</li>
<li><strong>Below-floor state:</strong> set the <code>newsletter</code> row's <code>sessions</code> below 100. Reload and confirm the card shows "Not enough data in this timeframe." instead of the comparison.</li>
<li><strong>Empty cohort:</strong> remove the <code>newsletter</code> row entirely. Confirm the empty state renders cleanly (no divide-by-zero, no broken headline).</li>
<li>From <code>plugins/newspack-plugin</code>, run <code>n test-php --filter Newspack_Test_Insights_Engagement_Metric</code> — 12/12 pass.</li>
<li><code>npm run lint:php</code>, <code>npm run lint:js</code>, <code>npm run tsc</code> all clean.</li>
</ol>
<h2>Heads-up on the test harness</h2>
<p>PHPCS, ESLint, and tsc are clean; PHP unit tests pass 12/12. The new <code>.tsx</code> tests are written to the sibling convention but do not execute under the current JS test harness (NPPD-1683 — confirmed against the untouched <code>insights-ui.test.tsx</code>, which fails identically). They will run once the harness lands.</p>
<h2>Known limitations (documented on the card spec)</h2>
<ul>
<li><strong>UTM-stripping email clients</strong> (Apple Mail Privacy Protection, etc.) push some email opens into the <code>(none)</code> / direct bucket. The newsletter share shown is a floor — real share on an active publisher is typically 12–15%.</li>
<li><strong>Non-standard medium tags</strong> (e.g., <code>newsletter-weekly</code>) fall into "other." The <code>email</code> / <code>newsletter</code> convention is required for accurate attribution.</li>
<li><strong>Small newsletter programs</strong> below the 100-session floor get the needs-data state rather than a misleading comparison.</li>

</ul></body></html>