### PR TITLE
chore(env): activate newspack-theme on fresh env up

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -432,6 +432,13 @@ MIGRATE
                     --admin_password="${WP_ADMIN_PASSWORD:-password}" \
                     --admin_email="${WP_ADMIN_EMAIL:-wordpress@example.com}" \
                     --skip-email
+                # Activate newspack-theme so a fresh env starts on the Newspack
+                # theme rather than WordPress's default. link-repos.sh symlinks
+                # the theme into wp-content/themes at container startup, so it's
+                # available by now. `n setup` does this too, but envs brought up
+                # with just `n env up` skip that, so it has to happen here.
+                docker exec "$container_name" wp --allow-root theme activate newspack-theme 2>/dev/null \
+                    || echo "Warning: could not activate newspack-theme (is it built/symlinked?)."
                 break
             fi
             sleep 3


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A freshly created isolated environment (`n env create … --up` / `n env up`) installs a bare WordPress and is left on WordPress's default theme. `newspack-theme` was only activated when running the full `n setup`. This activates `newspack-theme` right after the env's `wp core install`, so an env brought up without `n setup` starts on the Newspack theme.

The theme is already symlinked into the env's `wp-content/themes` by `link-repos.sh` at container startup, so it's available at install time. Activation only runs on a fresh install, so re-running `n env up` won't override a theme you've since switched. If the theme can't be activated (e.g. not built), it logs a warning and continues rather than failing the env bring-up.

### How to test the changes in this Pull Request:

1. From the workspace root, create a throwaway env and bring it up: `n env create theme-test --up`.
2. Watch the output during install – it should print `Success: Switched to 'Newspack' theme.`
3. Confirm the active theme: `docker exec newspack_env_theme_test wp --allow-root theme list --status=active --field=name` → `newspack-theme`.
4. Tear it down: `n env destroy theme-test --yes`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?