### PR TITLE
fix(sync): pin release-stamped files to monorepo on legacy sync

### DIFF
--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -8,6 +8,9 @@
 #   • Path-rewrite / merge helpers used to land legacy commits cleanly:
 #       - apply_structural_overrides: drop legacy .github/, package-lock.json,
 #         and pin workspace:* in plugin/theme package.json.
+#       - restore_release_artifacts: pin release-stamped files (CHANGELOG.md,
+#         theme stylesheet headers, package.json name/version) to the monorepo
+#         side so a late legacy hotfix release can't downgrade the monorepo.
 #       - normalize_package_repos: rewrite repository.url in every workspace
 #         package.json so semantic-release resolves to the monorepo, not the
 #         standalone legacy repo.
@@ -91,6 +94,69 @@ apply_structural_overrides() {
         ;;
     esac
   done < <(git diff --name-only --diff-filter=U)
+}
+
+# Pin release-stamped files to the monorepo (HEAD) side after a merge.
+#
+# The monorepo owns its own release versioning: semantic-release at the root
+# bumps every version-bearing file and regenerates each CHANGELOG, so "the sync
+# brings code, not the release commits" (see lib-versions.sh). The legacy repos
+# are frozen but still occasionally cut a late hotfix; that hotfix's
+# `chore(release)` commit stamps a *regressed* version (the legacy line sits
+# below the monorepo's) into package.json, the theme stylesheet headers, and
+# CHANGELOG.md. apply_structural_overrides only rescues package.json when the
+# merge *conflicts*; a clean "legacy wins" merge (legacy advanced the file, the
+# monorepo had not touched it) lands the stale stamp unchallenged and downgrades
+# the monorepo. Restore those files from HEAD regardless of conflict state,
+# leaving the real source change the hotfix carried (the actual fix) intact.
+#
+# `git checkout HEAD -- <path>` resolves to the pre-merge monorepo blob whether
+# the path conflicted or merged cleanly (`--ours` only works for conflicts), and
+# also marks any conflicted path resolved. HEAD is the pre-merge monorepo tip
+# here because integrate runs `git merge --no-commit`.
+restore_release_artifacts() {
+  local target=$1
+
+  # CHANGELOG.md is 100% semantic-release-generated. Legacy entries reference
+  # the old standalone repo's URLs/tags and interleave out of order with the
+  # monorepo's own history.
+  if git cat-file -e "HEAD:$target/CHANGELOG.md" 2> /dev/null; then
+    git checkout HEAD -- "$target/CHANGELOG.md"
+  fi
+
+  # Theme stylesheet headers (Version / Requires at least / Tested up to) are
+  # stamped from the release version; the monorepo tracks them independently and
+  # runs ahead of the frozen legacy theme. These .scss files carry only the
+  # theme header block, so restoring them wholesale keeps the monorepo metadata
+  # authoritative without discarding any source change.
+  while IFS= read -r f; do
+    if git cat-file -e "HEAD:$f" 2> /dev/null; then
+      git checkout HEAD -- "$f"
+    fi
+  done < <(git ls-files "$target" | grep -E '(^|/)theme-description\.scss$' || true)
+
+  # package.json name + version are monorepo-owned (name renamed at cutover,
+  # version bumped only by the monorepo's semantic-release). Pin just those two
+  # fields back, preserving any real dependency change the legacy commit carried.
+  while IFS= read -r pj; do
+    git cat-file -e "HEAD:$pj" 2> /dev/null || continue
+    node -e '
+      const fs = require( "fs" ), cp = require( "child_process" );
+      const pj = process.argv[1];
+      const head = JSON.parse( cp.execSync( "git show HEAD:" + pj, { encoding: "utf8" } ) );
+      const src = fs.readFileSync( pj, "utf8" );
+      const indentMatch = src.match( /\n(\t+|[ ]+)"/ );
+      const indent = indentMatch ? indentMatch[1] : "  ";
+      const trail = src.endsWith( "\n" ) ? "\n" : "";
+      const j = JSON.parse( src );
+      let dirty = false;
+      for ( const k of [ "name", "version" ] ) {
+        if ( head[k] !== undefined && j[k] !== head[k] ) { j[k] = head[k]; dirty = true; }
+      }
+      if ( dirty ) fs.writeFileSync( pj, JSON.stringify( j, null, indent ) + trail );
+    ' "$pj"
+    git add -- "$pj"
+  done < <(git ls-files "$target" | grep -E '(^|/)package\.json$' || true)
 }
 
 # Rewrite repository field in every workspace package.json so semantic-release

--- a/bin/migration/sync-legacy.sh
+++ b/bin/migration/sync-legacy.sh
@@ -221,6 +221,7 @@ integrate_all() {
     fi
 
     apply_structural_overrides "$target"
+    restore_release_artifacts "$target"
 
     # newspack-plugin always runs the extracted-package routing — files under
     # plugins/newspack-plugin/packages/{colors,components,icons}/ leak in even

--- a/bin/migration/test-restore-release-artifacts.sh
+++ b/bin/migration/test-restore-release-artifacts.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# test-restore-release-artifacts.sh
+#
+# Self-proving spec for restore_release_artifacts (lib.sh). Simulates the state
+# left by a clean "legacy wins" merge where a late legacy hotfix release stamped
+# a regressed version into the version-bearing files while also carrying a real
+# source fix and a real new dependency. Asserts the helper pins the release
+# stamps back to the monorepo (HEAD) side without discarding the real changes.
+#
+# Run: bash bin/migration/test-restore-release-artifacts.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+WORK=$(mktemp -d -t restore-release-artifacts-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+git init -q
+git config user.email t@t.t
+git config user.name t
+
+T=themes/newspack-theme
+mkdir -p "$T/newspack-theme/sass/blocks" "$T/newspack-joseph/sass"
+
+# --- Monorepo (HEAD) state: ahead on version, owns CHANGELOG + theme headers ---
+cat > "$T/package.json" <<'JSON'
+{
+	"name": "newspack-theme",
+	"version": "2.23.1",
+	"dependencies": {
+		"keep-me": "^1.0.0"
+	}
+}
+JSON
+printf 'Theme Name: Newspack\nRequires at least: 6.9\nTested up to: 7.0\nVersion: 2.23.1\n' \
+  > "$T/newspack-theme/sass/theme-description.scss"
+printf 'Theme Name: Joseph\nVersion: 2.23.1\n' \
+  > "$T/newspack-joseph/sass/theme-description.scss"
+printf '# newspack-theme [2.23.1] (monorepo)\n' > "$T/CHANGELOG.md"
+printf '.block { color: red; }\n' > "$T/newspack-theme/sass/blocks/_blocks.scss"
+git add -A
+git commit -qm "monorepo state"
+
+# --- Legacy state landed by a clean merge: regressed stamps + a real fix + a
+#     real new dependency. Staged as if -Xtheirs brought it in with no conflict.
+cat > "$T/package.json" <<'JSON'
+{
+	"name": "newspack",
+	"version": "2.22.3",
+	"dependencies": {
+		"keep-me": "^1.0.0",
+		"legit-new-dep": "^2.0.0"
+	}
+}
+JSON
+printf 'Theme Name: Newspack\nRequires at least: 6.7\nTested up to: 6.8\nVersion: 2.22.3\n' \
+  > "$T/newspack-theme/sass/theme-description.scss"
+printf 'Theme Name: Joseph\nVersion: 2.22.3\n' \
+  > "$T/newspack-joseph/sass/theme-description.scss"
+printf '## [2.22.3] (legacy)\n# newspack-theme [2.23.1] (monorepo)\n' > "$T/CHANGELOG.md"
+printf '.block { color: red; }\n.everlit-audio > * { width: 100%%; }\n' \
+  > "$T/newspack-theme/sass/blocks/_blocks.scss"
+git add -A
+
+restore_release_artifacts "$T"
+
+fail=0
+assert() { # <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1 — expected [$2], got [$3]"; fail=1
+  fi
+}
+pjv() { node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync('$1','utf8'))['$2']))"; }
+has() { grep -q "$2" "$1" && echo yes || echo no; }
+
+echo "Release stamps restored to monorepo:"
+assert "package.json name"           "newspack-theme" "$(pjv "$T/package.json" name)"
+assert "package.json version"        "2.23.1"         "$(pjv "$T/package.json" version)"
+assert "theme header version"        "yes"            "$(has "$T/newspack-theme/sass/theme-description.scss" 'Version: 2.23.1')"
+assert "theme header requires"       "yes"            "$(has "$T/newspack-theme/sass/theme-description.scss" 'Requires at least: 6.9')"
+assert "child theme header version"  "yes"            "$(has "$T/newspack-joseph/sass/theme-description.scss" 'Version: 2.23.1')"
+assert "CHANGELOG is monorepo's"     "no"             "$(has "$T/CHANGELOG.md" 'legacy')"
+
+echo "Real legacy changes kept:"
+assert "source fix kept"             "yes"            "$(has "$T/newspack-theme/sass/blocks/_blocks.scss" 'everlit-audio')"
+assert "new dependency kept"         "^2.0.0"         "$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$T/package.json','utf8')).dependencies['legit-new-dep'])")"
+
+[ "$fail" = 0 ] && echo "PASS" || { echo "FAIL"; exit 1; }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A frozen legacy repo that cuts a late hotfix release stamps a **regressed** version (its release line sits *below* the monorepo's current line) into version-bearing files: `package.json` (`version` + `name`), the theme stylesheet headers (`theme-description.scss`), and `CHANGELOG.md`. The daily sync's `apply_structural_overrides` only rescued `package.json` on a merge **conflict** (`--diff-filter=U`); a clean "legacy wins" merge - where legacy advanced the file and the monorepo hadn't touched it - landed the stale stamp unchallenged.

This was hit live: PR #280 (the held `sync/legacy-incoming` integration) regressed `newspack-theme` from `2.23.1` to `2.22.3`, flipped the package `name` back to `newspack`, and downgraded the theme headers across all five child-theme variations (`Requires at least` 6.9→6.7, `Tested up to` 7.0→6.8) - while only the changelog tripped the silent-blend detector. (The theme delta on #280 has been reverted separately; this PR stops it recurring.)

Adds `restore_release_artifacts()` (lib.sh), called per-target in the integrate loop right after `apply_structural_overrides`. After each legacy merge it restores release-owned files to the monorepo (`HEAD`) side **regardless of conflict state**, while preserving the real source change the hotfix carried:

- `CHANGELOG.md` - restored wholesale (semantic-release regenerates it; legacy entries reference the old standalone repo).
- `theme-description.scss` (any depth) - restored wholesale (header-only files; monorepo metadata is authoritative post-cutover).
- `package.json` `name` + `version` - pinned to `HEAD` surgically, so a legit legacy dependency change still lands.

This enforces the "the sync brings code, not the release commits" invariant already assumed by `lib-versions.sh`.

Closes # .

### How to test the changes in this Pull Request:

1. From the repo root, run the self-contained spec: `bash bin/migration/test-restore-release-artifacts.sh` - it simulates a clean legacy-wins merge that regresses the stamps while carrying a real fix + a new dependency, and asserts 8/8 (stamps restored to monorepo, real changes kept).
2. `bash -n bin/migration/lib.sh && bash -n bin/migration/sync-legacy.sh` - syntax check.
3. Confirm the live regression is gone: `bash bin/migration/detect-sync-collisions.sh origin/sync/legacy-incoming origin/main` reports `0 file(s) to review`.

### Other information:

* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)