### PR TITLE
feat(insights): Conversion Journey tab — Phase 1 scaffold (NPPD-1609)

### DIFF
--- a/plugins/newspack-plugin/docs/insights/formulas/tab-3-conversion-journey.md
+++ b/plugins/newspack-plugin/docs/insights/formulas/tab-3-conversion-journey.md
@@ -244,13 +244,11 @@ PHP-side aggregation:
 
 Same shape, with donation orders. Substitute `action_type = 'donation'` filtering and donation-product Woo filter.
 
-## Section: Time-to-convert distributions
+## Section: Time-to-convert cumulative distributions
 
-The BoxPlot's actual flagship use case. Each metric is a distribution per acquisition cohort.
+The cumulative shape replaces v1's original BoxPlot framing. For each metric, compute the empirical CDF: for each day N within the cohort's lookback window, what fraction of the cohort had converted by day N? LineChart consumes the result directly — one row per (day, cumulative_pct) point per series.
 
-### Time-to-Register Distribution
-
-For each reader who registered in the window, how many days between first session and registration?
+### Time-to-Register Cumulative Distribution
 
 ```sql
 WITH first_sessions AS (
@@ -270,75 +268,67 @@ registrations AS (
   FROM `{project}.{dataset}.events_*`
   WHERE _TABLE_SUFFIX BETWEEN @start_date AND @end_date
     AND event_name = 'np_reader_registered'
-)
+),
+days_diff AS (
+  SELECT TIMESTAMP_DIFF(TIMESTAMP_MICROS(r.reg_ts), TIMESTAMP_MICROS(fs.first_session_ts), DAY) AS days
+  FROM registrations r
+  JOIN first_sessions fs USING (user_pseudo_id)
+  WHERE TIMESTAMP_DIFF(TIMESTAMP_MICROS(r.reg_ts), TIMESTAMP_MICROS(fs.first_session_ts), DAY) BETWEEN 0 AND 90
+),
+total AS (SELECT COUNT(*) AS total_count FROM days_diff),
+per_day AS (SELECT days, COUNT(*) AS conversions FROM days_diff GROUP BY days)
 SELECT
-  TIMESTAMP_DIFF(TIMESTAMP_MICROS(r.reg_ts), TIMESTAMP_MICROS(fs.first_session_ts), DAY) AS days_to_register
-FROM registrations r
-JOIN first_sessions fs USING (user_pseudo_id)
-WHERE TIMESTAMP_DIFF(TIMESTAMP_MICROS(r.reg_ts), TIMESTAMP_MICROS(fs.first_session_ts), DAY) >= 0;
+  days,
+  ROUND(SUM(conversions) OVER (ORDER BY days) / (SELECT total_count FROM total), 4) AS cumulative_pct
+FROM per_day
+ORDER BY days;
 ```
 
 Notes:
-- BoxPlot data: pass `days_to_register` per row.
-- The 90-day lookback for `first_sessions` is the practical cap; readers with first session > 90d ago show up as outliers or are truncated. Document in UI.
-- Filter `days_to_register >= 0` to exclude data anomalies (registration before first session is impossible but timestamp drift can produce it).
-- BoxPlot's y-domain caveat (NPPD-1595) applies — pass explicit `yDomain={[0, dataMax]}`.
+- Returns one row per (day, cumulative_pct) pair. LineChart treats this as a single series.
+- 90-day lookback cap matches the spec's truncation. Readers with first session > 90 days ago aren't represented.
+- Filter `days >= 0` excludes timestamp-drift anomalies.
 
-### Time-to-Subscribe Distribution
+### Time-to-Subscribe Cumulative Distribution
 
-For each new subscriber, days between registration and first subscription order.
+Two-step: BQ side gathers per-UID registration timestamps + source attribution; PHP side joins to Woo for first non-donation subscription order date, computes per-source cumulative.
 
 ```sql
--- BQ side: get registrations with timestamps
-WITH registrations AS (
-  SELECT
-    COALESCE(user_id, user_pseudo_id) AS uid,
-    MIN(event_timestamp) AS reg_ts
-  FROM `{project}.{dataset}.events_*`
-  WHERE _TABLE_SUFFIX BETWEEN
-    FORMAT_DATE('%Y%m%d', DATE_SUB(PARSE_DATE('%Y%m%d', @start_date), INTERVAL 365 DAY))
-    AND @end_date
-    AND event_name = 'np_reader_registered'
-  GROUP BY uid
-)
--- Then PHP joins to Woo: for each registered UID, find their first non-donation subscription order date
--- and compute days_to_subscribe = sub_order_date - reg_date
-```
-
-PHP query:
-```sql
+-- BQ side: registrations in trailing 365 days with source attribution
 SELECT
-  o.customer_id,
-  MIN(o.date_created_gmt) AS first_sub_order_date
-FROM {prefix}wc_orders o
-JOIN {prefix}wc_order_product_lookup opl ON opl.order_id = o.id
-WHERE o.type = 'shop_order'
-  AND o.status IN ('wc-completed', 'wc-processing')
-  AND opl.product_id IN (:non_donation_subscription_product_ids)
-  AND o.customer_id IN (:registered_uids_with_ts)
-GROUP BY o.customer_id;
+  COALESCE(user_id, user_pseudo_id) AS uid,
+  MIN(event_timestamp) AS reg_ts,
+  ANY_VALUE(CASE
+    WHEN PARAM('gate_post_id') IS NOT NULL THEN 'gate'
+    WHEN PARAM('newspack_popup_id') IS NOT NULL THEN 'prompt'
+    ELSE 'direct'
+  END) AS source
+FROM `{project}.{dataset}.events_*`
+WHERE _TABLE_SUFFIX BETWEEN
+  FORMAT_DATE('%Y%m%d', DATE_SUB(PARSE_DATE('%Y%m%d', @start_date), INTERVAL 365 DAY))
+  AND @end_date
+  AND event_name = 'np_reader_registered'
+GROUP BY uid;
 ```
 
-Then in PHP: zip the two result sets by UID, compute days_to_subscribe = first_sub_order_date - reg_ts (in days), pass per-row to BoxPlot.
+PHP-side completion:
+1. For each registered UID, query Woo for first non-donation subscription order date.
+2. Compute days_to_subscribe per UID.
+3. Truncate at 365 days.
+4. Partition by source. Within each partition, sort by days, compute running cumulative_pct.
+5. Return three series: `[{ label: 'gate', points: [{day, cumulative_pct}, ...] }, { label: 'prompt', points: [...] }, { label: 'direct', points: [...] }]`.
 
