### PR TITLE
fix(webhooks): keep retries scheduled past the publish boundary

### DIFF
--- a/plugins/newspack-plugin/includes/data-events/class-webhooks.php
+++ b/plugins/newspack-plugin/includes/data-events/class-webhooks.php
@@ -32,6 +32,16 @@ final class Webhooks {
 	const MAX_RETRIES = 15;
 
 	/**
+	 * Seconds of headroom added when scheduling a retry so the request stays in
+	 * 'future' status. WordPress publishes a 'future' post immediately when its
+	 * date is less than MINUTE_IN_SECONDS away; the 1-minute minimum backoff
+	 * sits exactly on that edge, so without this buffer a wall-clock second
+	 * elapsing before WordPress's own check can shave the gap to 59s and publish
+	 * the request early, burning a retry.
+	 */
+	const SCHEDULE_HEADROOM_SECONDS = 5;
+
+	/**
 	 * Time to retain finished requests.
 	 */
 	const DELETE_REQUESTS_BEFORE = '7 days ago';
@@ -722,9 +732,21 @@ final class Webhooks {
 	 * @param int $delay      Delay in minutes. Default is 1 minute.
 	 */
 	private static function schedule_request( $request_id, $delay = 1 ) {
-		$time     = strtotime( sprintf( '+%d minutes', \absint( $delay ) ) );
-		$date     = date( 'Y-m-d H:i:s', $time ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-		$date_gmt = gmdate( 'Y-m-d H:i:s', strtotime( $date ) );
+		/*
+		 * WordPress publishes a 'future' post immediately when its date is less
+		 * than MINUTE_IN_SECONDS away (wp_insert_post(), which wp_update_post()
+		 * funnels through). The shortest backoff is 1 minute, landing exactly on
+		 * that edge, so a wall-clock second elapsing before WordPress runs its
+		 * own check can shave the gap to 59s and publish the request early,
+		 * firing an extra processing pass and consuming a retry. Clamp to that
+		 * 1-minute minimum and add SCHEDULE_HEADROOM_SECONDS so the request
+		 * reliably stays scheduled regardless of sub-second timing. WordPress
+		 * forces the PHP timezone to UTC, so a single gmdate() serves both the
+		 * local and GMT post dates.
+		 */
+		$delay    = max( 1, \absint( $delay ) );
+		$time     = time() + ( $delay * MINUTE_IN_SECONDS ) + self::SCHEDULE_HEADROOM_SECONDS;
+		$date_gmt = gmdate( 'Y-m-d H:i:s', $time );
 		\update_post_meta( $request_id, 'scheduled', $time );
 		if ( self::use_action_scheduler() ) {
 			Logger::log( "Scheduling request {$request_id} for {$date_gmt} via Action Scheduler.", self::LOGGER_HEADER );
@@ -742,7 +764,7 @@ final class Webhooks {
 				[
 					'ID'            => $request_id,
 					'post_status'   => 'future',
-					'post_date'     => $date,
+					'post_date'     => $date_gmt,
 					'post_date_gmt' => $date_gmt,
 					'edit_date'     => true,
 				]

--- a/plugins/newspack-plugin/includes/data-events/class-webhooks.php
+++ b/plugins/newspack-plugin/includes/data-events/class-webhooks.php
@@ -729,7 +729,8 @@ final class Webhooks {
 	 * Schedule a webhook request.
 	 *
 	 * @param int $request_id Request ID.
-	 * @param int $delay      Delay in minutes. Default is 1 minute.
+	 * @param int $delay      Delay in minutes. Default and enforced minimum is 1
+	 *                        minute; values below 1 are clamped (see below).
 	 */
 	private static function schedule_request( $request_id, $delay = 1 ) {
 		/*

--- a/plugins/newspack-plugin/tests/unit-tests/webhooks.php
+++ b/plugins/newspack-plugin/tests/unit-tests/webhooks.php
@@ -290,6 +290,38 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A rescheduled request must stay in 'future' status until its scheduled time.
+	 *
+	 * WordPress' wp_insert_post() flips a 'future' post straight to 'publish'
+	 * when its date is less than MINUTE_IN_SECONDS away. The shortest retry
+	 * backoff is 1 minute, which lands exactly on that edge: scheduling at +60s
+	 * means a single wall-clock second ticking before WordPress runs its own
+	 * check shaves the gap to 59s and publishes the request immediately. That
+	 * spurious publish fires an extra processing pass and burns a retry, which
+	 * made test_request_max_retries intermittently trash one iteration early.
+	 * The scheduled time must clear the boundary by more than MINUTE_IN_SECONDS.
+	 */
+	public function test_scheduled_retry_clears_publish_boundary() {
+		add_filter( 'newspack_data_events_use_action_scheduler', '__return_false' );
+		$this->dispatch_event();
+
+		$request_id = Data_Events\Webhooks::get_endpoint_requests( $this->action_endpoint )[0]['id'];
+
+		$schedule_request_method = new ReflectionMethod( Data_Events\Webhooks::class, 'schedule_request' );
+		$schedule_request_method->setAccessible( true );
+
+		// Capture the reference time before scheduling so the measured offset is
+		// immune to a wall-clock second elapsing during the assertion.
+		$before_schedule = time();
+		$schedule_request_method->invoke( null, $request_id, 1 );
+		$scheduled_offset = (int) get_post_meta( $request_id, 'scheduled', true ) - $before_schedule;
+		$this->assertGreaterThan( MINUTE_IN_SECONDS, $scheduled_offset );
+		$this->assertEquals( 'future', get_post_status( $request_id ) );
+
+		remove_filter( 'newspack_data_events_use_action_scheduler', '__return_false' );
+	}
+
+	/**
 	 * Test that finished requests older than 7 days should be deleted.
 	 */
 	public function test_finished_request_deletion() {

--- a/plugins/newspack-plugin/tests/unit-tests/webhooks.php
+++ b/plugins/newspack-plugin/tests/unit-tests/webhooks.php
@@ -303,22 +303,26 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	 */
 	public function test_scheduled_retry_clears_publish_boundary() {
 		add_filter( 'newspack_data_events_use_action_scheduler', '__return_false' );
-		$this->dispatch_event();
+		try {
+			$this->dispatch_event();
 
-		$request_id = Data_Events\Webhooks::get_endpoint_requests( $this->action_endpoint )[0]['id'];
+			$requests = Data_Events\Webhooks::get_endpoint_requests( $this->action_endpoint );
+			$this->assertNotEmpty( $requests );
+			$request_id = $requests[0]['id'];
 
-		$schedule_request_method = new ReflectionMethod( Data_Events\Webhooks::class, 'schedule_request' );
-		$schedule_request_method->setAccessible( true );
+			$schedule_request_method = new ReflectionMethod( Data_Events\Webhooks::class, 'schedule_request' );
+			$schedule_request_method->setAccessible( true );
 
-		// Capture the reference time before scheduling so the measured offset is
-		// immune to a wall-clock second elapsing during the assertion.
-		$before_schedule = time();
-		$schedule_request_method->invoke( null, $request_id, 1 );
-		$scheduled_offset = (int) get_post_meta( $request_id, 'scheduled', true ) - $before_schedule;
-		$this->assertGreaterThan( MINUTE_IN_SECONDS, $scheduled_offset );
-		$this->assertEquals( 'future', get_post_status( $request_id ) );
-
-		remove_filter( 'newspack_data_events_use_action_scheduler', '__return_false' );
+			// Capture the reference time before scheduling so the measured offset is
+			// immune to a wall-clock second elapsing during the assertion.
+			$before_schedule = time();
+			$schedule_request_method->invoke( null, $request_id, 1 );
+			$scheduled_offset = (int) get_post_meta( $request_id, 'scheduled', true ) - $before_schedule;
+			$this->assertGreaterThan( MINUTE_IN_SECONDS, $scheduled_offset );
+			$this->assertEquals( 'future', get_post_status( $request_id ) );
+		} finally {
+			remove_filter( 'newspack_data_events_use_action_scheduler', '__return_false' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes the intermittently-failing `Newspack_Test_Webhooks::test_request_max_retries`, which was red-lighting unrelated PRs on unlucky CI timing.

The failure was a real timing bug, not a test problem. The webhook retry mechanism parks a failed request as a `future` WordPress post and re-processes it when WordPress republishes it. WordPress core (`wp_insert_post()`, `wp-includes/post.php`) flips a `future` post straight to `publish` when its date is **less than `MINUTE_IN_SECONDS` (60s) away**. `schedule_request()` scheduled the shortest backoff at exactly `strtotime( '+1 minutes' )` = `+60s`, sitting right on that edge. When a wall-clock second ticked between computing that timestamp and WordPress' own `gmdate()` check, the gap became 59s and the post published immediately, firing an extra `transition_post_status` → `process_request` → recorded error. The retry counter (`count( $errors )`) then hit `MAX_RETRIES` one iteration early, so the request was trashed before its last attempt.

Empirically: replaying the old schedule math flipped to `publish` ~0.2% of the time; with the fix, 0/3000.

Changes:
- `schedule_request()` clamps the delay to a 1-minute minimum and adds a named `SCHEDULE_HEADROOM_SECONDS` (5s) buffer, so a scheduled retry reliably clears the publish boundary regardless of sub-second timing.
- Derives both `post_date` and `post_date_gmt` from a single `gmdate()` (WordPress forces the PHP timezone to UTC), dropping a no-op `strtotime()` round-trip and its `phpcs:ignore`.
- Adds `test_scheduled_retry_clears_publish_boundary` — a deterministic regression test asserting the scheduled offset clears `MINUTE_IN_SECONDS`.

Behaviour change is publisher-invisible: retries land ~5s later, never sooner.

Closes # .

### How to test the changes in this Pull Request:

1. From `plugins/newspack-plugin`, run the new regression test: `n test-php --filter test_scheduled_retry_clears_publish_boundary` (green; it fails on `main` with `Failed asserting that 60 is greater than 60`).
2. Loop the previously-flaky test to confirm stability: `for i in $(seq 1 30); do n test-php --filter test_request_max_retries || break; done` (all green).
3. Run the full webhooks class: `n test-php --filter Newspack_Test_Webhooks` (26 tests, 56 assertions).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?