### PR TITLE
fix(content-gate): cascade taxonomy content rules to child terms (NPPD-1670)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -189,7 +189,12 @@ class Content_Restriction_Control {
 					if ( ( ! $is_exclusion && ! $terms ) || is_wp_error( $terms ) ) {
 						continue 2;
 					}
-					if ( $is_exclusion ? ! empty( array_intersect( $terms, $content_rule['value'] ) ) : empty( array_intersect( $terms, $content_rule['value'] ) ) ) {
+					// For hierarchical taxonomies, a rule targeting a term also covers
+					// that term's descendants, mirroring WooCommerce Memberships' cascade.
+					// The helper also casts the rule's term IDs to integers, matching the
+					// integer IDs from wp_get_post_terms() on the other side of the intersect.
+					$target_terms = self::expand_hierarchical_terms( $content_rule['value'], $taxonomy );
+					if ( $is_exclusion ? ! empty( array_intersect( $terms, $target_terms ) ) : empty( array_intersect( $terms, $target_terms ) ) ) {
 						continue 2;
 					}
 				}
@@ -204,6 +209,36 @@ class Content_Restriction_Control {
 			$post_gates[] = $gate;
 		}
 		return $post_gates;
+	}
+
+	/**
+	 * Expand a set of taxonomy term IDs to include descendant terms when the
+	 * taxonomy is hierarchical.
+	 *
+	 * A content rule targeting a parent term should also match content assigned
+	 * only to that term's descendants, mirroring WooCommerce Memberships' cascade
+	 * behavior. Expansion happens at evaluation time so newly-added child terms
+	 * are covered without re-saving the rule. Non-hierarchical taxonomies (e.g.
+	 * tags) have no descendants and are returned as integer-cast IDs unchanged.
+	 *
+	 * @param array        $term_ids Term IDs from a content rule's value.
+	 * @param \WP_Taxonomy $taxonomy Taxonomy object the term IDs belong to.
+	 *
+	 * @return int[] De-duplicated term IDs including descendants.
+	 */
+	private static function expand_hierarchical_terms( $term_ids, $taxonomy ) {
+		$term_ids = array_map( 'intval', (array) $term_ids );
+		if ( ! $taxonomy->hierarchical ) {
+			return $term_ids;
+		}
+		$expanded = $term_ids;
+		foreach ( $term_ids as $term_id ) {
+			$children = get_term_children( $term_id, $taxonomy->name );
+			if ( ! is_wp_error( $children ) ) {
+				$expanded = array_merge( $expanded, array_map( 'intval', $children ) );
+			}
+		}
+		return array_values( array_unique( $expanded ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -28,6 +28,26 @@ class Content_Restriction_Control {
 	private static $post_gate_layout_id_map = [];
 
 	/**
+	 * Request-scoped cache of the gates that apply to a post, keyed by post ID.
+	 * The gate set a post matches depends only on the post and the (request-stable)
+	 * gate configuration, so it is safe to memoise for the request lifetime. Caches
+	 * the empty (no-gates) result too, which matters for the Premium Newsletters
+	 * cron loop that evaluates the same post for many readers.
+	 *
+	 * @var array<int,array>
+	 */
+	private static $post_gates_map = [];
+
+	/**
+	 * Request-scoped cache of a hierarchical term's descendant IDs, keyed by
+	 * "{taxonomy}:{term_id}". The term hierarchy is request-stable, so this avoids
+	 * re-walking the tree across content rules and across get_post_gates() calls.
+	 *
+	 * @var array<string,int[]>
+	 */
+	private static $term_descendants_map = [];
+
+	/**
 	 * Post meta key for exempting a post from access control restrictions.
 	 *
 	 * @var string
@@ -121,6 +141,9 @@ class Content_Restriction_Control {
 		if ( ! $post_id ) {
 			return [];
 		}
+		if ( array_key_exists( $post_id, self::$post_gates_map ) ) {
+			return self::$post_gates_map[ $post_id ];
+		}
 		$is_newsletter = false;
 		if ( class_exists( 'Newspack\Newsletters\Subscription_Lists' ) && Subscription_Lists::CPT && get_post_type( $post_id ) === Subscription_Lists::CPT ) {
 			$is_newsletter = true;
@@ -128,7 +151,8 @@ class Content_Restriction_Control {
 
 		$gates = Content_Gate::get_gates( Content_Gate::GATE_CPT, 'publish', $is_newsletter );
 		if ( empty( $gates ) ) {
-			return [];
+			self::$post_gates_map[ $post_id ] = [];
+			return self::$post_gates_map[ $post_id ];
 		}
 
 		$post_gates = [];
@@ -191,9 +215,10 @@ class Content_Restriction_Control {
 					}
 					// For hierarchical taxonomies, a rule targeting a term also covers
 					// that term's descendants, mirroring WooCommerce Memberships' cascade.
-					// The helper also casts the rule's term IDs to integers, matching the
-					// integer IDs from wp_get_post_terms() on the other side of the intersect.
-					$target_terms = self::expand_hierarchical_terms( $content_rule['value'], $taxonomy );
+					// The helper also normalizes the rule's term IDs to integers: stored
+					// rule values can be strings, and array_intersect() below compares as
+					// strings, so this keeps both sides of the comparison consistent.
+					$target_terms = self::expand_hierarchical_terms( (array) $content_rule['value'], $taxonomy );
 					if ( $is_exclusion ? ! empty( array_intersect( $terms, $target_terms ) ) : empty( array_intersect( $terms, $target_terms ) ) ) {
 						continue 2;
 					}
@@ -208,6 +233,7 @@ class Content_Restriction_Control {
 
 			$post_gates[] = $gate;
 		}
+		self::$post_gates_map[ $post_id ] = $post_gates;
 		return $post_gates;
 	}
 
@@ -221,22 +247,28 @@ class Content_Restriction_Control {
 	 * are covered without re-saving the rule. Non-hierarchical taxonomies (e.g.
 	 * tags) have no descendants and are returned as integer-cast IDs unchanged.
 	 *
-	 * @param array        $term_ids Term IDs from a content rule's value.
+	 * Descendant lookups are memoised per (taxonomy, term) for the request so the
+	 * tree is walked at most once per term, even across many rules and posts (e.g.
+	 * the Premium Newsletters cron loop).
+	 *
+	 * @param array        $term_ids Term IDs from a content rule's value (may be stored as strings).
 	 * @param \WP_Taxonomy $taxonomy Taxonomy object the term IDs belong to.
 	 *
 	 * @return int[] De-duplicated term IDs including descendants.
 	 */
-	private static function expand_hierarchical_terms( $term_ids, $taxonomy ) {
-		$term_ids = array_map( 'intval', (array) $term_ids );
+	private static function expand_hierarchical_terms( array $term_ids, \WP_Taxonomy $taxonomy ): array {
+		$term_ids = array_map( 'intval', $term_ids );
 		if ( ! $taxonomy->hierarchical ) {
 			return $term_ids;
 		}
 		$expanded = $term_ids;
 		foreach ( $term_ids as $term_id ) {
-			$children = get_term_children( $term_id, $taxonomy->name );
-			if ( ! is_wp_error( $children ) ) {
-				$expanded = array_merge( $expanded, array_map( 'intval', $children ) );
+			$cache_key = $taxonomy->name . ':' . $term_id;
+			if ( ! isset( self::$term_descendants_map[ $cache_key ] ) ) {
+				$children = get_term_children( $term_id, $taxonomy->name );
+				self::$term_descendants_map[ $cache_key ] = is_wp_error( $children ) ? [] : array_map( 'intval', $children );
 			}
+			$expanded = array_merge( $expanded, self::$term_descendants_map[ $cache_key ] );
 		}
 		return array_values( array_unique( $expanded ) );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -314,6 +314,137 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a content rule targeting a parent term in a hierarchical
+	 * taxonomy cascades to descendant terms, matching WooCommerce Memberships.
+	 */
+	public function test_content_rules_hierarchical_child_terms() {
+		// Build a category tree: parent > child > grandchild.
+		$parent_cat = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Parent Category',
+			]
+		);
+		$child_cat = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Child Category',
+				'parent'   => $parent_cat,
+			]
+		);
+		$grandchild_cat = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Grandchild Category',
+				'parent'   => $child_cat,
+			]
+		);
+		// An unrelated category outside the parent's subtree.
+		$other_cat = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Other Category',
+			]
+		);
+
+		// Posts assigned only to a descendant term, never directly to the parent.
+		$parent_post     = $this->factory->post->create( [ 'post_category' => [ $parent_cat ] ] );
+		$child_post      = $this->factory->post->create( [ 'post_category' => [ $child_cat ] ] );
+		$grandchild_post = $this->factory->post->create( [ 'post_category' => [ $grandchild_cat ] ] );
+		$other_post      = $this->factory->post->create( [ 'post_category' => [ $other_cat ] ] );
+		$this->post_ids  = array_merge( $this->post_ids, [ $parent_post, $child_post, $grandchild_post, $other_post ] );
+
+		// Inclusion rule targeting only the parent term.
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'category',
+					'value' => [ $parent_cat ],
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $child_post );
+		$this->assertCount( 1, $gates, 'Post in a child of the targeted parent category is gated' );
+
+		$gates = Content_Restriction_Control::get_post_gates( $grandchild_post );
+		$this->assertCount( 1, $gates, 'Post in a grandchild of the targeted parent category is gated' );
+
+		$gates = Content_Restriction_Control::get_post_gates( $other_post );
+		$this->assertCount( 0, $gates, 'Post outside the targeted subtree is not gated' );
+
+		// Exclusion rule targeting the parent term: descendants are excluded too.
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'      => 'category',
+					'value'     => [ $parent_cat ],
+					'exclusion' => true,
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $child_post );
+		$this->assertCount( 0, $gates, 'Post in a child of an excluded parent category is not gated' );
+
+		$gates = Content_Restriction_Control::get_post_gates( $grandchild_post );
+		$this->assertCount( 0, $gates, 'Post in a grandchild of an excluded parent category is not gated' );
+
+		$gates = Content_Restriction_Control::get_post_gates( $other_post );
+		$this->assertCount( 1, $gates, 'Post outside the excluded subtree is still gated' );
+
+		// The cascade is one-directional: a rule targeting a child term does NOT
+		// pull in posts that only carry the parent term.
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'category',
+					'value' => [ $child_cat ],
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $parent_post );
+		$this->assertCount( 0, $gates, 'Post in the parent term is not gated by a rule targeting a child term' );
+
+		$gates = Content_Restriction_Control::get_post_gates( $child_post );
+		$this->assertCount( 1, $gates, 'Post in the targeted child term is gated' );
+	}
+
+	/**
+	 * Test that a content rule on a non-hierarchical taxonomy (tags) matches
+	 * only the targeted term, with no descendant expansion.
+	 */
+	public function test_content_rules_non_hierarchical_terms() {
+		$tag         = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
+		$other_tag   = $this->factory->term->create( [ 'taxonomy' => 'post_tag' ] );
+		$tagged_post = $this->factory->post->create();
+		$other_post  = $this->factory->post->create();
+		wp_set_post_terms( $tagged_post, [ $tag ], 'post_tag' );
+		wp_set_post_terms( $other_post, [ $other_tag ], 'post_tag' );
+		$this->post_ids = array_merge( $this->post_ids, [ $tagged_post, $other_post ] );
+
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'post_tag',
+					'value' => [ $tag ],
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $tagged_post );
+		$this->assertCount( 1, $gates, 'Post with the targeted tag is gated' );
+
+		$gates = Content_Restriction_Control::get_post_gates( $other_post );
+		$this->assertCount( 0, $gates, 'Post with a different tag is not gated' );
+	}
+
+	/**
 	 * Test that gate layouts are created when a gate is created.
 	 */
 	public function test_create_gate_creates_layouts() {

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -259,6 +259,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				],
 			]
 		);