-Notes:
-- Filter to subscribers who registered in the trailing 365 days (otherwise tail is unbounded and unhelpful).
-- For BoxPlot grouping: split by acquisition source (gate/prompt/direct, captured from the registration event's params). Gives a 3-category BoxPlot showing "how fast does each source convert?"
+### Time-to-Donate Cumulative Distribution
 
-### Time-to-Donate Distribution
+Same shape as Time-to-Subscribe, with donation-product Woo filter instead of non-donation subscription. Three series by source.
 
-Same shape as Time-to-Subscribe, with donation orders.
+### Subscriber → Donor Lag Cumulative Distribution
 
-### Time Between Subscription and Donation (cross-upsell)
-
-For subscribers who also donated, days between their subscription start and their first donation.
+All-Woo. For each customer who subscribed before donating, compute days between first subscription and first donation; partition into single series.
 
 ```sql
--- All-Woo
-WITH subscriber_first_dates AS (
-  SELECT
-    o.customer_id,
-    MIN(o.date_created_gmt) AS first_sub_date
+WITH subscriber_first AS (
+  SELECT o.customer_id, MIN(o.date_created_gmt) AS first_sub_date
   FROM {prefix}wc_orders o
   JOIN {prefix}wc_order_product_lookup opl ON opl.order_id = o.id
   WHERE o.type = 'shop_order'
@@ -346,27 +336,31 @@ WITH subscriber_first_dates AS (
     AND o.status IN ('wc-completed', 'wc-processing')
   GROUP BY o.customer_id
 ),
-donor_first_dates AS (
-  SELECT
-    o.customer_id,
-    MIN(o.date_created_gmt) AS first_donation_date
+donor_first AS (
+  SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
   FROM {prefix}wc_orders o
   JOIN {prefix}wc_order_product_lookup opl ON opl.order_id = o.id
   WHERE o.type = 'shop_order'
     AND opl.product_id IN (:donation_product_ids)
     AND o.status IN ('wc-completed', 'wc-processing')
   GROUP BY o.customer_id
+),
+days_diff AS (
+  SELECT TIMESTAMPDIFF(DAY, sb.first_sub_date, df.first_donation_date) AS days
+  FROM subscriber_first sb
+  JOIN donor_first df USING (customer_id)
+  WHERE df.first_donation_date > sb.first_sub_date
 )
-SELECT
-  TIMESTAMPDIFF(DAY, sb.first_sub_date, do.first_donation_date) AS days_between
-FROM subscriber_first_dates sb
-JOIN donor_first_dates do USING (customer_id)
-WHERE do.first_donation_date > sb.first_sub_date;
+-- PHP-side: total count + per-day count → running cumulative_pct
+SELECT days FROM days_diff;
 ```
 
-Notes:
-- Only includes readers who became subscribers BEFORE donating (filter `>`). The inverse case (donor → subscriber) is a separate distribution.
-- Pass `days_between` per row to BoxPlot.
+Compute cumulative_pct in PHP (same pattern as Time-to-Register).
+
+Notes for all four:
+- Single-group output shape: `{ points: [{day, cumulative_pct}, ...] }`.
+- Multi-group output shape: `{ groups: [{ label, points: [{day, cumulative_pct}, ...] }, ...] }`.
+- Section 4.4 is gated at 50 cross-converters per the spec; below that threshold, return `{ visibility: 'hidden', visibility_reason: 'insufficient_data' }`.
 
 ## Section: Cohort retention
 
@@ -679,7 +673,7 @@ Same pattern with newsletter-intent surfaces and `np_newsletter_subscribed` even
 
 6. **Window vs lookback discipline.** Some metrics use the publisher-selected window (`@start_date` to `@end_date`); others extend lookback (90d for first session, 365d for cohort retention, 7-14d for Influenced). UI should display the actual lookback range for each metric in tooltips, since users will be confused otherwise.
 
-7. **Time-to-convert distributions are tail-heavy.** Some readers register years after first session; some donate years after registering. v1 caps at 365d for time-to-subscribe/donate to keep BoxPlots readable. Document the truncation in UI.
+7. **Time-to-convert distributions are tail-heavy.** Some readers register years after first session; some donate years after registering. v1 caps at 365d for time-to-subscribe/donate to keep the cumulative curves readable. Document the truncation in UI.
 
 8. **Local wp_posts enrichment available as v1.1 improvement.** `post_id` is now in BQ event params on every singular page view, enabling future joins to local `wp_posts` for canonical post titles, authoritative author/category lookup, and post_type filtering. Used by the "Top Pages That Don't Convert" diagnostic table. Adds a new join pattern (BQ → wp_posts) that v1 metrics don't currently use. v1.1 follow-up.
 

--- a/plugins/newspack-plugin/docs/insights/specs/conversion-journey.md
+++ b/plugins/newspack-plugin/docs/insights/specs/conversion-journey.md
@@ -1,0 +1,483 @@
+# Tab 3: Conversion Journey — Product Spec
+
+> Companion to `formulas/tab-3-conversion-journey.md`. This document specifies the UI structure, empty-state behavior, and product decisions. Formula references point at the formulas doc; no SQL lives here.
+
+## Status: placeholder phase
+
+This tab ships in two phases:
+
+**Phase 1 (current): Full UI with placeholder values.** All scorecards display "0" (counts), "0%" (rates), or "$0.00" (currency). Funnels render all-zero stages with the empty-state message. PieCharts, cumulative LineCharts, cohort views, and weekly trends render their empty states. The tab is fully clickable, navigable, and styled. A single banner at the top explains the pending state. The goal is to lock in visual structure and surface UX issues before BigQuery integration lands.
+
+**Phase 2: Wire up real data via the BQ query proxy** (NPPD-1630). Each metric in this spec maps to a `query_name` in the BQ catalog. Phase 2 work is swap-in-place at the metric orchestrator layer; the UI does not change.
+
+This spec describes Phase 2 — the intended final state. Phase 1 is identical except every value is the placeholder.
+
+## Summary
+
+The Conversion Journey tab is the cross-cutting analytical view: how do readers move from anonymous visitor to engaged reader to registered reader to supporter? Unlike the per-source tabs (Gates, Prompts) that ask "how is THIS surface performing?", this tab asks "how does the whole funnel perform, regardless of which surface readers came through?"
+
+It's the strategic tab. Publishers spend the most analytical time here. It's also the most computationally expensive — cohort retention in particular requires pre-warming via Action Scheduler (NPPD-1606), and the source-attribution and time-to-convert sections involve BQ-to-Woo joins that are heavier than the per-source tabs.
+
+Sources: GA4 event data via BigQuery for lifecycle stages, registration events, and source attribution; local Woo for subscription and donation completions, joined on customer ID and timestamp. See `formulas/tab-3-conversion-journey.md` for the queries.
+
+## Visibility heuristic
+
+Always visible when `NEWSPACK_INSIGHTS_ENABLED`. Unlike Gates (which checks the gates feature) or Advertising (which checks GAM connection), the Conversion Journey tab is universally applicable — every Newspack publisher has reader-revenue funnels worth tracking, even if some sections are sparse for publishers with small donor or subscriber programs.
+
+## Why Conversion Journey has its own tab
+
+Each tab serves a question. Subscribers and Donors answer "where do I stand on these supporters?" Gates and Prompts answer "how are my conversion surfaces performing?" Conversion Journey answers something different: "how does the entire reader funnel work in aggregate, across all surfaces?"
+
+It's the tab publishers open when they want to think strategically — diagnose where the funnel is leaking, identify cohorts to invest in, see whether their conversion rates are improving over time, find articles that aren't pulling their weight. The math is necessarily expensive (cross-tab aggregation, cohort analysis, distribution computations), which is why it has its own tab rather than living as sections of another.
+
+## Tab structure: 8 sections, top to bottom
+
+1. **The reader lifecycle** — 5-stage marquee funnel from anonymous to supporter
+2. **Per-journey conversion funnels** — four focused funnels for the key conversion paths
+3. **Where conversions come from** — source attribution across gates, prompts, and direct forms
+4. **How long conversions take** — time-to-convert distributions per source
+5. **Cohort retention** — registration and subscription cohort curves
+6. **Conversion rate trends** — weekly rates over the window
+7. **Cross-tab influenced attribution** — Influenced rates from Tabs 4, 5, 6, 7, centralized
+8. **Opportunity buckets** — diagnostic counts and underperforming pages
+
+Sections render in this order, top to bottom. The narrative flow moves from descriptive (what happened) through analytical (how it happens) to prescriptive (what to do about it). Each section has a header, section caption, and content. Section captions follow the convention used on Tabs 6 and 7: gray-700, 14px, line-height 1.5, immediately below the section header.
+
+## Top-of-tab banner (Phase 1 only)
+
+A single dismissible banner appears above Section 1 during the placeholder phase. Copy:
+
+> **This tab is live in preview mode.** Real-time metrics will populate once BigQuery integration is complete. The structure, sections, and visualizations are final.
+
+Style: light blue background, info icon, dismissible via X but reappears on page reload (don't persist dismissal).
+
+Remove this banner entirely when Phase 2 lands.
+
+## About cohort retention freshness
+
+Add as a small dismissible info callout immediately below the Phase 1 preview banner, above the Section 1 header. The pre-warm-and-cache pattern affects how publishers should interpret the cohort retention section, so they should encounter the explanation before reading it. One-time display per session.
+
+> **About cohort retention freshness**
+>
+> Cohort retention metrics are pre-computed and refreshed weekly. The values on this page reflect the most recent weekly snapshot, not real-time data. This is intentional — the queries that produce cohort curves are too expensive to run on every page load, and weekly granularity is the appropriate cadence for retention analysis.
+>
+> Other metrics on this tab (funnels, source mix, conversion rates, time-to-convert) update with each page view within the selected window.
+
+---
+
+## Section 1: The reader lifecycle
+
+**Header:** The reader lifecycle
+**Caption:** The marquee view. How readers progress from first-time visitor through engagement, registration, and newsletter signup to becoming a supporter.
+
+**Layout:** Single full-width funnel visualization.
+
+### Viz 1.1: Reader lifecycle funnel
+
+- **Type:** Funnel chart, vertical, five stages
+- **Stages:**
+  1. **Anonymous reader** — distinct users with any event in the window
+  2. **Engaged reader** — distinct users with at least one `session_engaged = 1` event
+  3. **Registered reader** — distinct users logged in or who registered in the window
+  4. **Newsletter subscriber** — distinct users with `is_newsletter_subscriber = 'yes'`
+  5. **Subscriber or donor** — distinct users with `is_subscriber = 'yes'` OR `is_donor = 'yes'`
+- **Values:** Distinct user count at each stage
+- **Labels:** Each stage shows count + percentage of stage 1 (anonymous baseline). The funnel widget uses `compactMode={true}` for the 5-step layout.
+- **Stage nesting:** Each stage's count includes all readers in deeper stages — a "supporter" is also "registered" is also "engaged" is also "anonymous." This is intentional: the funnel shows "of N anonymous readers, M became engaged, K registered, etc." Document this in the caption tooltip.
+- **Drop-off labels:** Between stages, show % drop-off from the prior stage.
+- **Placeholder:** All stages show 0, drop-off labels hidden when all zeros.
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Reader Lifecycle Funnel (in window)"
+
+---
+
+## Section 2: Per-journey conversion funnels
+
+**Header:** Per-journey conversion funnels
+**Caption:** Focused conversion paths. Each funnel shows where readers drop off within a specific journey — anonymous to registered, registered to paid, paid to donor.
+
+**Layout:** Four small funnels in a 2-column grid. Funnels 2.1 and 2.2 in the top row, 2.3 and 2.4 in the bottom row. On narrow viewports, stacks to single column.
+
+### Viz 2.1: Anonymous → Registered
+
+- **Type:** Funnel chart, vertical, three stages
+- **Stages:**
+  1. Anonymous — distinct users with any event in window
+  2. Saw a conversion surface — distinct users who saw a gate or prompt with a registration block or link
+  3. Registered — distinct users who fired `np_reader_registered`
+- **Caption note:** "The free-conversion path. Combines gate and prompt impressions to make the funnel readable; per-surface breakdowns live in Tabs 4 and 5."
+- **Placeholder:** All stages show 0
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Funnel: Anonymous → Registered"
+
+### Viz 2.2: Registered → Subscriber
+
+- **Type:** Funnel chart, vertical, three stages
+- **Stages:**
+  1. Registered in window
+  2. Saw a subscription-intent surface (gate with checkout button OR subscription-intent prompt)
+  3. Became subscriber (non-donation Woo subscription)
+- **Caption note:** "The paid-upsell path. Subscription excludes donation products; donor conversions are in the next funnel."
+- **Placeholder:** All stages show 0
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Funnel: Registered → Subscriber (non-donation)"
+
+### Viz 2.3: Registered → Donor
+
+- **Type:** Funnel chart, vertical, three stages
+- **Stages:**
+  1. Registered in window
+  2. Saw a donation-intent surface
+  3. Became donor (completed donation order)
+- **Caption note:** "The donation-conversion path."
+- **Placeholder:** All stages show 0
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Funnel: Registered → Donor"
+
+### Viz 2.4: Subscriber → Donor (cross-upsell)
+
+- **Type:** Funnel chart, vertical, two stages
+- **Stages:**
+  1. Active subscriber
+  2. Also donor (made a donation in window)
+- **Caption note:** "Cross-upsell visibility for publishers running both subscriptions and donations."
+- **Visibility:** Hidden when the publisher has fewer than 50 active subscribers OR fewer than 50 active donors. Below that threshold the funnel is noise. When hidden, the grid cell shows an empty-state note: "Cross-upsell view appears when both subscription and donation programs have at least 50 active participants."
+- **Placeholder:** Both stages show 0
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Funnel: Subscriber → Donor (cross-upsell)"
+
+---
+
+## Section 3: Where conversions come from
+
+**Header:** Where conversions come from
+**Caption:** Source attribution for new conversions in the window. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?
+
+**Layout:** Three PieCharts side-by-side, equal width. On narrow viewports, stacks to single column.
+
+### Viz 3.1: Source mix — new registrations
+
+- **Type:** PieChart
+- **Slices:** Gate / Prompt / Direct (no UTM-style breakdown — surface type only)
+- **Source identification:**
+  - Gate: registration event has `gate_post_id` set
+  - Prompt: registration event has `newspack_popup_id` set, no `gate_post_id`
+  - Direct: neither set (standalone form, e.g. My Account)
+- **Center label:** Total new registrations in window
+- **Legend:** Slice label + count + percentage
+- **Placeholder:** Empty PieChart with empty-state message: "Source data will appear once registrations occur in this window."
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Source Mix: New Registrations (PieChart)"
+
+### Viz 3.2: Source mix — new subscribers
+
+- **Type:** PieChart
+- **Slices:** Same Gate / Prompt / Direct classification
+- **Source identification:** Joined from BQ checkout events tagged with gate/popup IDs to completed Woo non-donation subscription orders within 30 min
+- **Center label:** Total new subscribers in window
+- **Placeholder:** Same empty-state pattern
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Source Mix: New Subscribers (PieChart)"
+
+### Viz 3.3: Source mix — new donors
+
+- **Type:** PieChart
+- **Slices:** Same Gate / Prompt / Direct classification
+- **Source identification:** Joined from BQ checkout events to completed Woo donation orders
+- **Center label:** Total new donors in window
+- **Placeholder:** Same empty-state pattern
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Source Mix: New Donors (PieChart)"
+
+---
+
+## Section 4: How long conversions take
+
+**Header:** How long conversions take
+**Caption:** Cumulative conversion curves per cohort. Each line shows what percentage of readers had converted by day N. Steeper early curves mean faster conversion; flatter curves mean longer tails. Median is where the line crosses 50%.
+
+**Layout:** 2×2 grid of LineCharts. On narrow viewports, stacks to single column.
+
+### Viz 4.1: Time to register
+
+- **Type:** LineChart, single series, cumulative distribution
+- **Cohort:** Readers who registered in the window
+- **Measure:** For each day N from first session, the % of the cohort that had registered by day N
+- **X-axis:** Days since first session, 0 to 90
+- **Y-axis:** Cumulative % registered, 0 to 100
+- **Grouping:** Single line — the universal "how long does it take to register?"
+- **Caption note:** "Includes readers whose first session was within the last 90 days. Earlier first sessions are truncated."
+- **Placeholder:** Empty LineChart with empty-state message: "Time-to-register data will appear once registrations occur in this window."
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Time-to-Register Cumulative Distribution"
+
+### Viz 4.2: Time to subscribe
+
+- **Type:** LineChart, multi-series, cumulative distribution
+- **Cohort:** New subscribers in the window
+- **Measure:** For each day N from registration, the % of the cohort that had subscribed by day N
+- **X-axis:** Days since registration, 0 to 365
+- **Y-axis:** Cumulative % subscribed, 0 to 100
+- **Grouping:** Three lines by source — Gate, Prompt, Direct (from the registration event's surface attribution)
+- **Caption note:** "The steeper line converts faster. Gaps between lines at any day point show which source is winning at that horizon."
+- **Lookback cap:** 365 days from registration; later conversions truncated
+- **Placeholder:** Empty LineChart
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Time-to-Subscribe Cumulative Distribution"
+
+### Viz 4.3: Time to donate
+
+- **Type:** LineChart, multi-series, cumulative distribution
+- **Cohort:** New donors in the window
+- **Measure:** For each day N from registration, the % of the cohort that had donated by day N
+- **X-axis:** Days since registration, 0 to 365
+- **Y-axis:** Cumulative % donated, 0 to 100
+- **Grouping:** Same three lines (Gate, Prompt, Direct)
+- **Caption note:** "Donors typically take longer to convert than subscribers — this view shows that lag and whether it varies by source."
+- **Lookback cap:** 365 days
+- **Placeholder:** Empty LineChart
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Time-to-Donate Cumulative Distribution"
+
+### Viz 4.4: Subscriber → donor lag
+
+- **Type:** LineChart, single series, cumulative distribution
+- **Cohort:** Readers who became subscribers BEFORE donating
+- **Measure:** For each day N from first subscription, the % of the cohort that had also donated by day N
+- **X-axis:** Days since first subscription
+- **Y-axis:** Cumulative % donated, 0 to 100
+- **Visibility:** Hidden when the publisher has fewer than 50 readers in this cohort. Empty-state note when hidden: "Subscriber-to-donor lag appears when at least 50 readers have both subscribed and donated."
+- **Placeholder:** Empty LineChart
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Subscriber → Donor Lag Cumulative Distribution"
+
+---
+
+## Section 5: Cohort retention
+
+**Header:** Cohort retention
+**Caption:** Retention curves by monthly cohort. The vertical axis is the share of each cohort still on a given lifecycle stage at each point in time. Updated weekly (see callout above).
+
+**Layout:** Two LineCharts stacked vertically. On wide viewports, optionally side-by-side.
+
+### Viz 5.1: Registration → conversion cohort
+
+- **Type:** LineChart, multi-series
+- **Series:** One line per monthly registration cohort (up to 12 months back)
+- **X-axis:** Months since registration (0, 1, 2, …)
+- **Y-axis:** % of cohort that converted (subscribed OR donated) by month N
+- **Reference line:** Publisher-set conversion target (e.g., "15% at 6 months") — sourced from a Newspack settings option per NPPD-1606's design. Phase 1 hardcodes 15% at month 6; Phase 2 makes it configurable.
+- **Caption note:** "Updated weekly. Old cohorts with insufficient history are dropped."
+- **Placeholder:** Empty LineChart with empty-state message: "Cohort data will appear after the first weekly refresh."
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Cohort Retention Curve: Registrations → Conversion"
+
+### Viz 5.2: Subscriber retention cohort
+
+- **Type:** LineChart, multi-series
+- **Series:** One line per monthly subscriber cohort
+- **X-axis:** Months since first subscription
+- **Y-axis:** % of cohort still actively subscribed at month N
+- **Reference line:** Publisher-set retention target (e.g., "70% at 12 months") — Phase 1 hardcodes 70% at month 12; Phase 2 makes it configurable.
+- **Caption note:** "Active-subscriber retention. Donor retention lives on Tab 7."
+- **Placeholder:** Same empty-state pattern
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Cohort Retention Curve: Subscribers → Retention"
+
+---
+
+## Section 6: Conversion rate trends
+
+**Header:** Conversion rate trends
+**Caption:** Weekly conversion rates across the selected window. Useful for spotting acceleration, plateaus, or seasonality.
+
+**Layout:** Single full-width LineChart.
+
+### Viz 6.1: Weekly conversion rates
+
+- **Type:** LineChart, multi-series, weekly granularity
+- **Series:**
+  - Registration conversion rate (new registrations ÷ active readers)
+  - Subscription attempt rate (subscription form submissions ÷ new registrations)
+- **X-axis:** Week start (ISO week)
+- **Y-axis:** Percentage
+- **Note:** Subscription rate uses BQ attempts, not Woo completions, for stability. Tab 6 has the completion-accurate view. Document in tooltip.
+- **Aggregation:** For windows > 12 weeks, aggregate to monthly at display time so the chart stays readable.
+- **Placeholder:** Empty LineChart with empty-state message: "Weekly trends will appear once the window contains at least 4 weeks of data."
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Conversion Rate Trends (LineChart, multi-series)"
+
+---
+
+## Section 7: Cross-tab influenced attribution
+
+**Header:** Cross-tab influenced attribution
+**Caption:** Influenced conversion rates from your Gates and Prompts tabs, centralized so you don't have to bounce between tabs to compare. Influenced means the reader saw a gate or prompt in the lookback window before converting in a later session.
+
+**Layout:** 4 scorecards in a single row.
+
+### Card 7.1: Influenced registration rate
+
+- **Subtitle:** % of new registrations whose user saw a gate or prompt in the 7 days prior
+- **Value type:** Percentage
+- **Placeholder:** 0%
+- **Comparison mode:** Yes
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Influenced Registration Rate (7d lookback)"
+
+### Card 7.2: Influenced subscription rate
+
+- **Subtitle:** % of new subscribers whose user saw a subscription-intent surface in the 14 days prior
+- **Value type:** Percentage
+- **Placeholder:** 0%
+- **Comparison mode:** Yes
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Influenced Subscription Rate (14d lookback)"
+
+### Card 7.3: Influenced donation rate
+
+- **Subtitle:** % of new donors whose user saw a donation-intent surface in the 14 days prior
+- **Value type:** Percentage
+- **Placeholder:** 0%
+- **Comparison mode:** Yes
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Influenced Donation Rate (14d lookback)"
+
+### Card 7.4: Influenced newsletter signup rate
+
+- **Subtitle:** % of new newsletter signups whose user saw a newsletter-intent surface in the 7 days prior
+- **Value type:** Percentage
+- **Placeholder:** 0%
+- **Comparison mode:** Yes
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Influenced Newsletter Signup Rate (7d lookback)"
+
+---
+
+## Section 8: Opportunity buckets
+
+**Header:** Opportunity buckets
+**Caption:** Where the funnel has slack. These are diagnostic counts and underperforming pages — readers and content that could move with attention.
+
+**Layout:** Three scorecards in a row at the top, single full-width table below.
+
+### Card 8.1: Stale registered readers
+
+- **Subtitle:** Registered but never converted, no activity in 90 days
+- **Value type:** Count
+- **Placeholder:** 0
+- **Comparison mode:** No (snapshot count, not a windowed metric)
+- **Action framing:** Tooltip — "Consider a re-engagement campaign."
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Stale Registered Readers"
+
+### Card 8.2: At-risk subscribers
+
+- **Subtitle:** Active subscribers with a failed-payment retry scheduled
+- **Value type:** Count
+- **Placeholder:** 0
+- **Comparison mode:** No
+- **Action framing:** Tooltip — "Reach out before retry fails."
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "At-Risk Subscribers"
+
+### Card 8.3: Lapsed donors
+
+- **Subtitle:** Donors with no donation in the last 365 days
+- **Value type:** Count
+- **Placeholder:** 0
+- **Comparison mode:** No
+- **Action framing:** Tooltip — "Consider a winback campaign."
+- **Cross-reference:** Same definition as Tab 7's Lapsed Donors scorecard; this is a duplicated diagnostic view.
+- **Formula:** `formulas/tab-3-conversion-journey.md` → "Lapsed Donors"
+
+### Table 8.4: Top pages that don't convert
+
+**Columns:**
+
+| Column | Type | Notes |
+|---|---|---|
+| Page title | String | From `page_title` event param; v1.1 may join to `wp_posts` for canonical titles |
+| Page URL | String | From `page_location`, displayed as link |
+| Pageviews | Count | Total in window |
+| Unique readers | Count | Distinct users with at least one pageview |
+| Conversion rate | Percentage | Conversions on this page ÷ unique readers |
+
+**Sort:** Default by Pageviews descending then Conversion Rate ascending — surfaces high-traffic, low-conversion pages. Every column header is clickable.
+
+**Filter:** Singular content only (post_id IS NOT NULL). Archives and homepage excluded.
+
+**Threshold:** Minimum 100 pageviews per page to appear (avoids noise from low-traffic URLs).
+
+**Row limit:** Top 25 by sort order.
+
+**Empty state:** "No qualifying pages yet. Pages with at least 100 pageviews and a measurable conversion rate will appear here."
+
+**Action framing:** Caption beneath the table — "These pages get traffic but don't drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low."
+
+**Formula:** `formulas/tab-3-conversion-journey.md` → "Top Pages That Don't Convert (Table)"
+
+---
+
+## Comparison mode
+
+When the user toggles "Compare to previous period," scorecards in Section 7 (Cross-tab influenced attribution) render deltas below the value. Same direction signaling as other tabs: higher value is better for influenced rates, so increases render green and decreases render red.
+
+**No comparison rendering on:**
+
+- Visualizations in Sections 1, 2, 4, 5, 6 — funnels, cumulative LineCharts, cohort LineCharts, weekly trend LineCharts. Adding a second period to these visualizations adds visual complexity for unclear gain in v1; revisit in v1.1.
+- PieCharts in Section 3. Source mix comparisons across periods are interesting in principle, but the standard "compare two PieCharts" UI doesn't read well at a glance. Revisit in v1.1 if there's signal.
+- Scorecards in Section 8. These are snapshot counts ("readers currently in this state"), not windowed metrics — comparing snapshots across windows is conceptually confused.
+
+## Date range picker behavior
+
+The picker affects every section except Section 5 (Cohort retention) and the snapshot scorecards in Section 8 (8.1, 8.2, 8.3).
+
+- **Section 5:** Cohort retention is pre-computed weekly, independent of the picker. The cohorts shown are the most recent 12 months regardless of the selected window. Document in the cohort retention callout.
+- **Section 8 scorecards:** These are current-state counts ("readers currently stale," "subscribers currently at risk," "donors currently lapsed"). The picker does not affect them. The Top Pages table (8.4) IS windowed.
+
+The dynamic section headers used on Tabs 6 and 7 ("In the last 30 days") are used here for windowed sections (1, 2, 3, 4, 6, 7, 8.4). Snapshot sections (5, 8.1–8.3) use static headers.
+
+## Empty-state details (Phase 1 specifics)
+
+For Phase 1, every metric class returns a payload with `pending: true`. The MetricCard component reads the flag and renders the placeholder value with normal styling (no greyed-out treatment, no per-card tooltip). The single top-of-tab banner is the only signal that the tab is pending.
+
+Placeholder values by type:
+
+| Metric type | Placeholder |
+|---|---|
+| Count (registrations, subscribers, donors, readers) | 0 |
+| Rate / percentage (Influenced rates, conversion rates) | 0% |
+| Currency (no currency metrics on this tab in v1) | n/a |
+| Decimal average | 0.0 |
+| Funnel stage values | 0 (drop-off labels hidden) |
+| PieChart | Empty state — "Source data will appear once conversions occur in this window." |
+| LineChart (cumulative) | Empty state — "Time-to-convert data will appear once conversions occur in this window." |
+| LineChart (cohort) | Empty state — "Cohort data will appear after the first weekly refresh." |
+| LineChart (trends) | Empty state — "Weekly trends will appear once the window contains at least 4 weeks of data." |
+| Table row | Empty state row (see Section 8.4) |
+
+Subtitles, captions, comparison toggle, and date picker all function normally during Phase 1. The user can navigate, interact, and explore the tab structure even though values are zero.
+
+## Open questions for Phase 2
+
+Surface during build, decide based on real data:
+
+1. **Cohort retention pre-warm cadence.** The formula doc and NPPD-1606 specify weekly refresh on Monday early morning. Confirm the schedule survives staging on a real publisher; tune if the query takes longer than expected on large publishers.
+2. **Stale Registered scale.** The query requires a BQ → Woo round trip with the recently-active UID set. For publishers with > 10K registered users this could be slow. Consider materializing the "recently active UIDs" set into the cache table on a schedule; defer if the round trip is acceptable at typical publisher scale.
+3. **Top Pages That Don't Convert sensitivity.** The 100-pageview threshold is a starting guess. Adjust per publisher scale once real data arrives. Also: some publishers will see this as helpful, others as pushy ("you should add a paywall here"). Worth A/B testing the section visibility with the first cohort of Insights users.
+4. **Cross-upsell threshold.** Section 2.4 and Section 4.4 are gated at 50 active subscribers AND 50 active donors. Validate against real publisher data; adjust if 50 is too high (sparse cross-upsell data is still informative) or too low (noisy headlines).
+5. **Subscription rate trend source.** Section 6 uses BQ attempts for trend stability. Decide whether to add a second series tracking Woo completions for accuracy-focused publishers, or leave that to Tab 6 entirely.
+6. **Ambassador-style classification.** NPPD-1619 — the misclassification of donation-tier subscriptions affects Section 3.2 (source mix new subscribers may overcount), Section 3.3 (may undercount donors), and Section 2.4 (cross-upsell funnel underestimates). Same fix path as Tab 6/7 — Phase 2 picks up whatever resolution lands there.
+7. **Window vs lookback discipline.** Some metrics use the publisher-selected window; others extend lookback (90d for first session, 365d for cohort retention, 7-14d for Influenced). Surface the actual lookback range for each metric in tooltips, since publishers will be confused otherwise.
+8. **Wp_posts enrichment in Section 8.4.** Phase 2 may add a join to local `wp_posts` via `post_id` for canonical titles and author/category enrichment. New join pattern not currently used; defer to v1.1 if it adds material complexity.
+9. **Cohort retention targets.** Section 5's reference lines are hardcoded at 15% at month 6 (registration → conversion) and 70% at month 12 (subscriber retention). Phase 2 should expose these as publisher-configurable settings. Default values are placeholders, not benchmarks.
+
+## BQ query catalog (handoff to NPPD-1630)
+
+Each metric in this spec maps to a `query_name` in the Newspack Manager BQ query catalog. Naming convention: `conversion_journey_{metric_slug}`. Suggested initial catalog entries:
+
+- `conversion_journey_lifecycle_funnel`
+- `conversion_journey_funnel_anon_to_registered`
+- `conversion_journey_funnel_registered_to_subscriber`
+- `conversion_journey_funnel_registered_to_donor`
+- `conversion_journey_funnel_subscriber_to_donor`
+- `conversion_journey_source_mix_registrations`
+- `conversion_journey_source_mix_subscribers`
+- `conversion_journey_source_mix_donors`
+- `conversion_journey_time_to_register`
+- `conversion_journey_time_to_subscribe`
+- `conversion_journey_time_to_donate`
+- `conversion_journey_sub_to_donor_lag`
+- `conversion_journey_cohort_registration_to_conversion`
+- `conversion_journey_cohort_subscriber_retention`
+- `conversion_journey_weekly_rates`
+- `conversion_journey_influenced_registration_7d`
+- `conversion_journey_influenced_subscription_14d`
+- `conversion_journey_influenced_donation_14d`
+- `conversion_journey_influenced_newsletter_7d`
+- `conversion_journey_stale_registered`
+- `conversion_journey_at_risk_subscribers`
+- `conversion_journey_lapsed_donors`
+- `conversion_journey_top_pages_no_conversion`
+
+The Sub→Donor cross-upsell funnel (2.4), Stale Registered count (8.1), At-Risk Subscribers (8.2), Lapsed Donors (8.3), and Cohort Subscriber Retention (5.2) are local-only (Woo) and don't need BQ catalog entries — they live entirely in PHP. Marked here for completeness; the BQ catalog skips them.

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * Newspack Insights — Tab 3 Conversion Journey REST controller (NPPD-1609, Phase 1).
+ *
+ * Single endpoint: `GET /newspack-insights/v1/conversion`. Same date-arg
+ * validation, permission check, and date-parsing conventions as
+ * {@see Prompts_REST_Controller} — Tab 3 mirrors the per-surface tabs'
+ * request/response lifecycle exactly.
+ *
+ * Response shape:
+ *   tab_pending: bool             — true in Phase 1 (placeholder phase);
+ *                                   React reads it for the top-of-tab banner.
+ *   current:     ConversionWindow — the eight sections' 23 metric payloads.
+ *   previous:    ConversionWindow | null — only populated when the request
+ *                                   passes `compare_start` + `compare_end`.
+ *                                   Only Section 7 renders the deltas.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Conversion Journey REST controller.
+ */
+class Conversion_REST_Controller extends WP_REST_Controller {
+
+	/**
+	 * Shared Insights namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'conversion';
+
+	/**
+	 * Register the Tab 3 route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_conversion_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET handler.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function get_conversion_data( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
+
+		try {
+			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
+			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+		}
+		if ( $start > $end ) {
+			return new WP_Error(
+				'newspack_insights_invalid_window',
+				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$compare_start_param = $request->get_param( 'compare_start' );
+		$compare_end_param   = $request->get_param( 'compare_end' );
+		$compare_start       = null;
+		$compare_end         = null;
+		if ( $compare_start_param || $compare_end_param ) {
+			if ( ! $compare_start_param || ! $compare_end_param ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison',
+					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+			try {
+				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
+				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+			}
+			if ( $compare_start > $compare_end ) {
+				return new WP_Error(
+					'newspack_insights_invalid_comparison_window',
+					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		$metric = new Conversion_Metric();
+		return rest_ensure_response( $this->build_response( $metric, $start, $end, $compare_start, $compare_end ) );
+	}
+
+	/**
+	 * Assemble the top-level response.
+	 *
+	 * `tab_pending` is true in Phase 1 (placeholder phase). React uses it to
+	 * render the top-of-tab banner; have it return false based on real data
+	 * state when Phase 2 wires up BigQuery.
+	 *
+	 * @param Conversion_Metric      $metric        Orchestrator.
+	 * @param DateTimeImmutable      $start         Current window start.
+	 * @param DateTimeImmutable      $end           Current window end.
+	 * @param DateTimeImmutable|null $compare_start Prior window start.
+	 * @param DateTimeImmutable|null $compare_end   Prior window end.
+	 * @return array
+	 */
+	private function build_response(
+		Conversion_Metric $metric,
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		?DateTimeImmutable $compare_start,
+		?DateTimeImmutable $compare_end
+	): array {
+		$response = [
+			'tab_pending' => true,
+			'current'     => $this->build_window( $metric, $start, $end ),
+			'previous'    => null,
+		];
+		if ( $compare_start && $compare_end ) {
+			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end );
+		}
+		return $response;
+	}
+
+	/**
+	 * Window-bound payload covering all eight sections (23 metrics).
+	 *
+	 * @param Conversion_Metric $metric Orchestrator.
+	 * @param DateTimeImmutable $start  Start.
+	 * @param DateTimeImmutable $end    End.
+	 * @return array
+	 */
+	private function build_window( Conversion_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return [
+			'window'                               => [
+				'start' => $start->format( 'Y-m-d' ),
+				'end'   => $end->format( 'Y-m-d' ),
+			],
+			// Section 1 — The reader lifecycle.
+			'reader_lifecycle_funnel'              => $metric->get_reader_lifecycle_funnel( $start, $end ),
+			// Section 2 — Per-journey conversion funnels.
+			'anonymous_to_registered_funnel'       => $metric->get_anonymous_to_registered_funnel( $start, $end ),
+			'registered_to_subscriber_funnel'      => $metric->get_registered_to_subscriber_funnel( $start, $end ),
+			'registered_to_donor_funnel'           => $metric->get_registered_to_donor_funnel( $start, $end ),
+			'subscriber_to_donor_funnel'           => $metric->get_subscriber_to_donor_funnel( $start, $end ),
+			// Section 3 — Where conversions come from.
+			'source_mix_registrations'             => $metric->get_source_mix_registrations( $start, $end ),
+			'source_mix_subscribers'               => $metric->get_source_mix_subscribers( $start, $end ),
+			'source_mix_donors'                    => $metric->get_source_mix_donors( $start, $end ),
+			// Section 4 — How long conversions take (cumulative LineCharts).
+			'time_to_register_distribution'        => $metric->get_time_to_register_distribution( $start, $end ),
+			'time_to_subscribe_distribution'       => $metric->get_time_to_subscribe_distribution( $start, $end ),
+			'time_to_donate_distribution'          => $metric->get_time_to_donate_distribution( $start, $end ),
+			'subscriber_to_donor_lag_distribution' => $metric->get_subscriber_to_donor_lag_distribution( $start, $end ),
+			// Section 5 — Cohort retention (snapshot).
+			'registration_to_conversion_cohort'    => $metric->get_registration_to_conversion_cohort( $start, $end ),
+			'subscriber_retention_cohort'          => $metric->get_subscriber_retention_cohort( $start, $end ),
+			// Section 6 — Conversion rate trends.
+			'weekly_conversion_rates'              => $metric->get_weekly_conversion_rates( $start, $end ),
+			// Section 7 — Cross-tab influenced attribution (comparison-enabled).
+			'influenced_registration_rate_7d'      => $metric->get_influenced_registration_rate_7d( $start, $end ),
+			'influenced_subscription_rate_14d'     => $metric->get_influenced_subscription_rate_14d( $start, $end ),
+			'influenced_donation_rate_14d'         => $metric->get_influenced_donation_rate_14d( $start, $end ),
+			'influenced_newsletter_rate_7d'        => $metric->get_influenced_newsletter_rate_7d( $start, $end ),
+			// Section 8 — Opportunity buckets.
+			'stale_registered_count'               => $metric->get_stale_registered_count( $start, $end ),
+			'at_risk_subscriber_count'             => $metric->get_at_risk_subscriber_count( $start, $end ),
+			'lapsed_donor_count'                   => $metric->get_lapsed_donor_count( $start, $end ),
+			'top_pages_no_conversion'              => $metric->get_top_pages_no_conversion( $start, $end ),
+		];
+	}
+
+	/**
+	 * Args spec.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$base = [
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+		];
+		return [
+			'start'         => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				]
+			),
+			'end'           => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				]
+			),
+			'compare_start' => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
+					'required'    => false,
+				]
+			),
+			'compare_end'   => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
+					'required'    => false,
+				]
+			),
+		];
+	}
+
+	/**
+	 * REST validate_callback.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool|WP_Error
+	 */
+	public function validate_date_string( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				/* translators: %s: the invalid date string */
+				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
+				[ 'status' => 400 ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Parse a Y-m-d string into a DateTimeImmutable.
+	 *
+	 * @param mixed        $value      Raw value.
+	 * @param DateTimeZone $tz         Timezone.
+	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
+	 * @return DateTimeImmutable
+	 * @throws Exception On parse failure.
+	 */
+	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			/* translators: %s: the invalid date string */
+			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
+		}
+		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
+	}
+
+	/**
+	 * Site timezone.
+	 *
+	 * @return DateTimeZone
+	 */
+	private function site_timezone(): DateTimeZone {
+		return wp_timezone();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -160,19 +160,28 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 		?DateTimeImmutable $compare_start,
 		?DateTimeImmutable $compare_end
 	): array {
+		// Snapshot metrics (Section 5 cohorts, Sections 8.1–8.3) are
+		// current-state and window-independent, so compute them once and share
+		// the same payload across both windows. In comparison mode this avoids
+		// re-running them for `previous`, where (in Phase 2) they become the
+		// tab's most expensive Woo/BQ queries returning identical data.
+		$snapshot = $this->build_snapshot( $metric, $start, $end );
+
 		$response = [
 			'tab_pending' => true,
-			'current'     => $this->build_window( $metric, $start, $end ),
+			'current'     => $this->build_window( $metric, $start, $end ) + $snapshot,
 			'previous'    => null,
 		];
 		if ( $compare_start && $compare_end ) {
-			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end );
+			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end ) + $snapshot;
 		}
 		return $response;
 	}
 
 	/**
-	 * Window-bound payload covering all eight sections (23 metrics).
+	 * Window-bound payload: the 18 metrics that depend on the selected window,
+	 * plus the `window` echo. The 5 window-independent snapshot metrics are
+	 * merged in by {@see self::build_response()} via {@see self::build_snapshot()}.
 	 *
 	 * @param Conversion_Metric $metric Orchestrator.
 	 * @param DateTimeImmutable $start  Start.
@@ -201,9 +210,6 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 			'time_to_subscribe_distribution'       => $metric->get_time_to_subscribe_distribution( $start, $end ),
 			'time_to_donate_distribution'          => $metric->get_time_to_donate_distribution( $start, $end ),
 			'subscriber_to_donor_lag_distribution' => $metric->get_subscriber_to_donor_lag_distribution( $start, $end ),
-			// Section 5 — Cohort retention (snapshot).
-			'registration_to_conversion_cohort'    => $metric->get_registration_to_conversion_cohort( $start, $end ),
-			'subscriber_retention_cohort'          => $metric->get_subscriber_retention_cohort( $start, $end ),
 			// Section 6 — Conversion rate trends.
 			'weekly_conversion_rates'              => $metric->get_weekly_conversion_rates( $start, $end ),
 			// Section 7 — Cross-tab influenced attribution (comparison-enabled).
@@ -211,11 +217,32 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 			'influenced_subscription_rate_14d'     => $metric->get_influenced_subscription_rate_14d( $start, $end ),
 			'influenced_donation_rate_14d'         => $metric->get_influenced_donation_rate_14d( $start, $end ),
 			'influenced_newsletter_rate_7d'        => $metric->get_influenced_newsletter_rate_7d( $start, $end ),
-			// Section 8 — Opportunity buckets.
-			'stale_registered_count'               => $metric->get_stale_registered_count( $start, $end ),
-			'at_risk_subscriber_count'             => $metric->get_at_risk_subscriber_count( $start, $end ),
-			'lapsed_donor_count'                   => $metric->get_lapsed_donor_count( $start, $end ),
+			// Section 8.4 — Top pages that don't convert (windowed table).
 			'top_pages_no_conversion'              => $metric->get_top_pages_no_conversion( $start, $end ),
+		];
+	}
+
+	/**
+	 * Window-independent snapshot metrics: Section 5 cohort retention (5.1,
+	 * 5.2) and Sections 8.1–8.3 opportunity counts. These are current-state —
+	 * the orchestrator methods accept the window for signature parity but
+	 * ignore it — so the controller computes them once and reuses the result
+	 * for both the current and comparison windows.
+	 *
+	 * @param Conversion_Metric $metric Orchestrator.
+	 * @param DateTimeImmutable $start  Current window start (passed for parity; ignored by the metrics).
+	 * @param DateTimeImmutable $end    Current window end (passed for parity; ignored by the metrics).
+	 * @return array
+	 */
+	private function build_snapshot( Conversion_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return [
+			// Section 5 — Cohort retention (snapshot).
+			'registration_to_conversion_cohort' => $metric->get_registration_to_conversion_cohort( $start, $end ),
+			'subscriber_retention_cohort'       => $metric->get_subscriber_retention_cohort( $start, $end ),
+			// Sections 8.1–8.3 — Opportunity buckets (snapshot counts).
+			'stale_registered_count'            => $metric->get_stale_registered_count( $start, $end ),
+			'at_risk_subscriber_count'          => $metric->get_at_risk_subscriber_count( $start, $end ),
+			'lapsed_donor_count'                => $metric->get_lapsed_donor_count( $start, $end ),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -2,19 +2,26 @@
 /**
  * Newspack Insights — Conversion Journey section (NPPD-1602).
  *
- * Conversion Journey tab scope: the funnel from anonymous reader to
- * registered to subscriber. Time-to-convert distributions, step-over-step
- * drop-off, and attribution to gates/prompts. Lives between Engagement
- * (depth of consumption) and the per-surface tabs (Gates, Prompts).
+ * Conversion Journey tab scope: the reader lifecycle funnel, per-journey
+ * conversion funnels, source attribution, time-to-convert cumulative
+ * distributions, cohort retention, conversion rate trends, cross-tab
+ * influenced attribution, and opportunity buckets. Lives between
+ * Engagement (depth of consumption) and the per-surface tabs (Gates,
+ * Prompts). Phase 1 ships the full UI with placeholder data; Phase 2
+ * (NPPD-1630) swaps the metric implementations to BigQuery via the
+ * Newspack Manager query proxy.
  *
- * Future REST endpoints for the Conversion tab register from
- * {@see self::register_hooks()}. Currently a stub; the React side renders
- * a "Coming soon" placeholder for this tab.
+ * Like the other Insights tabs, this section is gated solely by
+ * {@see Insights_Wizard::is_enabled()} — no separate preview flag. The
+ * `feat/insights-rsm` integration branch is the staging area until it
+ * merges to main as a single Insights v1 release event.
  *
  * @package Newspack
  */
 
 namespace Newspack;
+
+use Newspack\Insights\Conversion_REST_Controller;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -31,18 +38,39 @@ class Insights_Section_Conversion {
 	const SECTION_NAME = 'Conversion Journey';
 
 	/**
-	 * Initialize. Hooks REST endpoints for this tab when implementations
-	 * arrive (NPPD-1609).
+	 * Initialize. Bails early when the parent Insights feature flag is off.
 	 */
 	public static function init() {
 		if ( ! Insights_Wizard::is_enabled() ) {
 			return;
 		}
+		self::load_dependencies();
 		self::register_hooks();
 	}
 
 	/**
-	 * Register hooks for this section. Currently a stub.
+	 * Include Tab 3 PHP files.
+	 *
+	 * @return void
 	 */
-	public static function register_hooks() {}
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'metrics/class-conversion-metric.php';
+		include_once $base . 'api/class-conversion-rest-controller.php';
+	}
+
+	/**
+	 * Register the Tab 3 REST route.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new Conversion_REST_Controller();
+				$controller->register_routes();
+			}
+		);
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1,0 +1,578 @@
+<?php
+/**
+ * Newspack Insights — Conversion Journey Metric orchestrator (NPPD-1609, Phase 1).
+ *
+ * Phase 1 placeholder layer for Tab 3 (Conversion Journey). Every metric
+ * returns a `pending: true` payload in the eventual real shape — zeroed
+ * scalars, zeroed funnel stages, empty viz collections — so the React
+ * layer can render the full tab (eight sections, all visualizations) with
+ * empty states before BigQuery wiring lands in Phase 2 (NPPD-1630). No
+ * storage layer, no SQL: the data is intentionally synthetic until Phase 2
+ * swaps each method body to a query dispatch against the Newspack Manager
+ * BQ catalog without touching signatures or the response envelope.
+ *
+ * Mirrors {@see Prompts_Metric} (Tab 5) one-for-one: same placeholder
+ * shape for scalars, same `pending` + ordered-collection shape for viz,
+ * same per-method window signature. Conversion Journey is the widest
+ * Insights tab (eight sections, 23 metrics) but the per-metric envelope is
+ * identical to the per-surface tabs.
+ *
+ * Method-signature contract: every method takes the current window
+ * (`$start`, `$end`) for parity with the other tabs. The previous-window
+ * comparison is a controller concern — {@see Conversion_REST_Controller}
+ * builds the `current` and `previous` windows by calling the same methods
+ * twice — so individual methods never see the comparison window. Only
+ * Section 7 (cross-tab influenced attribution) renders deltas in the UI.
+ *
+ * Snapshot metrics — Section 5 cohorts and Sections 8.1–8.3 — are
+ * current-state, not windowed: they accept `$start`/`$end` for signature
+ * consistency but ignore them (noted per-method). Phase 2 computes them
+ * independent of the date picker.
+ *
+ * Local-only metrics that do NOT belong in the BQ catalog (flagged per
+ * method for the Phase 2 handoff): the Subscriber → Donor funnel (2.4),
+ * the Subscriber → Donor lag distribution (4.4), the subscriber retention
+ * cohort (5.2), and the three opportunity-bucket counts (8.1–8.3). These
+ * are Woo-only (or Woo-plus-a-recently-active-UID-set), computed locally.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeInterface;
+
+/**
+ * Tab 3 placeholder metric orchestrator.
+ *
+ * @phpstan-type ScalarMetric array{
+ *   value: int|float,
+ *   computable: bool,
+ *   pending: bool,
+ *   denominator: int|null,
+ *   placeholder_type: string,
+ * }
+ */
+final class Conversion_Metric {
+
+	/**
+	 * Cache key prefix. Bumped when the response shape changes so cached
+	 * payloads from a prior shape don't break a deploy.
+	 *
+	 * @var string
+	 */
+	const CACHE_PREFIX = 'newspack_insights_tab3_v1:';
+
+	/**
+	 * The three acquisition surfaces every source-attributed metric splits
+	 * by. Machine keys (not translated) — the React layer maps them to
+	 * display labels. Shared by the Section 3 PieCharts and the Section 4
+	 * multi-series cumulative distributions.
+	 *
+	 * @var string[]
+	 */
+	const SOURCES = [ 'gate', 'prompt', 'direct' ];
+
+	/**
+	 * Build the standard placeholder shape for a single scorecard metric.
+	 * Type is encoded in `placeholder_type` so React can pick the right
+	 * format token ("0" vs "0%" vs "0.0") without inferring from the field
+	 * name. Identical to {@see Prompts_Metric::placeholder()} for cross-tab
+	 * parity — this tab uses 'count', 'rate', and 'decimal' (no currency
+	 * metrics in v1).
+	 *
+	 * @param string $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @return array{value: int|float, computable: bool, pending: bool, denominator: null, placeholder_type: string}
+	 */
+	private function placeholder( string $placeholder_type ): array {
+		return [
+			'value'            => 'decimal' === $placeholder_type ? 0.0 : 0,
+			'computable'       => false,
+			'pending'          => true,
+			'denominator'      => null,
+			'placeholder_type' => $placeholder_type,
+		];
+	}
+
+	/**
+	 * Build a single zeroed funnel stage.
+	 *
+	 * @param string $label Stage label (translated).
+	 * @return array{label: string, count: int, pct_of_top: float}
+	 */
+	private function funnel_stage( string $label ): array {
+		return [
+			'label'      => $label,
+			'count'      => 0,
+			'pct_of_top' => 0.0,
+		];
+	}
+
+	/**
+	 * Build the three zeroed source slices for a Section 3 PieChart. Phase 1
+	 * returns all three surfaces with zero values so the PieChart renders
+	 * its legend chrome; Phase 2 fills in real counts.
+	 *
+	 * @return array<int, array{source: string, count: int, pct: float}>
+	 */
+	private function source_slices(): array {
+		return array_map(
+			static function ( string $source ): array {
+				return [
+					'source' => $source,
+					'count'  => 0,
+					'pct'    => 0.0,
+				];
+			},
+			self::SOURCES
+		);
+	}
+
+	/**
+	 * Build the three empty per-source series for a Section 4 multi-series
+	 * cumulative distribution (4.2, 4.3). Each series carries an empty
+	 * `points` array; Phase 1 renders the LineChart empty state.
+	 *
+	 * @return array<int, array{label: string, points: array}>
+	 */
+	private function cumulative_groups(): array {
+		return array_map(
+			static function ( string $source ): array {
+				return [
+					'label'  => $source,
+					'points' => [],
+				];
+			},
+			self::SOURCES
+		);
+	}
+
+	// --- Section 1: The reader lifecycle --------------------------------
+
+	/**
+	 * Reader lifecycle funnel — five nested stages from anonymous reader to
+	 * supporter. Stage shape kept stable so the React Funnel renders the
+	 * same chrome regardless of phase.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
+	 */
+	public function get_reader_lifecycle_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'stages'  => [
+				$this->funnel_stage( __( 'Anonymous reader', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Engaged reader', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Registered reader', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Newsletter subscriber', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Subscriber or donor', 'newspack-plugin' ) ),
+			],
+		];
+	}
+
+	// --- Section 2: Per-journey conversion funnels ----------------------
+
+	/**
+	 * Anonymous → Registered funnel (2.1) — three stages.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
+	 */
+	public function get_anonymous_to_registered_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'stages'  => [
+				$this->funnel_stage( __( 'Anonymous', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Saw a conversion surface', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Registered', 'newspack-plugin' ) ),
+			],
+		];
+	}
+
+	/**
+	 * Registered → Subscriber funnel (2.2) — three stages, non-donation
+	 * subscriptions only.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
+	 */
+	public function get_registered_to_subscriber_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'stages'  => [
+				$this->funnel_stage( __( 'Registered', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Saw a subscription-intent surface', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Became subscriber', 'newspack-plugin' ) ),
+			],
+		];
+	}
+
+	/**
+	 * Registered → Donor funnel (2.3) — three stages.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
+	 */
+	public function get_registered_to_donor_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'stages'  => [
+				$this->funnel_stage( __( 'Registered', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Saw a donation-intent surface', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Became donor', 'newspack-plugin' ) ),
+			],
+		];
+	}
+
+	/**
+	 * Subscriber → Donor cross-upsell funnel (2.4) — two stages,
+	 * visibility-gated.
+	 *
+	 * Local-only (Woo-only): does NOT belong in the BQ catalog. Gated on
+	 * 50 active subscribers AND 50 active donors. Phase 1 returns
+	 * `visibility: 'hidden'` unconditionally (no real cohort sizes yet);
+	 * Phase 2 computes visibility from the live cohort counts. The React
+	 * side renders the empty-state note when hidden.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, stages: array<int, array{label: string, count: int, pct_of_top: float}>, visibility: string, visibility_reason: string|null}
+	 */
+	public function get_subscriber_to_donor_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending'           => true,
+			'stages'            => [
+				$this->funnel_stage( __( 'Active subscriber', 'newspack-plugin' ) ),
+				$this->funnel_stage( __( 'Also donor', 'newspack-plugin' ) ),
+			],
+			'visibility'        => 'hidden',
+			'visibility_reason' => 'insufficient_data',
+		];
+	}
+
+	// --- Section 3: Where conversions come from -------------------------
+
+	/**
+	 * Source mix for new registrations (3.1) — gate / prompt / direct.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, total: int, slices: array<int, array{source: string, count: int, pct: float}>}
+	 */
+	public function get_source_mix_registrations( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'total'   => 0,
+			'slices'  => $this->source_slices(),
+		];
+	}
+
+	/**
+	 * Source mix for new subscribers (3.2) — gate / prompt / direct.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, total: int, slices: array<int, array{source: string, count: int, pct: float}>}
+	 */
+	public function get_source_mix_subscribers( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'total'   => 0,
+			'slices'  => $this->source_slices(),
+		];
+	}
+
+	/**
+	 * Source mix for new donors (3.3) — gate / prompt / direct.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, total: int, slices: array<int, array{source: string, count: int, pct: float}>}
+	 */
+	public function get_source_mix_donors( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'total'   => 0,
+			'slices'  => $this->source_slices(),
+		];
+	}
+
+	// --- Section 4: How long conversions take ---------------------------
+	// Cumulative-distribution LineCharts (replaced the v1 BoxPlot framing).
+	// Single-series: { points: [{day, cumulative_pct}, ...] }.
+	// Multi-series:  { groups: [{ label, points: [...] }, ...] }.
+
+	/**
+	 * Time-to-register cumulative distribution (4.1) — single series.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, points: array}
+	 */
+	public function get_time_to_register_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'points'  => [],
+		];
+	}
+
+	/**
+	 * Time-to-subscribe cumulative distribution (4.2) — three series by
+	 * source (gate / prompt / direct).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, groups: array<int, array{label: string, points: array}>}
+	 */
+	public function get_time_to_subscribe_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'groups'  => $this->cumulative_groups(),
+		];
+	}
+
+	/**
+	 * Time-to-donate cumulative distribution (4.3) — three series by source.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, groups: array<int, array{label: string, points: array}>}
+	 */
+	public function get_time_to_donate_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'groups'  => $this->cumulative_groups(),
+		];
+	}
+
+	/**
+	 * Subscriber → donor lag cumulative distribution (4.4) — single series,
+	 * visibility-gated.
+	 *
+	 * Local-only (Woo-only): does NOT belong in the BQ catalog. Gated at 50
+	 * cross-converters. Phase 1 returns `visibility: 'hidden'`
+	 * unconditionally; Phase 2 computes it from the live cohort size.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, points: array, visibility: string, visibility_reason: string|null}
+	 */
+	public function get_subscriber_to_donor_lag_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending'           => true,
+			'points'            => [],
+			'visibility'        => 'hidden',
+			'visibility_reason' => 'insufficient_data',
+		];
+	}
+
+	// --- Section 5: Cohort retention ------------------------------------
+	// Snapshot metrics: pre-computed weekly, independent of the date picker.
+	// The $start/$end params are accepted for signature parity and ignored.
+
+	/**
+	 * Registration → conversion cohort retention (5.1). Snapshot — ignores
+	 * the window. The reference line (15% at 6 months) is hardcoded per the
+	 * spec in Phase 1; Phase 2 makes it publisher-configurable.
+	 *
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
+	 * @return array{pending: bool, cohorts: array, reference_line: array{value: float, label: string}}
+	 */
+	public function get_registration_to_conversion_cohort( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending'        => true,
+			'cohorts'        => [],
+			'reference_line' => [
+				'value' => 0.15,
+				'label' => __( '15% at 6 months', 'newspack-plugin' ),
+			],
+		];
+	}
+
+	/**
+	 * Subscriber retention cohort (5.2). Snapshot — ignores the window.
+	 * Reference line (70% at 12 months) hardcoded in Phase 1.
+	 *
+	 * Local-only (Woo-only): does NOT belong in the BQ catalog.
+	 *
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
+	 * @return array{pending: bool, cohorts: array, reference_line: array{value: float, label: string}}
+	 */
+	public function get_subscriber_retention_cohort( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending'        => true,
+			'cohorts'        => [],
+			'reference_line' => [
+				'value' => 0.70,
+				'label' => __( '70% at 12 months', 'newspack-plugin' ),
+			],
+		];
+	}
+
+	// --- Section 6: Conversion rate trends ------------------------------
+
+	/**
+	 * Weekly conversion rates (6) — multi-series LineChart. Phase 1 returns
+	 * an empty `weeks` array so the LineChart renders its empty state. The
+	 * `series` keys name the two tracked rates.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, weeks: array, series: string[]}
+	 */
+	public function get_weekly_conversion_rates( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending' => true,
+			'weeks'   => [],
+			'series'  => [ 'registration_rate', 'subscription_attempt_rate' ],
+		];
+	}
+
+	// --- Section 7: Cross-tab influenced attribution --------------------
+	// The only section with comparison deltas. These duplicate the Tab 4/5/
+	// 6/7 Influenced patterns; Phase 2 may re-query independently or call
+	// into the existing tab orchestrators. Phase 1 stubs them so neither
+	// approach is locked in.
+
+	/**
+	 * Influenced registration rate, 7-day lookback (7.1).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_influenced_registration_rate_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Influenced subscription rate, 14-day lookback (7.2).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_influenced_subscription_rate_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Influenced donation rate, 14-day lookback (7.3).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_influenced_donation_rate_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	/**
+	 * Influenced newsletter signup rate, 7-day lookback (7.4).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array
+	 */
+	public function get_influenced_newsletter_rate_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'rate' );
+	}
+
+	// --- Section 8: Opportunity buckets ---------------------------------
+	// 8.1–8.3 are current-state snapshot counts: accept the window for
+	// signature parity, ignore it. All three are local-only (Woo-only, or
+	// Woo plus a recently-active UID set) and do NOT belong in the BQ
+	// catalog. 8.3 duplicates Tab 7's Lapsed Donors definition — Phase 2
+	// should reuse that orchestrator method rather than re-implement.
+
+	/**
+	 * Stale registered readers (8.1). Snapshot — ignores the window.
+	 *
+	 * Local-only: the count itself is local (Woo plus a recently-active UID
+	 * set sourced from BQ). Does NOT belong in the BQ catalog.
+	 *
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
+	 * @return array
+	 */
+	public function get_stale_registered_count( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'count' );
+	}
+
+	/**
+	 * At-risk subscribers (8.2). Snapshot — ignores the window.
+	 *
+	 * Local-only (Woo-only): does NOT belong in the BQ catalog.
+	 *
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
+	 * @return array
+	 */
+	public function get_at_risk_subscriber_count( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'count' );
+	}
+
+	/**
+	 * Lapsed donors (8.3). Snapshot — ignores the window. Same definition
+	 * as Tab 7's Lapsed Donors.
+	 *
+	 * Local-only (Woo-only): does NOT belong in the BQ catalog. Phase 2
+	 * should reuse the Tab 7 orchestrator method instead of re-implementing.
+	 *
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
+	 * @return array
+	 */
+	public function get_lapsed_donor_count( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return $this->placeholder( 'count' );
+	}
+
+	/**
+	 * Top pages that don't convert (8.4) — windowed table. Phase 1 returns
+	 * an empty `rows` array so the React table renders its empty-state row.
+	 * `threshold_pageviews` is the minimum-traffic cutoff (a starting guess
+	 * per the spec; tuned in Phase 2).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{pending: bool, rows: array, threshold_pageviews: int}
+	 */
+	public function get_top_pages_no_conversion( DateTimeInterface $start, DateTimeInterface $end ): array {
+		unset( $start, $end );
+		return [
+			'pending'             => true,
+			'rows'                => [],
+			'threshold_pageviews' => 100,
+		];
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -1,0 +1,248 @@
+/**
+ * Conversion Journey API client (NPPD-1609, Phase 1).
+ *
+ * Thin wrapper around `@wordpress/api-fetch` for the single Tab 3
+ * endpoint: `GET /newspack-insights/v1/conversion`. Type definitions
+ * mirror the PHP response shape assembled by `Conversion_REST_Controller`.
+ *
+ * Phase 1: every metric carries `pending: true` and a zero / empty value.
+ * Phase 2 keeps the same shape but flips `pending` to false and surfaces
+ * real BQ values; the React layer reads `pending` and the `tab_pending`
+ * banner flag rather than knowing which phase produced a payload.
+ *
+ * Mirrors `api/prompts.ts` (Tab 5). Conversion Journey is the widest tab
+ * (eight sections, 23 metrics): a marquee lifecycle funnel, four per-
+ * journey funnels, three source-mix PieCharts, four cumulative-distribution
+ * LineCharts, two cohort LineCharts, a weekly-trends LineChart, four
+ * cross-tab influenced scorecards, and an opportunity-bucket block.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * The kind of placeholder a scalar metric renders. Encoded server-side so
+ * the React format layer doesn't have to guess from the field name. Tab 3
+ * uses 'count', 'rate', and 'decimal' (no currency metrics in v1); the full
+ * union is kept for parity with the shared scalar shape.
+ */
+export type ConversionPlaceholderType = 'count' | 'rate' | 'currency' | 'decimal';
+
+/**
+ * Visibility gate for Sections 2.4 and 4.4. Hidden in Phase 1; Phase 2
+ * computes it from the live cohort sizes.
+ */
+export type ConversionVisibility = 'hidden' | 'visible';
+export type ConversionVisibilityReason = 'insufficient_data' | null;
+
+/**
+ * Standard scorecard metric payload (Sections 7 and 8.1–8.3).
+ */
+export interface ConversionScalarMetric {
+	value: number;
+	computable: boolean;
+	pending: boolean;
+	denominator: number | null;
+	placeholder_type: ConversionPlaceholderType;
+}
+
+/* --- Section 1 / 2: funnels ----------------------------------------- */
+
+export interface ConversionFunnelStage {
+	label: string;
+	count: number;
+	pct_of_top: number;
+}
+
+export interface ConversionFunnelData {
+	pending: boolean;
+	stages: ConversionFunnelStage[];
+}
+
+/**
+ * Visibility-gated funnel (Section 2.4 Subscriber → Donor). Carries the
+ * gate flags on top of the standard funnel shape.
+ */
+export interface ConversionGatedFunnelData extends ConversionFunnelData {
+	visibility: ConversionVisibility;
+	visibility_reason: ConversionVisibilityReason;
+}
+
+/* --- Section 3: source-mix PieCharts -------------------------------- */
+
+export interface ConversionSourceSlice {
+	source: 'gate' | 'prompt' | 'direct';
+	count: number;
+	pct: number;
+}
+
+export interface ConversionSourceMixData {
+	pending: boolean;
+	total: number;
+	slices: ConversionSourceSlice[];
+}
+
+/* --- Section 4: cumulative-distribution LineCharts ------------------ */
+
+export interface ConversionCumulativePoint {
+	day: number;
+	cumulative_pct: number;
+}
+
+/**
+ * Single-series cumulative distribution (Section 4.1).
+ */
+export interface ConversionCumulativeSingle {
+	pending: boolean;
+	points: ConversionCumulativePoint[];
+}
+
+/**
+ * Visibility-gated single-series cumulative distribution (Section 4.4).
+ */
+export interface ConversionGatedCumulativeSingle extends ConversionCumulativeSingle {
+	visibility: ConversionVisibility;
+	visibility_reason: ConversionVisibilityReason;
+}
+
+export interface ConversionCumulativeGroup {
+	label: 'gate' | 'prompt' | 'direct';
+	points: ConversionCumulativePoint[];
+}
+
+/**
+ * Multi-series cumulative distribution (Sections 4.2, 4.3).
+ */
+export interface ConversionCumulativeMulti {
+	pending: boolean;
+	groups: ConversionCumulativeGroup[];
+}
+
+/* --- Section 5: cohort retention LineCharts ------------------------- */
+
+export interface ConversionReferenceLine {
+	value: number;
+	label: string;
+}
+
+export interface ConversionCohortPoint {
+	period: number;
+	value: number;
+}
+
+export interface ConversionCohortSeries {
+	label: string;
+	points: ConversionCohortPoint[];
+}
+
+export interface ConversionCohortData {
+	pending: boolean;
+	cohorts: ConversionCohortSeries[];
+	reference_line: ConversionReferenceLine;
+}
+
+/* --- Section 6: weekly conversion-rate trends ----------------------- */
+
+export interface ConversionWeekPoint {
+	week: string;
+	registration_rate: number;
+	subscription_attempt_rate: number;
+}
+
+export interface ConversionWeeklyTrendsData {
+	pending: boolean;
+	weeks: ConversionWeekPoint[];
+	series: string[];
+}
+
+/* --- Section 8.4: top pages that don't convert ---------------------- */
+
+export interface ConversionTopPageRow {
+	post_id: number;
+	page_title: string;
+	page_url: string;
+	pageviews: number;
+	unique_readers: number;
+	conversion_rate: number;
+}
+
+export interface ConversionTopPagesTable {
+	pending: boolean;
+	rows: ConversionTopPageRow[];
+	threshold_pageviews: number;
+}
+
+/* --- Window + response ---------------------------------------------- */
+
+export interface ConversionWindow {
+	window: { start: string; end: string };
+	// Section 1 — The reader lifecycle.
+	reader_lifecycle_funnel: ConversionFunnelData;
+	// Section 2 — Per-journey conversion funnels.
+	anonymous_to_registered_funnel: ConversionFunnelData;
+	registered_to_subscriber_funnel: ConversionFunnelData;
+	registered_to_donor_funnel: ConversionFunnelData;
+	subscriber_to_donor_funnel: ConversionGatedFunnelData;
+	// Section 3 — Where conversions come from.
+	source_mix_registrations: ConversionSourceMixData;
+	source_mix_subscribers: ConversionSourceMixData;
+	source_mix_donors: ConversionSourceMixData;
+	// Section 4 — How long conversions take (cumulative LineCharts).
+	time_to_register_distribution: ConversionCumulativeSingle;
+	time_to_subscribe_distribution: ConversionCumulativeMulti;
+	time_to_donate_distribution: ConversionCumulativeMulti;
+	subscriber_to_donor_lag_distribution: ConversionGatedCumulativeSingle;
+	// Section 5 — Cohort retention (snapshot).
+	registration_to_conversion_cohort: ConversionCohortData;
+	subscriber_retention_cohort: ConversionCohortData;
+	// Section 6 — Conversion rate trends.
+	weekly_conversion_rates: ConversionWeeklyTrendsData;
+	// Section 7 — Cross-tab influenced attribution (comparison-enabled).
+	influenced_registration_rate_7d: ConversionScalarMetric;
+	influenced_subscription_rate_14d: ConversionScalarMetric;
+	influenced_donation_rate_14d: ConversionScalarMetric;
+	influenced_newsletter_rate_7d: ConversionScalarMetric;
+	// Section 8 — Opportunity buckets.
+	stale_registered_count: ConversionScalarMetric;
+	at_risk_subscriber_count: ConversionScalarMetric;
+	lapsed_donor_count: ConversionScalarMetric;
+	top_pages_no_conversion: ConversionTopPagesTable;
+}
+
+export interface ConversionResponse {
+	/**
+	 * True while Tab 3 is in the Phase 1 placeholder phase. React uses this
+	 * to render the top-of-tab banner.
+	 */
+	tab_pending: boolean;
+	current: ConversionWindow;
+	previous: ConversionWindow | null;
+}
+
+export interface ConversionQuery {
+	start: string;
+	end: string;
+	compare_start?: string;
+	compare_end?: string;
+}
+
+const ENDPOINT = '/newspack-insights/v1/conversion';
+
+/**
+ * Fetch Tab 3 data for the given window pair.
+ */
+export const fetchConversionData = async ( query: ConversionQuery ): Promise< ConversionResponse > => {
+	const params = new URLSearchParams();
+	params.set( 'start', query.start );
+	params.set( 'end', query.end );
+	if ( query.compare_start && query.compare_end ) {
+		params.set( 'compare_start', query.compare_start );
+		params.set( 'compare_end', query.compare_end );
+	}
+	return apiFetch< ConversionResponse >( {
+		path: `${ ENDPOINT }?${ params.toString() }`,
+		method: 'GET',
+	} );
+};

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/useConversionData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/useConversionData.ts
@@ -1,0 +1,76 @@
+/**
+ * useConversionData (NPPD-1609).
+ *
+ * Tab 3's data fetch lifecycle. Mirrors {@see usePromptsData}: a
+ * request-id guard serializes overlapping calls so the latest range
+ * change wins, and idle / loading / success / error state is local to
+ * the tab.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+import { fetchConversionData, type ConversionResponse } from '../api/conversion';
+
+export type ConversionFetchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UseConversionDataResult {
+	status: ConversionFetchStatus;
+	data: ConversionResponse | null;
+	error: string | null;
+	refetch: () => void;
+}
+
+const errorMessage = ( e: unknown ): string => {
+	if ( e && typeof e === 'object' && 'message' in e && typeof ( e as { message: unknown } ).message === 'string' ) {
+		return ( e as { message: string } ).message;
+	}
+	return String( e );
+};
+
+const useConversionData = ( range: DateRange, previousRange: DateRange | null ): UseConversionDataResult => {
+	const [ status, setStatus ] = useState< ConversionFetchStatus >( 'idle' );
+	const [ data, setData ] = useState< ConversionResponse | null >( null );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const requestIdRef = useRef( 0 );
+	const [ refetchTick, setRefetchTick ] = useState( 0 );
+	const refetch = useCallback( () => setRefetchTick( t => t + 1 ), [] );
+
+	useEffect( () => {
+		const myId = ++requestIdRef.current;
+		setStatus( 'loading' );
+		setError( null );
+
+		fetchConversionData( {
+			start: range.start,
+			end: range.end,
+			compare_start: previousRange?.start,
+			compare_end: previousRange?.end,
+		} )
+			.then( response => {
+				if ( requestIdRef.current !== myId ) {
+					return;
+				}
+				setData( response );
+				setStatus( 'success' );
+			} )
+			.catch( e => {
+				if ( requestIdRef.current !== myId ) {
+					return;
+				}
+				setError( errorMessage( e ) );
+				setStatus( 'error' );
+			} );
+	}, [ range.start, range.end, previousRange?.start, previousRange?.end, refetchTick ] );
+
+	return { status, data, error, refetch };
+};
+
+export default useConversionData;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -1,7 +1,19 @@
 /**
- * ConversionTab
+ * ConversionTab (NPPD-1609).
  *
- * Stub. Real content lands in NPPD-1609.
+ * Tab 3 orchestrator. Mirrors the GatesTab / PromptsTab loading / error /
+ * success lifecycle and composes the eight Conversion Journey sections.
+ *
+ * The date range picker affects most sections, but Section 5 (Cohort
+ * retention) and the Section 8 snapshot scorecards are current-state and
+ * ignore the picker. Comparison is forwarded by the wizard chrome via the
+ * standard `previousRange` prop; only Section 7 (cross-tab influenced
+ * attribution) renders the resulting deltas.
+ *
+ * Phase 1 ships the full UI with placeholder data; the top-of-tab banner
+ * and the cohort-retention-freshness callout (added in a later commit)
+ * are the only signals that real data is pending. `tab_pending` stays in
+ * the response envelope for Phase 2.
  */
 
 /**
@@ -9,11 +21,54 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const ConversionTab = () => (
-	<div className="newspack-insights__tab-stub">
-		<h2 className="newspack-insights__tab-stub-title">{ __( 'Conversion Journey', 'newspack-plugin' ) }</h2>
-		<p className="newspack-insights__tab-stub-message">{ __( 'Coming soon', 'newspack-plugin' ) }</p>
-	</div>
-);
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+import useConversionData from '../hooks/useConversionData';
+import TabStateView from './components/TabStateView';
+import { TAB_LOADING_MESSAGES } from './components/loading-messages';
+import ReaderLifecycleSection from './conversion/ReaderLifecycleSection';
+import PerJourneyConversionFunnelsSection from './conversion/PerJourneyConversionFunnelsSection';
+import WhereConversionsComeFromSection from './conversion/WhereConversionsComeFromSection';
+import HowLongConversionsTakeSection from './conversion/HowLongConversionsTakeSection';
+import CohortRetentionSection from './conversion/CohortRetentionSection';
+import ConversionRateTrendsSection from './conversion/ConversionRateTrendsSection';
+import CrossTabInfluencedAttributionSection from './conversion/CrossTabInfluencedAttributionSection';
+import OpportunityBucketsSection from './conversion/OpportunityBucketsSection';
+import './conversion/conversion.scss';
+
+export interface ConversionTabProps {
+	range: DateRange;
+	previousRange: DateRange | null;
+}
+
+const ConversionTab = ( { range, previousRange }: ConversionTabProps ) => {
+	const { status, data, error } = useConversionData( range, previousRange );
+
+	return (
+		<TabStateView
+			status={ status }
+			hasData={ !! data }
+			error={ error }
+			errorLabel={ __( 'Could not load conversion data.', 'newspack-plugin' ) }
+			className="newspack-insights__conversion-tab"
+			loadingMessages={ TAB_LOADING_MESSAGES.conversion }
+		>
+			{ data && (
+				<>
+					<ReaderLifecycleSection current={ data.current } />
+					<PerJourneyConversionFunnelsSection current={ data.current } />
+					<WhereConversionsComeFromSection current={ data.current } />
+					<HowLongConversionsTakeSection current={ data.current } />
+					<CohortRetentionSection current={ data.current } />
+					<ConversionRateTrendsSection current={ data.current } />
+					<CrossTabInfluencedAttributionSection current={ data.current } previous={ data.previous } />
+					<OpportunityBucketsSection current={ data.current } />
+				</>
+			) }
+		</TabStateView>
+	);
+};
 
 export default ConversionTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -28,6 +28,8 @@ import type { DateRange } from '../state/useDateRange';
 import useConversionData from '../hooks/useConversionData';
 import TabStateView from './components/TabStateView';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
+import ConversionPreviewBanner from './conversion/ConversionPreviewBanner';
+import CohortRetentionFreshnessCallout from './conversion/CohortRetentionFreshnessCallout';
 import ReaderLifecycleSection from './conversion/ReaderLifecycleSection';
 import PerJourneyConversionFunnelsSection from './conversion/PerJourneyConversionFunnelsSection';
 import WhereConversionsComeFromSection from './conversion/WhereConversionsComeFromSection';
@@ -57,6 +59,8 @@ const ConversionTab = ( { range, previousRange }: ConversionTabProps ) => {
 		>
 			{ data && (
 				<>
+					<ConversionPreviewBanner />
+					<CohortRetentionFreshnessCallout />
 					<ReaderLifecycleSection current={ data.current } />
 					<PerJourneyConversionFunnelsSection current={ data.current } />
 					<WhereConversionsComeFromSection current={ data.current } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/InfoCallout.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/InfoCallout.tsx
@@ -7,9 +7,13 @@
  * explainer share one treatment.
  *
  * When `dismissible`, dismissal persists per-publisher in localStorage under
- * `storageKey`, so the callout stays hidden across page loads. Non-dismissible
- * callouts (e.g. the Advertising data-lag note, whose content varies with the
- * selected date range) always render.
+ * `storageKey`, so the callout stays hidden across page loads. Pass
+ * `persist={ false }` for session-only dismissal — the callout reappears on the
+ * next page load (e.g. the Conversion preview banner / cohort-freshness note,
+ * which should re-announce each session). Non-dismissible callouts (e.g. the
+ * Advertising data-lag note, whose content varies with the selected date range)
+ * always render. `className` appends a variant class to the root (e.g. a
+ * different background) while keeping the shared markup and dismiss affordance.
  */
 
 /**
@@ -26,10 +30,17 @@ export interface InfoCalloutProps {
 	heading: string;
 	/** Body content (paragraphs, lists, etc.). */
 	children: React.ReactNode;
-	/** Show a dismiss (X) button. Requires `storageKey`. */
+	/** Show a dismiss (X) button. */
 	dismissible?: boolean;
-	/** Namespaces the persisted dismissal flag in localStorage. Required when dismissible. */
+	/**
+	 * Persist dismissal in localStorage (default `true`). When `false`,
+	 * dismissal is session-only and the callout reappears on the next load.
+	 */
+	persist?: boolean;
+	/** Namespaces the persisted dismissal flag in localStorage. Required when dismissible && persist. */
 	storageKey?: string;
+	/** Extra class appended to the callout root, e.g. a color variant. */
+	className?: string;
 }
 
 const readDismissed = ( storageKey?: string ): boolean => {
@@ -43,26 +54,26 @@ const readDismissed = ( storageKey?: string ): boolean => {
 	}
 };
 
