### PR TITLE
fix(sync): cover plugin PHP and block-theme version stamps

### DIFF
--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -139,7 +139,10 @@ restore_release_artifacts() {
 
   # package.json: pin name + version, keeping any real dependency change. The
   # node block is the `if` condition so a malformed package.json skips that one
-  # file (exit 1) instead of aborting the whole sync under `set -e`.
+  # file (exit 1) instead of aborting the whole sync under `set -e`. Any
+  # conflicted package.json was already taken --ours by apply_structural_overrides
+  # above; the later normalize_package_repos / restore_workspace_deps passes
+  # rewrite other fields, so this is not the last word on the file.
   while IFS= read -r pj; do
     if node -e '
       const fs = require( "fs" ), cp = require( "child_process" );
@@ -166,8 +169,13 @@ restore_release_artifacts() {
   # header (and any `*_VERSION` constant) to HEAD's version, leaving real code
   # intact. The version is read from HEAD's own copy of the file, so a package
   # without a stamped header is a no-op. Restricted to files directly under the
-  # target so a vendored library header is never touched.
+  # target so a vendored library header is never touched. An unmerged PHP file
+  # (a conflict -Xtheirs couldn't auto-resolve) is skipped rather than edited:
+  # a surgical rewrite + `git add` would mark it resolved with conflict markers
+  # still inside, hiding it from the post-merge unmerged-paths check that
+  # escalates. Leaving it unmerged lets that escalation fire.
   while IFS= read -r f; do
+    if git ls-files --unmerged -- "$f" | grep -q .; then continue; fi
     if node -e '
       const fs = require( "fs" ), cp = require( "child_process" );
       const f = process.argv[1];

--- a/bin/migration/lib.sh
+++ b/bin/migration/lib.sh
@@ -9,8 +9,8 @@
 #       - apply_structural_overrides: drop legacy .github/, package-lock.json,
 #         and pin workspace:* in plugin/theme package.json.
 #       - restore_release_artifacts: pin release-stamped files (CHANGELOG.md,
-#         theme stylesheet headers, package.json name/version) to the monorepo
-#         side so a late legacy hotfix release can't downgrade the monorepo.
+#         theme SCSS + plugin-PHP version headers, package.json name/version) to
+#         the monorepo side so a late legacy hotfix release can't downgrade it.
 #       - normalize_package_repos: rewrite repository.url in every workspace
 #         package.json so semantic-release resolves to the monorepo, not the
 #         standalone legacy repo.
@@ -103,12 +103,24 @@ apply_structural_overrides() {
 # brings code, not the release commits" (see lib-versions.sh). The legacy repos
 # are frozen but still occasionally cut a late hotfix; that hotfix's
 # `chore(release)` commit stamps a *regressed* version (the legacy line sits
-# below the monorepo's) into package.json, the theme stylesheet headers, and
-# CHANGELOG.md. apply_structural_overrides only rescues package.json when the
-# merge *conflicts*; a clean "legacy wins" merge (legacy advanced the file, the
-# monorepo had not touched it) lands the stale stamp unchallenged and downgrades
-# the monorepo. Restore those files from HEAD regardless of conflict state,
-# leaving the real source change the hotfix carried (the actual fix) intact.
+# below the monorepo's) into the package's version-bearing files. A clean
+# "legacy wins" merge (legacy advanced the file, the monorepo had not touched
+# it) lands the stale stamp unchallenged and downgrades the monorepo;
+# apply_structural_overrides only rescues package.json, and only on a conflict.
+#
+# Two kinds of release-stamped file, handled differently:
+#
+#   • Pure artifacts — CHANGELOG.md and the theme stylesheet header SCSS
+#     (classic `theme-description.scss`, the block theme's underscore-prefixed
+#     `_theme-description.scss`). Comment / generated content only, no SCSS
+#     rules or source, so they are restored to HEAD wholesale.
+#   • Source files that merely carry a stamped version — package.json
+#     (name+version), each plugin's main PHP file (the WordPress `Version:`
+#     header that WP itself reads, plus any `*_VERSION` constant kept in lockstep
+#     with it; see config/release.js `files: [ phpFile ]`), and a theme
+#     `functions.php`. Restoring these wholesale would drop the real fix the
+#     hotfix carried, so only the version token is reset to HEAD's value; every
+#     other line the legacy commit touched survives.
 #
 # `git checkout HEAD -- <path>` resolves to the pre-merge monorepo blob whether
 # the path conflicted or merged cleanly (`--ours` only works for conflicts), and
@@ -117,33 +129,24 @@ apply_structural_overrides() {
 restore_release_artifacts() {
   local target=$1
 
-  # CHANGELOG.md is 100% semantic-release-generated. Legacy entries reference
-  # the old standalone repo's URLs/tags and interleave out of order with the
-  # monorepo's own history.
-  if git cat-file -e "HEAD:$target/CHANGELOG.md" 2> /dev/null; then
-    git checkout HEAD -- "$target/CHANGELOG.md"
-  fi
-
-  # Theme stylesheet headers (Version / Requires at least / Tested up to) are
-  # stamped from the release version; the monorepo tracks them independently and
-  # runs ahead of the frozen legacy theme. These .scss files carry only the
-  # theme header block, so restoring them wholesale keeps the monorepo metadata
-  # authoritative without discarding any source change.
+  # Pure artifacts: restore wholesale.
   while IFS= read -r f; do
     if git cat-file -e "HEAD:$f" 2> /dev/null; then
       git checkout HEAD -- "$f"
     fi
-  done < <(git ls-files "$target" | grep -E '(^|/)theme-description\.scss$' || true)
+  done < <(git ls-files "$target" \
+    | grep -E '(^|/)(CHANGELOG\.md|_?theme-description\.scss)$' || true)
 
-  # package.json name + version are monorepo-owned (name renamed at cutover,
-  # version bumped only by the monorepo's semantic-release). Pin just those two
-  # fields back, preserving any real dependency change the legacy commit carried.
+  # package.json: pin name + version, keeping any real dependency change. The
+  # node block is the `if` condition so a malformed package.json skips that one
+  # file (exit 1) instead of aborting the whole sync under `set -e`.
   while IFS= read -r pj; do
-    git cat-file -e "HEAD:$pj" 2> /dev/null || continue
-    node -e '
+    if node -e '
       const fs = require( "fs" ), cp = require( "child_process" );
       const pj = process.argv[1];
-      const head = JSON.parse( cp.execSync( "git show HEAD:" + pj, { encoding: "utf8" } ) );
+      let head;
+      try { head = JSON.parse( cp.execSync( "git show HEAD:" + pj, { encoding: "utf8", stdio: [ "pipe", "pipe", "ignore" ] } ) ); }
+      catch ( e ) { process.exit( 0 ); }   // not in HEAD (new package) — leave as-is.
       const src = fs.readFileSync( pj, "utf8" );
       const indentMatch = src.match( /\n(\t+|[ ]+)"/ );
       const indent = indentMatch ? indentMatch[1] : "  ";
@@ -154,9 +157,34 @@ restore_release_artifacts() {
         if ( head[k] !== undefined && j[k] !== head[k] ) { j[k] = head[k]; dirty = true; }
       }
       if ( dirty ) fs.writeFileSync( pj, JSON.stringify( j, null, indent ) + trail );
-    ' "$pj"
-    git add -- "$pj"
+    ' "$pj"; then
+      git add -- "$pj"
+    fi
   done < <(git ls-files "$target" | grep -E '(^|/)package\.json$' || true)
+
+  # Main plugin PHP file + theme functions.php: reset the WordPress `Version:`
+  # header (and any `*_VERSION` constant) to HEAD's version, leaving real code
+  # intact. The version is read from HEAD's own copy of the file, so a package
+  # without a stamped header is a no-op. Restricted to files directly under the
+  # target so a vendored library header is never touched.
+  while IFS= read -r f; do
+    if node -e '
+      const fs = require( "fs" ), cp = require( "child_process" );
+      const f = process.argv[1];
+      let head;
+      try { head = cp.execSync( "git show HEAD:" + f, { encoding: "utf8", stdio: [ "pipe", "pipe", "ignore" ] } ); }
+      catch ( e ) { process.exit( 0 ); }
+      const headVer = ( head.match( /^[\s*#\/]*Version:\s*(\S+)/m ) || [] )[1];
+      if ( ! headVer ) process.exit( 0 );   // not version-stamped in HEAD.
+      const src = fs.readFileSync( f, "utf8" );
+      const next = src
+        .replace( /^([\s*#\/]*Version:\s*)\S+/m, "$1" + headVer )
+        .replace( /(define\(\s*[\x27"][A-Z0-9_]*_VERSION[\x27"]\s*,\s*[\x27"])[^\x27"]+([\x27"])/g, "$1" + headVer + "$2" );
+      if ( next !== src ) fs.writeFileSync( f, next );
+    ' "$f"; then
+      git add -- "$f"
+    fi
+  done < <(git ls-files "$target" | grep -E "^${target}/[^/]+\.php$" || true)
 }
 
 # Rewrite repository field in every workspace package.json so semantic-release

--- a/bin/migration/test-restore-release-artifacts.sh
+++ b/bin/migration/test-restore-release-artifacts.sh
@@ -181,4 +181,30 @@ assert "functions.php Version"       "yes"            "$(has "$BLOCK/functions.p
 assert "block source fix kept"       "yes"            "$(has "$BLOCK/functions.php" 'newspack_block_theme_legacy_fix')"
 assert "block package.json version"  "1.28.1"         "$(pjv "$BLOCK/package.json" version)"
 
+# ---------------------------------------------------------------------------
+# Conflict path: drive an actual `git merge --no-commit -Xtheirs` where both
+# sides changed the same release artifact, then prove the restore resolves it
+# to the monorepo side (the scenarios above stage a post-merge state directly;
+# this one exercises the real merge the integrate phase runs).
+# ---------------------------------------------------------------------------
+WORK2=$(mktemp -d -t restore-release-artifacts-merge-XXXXXX)
+trap 'rm -rf "$WORK" "$WORK2"' EXIT
+(
+  cd "$WORK2"
+  git init -q && git config user.email t@t.t && git config user.name t
+  printf '# base\n' > CHANGELOG.md
+  git add -A && git commit -qm base
+  git branch legacy
+  printf '# newspack-theme [2.23.1] (monorepo)\n' > CHANGELOG.md
+  git commit -qam monorepo
+  git checkout -q legacy
+  printf '## [2.22.3] (legacy)\n# base\n' > CHANGELOG.md
+  git commit -qam "legacy hotfix"
+  git checkout -q main 2> /dev/null || git checkout -q master
+  git merge --no-commit -Xtheirs legacy > /dev/null 2>&1 || true
+  restore_release_artifacts .
+)
+echo "Conflict path — release artifact resolves to monorepo after a real merge:"
+assert "CHANGELOG is monorepo's" "no" "$(has "$WORK2/CHANGELOG.md" 'legacy')"
+
 [ "$fail" = 0 ] && echo "PASS" || { echo "FAIL"; exit 1; }

--- a/bin/migration/test-restore-release-artifacts.sh
+++ b/bin/migration/test-restore-release-artifacts.sh
@@ -6,7 +6,9 @@
 # left by a clean "legacy wins" merge where a late legacy hotfix release stamped
 # a regressed version into the version-bearing files while also carrying a real
 # source fix and a real new dependency. Asserts the helper pins the release
-# stamps back to the monorepo (HEAD) side without discarding the real changes.
+# stamps back to the monorepo (HEAD) side without discarding the real changes,
+# across all three release-stamped shapes in the manifest: a classic theme, a
+# plugin (main PHP file + version constant), and the block theme.
 #
 # Run: bash bin/migration/test-restore-release-artifacts.sh
 
@@ -24,11 +26,16 @@ git init -q
 git config user.email t@t.t
 git config user.name t
 
-T=themes/newspack-theme
-mkdir -p "$T/newspack-theme/sass/blocks" "$T/newspack-joseph/sass"
+THEME=themes/newspack-theme
+PLUGIN=plugins/newspack-blocks
+BLOCK=themes/newspack-block-theme
+mkdir -p "$THEME/newspack-theme/sass/blocks" "$THEME/newspack-joseph/sass" \
+         "$PLUGIN" "$BLOCK/src/scss"
 
-# --- Monorepo (HEAD) state: ahead on version, owns CHANGELOG + theme headers ---
-cat > "$T/package.json" <<'JSON'
+# ---------------------------------------------------------------------------
+# Monorepo (HEAD) state: ahead on version, owns the changelogs and stamps.
+# ---------------------------------------------------------------------------
+cat > "$THEME/package.json" <<'JSON'
 {
 	"name": "newspack-theme",
 	"version": "2.23.1",
@@ -38,17 +45,55 @@ cat > "$T/package.json" <<'JSON'
 }
 JSON
 printf 'Theme Name: Newspack\nRequires at least: 6.9\nTested up to: 7.0\nVersion: 2.23.1\n' \
-  > "$T/newspack-theme/sass/theme-description.scss"
+  > "$THEME/newspack-theme/sass/theme-description.scss"
 printf 'Theme Name: Joseph\nVersion: 2.23.1\n' \
-  > "$T/newspack-joseph/sass/theme-description.scss"
-printf '# newspack-theme [2.23.1] (monorepo)\n' > "$T/CHANGELOG.md"
-printf '.block { color: red; }\n' > "$T/newspack-theme/sass/blocks/_blocks.scss"
+  > "$THEME/newspack-joseph/sass/theme-description.scss"
+printf '# newspack-theme [2.23.1] (monorepo)\n' > "$THEME/CHANGELOG.md"
+printf '.block { color: red; }\n' > "$THEME/newspack-theme/sass/blocks/_blocks.scss"
+
+cat > "$PLUGIN/package.json" <<'JSON'
+{
+	"name": "@automattic/newspack-blocks",
+	"version": "4.26.3"
+}
+JSON
+cat > "$PLUGIN/newspack-blocks.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Newspack Blocks
+ * Version:     4.26.3
+ */
+define( 'NEWSPACK_BLOCKS__VERSION', '4.26.3' );
+function newspack_blocks_init() { return true; }
+PHP
+printf '# newspack-blocks [4.26.3] (monorepo)\n' > "$PLUGIN/CHANGELOG.md"
+
+cat > "$BLOCK/package.json" <<'JSON'
+{
+	"name": "newspack-block-theme",
+	"version": "1.28.1"
+}
+JSON
+printf '/*!\nTheme Name: Newspack Block Theme\nVersion: 1.28.1\n*/\n' \
+  > "$BLOCK/src/scss/_theme-description.scss"
+cat > "$BLOCK/functions.php" <<'PHP'
+<?php
+/**
+ * Newspack Block Theme functions.
+ *
+ * Version: 1.28.1
+ */
+function newspack_block_theme_setup() { return true; }
+PHP
+
 git add -A
 git commit -qm "monorepo state"
 
-# --- Legacy state landed by a clean merge: regressed stamps + a real fix + a
-#     real new dependency. Staged as if -Xtheirs brought it in with no conflict.
-cat > "$T/package.json" <<'JSON'
+# ---------------------------------------------------------------------------
+# Legacy state landed by a clean merge: regressed stamps + real fixes + a real
+# new dependency. Staged as if -Xtheirs brought it in with no conflict.
+# ---------------------------------------------------------------------------
+cat > "$THEME/package.json" <<'JSON'
 {
 	"name": "newspack",
 	"version": "2.22.3",
@@ -59,15 +104,48 @@ cat > "$T/package.json" <<'JSON'
 }
 JSON
 printf 'Theme Name: Newspack\nRequires at least: 6.7\nTested up to: 6.8\nVersion: 2.22.3\n' \
-  > "$T/newspack-theme/sass/theme-description.scss"
+  > "$THEME/newspack-theme/sass/theme-description.scss"
 printf 'Theme Name: Joseph\nVersion: 2.22.3\n' \
-  > "$T/newspack-joseph/sass/theme-description.scss"
-printf '## [2.22.3] (legacy)\n# newspack-theme [2.23.1] (monorepo)\n' > "$T/CHANGELOG.md"
+  > "$THEME/newspack-joseph/sass/theme-description.scss"
+printf '## [2.22.3] (legacy)\n# newspack-theme [2.23.1] (monorepo)\n' > "$THEME/CHANGELOG.md"
 printf '.block { color: red; }\n.everlit-audio > * { width: 100%%; }\n' \
-  > "$T/newspack-theme/sass/blocks/_blocks.scss"
+  > "$THEME/newspack-theme/sass/blocks/_blocks.scss"
+
+cat > "$PLUGIN/package.json" <<'JSON'
+{
+	"name": "@automattic/newspack-blocks",
+	"version": "4.25.0"
+}
+JSON
+cat > "$PLUGIN/newspack-blocks.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Newspack Blocks
+ * Version:     4.25.0
+ */
+define( 'NEWSPACK_BLOCKS__VERSION', '4.25.0' );
+function newspack_blocks_init() { return true; }
+function newspack_blocks_legacy_fix() { return 'fixed'; }
+PHP
+
+printf '/*!\nTheme Name: Newspack Block Theme\nVersion: 1.27.0\n*/\n' \
+  > "$BLOCK/src/scss/_theme-description.scss"
+cat > "$BLOCK/functions.php" <<'PHP'
+<?php
+/**
+ * Newspack Block Theme functions.
+ *
+ * Version: 1.27.0
+ */
+function newspack_block_theme_setup() { return true; }
+function newspack_block_theme_legacy_fix() { return 'fixed'; }
+PHP
+
 git add -A
 
-restore_release_artifacts "$T"
+restore_release_artifacts "$THEME"
+restore_release_artifacts "$PLUGIN"
+restore_release_artifacts "$BLOCK"
 
 fail=0
 assert() { # <description> <expected> <actual>
@@ -80,16 +158,27 @@ assert() { # <description> <expected> <actual>
 pjv() { node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync('$1','utf8'))['$2']))"; }
 has() { grep -q "$2" "$1" && echo yes || echo no; }
 
-echo "Release stamps restored to monorepo:"
-assert "package.json name"           "newspack-theme" "$(pjv "$T/package.json" name)"
-assert "package.json version"        "2.23.1"         "$(pjv "$T/package.json" version)"
-assert "theme header version"        "yes"            "$(has "$T/newspack-theme/sass/theme-description.scss" 'Version: 2.23.1')"
-assert "theme header requires"       "yes"            "$(has "$T/newspack-theme/sass/theme-description.scss" 'Requires at least: 6.9')"
-assert "child theme header version"  "yes"            "$(has "$T/newspack-joseph/sass/theme-description.scss" 'Version: 2.23.1')"
-assert "CHANGELOG is monorepo's"     "no"             "$(has "$T/CHANGELOG.md" 'legacy')"
+echo "Classic theme — stamps restored, real changes kept:"
+assert "package.json name"           "newspack-theme" "$(pjv "$THEME/package.json" name)"
+assert "package.json version"        "2.23.1"         "$(pjv "$THEME/package.json" version)"
+assert "theme header version"        "yes"            "$(has "$THEME/newspack-theme/sass/theme-description.scss" 'Version: 2.23.1')"
+assert "theme header requires"       "yes"            "$(has "$THEME/newspack-theme/sass/theme-description.scss" 'Requires at least: 6.9')"
+assert "child theme header version"  "yes"            "$(has "$THEME/newspack-joseph/sass/theme-description.scss" 'Version: 2.23.1')"
+assert "CHANGELOG is monorepo's"     "no"             "$(has "$THEME/CHANGELOG.md" 'legacy')"
+assert "source fix kept"             "yes"            "$(has "$THEME/newspack-theme/sass/blocks/_blocks.scss" 'everlit-audio')"
+assert "new dependency kept"         "^2.0.0"         "$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$THEME/package.json','utf8')).dependencies['legit-new-dep'])")"
 
-echo "Real legacy changes kept:"
-assert "source fix kept"             "yes"            "$(has "$T/newspack-theme/sass/blocks/_blocks.scss" 'everlit-audio')"
-assert "new dependency kept"         "^2.0.0"         "$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$T/package.json','utf8')).dependencies['legit-new-dep'])")"
+echo "Plugin — PHP header + version constant restored, real fix kept:"
+assert "php Version header"          "yes"            "$(has "$PLUGIN/newspack-blocks.php" 'Version:     4.26.3')"
+assert "php _VERSION constant"       "yes"            "$(has "$PLUGIN/newspack-blocks.php" "NEWSPACK_BLOCKS__VERSION', '4.26.3'")"
+assert "old version fully gone"      "no"             "$(has "$PLUGIN/newspack-blocks.php" '4.25.0')"
+assert "plugin source fix kept"      "yes"            "$(has "$PLUGIN/newspack-blocks.php" 'newspack_blocks_legacy_fix')"
+assert "plugin package.json version" "4.26.3"         "$(pjv "$PLUGIN/package.json" version)"
+
+echo "Block theme — underscore SCSS + functions.php restored, real fix kept:"
+assert "_theme-description version"  "yes"            "$(has "$BLOCK/src/scss/_theme-description.scss" 'Version: 1.28.1')"
+assert "functions.php Version"       "yes"            "$(has "$BLOCK/functions.php" 'Version: 1.28.1')"
+assert "block source fix kept"       "yes"            "$(has "$BLOCK/functions.php" 'newspack_block_theme_legacy_fix')"
+assert "block package.json version"  "1.28.1"         "$(pjv "$BLOCK/package.json" version)"
 
 [ "$fail" = 0 ] && echo "PASS" || { echo "FAIL"; exit 1; }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #282. A code review of that fix surfaced that `restore_release_artifacts` only protected a subset of release-stamped files, leaving the same downgrade-on-clean-merge bug open for:

- **Every plugin's main PHP file** - the `Version:` header (the version WordPress and publishers actually read, e.g. `newspack-popups.php` `Version: 3.12.1`) plus any `*_VERSION` constant kept in lockstep with it (`NEWSPACK_BLOCKS__VERSION`, `NEWSPACK_ADS_VERSION`). Stamped via `config/release.js` `files: [ phpFile ]`. None were restored, so a legacy plugin hotfix would downgrade the WP-visible plugin version.
- **The block theme** - `src/scss/_theme-description.scss` (the leading underscore slipped past the `theme-description.scss` regex) and `functions.php` (`Version:` header), both committed by its release config's `gitCommitStep`.

Classic themes were already fully covered (they commit only `theme-description.scss` + `CHANGELOG.md`).

**Fix:**
- Broaden the wholesale restore to `_?theme-description.scss` (covers the block theme).
- Add a surgical pass that resets **only** the `Version:` header and `*_VERSION` constants in the main plugin PHP file / theme `functions.php` to HEAD's version - these are real source, so the rest of the file (the actual fix the hotfix carried) is preserved.
- Harden the embedded `node` calls: each is now the `if` condition, so a single malformed file is skipped instead of aborting the whole sync under `set -e` (also drops a redundant `git cat-file` + `git show` double-fetch).

### How to test the changes in this Pull Request:

1. `bash bin/migration/test-restore-release-artifacts.sh` - 18/18 assertions across all three release-stamped shapes (classic theme, plugin with PHP header + version constant, block theme with `functions.php` + underscore SCSS). Each shape asserts both "stamp restored to monorepo version" and "real source change kept".
2. Red/green check: the new plugin/block-theme assertions fail against the pre-fix function and pass against this one (the classic-theme assertions stay green in both).
3. `bash -n bin/migration/lib.sh` - syntax check.

### Other information:

* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)