+		$this->reset_restriction_cache();
 
 		$gates = Content_Restriction_Control::get_post_gates( $post1 );
 		$this->assertCount( 1, $gates, 'One gate for the post in category 1' );
@@ -285,6 +286,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				],
 			]
 		);
+		$this->reset_restriction_cache();
 		$gates = Content_Restriction_Control::get_post_gates( $post1 );
 		$this->assertCount( 1, $gates, 'One gate for the post in category 1' );
 		$this->assertEquals( $this->gate_ids[2], $gates[0]['id'], 'Rule with an empty array-like value is ignored; category rule still matches' );
@@ -300,6 +302,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				],
 			]
 		);
+		$this->reset_restriction_cache();
 
 		$gates = Content_Restriction_Control::get_post_gates( $post1 );
 		$this->assertCount( 0, $gates, 'No gates for the post in category 1' );
@@ -364,6 +367,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				],
 			]
 		);
+		$this->reset_restriction_cache();
 
 		$gates = Content_Restriction_Control::get_post_gates( $child_post );
 		$this->assertCount( 1, $gates, 'Post in a child of the targeted parent category is gated' );
@@ -385,6 +389,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				],
 			]
 		);
+		$this->reset_restriction_cache();
 
 		$gates = Content_Restriction_Control::get_post_gates( $child_post );
 		$this->assertCount( 0, $gates, 'Post in a child of an excluded parent category is not gated' );