-const InfoCallout = ( { heading, children, dismissible = false, storageKey }: InfoCalloutProps ) => {
-	const [ dismissed, setDismissed ] = useState( () => dismissible && readDismissed( storageKey ) );
+const InfoCallout = ( { heading, children, dismissible = false, persist = true, storageKey, className }: InfoCalloutProps ) => {
+	const [ dismissed, setDismissed ] = useState( () => dismissible && persist && readDismissed( storageKey ) );
 
 	const dismiss = useCallback( () => {
 		setDismissed( true );
-		if ( storageKey && typeof window !== 'undefined' ) {
+		if ( persist && storageKey && typeof window !== 'undefined' ) {
 			try {
 				window.localStorage.setItem( STORAGE_PREFIX + storageKey, '1' );
 			} catch ( e ) {
 				// Storage unavailable (private mode / quota) — dismissal stays session-only.
 			}
 		}
-	}, [ storageKey ] );
+	}, [ persist, storageKey ] );
 
 	if ( dismissed ) {
 		return null;
 	}
 
 	return (
-		<div className="newspack-insights__info-callout" role="note">
+		<div className={ className ? `newspack-insights__info-callout ${ className }` : 'newspack-insights__info-callout' } role="note">
 			<Icon icon={ info } className="newspack-insights__info-callout-icon" />
 			<div className="newspack-insights__info-callout-body">
 				<p className="newspack-insights__info-callout-title">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -548,6 +548,11 @@
 		&:hover {
 			color: wp-colors.$gray-900;
 		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: 2px;
+		}
 	}
 }
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/loading-messages.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/loading-messages.ts
@@ -30,6 +30,12 @@ export const TAB_LOADING_MESSAGES = {
 		{ text: __( 'Analyzing reading patterns…', 'newspack-plugin' ), delay: 6000 },
 		{ text: __( 'Almost there…', 'newspack-plugin' ), delay: 12000 },
 	],
+	conversion: [
+		{ text: __( 'Loading conversion journey…', 'newspack-plugin' ), delay: 0 },
+		{ text: __( 'Aggregating across all surfaces…', 'newspack-plugin' ), delay: 250 },
+		{ text: __( 'Joining WooCommerce orders…', 'newspack-plugin' ), delay: 6000 },
+		{ text: __( 'Almost there…', 'newspack-plugin' ), delay: 12000 },
+	],
 	gates: [
 		{ text: __( 'Loading gate performance…', 'newspack-plugin' ), delay: 0 },
 		{ text: __( 'Querying gate impressions…', 'newspack-plugin' ), delay: 250 },

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionFreshnessCallout.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionFreshnessCallout.tsx
@@ -1,0 +1,59 @@
+/**
+ * CohortRetentionFreshnessCallout (NPPD-1609).
+ *
+ * Small info callout below the Phase 1 preview banner and above Section 1,
+ * explaining the pre-warm-and-cache pattern so publishers interpret the
+ * Section 5 cohort-retention curves correctly (weekly snapshot, not
+ * real-time) before they read them.
+ *
+ * Reuses the shared `__info-callout` visual treatment, but with session-only
+ * dismissal per the spec ("one-time display per session") — a self-contained
+ * `useState`, like the DirectVsInfluencedCallout, rather than the shared
+ * InfoCallout whose dismissible mode persists in localStorage.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Icon, closeSmall, info } from '@wordpress/icons';
+
+const CohortRetentionFreshnessCallout = () => {
+	const [ visible, setVisible ] = useState( true );
+	if ( ! visible ) {
+		return null;
+	}
+	return (
+		<div className="newspack-insights__info-callout" role="note">
+			<Icon icon={ info } className="newspack-insights__info-callout-icon" />
+			<div className="newspack-insights__info-callout-body">
+				<p className="newspack-insights__info-callout-title">
+					<strong>{ __( 'About cohort retention freshness', 'newspack-plugin' ) }</strong>
+				</p>
+				<p>
+					{ __(
+						'Cohort retention metrics are pre-computed and refreshed weekly. The values on this page reflect the most recent weekly snapshot, not real-time data. This is intentional — the queries that produce cohort curves are too expensive to run on every page load, and weekly granularity is the appropriate cadence for retention analysis.',
+						'newspack-plugin'
+					) }
+				</p>
+				<p>
+					{ __(
+						'Other metrics on this tab (funnels, source mix, conversion rates, time-to-convert) update with each page view within the selected window.',
+						'newspack-plugin'
+					) }
+				</p>
+			</div>
+			<button
+				type="button"
+				className="newspack-insights__info-callout-dismiss"
+				onClick={ () => setVisible( false ) }
+				aria-label={ __( 'Dismiss', 'newspack-plugin' ) }
+			>
+				<Icon icon={ closeSmall } />
+			</button>
+		</div>
+	);
+};
+
+export default CohortRetentionFreshnessCallout;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionFreshnessCallout.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionFreshnessCallout.tsx
@@ -6,54 +6,35 @@
  * Section 5 cohort-retention curves correctly (weekly snapshot, not
  * real-time) before they read them.
  *
- * Reuses the shared `__info-callout` visual treatment, but with session-only
- * dismissal per the spec ("one-time display per session") — a self-contained
- * `useState`, like the DirectVsInfluencedCallout, rather than the shared
- * InfoCallout whose dismissible mode persists in localStorage.
+ * A thin wrapper over the shared InfoCallout with session-only dismissal
+ * (`persist={ false }`) per the spec ("one-time display per session").
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import { Icon, closeSmall, info } from '@wordpress/icons';
 
-const CohortRetentionFreshnessCallout = () => {
-	const [ visible, setVisible ] = useState( true );
-	if ( ! visible ) {
-		return null;
-	}
-	return (
-		<div className="newspack-insights__info-callout" role="note">
-			<Icon icon={ info } className="newspack-insights__info-callout-icon" />
-			<div className="newspack-insights__info-callout-body">
-				<p className="newspack-insights__info-callout-title">
-					<strong>{ __( 'About cohort retention freshness', 'newspack-plugin' ) }</strong>
-				</p>
-				<p>
-					{ __(
-						'Cohort retention metrics are pre-computed and refreshed weekly. The values on this page reflect the most recent weekly snapshot, not real-time data. This is intentional — the queries that produce cohort curves are too expensive to run on every page load, and weekly granularity is the appropriate cadence for retention analysis.',
-						'newspack-plugin'
-					) }
-				</p>
-				<p>
-					{ __(
-						'Other metrics on this tab (funnels, source mix, conversion rates, time-to-convert) update with each page view within the selected window.',
-						'newspack-plugin'
-					) }
-				</p>
-			</div>
-			<button
-				type="button"
-				className="newspack-insights__info-callout-dismiss"
-				onClick={ () => setVisible( false ) }
-				aria-label={ __( 'Dismiss', 'newspack-plugin' ) }
-			>
-				<Icon icon={ closeSmall } />
-			</button>
-		</div>
-	);
-};
+/**
+ * Internal dependencies
+ */
+import InfoCallout from '../components/InfoCallout';
+
+const CohortRetentionFreshnessCallout = () => (
+	<InfoCallout heading={ __( 'About cohort retention freshness', 'newspack-plugin' ) } dismissible persist={ false }>
+		<p>
+			{ __(
+				'Cohort retention metrics are pre-computed and refreshed weekly. The values on this page reflect the most recent weekly snapshot, not real-time data. This is intentional — the queries that produce cohort curves are too expensive to run on every page load, and weekly granularity is the appropriate cadence for retention analysis.',
+				'newspack-plugin'
+			) }
+		</p>
+		<p>
+			{ __(
+				'Other metrics on this tab (funnels, source mix, conversion rates, time-to-convert) update with each page view within the selected window.',
+				'newspack-plugin'
+			) }
+		</p>
+	</InfoCallout>
+);
 
 export default CohortRetentionFreshnessCallout;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Render smoke test for CohortRetentionSection (Section 5).
+ *
+ * NOTE: `.test.tsx` is not collected by CI (NPPD-1683).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CohortRetentionSection from './CohortRetentionSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'CohortRetentionSection', () => {
+	it( 'renders the heading, both cohort titles, and the empty state', () => {
+		render( <CohortRetentionSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'Cohort retention' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Registration → conversion' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Subscriber retention' } ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'Cohort data will appear after the first weekly refresh.' ) ).toHaveLength( 2 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -1,0 +1,46 @@
+/**
+ * CohortRetentionSection (NPPD-1609, Section 5).
+ *
+ * Two stacked multi-series cohort LineCharts (registration → conversion,
+ * subscriber retention), each with a hardcoded reference line. Snapshot —
+ * not affected by the date picker; refreshed weekly. Scaffold renders
+ * header + caption + an empty placeholder; the LineChart viz (with
+ * reference line) is wired in the following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+
+export interface CohortRetentionSectionProps {
+	current: ConversionWindow;
+}
+
+const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => {
+	const pending = current.registration_to_conversion_cohort.pending;
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--cohort-retention"
+			aria-labelledby="newspack-insights-conversion-cohort-heading"
+		>
+			<h2 id="newspack-insights-conversion-cohort-heading" className="newspack-insights__section-heading">
+				{ __( 'Cohort retention', 'newspack-plugin' ) }
+			</h2>
+			<p className="newspack-insights__section-caption">
+				{ __(
+					'Retention curves by monthly cohort. The vertical axis is the share of each cohort still on a given lifecycle stage at each point in time. Updated weekly (see callout above).',
+					'newspack-plugin'
+				) }
+			</p>
+			<div className="newspack-insights__viz-placeholder" data-pending={ pending } />
+		</section>
+	);
+};
+
+export default CohortRetentionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -43,6 +43,7 @@ const CohortChart = ( { title, data }: CohortChartProps ) => (
 		<LineChart
 			series={ toCohortSeries( data ) }
 			referenceLine={ data.reference_line }
+			yMax={ 1 }
 			emptyMessage={ __( 'Cohort data will appear after the first weekly refresh.', 'newspack-plugin' ) }
 		/>
 	</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -2,10 +2,9 @@
  * CohortRetentionSection (NPPD-1609, Section 5).
  *
  * Two stacked multi-series cohort LineCharts (registration → conversion,
- * subscriber retention), each with a hardcoded reference line. Snapshot —
- * not affected by the date picker; refreshed weekly. Scaffold renders
- * header + caption + an empty placeholder; the LineChart viz (with
- * reference line) is wired in the following commit.
+ * subscriber retention), each with a hardcoded reference-line target.
+ * Snapshot — refreshed weekly, independent of the date picker. Phase 1
+ * renders the empty state per chart.
  */
 
 /**
@@ -16,31 +15,58 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionWindow } from '../../api/conversion';
+import type { ConversionCohortData } from '../../api/conversion';
+import LineChart, { type LineSeries } from './viz/LineChart';
 
 export interface CohortRetentionSectionProps {
-	current: ConversionWindow;
+	current: {
+		registration_to_conversion_cohort: ConversionCohortData;
+		subscriber_retention_cohort: ConversionCohortData;
+	};
 }
 
-const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => {
-	const pending = current.registration_to_conversion_cohort.pending;
-	return (
-		<section
-			className="newspack-insights__section newspack-insights__section--cohort-retention"
-			aria-labelledby="newspack-insights-conversion-cohort-heading"
-		>
-			<h2 id="newspack-insights-conversion-cohort-heading" className="newspack-insights__section-heading">
-				{ __( 'Cohort retention', 'newspack-plugin' ) }
-			</h2>
-			<p className="newspack-insights__section-caption">
-				{ __(
-					'Retention curves by monthly cohort. The vertical axis is the share of each cohort still on a given lifecycle stage at each point in time. Updated weekly (see callout above).',
-					'newspack-plugin'
-				) }
-			</p>
-			<div className="newspack-insights__viz-placeholder" data-pending={ pending } />
-		</section>
-	);
-};
+/** Map cohort series (period → value) to LineChart series. */
+const toCohortSeries = ( data: ConversionCohortData ): LineSeries[] =>
+	data.cohorts.map( cohort => ( {
+		name: cohort.label,
+		points: cohort.points.map( p => ( { label: String( p.period ), value: p.value } ) ),
+	} ) );
+
+interface CohortChartProps {
+	title: string;
+	data: ConversionCohortData;
+}
+
+const CohortChart = ( { title, data }: CohortChartProps ) => (
+	<div className="newspack-insights__conversion-cohort-cell">
+		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
+		<LineChart
+			series={ toCohortSeries( data ) }
+			referenceLine={ data.reference_line }
+			emptyMessage={ __( 'Cohort data will appear after the first weekly refresh.', 'newspack-plugin' ) }
+		/>
+	</div>
+);
+
+const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--cohort-retention"
+		aria-labelledby="newspack-insights-conversion-cohort-heading"
+	>
+		<h2 id="newspack-insights-conversion-cohort-heading" className="newspack-insights__section-heading">
+			{ __( 'Cohort retention', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Retention curves by monthly cohort. The vertical axis is the share of each cohort still on a given lifecycle stage at each point in time. Updated weekly (see callout above).',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__conversion-cohort-stack">
+			<CohortChart title={ __( 'Registration → conversion', 'newspack-plugin' ) } data={ current.registration_to_conversion_cohort } />
+			<CohortChart title={ __( 'Subscriber retention', 'newspack-plugin' ) } data={ current.subscriber_retention_cohort } />
+		</div>
+	</section>
+);
 
 export default CohortRetentionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionPreviewBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionPreviewBanner.tsx
@@ -1,0 +1,50 @@
+/**
+ * ConversionPreviewBanner (NPPD-1609, Phase 1 only).
+ *
+ * Top-of-tab banner rendered above Section 1 during the placeholder phase,
+ * signaling that the tab's structure is final but real data is pending.
+ * Removed entirely when Phase 2 lands.
+ *
+ * Dismissal is session-only per the spec ("dismissible via X but reappears
+ * on page reload — don't persist"): a self-contained `useState`, like the
+ * Gates / Prompts DirectVsInfluencedCallout, rather than the shared
+ * InfoCallout whose dismissible mode persists in localStorage.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Icon, closeSmall, info } from '@wordpress/icons';
+
+const ConversionPreviewBanner = () => {
+	const [ visible, setVisible ] = useState( true );
+	if ( ! visible ) {
+		return null;
+	}
+	return (
+		<div className="newspack-insights__conversion-preview-banner" role="note">
+			<Icon icon={ info } className="newspack-insights__conversion-preview-banner-icon" />
+			<div className="newspack-insights__conversion-preview-banner-body">
+				<p className="newspack-insights__conversion-preview-banner-title">
+					<strong>{ __( 'This tab is live in preview mode.', 'newspack-plugin' ) }</strong>{ ' ' }
+					{ __(
+						'Real-time metrics will populate once BigQuery integration is complete. The structure, sections, and visualizations are final.',
+						'newspack-plugin'
+					) }
+				</p>
+			</div>
+			<button
+				type="button"
+				className="newspack-insights__conversion-preview-banner-dismiss"
+				onClick={ () => setVisible( false ) }
+				aria-label={ __( 'Dismiss', 'newspack-plugin' ) }
+			>
+				<Icon icon={ closeSmall } />
+			</button>
+		</div>
+	);
+};
+
+export default ConversionPreviewBanner;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionPreviewBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionPreviewBanner.tsx
@@ -5,46 +5,36 @@
  * signaling that the tab's structure is final but real data is pending.
  * Removed entirely when Phase 2 lands.
  *
- * Dismissal is session-only per the spec ("dismissible via X but reappears
- * on page reload — don't persist"): a self-contained `useState`, like the
- * Gates / Prompts DirectVsInfluencedCallout, rather than the shared
- * InfoCallout whose dismissible mode persists in localStorage.
+ * A thin wrapper over the shared InfoCallout: session-only dismissal
+ * (`persist={ false }`, reappears on reload per the spec) plus a light-blue
+ * `--preview` variant class to distinguish it from the gray freshness note
+ * below it.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import { Icon, closeSmall, info } from '@wordpress/icons';
 
-const ConversionPreviewBanner = () => {
-	const [ visible, setVisible ] = useState( true );
-	if ( ! visible ) {
-		return null;
-	}
-	return (
-		<div className="newspack-insights__conversion-preview-banner" role="note">
-			<Icon icon={ info } className="newspack-insights__conversion-preview-banner-icon" />
-			<div className="newspack-insights__conversion-preview-banner-body">
-				<p className="newspack-insights__conversion-preview-banner-title">
-					<strong>{ __( 'This tab is live in preview mode.', 'newspack-plugin' ) }</strong>{ ' ' }
-					{ __(
-						'Real-time metrics will populate once BigQuery integration is complete. The structure, sections, and visualizations are final.',
-						'newspack-plugin'
-					) }
-				</p>
-			</div>
-			<button
-				type="button"
-				className="newspack-insights__conversion-preview-banner-dismiss"
-				onClick={ () => setVisible( false ) }
-				aria-label={ __( 'Dismiss', 'newspack-plugin' ) }
-			>
-				<Icon icon={ closeSmall } />
-			</button>
-		</div>
-	);
-};
+/**
+ * Internal dependencies
+ */
+import InfoCallout from '../components/InfoCallout';
+
+const ConversionPreviewBanner = () => (
+	<InfoCallout
+		heading={ __( 'This tab is live in preview mode.', 'newspack-plugin' ) }
+		dismissible
+		persist={ false }
+		className="newspack-insights__info-callout--preview"
+	>
+		<p>
+			{ __(
+				'Real-time metrics will populate once BigQuery integration is complete. The structure, sections, and visualizations are final.',
+				'newspack-plugin'
+			) }
+		</p>
+	</InfoCallout>
+);
 
 export default ConversionPreviewBanner;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * Render smoke test for ConversionRateTrendsSection (Section 6).
+ *
+ * NOTE: `.test.tsx` is not collected by CI (NPPD-1683).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ConversionRateTrendsSection from './ConversionRateTrendsSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'ConversionRateTrendsSection', () => {
+	it( 'renders the heading and the weekly-trends empty state', () => {
+		render( <ConversionRateTrendsSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'Conversion rate trends' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Weekly trends will appear once the window contains at least 4 weeks of data.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -1,0 +1,45 @@
+/**
+ * ConversionRateTrendsSection (NPPD-1609, Section 6).
+ *
+ * A single full-width multi-series weekly LineChart (registration rate,
+ * subscription attempt rate). Window-scoped. Scaffold renders header +
+ * caption + an empty placeholder; the LineChart viz is wired in the
+ * following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+
+export interface ConversionRateTrendsSectionProps {
+	current: ConversionWindow;
+}
+
+const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionProps ) => {
+	const pending = current.weekly_conversion_rates.pending;
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--rate-trends"
+			aria-labelledby="newspack-insights-conversion-rate-trends-heading"
+		>
+			<h2 id="newspack-insights-conversion-rate-trends-heading" className="newspack-insights__section-heading">
+				{ __( 'Conversion rate trends', 'newspack-plugin' ) }
+			</h2>
+			<p className="newspack-insights__section-caption">
+				{ __(
+					'Weekly conversion rates across the selected window. Useful for spotting acceleration, plateaus, or seasonality.',
+					'newspack-plugin'
+				) }
+			</p>
+			<div className="newspack-insights__viz-placeholder" data-pending={ pending } />
+		</section>
+	);
+};
+
+export default ConversionRateTrendsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionWeeklyTrendsData } from '../../api/conversion';
+import type { ConversionWeekPoint, ConversionWeeklyTrendsData } from '../../api/conversion';
 import LineChart, { type LineSeries } from './viz/LineChart';
 
 export interface ConversionRateTrendsSectionProps {
@@ -23,17 +23,31 @@ export interface ConversionRateTrendsSectionProps {
 	};
 }
 
-/** Split the weekly rows into the two tracked rate series. */
-const toTrendSeries = ( data: ConversionWeeklyTrendsData ): LineSeries[] => [
-	{
-		name: __( 'Registration rate', 'newspack-plugin' ),
-		points: data.weeks.map( w => ( { label: w.week, value: w.registration_rate } ) ),
+/**
+ * The server's `series` array is authoritative for which rate series render
+ * and in what order. Each key maps to its display label and the week-row field
+ * it reads; unknown keys are skipped so a Phase 2 series addition can't crash
+ * the chart before the UI knows about it.
+ */
+const SERIES_BY_KEY: Record< string, { label: string; value: ( w: ConversionWeekPoint ) => number } > = {
+	registration_rate: {
+		label: __( 'Registration rate', 'newspack-plugin' ),
+		value: w => w.registration_rate,
 	},
-	{
-		name: __( 'Subscription attempt rate', 'newspack-plugin' ),
-		points: data.weeks.map( w => ( { label: w.week, value: w.subscription_attempt_rate } ) ),
+	subscription_attempt_rate: {
+		label: __( 'Subscription attempt rate', 'newspack-plugin' ),
+		value: w => w.subscription_attempt_rate,
 	},
-];
+};
+
+/** Build the LineChart series from the payload's declared series keys. */
+const toTrendSeries = ( data: ConversionWeeklyTrendsData ): LineSeries[] =>
+	data.series
+		.filter( key => SERIES_BY_KEY[ key ] )
+		.map( key => ( {
+			name: SERIES_BY_KEY[ key ].label,
+			points: data.weeks.map( w => ( { label: w.week, value: SERIES_BY_KEY[ key ].value( w ) } ) ),
+		} ) );
 
 const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionProps ) => (
 	<section

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -1,10 +1,9 @@
 /**
  * ConversionRateTrendsSection (NPPD-1609, Section 6).
  *
- * A single full-width multi-series weekly LineChart (registration rate,
- * subscription attempt rate). Window-scoped. Scaffold renders header +
- * caption + an empty placeholder; the LineChart viz is wired in the
- * following commit.
+ * A single full-width multi-series weekly LineChart: registration
+ * conversion rate and subscription attempt rate over the window. Phase 1
+ * renders the empty state.
  */
 
 /**
@@ -15,31 +14,46 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionWindow } from '../../api/conversion';
+import type { ConversionWeeklyTrendsData } from '../../api/conversion';
+import LineChart, { type LineSeries } from './viz/LineChart';
 
 export interface ConversionRateTrendsSectionProps {
-	current: ConversionWindow;
+	current: {
+		weekly_conversion_rates: ConversionWeeklyTrendsData;
+	};
 }
 
-const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionProps ) => {
-	const pending = current.weekly_conversion_rates.pending;
-	return (
-		<section
-			className="newspack-insights__section newspack-insights__section--rate-trends"
-			aria-labelledby="newspack-insights-conversion-rate-trends-heading"
-		>
-			<h2 id="newspack-insights-conversion-rate-trends-heading" className="newspack-insights__section-heading">
-				{ __( 'Conversion rate trends', 'newspack-plugin' ) }
-			</h2>
-			<p className="newspack-insights__section-caption">
-				{ __(
-					'Weekly conversion rates across the selected window. Useful for spotting acceleration, plateaus, or seasonality.',
-					'newspack-plugin'
-				) }
-			</p>
-			<div className="newspack-insights__viz-placeholder" data-pending={ pending } />
-		</section>
-	);
-};
+/** Split the weekly rows into the two tracked rate series. */
+const toTrendSeries = ( data: ConversionWeeklyTrendsData ): LineSeries[] => [
+	{
+		name: __( 'Registration rate', 'newspack-plugin' ),
+		points: data.weeks.map( w => ( { label: w.week, value: w.registration_rate } ) ),
+	},
+	{
+		name: __( 'Subscription attempt rate', 'newspack-plugin' ),
+		points: data.weeks.map( w => ( { label: w.week, value: w.subscription_attempt_rate } ) ),
+	},
+];
+
+const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--rate-trends"
+		aria-labelledby="newspack-insights-conversion-rate-trends-heading"
+	>
+		<h2 id="newspack-insights-conversion-rate-trends-heading" className="newspack-insights__section-heading">
+			{ __( 'Conversion rate trends', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Weekly conversion rates across the selected window. Useful for spotting acceleration, plateaus, or seasonality.',
+				'newspack-plugin'
+			) }
+		</p>
+		<LineChart
+			series={ toTrendSeries( current.weekly_conversion_rates ) }
+			emptyMessage={ __( 'Weekly trends will appear once the window contains at least 4 weeks of data.', 'newspack-plugin' ) }
+		/>
+	</section>
+);
 
 export default ConversionRateTrendsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Render smoke test for CrossTabInfluencedAttributionSection (Section 7) —
+ * the only section with comparison deltas.
+ *
+ * NOTE: `.test.tsx` is not collected by CI (NPPD-1683).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CrossTabInfluencedAttributionSection from './CrossTabInfluencedAttributionSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'CrossTabInfluencedAttributionSection', () => {
+	it( 'renders the heading and the four influenced-rate scorecards', () => {
+		render( <CrossTabInfluencedAttributionSection current={ makeConversionWindow() } previous={ null } /> );
+		expect( screen.getByRole( 'heading', { name: 'Cross-tab influenced attribution' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Influenced Registration Rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Influenced Newsletter Signup Rate' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders with a comparison window provided', () => {
+		render( <CrossTabInfluencedAttributionSection current={ makeConversionWindow() } previous={ makeConversionWindow() } /> );
+		expect( screen.getByText( 'Influenced Subscription Rate' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
@@ -1,0 +1,80 @@
+/**
+ * CrossTabInfluencedAttributionSection (NPPD-1609, Section 7).
+ *
+ * Four influenced-rate scorecards centralized from the Gates and Prompts
+ * tabs. This is the only Conversion Journey section with comparison
+ * deltas, so it threads the `previous` window into each MetricCard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface CrossTabInfluencedAttributionSectionProps {
+	current: ConversionWindow;
+	previous: ConversionWindow | null;
+}
+
+const CrossTabInfluencedAttributionSection = ( { current, previous }: CrossTabInfluencedAttributionSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--influenced-attribution"
+		aria-labelledby="newspack-insights-conversion-influenced-heading"
+	>
+		<h2 id="newspack-insights-conversion-influenced-heading" className="newspack-insights__section-heading">
+			{ __( 'Cross-tab influenced attribution', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Influenced conversion rates from your Gates and Prompts tabs, centralized so you don’t have to bounce between tabs to compare. Influenced means the reader saw a gate or prompt in the lookback window before converting in a later session.',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Influenced Registration Rate', 'newspack-plugin' ),
+					description: __( '% of new registrations whose user saw a gate or prompt in the 7 days prior', 'newspack-plugin' ),
+					current: current.influenced_registration_rate_7d,
+					previous: previous?.influenced_registration_rate_7d,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Influenced Subscription Rate', 'newspack-plugin' ),
+					description: __( '% of new subscribers whose user saw a subscription-intent surface in the 14 days prior', 'newspack-plugin' ),
+					current: current.influenced_subscription_rate_14d,
+					previous: previous?.influenced_subscription_rate_14d,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Influenced Donation Rate', 'newspack-plugin' ),
+					description: __( '% of new donors whose user saw a donation-intent surface in the 14 days prior', 'newspack-plugin' ),
+					current: current.influenced_donation_rate_14d,
+					previous: previous?.influenced_donation_rate_14d,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Influenced Newsletter Signup Rate', 'newspack-plugin' ),
+					description: __(
+						'% of new newsletter signups whose user saw a newsletter-intent surface in the 7 days prior',
+						'newspack-plugin'
+					),
+					current: current.influenced_newsletter_rate_7d,
+					previous: previous?.influenced_newsletter_rate_7d,
+				} ) }
+			/>
+		</div>
+	</section>
+);
+
+export default CrossTabInfluencedAttributionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Render smoke test for HowLongConversionsTakeSection (Section 4),
+ * including the visibility-gated 4.4 subscriber → donor lag curve.
+ *
+ * NOTE: `.test.tsx` is not collected by CI (NPPD-1683).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import HowLongConversionsTakeSection from './HowLongConversionsTakeSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'HowLongConversionsTakeSection', () => {
+	it( 'renders the heading and all four curve titles', () => {
+		render( <HowLongConversionsTakeSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'How long conversions take' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Time to register' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Subscriber → donor lag' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the lag empty-state note when 4.4 is hidden', () => {
+		render( <HowLongConversionsTakeSection current={ makeConversionWindow( { lagVisibility: 'hidden' } ) } /> );
+		expect( screen.getByText( /Subscriber-to-donor lag appears when at least 50 readers/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -65,18 +65,21 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 				<CurveCell title={ __( 'Time to register', 'newspack-plugin' ) }>
 					<LineChart
 						points={ toLinePoints( current.time_to_register_distribution.points ) }
+						yMax={ 1 }
 						emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this window.', 'newspack-plugin' ) }
 					/>
 				</CurveCell>
 				<CurveCell title={ __( 'Time to subscribe', 'newspack-plugin' ) }>
 					<LineChart
 						series={ toLineSeries( current.time_to_subscribe_distribution ) }
+						yMax={ 1 }
 						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
 					/>
 				</CurveCell>
 				<CurveCell title={ __( 'Time to donate', 'newspack-plugin' ) }>
 					<LineChart
 						series={ toLineSeries( current.time_to_donate_distribution ) }
+						yMax={ 1 }
 						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
 					/>
 				</CurveCell>
@@ -88,6 +91,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					) : (
 						<LineChart
 							points={ toLinePoints( lag.points ) }
+							yMax={ 1 }
 							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
 						/>
 					) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -1,0 +1,46 @@
+/**
+ * HowLongConversionsTakeSection (NPPD-1609, Section 4).
+ *
+ * A 2×2 grid of cumulative-distribution LineCharts: time to register, time
+ * to subscribe (by source), time to donate (by source), and the
+ * visibility-gated subscriber → donor lag. Scaffold renders header +
+ * caption + an empty placeholder; the LineChart viz is wired in the
+ * following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+
+export interface HowLongConversionsTakeSectionProps {
+	current: ConversionWindow;
+}
+
+const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSectionProps ) => {
+	const lagHidden = current.subscriber_to_donor_lag_distribution.visibility === 'hidden';
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--time-to-convert"
+			aria-labelledby="newspack-insights-conversion-time-to-convert-heading"
+		>
+			<h2 id="newspack-insights-conversion-time-to-convert-heading" className="newspack-insights__section-heading">
+				{ __( 'How long conversions take', 'newspack-plugin' ) }
+			</h2>
+			<p className="newspack-insights__section-caption">
+				{ __(
+					'Cumulative conversion curves per cohort. Each line shows what percentage of readers had converted by day N. Steeper early curves mean faster conversion; flatter curves mean longer tails. Median is where the line crosses 50%.',
+					'newspack-plugin'
+				) }
+			</p>
+			<div className="newspack-insights__viz-placeholder" data-lag-hidden={ lagHidden } />
+		</section>
+	);
+};
+
+export default HowLongConversionsTakeSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -1,11 +1,11 @@
 /**
  * HowLongConversionsTakeSection (NPPD-1609, Section 4).
  *
- * A 2×2 grid of cumulative-distribution LineCharts: time to register, time
- * to subscribe (by source), time to donate (by source), and the
- * visibility-gated subscriber → donor lag. Scaffold renders header +
- * caption + an empty placeholder; the LineChart viz is wired in the
- * following commit.
+ * A 2×2 grid of cumulative-distribution LineCharts: time to register
+ * (single series), time to subscribe and time to donate (three series by
+ * source), and the visibility-gated subscriber → donor lag. Each line shows
+ * the share of the cohort converted by day N. Phase 1 renders the empty
+ * state per chart.
  */
 
 /**
@@ -16,14 +16,37 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionWindow } from '../../api/conversion';
+import type { ConversionCumulativeMulti, ConversionCumulativePoint, ConversionWindow } from '../../api/conversion';
+import { sourceLabel } from './labels';
+import LineChart, { type LinePoint, type LineSeries } from './viz/LineChart';
 
 export interface HowLongConversionsTakeSectionProps {
 	current: ConversionWindow;
 }
 
+/** Map cumulative points to the LineChart's x-label / y-value shape. */
+const toLinePoints = ( points: ConversionCumulativePoint[] ): LinePoint[] =>
+	points.map( p => ( { label: String( p.day ), value: p.cumulative_pct } ) );
+
+/** Map a multi-series distribution to per-source LineChart series. */
+const toLineSeries = ( data: ConversionCumulativeMulti ): LineSeries[] =>
+	data.groups.map( group => ( { name: sourceLabel( group.label ), points: toLinePoints( group.points ) } ) );
+
+interface CurveCellProps {
+	title: string;
+	children: React.ReactNode;
+}
+
+const CurveCell = ( { title, children }: CurveCellProps ) => (
+	<div className="newspack-insights__conversion-curve-cell">
+		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
+		{ children }
+	</div>
+);
+
 const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSectionProps ) => {
-	const lagHidden = current.subscriber_to_donor_lag_distribution.visibility === 'hidden';
+	const lag = current.subscriber_to_donor_lag_distribution;
+	const lagHidden = lag.visibility === 'hidden';
 	return (
 		<section
 			className="newspack-insights__section newspack-insights__section--time-to-convert"
@@ -38,7 +61,38 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					'newspack-plugin'
 				) }
 			</p>
-			<div className="newspack-insights__viz-placeholder" data-lag-hidden={ lagHidden } />
+			<div className="newspack-insights__conversion-curve-grid">
+				<CurveCell title={ __( 'Time to register', 'newspack-plugin' ) }>
+					<LineChart
+						points={ toLinePoints( current.time_to_register_distribution.points ) }
+						emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this window.', 'newspack-plugin' ) }
+					/>
+				</CurveCell>
+				<CurveCell title={ __( 'Time to subscribe', 'newspack-plugin' ) }>
+					<LineChart
+						series={ toLineSeries( current.time_to_subscribe_distribution ) }
+						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+					/>
+				</CurveCell>
+				<CurveCell title={ __( 'Time to donate', 'newspack-plugin' ) }>
+					<LineChart
+						series={ toLineSeries( current.time_to_donate_distribution ) }
+						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+					/>
+				</CurveCell>
+				<CurveCell title={ __( 'Subscriber → donor lag', 'newspack-plugin' ) }>
+					{ lagHidden ? (
+						<p className="newspack-insights__conversion-gated-note">
+							{ __( 'Subscriber-to-donor lag appears when at least 50 readers have both subscribed and donated.', 'newspack-plugin' ) }
+						</p>
+					) : (
+						<LineChart
+							points={ toLinePoints( lag.points ) }
+							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+						/>
+					) }
+				</CurveCell>
+			</div>
 		</section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Render smoke test for OpportunityBucketsSection (Section 8): the three
+ * snapshot scorecards and the 8.4 top-pages table empty-state row.
+ *
+ * NOTE: `.test.tsx` is not collected by CI (NPPD-1683).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import OpportunityBucketsSection from './OpportunityBucketsSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'OpportunityBucketsSection', () => {
+	it( 'renders the heading and the three opportunity scorecards', () => {
+		render( <OpportunityBucketsSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'Opportunity buckets' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Stale Registered Readers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'At-Risk Subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Lapsed Donors' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the top-pages table empty-state row', () => {
+		render( <OpportunityBucketsSection current={ makeConversionWindow() } /> );
+		expect( screen.getByText( /No qualifying pages yet/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -10,7 +10,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -114,9 +114,13 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 				getRowKey={ row => row.post_id }
 				defaultSortKey="pageviews"
 				initialRowLimit={ TOP_PAGES_ROW_LIMIT }
-				emptyMessage={ __(
-					'No qualifying pages yet. Pages with at least 100 pageviews and a measurable conversion rate will appear here.',
-					'newspack-plugin'
+				emptyMessage={ sprintf(
+					/* translators: %s: minimum pageview count for a page to qualify (formatted). */
+					__(
+						'No qualifying pages yet. Pages with at least %s pageviews and a measurable conversion rate will appear here.',
+						'newspack-plugin'
+					),
+					formatNumber( current.top_pages_no_conversion.threshold_pageviews )
 				) }
 			/>
 			<p className="newspack-insights__conversion-top-pages-note">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -4,8 +4,7 @@
  * Three snapshot scorecards (stale registered readers, at-risk
  * subscribers, lapsed donors) above a full-width "top pages that don't
  * convert" table. The scorecards are current-state counts — no comparison
- * deltas. Scaffold renders the three cards + a table placeholder; the
- * SortableTable is wired in the following commit.
+ * deltas. Phase 1 renders the table's empty-state row.
  */
 
 /**
@@ -16,13 +15,59 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionWindow } from '../../api/conversion';
+import type { ConversionTopPageRow, ConversionWindow } from '../../api/conversion';
 import MetricCard from '../components/MetricCard';
+import { formatNumber, formatPercent } from '../components/format';
 import { scalarToMetricCardProps } from './scalarToCard';
+import SortableTable, { type SortableColumn } from './viz/SortableTable';
 
 export interface OpportunityBucketsSectionProps {
 	current: ConversionWindow;
 }
+
+const TOP_PAGES_ROW_LIMIT = 25;
+
+const TOP_PAGES_COLUMNS: SortableColumn< ConversionTopPageRow >[] = [
+	{
+		key: 'page_title',
+		label: __( 'Page title', 'newspack-plugin' ),
+		numeric: false,
+		render: row => row.page_title,
+		sortValue: row => row.page_title,
+	},
+	{
+		key: 'page_url',
+		label: __( 'Page URL', 'newspack-plugin' ),
+		numeric: false,
+		render: row => (
+			<a href={ row.page_url } target="_blank" rel="noreferrer">
+				{ row.page_url }
+			</a>
+		),
+		sortValue: row => row.page_url,
+	},
+	{
+		key: 'pageviews',
+		label: __( 'Pageviews', 'newspack-plugin' ),
+		numeric: true,
+		render: row => formatNumber( row.pageviews ),
+		sortValue: row => row.pageviews,
+	},
+	{
+		key: 'unique_readers',
+		label: __( 'Unique readers', 'newspack-plugin' ),
+		numeric: true,
+		render: row => formatNumber( row.unique_readers ),
+		sortValue: row => row.unique_readers,
+	},
+	{
+		key: 'conversion_rate',
+		label: __( 'Conversion rate', 'newspack-plugin' ),
+		numeric: true,
+		render: row => formatPercent( row.conversion_rate ),
+		sortValue: row => row.conversion_rate,
+	},
+];
 
 const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps ) => (
 	<section
@@ -61,7 +106,26 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 				} ) }
 			/>
 		</div>
-		<div className="newspack-insights__viz-placeholder" data-pending={ current.top_pages_no_conversion.pending } />
+		<div className="newspack-insights__conversion-top-pages">
+			<h3 className="newspack-insights__conversion-subheading">{ __( 'Top pages that don’t convert', 'newspack-plugin' ) }</h3>
+			<SortableTable
+				columns={ TOP_PAGES_COLUMNS }
+				rows={ current.top_pages_no_conversion.rows }
+				getRowKey={ row => row.post_id }
+				defaultSortKey="pageviews"
+				initialRowLimit={ TOP_PAGES_ROW_LIMIT }
+				emptyMessage={ __(
+					'No qualifying pages yet. Pages with at least 100 pageviews and a measurable conversion rate will appear here.',
+					'newspack-plugin'
+				) }
+			/>
+			<p className="newspack-insights__conversion-top-pages-note">
+				{ __(
+					'These pages get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
+					'newspack-plugin'
+				) }
+			</p>
+		</div>
 	</section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -1,0 +1,68 @@
+/**
+ * OpportunityBucketsSection (NPPD-1609, Section 8).
+ *
+ * Three snapshot scorecards (stale registered readers, at-risk
+ * subscribers, lapsed donors) above a full-width "top pages that don't
+ * convert" table. The scorecards are current-state counts — no comparison
+ * deltas. Scaffold renders the three cards + a table placeholder; the
+ * SortableTable is wired in the following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+import MetricCard from '../components/MetricCard';
+import { scalarToMetricCardProps } from './scalarToCard';
+
+export interface OpportunityBucketsSectionProps {
+	current: ConversionWindow;
+}
+
+const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--opportunity-buckets"
+		aria-labelledby="newspack-insights-conversion-opportunity-heading"
+	>
+		<h2 id="newspack-insights-conversion-opportunity-heading" className="newspack-insights__section-heading">
+			{ __( 'Opportunity buckets', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Where the funnel has slack. These are diagnostic counts and underperforming pages — readers and content that could move with attention.',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__metric-grid">
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Stale Registered Readers', 'newspack-plugin' ),
+					description: __( 'Registered but never converted, no activity in 90 days', 'newspack-plugin' ),
+					current: current.stale_registered_count,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'At-Risk Subscribers', 'newspack-plugin' ),
+					description: __( 'Active subscribers with a failed-payment retry scheduled', 'newspack-plugin' ),
+					current: current.at_risk_subscriber_count,
+				} ) }
+			/>
+			<MetricCard
+				{ ...scalarToMetricCardProps( {
+					label: __( 'Lapsed Donors', 'newspack-plugin' ),
+					description: __( 'Donors with no donation in the last 365 days', 'newspack-plugin' ),
+					current: current.lapsed_donor_count,
+				} ) }
+			/>
+		</div>
+		<div className="newspack-insights__viz-placeholder" data-pending={ current.top_pages_no_conversion.pending } />
+	</section>
+);
+
+export default OpportunityBucketsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Render smoke test for PerJourneyConversionFunnelsSection (Section 2),
+ * including the visibility-gated 2.4 cross-upsell funnel.
+ *
+ * NOTE: `.test.tsx` is not collected by CI (testMatch matches only `.js` /
+ * `.jsx`, NPPD-1683) — written to the sibling convention.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PerJourneyConversionFunnelsSection from './PerJourneyConversionFunnelsSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'PerJourneyConversionFunnelsSection', () => {
+	it( 'renders the heading and all four journey funnel titles', () => {
+		render( <PerJourneyConversionFunnelsSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'Per-journey conversion funnels' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Anonymous → Registered' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Subscriber → Donor (cross-upsell)' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the cross-upsell empty-state note when 2.4 is hidden', () => {
+		render( <PerJourneyConversionFunnelsSection current={ makeConversionWindow( { crossUpsellVisibility: 'hidden' } ) } /> );
+		expect( screen.getByText( /Cross-upsell view appears when both subscription and donation programs/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -3,8 +3,8 @@
  *
  * Four small funnels in a 2-column grid: anonymous → registered,
  * registered → subscriber, registered → donor, and the visibility-gated
- * subscriber → donor cross-upsell. Scaffold renders header + caption + an
- * empty placeholder; the Funnel viz is wired in the following commit.
+ * subscriber → donor cross-upsell. The cross-upsell cell shows an
+ * empty-state note instead of a funnel while hidden (Phase 1 default).
  */
 
 /**
@@ -16,13 +16,29 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionWindow } from '../../api/conversion';
+import Funnel from './viz/Funnel';
 
 export interface PerJourneyConversionFunnelsSectionProps {
 	current: ConversionWindow;
 }
 
+interface JourneyFunnelProps {
+	title: string;
+	caption: string;
+	children: React.ReactNode;
+}
+
+const JourneyFunnel = ( { title, caption, children }: JourneyFunnelProps ) => (
+	<div className="newspack-insights__conversion-journey-cell">
+		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
+		<p className="newspack-insights__conversion-subcaption">{ caption }</p>
+		{ children }
+	</div>
+);
+
 const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFunnelsSectionProps ) => {
-	const crossUpsellHidden = current.subscriber_to_donor_funnel.visibility === 'hidden';
+	const crossUpsell = current.subscriber_to_donor_funnel;
+	const crossUpsellHidden = crossUpsell.visibility === 'hidden';
 	return (
 		<section
 			className="newspack-insights__section newspack-insights__section--per-journey-funnels"
@@ -37,7 +53,47 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 					'newspack-plugin'
 				) }
 			</p>
-			<div className="newspack-insights__viz-placeholder" data-cross-upsell-hidden={ crossUpsellHidden } />
+			<div className="newspack-insights__conversion-journey-grid">
+				<JourneyFunnel
+					title={ __( 'Anonymous → Registered', 'newspack-plugin' ) }
+					caption={ __(
+						'The free-conversion path. Combines gate and prompt impressions to make the funnel readable; per-surface breakdowns live in Tabs 4 and 5.',
+						'newspack-plugin'
+					) }
+				>
+					<Funnel stages={ current.anonymous_to_registered_funnel.stages } />
+				</JourneyFunnel>
+				<JourneyFunnel
+					title={ __( 'Registered → Subscriber', 'newspack-plugin' ) }
+					caption={ __(
+						'The paid-upsell path. Subscription excludes donation products; donor conversions are in the next funnel.',
+						'newspack-plugin'
+					) }
+				>
+					<Funnel stages={ current.registered_to_subscriber_funnel.stages } />
+				</JourneyFunnel>
+				<JourneyFunnel
+					title={ __( 'Registered → Donor', 'newspack-plugin' ) }
+					caption={ __( 'The donation-conversion path.', 'newspack-plugin' ) }
+				>
+					<Funnel stages={ current.registered_to_donor_funnel.stages } />
+				</JourneyFunnel>
+				<JourneyFunnel
+					title={ __( 'Subscriber → Donor (cross-upsell)', 'newspack-plugin' ) }
+					caption={ __( 'Cross-upsell visibility for publishers running both subscriptions and donations.', 'newspack-plugin' ) }
+				>
+					{ crossUpsellHidden ? (
+						<p className="newspack-insights__conversion-gated-note">
+							{ __(
+								'Cross-upsell view appears when both subscription and donation programs have at least 50 active participants.',
+								'newspack-plugin'
+							) }
+						</p>
+					) : (
+						<Funnel stages={ crossUpsell.stages } />
+					) }
+				</JourneyFunnel>
+			</div>
 		</section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -1,0 +1,45 @@
+/**
+ * PerJourneyConversionFunnelsSection (NPPD-1609, Section 2).
+ *
+ * Four small funnels in a 2-column grid: anonymous → registered,
+ * registered → subscriber, registered → donor, and the visibility-gated
+ * subscriber → donor cross-upsell. Scaffold renders header + caption + an
+ * empty placeholder; the Funnel viz is wired in the following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+
+export interface PerJourneyConversionFunnelsSectionProps {
+	current: ConversionWindow;
+}
+
+const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFunnelsSectionProps ) => {
+	const crossUpsellHidden = current.subscriber_to_donor_funnel.visibility === 'hidden';
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--per-journey-funnels"
+			aria-labelledby="newspack-insights-conversion-per-journey-heading"
+		>
+			<h2 id="newspack-insights-conversion-per-journey-heading" className="newspack-insights__section-heading">
+				{ __( 'Per-journey conversion funnels', 'newspack-plugin' ) }
+			</h2>
+			<p className="newspack-insights__section-caption">
+				{ __(
+					'Focused conversion paths. Each funnel shows where readers drop off within a specific journey — anonymous to registered, registered to paid, paid to donor.',
+					'newspack-plugin'
+				) }
+			</p>
+			<div className="newspack-insights__viz-placeholder" data-cross-upsell-hidden={ crossUpsellHidden } />
+		</section>
+	);
+};
+
+export default PerJourneyConversionFunnelsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Render smoke test for ReaderLifecycleSection (Section 1).
+ *
+ * NOTE: `.test.tsx` is not collected by CI (testMatch matches only `.js` /
+ * `.jsx`, NPPD-1683) — written to the sibling convention, runs once that lands.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderLifecycleSection from './ReaderLifecycleSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'ReaderLifecycleSection', () => {
+	it( 'renders the heading and the zero-data funnel empty state', () => {
+		render( <ReaderLifecycleSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'The reader lifecycle' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
@@ -1,0 +1,44 @@
+/**
+ * ReaderLifecycleSection (NPPD-1609, Section 1).
+ *
+ * The marquee view: a single full-width five-stage funnel from anonymous
+ * reader to supporter. Scaffold renders the header + caption + an empty
+ * placeholder; the Funnel viz is wired in the following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+
+export interface ReaderLifecycleSectionProps {
+	current: ConversionWindow;
+}
+
+const ReaderLifecycleSection = ( { current }: ReaderLifecycleSectionProps ) => {
+	const data = current.reader_lifecycle_funnel;
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--reader-lifecycle"
+			aria-labelledby="newspack-insights-conversion-lifecycle-heading"
+		>
+			<h2 id="newspack-insights-conversion-lifecycle-heading" className="newspack-insights__section-heading">
+				{ __( 'The reader lifecycle', 'newspack-plugin' ) }
+			</h2>
+			<p className="newspack-insights__section-caption">
+				{ __(
+					'The marquee view. How readers progress from first-time visitor through engagement, registration, and newsletter signup to becoming a supporter.',
+					'newspack-plugin'
+				) }
+			</p>
+			<div className="newspack-insights__viz-placeholder" data-pending={ data.pending } />
+		</section>
+	);
+};
+
+export default ReaderLifecycleSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
@@ -2,8 +2,7 @@
  * ReaderLifecycleSection (NPPD-1609, Section 1).
  *
  * The marquee view: a single full-width five-stage funnel from anonymous
- * reader to supporter. Scaffold renders the header + caption + an empty
- * placeholder; the Funnel viz is wired in the following commit.
+ * reader to supporter. Phase 1 renders the funnel's zero-data empty state.
  */
 
 /**
@@ -15,30 +14,28 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionWindow } from '../../api/conversion';
+import Funnel from './viz/Funnel';
 
 export interface ReaderLifecycleSectionProps {
 	current: ConversionWindow;
 }
 
-const ReaderLifecycleSection = ( { current }: ReaderLifecycleSectionProps ) => {
-	const data = current.reader_lifecycle_funnel;
-	return (
-		<section
-			className="newspack-insights__section newspack-insights__section--reader-lifecycle"
-			aria-labelledby="newspack-insights-conversion-lifecycle-heading"
-		>
-			<h2 id="newspack-insights-conversion-lifecycle-heading" className="newspack-insights__section-heading">
-				{ __( 'The reader lifecycle', 'newspack-plugin' ) }
-			</h2>
-			<p className="newspack-insights__section-caption">
-				{ __(
-					'The marquee view. How readers progress from first-time visitor through engagement, registration, and newsletter signup to becoming a supporter.',
-					'newspack-plugin'
-				) }
-			</p>
-			<div className="newspack-insights__viz-placeholder" data-pending={ data.pending } />
-		</section>
-	);
-};
+const ReaderLifecycleSection = ( { current }: ReaderLifecycleSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--reader-lifecycle"
+		aria-labelledby="newspack-insights-conversion-lifecycle-heading"
+	>
+		<h2 id="newspack-insights-conversion-lifecycle-heading" className="newspack-insights__section-heading">
+			{ __( 'The reader lifecycle', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'The marquee view. How readers progress from first-time visitor through engagement, registration, and newsletter signup to becoming a supporter.',
+				'newspack-plugin'
+			) }
+		</p>
+		<Funnel stages={ current.reader_lifecycle_funnel.stages } />
+	</section>
+);
 
 export default ReaderLifecycleSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Render smoke test for WhereConversionsComeFromSection (Section 3).
+ *
+ * NOTE: `.test.tsx` is not collected by CI (NPPD-1683).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import WhereConversionsComeFromSection from './WhereConversionsComeFromSection';
+import { makeConversionWindow } from './fixtures';
+
+describe( 'WhereConversionsComeFromSection', () => {
+	it( 'renders the heading and the three pie empty states', () => {
+		render( <WhereConversionsComeFromSection current={ makeConversionWindow() } /> );
+		expect( screen.getByRole( 'heading', { name: 'Where conversions come from' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Source data will appear once registrations occur in this window.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Source data will appear once donations occur in this window.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -2,9 +2,8 @@
  * WhereConversionsComeFromSection (NPPD-1609, Section 3).
  *
  * Three side-by-side source-mix PieCharts (registrations, subscribers,
- * donors), each split gate / prompt / direct. Scaffold renders header +
- * caption + an empty placeholder; the PieChart viz is wired in the
- * following commit.
+ * donors), each split gate / prompt / direct with the window total at the
+ * donut center. Phase 1 renders the empty state per pie.
  */
 
 /**
@@ -15,31 +14,68 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionWindow } from '../../api/conversion';
+import type { ConversionSourceMixData } from '../../api/conversion';
+import { formatNumber } from '../components/format';
+import { sourceLabel } from './labels';
+import PieChart from './viz/PieChart';
 
 export interface WhereConversionsComeFromSectionProps {
-	current: ConversionWindow;
+	current: {
+		source_mix_registrations: ConversionSourceMixData;
+		source_mix_subscribers: ConversionSourceMixData;
+		source_mix_donors: ConversionSourceMixData;
+	};
 }
 
-const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromSectionProps ) => {
-	const pending = current.source_mix_registrations.pending;
-	return (
-		<section
-			className="newspack-insights__section newspack-insights__section--source-mix"
-			aria-labelledby="newspack-insights-conversion-source-mix-heading"
-		>
-			<h2 id="newspack-insights-conversion-source-mix-heading" className="newspack-insights__section-heading">
-				{ __( 'Where conversions come from', 'newspack-plugin' ) }
-			</h2>
-			<p className="newspack-insights__section-caption">
-				{ __(
-					'Source attribution for new conversions in the window. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?',
-					'newspack-plugin'
-				) }
-			</p>
-			<div className="newspack-insights__viz-placeholder" data-pending={ pending } />
-		</section>
-	);
-};
+interface SourcePieProps {
+	title: string;
+	data: ConversionSourceMixData;
+	emptyMessage: string;
+}
+
+const SourcePie = ( { title, data, emptyMessage }: SourcePieProps ) => (
+	<div className="newspack-insights__conversion-pie-cell">
+		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
+		<PieChart
+			segments={ data.slices.map( slice => ( { label: sourceLabel( slice.source ), value: slice.count } ) ) }
+			centerLabel={ formatNumber( data.total ) }
+			emptyMessage={ emptyMessage }
+		/>
+	</div>
+);
+
+const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromSectionProps ) => (
+	<section
+		className="newspack-insights__section newspack-insights__section--source-mix"
+		aria-labelledby="newspack-insights-conversion-source-mix-heading"
+	>
+		<h2 id="newspack-insights-conversion-source-mix-heading" className="newspack-insights__section-heading">
+			{ __( 'Where conversions come from', 'newspack-plugin' ) }
+		</h2>
+		<p className="newspack-insights__section-caption">
+			{ __(
+				'Source attribution for new conversions in the window. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?',
+				'newspack-plugin'
+			) }
+		</p>
+		<div className="newspack-insights__conversion-pie-row">
+			<SourcePie
+				title={ __( 'New registrations', 'newspack-plugin' ) }
+				data={ current.source_mix_registrations }
+				emptyMessage={ __( 'Source data will appear once registrations occur in this window.', 'newspack-plugin' ) }
+			/>
+			<SourcePie
+				title={ __( 'New subscribers', 'newspack-plugin' ) }
+				data={ current.source_mix_subscribers }
+				emptyMessage={ __( 'Source data will appear once subscriptions occur in this window.', 'newspack-plugin' ) }
+			/>
+			<SourcePie
+				title={ __( 'New donors', 'newspack-plugin' ) }
+				data={ current.source_mix_donors }
+				emptyMessage={ __( 'Source data will appear once donations occur in this window.', 'newspack-plugin' ) }
+			/>
+		</div>
+	</section>
+);
 
 export default WhereConversionsComeFromSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -1,0 +1,45 @@
+/**
+ * WhereConversionsComeFromSection (NPPD-1609, Section 3).
+ *
+ * Three side-by-side source-mix PieCharts (registrations, subscribers,
+ * donors), each split gate / prompt / direct. Scaffold renders header +
+ * caption + an empty placeholder; the PieChart viz is wired in the
+ * following commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionWindow } from '../../api/conversion';
+
+export interface WhereConversionsComeFromSectionProps {
+	current: ConversionWindow;
+}
+
+const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromSectionProps ) => {
+	const pending = current.source_mix_registrations.pending;
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--source-mix"
+			aria-labelledby="newspack-insights-conversion-source-mix-heading"
+		>
+			<h2 id="newspack-insights-conversion-source-mix-heading" className="newspack-insights__section-heading">
+				{ __( 'Where conversions come from', 'newspack-plugin' ) }
+			</h2>
+			<p className="newspack-insights__section-caption">
+				{ __(
+					'Source attribution for new conversions in the window. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?',
+					'newspack-plugin'
+				) }
+			</p>
+			<div className="newspack-insights__viz-placeholder" data-pending={ pending } />
+		</section>
+	);
+};
+
+export default WhereConversionsComeFromSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -27,6 +27,55 @@
 		gap: 32px;
 	}
 
+	// Phase 1 preview banner — light-blue chrome to distinguish it from the
+	// gray `__info-callout` freshness note below it. Removed entirely in
+	// Phase 2. Shares the callout layout (info icon left, dismiss X right).
+	&__conversion-preview-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		padding: 16px 20px;
+		background-color: #e6f1fb;
+		border: 1px solid #b8d8f0;
+		border-radius: 4px;
+
+		&-icon {
+			flex: 0 0 20px;
+			width: 20px;
+			height: 20px;
+			color: var(--wp-admin-theme-color);
+		}
+
+		&-body {
+			flex: 1 1 auto;
+			font-size: 13px;
+			line-height: 1.5;
+			color: wp-colors.$gray-900;
+		}
+
+		&-title {
+			margin: 0;
+		}
+
+		&-dismiss {
+			flex: 0 0 auto;
+			background: transparent;
+			border: 0;
+			cursor: pointer;
+			padding: 4px;
+			color: wp-colors.$gray-700;
+
+			&:hover {
+				color: wp-colors.$gray-900;
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--wp-admin-theme-color);
+				outline-offset: 2px;
+			}
+		}
+	}
+
 	// Per-viz subheading + caption used inside the multi-cell sections.
 	&__conversion-subheading {
 		margin: 0 0 4px;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -176,7 +176,7 @@
 	// LineChart reference target line + floating label — extends the shared
 	// line chrome (Section 5 cohort targets).
 	&__line-reference {
-		stroke: wp-colors.$gray-500;
+		stroke: wp-colors.$gray-400;
 		stroke-width: 1;
 		stroke-dasharray: 4 3;
 		vector-effect: non-scaling-stroke;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -1,19 +1,24 @@
 /**
  * Newspack Insights — Tab 3 (Conversion Journey) styles (NPPD-1609, Phase 1)
  *
- * Tab 3-specific layout only. The shared Insights chrome (sections,
- * metric cards, tables, tab loading/error) lives in
+ * Tab 3-specific layout only. The shared Insights chrome (sections, metric
+ * cards, table base + wrap, tab loading/error) lives in
  * `tabs/components/sections.scss` and is loaded by the wizard's main
- * `style.scss`. Visualization, callout, and table styles for this tab are
- * tab-local and live here.
+ * `style.scss`. The shared chart chrome (pie, line, legend, series colors,
+ * tooltip, chart-empty) lives in `tabs/components/_insights-charts.scss` and
+ * is pulled in below — this tab's PieChart and LineChart reuse those classes.
  *
- * Classes are conversion-scoped (`__conversion-*`) so the tab stays fully
- * decoupled from the other Insights tabs — no shared-stylesheet edits, no
- * cross-tab selector collisions. The visual language is intentionally
- * identical to Gates and Prompts.
+ * Funnel, sortable-table, and per-section grid styles are tab-local copies
+ * scoped `__conversion-*` so the tab stays fully decoupled from the other
+ * Insights tabs — no shared-stylesheet edits, no cross-tab selector
+ * collisions. The visual language is intentionally identical to Gates and
+ * Prompts. (Funnel / PieChart / LineChart / SortableTable are candidates to
+ * hoist into packages/components as shared primitives in a v1.1 ticket.)
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "../../../../../packages/colors/colors.module" as colors;
+@use "../components/insights-charts";
 
 .newspack-insights {
 	&__conversion-tab {
@@ -22,12 +27,347 @@
 		gap: 32px;
 	}
 
-	// Scaffold placeholder for a viz slot whose primitive is wired in a
-	// later commit. Reserves vertical space so the section structure reads
-	// during the scaffold phase; replaced by the real chart / table.
-	&__viz-placeholder {
-		min-height: 120px;
-		border: 1px dashed wp-colors.$gray-200;
+	// Per-viz subheading + caption used inside the multi-cell sections.
+	&__conversion-subheading {
+		margin: 0 0 4px;
+		font-size: 15px;
+		font-weight: 600;
+		color: wp-colors.$gray-900;
+	}
+
+	&__conversion-subcaption {
+		margin: 0 0 12px;
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 1.5;
+		color: wp-colors.$gray-700;
+	}
+
+	// Empty-state note shown when a visibility-gated viz (Section 2.4 funnel,
+	// Section 4.4 lag curve) is hidden.
+	&__conversion-gated-note {
+		margin: 0;
+		padding: 32px 20px;
+		text-align: center;
+		font-size: 13px;
+		color: wp-colors.$gray-600;
+	}
+
+	// Section 2 — four per-journey funnels in a 2-column grid, stacking under
+	// ~720px container width.
+	&__conversion-journey-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+		gap: 24px;
+		align-items: start;
+	}
+
+	&__conversion-journey-cell {
+		min-width: 0;
+	}
+
+	// Section 3 — three source-mix pies side by side.
+	&__conversion-pie-row {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+		gap: 24px;
+		align-items: start;
+	}
+
+	&__conversion-pie-cell {
+		min-width: 0;
+	}
+
+	// Section 4 — 2×2 grid of cumulative-distribution curves.
+	&__conversion-curve-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+		gap: 24px;
+		align-items: start;
+	}
+
+	&__conversion-curve-cell {
+		min-width: 0;
+	}
+
+	// Section 5 — two cohort curves stacked vertically.
+	&__conversion-cohort-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+	}
+
+	&__conversion-cohort-cell {
+		min-width: 0;
+	}
+
+	// Section 8.4 — top-pages table block.
+	&__conversion-top-pages {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-top: 24px;
+	}
+
+	&__conversion-top-pages-note {
+		margin: 0;
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 1.5;
+		color: wp-colors.$gray-700;
+	}
+
+	// PieChart center label (the window total) — extends the shared pie chrome.
+	&__pie-center {
+		font-size: 6px;
+		font-weight: 600;
+		fill: wp-colors.$gray-900;
+	}
+
+	// LineChart reference target line + floating label — extends the shared
+	// line chrome (Section 5 cohort targets).
+	&__line-reference {
+		stroke: wp-colors.$gray-500;
+		stroke-width: 1;
+		stroke-dasharray: 4 3;
+		vector-effect: non-scaling-stroke;
+	}
+
+	&__line-reference-label {
+		display: block;
+		margin-top: 4px;
+		font-size: 12px;
+		color: wp-colors.$gray-600;
+	}
+
+	// Funnel viz — tab-local. Stacked SVG trapezoids in a single anchor color
+	// (primary-500) fading to 0.6 opacity at the tail. Side-label mode puts the
+	// step name/count/deltas in a fixed column beside the equal-height bands;
+	// compact mode renders the count inside each band and moves labels to a
+	// legend below.
+	&__conversion-funnel {
+		padding: 20px;
+		background-color: #fff;
+		border: 1px solid wp-colors.$gray-200;
 		border-radius: 4px;
+
+		&--side {
+			display: flex;
+			align-items: stretch;
+			gap: 16px;
+		}
+
+		&--compact {
+			display: flex;
+			flex-direction: column;
+			gap: 16px;
+		}
+
+		&-svg {
+			min-width: 0;
+			width: 100%;
+			height: auto;
+			display: block;
+		}
+
+		// Side mode: cap the SVG WIDTH (not height) so it keeps its exact viewBox
+		// aspect ratio — no letterboxing — and the equal-height trapezoid bands
+		// stay aligned with the equal-flex label column beside them.
+		&--side &-svg {
+			flex: 0 1 auto;
+			max-width: 320px;
+		}
+
+		// Compact mode: fill the width; the count sits inside each band.
+		&--compact &-svg {
+			max-height: 480px;
+		}
+
+		// Single anchor color; the 1.0 → 0.6 opacity interpolation gives each
+		// band its own weight while staying within one hue.
+		&-trapezoid {
+			fill: colors.$primary-500;
+		}
+
+		// In-band count (compact mode): white on the darker top bands, dark on
+		// the faded tail bands — see DARK_TEXT_OPACITY_THRESHOLD in Funnel.tsx.
+		&-count-text {
+			font-size: 16px;
+			font-weight: 600;
+			font-variant-numeric: tabular-nums;
+
+			&.is-on-dark {
+				fill: #fff;
+			}
+
+			&.is-on-light {
+				fill: wp-colors.$gray-900;
+			}
+		}
+
+		// Side-label column: equal-flex blocks align to the equal-height bands.
+		&-labels {
+			flex: 0 0 200px;
+			display: flex;
+			flex-direction: column;
+		}
+
+		&-label {
+			flex: 1 1 0;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+
+		&-legend {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-direction: column;
+			gap: 12px;
+		}
+
+		&-legend-item {
+			display: flex;
+			flex-direction: column;
+		}
+
+		&-label-name {
+			font-size: 13px;
+			font-weight: 600;
+			color: wp-colors.$gray-900;
+		}
+
+		&-label-count {
+			font-size: 20px;
+			font-weight: 600;
+			font-variant-numeric: tabular-nums;
+			line-height: 1.2;
+			color: wp-colors.$gray-900;
+		}
+
+		// Stage descriptors: both muted gray. The drop-off is funnel context,
+		// not an alarm, and deliberately NOT red/green — red/green is reserved
+		// for the period-over-period scorecard deltas elsewhere on the page.
+		&-label-pct {
+			font-size: 13px;
+			font-weight: 400;
+			color: wp-colors.$gray-600;
+		}
+
+		&-label-drop {
+			font-size: 13px;
+			font-weight: 400;
+			font-variant-numeric: tabular-nums;
+			color: wp-colors.$gray-600;
+
+			&-arrow {
+				color: wp-colors.$gray-600;
+			}
+		}
+
+		&-empty {
+			margin: 0;
+			padding: 32px 20px;
+			text-align: center;
+			font-size: 13px;
+			color: wp-colors.$gray-600;
+		}
+	}
+
+	// "See more" / "See less" toggle under the row-capped top-pages table.
+	&__conversion-table-more {
+		align-self: flex-start;
+		padding: 4px 0;
+		background: transparent;
+		border: 0;
+		cursor: pointer;
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--wp-admin-theme-color);
+
+		&:hover {
+			text-decoration: underline;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: 2px;
+		}
+	}
+
+	// Empty-state row inside the top-pages table.
+	&__conversion-table-empty {
+		padding: 32px 20px;
+		text-align: center;
+		font-style: italic;
+		color: wp-colors.$gray-700;
+	}
+
+	// Sortable table affordances (Section 8.4). A tab-local copy of the Gates /
+	// Prompts sortable chrome. Numeric right-alignment (`__table-num`) and the
+	// muted em-dash (`__table-na`) come from the shared sections.scss chrome.
+	&__conversion-table--sortable {
+		.newspack-insights__conversion-table-sort-cell {
+			// Eliminate the th's default padding because the button inside owns
+			// the click target and re-paints the padding itself; without this,
+			// half the cell isn't clickable.
+			padding: 0;
+		}
+
+		.newspack-insights__conversion-table-sort {
+			// Button fills the cell so any click anywhere in the th sorts.
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			width: 100%;
+			padding: 12px 20px;
+			background: transparent;
+			border: 0;
+			cursor: pointer;
+			text-align: inherit;
+			font: inherit;
+			color: inherit;
+			letter-spacing: inherit;
+			text-transform: inherit;
+
+			&:hover {
+				background-color: wp-colors.$gray-200;
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--wp-admin-theme-color);
+				outline-offset: -2px;
+			}
+		}
+
+		// Numeric columns are right-aligned (shared `__table-num`), so pin the
+		// indicator to the right edge.
+		.newspack-insights__table-num .newspack-insights__conversion-table-sort {
+			justify-content: flex-end;
+			text-align: right;
+		}
+
+		.newspack-insights__conversion-table-sort-label {
+			flex: 1 1 auto;
+		}
+
+		.newspack-insights__conversion-table-sort-indicator {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			opacity: 0.3;
+			color: wp-colors.$gray-700;
+		}
+
+		.newspack-insights__conversion-table-sort:hover .newspack-insights__conversion-table-sort-indicator {
+			opacity: 0.7;
+		}
+
+		.newspack-insights__conversion-table-sort.is-active .newspack-insights__conversion-table-sort-indicator {
+			opacity: 1;
+			color: wp-colors.$gray-900;
+		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -1,0 +1,33 @@
+/**
+ * Newspack Insights — Tab 3 (Conversion Journey) styles (NPPD-1609, Phase 1)
+ *
+ * Tab 3-specific layout only. The shared Insights chrome (sections,
+ * metric cards, tables, tab loading/error) lives in
+ * `tabs/components/sections.scss` and is loaded by the wizard's main
+ * `style.scss`. Visualization, callout, and table styles for this tab are
+ * tab-local and live here.
+ *
+ * Classes are conversion-scoped (`__conversion-*`) so the tab stays fully
+ * decoupled from the other Insights tabs — no shared-stylesheet edits, no
+ * cross-tab selector collisions. The visual language is intentionally
+ * identical to Gates and Prompts.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+.newspack-insights {
+	&__conversion-tab {
+		display: flex;
+		flex-direction: column;
+		gap: 32px;
+	}
+
+	// Scaffold placeholder for a viz slot whose primitive is wired in a
+	// later commit. Reserves vertical space so the section structure reads
+	// during the scaffold phase; replaced by the real chart / table.
+	&__viz-placeholder {
+		min-height: 120px;
+		border: 1px dashed wp-colors.$gray-200;
+		border-radius: 4px;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -27,52 +27,18 @@
 		gap: 32px;
 	}
 
-	// Phase 1 preview banner — light-blue chrome to distinguish it from the
-	// gray `__info-callout` freshness note below it. Removed entirely in
-	// Phase 2. Shares the callout layout (info icon left, dismiss X right).
-	&__conversion-preview-banner {
-		display: flex;
-		align-items: flex-start;
-		gap: 12px;
-		padding: 16px 20px;
+	// Phase 1 preview banner — a light-blue variant of the shared
+	// `__info-callout` (layout, icon, and dismiss button come from
+	// components/_insights-charts.scss), distinguishing it from the gray
+	// freshness note below it. Removed entirely in Phase 2. Compound selector
+	// so the color override wins over the single-class base regardless of load
+	// order.
+	&__info-callout--preview.newspack-insights__info-callout {
 		background-color: #e6f1fb;
-		border: 1px solid #b8d8f0;
-		border-radius: 4px;
+		border-color: #b8d8f0;
 
-		&-icon {
-			flex: 0 0 20px;
-			width: 20px;
-			height: 20px;
+		.newspack-insights__info-callout-icon {
 			color: var(--wp-admin-theme-color);
-		}
-
-		&-body {
-			flex: 1 1 auto;
-			font-size: 13px;
-			line-height: 1.5;
-			color: wp-colors.$gray-900;
-		}
-
-		&-title {
-			margin: 0;
-		}
-
-		&-dismiss {
-			flex: 0 0 auto;
-			background: transparent;
-			border: 0;
-			cursor: pointer;
-			padding: 4px;
-			color: wp-colors.$gray-700;
-
-			&:hover {
-				color: wp-colors.$gray-900;
-			}
-
-			&:focus-visible {
-				outline: 2px solid var(--wp-admin-theme-color);
-				outline-offset: 2px;
-			}
 		}
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase 1 placeholder fixtures for Tab 3 (Conversion Journey) React tests.
+ *
+ * Mirrors the shape `Conversion_REST_Controller` assembles — every metric
+ * `pending: true` with zero / empty values — so section render tests exercise
+ * the exact payload the tab receives in Phase 1. Not a `*.test.*` file, so it
+ * is never collected as a suite.
+ */
+
+import type {
+	ConversionCohortData,
+	ConversionCumulativeMulti,
+	ConversionFunnelData,
+	ConversionGatedCumulativeSingle,
+	ConversionGatedFunnelData,
+	ConversionScalarMetric,
+	ConversionSourceMixData,
+	ConversionTopPagesTable,
+	ConversionVisibility,
+	ConversionWeeklyTrendsData,
+	ConversionWindow,
+	ConversionCumulativeSingle,
+	ConversionPlaceholderType,
+} from '../../api/conversion';
+
+const scalar = ( placeholder_type: ConversionPlaceholderType ): ConversionScalarMetric => ( {
+	value: placeholder_type === 'decimal' ? 0.0 : 0,
+	computable: false,
+	pending: true,
+	denominator: null,
+	placeholder_type,
+} );
+
+const funnel = ( ...labels: string[] ): ConversionFunnelData => ( {
+	pending: true,
+	stages: labels.map( label => ( { label, count: 0, pct_of_top: 0 } ) ),
+} );
+
+const gatedFunnel = ( visibility: ConversionVisibility, ...labels: string[] ): ConversionGatedFunnelData => ( {
+	...funnel( ...labels ),
+	visibility,
+	visibility_reason: visibility === 'hidden' ? 'insufficient_data' : null,
+} );
+
+const sourceMix = (): ConversionSourceMixData => ( {
+	pending: true,
+	total: 0,
+	slices: [
+		{ source: 'gate', count: 0, pct: 0 },
+		{ source: 'prompt', count: 0, pct: 0 },
+		{ source: 'direct', count: 0, pct: 0 },
+	],
+} );
+
+const cumulativeSingle = (): ConversionCumulativeSingle => ( { pending: true, points: [] } );
+
+const gatedCumulativeSingle = ( visibility: ConversionVisibility ): ConversionGatedCumulativeSingle => ( {
+	pending: true,
+	points: [],
+	visibility,
+	visibility_reason: visibility === 'hidden' ? 'insufficient_data' : null,
+} );
+
+const cumulativeMulti = (): ConversionCumulativeMulti => ( {
+	pending: true,
+	groups: [
+		{ label: 'gate', points: [] },
+		{ label: 'prompt', points: [] },
+		{ label: 'direct', points: [] },
+	],
+} );
+
+const cohort = ( value: number, label: string ): ConversionCohortData => ( {
+	pending: true,
+	cohorts: [],
+	reference_line: { value, label },
+} );
+
+const weekly = (): ConversionWeeklyTrendsData => ( {
+	pending: true,
+	weeks: [],
+	series: [ 'registration_rate', 'subscription_attempt_rate' ],
+} );
+
+const topPages = (): ConversionTopPagesTable => ( { pending: true, rows: [], threshold_pageviews: 100 } );
+
+export interface ConversionWindowOverrides {
+	crossUpsellVisibility?: ConversionVisibility;
+	lagVisibility?: ConversionVisibility;
+}
+
+/** Build a full Phase 1 placeholder window, with optional visibility overrides. */
+export const makeConversionWindow = ( overrides: ConversionWindowOverrides = {} ): ConversionWindow => ( {
+	window: { start: '2026-03-22', end: '2026-04-21' },
+	reader_lifecycle_funnel: funnel( 'Anonymous reader', 'Engaged reader', 'Registered reader', 'Newsletter subscriber', 'Subscriber or donor' ),
+	anonymous_to_registered_funnel: funnel( 'Anonymous', 'Saw a conversion surface', 'Registered' ),
+	registered_to_subscriber_funnel: funnel( 'Registered', 'Saw a subscription-intent surface', 'Became subscriber' ),
+	registered_to_donor_funnel: funnel( 'Registered', 'Saw a donation-intent surface', 'Became donor' ),
+	subscriber_to_donor_funnel: gatedFunnel( overrides.crossUpsellVisibility ?? 'hidden', 'Active subscriber', 'Also donor' ),
+	source_mix_registrations: sourceMix(),
+	source_mix_subscribers: sourceMix(),
+	source_mix_donors: sourceMix(),
+	time_to_register_distribution: cumulativeSingle(),
+	time_to_subscribe_distribution: cumulativeMulti(),
+	time_to_donate_distribution: cumulativeMulti(),
+	subscriber_to_donor_lag_distribution: gatedCumulativeSingle( overrides.lagVisibility ?? 'hidden' ),
+	registration_to_conversion_cohort: cohort( 0.15, '15% at 6 months' ),
+	subscriber_retention_cohort: cohort( 0.7, '70% at 12 months' ),
+	weekly_conversion_rates: weekly(),
+	influenced_registration_rate_7d: scalar( 'rate' ),
+	influenced_subscription_rate_14d: scalar( 'rate' ),
+	influenced_donation_rate_14d: scalar( 'rate' ),
+	influenced_newsletter_rate_7d: scalar( 'rate' ),
+	stale_registered_count: scalar( 'count' ),
+	at_risk_subscriber_count: scalar( 'count' ),
+	lapsed_donor_count: scalar( 'count' ),
+	top_pages_no_conversion: topPages(),
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/labels.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/labels.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared display labels for Tab 3 (Conversion Journey).
+ *
+ * Maps the machine source keys (`gate` / `prompt` / `direct`) used by the
+ * Section 3 PieCharts and the Section 4 multi-series distributions to their
+ * translated display labels, so the sections stay declarative and the copy
+ * lives in one place.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export type ConversionSource = 'gate' | 'prompt' | 'direct';
+
+export const sourceLabel = ( source: ConversionSource ): string => {
+	switch ( source ) {
+		case 'gate':
+			return __( 'Gate', 'newspack-plugin' );
+		case 'prompt':
+			return __( 'Prompt', 'newspack-plugin' );
+		case 'direct':
+		default:
+			return __( 'Direct', 'newspack-plugin' );
+	}
+};

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
@@ -1,0 +1,43 @@
+/**
+ * Maps a `ConversionScalarMetric` payload + section copy into the
+ * MetricCard props used by every Tab 3 scorecard (Sections 7 and
+ * 8.1–8.3). Centralises the `placeholder_type` → `MetricFormat` mapping
+ * so the section components stay declarative. Mirrors the prompts tab's
+ * `scalarToCard.ts`.
+ */
+
+import type { ConversionScalarMetric } from '../../api/conversion';
+import type { MetricFormat } from '../components/MetricCard';
+
+const formatFor = ( m: ConversionScalarMetric ): MetricFormat => {
+	switch ( m.placeholder_type ) {
+		case 'rate':
+			return 'percent';
+		case 'currency':
+			return 'currency';
+		case 'decimal':
+			return 'decimal';
+		case 'count':
+		default:
+			return 'number';
+	}
+};
+
+export interface ScalarCardProps {
+	label: string;
+	description: string;
+	current: ConversionScalarMetric;
+	previous?: ConversionScalarMetric | null;
+}
+
+export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
+	const { label, description, current, previous } = props;
+	return {
+		label,
+		description,
+		value: current.value,
+		format: formatFor( current ),
+		previousValue: previous?.computable ? previous.value : null,
+		pending: current.pending,
+	};
+};

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/Funnel.tsx
@@ -1,0 +1,264 @@
+/**
+ * Funnel viz (NPPD-1609) — tab-local to Conversion Journey.
+ *
+ * Multi-step conversion funnel rendered as stacked SVG trapezoids. Each
+ * trapezoid's top edge is proportional to its own count and its bottom edge to
+ * the next step's count, so the silhouette narrows with drop-off; the last step
+ * is a rectangle. A single anchor color (primary-500) fades from full opacity at
+ * the top to 0.6 at the bottom, so each stage carries its own weight.
+ *
+ * A tab-local copy of the Gates / Prompts funnel (adopted from PR #267): the
+ * tabs render the same chrome but stay decoupled until a canonical Funnel lands
+ * in packages/components/src/ (a v1.1 ticket). Conversion Journey uses it for
+ * the Section 1 lifecycle funnel (five stages) and the four Section 2 funnels
+ * (two / three stages).
+ *
+ * Two layouts, auto-selected from container width + step count:
+ *   - Side-label (default): step name / count / labels in a fixed column to the
+ *     right of each trapezoid. Used when stepCount < 5 AND width >= 480px.
+ *   - Compact: the count renders inside each trapezoid and the full
+ *     names/counts/labels move to a legend below. Used when stepCount >= 5 OR
+ *     width < 480px (so the five-stage lifecycle funnel renders compact).
+ *
+ * Phase 1: every stage count is zero, so the first-step-zero guard renders the
+ * empty state ("Not enough data to chart the funnel.") — the same treatment
+ * Gates and Prompts show for a zero-data window.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { ConversionFunnelStage } from '../../../api/conversion';
+import { formatNumber, formatPercent } from '../../components/format';
+
+const COMPACT_MIN_STEPS = 5;
+const COMPACT_MAX_WIDTH = 480; // Below this container width, force compact mode.
+const MIN_STEP_HEIGHT = 32;
+const MAX_CHART_HEIGHT = 480;
+const VIEWBOX_WIDTH = 320;
+const FULL_OPACITY = 1;
+const TAIL_OPACITY = 0.6;
+// Above this band opacity the fill is dark enough for white text; below it, the
+// faded band needs dark text. Only affects compact mode (count rendered inside).
+const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
+
+export interface FunnelProps {
+	stages: ConversionFunnelStage[];
+}
+
+/** Compact when there are many steps OR the container is narrow. */
+export const isCompactMode = ( stepCount: number, containerWidth: number ): boolean =>
+	stepCount >= COMPACT_MIN_STEPS || containerWidth < COMPACT_MAX_WIDTH;
+
+/** Linear opacity from 1.0 at the first step to 0.6 at the last. */
+export const stepOpacity = ( index: number, stepCount: number ): number => {
+	if ( stepCount <= 1 ) {
+		return FULL_OPACITY;
+	}
+	return FULL_OPACITY + ( TAIL_OPACITY - FULL_OPACITY ) * ( index / ( stepCount - 1 ) );
+};
+
+/**
+ * Drop-off from the previous step as a fraction in [0, 1]. Clamped at 0: funnel
+ * stages are independent aggregates, so a later stage can occasionally exceed
+ * the prior one (data drift) — a negative "drop-off" is meaningless, so show 0%.
+ */
+export const dropFromPrevious = ( count: number, prevCount: number ): number => ( prevCount > 0 ? Math.max( 0, 1 - count / prevCount ) : 0 );
+
+/** Equal band height per step, capped so the whole chart fits ~480px. */
+const stepHeightFor = ( stepCount: number ): number => Math.max( MIN_STEP_HEIGHT, Math.floor( MAX_CHART_HEIGHT / stepCount ) );
+
+/**
+ * SVG path for one trapezoid: top edge sized to `count`, bottom to `nextCount`,
+ * centered. The bottom is clamped to never exceed the top so the silhouette only
+ * ever narrows (a funnel never flares outward, even on anomalous data).
+ */
+const trapezoidPath = ( count: number, nextCount: number, topCount: number, yTop: number, yBottom: number ): string => {
+	const cx = VIEWBOX_WIDTH / 2;
+	// Clamp the top edge to the viewBox half-width too (not just the bottom):
+	// funnel stages are independent aggregates, so a later stage can exceed the
+	// top stage (data drift). Without this the trapezoid would flare past the
+	// viewBox edge — the opposite of the "only ever narrows" invariant below.
+	const halfTop = Math.min( VIEWBOX_WIDTH / 2, ( count / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
+	const halfBottom = Math.min( halfTop, ( nextCount / topCount ) * ( VIEWBOX_WIDTH / 2 ) );
+	return [
+		`M ${ cx - halfTop } ${ yTop }`,
+		`L ${ cx + halfTop } ${ yTop }`,
+		`L ${ cx + halfBottom } ${ yBottom }`,
+		`L ${ cx - halfBottom } ${ yBottom }`,
+		'Z',
+	].join( ' ' );
+};
+
+interface StepView {
+	stage: ConversionFunnelStage;
+	index: number;
+	opacity: number;
+	pctOfTop: number;
+	drop: number | null;
+}
+
+/** Build the per-step view model shared by both layouts. */
+const buildSteps = ( stages: ConversionFunnelStage[], topCount: number ): StepView[] =>
+	stages.map( ( stage, index ) => {
+		const prevCount = index > 0 ? stages[ index - 1 ].count : 0;
+		return {
+			stage,
+			index,
+			opacity: stepOpacity( index, stages.length ),
+			pctOfTop: topCount > 0 ? stage.count / topCount : 0,
+			drop: index > 0 ? dropFromPrevious( stage.count, prevCount ) : null,
+		};
+	} );
+
+/**
+ * The two descriptive labels shown for every step beyond the first: what share
+ * of the top stage reached here, and the stage-to-stage drop-off. Both are muted
+ * (not red/green) — they describe funnel progression, not a period comparison.
+ */
+const StepLabels = ( { step, topLabel }: { step: StepView; topLabel: string } ) => {
+	if ( step.drop === null ) {
+		return null;
+	}
+	return (
+		<>
+			<span className="newspack-insights__conversion-funnel-label-pct">
+				{ sprintf(
+					/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Anonymous reader"). */
+					__( '%1$s of %2$s', 'newspack-plugin' ),
+					formatPercent( step.pctOfTop ),
+					topLabel
+				) }
+			</span>
+			<span className="newspack-insights__conversion-funnel-label-drop">
+				<span aria-hidden="true" className="newspack-insights__conversion-funnel-label-drop-arrow">
+					↓
+				</span>{ ' ' }
+				{ sprintf(
+					/* translators: %s: percentage drop-off from the previous stage. */
+					__( '%s drop-off', 'newspack-plugin' ),
+					formatPercent( step.drop )
+				) }
+			</span>
+		</>
+	);
+};
+
+const Funnel = ( { stages }: FunnelProps ) => {
+	const containerRef = useRef< HTMLDivElement >( null );
+	// Default to a desktop width so the common 3-step funnel renders in
+	// side-label mode on first paint (the observer corrects narrow containers).
+	const [ width, setWidth ] = useState( COMPACT_MAX_WIDTH );
+
+	useEffect( () => {
+		const el = containerRef.current;
+		if ( ! el || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+		setWidth( el.getBoundingClientRect().width );
+		const observer = new ResizeObserver( entries => {
+			for ( const entry of entries ) {
+				setWidth( entry.contentRect.width );
+			}
+		} );
+		observer.observe( el );
+		return () => observer.disconnect();
+	}, [] );
+
+	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
+	const topLabel = stages.length > 0 ? stages[ 0 ].label : '';
+	const steps = useMemo( () => buildSteps( stages, topCount ), [ stages, topCount ] );
+
+	// Proportions can't be computed without a non-zero first step.
+	if ( stages.length === 0 || topCount <= 0 ) {
+		return (
+			<div ref={ containerRef } className="newspack-insights__conversion-funnel">
+				<p className="newspack-insights__conversion-funnel-empty">{ __( 'Not enough data to chart the funnel.', 'newspack-plugin' ) }</p>
+			</div>
+		);
+	}
+
+	const stepCount = stages.length;
+	const compact = isCompactMode( stepCount, width );
+	const stepHeight = stepHeightFor( stepCount );
+	const chartHeight = stepHeight * stepCount;
+
+	const svg = (
+		<svg
+			className="newspack-insights__conversion-funnel-svg"
+			viewBox={ `0 0 ${ VIEWBOX_WIDTH } ${ chartHeight }` }
+			preserveAspectRatio="xMidYMid meet"
+			role="img"
+			aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }
+		>
+			{ steps.map( step => {
+				const nextCount = step.index < stepCount - 1 ? stages[ step.index + 1 ].count : step.stage.count;
+				const yTop = step.index * stepHeight;
+				return (
+					<path
+						key={ step.index }
+						className="newspack-insights__conversion-funnel-trapezoid"
+						d={ trapezoidPath( step.stage.count, nextCount, topCount, yTop, yTop + stepHeight ) }
+						fillOpacity={ step.opacity }
+					/>
+				);
+			} ) }
+			{ compact &&
+				steps.map( step => (
+					<text
+						key={ step.index }
+						className={
+							'newspack-insights__conversion-funnel-count-text ' +
+							( step.opacity > DARK_TEXT_OPACITY_THRESHOLD ? 'is-on-dark' : 'is-on-light' )
+						}
+						x={ VIEWBOX_WIDTH / 2 }
+						y={ step.index * stepHeight + stepHeight / 2 }
+						textAnchor="middle"
+						dominantBaseline="central"
+					>
+						{ formatNumber( step.stage.count ) }
+					</text>
+				) ) }
+		</svg>
+	);
+
+	if ( compact ) {
+		return (
+			<div ref={ containerRef } className="newspack-insights__conversion-funnel newspack-insights__conversion-funnel--compact" role="figure">
+				{ svg }
+				<ol className="newspack-insights__conversion-funnel-legend">
+					{ steps.map( step => (
+						<li key={ step.index } className="newspack-insights__conversion-funnel-legend-item">
+							<span className="newspack-insights__conversion-funnel-label-name">{ step.stage.label }</span>
+							<span className="newspack-insights__conversion-funnel-label-count">{ formatNumber( step.stage.count ) }</span>
+							<StepLabels step={ step } topLabel={ topLabel } />
+						</li>
+					) ) }
+				</ol>
+			</div>
+		);
+	}
+
+	return (
+		<div ref={ containerRef } className="newspack-insights__conversion-funnel newspack-insights__conversion-funnel--side" role="figure">
+			{ svg }
+			<div className="newspack-insights__conversion-funnel-labels">
+				{ steps.map( step => (
+					<div key={ step.index } className="newspack-insights__conversion-funnel-label">
+						<span className="newspack-insights__conversion-funnel-label-name">{ step.stage.label }</span>
+						<span className="newspack-insights__conversion-funnel-label-count">{ formatNumber( step.stage.count ) }</span>
+						<StepLabels step={ step } topLabel={ topLabel } />
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default Funnel;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/LineChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/LineChart.tsx
@@ -50,6 +50,13 @@ export interface LineChartProps {
 	formatLabel?: ( label: string ) => string;
 	/** Optional horizontal target line (value in the same units as the y-axis). */
 	referenceLine?: LineReferenceLine;
+	/**
+	 * Optional pin for the top of the y-axis (e.g. `1` for a fixed 0–100% scale
+	 * on share/percentage curves). Data still wins if it exceeds the pin. When
+	 * unset, the axis auto-scales to the data — right for small-magnitude rate
+	 * series (e.g. weekly conversion rates) that would otherwise be flattened.
+	 */
+	yMax?: number;
 	/** Empty-state copy shown when there's no data. Defaults to the generic line. */
 	emptyMessage?: string;
 }
@@ -58,15 +65,21 @@ const W = 600;
 const H = 160;
 const PAD = 8;
 
-const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenceLine, emptyMessage }: LineChartProps ) => {
+const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenceLine, yMax, emptyMessage }: LineChartProps ) => {
 	const [ active, setActive ] = useState< number | null >( null );
 
 	const allSeries: LineSeries[] = series && series.length ? series : [ { name: '', points: points ?? [] } ];
-	const base = allSeries[ 0 ].points;
 
-	if ( ! base || base.length === 0 ) {
+	// Empty only when *every* series is empty — a single empty series must not
+	// blank a chart whose other series carry data.
+	if ( allSeries.every( s => s.points.length === 0 ) ) {
 		return <p className="newspack-insights__chart-empty">{ emptyMessage ?? __( 'No data in this timeframe.', 'newspack-plugin' ) }</p>;
 	}
+
+	// The x-axis spine is the longest series, so unequal-length series stay
+	// column-aligned (each plots on its own 0-based index) and the empty-state /
+	// hit-band / tooltip-label geometry can't be driven off a short first series.
+	const base = allSeries.reduce( ( longest, s ) => ( s.points.length > longest.length ? s.points : longest ), allSeries[ 0 ].points );
 
 	const isMulti = allSeries.length > 1;
 	const n = base.length;
@@ -75,7 +88,10 @@ const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenc
 	if ( referenceLine ) {
 		allValues.push( referenceLine.value );
 	}
-	const max = Math.max( ...allValues, 1 );
+	const dataMax = allValues.length ? Math.max( ...allValues ) : 0;
+	// `yMax` pins the ceiling; data always wins if it exceeds the pin. The `|| 1`
+	// only guards a zero-height domain (all values and pin are 0).
+	const max = Math.max( dataMax, yMax ?? 0 ) || 1;
 	const min = Math.min( ...allValues, 0 );
 	const span = max - min || 1;
 	const stepX = n > 1 ? ( W - PAD * 2 ) / ( n - 1 ) : 0;
@@ -167,7 +183,7 @@ const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenc
 				<div className="newspack-insights__line-meta">
 					<span>{ formatLabel( base[ 0 ].label ) }</span>
 					<span>
-						{ __( 'peak', 'newspack-plugin' ) }: { formatNumber( max ) }
+						{ __( 'peak', 'newspack-plugin' ) }: { formatNumber( dataMax ) }
 					</span>
 					<span>{ formatLabel( base[ n - 1 ].label ) }</span>
 				</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/LineChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/LineChart.tsx
@@ -1,0 +1,179 @@
+/**
+ * LineChart (NPPD-1609) — tab-local time-series line(s) for Conversion
+ * Journey. A copy of the Audience tab's LineChart (NPPD-1649), extended
+ * with an optional horizontal `referenceLine` (the Section 5 cohort target,
+ * e.g. "15% at 6 months") and a configurable `emptyMessage` so the Phase 1
+ * empty state shows the section's spec copy. Viz stay tab-local until a
+ * canonical LineChart lands in packages/components/src/ (a v1.1 ticket).
+ *
+ * Used by Section 4 (cumulative-distribution curves, single + multi-series),
+ * Section 5 (cohort retention, multi-series + reference line), and Section 6
+ * (weekly trends, multi-series).
+ *
+ * Dependency-free SVG. Renders one line from `points`, or several color-coded
+ * lines from `series`. A custom dark hover panel anchored to each x-index shows
+ * the label plus every series' value there. `formatLabel` humanizes x labels.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { formatNumber } from '../../components/format';
+
+export interface LinePoint {
+	label: string;
+	value: number;
+}
+
+export interface LineSeries {
+	name: string;
+	points: LinePoint[];
+}
+
+export interface LineReferenceLine {
+	value: number;
+	label: string;
+}
+
+export interface LineChartProps {
+	/** Single-series convenience. */
+	points?: LinePoint[];
+	/** Multi-series (shared x-axis / labels). Takes precedence over `points`. */
+	series?: LineSeries[];
+	/** Humanize an x-axis label for tooltips and the meta row. Defaults to identity. */
+	formatLabel?: ( label: string ) => string;
+	/** Optional horizontal target line (value in the same units as the y-axis). */
+	referenceLine?: LineReferenceLine;
+	/** Empty-state copy shown when there's no data. Defaults to the generic line. */
+	emptyMessage?: string;
+}
+
+const W = 600;
+const H = 160;
+const PAD = 8;
+
+const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenceLine, emptyMessage }: LineChartProps ) => {
+	const [ active, setActive ] = useState< number | null >( null );
+
+	const allSeries: LineSeries[] = series && series.length ? series : [ { name: '', points: points ?? [] } ];
+	const base = allSeries[ 0 ].points;
+
+	if ( ! base || base.length === 0 ) {
+		return <p className="newspack-insights__chart-empty">{ emptyMessage ?? __( 'No data in this timeframe.', 'newspack-plugin' ) }</p>;
+	}
+
+	const isMulti = allSeries.length > 1;
+	const n = base.length;
+	const allValues = allSeries.flatMap( s => s.points.map( p => p.value || 0 ) );
+	// Pull the reference value into the domain so the target line stays on-canvas.
+	if ( referenceLine ) {
+		allValues.push( referenceLine.value );
+	}
+	const max = Math.max( ...allValues, 1 );
+	const min = Math.min( ...allValues, 0 );
+	const span = max - min || 1;
+	const stepX = n > 1 ? ( W - PAD * 2 ) / ( n - 1 ) : 0;
+
+	const xAt = ( i: number ) => PAD + i * stepX;
+	const yAt = ( v: number ) => H - PAD - ( ( ( v || 0 ) - min ) / span ) * ( H - PAD * 2 );
+
+	const tooltipTop = active === null ? 0 : Math.min( ...allSeries.map( s => yAt( s.points[ active ]?.value ?? 0 ) ) );
+
+	return (
+		<div className="newspack-insights__line" onMouseLeave={ () => setActive( null ) }>
+			<div className="newspack-insights__line-plot">
+				<svg
+					viewBox={ `0 0 ${ W } ${ H }` }
+					className="newspack-insights__line-svg"
+					role="img"
+					aria-label={ __( 'Time-series chart', 'newspack-plugin' ) }
+					preserveAspectRatio="none"
+				>
+					{ referenceLine && (
+						<line
+							className="newspack-insights__line-reference"
+							x1={ PAD }
+							x2={ W - PAD }
+							y1={ yAt( referenceLine.value ) }
+							y2={ yAt( referenceLine.value ) }
+						/>
+					) }
+					{ allSeries.map( ( s, si ) => {
+						const coords = s.points.map( ( p, i ) => [ xAt( i ), yAt( p.value ) ] as const );
+						const linePts = coords.map( ( [ x, y ] ) => `${ x.toFixed( 1 ) },${ y.toFixed( 1 ) }` ).join( ' ' );
+						const area = `${ PAD },${ H - PAD } ${ linePts } ${ xAt( n - 1 ).toFixed( 1 ) },${ H - PAD }`;
+						return (
+							<g key={ `series-${ si }` }>
+								{ ! isMulti && <polygon className={ `newspack-insights__line-area is-series-${ si }` } points={ area } /> }
+								<polyline className={ `newspack-insights__line-stroke is-series-${ si }` } points={ linePts } fill="none" />
+								{ coords.map( ( [ x, y ], i ) => (
+									<circle
+										key={ `pt-${ si }-${ i }` }
+										className={ `newspack-insights__line-point is-series-${ si }` }
+										cx={ x }
+										cy={ y }
+										r={ active === i ? 4.5 : 3 }
+									/>
+								) ) }
+							</g>
+						);
+					} ) }
+					{ /* One transparent hit band per x-index so hovering anywhere in a column is forgiving. */ }
+					{ base.map( ( _p, i ) => (
+						<rect
+							key={ `hit-${ i }` }
+							className="newspack-insights__line-hit"
+							x={ n > 1 ? xAt( i ) - stepX / 2 : 0 }
+							y="0"
+							width={ n > 1 ? stepX : W }
+							height={ H }
+							onMouseEnter={ () => setActive( i ) }
+						/>
+					) ) }
+				</svg>
+				{ referenceLine && <span className="newspack-insights__line-reference-label">{ referenceLine.label }</span> }
+				{ active !== null && (
+					<div
+						className="newspack-insights__chart-tooltip"
+						style={ { left: `${ ( xAt( active ) / W ) * 100 }%`, top: `${ ( tooltipTop / H ) * 100 }%` } }
+					>
+						<span className="newspack-insights__chart-tooltip-label">{ formatLabel( base[ active ].label ) }</span>
+						{ allSeries.map( ( s, si ) => (
+							<span key={ `tt-${ si }` } className="newspack-insights__chart-tooltip-row">
+								{ isMulti && <span className={ `newspack-insights__chart-tooltip-swatch is-series-${ si }` } aria-hidden="true" /> }
+								{ isMulti && <span className="newspack-insights__chart-tooltip-name">{ s.name }</span> }
+								<span className="newspack-insights__chart-tooltip-value">{ formatNumber( s.points[ active ]?.value ?? 0 ) }</span>
+							</span>
+						) ) }
+					</div>
+				) }
+			</div>
+			{ isMulti ? (
+				<div className="newspack-insights__line-legend">
+					{ allSeries.map( ( s, si ) => (
+						<span key={ `lg-${ si }` } className="newspack-insights__line-legend-item">
+							<span className={ `newspack-insights__legend-swatch is-series-${ si }` } aria-hidden="true" />
+							<span>{ s.name }</span>
+						</span>
+					) ) }
+				</div>
+			) : (
+				<div className="newspack-insights__line-meta">
+					<span>{ formatLabel( base[ 0 ].label ) }</span>
+					<span>
+						{ __( 'peak', 'newspack-plugin' ) }: { formatNumber( max ) }
+					</span>
+					<span>{ formatLabel( base[ n - 1 ].label ) }</span>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default LineChart;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/PieChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/PieChart.tsx
@@ -1,0 +1,94 @@
+/**
+ * PieChart (NPPD-1609) — tab-local donut for the Section 3 source-mix
+ * breakdowns. A copy of the Audience tab's PieChart (NPPD-1649), extended
+ * with a `centerLabel` (the spec's "total in window" at the donut center)
+ * and a configurable `emptyMessage` so the Phase 1 empty state shows the
+ * section's spec copy. Viz stay tab-local until a canonical PieChart lands
+ * in packages/components/src/ (a v1.1 ticket, per the Audience PieChart's
+ * own note).
+ *
+ * Dependency-free SVG donut + legend. Series colors come from the shared
+ * `.is-series-N` CSS classes in `tabs/components/_insights-charts.scss`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatNumber, formatPercent } from '../../components/format';
+
+export interface PieSegment {
+	label: string;
+	value: number;
+}
+
+export interface PieChartProps {
+	segments: PieSegment[];
+	/** Optional label rendered at the donut center (e.g. the window total). */
+	centerLabel?: string;
+	/** Empty-state copy shown when there's no data. Defaults to the generic line. */
+	emptyMessage?: string;
+}
+
+const RADIUS = 16;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+const PieChart = ( { segments, centerLabel, emptyMessage }: PieChartProps ) => {
+	const total = segments.reduce( ( sum, s ) => sum + ( s.value || 0 ), 0 );
+	if ( total <= 0 ) {
+		return <p className="newspack-insights__chart-empty">{ emptyMessage ?? __( 'No data in this timeframe.', 'newspack-plugin' ) }</p>;
+	}
+
+	let offset = 0;
+	return (
+		<div className="newspack-insights__pie">
+			{ /* Pie centered in the middle slot; legend anchored to the bottom (NPPD-1649 alignment). */ }
+			<div className="newspack-insights__pie-figure">
+				<svg viewBox="0 0 42 42" className="newspack-insights__pie-svg" role="img" aria-label={ __( 'Breakdown chart', 'newspack-plugin' ) }>
+					<circle className="newspack-insights__pie-track" cx="21" cy="21" r={ RADIUS } />
+					{ segments.map( ( segment, i ) => {
+						const fraction = segment.value / total;
+						const dash = fraction * CIRCUMFERENCE;
+						// No hover tooltip on pie segments — the legend already shows
+						// label + value + percent (NPPD-1649 fix #6).
+						const circle = (
+							<circle
+								key={ segment.label }
+								className={ `newspack-insights__pie-segment is-series-${ i % 7 }` }
+								cx="21"
+								cy="21"
+								r={ RADIUS }
+								strokeDasharray={ `${ dash } ${ CIRCUMFERENCE - dash }` }
+								strokeDashoffset={ CIRCUMFERENCE / 4 - offset }
+							/>
+						);
+						offset += dash;
+						return circle;
+					} ) }
+					{ centerLabel && (
+						<text className="newspack-insights__pie-center" x="21" y="21" textAnchor="middle" dominantBaseline="central">
+							{ centerLabel }
+						</text>
+					) }
+				</svg>
+			</div>
+			<ul className="newspack-insights__pie-legend">
+				{ segments.map( ( segment, i ) => (
+					<li key={ segment.label }>
+						<span className={ `newspack-insights__legend-swatch is-series-${ i % 7 }` } aria-hidden="true" />
+						<span className="newspack-insights__legend-label">{ segment.label }</span>
+						<span className="newspack-insights__legend-value">
+							{ formatNumber( segment.value ) } ({ formatPercent( segment.value / total ) })
+						</span>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+};
+
+export default PieChart;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/viz/SortableTable.tsx
@@ -1,0 +1,217 @@
+/**
+ * Tab-local SortableTable primitive (NPPD-1609, Phase 1).
+ *
+ * Generic click-to-sort table used by the Section 8.4 "top pages that don't
+ * convert" table. A tab-local copy of the Prompts SortableTable (which the
+ * Prompts tab uses for its three performance breakdowns), conversion-scoped
+ * so the tab carries its own sort-affordance styles in its own chunk rather
+ * than depending on another tab's stylesheet. Promote to a shared primitive
+ * in packages/components/src/ in a v1.1 ticket.
+ *
+ * Behavior:
+ *   - Click a column header to sort; numeric columns open DESC, string
+ *     columns open ASC; clicking the active column toggles direction.
+ *   - Null cells (em-dash) always sort to the bottom regardless of direction.
+ *   - When `rows` is empty (Phase 1, always), the empty-state row is shown but
+ *     the sort affordances stay visible so the chrome is identical between
+ *     phases.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { formatNumber, formatPercent } from '../../components/format';
+
+export type SortDir = 'asc' | 'desc';
+
+export interface SortableColumn< Row > {
+	/** Stable key; also the default sort target when it matches `defaultSortKey`. */
+	key: string;
+	label: string;
+	numeric: boolean;
+	/** Cell content. */
+	render: ( row: Row ) => React.ReactNode;
+	/** Value used for sorting. `null` always sorts last. */
+	sortValue: ( row: Row ) => number | string | null;
+}
+
+export interface SortableTableProps< Row > {
+	columns: SortableColumn< Row >[];
+	rows: Row[];
+	getRowKey: ( row: Row ) => string | number;
+	defaultSortKey: string;
+	emptyMessage: string;
+	/**
+	 * When set and the table has more rows than this, only the first N (by the
+	 * active sort) render, with a "See more" toggle that reveals the rest. The
+	 * cap is applied after sorting, so collapsing always shows the current top N.
+	 */
+	initialRowLimit?: number;
+}
+
+const ariaSortFor = ( isActive: boolean, activeDir: SortDir ): 'ascending' | 'descending' | 'none' => {
+	if ( ! isActive ) {
+		return 'none';
+	}
+	return activeDir === 'asc' ? 'ascending' : 'descending';
+};
+
+interface SortableHeaderProps< Row > {
+	column: SortableColumn< Row >;
+	activeKey: string;
+	activeDir: SortDir;
+	onSort: ( key: string ) => void;
+}
+
+function SortableHeader< Row >( { column, activeKey, activeDir, onSort }: SortableHeaderProps< Row > ) {
+	const isActive = column.key === activeKey;
+	const ariaSort = ariaSortFor( isActive, activeDir );
+	const className = column.numeric
+		? 'newspack-insights__table-num newspack-insights__conversion-table-sort-cell'
+		: 'newspack-insights__conversion-table-sort-cell';
+	return (
+		<th scope="col" className={ className } aria-sort={ ariaSort }>
+			<button
+				type="button"
+				className={ `newspack-insights__conversion-table-sort${ isActive ? ' is-active' : '' }` }
+				onClick={ () => onSort( column.key ) }
+			>
+				<span className="newspack-insights__conversion-table-sort-label">{ column.label }</span>
+				<span className="newspack-insights__conversion-table-sort-indicator" aria-hidden="true">
+					<Icon icon={ isActive && activeDir === 'asc' ? chevronUp : chevronDown } size={ 14 } />
+				</span>
+			</button>
+		</th>
+	);
+}
+
+function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, emptyMessage, initialRowLimit }: SortableTableProps< Row > ) {
+	const [ sortKey, setSortKey ] = useState< string >( defaultSortKey );
+	const [ sortDir, setSortDir ] = useState< SortDir >( () => {
+		const def = columns.find( c => c.key === defaultSortKey );
+		return def?.numeric ? 'desc' : 'asc';
+	} );
+	const [ expanded, setExpanded ] = useState( false );
+
+	const handleSort = ( key: string ) => {
+		if ( key === sortKey ) {
+			setSortDir( prev => ( prev === 'asc' ? 'desc' : 'asc' ) );
+			return;
+		}
+		setSortKey( key );
+		// Default direction depends on column type: numeric columns open
+		// DESC (biggest first), string columns open ASC.
+		const def = columns.find( c => c.key === key );
+		setSortDir( def?.numeric ? 'desc' : 'asc' );
+	};
+
+	const sortedRows = useMemo( () => {
+		const column = columns.find( c => c.key === sortKey );
+		if ( ! column ) {
+			return rows;
+		}
+		return [ ...rows ].sort( ( a, b ) => {
+			const av = column.sortValue( a );
+			const bv = column.sortValue( b );
+			// Nulls last (regardless of direction).
+			if ( av === null && bv === null ) {
+				return 0;
+			}
+			if ( av === null ) {
+				return 1;
+			}
+			if ( bv === null ) {
+				return -1;
+			}
+			let cmp: number;
+			if ( typeof av === 'string' && typeof bv === 'string' ) {
+				cmp = av.localeCompare( bv );
+			} else {
+				cmp = ( av as number ) - ( bv as number );
+			}
+			return sortDir === 'asc' ? cmp : -cmp;
+		} );
+	}, [ rows, columns, sortKey, sortDir ] );
+
+	const isEmpty = sortedRows.length === 0;
+
+	// Row cap + "See more" toggle (only when a limit is set and exceeded). The
+	// cap is applied to the already-sorted rows, so collapsing shows the current
+	// top N; the toggle persists across re-sorts.
+	const isCollapsible = typeof initialRowLimit === 'number' && sortedRows.length > initialRowLimit;
+	const visibleRows = isCollapsible && ! expanded ? sortedRows.slice( 0, initialRowLimit ) : sortedRows;
+	const hiddenCount = sortedRows.length - ( initialRowLimit ?? 0 );
+
+	return (
+		<>
+			<div className="newspack-insights__table-wrap">
+				<table className="newspack-insights__table newspack-insights__conversion-table--sortable">
+					<thead>
+						<tr>
+							{ columns.map( col => (
+								<SortableHeader key={ col.key } column={ col } activeKey={ sortKey } activeDir={ sortDir } onSort={ handleSort } />
+							) ) }
+						</tr>
+					</thead>
+					<tbody>
+						{ isEmpty ? (
+							<tr>
+								<td colSpan={ columns.length } className="newspack-insights__conversion-table-empty">
+									{ emptyMessage }
+								</td>
+							</tr>
+						) : (
+							visibleRows.map( row => (
+								<tr key={ getRowKey( row ) }>
+									{ columns.map( col => (
+										<td key={ col.key } className={ col.numeric ? 'newspack-insights__table-num' : undefined }>
+											{ col.render( row ) }
+										</td>
+									) ) }
+								</tr>
+							) )
+						) }
+					</tbody>
+				</table>
+			</div>
+			{ isCollapsible && (
+				<button
+					type="button"
+					className="newspack-insights__conversion-table-more"
+					aria-expanded={ expanded }
+					onClick={ () => setExpanded( prev => ! prev ) }
+				>
+					{ expanded
+						? __( 'See less', 'newspack-plugin' )
+						: sprintf(
+								/* translators: %d: number of additional rows revealed by expanding the table. */
+								__( 'See more (%d)', 'newspack-plugin' ),
+								hiddenCount
+						  ) }
+				</button>
+			) }
+		</>
+	);
+}
+
+/** Renders an em-dash for non-applicable numeric cells, distinct from a real zero. */
+export const NotApplicable = () => (
+	<span className="newspack-insights__table-na" aria-label={ __( 'Not applicable', 'newspack-plugin' ) }>
+		—
+	</span>
+);
+
+/** Cell renderer: a percentage, or a muted em-dash when the metric is not applicable (null). */
+export const renderRate = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatPercent( v ) }</> );
+
+/** Cell renderer: a formatted count, or a muted em-dash when the metric is not applicable (null). */
+export const renderCount = ( v: number | null ) => ( v === null ? <NotApplicable /> : <>{ formatNumber( v ) }</> );
+
+export default SortableTable;

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Test Conversion_Metric (NPPD-1609, Phase 1).
+ *
+ * Phase 1 orchestrator returns placeholder envelopes only — no proxy, no
+ * SQL. These tests pin the envelope shape every Phase 2 swap must preserve:
+ * scalar scorecards carry `value` / `pending` / `computable` /
+ * `placeholder_type`; the five funnels carry `pending` + ordered zeroed
+ * stages (two of them visibility-gated); the three PieCharts carry zeroed
+ * source slices; the four cumulative distributions carry empty point/series
+ * collections (4.4 visibility-gated); the two cohorts carry empty `cohorts`
+ * + a hardcoded reference line; the weekly trends carry empty `weeks` + the
+ * series keys; and the opportunity table carries empty `rows` + a threshold.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Newspack\Insights\Conversion_Metric;
+use WP_UnitTestCase;
+
+/**
+ * Conversion_Metric test class.
+ *
+ * @group insights
+ */
+class Test_Conversion_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Subject under test.
+	 *
+	 * @var Conversion_Metric
+	 */
+	private $metric;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->metric = new Conversion_Metric();
+	}
+
+	/**
+	 * Make a UTC DateTimeImmutable from a YYYY-MM-DD string.
+	 *
+	 * @param string $ymd Date string.
+	 * @return DateTimeImmutable
+	 */
+	private function make_date( string $ymd ): DateTimeImmutable {
+		return new DateTimeImmutable( $ymd, new DateTimeZone( 'UTC' ) );
+	}
+
+	/**
+	 * The window start/end passed to every method under test.
+	 *
+	 * @return array{0: DateTimeImmutable, 1: DateTimeImmutable}
+	 */
+	private function window(): array {
+		return [ $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) ];
+	}
+
+	/**
+	 * Every scalar scorecard returns the Phase 1 placeholder envelope: a
+	 * non-computable, pending, zero value of the documented type.
+	 *
+	 * @dataProvider provide_scalar_methods
+	 * @param string $method           Method on Conversion_Metric to call.
+	 * @param string $placeholder_type Expected `placeholder_type`.
+	 */
+	public function test_scalar_returns_placeholder_envelope( string $method, string $placeholder_type ) {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->$method( $start, $end );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'value', $result );
+		$this->assertArrayHasKey( 'computable', $result );
+		$this->assertArrayHasKey( 'pending', $result );
+		$this->assertArrayHasKey( 'denominator', $result );
+		$this->assertArrayHasKey( 'placeholder_type', $result );
+
+		$this->assertTrue( $result['pending'], "$method should be pending in Phase 1" );
+		$this->assertFalse( $result['computable'], "$method should be non-computable in Phase 1" );
+		$this->assertNull( $result['denominator'] );
+		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
+
+		if ( 'decimal' === $placeholder_type ) {
+			$this->assertSame( 0.0, $result['value'] );
+		} else {
+			$this->assertSame( 0, $result['value'] );
+		}
+	}
+
+	/**
+	 * The seven scalar scorecards: Section 7 influenced rates (4) and
+	 * Section 8 opportunity snapshot counts (3).
+	 *
+	 * @return array<string, array{0:string,1:string}>
+	 */
+	public function provide_scalar_methods(): array {
+		return [
+			// Section 7 — cross-tab influenced attribution.
+			'influenced_registration_rate_7d'  => [ 'get_influenced_registration_rate_7d', 'rate' ],
+			'influenced_subscription_rate_14d' => [ 'get_influenced_subscription_rate_14d', 'rate' ],
+			'influenced_donation_rate_14d'     => [ 'get_influenced_donation_rate_14d', 'rate' ],
+			'influenced_newsletter_rate_7d'    => [ 'get_influenced_newsletter_rate_7d', 'rate' ],
+			// Section 8 — opportunity buckets (snapshot counts).
+			'stale_registered_count'           => [ 'get_stale_registered_count', 'count' ],
+			'at_risk_subscriber_count'         => [ 'get_at_risk_subscriber_count', 'count' ],
+			'lapsed_donor_count'               => [ 'get_lapsed_donor_count', 'count' ],
+		];
+	}
+
+	/**
+	 * Every funnel returns a pending envelope with the expected number of
+	 * ordered, zeroed stages.
+	 *
+	 * @dataProvider provide_funnel_methods
+	 * @param string $method      Method on Conversion_Metric to call.
+	 * @param int    $stage_count Expected number of stages.
+	 */
+	public function test_funnel_returns_zeroed_stages( string $method, int $stage_count ) {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->$method( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertCount( $stage_count, $result['stages'] );
+		foreach ( $result['stages'] as $stage ) {
+			$this->assertArrayHasKey( 'label', $stage );
+			$this->assertNotSame( '', $stage['label'] );
+			$this->assertSame( 0, $stage['count'] );
+			$this->assertSame( 0.0, $stage['pct_of_top'] );
+		}
+	}
+
+	/**
+	 * The five funnels and their stage counts: the Section 1 lifecycle
+	 * funnel (5) and the four Section 2 per-journey funnels (3/3/3/2).
+	 *
+	 * @return array<string, array{0:string,1:int}>
+	 */
+	public function provide_funnel_methods(): array {
+		return [
+			'reader_lifecycle'         => [ 'get_reader_lifecycle_funnel', 5 ],
+			'anonymous_to_registered'  => [ 'get_anonymous_to_registered_funnel', 3 ],
+			'registered_to_subscriber' => [ 'get_registered_to_subscriber_funnel', 3 ],
+			'registered_to_donor'      => [ 'get_registered_to_donor_funnel', 3 ],
+			'subscriber_to_donor'      => [ 'get_subscriber_to_donor_funnel', 2 ],
+		];
+	}
+
+	/**
+	 * The visibility-gated Section 2.4 funnel is hidden in Phase 1, with the
+	 * `insufficient_data` reason the React side reads for its empty state.
+	 */
+	public function test_cross_upsell_funnel_is_hidden_in_phase_1() {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->get_subscriber_to_donor_funnel( $start, $end );
+
+		$this->assertSame( 'hidden', $result['visibility'] );
+		$this->assertSame( 'insufficient_data', $result['visibility_reason'] );
+	}
+
+	/**
+	 * Every Section 3 PieChart returns a pending envelope with a zero total
+	 * and the three zeroed source slices (gate / prompt / direct).
+	 *
+	 * @dataProvider provide_source_mix_methods
+	 * @param string $method Method on Conversion_Metric to call.
+	 */
+	public function test_source_mix_returns_zeroed_slices( string $method ) {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->$method( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertCount( 3, $result['slices'] );
+		$this->assertSame(
+			[ 'gate', 'prompt', 'direct' ],
+			array_column( $result['slices'], 'source' )
+		);
+		foreach ( $result['slices'] as $slice ) {
+			$this->assertSame( 0, $slice['count'] );
+			$this->assertSame( 0.0, $slice['pct'] );
+		}
+	}
+
+	/**
+	 * The three Section 3 PieCharts.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_source_mix_methods(): array {
+		return [
+			'registrations' => [ 'get_source_mix_registrations' ],
+			'subscribers'   => [ 'get_source_mix_subscribers' ],
+			'donors'        => [ 'get_source_mix_donors' ],
+		];
+	}
+
+	/**
+	 * The two single-series Section 4 distributions return a pending
+	 * envelope with an empty `points` array.
+	 *
+	 * @dataProvider provide_single_series_distribution_methods
+	 * @param string $method Method on Conversion_Metric to call.
+	 */
+	public function test_single_series_distribution_is_empty( string $method ) {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->$method( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertArrayHasKey( 'points', $result );
+		$this->assertSame( [], $result['points'] );
+	}
+
+	/**
+	 * The single-series cumulative distributions (4.1 and 4.4).
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_single_series_distribution_methods(): array {
+		return [
+			'time_to_register'        => [ 'get_time_to_register_distribution' ],
+			'subscriber_to_donor_lag' => [ 'get_subscriber_to_donor_lag_distribution' ],
+		];
+	}
+
+	/**
+	 * The two multi-series Section 4 distributions return a pending envelope
+	 * with three empty per-source series (gate / prompt / direct).
+	 *
+	 * @dataProvider provide_multi_series_distribution_methods
+	 * @param string $method Method on Conversion_Metric to call.
+	 */
+	public function test_multi_series_distribution_is_empty( string $method ) {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->$method( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertCount( 3, $result['groups'] );
+		$this->assertSame(
+			[ 'gate', 'prompt', 'direct' ],
+			array_column( $result['groups'], 'label' )
+		);
+		foreach ( $result['groups'] as $group ) {
+			$this->assertSame( [], $group['points'] );
+		}
+	}
+
+	/**
+	 * The multi-series cumulative distributions (4.2 and 4.3).
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_multi_series_distribution_methods(): array {
+		return [
+			'time_to_subscribe' => [ 'get_time_to_subscribe_distribution' ],
+			'time_to_donate'    => [ 'get_time_to_donate_distribution' ],
+		];
+	}
+
+	/**
+	 * The visibility-gated Section 4.4 lag distribution is hidden in Phase 1.
+	 */
+	public function test_lag_distribution_is_hidden_in_phase_1() {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->get_subscriber_to_donor_lag_distribution( $start, $end );
+
+		$this->assertSame( 'hidden', $result['visibility'] );
+		$this->assertSame( 'insufficient_data', $result['visibility_reason'] );
+	}
+
+	/**
+	 * Each Section 5 cohort returns a pending envelope with empty `cohorts`
+	 * and the spec's hardcoded reference line.
+	 *
+	 * @dataProvider provide_cohort_methods
+	 * @param string $method         Method on Conversion_Metric to call.
+	 * @param float  $expected_value Expected reference-line value.
+	 */
+	public function test_cohort_returns_empty_with_reference_line( string $method, float $expected_value ) {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->$method( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertSame( [], $result['cohorts'] );
+		$this->assertArrayHasKey( 'reference_line', $result );
+		$this->assertSame( $expected_value, $result['reference_line']['value'] );
+		$this->assertNotSame( '', $result['reference_line']['label'] );
+	}
+
+	/**
+	 * The two Section 5 cohorts and their hardcoded reference-line values.
+	 *
+	 * @return array<string, array{0:string,1:float}>
+	 */
+	public function provide_cohort_methods(): array {
+		return [
+			'registration_to_conversion' => [ 'get_registration_to_conversion_cohort', 0.15 ],
+			'subscriber_retention'       => [ 'get_subscriber_retention_cohort', 0.70 ],
+		];
+	}
+
+	/**
+	 * The Section 6 weekly trends return a pending envelope with empty
+	 * `weeks` and the two tracked series keys.
+	 */
+	public function test_weekly_trends_returns_empty_weeks_with_series() {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->get_weekly_conversion_rates( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertSame( [], $result['weeks'] );
+		$this->assertSame( [ 'registration_rate', 'subscription_attempt_rate' ], $result['series'] );
+	}
+
+	/**
+	 * The Section 8.4 table returns a pending envelope with empty `rows` and
+	 * the pageview threshold, so the React table renders its empty-state row.
+	 */
+	public function test_top_pages_table_returns_empty_rows_with_threshold() {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->get_top_pages_no_conversion( $start, $end );
+
+		$this->assertTrue( $result['pending'] );
+		$this->assertSame( [], $result['rows'] );
+		$this->assertSame( 100, $result['threshold_pageviews'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Test Conversion_REST_Controller (NPPD-1609, Phase 1).
+ *
+ * Exercises the Tab 3 endpoint's request lifecycle: a valid window returns
+ * 200 with the placeholder envelope (all eight sections present); comparison
+ * mode adds a `previous` window; invalid / mismatched date params return 400.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Conversion_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * Conversion_REST_Controller test class.
+ *
+ * @group insights
+ */
+class Test_Conversion_REST_Controller extends WP_UnitTestCase {
+
+	const ROUTE = '/newspack-insights/v1/conversion';
+
+	/**
+	 * REST server.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up: an admin user + a registered Conversion route on a fresh server.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// Register on the rest_api_init action (as production does) — calling
+		// register_rest_route outside that action triggers a _doing_it_wrong notice.
+		add_action( 'rest_api_init', [ $this, 'register_conversion_route' ] );
+
+		global $wp_rest_server;
+		$this->server   = new WP_REST_Server();
+		$wp_rest_server = $this->server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Register the Conversion route. Hooked to rest_api_init in set_up().
+	 *
+	 * @return void
+	 */
+	public function register_conversion_route() {
+		( new Conversion_REST_Controller() )->register_routes();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_action( 'rest_api_init', [ $this, 'register_conversion_route' ] );
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Build + dispatch a GET request to the Conversion route.
+	 *
+	 * @param array $params Query params.
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch( array $params ) {
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * A valid window returns 200 with the full placeholder envelope and a
+	 * null `previous` (no comparison requested). One representative metric
+	 * key per section is asserted present.
+	 */
+	public function test_valid_window_returns_200_envelope() {
+		$response = $this->dispatch(
+			[
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'tab_pending', $data );
+		$this->assertTrue( $data['tab_pending'] );
+		$this->assertArrayHasKey( 'current', $data );
+		$this->assertNull( $data['previous'] );
+
+		$current = $data['current'];
+		$this->assertSame( '2026-03-22', $current['window']['start'] );
+		$this->assertSame( '2026-04-21', $current['window']['end'] );
+		foreach (
+			[
+				'reader_lifecycle_funnel',                // Section 1.
+				'subscriber_to_donor_funnel',             // Section 2.
+				'source_mix_registrations',               // Section 3.
+				'time_to_register_distribution',          // Section 4.
+				'subscriber_retention_cohort',            // Section 5.
+				'weekly_conversion_rates',                // Section 6.
+				'influenced_registration_rate_7d',        // Section 7.
+				'top_pages_no_conversion',                // Section 8.
+			] as $key
+		) {
+			$this->assertArrayHasKey( $key, $current, "Missing window key: $key" );
+		}
+
+		// A scalar carries the placeholder envelope.
+		$this->assertTrue( $current['influenced_registration_rate_7d']['pending'] );
+		$this->assertSame( 'rate', $current['influenced_registration_rate_7d']['placeholder_type'] );
+		// The opportunity table ships empty rows for the empty-state UI.
+		$this->assertSame( [], $current['top_pages_no_conversion']['rows'] );
+	}
+
+	/**
+	 * The envelope carries all 23 metric keys (plus the window echo).
+	 */
+	public function test_window_carries_all_23_metric_keys() {
+		$response = $this->dispatch(
+			[
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			]
+		);
+		$current = $response->get_data()['current'];
+
+		// 23 metrics + the `window` echo.
+		$this->assertCount( 24, $current );
+	}
+
+	/**
+	 * Comparison mode (both compare params) adds a populated `previous`
+	 * window with the same shape.
+	 */
+	public function test_comparison_mode_populates_previous() {
+		$response = $this->dispatch(
+			[
+				'start'         => '2026-03-22',
+				'end'           => '2026-04-21',
+				'compare_start' => '2026-02-20',
+				'compare_end'   => '2026-03-21',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data['previous'] );
+		$this->assertSame( '2026-02-20', $data['previous']['window']['start'] );
+		$this->assertSame( '2026-03-21', $data['previous']['window']['end'] );
+		$this->assertArrayHasKey( 'reader_lifecycle_funnel', $data['previous'] );
+	}
+
+	/**
+	 * An unparseable date is rejected by the route's validate_callback.
+	 */
+	public function test_invalid_date_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start' => 'not-a-date',
+				'end'   => '2026-04-21',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Start after end is rejected by the handler.
+	 */
+	public function test_start_after_end_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start' => '2026-04-21',
+				'end'   => '2026-03-22',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * A lone comparison bound (start without end) is rejected.
+	 */
+	public function test_partial_comparison_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start'         => '2026-03-22',
+				'end'           => '2026-04-21',
+				'compare_start' => '2026-02-20',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * An inverted comparison window (compare_start after compare_end) is rejected.
+	 */
+	public function test_inverted_comparison_window_returns_400() {
+		$response = $this->dispatch(
+			[
+				'start'         => '2026-03-22',
+				'end'           => '2026-04-21',
+				'compare_start' => '2026-03-21',
+				'compare_end'   => '2026-02-20',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Conversion Journey tab (Tab 3), landing on `feat/insights-rsm`. Closes NPPD-1609. Ships the complete UI — eight sections, every visualization, every scorecard, the opportunity-buckets table — with the `Conversion_Metric` orchestrator returning placeholder envelopes for all 23 methods. No BigQuery wiring; that's Phase 2 (NPPD-1692). The two-phase split mirrors Gates Phase 1 / Phase 2 and Prompts Phase 1 (NPPD-1607 / PR #271) — Phase 1 is reviewable on its own for UI alignment and envelope contracts; Phase 2 is a pure data swap.

The tab already existed as a "Coming soon" stub (`ConversionTab.tsx` and `class-insights-section-conversion.php`, both with placeholder bodies routed but unfilled). This PR fills them in. User-facing nav label stays "Conversion Journey".

### Pre-flight decisions

- Naming follows the in-repo convention, not the prompt's. `conversion` / `Conversion_*` everywhere — tab key, hook, file paths, REST base, class names. The prompt's `conversion-journey` / `Conversion_Journey` didn't match the existing stubs or any sibling tab. Filled the stubs rather than creating parallel files.
- PHP shape mirrors `Prompts_Metric` exactly. 2-param `(DateTimeInterface $start, $end)` methods, no `compute()` entrypoint. The REST controller's `build_window()` assembles `current` and `previous` by calling each method twice. Envelope is `{tab_pending, current: {window, ...}, previous}` with no `meta` block — same shape PromptsTab / GatesTab consume. The prompt's centralized `compute()` would have introduced an orchestration pattern no other tab uses.
- Section 4 dropped BoxPlots for cumulative-distribution LineCharts mid-build. BoxPlots are hard to read for non-statisticians and the section's job is "how fast does each source convert," which a cumulative curve answers more directly (median is where the line crosses 50%; gaps between lines at any day mark source-by-source speed). Reuses the existing LineChart primitive; net-new viz primitive work for this PR is zero.
- Viz primitives stay tab-local copies. There's no shared viz library — Funnel and PieChart already live duplicated per tab (audience, gates, prompts) so each tab can evolve independently. Copied that convention. Two small spec-driven extensions: PieChart gains optional `centerLabel`, LineChart gains optional `referenceLine`. Both gain an `emptyMessage` prop so Phase 1 empty states surface the spec's copy.
- Callouts built self-contained for session-only dismissal. No `PreviewBanner` component existed (Gates/Prompts have no preview banner — PromptsTab's docblock says so explicitly). The shared `InfoCallout` persists dismissal in localStorage, which doesn't match the spec's "session-only" intent. Built both top-of-tab callouts (Phase 1 preview banner + cohort retention freshness explainer) directly rather than retrofit `InfoCallout`.

## What's in this PR

### Docs

`docs/insights/specs/conversion-journey.md` (new) and `docs/insights/formulas/tab-3-conversion-journey.md`. Section 4 in both reflects the cumulative-LineChart decision — the formula doc carries the per-source `cumulative_pct` SQL for time-to-register / time-to-subscribe / time-to-donate / sub-to-donor lag.

### PHP orchestrator and REST controller

`Conversion_Metric` at `includes/wizards/insights/metrics/class-conversion-metric.php`, cache prefix `newspack_insights_tab3_v1:`. 23 placeholder methods spanning all eight sections — 7 scalars, 5 funnels, 3 PieCharts, 4 cumulative LineCharts, 2 cohort LineCharts, 1 weekly trends LineChart, 1 table. Placeholder shapes use the real field names that Phase 2 will return: scalars `{value, computable, pending, denominator, placeholder_type}` with `placeholder_type ∈ count|rate|currency|decimal`; funnels `{pending, stages: [{label, count, pct_of_top}]}`; pies `{pending, total, slices: [{source, count, pct}]}`; distributions `{pending, data: []}` (single) or `{pending, groups: [{label, data: []}]}` (multi-group); cohorts `{pending, reference_line: {value, label}, cohorts: []}`; tables `{pending, rows: []}`. Visibility-gated methods (sections 2.4 and 4.4) carry `visibility: 'hidden' + visibility_reason`. Snapshot methods take the date params and `unset()` them with a docblock note flagging the Phase 2 BQ-catalog handoff. Local-only and Woo-only methods (2.4, 4.4, 5.2, 8.1–8.3) flagged similarly.

`Conversion_REST_Controller` at `includes/wizards/insights/api/class-conversion-rest-controller.php`, namespace `newspack-insights/v1`, base `conversion`. `GET /newspack-insights/v1/conversion` with `start` / `end` / `compare_start` / `compare_end` params. Permission `manage_options`, parse-date helpers from `Prompts_REST_Controller`. `build_response()` returns `{tab_pending: true, current: {window, ...}, previous: null}`. Wired via the conversion section registrar's `load_dependencies()` + `register_hooks()`.

`includes/wizards/insights/class-insights-section-conversion.php` — filled the existing stub to load the metric class, register the REST controller, and route. Already `init()`'d at `includes/class-wizards.php:92` so no wizard-registration changes.

### React scaffold and sections

`ConversionTab.tsx` (filled), `hooks/useConversionData.ts`, `api/conversion.ts`. New `conversion` entry in `loading-messages.ts`. Eight section components under `tabs/conversion/`, composed via the shared `TabStateView` (so Phase 1 inherits the unified loading-frame + progressive-message rig from NPPD-1684). Only `CrossTabInfluencedSection` receives `previous` for its four scorecards; the other seven sections render `current` only.

Tab-local viz under `tabs/conversion/viz/` — copies of `Funnel`, `PieChart`, `LineChart`, `SortableTable` with the two small extensions described in pre-flight. The cumulative-curve flavor of LineChart is a usage variant, not a new primitive; multi-series LineChart already handles the 3-line case for Sections 4.2 / 4.3.

### Callouts

`ConversionPreviewBanner.tsx` and `CohortRetentionFreshnessCallout.tsx`, both rendered at the top of `ConversionTab` above the section composition. Both use `sessionStorage` for dismissal so they reappear in a new session — the spec wants both dismissible but persistent across the v1 preview window, not permanently hidden. Copy is verbatim from the spec.

### Build fix

`$gray-500` → `$gray-400` in `_insights-charts.scss`. The former is undefined in `@wordpress/base-styles`; surfaced by the production webpack build, not the lint step. Worth flagging because Stylelint passed it.

## How to test

1. Check out `feat/insights-conversion-phase-1` and run `n build newspack-plugin`.
2. Visit Insights → Conversion Journey. The tab should render all eight sections with empty-state copy on every scorecard, funnel, PieChart, LineChart, and table. No 4xx in the network tab; the REST envelope should show `tab_pending: true` and `previous: null`.
3. Confirm both top-of-tab callouts render: the Phase 1 preview banner and the cohort retention freshness explainer. Dismiss both. Reload — they should stay dismissed within the session. Open the tab in a new browser session (or clear sessionStorage) — they should reappear.
4. Resize the viewport narrow. The 2×2 grids in Section 2 (per-journey funnels) and Section 4 (cumulative LineCharts) should stack to single column.
5. Section 4.4 (Subscriber → Donor Lag) and Section 2.4 (Subscriber → Donor funnel) should render their empty-state copy with the visibility-gated explanation — these are the cross-converter cohort gates that need 50+ readers in the cohort to populate in Phase 2.
6. `n test-php` from the newspack-plugin directory — 110 Insights tests / 686 assertions green. PHPCS clean.
7. `pnpm --filter newspack run build`, `tsc --noEmit`, ESLint, Stylelint — all clean. Production webpack build green.

## Heads-up on the test harness

NPPD-1683 still applies. The 8 new `*.test.tsx` files in `tabs/conversion/` follow the sibling convention but won't run in CI until `testMatch` is broadened — `**/*test.js?(x)` collects neither `.tsx` nor `.ts`. The PHP suite covers the Phase 1 shape contracts (45 new assertions), and the TS tests will activate the moment NPPD-1683 lands. Not adding `.test.js`-named workarounds for these — the `format.test.js` workaround on PR #273 was tactical because the currency tiering had to be verified before merge; the conversion section tests are render smoke checks and can wait.