@@ -406,12 +411,29 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				],
 			]
 		);
+		$this->reset_restriction_cache();
 
 		$gates = Content_Restriction_Control::get_post_gates( $parent_post );
 		$this->assertCount( 0, $gates, 'Post in the parent term is not gated by a rule targeting a child term' );
 
 		$gates = Content_Restriction_Control::get_post_gates( $child_post );
 		$this->assertCount( 1, $gates, 'Post in the targeted child term is gated' );
+
+		// Stored rule values may be strings; the cascade must still match because the
+		// helper normalizes term IDs to integers before intersecting.
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'category',
+					'value' => [ (string) $parent_cat ],
+				],
+			]
+		);
+		$this->reset_restriction_cache();
+
+		$gates = Content_Restriction_Control::get_post_gates( $child_post );
+		$this->assertCount( 1, $gates, 'Stringified parent term ID still cascades to gate a child-category post' );
 	}
 
 	/**
@@ -1013,7 +1035,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	 * tests to prevent cross-test contamination.
 	 */
 	private function reset_restriction_cache() {
-		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map' ] as $prop ) {
+		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map', 'post_gates_map', 'term_descendants_map' ] as $prop ) {
 			$reflection = new \ReflectionProperty( Content_Restriction_Control::class, $prop );
 			$reflection->setAccessible( true );
 			$reflection->setValue( null, [] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes [NPPD-1670](https://linear.app/a8c/issue/NPPD-1670). Content gates with taxonomy-term content rules now cascade to a targeted term's child terms for hierarchical taxonomies (categories), matching WooCommerce Memberships.

Previously `Content_Restriction_Control::get_post_gates()` matched a post's term IDs against a rule's term IDs with a flat `array_intersect`, so a rule targeting a *parent* category did **not** gate posts assigned only to a *child* category. Restricted content leaked: a publisher reported no paywall appearing on child-category posts.

The fix adds a private `expand_hierarchical_terms()` helper that expands a hierarchical-taxonomy rule's target terms to include all descendants (via `get_term_children()`) before the intersect. Key properties:

- **Evaluation-time expansion**, so child terms added *after* a rule is saved are covered automatically (matches Woo's dynamic behavior).
- **Symmetric** for inclusion and exclusion rules.
- **No-op** for non-hierarchical taxonomies (tags), and no public-contract change (private method only) — the cross-repo `newspack-manager` consumer is unaffected.

### How to test the changes in this Pull Request:

1. Create a category tree (parent → child → grandchild) and a post assigned **only** to the child or grandchild category (not the parent).
2. Create a content gate with a content rule targeting the **parent** category, with registration or custom access active.
3. Visit the child/grandchild post as a logged-out reader → the gate (paywall/regwall) now appears. Before this change it did not.
4. Flip the rule to an **exclusion** rule on the parent → the child/grandchild post is no longer gated, while posts outside the subtree still are.
5. Or run the unit tests: `n test-php --filter test_content_rules` (covers inclusion cascade, exclusion cascade, the one-directional guarantee, and non-hierarchical passthrough).

### Rollout note

Because expansion is evaluation-time, on deploy every existing gate targeting a **parent** category recomputes its gated-post set with no migration step — this is a behavior-changing deploy, not a transparent fix. A per-site audit of the currently-live Access-Control sites (which gates expand and by how much) is tracked on [NPPD-1670](https://linear.app/a8c/issue/NPPD-1670).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? (`Test_Content_Gates`: 56 tests / 167 assertions green; PHPCS clean.)