### PR TITLE
feat(insights): wire Prompts (Tab 5) to BigQuery + cache (NPPD-1607)

### DIFF
--- a/plugins/newspack-plugin/docs/insights/event-reference.md
+++ b/plugins/newspack-plugin/docs/insights/event-reference.md
@@ -184,7 +184,7 @@ Fires when a reader interacts with a Newspack Campaigns prompt. This is your pri
 
 | Parameter | What it tells you |
 |---|---|
-| `newspack_popup_id` | Numeric ID of the prompt. |
+| `newspack_popup_id` | Numeric ID of the prompt. Live BQ data stores this as `value.int_value`; the canonical queries cast it to STRING via `CAST(value.int_value AS STRING)` and fall back to `value.string_value` for safety. |
 | `prompt_title` | Name of the prompt. |
 | `prompt_placement` | Where the prompt appeared (inline, overlay, above-header, etc.). |
 | `prompt_frequency` | Frequency setting on the prompt. |
@@ -192,9 +192,11 @@ Fires when a reader interacts with a Newspack Campaigns prompt. This is your pri
 | `action_type` | `donation`, `registration`, or `newsletters_subscription`. **Single-valued per prompt** — see update #4 above. |
 | `ab_test_id` | Test ID of the A/B test this prompt belongs to, if any. |
 | `ab_variant` | Which variant the reader saw — `a` (control), `b`, `c`, etc. |
-| `prompt_has_donation_block` | Whether the prompt contains a Donate block. |
-| `prompt_has_registration_block` | Whether the prompt contains a Registration block. |
-| `prompt_has_newsletters_subscription_block` | Whether the prompt contains a Newsletter Subscription block. |
+| `prompt_has_donation` (a.k.a. `prompt_has_donation_block`) | Whether the prompt contains a Donate block. |
+| `prompt_has_registration` (a.k.a. `prompt_has_registration_block`) | Whether the prompt contains a Registration block. |
+| `prompt_has_newsletters_subscription` (a.k.a. `prompt_has_newsletters_subscription_block`) | Whether the prompt contains a Newsletter Subscription block. |
+
+**Schema note (publisher drift):** live GA4 data on test publishers emits the no-`_block` form with `int_value = 1` (truthy). The Newspack help doc and earlier examples list the `_block` suffix with `string_value = 'yes'`. Both shapes may appear in the wild; the canonical BigQuery queries (see `docs/insights/formulas/tab-5-prompts.md`) defensively read both via `COALESCE(CAST(value.int_value AS STRING), value.string_value) IN ('1', 'yes')` so neither shape is silently dropped.
 
 **Notes:**
 

--- a/plugins/newspack-plugin/docs/insights/formulas/tab-5-prompts.md
+++ b/plugins/newspack-plugin/docs/insights/formulas/tab-5-prompts.md
@@ -9,6 +9,21 @@ Reference: see `formulas/README.md` for conventions used throughout (PARAM() sho
 - **Paywall completion:** same pattern as Gates — `np_modal_checkout_interaction(form_submission, checkout_button)` is an attempt; success requires a matching Woo order within the 30-min window. See `../open-questions.md` for the window default discussion.
 - **Influenced lookback:** 7 days for free conversions (registration, newsletter signup). 14 days for paid (subscription, donation).
 
+### Schema note: param shape drift across publishers
+
+The snippets below use `PARAM('foo') = 'yes'` shorthand for readability, but two pieces of param shape vary by publisher and the canonical BQ builder (`Newspack_Manager_Admin_BigQuery_Prompts_Queries`) wraps both in defensive COALESCEs:
+
+1. **`newspack_popup_id` value type** — live BQ data stores this as `value.int_value`. The canonical builder reads it as `COALESCE(CAST(value.int_value AS STRING), value.string_value)` so publishers emitting either type are matched.
+2. **`prompt_has_*` keys** — live BQ data emits `prompt_has_donation`, `prompt_has_registration`, `prompt_has_newsletters_subscription` (no `_block` suffix) with `int_value = 1`. The help doc and earlier examples use the `_block` suffix with `string_value = 'yes'`. The canonical builder reads both:
+   ```sql
+   COALESCE(
+     (SELECT CAST(value.int_value AS STRING) FROM UNNEST(event_params) WHERE key='prompt_has_X'),
+     (SELECT value.string_value FROM UNNEST(event_params) WHERE key='prompt_has_X_block')
+   ) IN ('1', 'yes')
+   ```
+
+The snippets in this doc keep the shorter `PARAM('prompt_has_X_block') = 'yes'` form for human readability — when porting them to BigQuery, expand to the COALESCE form above.
+
 ## Section: Prompt exposure
 
 ### Total Prompt Impressions (selected period)

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Insights — Tab 5 Prompts REST controller (NPPD-1607, Phase 1).
+ * Newspack Insights — Tab 5 Prompts REST controller (NPPD-1607, Phase 2).
  *
  * Single endpoint: `GET /newspack-insights/v1/prompts`. Same date-arg
  * validation, permission check, and date parsing conventions as
@@ -8,11 +8,16 @@
  * lifecycle exactly.
  *
  * Response shape:
- *   tab_pending: bool        — true in Phase 1 (placeholder phase); React
- *                              uses it to render the top-of-tab banner.
+ *   tab_error: bool          — true only when every section in the current
+ *                              window failed to load; React renders a
+ *                              tab-level error banner.
  *   current:     PromptsWindow — scorecards + funnel + distribution + tables
  *   previous:    PromptsWindow | null — only populated when the request
  *                              passes `compare_start` + `compare_end`.
+ *
+ * Each metric from {@see Prompts_Metric} carries its own `state`
+ * ('error' | 'empty' | 'populated'); sections render their own treatments,
+ * so the tab banner is reserved for the all-failed case.
  *
  * @package Newspack
  */
@@ -134,6 +139,15 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 			}
 		}
 
+		// Dev smoke-test path: serve canned fixture data so the UI renders without
+		// a BigQuery proxy connection. The optional _fixture_state param selects a
+		// render path ('populated' | 'empty' | 'error'). Never enable in production.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			$variant = (string) ( $request->get_param( '_fixture_state' ) ?? 'populated' );
+			$compare = null !== $compare_start && null !== $compare_end;
+			return rest_ensure_response( Prompts_Metric::get_fixture( $variant, $compare ) );
+		}
+
 		$metric = new Prompts_Metric();
 		return rest_ensure_response( $this->build_response( $metric, $start, $end, $compare_start, $compare_end ) );
 	}
@@ -141,9 +155,11 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	/**
 	 * Assemble the top-level response.
 	 *
-	 * `tab_pending` is true in Phase 1 (placeholder phase). React uses it
-	 * to render the top-of-tab banner; remove the flag (or have it return
-	 * false based on real data state) when Phase 2 wires up BigQuery.
+	 * `tab_error` is true only when every metric in the current window reports
+	 * `state: 'error'` — i.e. the whole tab failed to load (e.g. the BigQuery
+	 * proxy is down/misconfigured). React renders a tab-level error banner in
+	 * that case; otherwise each section renders its own error/empty/populated
+	 * treatment.
 	 *
 	 * @param Prompts_Metric         $metric        Orchestrator.
 	 * @param DateTimeImmutable      $start         Current window start.
@@ -159,15 +175,39 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 		?DateTimeImmutable $compare_start,
 		?DateTimeImmutable $compare_end
 	): array {
+		$current  = $this->build_window( $metric, $start, $end );
 		$response = [
-			'tab_pending' => true,
-			'current'     => $this->build_window( $metric, $start, $end ),
-			'previous'    => null,
+			'tab_error' => self::is_window_all_error( $current ),
+			'current'   => $current,
+			'previous'  => null,
 		];
 		if ( $compare_start && $compare_end ) {
 			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end );
 		}
 		return $response;
+	}
+
+	/**
+	 * Whether every metric in a window payload reports `state: 'error'`.
+	 *
+	 * Returns `false` as soon as any metric is not in the error state (the `window`
+	 * key is date metadata, not a metric, so it's skipped). A metric missing a
+	 * `state` key is treated as non-error, so the banner only shows on an
+	 * unambiguous all-failed window.
+	 *
+	 * @param array $window The shape returned by `build_window()`.
+	 * @return bool
+	 */
+	private static function is_window_all_error( array $window ): bool {
+		foreach ( $window as $key => $value ) {
+			if ( 'window' === $key ) {
+				continue;
+			}
+			if ( ! is_array( $value ) || ! isset( $value['state'] ) || 'error' !== $value['state'] ) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -39,6 +39,8 @@ use WP_REST_Server;
  */
 class Prompts_REST_Controller extends WP_REST_Controller {
 
+	use Cached_Controller_Trait;
+
 	/**
 	 * Shared Tab 4–7 namespace.
 	 *
@@ -52,6 +54,24 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	 * @var string
 	 */
 	protected $rest_base = 'prompts';
+
+	/**
+	 * Cache source classification for this controller.
+	 *
+	 * @return string
+	 */
+	protected function cache_source(): string {
+		return Cache::SOURCE_BIGQUERY;
+	}
+
+	/**
+	 * Tab slug used as the cache namespace.
+	 *
+	 * @return string
+	 */
+	protected function tab_slug(): string {
+		return 'prompts';
+	}
 
 	/**
 	 * Register the Tab 5 route.
@@ -71,10 +91,29 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 				],
 			]
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/refresh',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'refresh_prompts_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
 	}
 
 	/**
 	 * Permission check.
+	 *
+	 * This route is intentionally callable via application passwords. The
+	 * BQ-side rate limit is the 10-minute cooldown enforced in
+	 * {@see Cache::refresh()}, not a per-route rate limiter — any caller
+	 * authenticated as a user with `manage_options` (whether via cookie +
+	 * nonce or an application password) can trigger a refresh, and the
+	 * cooldown applies uniformly.
 	 *
 	 * @return bool|WP_Error
 	 */
@@ -96,8 +135,80 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function get_prompts_data( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
+		// Dev smoke-test path: serve canned fixture data so the UI renders without
+		// a BigQuery proxy connection. The optional _fixture_state param selects a
+		// render path ('populated' | 'empty' | 'error'). Never enable in production.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			$parsed = $this->parse_window_args( $request );
+			if ( is_wp_error( $parsed ) ) {
+				return $parsed;
+			}
+			[ , , $compare_start, $compare_end ] = $parsed;
+			$variant  = (string) ( $request->get_param( '_fixture_state' ) ?? 'populated' );
+			$compare  = null !== $compare_start && null !== $compare_end;
+			$response = rest_ensure_response(
+				[
+					'cache' => [
+						'source'         => Cache::SOURCE_LOCAL,
+						'computed_at'    => gmdate( 'Y-m-d\TH:i:s\Z' ),
+						'cooldown_until' => null,
+					],
+					'data'  => Prompts_Metric::get_fixture( $variant, $compare ),
+				]
+			);
+			$response->header( 'Cache-Control', 'no-store, private' );
+			return $response;
+		}
 
+		$parsed = $this->parse_window_args( $request );
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+		[ $start, $end, $compare_start, $compare_end ] = $parsed;
+
+		$metric = new Prompts_Metric();
+		return $this->cached_response(
+			$request,
+			function () use ( $metric, $start, $end, $compare_start, $compare_end ) {
+				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
+			}
+		);
+	}
+
+	/**
+	 * POST /prompts/refresh handler — bypass cache and recompute.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function refresh_prompts_data( WP_REST_Request $request ) {
+		// Fixture mode: delegate to GET so refresh is a no-op cache bypass.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			return $this->get_prompts_data( $request );
+		}
+		$parsed = $this->parse_window_args( $request );
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+		[ $start, $end, $compare_start, $compare_end ] = $parsed;
+		$metric = new Prompts_Metric();
+		return $this->refresh_response(
+			$request,
+			function () use ( $metric, $start, $end, $compare_start, $compare_end ) {
+				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
+			}
+		);
+	}
+
+	/**
+	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
+	 * success; WP_Error on validation failure.
+	 *
+	 * @param WP_REST_Request $request Incoming request.
+	 * @return array|WP_Error
+	 */
+	private function parse_window_args( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
 		try {
 			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
 			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
@@ -139,17 +250,7 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 			}
 		}
 
-		// Dev smoke-test path: serve canned fixture data so the UI renders without
-		// a BigQuery proxy connection. The optional _fixture_state param selects a
-		// render path ('populated' | 'empty' | 'error'). Never enable in production.
-		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
-			$variant = (string) ( $request->get_param( '_fixture_state' ) ?? 'populated' );
-			$compare = null !== $compare_start && null !== $compare_end;
-			return rest_ensure_response( Prompts_Metric::get_fixture( $variant, $compare ) );
-		}
-
-		$metric = new Prompts_Metric();
-		return rest_ensure_response( $this->build_response( $metric, $start, $end, $compare_start, $compare_end ) );
+		return [ $start, $end, $compare_start, $compare_end ];
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-woo-order-resolver.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-woo-order-resolver.php
@@ -6,12 +6,16 @@
  * identify which checkout attempts produced a completed order within a fixed
  * time window (default 30 minutes from `attempt_ts`).
  *
- * Input row shape (from the hub's `gates_paywall_*` queries):
- *   - `user_pseudo_id` (string) — **interpreted as integer `wp_wc_orders.customer_id`**.
- *     The upstream BQ query is expected to use `COALESCE(user_id, user_pseudo_id)`
- *     so this value is a numeric WP user ID for logged-in conversions. Anonymous
- *     conversions (where `user_pseudo_id` is a non-numeric GA4 pseudo ID) fail
- *     the `(int)` cast to 0 and are silently dropped.
+ * Input row shape (from the hub's `gates_paywall_*` and `prompts_*_conversion_*`
+ * queries):
+ *   - `uid` OR `user_pseudo_id` (string) — **interpreted as integer
+ *     `wp_wc_orders.customer_id`**. The upstream BQ query projects
+ *     `COALESCE(user_id, user_pseudo_id) AS uid` (Prompts; renamed per Copilot
+ *     review on newspack-manager-admin#457) or `AS user_pseudo_id` (Gates; not
+ *     renamed). The value is a numeric WP user ID for logged-in conversions.
+ *     Anonymous conversions (where the value is a non-numeric GA4 pseudo ID)
+ *     fail the `(int)` cast to 0 and are silently dropped. The resolver reads
+ *     `uid` first and falls back to `user_pseudo_id` so both shapes work.
  *   - `session_id` (string) — passthrough; not used in the Woo join.
  *   - `attempt_ts` (string|int) — GA4 microsecond timestamp (Unix epoch × 10^6).
  *
@@ -54,7 +58,7 @@ class Woo_Order_Resolver {
 	/**
 	 * Count how many BQ rows match a completed Woo order in the window.
 	 *
-	 * @param array $rows BQ rows: `[ [ 'user_pseudo_id', 'session_id', 'attempt_ts' ], ... ]`.
+	 * @param array $rows BQ rows: `[ [ 'uid' (or 'user_pseudo_id'), 'session_id', 'attempt_ts' ], ... ]`.
 	 * @param int   $window_seconds Window after `attempt_ts` to look for a completion.
 	 * @return int
 	 */
@@ -118,9 +122,12 @@ class Woo_Order_Resolver {
 		}
 
 		// Group attempts by customer_id for one query per customer (efficient on small sets).
+		// Prompts queries project the resolved user identifier as `uid` (Copilot review on
+		// newspack-manager-admin#457); Gates queries still use `user_pseudo_id`. Read `uid`
+		// first with a fallback so both shapes work without a hub-side coordinated rename.
 		$by_customer = [];
 		foreach ( $rows as $i => $row ) {
-			$customer_id = (int) ( $row['user_pseudo_id'] ?? 0 );
+			$customer_id = (int) ( $row['uid'] ?? $row['user_pseudo_id'] ?? 0 );
 			$attempt_ts  = (int) ( $row['attempt_ts'] ?? 0 );
 			if ( $customer_id <= 0 || $attempt_ts <= 0 ) {
 				continue;

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/prompts-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/prompts-fixture.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * Newspack Insights — Prompts (Tab 5) fixture payload (NPPD-1607).
+ *
+ * Realistic mock data for UI smoke testing without a BigQuery proxy connection,
+ * served by Prompts_REST_Controller when NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
+ * The optional `_fixture_state` request param selects a render path:
+ *   - 'populated' (default) — every section has data; funnel mirrors Tab 4's
+ *     12,400 / 2,800 / 320 shape so both drop-off deltas are visible.
+ *   - 'empty'    — every section reports the empty state (succeeded, no rows).
+ *   - 'error'    — every section reports the error state (tab banner shows).
+ *
+ * Returns a closure so the single required file can build any variant. Never
+ * enable fixture mode in production.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return function ( string $variant = 'populated', bool $compare = false ): array {
+	$now    = function_exists( 'current_datetime' ) ? current_datetime() : new DateTimeImmutable();
+	$end    = $now;
+	$start  = $now->modify( '-29 days' );
+	$window = [
+		'start' => $start->format( 'Y-m-d' ),
+		'end'   => $end->format( 'Y-m-d' ),
+	];
+
+	$prev_end    = $start->modify( '-1 day' );
+	$prev_start  = $prev_end->modify( '-29 days' );
+	$prev_window = [
+		'start' => $prev_start->format( 'Y-m-d' ),
+		'end'   => $prev_end->format( 'Y-m-d' ),
+	];
+
+	$scalar_types = [
+		// Section 1 — Prompt exposure.
+		'total_prompt_impressions'                   => 'count',
+		'unique_readers_reached'                     => 'count',
+		'avg_prompts_per_reader'                     => 'decimal',
+		// Section 2 — Prompt engagement.
+		'click_through_rate'                         => 'rate',
+		'form_submission_rate'                       => 'rate',
+		'dismissal_rate'                             => 'rate',
+		// Section 3 — Free reader conversion.
+		'registration_conversion_direct'             => 'rate',
+		'registration_conversion_influenced_7d'      => 'rate',
+		'newsletter_signup_conversion_direct'        => 'rate',
+		'newsletter_signup_conversion_influenced_7d' => 'rate',
+		// Section 4 — Paid reader conversion.
+		'donation_conversion_direct'                 => 'rate',
+		'donation_conversion_influenced_14d'         => 'rate',
+		'subscription_conversion_direct'             => 'rate',
+		'subscription_conversion_influenced_14d'     => 'rate',
+		// Section 5 — Revenue from prompts.
+		'donation_revenue_direct'                    => 'currency',
+		'donation_revenue_influenced_14d'            => 'currency',
+		'subscription_revenue_direct'                => 'currency',
+		'subscription_revenue_influenced_14d'        => 'currency',
+	];
+
+	$zero_value = static function ( string $type ) {
+		return 'count' === $type ? 0 : 0.0;
+	};
+
+	// --- Error variant: every section failed to load. ---
+	if ( 'error' === $variant ) {
+		$current = [ 'window' => $window ];
+		foreach ( $scalar_types as $key => $type ) {
+			$current[ $key ] = [
+				'state'            => 'error',
+				'value'            => $zero_value( $type ),
+				'computable'       => false,
+				'denominator'      => null,
+				'placeholder_type' => $type,
+				'error_code'       => 'bigquery_proxy_http_error',
+				'error_message'    => 'HTTP 500',
+			];
+		}
+		$collections = [
+			'conversion_funnel'        => 'stages',
+			'exposures_distribution'   => 'buckets',
+			'performance_by_prompt'    => 'rows',
+			'performance_by_intent'    => 'rows',
+			'performance_by_placement' => 'rows',
+		];
+		foreach ( $collections as $key => $rows_key ) {
+			$current[ $key ] = [
+				'state'         => 'error',
+				'error_code'    => 'bigquery_proxy_http_error',
+				'error_message' => 'HTTP 500',
+				$rows_key       => [],
+			];
+		}
+		return [
+			'tab_error' => true,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
+
+	// --- Empty variant: queries succeeded with no rows. ---
+	if ( 'empty' === $variant ) {
+		$current = [ 'window' => $window ];
+		foreach ( $scalar_types as $key => $type ) {
+			$current[ $key ] = [
+				'state'            => 'populated',
+				'value'            => $zero_value( $type ),
+				'computable'       => false,
+				'denominator'      => 'rate' === $type ? 0 : null,
+				'placeholder_type' => $type,
+			];
+		}
+		$current['conversion_funnel']        = [
+			'state'  => 'empty',
+			'stages' => [],
+		];
+		$current['exposures_distribution']   = [
+			'state'   => 'empty',
+			'buckets' => [],
+		];
+		$current['performance_by_prompt']    = [
+			'state' => 'empty',
+			'rows'  => [],
+		];
+		$current['performance_by_intent']    = [
+			'state' => 'empty',
+			'rows'  => [],
+		];
+		$current['performance_by_placement'] = [
+			'state' => 'empty',
+			'rows'  => [],
+		];
+		return [
+			'tab_error' => false,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
+
+	// --- Populated variant (default). ---
+	$scalar = static function ( $value, $denominator, string $type ) {
+		return [
+			'state'            => 'populated',
+			'value'            => $value,
+			'computable'       => true,
+			'denominator'      => $denominator,
+			'placeholder_type' => $type,
+		];
+	};
+
+	$build = static function ( float $f, array $window_arg ) use ( $scalar ) {
+		return [
+			'window'                                     => $window_arg,
+			// Section 1 — Prompt exposure.
+			'total_prompt_impressions'                   => $scalar( (int) round( 12400 * $f ), null, 'count' ),
+			'unique_readers_reached'                     => $scalar( (int) round( 7350 * $f ), null, 'count' ),
+			'avg_prompts_per_reader'                     => $scalar( round( 1.7 * $f, 1 ), null, 'decimal' ),
+			// Section 2 — Prompt engagement.
+			'click_through_rate'                         => $scalar( round( 0.058 * $f, 3 ), null, 'rate' ),
+			'form_submission_rate'                       => $scalar( round( 0.034 * $f, 3 ), null, 'rate' ),
+			'dismissal_rate'                             => $scalar( round( 0.21 * $f, 3 ), null, 'rate' ),
+			// Section 3 — Free reader conversion.
+			'registration_conversion_direct'             => $scalar( round( 0.027 * $f, 3 ), null, 'rate' ),
+			'registration_conversion_influenced_7d'      => $scalar( round( 0.041 * $f, 3 ), null, 'rate' ),
+			'newsletter_signup_conversion_direct'        => $scalar( round( 0.019 * $f, 3 ), null, 'rate' ),
+			'newsletter_signup_conversion_influenced_7d' => $scalar( round( 0.032 * $f, 3 ), null, 'rate' ),
+			// Section 4 — Paid reader conversion.
+			'donation_conversion_direct'                 => $scalar( round( 0.012 * $f, 3 ), (int) round( 320 * $f ), 'rate' ),
+			'donation_conversion_influenced_14d'         => $scalar( round( 0.024 * $f, 3 ), (int) round( 320 * $f ), 'rate' ),
+			'subscription_conversion_direct'             => $scalar( round( 0.008 * $f, 3 ), (int) round( 180 * $f ), 'rate' ),
+			'subscription_conversion_influenced_14d'     => $scalar( round( 0.016 * $f, 3 ), (int) round( 180 * $f ), 'rate' ),
+			// Section 5 — Revenue from prompts.
+			'donation_revenue_direct'                    => $scalar( round( 2840.75 * $f, 2 ), (int) round( 42 * $f ), 'currency' ),
+			'donation_revenue_influenced_14d'            => $scalar( round( 5210.25 * $f, 2 ), (int) round( 78 * $f ), 'currency' ),
+			'subscription_revenue_direct'                => $scalar( round( 1680.50 * $f, 2 ), (int) round( 24 * $f ), 'currency' ),
+			'subscription_revenue_influenced_14d'        => $scalar( round( 3120.00 * $f, 2 ), (int) round( 45 * $f ), 'currency' ),
+			// Section 6 — How readers convert. Funnel uses a visible drop-off shape
+			// so both deltas exceed 20% and render in the error color.
+			'conversion_funnel'                          => [
+				'state'  => 'populated',
+				'stages' => [
+					[
+						'label'      => __( 'Impression', 'newspack-plugin' ),
+						'count'      => (int) round( 12400 * $f ),
+						'pct_of_top' => 1.0,
+					],
+					[
+						'label'      => __( 'Engagement', 'newspack-plugin' ),
+						'count'      => (int) round( 2800 * $f ),
+						'pct_of_top' => 0.2258,
+					],
+					[
+						'label'      => __( 'Conversion', 'newspack-plugin' ),
+						'count'      => (int) round( 320 * $f ),
+						'pct_of_top' => 0.0258,
+					],
+				],
+			],
+			'exposures_distribution'                     => [
+				'state'   => 'populated',
+				'buckets' => [
+					[
+						'label' => __( '1 exposure', 'newspack-plugin' ),
+						'count' => (int) round( 160 * $f ),
+						'pct'   => 0.50,
+					],
+					[
+						'label' => __( '2 exposures', 'newspack-plugin' ),
+						'count' => (int) round( 90 * $f ),
+						'pct'   => 0.28,
+					],
+					[
+						'label' => __( '3–5 exposures', 'newspack-plugin' ),
+						'count' => (int) round( 50 * $f ),
+						'pct'   => 0.16,
+					],
+					[
+						'label' => __( '6+ exposures', 'newspack-plugin' ),
+						'count' => (int) round( 20 * $f ),
+						'pct'   => 0.06,
+					],
+				],
+			],
+			// Section 7 — Performance breakdown. The locked 15-key schema for
+			// per-prompt rows (Task 3.3): null conversion-rate cells exercise the
+			// em-dash path for the wrong-intent columns; real 0.0 cells render
+			// as "0.0%".
+			'performance_by_prompt'                      => [
+				'state' => 'populated',
+				'rows'  => [
+					[
+						'popup_id'                     => 201,
+						'prompt_title'                 => 'Support our newsroom',
+						'intent'                       => 'donation',
+						'placement'                    => 'overlay',
+						'impressions'                  => (int) round( 4200 * $f ),
+						'unique_viewers'               => (int) round( 2500 * $f ),
+						'ctr'                          => 0.063,
+						'form_submission_rate'         => 0.041,
+						'dismissal_rate'               => 0.18,
+						'registrations'                => 0,
+						'newsletter_signups'           => 0,
+						'donation_conversions'         => (int) round( 65 * $f ),
+						'donation_conversion_rate'     => 0.0155,
+						'subscription_conversions'     => 0,
+						'subscription_conversion_rate' => null,
+					],
+					[
+						'popup_id'                     => 202,
+						'prompt_title'                 => 'Monthly giving',
+						'intent'                       => 'donation',
+						'placement'                    => 'inline',
+						'impressions'                  => (int) round( 2100 * $f ),
+						'unique_viewers'               => (int) round( 1400 * $f ),
+						'ctr'                          => 0.048,
+						'form_submission_rate'         => 0.029,
+						'dismissal_rate'               => 0.12,
+						'registrations'                => 0,
+						'newsletter_signups'           => 0,
+						'donation_conversions'         => (int) round( 22 * $f ),
+						'donation_conversion_rate'     => 0.0105,
+						'subscription_conversions'     => 0,
+						'subscription_conversion_rate' => null,
+					],
+					[
+						'popup_id'                     => 203,
+						'prompt_title'                 => 'Become a member',
+						'intent'                       => 'registration',
+						'placement'                    => 'overlay',
+						'impressions'                  => (int) round( 3100 * $f ),
+						'unique_viewers'               => (int) round( 1900 * $f ),
+						'ctr'                          => 0.071,
+						'form_submission_rate'         => 0.045,
+						'dismissal_rate'               => 0.22,
+						'registrations'                => (int) round( 84 * $f ),
+						'newsletter_signups'           => 0,
+						'donation_conversions'         => 0,
+						'donation_conversion_rate'     => null,
+						'subscription_conversions'     => (int) round( 18 * $f ),
+						'subscription_conversion_rate' => 0.0058,
+					],
+					[
+						'popup_id'                     => 204,
+						'prompt_title'                 => 'Unlimited access',
+						'intent'                       => 'registration',
+						'placement'                    => 'above-header',
+						'impressions'                  => (int) round( 1850 * $f ),
+						'unique_viewers'               => (int) round( 1200 * $f ),
+						'ctr'                          => 0.052,
+						'form_submission_rate'         => 0.031,
+						'dismissal_rate'               => 0.16,
+						'registrations'                => (int) round( 41 * $f ),
+						'newsletter_signups'           => 0,
+						'donation_conversions'         => 0,
+						'donation_conversion_rate'     => null,
+						'subscription_conversions'     => (int) round( 9 * $f ),
+						'subscription_conversion_rate' => 0.0049,
+					],
+					[
+						'popup_id'                     => 205,
+						'prompt_title'                 => 'Get the morning brief',
+						'intent'                       => 'newsletters_subscription',
+						'placement'                    => 'inline',
+						'impressions'                  => (int) round( 1150 * $f ),
+						'unique_viewers'               => (int) round( 820 * $f ),
+						'ctr'                          => 0.039,
+						'form_submission_rate'         => 0.024,
+						'dismissal_rate'               => 0.09,
+						'registrations'                => 0,
+						'newsletter_signups'           => (int) round( 27 * $f ),
+						'donation_conversions'         => 0,
+						'donation_conversion_rate'     => null,
+						'subscription_conversions'     => 0,
+						'subscription_conversion_rate' => null,
+					],
+				],
+			],
+			'performance_by_intent'                      => [
+				'state' => 'populated',
+				'rows'  => [
+					[
+						'intent'               => 'donation',
+						'intent_label'         => 'Donation',
+						'impressions'          => (int) round( 6300 * $f ),
+						'unique_viewers'       => (int) round( 3900 * $f ),
+						'ctr'                  => 0.058,
+						'form_submission_rate' => 0.037,
+						'dismissal_rate'       => 0.16,
+					],
+					[
+						'intent'               => 'registration',
+						'intent_label'         => 'Registration',
+						'impressions'          => (int) round( 4950 * $f ),
+						'unique_viewers'       => (int) round( 3100 * $f ),
+						'ctr'                  => 0.064,
+						'form_submission_rate' => 0.040,
+						'dismissal_rate'       => 0.20,
+					],
+					[
+						'intent'               => 'newsletters_subscription',
+						'intent_label'         => 'Newsletter signup',
+						'impressions'          => (int) round( 1150 * $f ),
+						'unique_viewers'       => (int) round( 820 * $f ),
+						'ctr'                  => 0.039,
+						'form_submission_rate' => 0.024,
+						'dismissal_rate'       => 0.09,
+					],
+				],
+			],
+			'performance_by_placement'                   => [
+				'state' => 'populated',
+				'rows'  => [
+					[
+						'placement'       => 'overlay',
+						'placement_label' => 'Overlay',
+						'impressions'     => (int) round( 7300 * $f ),
+						'unique_viewers'  => (int) round( 4400 * $f ),
+						'ctr'             => 0.067,
+						'dismissal_rate'  => 0.20,
+					],
+					[
+						'placement'       => 'inline',
+						'placement_label' => 'Inline',
+						'impressions'     => (int) round( 3250 * $f ),
+						'unique_viewers'  => (int) round( 2220 * $f ),
+						'ctr'             => 0.044,
+						'dismissal_rate'  => 0.11,
+					],
+					[
+						'placement'       => 'above-header',
+						'placement_label' => 'Above header',
+						'impressions'     => (int) round( 1850 * $f ),
+						'unique_viewers'  => (int) round( 1200 * $f ),
+						'ctr'             => 0.052,
+						'dismissal_rate'  => 0.16,
+					],
+				],
+			],
+		];
+	};
+
+	return [
+		'tab_error' => false,
+		'current'   => $build( 1.0, $window ),
+		'previous'  => $compare ? $build( 0.9, $prev_window ) : null,
+	];
+};

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -207,6 +207,12 @@ final class Gates_Metric {
 			return $this->populated_scalar( $zero, false, null, $placeholder_type );
 		}
 		$value = $rows[0][ $row_key ];
+		// SAFE_DIVIDE returns NULL when the denominator is zero — a legitimate
+		// "no eligible events to compute a rate" case, not a schema regression.
+		// Same handling as the missing-key branch above: non-computable zero.
+		if ( null === $value ) {
+			return $this->populated_scalar( $zero, false, null, $placeholder_type );
+		}
 		// Non-numeric, or (for counts) a non-integer value, signals catalog/schema
 		// drift — malformed data, not an empty window. Surface it as an error so a
 		// real data-quality regression isn't masked as a benign zero.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -236,6 +236,12 @@ final class Prompts_Metric {
 			return $this->populated_scalar( $zero, false, null, $placeholder_type );
 		}
 		$value = $rows[0][ $row_key ];
+		// SAFE_DIVIDE returns NULL when the denominator is zero — a legitimate
+		// "no eligible events to compute a rate" case, not a schema regression.
+		// Same handling as the missing-key branch above: non-computable zero.
+		if ( null === $value ) {
+			return $this->populated_scalar( $zero, false, null, $placeholder_type );
+		}
 		// Non-numeric, or (for counts) a non-integer value, signals catalog/schema
 		// drift — malformed data, not an empty window. Surface it as an error so a
 		// real data-quality regression isn't masked as a benign zero.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -730,6 +730,12 @@ final class Prompts_Metric {
 
 		$by_bucket = [];
 		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				// Hub returned a row in an unexpected shape — a data-quality bug,
+				// not a legitimately empty bucket. Surface as malformed so the
+				// regression isn't masked as missing buckets.
+				return $this->malformed_collection( 'buckets' );
+			}
 			if ( isset( $row['bucket'] ) ) {
 				$by_bucket[ $row['bucket'] ] = [
 					'count' => (int) ( $row['converters_in_bucket'] ?? 0 ),
@@ -807,6 +813,12 @@ final class Prompts_Metric {
 
 		$mapped = [];
 		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				// Hub returned a row in an unexpected shape — a data-quality bug,
+				// not a legitimately empty table. Surface as malformed so the
+				// regression isn't masked as missing prompts.
+				return $this->malformed_collection( 'rows' );
+			}
 			$popup_id    = (int) ( $row['popup_id'] ?? 0 );
 			$intent      = (string) ( $row['intent'] ?? '' );
 			$impressions = (int) ( $row['impressions'] ?? 0 );
@@ -873,6 +885,10 @@ final class Prompts_Metric {
 
 		$mapped = [];
 		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				// Hub returned a row in an unexpected shape — surface as malformed.
+				return $this->malformed_collection( 'rows' );
+			}
 			$intent   = (string) ( $row['intent'] ?? '' );
 			$mapped[] = [
 				'intent'               => $intent,
@@ -920,6 +936,10 @@ final class Prompts_Metric {
 
 		$mapped = [];
 		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				// Hub returned a row in an unexpected shape — surface as malformed.
+				return $this->malformed_collection( 'rows' );
+			}
 			$placement = (string) ( $row['placement'] ?? '' );
 			$mapped[]  = [
 				'placement'       => $placement,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -19,12 +19,12 @@
  * Gates' two, so it has more scorecards and a three-table performance
  * breakdown — but the per-metric envelope is identical.
  *
- * This commit wires the 10 free-side scalar metrics (exposure + engagement +
- * registration/newsletter conversion). Paid-conversion (donation/subscription)
- * + revenue and the collection metrics (funnel/distribution/3 perf tables)
- * remain as placeholder envelopes that surface as state 'error' with the
- * `newspack_insights_prompts_not_yet_implemented` code — they will be wired in
- * follow-up commits (Task 3.2 = Woo join, Task 3.3 = collections).
+ * This commit wires the 8 paid-conversion + revenue metrics through the
+ * BigQuery proxy + Woo_Order_Resolver join (Task 3.2), on top of the 10
+ * free-side scalars wired in Task 3.1. The 5 collection metrics
+ * (funnel/distribution/3 perf tables) remain as placeholder envelopes that
+ * surface as state 'error' with the `newspack_insights_prompts_not_yet_implemented`
+ * code — they will be wired in Task 3.3.
  *
  * @package Newspack
  */
@@ -35,6 +35,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DateTimeInterface;
 use Newspack\Insights\BigQuery_Proxy_Client;
+use Newspack\Insights\Woo_Order_Resolver;
 
 /**
  * Tab 5 metric orchestrator.
@@ -67,12 +68,35 @@ final class Prompts_Metric {
 	private BigQuery_Proxy_Client $proxy;
 
 	/**
-	 * Constructor. Optionally inject a proxy client (used in tests).
+	 * Resolver used to match BQ paid-conversion attempts against Woo orders.
 	 *
-	 * @param BigQuery_Proxy_Client|null $proxy Injected proxy client, or null to lazy-resolve.
+	 * @var Woo_Order_Resolver
 	 */
-	public function __construct( ?BigQuery_Proxy_Client $proxy = null ) {
-		$this->proxy = $proxy ?? new BigQuery_Proxy_Client();
+	private Woo_Order_Resolver $woo_resolver;
+
+	/**
+	 * Per-request memoization for paid-conversion BQ row fetches.
+	 *
+	 * Keyed by `<query_name>|Ymd|Ymd` of (query_name, start UTC, end UTC). The
+	 * conversion-rate and revenue methods for the same intent + same window
+	 * share one round-trip to the hub.
+	 *
+	 * @var array<string, array{rows:array, conversions:int, revenue:float}|\WP_Error>
+	 */
+	private array $paid_attempt_cache = [];
+
+	/**
+	 * Constructor. Optionally inject collaborators (used in tests).
+	 *
+	 * @param BigQuery_Proxy_Client|null $proxy        Injected proxy client, or null to lazy-resolve.
+	 * @param Woo_Order_Resolver|null    $woo_resolver Injected Woo resolver, or null to lazy-create.
+	 */
+	public function __construct(
+		?BigQuery_Proxy_Client $proxy = null,
+		?Woo_Order_Resolver $woo_resolver = null
+	) {
+		$this->proxy        = $proxy ?? new BigQuery_Proxy_Client();
+		$this->woo_resolver = $woo_resolver ?? new Woo_Order_Resolver();
 	}
 
 	/**
@@ -191,24 +215,55 @@ final class Prompts_Metric {
 	}
 
 	/**
-	 * Bridge placeholder for scalar methods not yet wired to a catalog query.
+	 * Fetch paid-conversion rows for a given query and Woo-join them.
 	 *
-	 * Returns the `state: 'error'` envelope with a stable, explicit
-	 * `error_code` so the React layer can render an unambiguous
-	 * "not yet implemented" state. Replaces the Phase-1 `pending: true` shape
-	 * so the REST envelope is internally consistent across every metric.
+	 * Returns { rows, conversions, revenue } on success or a WP_Error on proxy
+	 * failure. Used by both the conversion-rate and revenue methods for the
+	 * same intent + direction; the per-(query_name, window) memoization avoids
+	 * a redundant round-trip to the hub when both methods run in one request.
 	 *
-	 * @param string $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
-	 * @return array
+	 * @param string            $query_name One of the 4 distinct paid query names
+	 *                                      (the 4 revenue aliases share rows with
+	 *                                      their conversion counterparts; pass the
+	 *                                      conversion name so the cache is shared).
+	 * @param DateTimeInterface $start      Window start.
+	 * @param DateTimeInterface $end        Window end.
+	 * @return array{rows:array, conversions:int, revenue:float}|\WP_Error
 	 */
-	private function placeholder_scalar( string $placeholder_type ): array {
-		return $this->error_scalar(
-			$placeholder_type,
-			new \WP_Error(
-				'newspack_insights_prompts_not_yet_implemented',
-				__( 'This metric will be wired in a follow-up commit (NPPD-1607 Phase 2).', 'newspack-plugin' )
-			)
-		);
+	private function fetch_paid_attempts_woo_join(
+		string $query_name,
+		DateTimeInterface $start,
+		DateTimeInterface $end
+	) {
+		// Normalize both bounds to UTC Ymd so callers passing different timezone
+		// objects don't bust the cache for the same logical window. Matches the
+		// proxy client's own UTC normalization.
+		$utc       = new \DateTimeZone( 'UTC' );
+		$cache_key = $query_name . '|'
+			. \DateTimeImmutable::createFromInterface( $start )->setTimezone( $utc )->format( 'Ymd' )
+			. '|'
+			. \DateTimeImmutable::createFromInterface( $end )->setTimezone( $utc )->format( 'Ymd' );
+
+		if ( array_key_exists( $cache_key, $this->paid_attempt_cache ) ) {
+			return $this->paid_attempt_cache[ $cache_key ];
+		}
+
+		$rows = $this->proxy->query( $query_name, $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			$this->paid_attempt_cache[ $cache_key ] = $rows;
+			return $rows;
+		}
+
+		// A successful but empty response is real "no conversions", not an error:
+		// zero conversions / zero revenue, which the callers render as $0.00.
+		$rows   = is_array( $rows ) ? $rows : [];
+		$result = [
+			'rows'        => $rows,
+			'conversions' => $this->woo_resolver->count_completed_orders( $rows ),
+			'revenue'     => $this->woo_resolver->sum_completed_revenue( $rows ),
+		];
+		$this->paid_attempt_cache[ $cache_key ] = $result;
+		return $result;
 	}
 
 	/**
@@ -364,108 +419,171 @@ final class Prompts_Metric {
 	}
 
 	// --- Section 4: Paid reader conversion ------------------------------
-	// Placeholder bridge — to be wired in Task 3.2 (Woo join for paid conversions).
+	//
+	// Each rate dispatches the BQ "attempt" query for the intent + direction,
+	// Woo-joins the rows via Woo_Order_Resolver, and returns
+	// `conversions / attempts`. The BQ-side `action_type` filter on the hub
+	// already scopes attempts to the right product intent (donation vs
+	// subscription), so the resolver's product-type-agnostic match is safe.
+	//
+	// v1 simplification: we use attempts as the denominator (not impressions).
+	// The spec acknowledges this as a known trade-off (see formulas-doc
+	// Section 4). The follow-up is a separate impression-count query; not
+	// blocking for this task.
 
 	/**
 	 * Donation conversion rate, direct attribution.
-	 *
-	 * Placeholder — surfaces as state 'error' with the
-	 * `newspack_insights_prompts_not_yet_implemented` code until wired.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_donation_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'rate' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_direct', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'rate', $joined );
+		}
+		$denominator = count( $joined['rows'] );
+		$numerator   = $joined['conversions'];
+		return $this->populated_scalar(
+			$denominator > 0 ? $numerator / $denominator : 0.0,
+			$denominator > 0,
+			$denominator,
+			'rate'
+		);
 	}
 
 	/**
-	 * Donation conversion rate, influenced (14-day lookback). Placeholder.
+	 * Donation conversion rate, influenced (14-day lookback).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_donation_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'rate' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_influenced_14d', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'rate', $joined );
+		}
+		$denominator = count( $joined['rows'] );
+		$numerator   = $joined['conversions'];
+		return $this->populated_scalar(
+			$denominator > 0 ? $numerator / $denominator : 0.0,
+			$denominator > 0,
+			$denominator,
+			'rate'
+		);
 	}
 
 	/**
-	 * Subscription conversion rate, direct attribution. Placeholder.
+	 * Subscription conversion rate, direct attribution.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_subscription_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'rate' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_direct', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'rate', $joined );
+		}
+		$denominator = count( $joined['rows'] );
+		$numerator   = $joined['conversions'];
+		return $this->populated_scalar(
+			$denominator > 0 ? $numerator / $denominator : 0.0,
+			$denominator > 0,
+			$denominator,
+			'rate'
+		);
 	}
 
 	/**
-	 * Subscription conversion rate, influenced (14-day lookback). Placeholder.
+	 * Subscription conversion rate, influenced (14-day lookback).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_subscription_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'rate' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_influenced_14d', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'rate', $joined );
+		}
+		$denominator = count( $joined['rows'] );
+		$numerator   = $joined['conversions'];
+		return $this->populated_scalar(
+			$denominator > 0 ? $numerator / $denominator : 0.0,
+			$denominator > 0,
+			$denominator,
+			'rate'
+		);
 	}
 
 	// --- Section 5: Revenue from prompts --------------------------------
-	// Placeholder bridge — to be wired in Task 3.2 (Woo join for paid revenue).
+	//
+	// Each revenue method dispatches the underlying CONVERSION query name (not
+	// the byte-identical hub `*_revenue_*` alias) so the per-window cache is
+	// shared with the matching rate method — both can be computed from one
+	// proxy round-trip when they appear in the same response.
 
 	/**
-	 * Total donation revenue from prompts, direct attribution. Placeholder.
+	 * Total donation revenue from prompts, direct attribution.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_donation_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'currency' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_direct', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'currency', $joined );
+		}
+		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
 	}
 
 	/**
-	 * Total donation revenue from prompts, influenced (14-day lookback). Placeholder.
+	 * Total donation revenue from prompts, influenced (14-day lookback).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_donation_revenue_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'currency' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_influenced_14d', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'currency', $joined );
+		}
+		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
 	}
 
 	/**
-	 * Total subscription revenue from prompts, direct attribution. Placeholder.
+	 * Total subscription revenue from prompts, direct attribution.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_subscription_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'currency' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_direct', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'currency', $joined );
+		}
+		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
 	}
 
 	/**
-	 * Total subscription revenue from prompts, influenced (14-day lookback). Placeholder.
+	 * Total subscription revenue from prompts, influenced (14-day lookback).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_subscription_revenue_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_scalar( 'currency' );
+		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_influenced_14d', $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return $this->error_scalar( 'currency', $joined );
+		}
+		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
 	}
 
 	// --- Section 6: How readers convert ---------------------------------

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -19,12 +19,15 @@
  * Gates' two, so it has more scorecards and a three-table performance
  * breakdown — but the per-metric envelope is identical.
  *
- * This commit wires the 8 paid-conversion + revenue metrics through the
- * BigQuery proxy + Woo_Order_Resolver join (Task 3.2), on top of the 10
- * free-side scalars wired in Task 3.1. The 5 collection metrics
- * (funnel/distribution/3 perf tables) remain as placeholder envelopes that
- * surface as state 'error' with the `newspack_insights_prompts_not_yet_implemented`
- * code — they will be wired in Task 3.3.
+ * Phase 2 wiring is now complete in this class: 10 scalar metrics (Task 3.1),
+ * 8 paid conversion + revenue metrics joined via {@see Woo_Order_Resolver}
+ * (Task 3.2), and 5 collection metrics — conversion funnel, exposures
+ * distribution, and three performance breakdown tables (Task 3.3). The
+ * performance-by-prompt table additionally augments each row with per-popup
+ * donation and subscription conversion counts using a Woo join scoped to the
+ * popup's intent; that augmentation degrades gracefully (engagement columns
+ * still render with zeros in the Woo columns) if the conversion-attempt query
+ * fails.
  *
  * @package Newspack
  */
@@ -59,6 +62,21 @@ final class Prompts_Metric {
 	 * @var string
 	 */
 	const CACHE_PREFIX = 'newspack_insights_tab5_v1:';
+
+	/**
+	 * Display labels for each `action_type` (intent) value. Spec §7.2 prescribes
+	 * title-cased labels with `newsletters_subscription` rendered as the more
+	 * publisher-friendly "Newsletter signup" (the auto-ucwords result —
+	 * "Newsletters Subscription" — is awkward). Centralized so the per-intent
+	 * table and any future intent display agree.
+	 *
+	 * @var array<string, string>
+	 */
+	private const INTENT_LABELS = [
+		'donation'                 => 'Donation',
+		'registration'             => 'Registration',
+		'newsletters_subscription' => 'Newsletter signup',
+	];
 
 	/**
 	 * Proxy client used to dispatch catalog queries to the hub.
@@ -267,19 +285,42 @@ final class Prompts_Metric {
 	}
 
 	/**
-	 * Bridge placeholder for collection methods not yet wired to a catalog query.
+	 * Compute per-popup Woo-completed counts for an intent's attempt rows.
 	 *
-	 * @param string $rows_key Key holding the (empty) collection: 'stages'|'buckets'|'rows'.
-	 * @return array
+	 * Fetches the intent's BQ attempt rows (cached via fetch_paid_attempts_woo_join),
+	 * groups them by popup_id, and returns a map<popup_id, completed_count>.
+	 * Returns an empty map on proxy failure so the per-prompt breakdown still
+	 * renders the engagement columns even if the Woo-join augmentation fails —
+	 * the engagement data is the load-bearing part of the table; the Woo
+	 * augmentation is a bonus.
+	 *
+	 * @param string            $query_name Catalog `query_name` (e.g. 'prompts_donation_conversion_direct').
+	 * @param DateTimeInterface $start      Window start.
+	 * @param DateTimeInterface $end        Window end.
+	 * @return array<int, int> popup_id => completed_count
 	 */
-	private function placeholder_collection( string $rows_key ): array {
-		return $this->error_collection(
-			$rows_key,
-			new \WP_Error(
-				'newspack_insights_prompts_not_yet_implemented',
-				__( 'This metric will be wired in a follow-up commit (NPPD-1607 Phase 2).', 'newspack-plugin' )
-			)
-		);
+	private function fetch_per_popup_woo_counts(
+		string $query_name,
+		DateTimeInterface $start,
+		DateTimeInterface $end
+	): array {
+		$joined = $this->fetch_paid_attempts_woo_join( $query_name, $start, $end );
+		if ( is_wp_error( $joined ) ) {
+			return []; // Graceful degradation: render zeros, not error the whole table.
+		}
+		$by_popup = [];
+		foreach ( $joined['rows'] as $row ) {
+			$popup_id = (int) ( $row['popup_id'] ?? 0 );
+			if ( $popup_id <= 0 ) {
+				continue;
+			}
+			$by_popup[ $popup_id ][] = $row;
+		}
+		$counts = [];
+		foreach ( $by_popup as $popup_id => $rows_for_popup ) {
+			$counts[ $popup_id ] = $this->woo_resolver->count_completed_orders( $rows_for_popup );
+		}
+		return $counts;
 	}
 
 	// --- Section 1: Prompt exposure -------------------------------------
@@ -587,69 +628,293 @@ final class Prompts_Metric {
 	}
 
 	// --- Section 6: How readers convert ---------------------------------
-	// Placeholder bridge — to be wired in Task 3.3 (collections).
 
 	/**
 	 * Conversion funnel — three stages (impression → engagement → conversion).
-	 * Placeholder.
+	 *
+	 * Dispatches `prompts_funnel` and normalizes the single-row response into a
+	 * stage list with each stage's count and proportion-of-top-stage.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array
+	 * @return array{
+	 *   state: string,
+	 *   stages: array<int, array{label: string, count: int, pct_of_top: float}>,
+	 *   error_code?: string,
+	 *   error_message?: string
+	 * }
 	 */
 	public function get_conversion_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_collection( 'stages' );
+		$rows = $this->proxy->query( 'prompts_funnel', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_collection( 'stages', $rows );
+		}
+		if ( ! is_array( $rows ) || ( ! empty( $rows ) && ! is_array( $rows[0] ) ) ) {
+			// Successful response in an unexpected shape — a data-quality bug,
+			// not a legitimately empty window. Surface it as an error.
+			return $this->malformed_collection( 'stages' );
+		}
+		if ( empty( $rows ) ) {
+			return [
+				'state'  => 'empty',
+				'stages' => [],
+			];
+		}
+		$row   = $rows[0];
+		$step1 = (int) ( $row['step_1_impression'] ?? 0 );
+		$step2 = (int) ( $row['step_2_engagement'] ?? 0 );
+		$step3 = (int) ( $row['step_3_conversion'] ?? 0 );
+		$top   = $step1 > 0 ? $step1 : 1; // Avoid div-by-zero in pct_of_top.
+		return [
+			'state'  => 'populated',
+			'stages' => [
+				[
+					'label'      => __( 'Impression', 'newspack-plugin' ),
+					'count'      => $step1,
+					'pct_of_top' => 1.0,
+				],
+				[
+					'label'      => __( 'Engagement', 'newspack-plugin' ),
+					'count'      => $step2,
+					'pct_of_top' => $step2 / $top,
+				],
+				[
+					'label'      => __( 'Conversion', 'newspack-plugin' ),
+					'count'      => $step3,
+					'pct_of_top' => $step3 / $top,
+				],
+			],
+		];
 	}
 
 	/**
-	 * Exposures-before-conversion distribution buckets. Placeholder.
+	 * Exposures-before-conversion distribution buckets.
+	 *
+	 * Dispatches `prompts_exposures_before_conversion`. The hub emits one row
+	 * per non-zero bucket; we always render the full ordered set so missing
+	 * buckets show as zero rather than disappearing.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array
+	 * @return array{
+	 *   state: string,
+	 *   buckets: array<int, array{label: string, count: int, pct: float}>,
+	 *   error_code?: string,
+	 *   error_message?: string
+	 * }
 	 */
 	public function get_exposures_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_collection( 'buckets' );
+		$rows = $this->proxy->query( 'prompts_exposures_before_conversion', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_collection( 'buckets', $rows );
+		}
+		if ( ! is_array( $rows ) ) {
+			return $this->malformed_collection( 'buckets' );
+		}
+
+		$by_bucket = [];
+		foreach ( $rows as $row ) {
+			if ( isset( $row['bucket'] ) ) {
+				$by_bucket[ $row['bucket'] ] = [
+					'count' => (int) ( $row['converters_in_bucket'] ?? 0 ),
+					'pct'   => (float) ( $row['pct_of_converters'] ?? 0.0 ),
+				];
+			}
+		}
+
+		if ( empty( $by_bucket ) ) {
+			return [
+				'state'   => 'empty',
+				'buckets' => [],
+			];
+		}
+
+		$ordered_keys   = [ '1', '2', '3-5', '6+' ];
+		$ordered_labels = [
+			'1'   => __( '1 exposure', 'newspack-plugin' ),
+			'2'   => __( '2 exposures', 'newspack-plugin' ),
+			'3-5' => __( '3–5 exposures', 'newspack-plugin' ),
+			'6+'  => __( '6+ exposures', 'newspack-plugin' ),
+		];
+		$buckets        = [];
+		foreach ( $ordered_keys as $key ) {
+			$buckets[] = [
+				'label' => $ordered_labels[ $key ],
+				'count' => $by_bucket[ $key ]['count'] ?? 0,
+				'pct'   => $by_bucket[ $key ]['pct'] ?? 0.0,
+			];
+		}
+		return [
+			'state'   => 'populated',
+			'buckets' => $buckets,
+		];
 	}
 
 	// --- Section 7: Performance breakdown -------------------------------
-	// Placeholder bridge — to be wired in Task 3.3 (collections).
 
 	/**
-	 * Per-prompt breakdown. Placeholder.
+	 * Per-prompt breakdown, augmented with per-popup Woo-completed donation and
+	 * subscription counts (intent-scoped: donation_conversions are non-zero
+	 * only for `intent === 'donation'` rows; subscription_conversions only for
+	 * `intent === 'registration'` rows — subscription-intent prompts share the
+	 * registration `action_type` in the data model, see spec §"Subscription-
+	 * intent vs registration-intent prompts").
+	 *
+	 * The Woo augmentation degrades gracefully: if either conversion-attempt
+	 * query fails, the matching column renders as 0 conversions / null rate
+	 * (React renders null as the em-dash) rather than blanking the whole table.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array
+	 * @return array{state: string, rows: array, error_code?: string, error_message?: string}
 	 */
 	public function get_performance_by_prompt( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_collection( 'rows' );
+		$rows = $this->proxy->query( 'prompts_performance_by_prompt', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_collection( 'rows', $rows );
+		}
+		if ( ! is_array( $rows ) ) {
+			return $this->malformed_collection( 'rows' );
+		}
+		if ( empty( $rows ) ) {
+			return [
+				'state' => 'empty',
+				'rows'  => [],
+			];
+		}
+
+		// Fetch per-popup Woo augmentation once for each direction; the cache
+		// in fetch_paid_attempts_woo_join means this is free if the matching
+		// paid-rate / revenue method has already run this request.
+		$donation_counts     = $this->fetch_per_popup_woo_counts( 'prompts_donation_conversion_direct', $start, $end );
+		$subscription_counts = $this->fetch_per_popup_woo_counts( 'prompts_subscription_conversion_direct', $start, $end );
+
+		$mapped = [];
+		foreach ( $rows as $row ) {
+			$popup_id    = (int) ( $row['popup_id'] ?? 0 );
+			$intent      = (string) ( $row['intent'] ?? '' );
+			$impressions = (int) ( $row['impressions'] ?? 0 );
+
+			$donation_conversions = 'donation' === $intent ? (int) ( $donation_counts[ $popup_id ] ?? 0 ) : 0;
+			// Subscription-intent prompts share `action_type=registration` at
+			// the data layer; the Woo product-type filter on the hub-side
+			// subscription query already scopes attempts correctly.
+			$subscription_conversions = 'registration' === $intent ? (int) ( $subscription_counts[ $popup_id ] ?? 0 ) : 0;
+
+			$mapped[] = [
+				'popup_id'                     => $popup_id,
+				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),
+				'intent'                       => $intent,
+				'placement'                    => (string) ( $row['placement'] ?? '' ),
+				'impressions'                  => $impressions,
+				'unique_viewers'               => (int) ( $row['unique_viewers'] ?? 0 ),
+				'ctr'                          => isset( $row['ctr'] ) && null !== $row['ctr'] ? (float) $row['ctr'] : null,
+				'form_submission_rate'         => isset( $row['form_submission_rate'] ) && null !== $row['form_submission_rate'] ? (float) $row['form_submission_rate'] : null,
+				'dismissal_rate'               => isset( $row['dismissal_rate'] ) && null !== $row['dismissal_rate'] ? (float) $row['dismissal_rate'] : null,
+				'registrations'                => (int) ( $row['registrations'] ?? 0 ),
+				'newsletter_signups'           => (int) ( $row['newsletter_signups'] ?? 0 ),
+				'donation_conversions'         => $donation_conversions,
+				'donation_conversion_rate'     => ( 'donation' === $intent && $impressions > 0 ) ? $donation_conversions / $impressions : null,
+				'subscription_conversions'     => $subscription_conversions,
+				'subscription_conversion_rate' => ( 'registration' === $intent && $impressions > 0 ) ? $subscription_conversions / $impressions : null,
+			];
+		}
+
+		return [
+			'state' => 'populated',
+			'rows'  => $mapped,
+		];
 	}
 
 	/**
-	 * Per-intent breakdown (donation / registration / newsletter signup). Placeholder.
+	 * Per-intent breakdown (donation / registration / newsletter signup).
+	 *
+	 * Pure BQ → row mapping; no Woo or WP enrichment. Intent labels come from
+	 * {@see self::INTENT_LABELS}; an unknown `intent` value falls back to its
+	 * raw form so a hub-side catalog change isn't silently swallowed.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array
+	 * @return array{state: string, rows: array, error_code?: string, error_message?: string}
 	 */
 	public function get_performance_by_intent( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_collection( 'rows' );
+		$rows = $this->proxy->query( 'prompts_performance_by_intent', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_collection( 'rows', $rows );
+		}
+		if ( ! is_array( $rows ) ) {
+			return $this->malformed_collection( 'rows' );
+		}
+		if ( empty( $rows ) ) {
+			return [
+				'state' => 'empty',
+				'rows'  => [],
+			];
+		}
+
+		$mapped = [];
+		foreach ( $rows as $row ) {
+			$intent   = (string) ( $row['intent'] ?? '' );
+			$mapped[] = [
+				'intent'               => $intent,
+				'intent_label'         => self::INTENT_LABELS[ $intent ] ?? $intent,
+				'impressions'          => (int) ( $row['impressions'] ?? 0 ),
+				'unique_viewers'       => (int) ( $row['unique_viewers'] ?? 0 ),
+				'ctr'                  => isset( $row['ctr'] ) && null !== $row['ctr'] ? (float) $row['ctr'] : null,
+				'form_submission_rate' => isset( $row['form_submission_rate'] ) && null !== $row['form_submission_rate'] ? (float) $row['form_submission_rate'] : null,
+				'dismissal_rate'       => isset( $row['dismissal_rate'] ) && null !== $row['dismissal_rate'] ? (float) $row['dismissal_rate'] : null,
+			];
+		}
+
+		return [
+			'state' => 'populated',
+			'rows'  => $mapped,
+		];
 	}
 
 	/**
-	 * Per-placement breakdown (overlay / inline / above-header / etc.). Placeholder.
+	 * Per-placement breakdown (overlay / inline / above-header / etc.).
+	 *
+	 * Pure BQ → row mapping. Placement labels are humanized inline
+	 * (`above-header` → `Above header`); the raw value is also carried through
+	 * for any UI that needs to filter on it. This table intentionally has no
+	 * `form_submission_rate` column per spec §"Performance by Prompt Placement".
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array
+	 * @return array{state: string, rows: array, error_code?: string, error_message?: string}
 	 */
 	public function get_performance_by_placement( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder_collection( 'rows' );
+		$rows = $this->proxy->query( 'prompts_performance_by_placement', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_collection( 'rows', $rows );
+		}
+		if ( ! is_array( $rows ) ) {
+			return $this->malformed_collection( 'rows' );
+		}
+		if ( empty( $rows ) ) {
+			return [
+				'state' => 'empty',
+				'rows'  => [],
+			];
+		}
+
+		$mapped = [];
+		foreach ( $rows as $row ) {
+			$placement = (string) ( $row['placement'] ?? '' );
+			$mapped[]  = [
+				'placement'       => $placement,
+				'placement_label' => '' === $placement ? '' : ucfirst( str_replace( '-', ' ', $placement ) ),
+				'impressions'     => (int) ( $row['impressions'] ?? 0 ),
+				'unique_viewers'  => (int) ( $row['unique_viewers'] ?? 0 ),
+				'ctr'             => isset( $row['ctr'] ) && null !== $row['ctr'] ? (float) $row['ctr'] : null,
+				'dismissal_rate'  => isset( $row['dismissal_rate'] ) && null !== $row['dismissal_rate'] ? (float) $row['dismissal_rate'] : null,
+			];
+		}
+
+		return [
+			'state' => 'populated',
+			'rows'  => $mapped,
+		];
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -118,6 +118,22 @@ final class Prompts_Metric {
 	}
 
 	/**
+	 * Return the canned fixture payload for the Prompts tab.
+	 *
+	 * Returned by the REST controller when NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
+	 * The variant selects a render path: 'populated' (default), 'empty', 'error'.
+	 *
+	 * @param string $variant One of 'populated', 'empty', 'error'.
+	 * @param bool   $compare Whether comparison was requested; when false the
+	 *                        `previous` window is null (no period-over-period deltas).
+	 * @return array Full { tab_error, current, previous } response shape.
+	 */
+	public static function get_fixture( string $variant = 'populated', bool $compare = false ): array {
+		$build = require NEWSPACK_ABSPATH . 'includes/wizards/insights/fixtures/prompts-fixture.php';
+		return $build( $variant, $compare );
+	}
+
+	/**
 	 * Error payload for a scalar scorecard metric. Carries the proxy's error
 	 * code + message so the UI can render an error treatment (without exposing
 	 * internals to the reader) instead of a misleading zero.
@@ -801,6 +817,9 @@ final class Prompts_Metric {
 			// subscription query already scopes attempts correctly.
 			$subscription_conversions = 'registration' === $intent ? (int) ( $subscription_counts[ $popup_id ] ?? 0 ) : 0;
 
+			// When the popup's intent matches but the Woo-side proxy failed (degraded),
+			// the rate is a real 0.0 — the impression denominator is still applicable;
+			// the null branch covers only intent mismatch (the column is N/A).
 			$mapped[] = [
 				'popup_id'                     => $popup_id,
 				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -1,24 +1,30 @@
 <?php
 /**
- * Newspack Insights — Prompts Metric orchestrator (NPPD-1607, Phase 1).
+ * Newspack Insights — Prompts Metric orchestrator (NPPD-1607, Phase 2).
  *
- * Phase 1 placeholder layer. Every metric returns a `pending: true`
- * payload with a zero value and a `placeholder_type` so the React
- * layer can render the spec's empty-state value ("0", "0%", "$0.00",
- * "0.0") without inferring type. No storage layer, no SQL — the data
- * is intentionally synthetic until Phase 2 wires the BigQuery query
- * proxy into the same method signatures.
+ * Dispatches catalog queries to the Newspack Manager BigQuery proxy and shapes
+ * each result for the React layer. Every method reports an explicit `state`:
+ *   - 'error'     — the proxy/query failed (carries `error_code` + `error_message`)
+ *   - 'empty'     — the query succeeded but returned no rows (collections only)
+ *   - 'populated' — the query returned usable data
  *
- * Mirrors {@see Gates_Metric} (Tab 4) one-for-one: same placeholder
- * shape, same Phase 1 / Phase 2 split. Method names track the query
- * names in `formulas/tab-5-prompts.md` so Phase 2 swaps each method
- * body to a `query_name` dispatch against the Newspack Manager BQ
- * catalog without touching signatures or the response envelope.
+ * This replaces the Phase 1 `pending: true` flag, which collapsed proxy errors,
+ * legitimately-empty results, and malformed responses into one ambiguous
+ * "No data yet" state and masked real failures. Scalar scorecards use
+ * 'error' | 'populated' only ('empty' has no meaning for a single value — an
+ * absent value renders as a non-computable zero).
  *
- * Tab 5 carries four conversion intents (registration, newsletter
- * signup, donation, subscription) versus Gates' two, so it has more
- * scorecards and a three-table performance breakdown — but the
- * per-metric envelope is identical.
+ * Mirrors {@see Gates_Metric} (Tab 4) one-for-one. Tab 5 carries four conversion
+ * intents (registration, newsletter signup, donation, subscription) versus
+ * Gates' two, so it has more scorecards and a three-table performance
+ * breakdown — but the per-metric envelope is identical.
+ *
+ * This commit wires the 10 free-side scalar metrics (exposure + engagement +
+ * registration/newsletter conversion). Paid-conversion (donation/subscription)
+ * + revenue and the collection metrics (funnel/distribution/3 perf tables)
+ * remain as placeholder envelopes that surface as state 'error' with the
+ * `newspack_insights_prompts_not_yet_implemented` code — they will be wired in
+ * follow-up commits (Task 3.2 = Woo join, Task 3.3 = collections).
  *
  * @package Newspack
  */
@@ -28,16 +34,19 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeInterface;
+use Newspack\Insights\BigQuery_Proxy_Client;
 
 /**
- * Tab 5 placeholder metric orchestrator.
+ * Tab 5 metric orchestrator.
  *
  * @phpstan-type ScalarMetric array{
+ *   state: string,
  *   value: int|float,
  *   computable: bool,
- *   pending: bool,
  *   denominator: int|null,
  *   placeholder_type: string,
+ *   error_code?: string,
+ *   error_message?: string,
  * }
  */
 final class Prompts_Metric {
@@ -51,22 +60,171 @@ final class Prompts_Metric {
 	const CACHE_PREFIX = 'newspack_insights_tab5_v1:';
 
 	/**
-	 * Build the standard placeholder shape for a single scorecard
-	 * metric. Type is encoded in `placeholder_type` so React can pick
-	 * the right format token ("0" vs "0%" vs "$0.00" vs "0.0") without
-	 * inferring from the field name.
+	 * Proxy client used to dispatch catalog queries to the hub.
 	 *
-	 * @param string $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
-	 * @return array{value: int|float, computable: bool, pending: bool, denominator: null, placeholder_type: string}
+	 * @var BigQuery_Proxy_Client
 	 */
-	private function placeholder( string $placeholder_type ): array {
+	private BigQuery_Proxy_Client $proxy;
+
+	/**
+	 * Constructor. Optionally inject a proxy client (used in tests).
+	 *
+	 * @param BigQuery_Proxy_Client|null $proxy Injected proxy client, or null to lazy-resolve.
+	 */
+	public function __construct( ?BigQuery_Proxy_Client $proxy = null ) {
+		$this->proxy = $proxy ?? new BigQuery_Proxy_Client();
+	}
+
+	/**
+	 * Error payload for a scalar scorecard metric. Carries the proxy's error
+	 * code + message so the UI can render an error treatment (without exposing
+	 * internals to the reader) instead of a misleading zero.
+	 *
+	 * @param string    $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @param \WP_Error $error            The originating proxy error.
+	 * @return array
+	 */
+	private function error_scalar( string $placeholder_type, \WP_Error $error ): array {
 		return [
+			'state'            => 'error',
 			'value'            => 'decimal' === $placeholder_type ? 0.0 : 0,
 			'computable'       => false,
-			'pending'          => true,
 			'denominator'      => null,
 			'placeholder_type' => $placeholder_type,
+			'error_code'       => $error->get_error_code(),
+			'error_message'    => $error->get_error_message(),
 		];
+	}
+
+	/**
+	 * Populated payload for a scalar scorecard metric. A successful query that
+	 * yields no usable value is still 'populated' — it renders as a
+	 * non-computable zero ('empty' has no meaning for a single scalar).
+	 *
+	 * @param int|float $value            Metric value.
+	 * @param bool      $computable       Whether the value is a real computed figure.
+	 * @param int|null  $denominator      Optional denominator.
+	 * @param string    $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @return array
+	 */
+	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type ): array {
+		return [
+			'state'            => 'populated',
+			'value'            => $value,
+			'computable'       => $computable,
+			'denominator'      => $denominator,
+			'placeholder_type' => $placeholder_type,
+		];
+	}
+
+	/**
+	 * Error payload for a collection metric (funnel / distribution / table).
+	 *
+	 * @param string    $rows_key Key holding the (empty) collection: 'stages'|'buckets'|'rows'.
+	 * @param \WP_Error $error    The originating proxy error.
+	 * @return array
+	 */
+	private function error_collection( string $rows_key, \WP_Error $error ): array {
+		return [
+			'state'         => 'error',
+			'error_code'    => $error->get_error_code(),
+			'error_message' => $error->get_error_message(),
+			$rows_key       => [],
+		];
+	}
+
+	/**
+	 * Error payload for a collection whose query succeeded but returned an
+	 * unexpected (non-array) shape — a data-quality bug, not an empty window.
+	 *
+	 * @param string $rows_key Key holding the (empty) collection: 'stages'|'buckets'|'rows'.
+	 * @return array
+	 */
+	private function malformed_collection( string $rows_key ): array {
+		return $this->error_collection(
+			$rows_key,
+			new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) )
+		);
+	}
+
+	/**
+	 * Run a scalar catalog query and extract a single value from the first row.
+	 *
+	 * A proxy WP_Error becomes state 'error'. A successful query with no usable
+	 * value (empty rows, missing key, non-numeric, or count drift) becomes a
+	 * 'populated' non-computable zero.
+	 *
+	 * @param string            $query_name        Catalog `query_name`.
+	 * @param string            $row_key           Column to extract from the first row.
+	 * @param string            $placeholder_type  'count' | 'rate' | 'currency' | 'decimal'.
+	 * @param DateTimeInterface $start             Window start.
+	 * @param DateTimeInterface $end               Window end.
+	 * @return array
+	 */
+	private function compute_metric_from_proxy(
+		string $query_name,
+		string $row_key,
+		string $placeholder_type,
+		DateTimeInterface $start,
+		DateTimeInterface $end
+	): array {
+		$rows = $this->proxy->query( $query_name, $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_scalar( $placeholder_type, $rows );
+		}
+		$zero = 'decimal' === $placeholder_type ? 0.0 : 0;
+		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $row_key, $rows[0] ) ) {
+			// Query succeeded with no usable value → non-computable zero.
+			return $this->populated_scalar( $zero, false, null, $placeholder_type );
+		}
+		$value = $rows[0][ $row_key ];
+		// Non-numeric, or (for counts) a non-integer value, signals catalog/schema
+		// drift — malformed data, not an empty window. Surface it as an error so a
+		// real data-quality regression isn't masked as a benign zero.
+		if ( ! is_numeric( $value ) || ( 'count' === $placeholder_type && (float) $value !== (float) (int) $value ) ) {
+			return $this->error_scalar(
+				$placeholder_type,
+				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric value.', 'newspack-plugin' ) )
+			);
+		}
+		return $this->populated_scalar( 'count' === $placeholder_type ? (int) $value : (float) $value, true, null, $placeholder_type );
+	}
+
+	/**
+	 * Bridge placeholder for scalar methods not yet wired to a catalog query.
+	 *
+	 * Returns the `state: 'error'` envelope with a stable, explicit
+	 * `error_code` so the React layer can render an unambiguous
+	 * "not yet implemented" state. Replaces the Phase-1 `pending: true` shape
+	 * so the REST envelope is internally consistent across every metric.
+	 *
+	 * @param string $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @return array
+	 */
+	private function placeholder_scalar( string $placeholder_type ): array {
+		return $this->error_scalar(
+			$placeholder_type,
+			new \WP_Error(
+				'newspack_insights_prompts_not_yet_implemented',
+				__( 'This metric will be wired in a follow-up commit (NPPD-1607 Phase 2).', 'newspack-plugin' )
+			)
+		);
+	}
+
+	/**
+	 * Bridge placeholder for collection methods not yet wired to a catalog query.
+	 *
+	 * @param string $rows_key Key holding the (empty) collection: 'stages'|'buckets'|'rows'.
+	 * @return array
+	 */
+	private function placeholder_collection( string $rows_key ): array {
+		return $this->error_collection(
+			$rows_key,
+			new \WP_Error(
+				'newspack_insights_prompts_not_yet_implemented',
+				__( 'This metric will be wired in a follow-up commit (NPPD-1607 Phase 2).', 'newspack-plugin' )
+			)
+		);
 	}
 
 	// --- Section 1: Prompt exposure -------------------------------------
@@ -74,37 +232,40 @@ final class Prompts_Metric {
 	/**
 	 * Total prompt impressions in window.
 	 *
+	 * Dispatches `prompts_total_impressions`.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_total_prompt_impressions( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'count' );
+		return $this->compute_metric_from_proxy( 'prompts_total_impressions', 'prompt_impressions', 'count', $start, $end );
 	}
 
 	/**
 	 * Unique readers who saw at least one prompt.
+	 *
+	 * Dispatches `prompts_unique_viewers`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_unique_readers_reached( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'count' );
+		return $this->compute_metric_from_proxy( 'prompts_unique_viewers', 'unique_prompt_viewers', 'count', $start, $end );
 	}
 
 	/**
 	 * Average prompt exposures per reader.
+	 *
+	 * Dispatches `prompts_avg_prompts_per_reader`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_avg_prompts_per_reader( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'decimal' );
+		return $this->compute_metric_from_proxy( 'prompts_avg_prompts_per_reader', 'avg_prompts_per_reader', 'decimal', $start, $end );
 	}
 
 	// --- Section 2: Prompt engagement -----------------------------------
@@ -112,37 +273,40 @@ final class Prompts_Metric {
 	/**
 	 * Click-through rate (clicks ÷ impressions).
 	 *
+	 * Dispatches `prompts_click_through_rate`.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_click_through_rate( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_click_through_rate', 'click_through_rate', 'rate', $start, $end );
 	}
 
 	/**
 	 * Form submission rate (submissions ÷ form-bearing impressions).
+	 *
+	 * Dispatches `prompts_form_submission_rate`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_form_submission_rate( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_form_submission_rate', 'form_submission_rate', 'rate', $start, $end );
 	}
 
 	/**
 	 * Dismissal rate (explicit dismissals ÷ impressions).
+	 *
+	 * Dispatches `prompts_dismissal_rate`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_dismissal_rate( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_dismissal_rate', 'dismissal_rate', 'rate', $start, $end );
 	}
 
 	// --- Section 3: Free reader conversion ------------------------------
@@ -150,55 +314,63 @@ final class Prompts_Metric {
 	/**
 	 * Registration conversion rate, direct attribution.
 	 *
+	 * Dispatches `prompts_registration_conversion_direct`.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_registration_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_registration_conversion_direct', 'registration_conversion_direct', 'rate', $start, $end );
 	}
 
 	/**
 	 * Registration conversion rate, influenced (7-day lookback).
+	 *
+	 * Dispatches `prompts_registration_conversion_influenced_7d`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_registration_conversion_influenced_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_registration_conversion_influenced_7d', 'registration_conversion_influenced', 'rate', $start, $end );
 	}
 
 	/**
 	 * Newsletter signup conversion rate, direct attribution.
+	 *
+	 * Dispatches `prompts_newsletter_signup_conversion_direct`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_newsletter_signup_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_newsletter_signup_conversion_direct', 'newsletter_signup_conversion_direct', 'rate', $start, $end );
 	}
 
 	/**
 	 * Newsletter signup conversion rate, influenced (7-day lookback).
+	 *
+	 * Dispatches `prompts_newsletter_signup_conversion_influenced_7d`.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_newsletter_signup_conversion_influenced_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->compute_metric_from_proxy( 'prompts_newsletter_signup_conversion_influenced_7d', 'newsletter_signup_conversion_influenced', 'rate', $start, $end );
 	}
 
 	// --- Section 4: Paid reader conversion ------------------------------
+	// Placeholder bridge — to be wired in Task 3.2 (Woo join for paid conversions).
 
 	/**
 	 * Donation conversion rate, direct attribution.
+	 *
+	 * Placeholder — surfaces as state 'error' with the
+	 * `newspack_insights_prompts_not_yet_implemented` code until wired.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -206,11 +378,11 @@ final class Prompts_Metric {
 	 */
 	public function get_donation_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->placeholder_scalar( 'rate' );
 	}
 
 	/**
-	 * Donation conversion rate, influenced (14-day lookback).
+	 * Donation conversion rate, influenced (14-day lookback). Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -218,11 +390,11 @@ final class Prompts_Metric {
 	 */
 	public function get_donation_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->placeholder_scalar( 'rate' );
 	}
 
 	/**
-	 * Subscription conversion rate, direct attribution.
+	 * Subscription conversion rate, direct attribution. Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -230,11 +402,11 @@ final class Prompts_Metric {
 	 */
 	public function get_subscription_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->placeholder_scalar( 'rate' );
 	}
 
 	/**
-	 * Subscription conversion rate, influenced (14-day lookback).
+	 * Subscription conversion rate, influenced (14-day lookback). Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -242,13 +414,14 @@ final class Prompts_Metric {
 	 */
 	public function get_subscription_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'rate' );
+		return $this->placeholder_scalar( 'rate' );
 	}
 
 	// --- Section 5: Revenue from prompts --------------------------------
+	// Placeholder bridge — to be wired in Task 3.2 (Woo join for paid revenue).
 
 	/**
-	 * Total donation revenue from prompts, direct attribution.
+	 * Total donation revenue from prompts, direct attribution. Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -256,11 +429,11 @@ final class Prompts_Metric {
 	 */
 	public function get_donation_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'currency' );
+		return $this->placeholder_scalar( 'currency' );
 	}
 
 	/**
-	 * Total donation revenue from prompts, influenced (14-day lookback).
+	 * Total donation revenue from prompts, influenced (14-day lookback). Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -268,11 +441,11 @@ final class Prompts_Metric {
 	 */
 	public function get_donation_revenue_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'currency' );
+		return $this->placeholder_scalar( 'currency' );
 	}
 
 	/**
-	 * Total subscription revenue from prompts, direct attribution.
+	 * Total subscription revenue from prompts, direct attribution. Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -280,11 +453,11 @@ final class Prompts_Metric {
 	 */
 	public function get_subscription_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'currency' );
+		return $this->placeholder_scalar( 'currency' );
 	}
 
 	/**
-	 * Total subscription revenue from prompts, influenced (14-day lookback).
+	 * Total subscription revenue from prompts, influenced (14-day lookback). Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -292,145 +465,73 @@ final class Prompts_Metric {
 	 */
 	public function get_subscription_revenue_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->placeholder( 'currency' );
+		return $this->placeholder_scalar( 'currency' );
 	}
 
 	// --- Section 6: How readers convert ---------------------------------
+	// Placeholder bridge — to be wired in Task 3.3 (collections).
 
 	/**
-	 * Conversion funnel — three stages (impression → engagement →
-	 * conversion) with zeros and a pending flag. Stage shape kept
-	 * stable so the React Funnel viz renders the same chrome regardless
-	 * of phase. Stage 3 (Conversion) is a rollup across the four
-	 * conversion intents; the per-intent breakdowns live in Sections
-	 * 3 / 4 / 5.
+	 * Conversion funnel — three stages (impression → engagement → conversion).
+	 * Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array{
-	 *   pending: bool,
-	 *   stages: array<int, array{label: string, count: int, pct_of_top: float}>
-	 * }
+	 * @return array
 	 */
 	public function get_conversion_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return [
-			'pending' => true,
-			'stages'  => [
-				[
-					'label'      => __( 'Impression', 'newspack-plugin' ),
-					'count'      => 0,
-					'pct_of_top' => 0.0,
-				],
-				[
-					'label'      => __( 'Engagement', 'newspack-plugin' ),
-					'count'      => 0,
-					'pct_of_top' => 0.0,
-				],
-				[
-					'label'      => __( 'Conversion', 'newspack-plugin' ),
-					'count'      => 0,
-					'pct_of_top' => 0.0,
-				],
-			],
-		];
+		return $this->placeholder_collection( 'stages' );
 	}
 
 	/**
-	 * Exposures-before-conversion distribution buckets.
+	 * Exposures-before-conversion distribution buckets. Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array{
-	 *   pending: bool,
-	 *   buckets: array<int, array{label: string, count: int, pct: float}>
-	 * }
+	 * @return array
 	 */
 	public function get_exposures_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return [
-			'pending' => true,
-			'buckets' => [
-				[
-					'label' => __( '1 exposure', 'newspack-plugin' ),
-					'count' => 0,
-					'pct'   => 0.0,
-				],
-				[
-					'label' => __( '2 exposures', 'newspack-plugin' ),
-					'count' => 0,
-					'pct'   => 0.0,
-				],
-				[
-					'label' => __( '3–5 exposures', 'newspack-plugin' ),
-					'count' => 0,
-					'pct'   => 0.0,
-				],
-				[
-					'label' => __( '6+ exposures', 'newspack-plugin' ),
-					'count' => 0,
-					'pct'   => 0.0,
-				],
-			],
-		];
+		return $this->placeholder_collection( 'buckets' );
 	}
 
 	// --- Section 7: Performance breakdown -------------------------------
+	// Placeholder bridge — to be wired in Task 3.3 (collections).
 
 	/**
-	 * Per-prompt breakdown. Phase 1 returns an empty `rows` array; the
-	 * React PerformanceByPromptTable renders the spec's empty-state copy
-	 * when the array is empty. Phase 2 will populate this with real BQ
-	 * rows — `prompt_title` is captured directly in event params, so no
-	 * WP enrichment is needed (unlike Gates' `gate_post_id` → post_title
-	 * lookup). Donation/subscription columns report *conversions* (count
-	 * + rate), populated in Phase 2 by grouping per-prompt attempts and
-	 * matching Woo completions via `Woo_Order_Resolver` — mirroring the
-	 * Gates v1.1 decision (NPPD-1684).
+	 * Per-prompt breakdown. Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array{pending: bool, rows: array}
+	 * @return array
 	 */
 	public function get_performance_by_prompt( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return [
-			'pending' => true,
-			'rows'    => [],
-		];
+		return $this->placeholder_collection( 'rows' );
 	}
 
 	/**
-	 * Per-intent breakdown (donation / registration / newsletter signup),
-	 * aggregated across all prompts of that intent. Phase 1 returns an
-	 * empty `rows` array.
+	 * Per-intent breakdown (donation / registration / newsletter signup). Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array{pending: bool, rows: array}
+	 * @return array
 	 */
 	public function get_performance_by_intent( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return [
-			'pending' => true,
-			'rows'    => [],
-		];
+		return $this->placeholder_collection( 'rows' );
 	}
 
 	/**
-	 * Per-placement breakdown (overlay / inline / above-header / etc.),
-	 * aggregated across all prompts at that placement. Phase 1 returns an
-	 * empty `rows` array.
+	 * Per-placement breakdown (overlay / inline / above-header / etc.). Placeholder.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array{pending: bool, rows: array}
+	 * @return array
 	 */
 	public function get_performance_by_placement( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return [
-			'pending' => true,
-			'rows'    => [],
-		];
+		return $this->placeholder_collection( 'rows' );
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
@@ -21,6 +21,11 @@
 import apiFetch from '@wordpress/api-fetch';
 
 /**
+ * Internal dependencies
+ */
+import { type CachedEnvelope } from '../state/insightsCache';
+
+/**
  * The kind of placeholder a metric renders. Encoded server-side so
  * the React format layer doesn't have to guess from the field name.
  */
@@ -190,10 +195,7 @@ export interface PromptsQuery {
 
 const ENDPOINT = '/newspack-insights/v1/prompts';
 
-/**
- * Fetch Tab 5 data for the given window pair.
- */
-export const fetchPromptsData = async ( query: PromptsQuery ): Promise< PromptsResponse > => {
+const queryString = ( query: PromptsQuery ): string => {
 	const params = new URLSearchParams();
 	params.set( 'start', query.start );
 	params.set( 'end', query.end );
@@ -201,8 +203,20 @@ export const fetchPromptsData = async ( query: PromptsQuery ): Promise< PromptsR
 		params.set( 'compare_start', query.compare_start );
 		params.set( 'compare_end', query.compare_end );
 	}
-	return apiFetch< PromptsResponse >( {
-		path: `${ ENDPOINT }?${ params.toString() }`,
+	return params.toString();
+};
+
+/**
+ * Fetch Tab 5 data for the given window pair.
+ */
+export const fetchPromptsData = async ( query: PromptsQuery ): Promise< CachedEnvelope< PromptsResponse > > =>
+	apiFetch< CachedEnvelope< PromptsResponse > >( {
+		path: `${ ENDPOINT }?${ queryString( query ) }`,
 		method: 'GET',
 	} );
-};
+
+export const refreshPromptsData = async ( query: PromptsQuery ): Promise< CachedEnvelope< PromptsResponse > > =>
+	apiFetch< CachedEnvelope< PromptsResponse > >( {
+		path: `${ ENDPOINT }/refresh?${ queryString( query ) }`,
+		method: 'POST',
+	} );

--- a/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/prompts.ts
@@ -1,15 +1,14 @@
 /**
- * Prompts API client (NPPD-1607, Phase 1).
+ * Prompts API client (NPPD-1607).
  *
  * Thin wrapper around `@wordpress/api-fetch` for the single Tab 5
  * endpoint: `GET /newspack-insights/v1/prompts`. Type definitions
  * mirror the PHP response shape assembled by `Prompts_REST_Controller`.
  *
- * Phase 1: every metric carries `pending: true` and a zero value.
- * Phase 2 keeps the same shape but flips `pending` to false and
- * surfaces real BQ values; the React layer does not need to know
- * which phase produced a payload — it reads `pending` and the
- * `tab_pending` banner flag.
+ * Every metric carries an explicit `state`: 'error' (query failed —
+ * with `error_code` / `error_message`), 'empty' (succeeded, no rows),
+ * or 'populated'. Scalars use 'error' | 'populated' only. The
+ * `tab_error` flag is true only when every section is in the error state.
  *
  * Mirrors `api/gates.ts` (Tab 4) one-for-one. Tab 5 carries four
  * conversion intents instead of two, so it has more scorecards and a
@@ -27,15 +26,23 @@ import apiFetch from '@wordpress/api-fetch';
  */
 export type PromptsPlaceholderType = 'count' | 'rate' | 'currency' | 'decimal';
 
+/** Collection metrics report all three states; scalars use 'error' | 'populated'. */
+export type PromptsMetricState = 'error' | 'empty' | 'populated';
+
+/** Fields present on any metric in the error state. */
+export interface PromptsErrorFields {
+	error_code?: string;
+	error_message?: string;
+}
+
 /**
- * Standard scorecard metric payload. Carries the value plus the
- * `pending` and `placeholder_type` markers the UI needs to render
- * the Phase 1 zeros in the correct visual format.
+ * Standard scorecard metric payload. `state` is 'error' or 'populated'
+ * (an absent value is a non-computable zero, not an 'empty' state).
  */
-export interface PromptsScalarMetric {
+export interface PromptsScalarMetric extends PromptsErrorFields {
+	state: 'error' | 'populated';
 	value: number;
 	computable: boolean;
-	pending: boolean;
 	denominator: number | null;
 	placeholder_type: PromptsPlaceholderType;
 }
@@ -46,8 +53,8 @@ export interface PromptsFunnelStage {
 	pct_of_top: number;
 }
 
-export interface PromptsFunnelData {
-	pending: boolean;
+export interface PromptsFunnelData extends PromptsErrorFields {
+	state: PromptsMetricState;
 	stages: PromptsFunnelStage[];
 }
 
@@ -57,24 +64,23 @@ export interface PromptsDistributionBucket {
 	pct: number;
 }
 
-export interface PromptsDistributionData {
-	pending: boolean;
+export interface PromptsDistributionData extends PromptsErrorFields {
+	state: PromptsMetricState;
 	buckets: PromptsDistributionBucket[];
 }
 
 /**
- * One row in the Performance by prompt table (Table 7.1). Phase 1
- * returns no rows (the section renders the spec's empty-state copy).
- * Phase 2 populates this from BQ — `prompt_title` comes straight from
- * the event params, no WP enrichment needed. Donation / subscription
- * columns report *conversions* (Woo-completed outcomes), not attempts,
- * matching the Gates v1.1 decision (NPPD-1684). Count and rate columns
- * are nullable: a non-applicable cell (e.g. CTR on a button-less
- * prompt, or donation conversions on a registration prompt) renders as
- * an em-dash, distinct from a real 0 / 0%.
+ * One row in the Performance by prompt table (Table 7.1). The 15-key
+ * schema was locked by Task 3.3 (NPPD-1607). `prompt_title` comes
+ * straight from the event params, no WP enrichment needed. Donation /
+ * subscription columns report *conversions* (Woo-completed outcomes),
+ * not attempts, matching the Gates v1.1 decision (NPPD-1684). Count and
+ * rate columns are nullable: a non-applicable cell (e.g. CTR on a
+ * button-less prompt, or donation conversions on a registration prompt)
+ * renders as an em-dash, distinct from a real 0 / 0%.
  */
 export interface PromptsPerformanceByPromptRow {
-	newspack_popup_id: number;
+	popup_id: number;
 	prompt_title: string;
 	intent: string;
 	placement: string;
@@ -116,18 +122,18 @@ export interface PromptsPerformanceByPlacementRow {
 	dismissal_rate: number | null;
 }
 
-export interface PromptsPerformanceByPromptTable {
-	pending: boolean;
+export interface PromptsPerformanceByPromptTable extends PromptsErrorFields {
+	state: PromptsMetricState;
 	rows: PromptsPerformanceByPromptRow[];
 }
 
-export interface PromptsPerformanceByIntentTable {
-	pending: boolean;
+export interface PromptsPerformanceByIntentTable extends PromptsErrorFields {
+	state: PromptsMetricState;
 	rows: PromptsPerformanceByIntentRow[];
 }
 
-export interface PromptsPerformanceByPlacementTable {
-	pending: boolean;
+export interface PromptsPerformanceByPlacementTable extends PromptsErrorFields {
+	state: PromptsMetricState;
 	rows: PromptsPerformanceByPlacementRow[];
 }
 
@@ -167,10 +173,10 @@ export interface PromptsWindow {
 
 export interface PromptsResponse {
 	/**
-	 * True while Tab 5 is in the Phase 1 placeholder phase. React
-	 * uses this to render the top-of-tab banner.
+	 * True only when every section in the current window is in the error
+	 * state. React renders a tab-level error banner when set.
 	 */
-	tab_pending: boolean;
+	tab_error: boolean;
 	current: PromptsWindow;
 	previous: PromptsWindow | null;
 }

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/usePromptsData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/usePromptsData.ts
@@ -1,76 +1,69 @@
 /**
  * usePromptsData (NPPD-1607).
  *
- * Tab 5's data fetch lifecycle. Mirrors {@see useGatesData}: a
- * request-id guard serializes overlapping calls so the latest range
- * change wins, and idle / loading / success / error state is local to
- * the tab.
+ * Thin reader over the module insightsCache. The slot key embeds the
+ * date range + comparison window so cross-tab/date state stays coherent.
  */
 
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useSyncExternalStore } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import type { DateRange } from '../state/useDateRange';
-import { fetchPromptsData, type PromptsResponse } from '../api/prompts';
+import { fetchPromptsData, refreshPromptsData, type PromptsResponse } from '../api/prompts';
+import { insightsCache, makeSlotKey } from '../state/insightsCache';
+import { useRegisterRefresh } from '../state/refreshRegistry';
 
-export type PromptsFetchStatus = 'idle' | 'loading' | 'success' | 'error';
+export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
 
 export interface UsePromptsDataResult {
-	status: PromptsFetchStatus;
+	status: FetchStatus;
 	data: PromptsResponse | null;
 	error: string | null;
 	refetch: () => void;
+	computedAt: string | null;
+	source: 'bigquery' | 'external' | 'local' | null;
+	cooldownUntil: string | null;
 }
 
-const errorMessage = ( e: unknown ): string => {
-	if ( e && typeof e === 'object' && 'message' in e && typeof ( e as { message: unknown } ).message === 'string' ) {
-		return ( e as { message: string } ).message;
-	}
-	return String( e );
-};
+const queryFrom = ( range: DateRange, previousRange: DateRange | null ) => ( {
+	start: range.start,
+	end: range.end,
+	compare_start: previousRange?.start,
+	compare_end: previousRange?.end,
+} );
 
 const usePromptsData = ( range: DateRange, previousRange: DateRange | null ): UsePromptsDataResult => {
-	const [ status, setStatus ] = useState< PromptsFetchStatus >( 'idle' );
-	const [ data, setData ] = useState< PromptsResponse | null >( null );
-	const [ error, setError ] = useState< string | null >( null );
+	const key = makeSlotKey( 'prompts', range, previousRange );
 
-	const requestIdRef = useRef( 0 );
-	const [ refetchTick, setRefetchTick ] = useState( 0 );
-	const refetch = useCallback( () => setRefetchTick( t => t + 1 ), [] );
+	const slot = useSyncExternalStore(
+		listener => insightsCache.subscribe( key, listener ),
+		() => insightsCache.getSlot< PromptsResponse >( key )
+	);
 
 	useEffect( () => {
-		const myId = ++requestIdRef.current;
-		setStatus( 'loading' );
-		setError( null );
+		insightsCache.ensureFetched( key, () => fetchPromptsData( queryFrom( range, previousRange ) ) );
+	}, [ key, range.start, range.end, previousRange?.start, previousRange?.end ] );
 
-		fetchPromptsData( {
-			start: range.start,
-			end: range.end,
-			compare_start: previousRange?.start,
-			compare_end: previousRange?.end,
-		} )
-			.then( response => {
-				if ( requestIdRef.current !== myId ) {
-					return;
-				}
-				setData( response );
-				setStatus( 'success' );
-			} )
-			.catch( e => {
-				if ( requestIdRef.current !== myId ) {
-					return;
-				}
-				setError( errorMessage( e ) );
-				setStatus( 'error' );
-			} );
-	}, [ range.start, range.end, previousRange?.start, previousRange?.end, refetchTick ] );
+	const refetch = useCallback( () => {
+		insightsCache.refresh( key, () => refreshPromptsData( queryFrom( range, previousRange ) ) );
+	}, [ key, range.start, range.end, previousRange?.start, previousRange?.end ] );
 
-	return { status, data, error, refetch };
+	useRegisterRefresh( 'prompts', refetch );
+
+	return {
+		status: slot.status,
+		data: slot.data,
+		error: slot.error,
+		refetch,
+		computedAt: slot.computedAt,
+		source: slot.source,
+		cooldownUntil: slot.cooldownUntil,
+	};
 };
 
 export default usePromptsData;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
@@ -1,13 +1,11 @@
 /**
- * Tab-level tests for PromptsTab (NPPD-1607, Phase 1).
+ * Tab-level tests for PromptsTab (NPPD-1607).
  *
- * Phase 1 ships the whole tab against placeholder (`pending: true`)
- * data. These tests confirm the tab renders the full section
- * structure without crashing when every metric is pending, that the
- * funnel / distribution / performance tables render their zero / empty
- * states, and that loading + error states are handled. A snapshot pins
- * the section structure, card titles, table headers, and explainer
- * copy against the spec.
+ * Confirms the tab renders the full section structure under the state
+ * envelope: scalars in 'populated' state render their card chrome,
+ * collection metrics ('empty' state) render their empty-state copy, and
+ * the tab-level error banner appears when `tab_error` is set.
+ * Loading + error states are exercised separately.
  */
 
 /**
@@ -36,17 +34,28 @@ jest.mock( '@wordpress/icons', () => ( {
 	closeSmall: 'closeSmall',
 	chevronUp: 'chevronUp',
 	chevronDown: 'chevronDown',
+	caution: 'caution',
 } ) );
 
 const mockHook = usePromptsData as jest.Mock;
 const range = { start: '2026-05-09', end: '2026-06-08', preset: 'last-30' } as unknown as DateRange;
 
 const scalar = ( placeholder_type: PromptsPlaceholderType ): PromptsScalarMetric => ( {
+	state: 'populated',
 	value: 'decimal' === placeholder_type ? 0.0 : 0,
 	computable: false,
-	pending: true,
 	denominator: null,
 	placeholder_type,
+} );
+
+const errorScalar = ( placeholder_type: PromptsPlaceholderType ): PromptsScalarMetric => ( {
+	state: 'error',
+	value: 0,
+	computable: false,
+	denominator: null,
+	placeholder_type,
+	error_code: 'bq_unavailable',
+	error_message: 'BigQuery is unavailable.',
 } );
 
 const makeWindow = (): PromptsWindow => ( {
@@ -70,29 +79,20 @@ const makeWindow = (): PromptsWindow => ( {
 	subscription_revenue_direct: scalar( 'currency' ),
 	subscription_revenue_influenced_14d: scalar( 'currency' ),
 	conversion_funnel: {
-		pending: true,
-		stages: [
-			{ label: 'Impression', count: 0, pct_of_top: 0 },
-			{ label: 'Engagement', count: 0, pct_of_top: 0 },
-			{ label: 'Conversion', count: 0, pct_of_top: 0 },
-		],
+		state: 'empty',
+		stages: [],
 	},
 	exposures_distribution: {
-		pending: true,
-		buckets: [
-			{ label: '1 exposure', count: 0, pct: 0 },
-			{ label: '2 exposures', count: 0, pct: 0 },
-			{ label: '3–5 exposures', count: 0, pct: 0 },
-			{ label: '6+ exposures', count: 0, pct: 0 },
-		],
+		state: 'empty',
+		buckets: [],
 	},
-	performance_by_prompt: { pending: true, rows: [] },
-	performance_by_intent: { pending: true, rows: [] },
-	performance_by_placement: { pending: true, rows: [] },
+	performance_by_prompt: { state: 'empty', rows: [] },
+	performance_by_intent: { state: 'empty', rows: [] },
+	performance_by_placement: { state: 'empty', rows: [] },
 } );
 
 const makeResponse = (): PromptsResponse => ( {
-	tab_pending: true,
+	tab_error: false,
 	current: makeWindow(),
 	previous: null,
 } );
@@ -110,7 +110,7 @@ describe( 'PromptsTab', () => {
 		mockHook.mockReset();
 	} );
 
-	it( 'renders all seven section headings + the explainer when every metric is pending', () => {
+	it( 'renders all seven section headings + the explainer when scalars are populated', () => {
 		mockSuccess();
 		render( <PromptsTab range={ range } previousRange={ null } /> );
 
@@ -134,20 +134,14 @@ describe( 'PromptsTab', () => {
 		expect( screen.getByText( 'Donation Revenue (Direct)' ) ).toBeInTheDocument(); // currency
 	} );
 
-	it( 'renders the funnel empty state and the distribution four buckets when all-zero', () => {
+	it( 'renders the funnel + distribution empty-state copy when those sections are empty', () => {
 		mockSuccess();
 		render( <PromptsTab range={ range } previousRange={ null } /> );
 
-		// Phase 1 funnel data is all-zero; the SVG funnel needs a non-zero top step
-		// to chart proportions, so it shows its empty-state copy (matching Gates).
-		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Impression' ) ).not.toBeInTheDocument();
-
-		// The distribution still renders its four buckets at 0 / 0%.
-		expect( screen.getByText( '1 exposure' ) ).toBeInTheDocument();
-		expect( screen.getByText( '2 exposures' ) ).toBeInTheDocument();
-		expect( screen.getByText( '3–5 exposures' ) ).toBeInTheDocument();
-		expect( screen.getByText( '6+ exposures' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'No funnel data yet. The funnel will populate once readers begin moving through your prompts.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'No distribution data yet. This will populate once readers begin converting.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the three performance tables empty-state rows when rows are empty', () => {
@@ -163,6 +157,56 @@ describe( 'PromptsTab', () => {
 		expect(
 			screen.getByText( 'No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.' )
 		).toBeInTheDocument();
+	} );
+
+	it( 'renders the tab-level error banner when tab_error is true', () => {
+		const response = makeResponse();
+		response.tab_error = true;
+		// Flip every scalar to the error state so the per-card treatments line up
+		// with the banner; the banner itself only depends on `tab_error`.
+		Object.keys( response.current ).forEach( key => {
+			const metric = ( response.current as unknown as Record< string, { state?: string; placeholder_type?: PromptsPlaceholderType } > )[ key ];
+			if ( metric && 'placeholder_type' in metric && metric.placeholder_type ) {
+				( response.current as unknown as Record< string, PromptsScalarMetric > )[ key ] = errorScalar( metric.placeholder_type );
+			}
+		} );
+		response.current.conversion_funnel = {
+			state: 'error',
+			stages: [],
+			error_code: 'bq_unavailable',
+			error_message: 'BigQuery is unavailable.',
+		};
+		response.current.exposures_distribution = {
+			state: 'error',
+			buckets: [],
+			error_code: 'bq_unavailable',
+			error_message: 'BigQuery is unavailable.',
+		};
+		response.current.performance_by_prompt = {
+			state: 'error',
+			rows: [],
+			error_code: 'bq_unavailable',
+			error_message: 'BigQuery is unavailable.',
+		};
+		response.current.performance_by_intent = {
+			state: 'error',
+			rows: [],
+			error_code: 'bq_unavailable',
+			error_message: 'BigQuery is unavailable.',
+		};
+		response.current.performance_by_placement = {
+			state: 'error',
+			rows: [],
+			error_code: 'bq_unavailable',
+			error_message: 'BigQuery is unavailable.',
+		};
+		mockHook.mockReturnValue( { status: 'success', error: null, refetch: () => {}, data: response } );
+
+		render( <PromptsTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'Unable to load this tab.' ) ).toBeInTheDocument();
+		// Per-section error treatment renders the shared "Unable to load this section." copy.
+		expect( screen.getAllByText( 'Unable to load this section. Newspack Manager may need attention.' ).length ).toBeGreaterThan( 0 );
 	} );
 
 	it( 'renders the loading state', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -2,18 +2,14 @@
  * PromptsTab (NPPD-1607).
  *
  * Tab 5 orchestrator. Mirrors the GatesTab loading / error / success
- * lifecycle and composes the seven Prompts sections.
+ * lifecycle and composes the seven Prompts sections, plus a tab-level
+ * error banner when every section fails.
  *
  * Date range picker affects every metric — there are no current-state
  * metrics on this tab, only window-scoped ones. Comparison toggle is
  * forwarded by the wizard chrome via the standard `previousRange`
  * prop; when set, the response carries a `previous` window that the
  * sections thread into their per-card MetricCards.
- *
- * Note: unlike Gates, Prompts renders no top-of-tab "preview" banner —
- * the tab is not behind a preview flag, and the spec calls for none.
- * The `tab_pending` flag stays in the response envelope for parity
- * with the other Insights tabs and for Phase 2.
  */
 
 /**
@@ -28,6 +24,7 @@ import type { DateRange } from '../state/useDateRange';
 import usePromptsData from '../hooks/usePromptsData';
 import TabStateView from './components/TabStateView';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
+import PromptsErrorBanner from './prompts/PromptsErrorBanner';
 import DirectVsInfluencedCallout from './prompts/DirectVsInfluencedCallout';
 import PromptExposureSection from './prompts/PromptExposureSection';
 import PromptEngagementSection from './prompts/PromptEngagementSection';
@@ -57,6 +54,7 @@ const PromptsTab = ( { range, previousRange }: PromptsTabProps ) => {
 		>
 			{ data && (
 				<>
+					{ data.tab_error && <PromptsErrorBanner /> }
 					<DirectVsInfluencedCallout />
 					<PromptExposureSection current={ data.current } previous={ data.previous } />
 					<PromptEngagementSection current={ data.current } previous={ data.previous } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { DateRange } from '../state/useDateRange';
 import usePromptsData from '../hooks/usePromptsData';
+import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import PromptsErrorBanner from './prompts/PromptsErrorBanner';
@@ -56,7 +57,11 @@ const PromptsTab = ( { range, previousRange }: PromptsTabProps ) => {
 				<>
 					{ data.tab_error && <PromptsErrorBanner /> }
 					<DirectVsInfluencedCallout />
-					<PromptExposureSection current={ data.current } previous={ data.previous } />
+					<PromptExposureSection
+						current={ data.current }
+						previous={ data.previous }
+						lastUpdated={ <LastUpdated tab="prompts" range={ range } previousRange={ previousRange } /> }
+					/>
 					<PromptEngagementSection current={ data.current } previous={ data.previous } />
 					<FreeReaderConversionSection current={ data.current } previous={ data.previous } />
 					<PaidReaderConversionSection current={ data.current } previous={ data.previous } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
 import type { PromptsWindow } from '../../api/prompts';
 import Funnel from './viz/Funnel';
 import DistributionTable from './viz/DistributionTable';
+import SectionState from './SectionState';
 
 export interface HowReadersConvertSectionProps {
 	current: PromptsWindow;
@@ -37,10 +38,23 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 		</p>
 		<div className="newspack-insights__prompts-convert-grid">
 			<div className="newspack-insights__prompts-convert-col">
-				<Funnel stages={ current.conversion_funnel.stages } />
+				<SectionState
+					state={ current.conversion_funnel.state }
+					emptyMessage={ __(
+						'No funnel data yet. The funnel will populate once readers begin moving through your prompts.',
+						'newspack-plugin'
+					) }
+				>
+					<Funnel stages={ current.conversion_funnel.stages } />
+				</SectionState>
 			</div>
 			<div className="newspack-insights__prompts-convert-col">
-				<DistributionTable data={ current.exposures_distribution } />
+				<SectionState
+					state={ current.exposures_distribution.state }
+					emptyMessage={ __( 'No distribution data yet. This will populate once readers begin converting.', 'newspack-plugin' ) }
+				>
+					<DistributionTable data={ current.exposures_distribution } />
+				</SectionState>
 			</div>
 		</div>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
@@ -8,6 +8,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -22,16 +27,22 @@ import { scalarToMetricCardProps } from './scalarToCard';
 export interface PromptExposureSectionProps {
 	current: PromptsWindow;
 	previous: PromptsWindow | null;
+	lastUpdated?: ReactNode;
 }
 
-const PromptExposureSection = ( { current, previous }: PromptExposureSectionProps ) => (
+const PromptExposureSection = ( { current, previous, lastUpdated }: PromptExposureSectionProps ) => (
 	<section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-prompts-exposure-heading">
-		<h2 id="newspack-insights-prompts-exposure-heading" className="newspack-insights__section-heading">
-			{ __( 'Prompt exposure', 'newspack-plugin' ) }
-		</h2>
-		<p className="newspack-insights__section-caption">
-			{ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
-		</p>
+		<div className="newspack-insights__section-header-container">
+			<div className="newspack-insights__section-header-text">
+				<h2 id="newspack-insights-prompts-exposure-heading" className="newspack-insights__section-heading">
+					{ __( 'Prompt exposure', 'newspack-plugin' ) }
+				</h2>
+				<p className="newspack-insights__section-caption">
+					{ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
+				</p>
+			</div>
+			{ lastUpdated }
+		</div>
 		<div className="newspack-insights__metric-grid">
 			<MetricCard
 				{ ...scalarToMetricCardProps( {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptsErrorBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptsErrorBanner.tsx
@@ -1,0 +1,27 @@
+/**
+ * PromptsErrorBanner (NPPD-1607).
+ *
+ * Tab-level error banner shown when every Prompts section fails to load (e.g.
+ * the BigQuery proxy is down or Newspack Manager isn't configured). Per-section
+ * error treatments still render beneath it; this is the at-a-glance summary.
+ * Publisher-friendly copy only — no internal error codes are surfaced. Mirrors
+ * the tab-local Gates `GatesErrorBanner`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, caution } from '@wordpress/icons';
+
+const PromptsErrorBanner = () => (
+	<div className="newspack-insights__prompts-banner" role="alert">
+		<Icon icon={ caution } className="newspack-insights__prompts-banner-icon" />
+		<p className="newspack-insights__prompts-banner-message">
+			<strong>{ __( 'Unable to load this tab.', 'newspack-plugin' ) }</strong>{ ' ' }
+			{ __( 'Newspack Manager may need attention. Try again shortly.', 'newspack-plugin' ) }
+		</p>
+	</div>
+);
+
+export default PromptsErrorBanner;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/SectionState.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/SectionState.tsx
@@ -1,0 +1,50 @@
+/**
+ * SectionState (NPPD-1607) — tab-local to Prompts.
+ *
+ * Renders the right treatment for a collection metric's `state`:
+ *   - 'error'     → a publisher-friendly error note (no internal codes)
+ *   - 'empty'     → the section's own "no data yet" copy
+ *   - 'populated' → the section's content (children)
+ *
+ * Keeps the funnel / distribution / performance sections declarative and
+ * consistent in how they handle the three orchestrator states. Mirrors
+ * the tab-local Gates `SectionState`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, caution } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { PromptsMetricState } from '../../api/prompts';
+
+/** Publisher-facing copy for a section that failed to load (no internal codes). */
+export const SECTION_ERROR_MESSAGE = __( 'Unable to load this section. Newspack Manager may need attention.', 'newspack-plugin' );
+
+export interface SectionStateProps {
+	state: PromptsMetricState;
+	/** Copy shown when the query succeeded with no rows. */
+	emptyMessage: string;
+	children: React.ReactNode;
+}
+
+const SectionState = ( { state, emptyMessage, children }: SectionStateProps ) => {
+	if ( state === 'error' ) {
+		return (
+			<p className="newspack-insights__section-error" role="alert">
+				<Icon icon={ caution } size={ 20 } />
+				<span>{ SECTION_ERROR_MESSAGE }</span>
+			</p>
+		);
+	}
+	if ( state === 'empty' ) {
+		return <p className="newspack-insights__section-empty">{ emptyMessage }</p>;
+	}
+	return <>{ children }</>;
+};
+
+export default SectionState;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
@@ -23,6 +23,32 @@
 		gap: 32px;
 	}
 
+	// Tab-level error banner — shown when every section fails to load.
+	&__prompts-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		padding: 16px 20px;
+		background-color: colors.$error-000;
+		border: 1px solid colors.$error-050;
+		border-radius: 4px;
+
+		&-icon {
+			flex: 0 0 24px;
+			width: 24px;
+			height: 24px;
+			color: colors.$error-600;
+		}
+
+		&-message {
+			margin: 0;
+			flex: 1 1 auto;
+			font-size: 14px;
+			line-height: 1.5;
+			color: wp-colors.$gray-900;
+		}
+	}
+
 	// Direct vs Influenced explainer — light gray chrome, info icon, X to
 	// dismiss (session-only). Mirrors the Gates callout.
 	&__prompts-callout {
@@ -221,6 +247,18 @@
 			font-size: 13px;
 			color: wp-colors.$gray-600;
 		}
+	}
+
+	// Collection-section error treatment (funnel / distribution / performance).
+	&__section-error {
+		display: flex;
+		align-items: flex-start;
+		gap: 6px;
+		margin: 0;
+		padding: 16px 0;
+		font-size: 13px;
+		line-height: 1.5;
+		color: colors.$error-600;
 	}
 
 	// Distribution viz — tab-local. Reuses the shared table chrome.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
@@ -8,6 +8,8 @@
  * placeholder type (Card 1.3 — Avg Prompts per Reader).
  */
 
+import { __ } from '@wordpress/i18n';
+
 import type { PromptsScalarMetric } from '../../api/prompts';
 import type { MetricFormat } from '../components/MetricCard';
 
@@ -34,12 +36,21 @@ export interface ScalarCardProps {
 
 export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	const { label, description, current, previous } = props;
+	// A failed query renders MetricCard's shared error treatment rather than a
+	// misleading zero. The raw message stays server-side; the card shows generic
+	// copy keyed off the `error` prop.
+	if ( current.state === 'error' ) {
+		return { label, description, error: current.error_message ?? __( 'Data unavailable', 'newspack-plugin' ) };
+	}
 	return {
 		label,
 		description,
 		value: current.value,
 		format: formatFor( current ),
-		previousValue: previous?.computable ? previous.value : null,
-		pending: current.pending,
+		// Suppress the period-over-period delta unless BOTH windows are real
+		// computed values. A non-computable current (e.g. an empty window's zero)
+		// must not show a delta against a real prior value (that would read as a
+		// misleading "↓ 100%").
+		previousValue: current.computable && previous && previous.state !== 'error' && previous.computable ? previous.value : null,
 	};
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
@@ -20,6 +20,7 @@ import type { PromptsPerformanceByIntentRow, PromptsPerformanceByIntentTable as 
 import { formatNumber } from '../../components/format';
 import SortableTable, { renderRate, type SortableColumn } from './SortableTable';
 import { humanizeTerm } from './humanize';
+import { SECTION_ERROR_MESSAGE } from '../SectionState';
 
 export interface PerformanceByIntentTableProps {
 	data: TableData;
@@ -70,6 +71,7 @@ const PerformanceByIntentTable = ( { data }: PerformanceByIntentTableProps ) => 
 				'No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.',
 				'newspack-plugin'
 			) }
+			errorMessage={ 'error' === data.state ? SECTION_ERROR_MESSAGE : undefined }
 		/>
 		<p className="newspack-insights__prompts-subsection-note">
 			{ __( "Answers 'are my donation prompts working better than my registration prompts?' at a glance.", 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
@@ -20,6 +20,7 @@ import type { PromptsPerformanceByPlacementRow, PromptsPerformanceByPlacementTab
 import { formatNumber } from '../../components/format';
 import SortableTable, { renderRate, type SortableColumn } from './SortableTable';
 import { humanizeTerm } from './humanize';
+import { SECTION_ERROR_MESSAGE } from '../SectionState';
 
 export interface PerformanceByPlacementTableProps {
 	data: TableData;
@@ -69,6 +70,7 @@ const PerformanceByPlacementTable = ( { data }: PerformanceByPlacementTableProps
 				'No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.',
 				'newspack-plugin'
 			) }
+			errorMessage={ 'error' === data.state ? SECTION_ERROR_MESSAGE : undefined }
 		/>
 		<p className="newspack-insights__prompts-subsection-note">
 			{ __( "Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.", 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -25,6 +25,7 @@ import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as 
 import { formatNumber } from '../../components/format';
 import SortableTable, { renderCount, renderRate, type SortableColumn } from './SortableTable';
 import { humanizeTerm } from './humanize';
+import { SECTION_ERROR_MESSAGE } from '../SectionState';
 
 export interface PerformanceByPromptTableProps {
 	data: TableData;
@@ -119,13 +120,14 @@ const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => 
 		<SortableTable
 			columns={ columns }
 			rows={ data.rows }
-			getRowKey={ row => row.newspack_popup_id }
+			getRowKey={ row => row.popup_id }
 			defaultSortKey="impressions"
 			initialRowLimit={ 10 }
 			emptyMessage={ __(
 				'No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.',
 				'newspack-plugin'
 			) }
+			errorMessage={ 'error' === data.state ? SECTION_ERROR_MESSAGE : undefined }
 		/>
 		<p className="newspack-insights__prompts-subsection-note">
 			{ __(

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/SortableTable.tsx
@@ -50,6 +50,13 @@ export interface SortableTableProps< Row > {
 	defaultSortKey: string;
 	emptyMessage: string;
 	/**
+	 * When set, replaces the empty-state row with a publisher-friendly error
+	 * message. Pass when the table's wrapper envelope reports `state === 'error'`
+	 * so a failed query renders the shared error treatment instead of the
+	 * neutral "no data yet" copy.
+	 */
+	errorMessage?: string;
+	/**
 	 * When set and the table has more rows than this, only the first N (by the
 	 * active sort) render, with a "See more" toggle that reveals the rest. The
 	 * cap is applied after sorting, so collapsing always shows the current top N.
@@ -93,7 +100,15 @@ function SortableHeader< Row >( { column, activeKey, activeDir, onSort }: Sortab
 	);
 }
 
-function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, emptyMessage, initialRowLimit }: SortableTableProps< Row > ) {
+function SortableTable< Row >( {
+	columns,
+	rows,
+	getRowKey,
+	defaultSortKey,
+	emptyMessage,
+	errorMessage,
+	initialRowLimit,
+}: SortableTableProps< Row > ) {
 	const [ sortKey, setSortKey ] = useState< string >( defaultSortKey );
 	const [ sortDir, setSortDir ] = useState< SortDir >( () => {
 		const def = columns.find( c => c.key === defaultSortKey );
@@ -165,7 +180,7 @@ function SortableTable< Row >( { columns, rows, getRowKey, defaultSortKey, empty
 						{ isEmpty ? (
 							<tr>
 								<td colSpan={ columns.length } className="newspack-insights__prompts-performance-empty">
-									{ emptyMessage }
+									{ errorMessage ?? emptyMessage }
 								</td>
 							</tr>
 						) : (

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -153,6 +153,25 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * SAFE_DIVIDE returns NULL when the denominator is zero (BigQuery semantics).
+	 * That's a legitimate "no eligible events" case, not a malformed payload —
+	 * surface as `state: 'populated'` with a non-computable zero so the UI
+	 * renders "0%" instead of "Data temporarily unavailable".
+	 */
+	public function test_scalar_treats_null_safe_divide_result_as_non_computable_zero() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [ [ 'regwall_conversion_rate_direct' => null ] ] );
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->get_regwall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 0, $result['value'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 'rate', $result['placeholder_type'] );
+	}
+
+	/**
 	 * Section 1 count metrics fall back when the catalog returns a non-integer numeric value.
 	 *
 	 * A `count` should always be a whole number; a float (e.g. 3.7) indicates upstream

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -10,10 +10,15 @@
  *   - state 'error' with `bigquery_proxy_malformed_value` when the catalog
  *     returns a non-numeric column.
  *
- * The 13 not-yet-wired methods (paid conversion / revenue / funnel /
- * distribution / 3 perf tables) are pinned to the bridge envelope:
+ * The 8 paid-conversion + revenue methods are also pinned (Task 3.2): they
+ * dispatch through the BigQuery proxy, Woo-join the rows via Woo_Order_Resolver,
+ * and share a per-window memoization cache (one proxy call per intent +
+ * direction).
+ *
+ * The 5 not-yet-wired collection methods (funnel / distribution / 3 perf
+ * tables) remain pinned to the bridge envelope:
  * state 'error' with `error_code: newspack_insights_prompts_not_yet_implemented`.
- * Locks the bridge behavior so Tasks 3.2 / 3.3 can refactor with confidence.
+ * Locks the bridge behavior so Task 3.3 can refactor with confidence.
  *
  * @package Newspack\Tests\Insights
  */
@@ -24,6 +29,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Prompts_Metric;
+use Newspack\Insights\Woo_Order_Resolver;
 use WP_UnitTestCase;
 
 /**
@@ -228,47 +234,288 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'bigquery_proxy_malformed_value', $result['error_code'] );
 	}
 
-	// --- Section 4/5/6/7: not-yet-implemented bridge -------------------
+	// --- Section 4: Paid reader conversion (Woo join) -------------------
 
 	/**
-	 * Placeholder methods return the bridge envelope:
-	 *   state 'error', error_code 'newspack_insights_prompts_not_yet_implemented'.
-	 * They must not touch the proxy.
+	 * Sample BQ rows in the shape returned by the 4 paid-conversion catalog
+	 * queries. Shared across the conversion-rate / revenue tests.
 	 *
-	 * @dataProvider provide_placeholder_scalar_methods
-	 * @param string $method           Method on Prompts_Metric to call.
-	 * @param string $placeholder_type Expected `placeholder_type` in the payload.
+	 * @return array
 	 */
-	public function test_placeholder_scalar_returns_bridge_envelope( string $method, string $placeholder_type ) {
-		$metric = $this->make_metric_with_unused_proxy();
+	protected function paid_attempt_rows(): array {
+		return [
+			[
+				'user_pseudo_id' => '101',
+				'session_id'     => 's1',
+				'attempt_ts'     => 1717000000000000,
+				'popup_id'       => '42',
+			],
+			[
+				'user_pseudo_id' => '102',
+				'session_id'     => 's2',
+				'attempt_ts'     => 1717001000000000,
+				'popup_id'       => '42',
+			],
+		];
+	}
+
+	/**
+	 * Wired paid-conversion RATE methods: dispatch the query, Woo-join, and
+	 * return `conversions / attempts` as a `placeholder_type: 'rate'` envelope.
+	 *
+	 * @dataProvider provide_paid_conversion_rate_methods
+	 * @param string $method     Method on Prompts_Metric to call.
+	 * @param string $query_name Catalog name the orchestrator must dispatch.
+	 */
+	public function test_paid_conversion_rate_returns_populated_on_success( string $method, string $query_name ) {
+		$rows  = $this->paid_attempt_rows();
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( $rows );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 1 ); // 1 of 2 attempts converted.
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 0.5, $result['value'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 2, $result['denominator'] );
+		$this->assertSame( 'rate', $result['placeholder_type'] );
+	}
+
+	/**
+	 * Wired paid-conversion RATE methods: proxy WP_Error → state 'error'.
+	 *
+	 * @dataProvider provide_paid_conversion_rate_methods
+	 * @param string $method     Method on Prompts_Metric to call.
+	 * @param string $query_name Catalog name the orchestrator must dispatch.
+	 */
+	public function test_paid_conversion_rate_returns_error_state_on_proxy_error( string $method, string $query_name ) {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' ) );
+
+		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
 		$result = $metric->$method( $this->start(), $this->end() );
 
 		$this->assertSame( 'error', $result['state'] );
 		$this->assertFalse( $result['computable'] );
-		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
-		$this->assertSame( 'newspack_insights_prompts_not_yet_implemented', $result['error_code'] );
-		$this->assertNotSame( '', $result['error_message'] );
-		// No `pending` key — bridge MUST NOT regress to the old shape.
-		$this->assertArrayNotHasKey( 'pending', $result );
+		$this->assertSame( 'rate', $result['placeholder_type'] );
+		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
+		$this->assertSame( 'HTTP 500', $result['error_message'] );
+		$this->assertSame( 0, $result['value'] );
 	}
 
 	/**
-	 * Data provider for the 8 not-yet-wired scalar methods.
+	 * Wired paid-conversion RATE methods: empty BQ response → non-computable
+	 * 0.0 with denominator 0 (a real "no attempts in window", not an error).
+	 *
+	 * @dataProvider provide_paid_conversion_rate_methods
+	 * @param string $method     Method on Prompts_Metric to call.
+	 * @param string $query_name Catalog name the orchestrator must dispatch.
+	 */
+	public function test_paid_conversion_rate_returns_noncomputable_zero_on_empty( string $method, string $query_name ) {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( [] );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 0, $result['denominator'] );
+		$this->assertSame( 'rate', $result['placeholder_type'] );
+		$this->assertSame( 0.0, $result['value'] );
+	}
+
+	/**
+	 * Data provider for the 4 paid-conversion rate methods.
 	 *
 	 * @return array
 	 */
-	public function provide_placeholder_scalar_methods(): array {
+	public function provide_paid_conversion_rate_methods(): array {
 		return [
-			'donation_direct'         => [ 'get_donation_conversion_direct', 'rate' ],
-			'donation_influenced'     => [ 'get_donation_conversion_influenced_14d', 'rate' ],
-			'subscription_direct'     => [ 'get_subscription_conversion_direct', 'rate' ],
-			'subscription_influenced' => [ 'get_subscription_conversion_influenced_14d', 'rate' ],
-			'donation_revenue_direct' => [ 'get_donation_revenue_direct', 'currency' ],
-			'donation_revenue_inf'    => [ 'get_donation_revenue_influenced_14d', 'currency' ],
-			'sub_revenue_direct'      => [ 'get_subscription_revenue_direct', 'currency' ],
-			'sub_revenue_inf'         => [ 'get_subscription_revenue_influenced_14d', 'currency' ],
+			'donation_direct'         => [ 'get_donation_conversion_direct', 'prompts_donation_conversion_direct' ],
+			'donation_influenced'     => [ 'get_donation_conversion_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
+			'subscription_direct'     => [ 'get_subscription_conversion_direct', 'prompts_subscription_conversion_direct' ],
+			'subscription_influenced' => [ 'get_subscription_conversion_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
 		];
 	}
+
+	// --- Section 5: Revenue from prompts --------------------------------
+
+	/**
+	 * Wired revenue methods: dispatch the underlying CONVERSION query name
+	 * (sharing cache with the matching rate method), return summed Woo revenue
+	 * as a `placeholder_type: 'currency'` envelope.
+	 *
+	 * @dataProvider provide_paid_revenue_methods
+	 * @param string $method     Method on Prompts_Metric to call.
+	 * @param string $query_name Underlying conversion query name dispatched.
+	 */
+	public function test_paid_revenue_returns_populated_on_success( string $method, string $query_name ) {
+		$rows  = $this->paid_attempt_rows();
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( $rows );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 25.0, $result['value'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 1, $result['denominator'] );
+		$this->assertSame( 'currency', $result['placeholder_type'] );
+	}
+
+	/**
+	 * Wired revenue methods: proxy WP_Error → state 'error'.
+	 *
+	 * @dataProvider provide_paid_revenue_methods
+	 * @param string $method     Method on Prompts_Metric to call.
+	 * @param string $query_name Underlying conversion query name dispatched.
+	 */
+	public function test_paid_revenue_returns_error_state_on_proxy_error( string $method, string $query_name ) {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' ) );
+
+		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 'currency', $result['placeholder_type'] );
+		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
+		$this->assertSame( 'HTTP 500', $result['error_message'] );
+		$this->assertSame( 0, $result['value'] );
+	}
+
+	/**
+	 * Wired revenue methods: empty BQ rows → $0.00 populated, computable=true
+	 * (the sum is a real 0), denominator 0 (zero conversions matched).
+	 *
+	 * @dataProvider provide_paid_revenue_methods
+	 * @param string $method     Method on Prompts_Metric to call.
+	 * @param string $query_name Underlying conversion query name dispatched.
+	 */
+	public function test_paid_revenue_returns_zero_on_empty( string $method, string $query_name ) {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( [] );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 0.0, $result['value'] );
+		$this->assertSame( 0, $result['denominator'] );
+		$this->assertSame( 'currency', $result['placeholder_type'] );
+	}
+
+	/**
+	 * Data provider for the 4 revenue methods. The `query_name` is the
+	 * underlying conversion-query name (revenue methods share the cache with
+	 * their rate counterparts; the hub's revenue alias is byte-identical).
+	 *
+	 * @return array
+	 */
+	public function provide_paid_revenue_methods(): array {
+		return [
+			'donation_direct'         => [ 'get_donation_revenue_direct', 'prompts_donation_conversion_direct' ],
+			'donation_influenced'     => [ 'get_donation_revenue_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
+			'subscription_direct'     => [ 'get_subscription_revenue_direct', 'prompts_subscription_conversion_direct' ],
+			'subscription_influenced' => [ 'get_subscription_revenue_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
+		];
+	}
+
+	/**
+	 * Per-(query_name, window) memoization: the matching rate + revenue
+	 * methods for the same intent + direction share one proxy round-trip.
+	 *
+	 * `expects($this->once())` is the regression guard — a second call fails
+	 * the test. The two methods read different fields from the same Woo-joined
+	 * result, so they must dispatch the underlying conversion query exactly
+	 * once.
+	 */
+	public function test_paid_methods_share_single_proxy_call_per_window() {
+		$rows  = $this->paid_attempt_rows();
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'prompts_donation_conversion_direct', $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( $rows );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$start  = $this->start();
+		$end    = $this->end();
+
+		$rate    = $metric->get_donation_conversion_direct( $start, $end );
+		$revenue = $metric->get_donation_revenue_direct( $start, $end );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertSame( 0.5, $rate['value'] );
+		$this->assertSame( 'populated', $revenue['state'] );
+		$this->assertSame( 25.0, $revenue['value'] );
+	}
+
+	/**
+	 * Memoization keys by (query_name, window): two different intents must
+	 * NOT share a cache entry. Each distinct query_name triggers its own
+	 * proxy round-trip; the cache only deduplicates within an intent.
+	 */
+	public function test_paid_cache_is_keyed_per_query_name() {
+		$rows  = $this->paid_attempt_rows();
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		// Two distinct query_names → two proxy calls.
+		$proxy->expects( $this->exactly( 2 ) )
+			->method( 'query' )
+			->willReturn( $rows );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$metric->get_donation_conversion_direct( $this->start(), $this->end() );
+		$metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+	}
+
+	// --- Section 6/7: not-yet-implemented bridge (collections) ---------
 
 	/**
 	 * Placeholder collection methods (funnel, distribution, 3 perf tables)

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -1,13 +1,19 @@
 <?php
 /**
- * Test Prompts_Metric (NPPD-1607, Phase 1).
+ * Test Prompts_Metric (NPPD-1607, Phase 2).
  *
- * Phase 1 orchestrator returns placeholder envelopes only — no proxy,
- * no SQL. These tests pin the envelope shape every Phase 2 swap must
- * preserve: scalar scorecards carry `value` / `pending` / `computable`
- * / `placeholder_type`, the funnel/distribution carry `pending` + an
- * ordered collection, and the three performance tables carry `pending`
- * + an empty `rows` array.
+ * Pins the state-envelope contract every wired scalar metric must satisfy:
+ *   - state 'populated' with a real value on a successful proxy response,
+ *   - state 'error' (with `error_code`/`error_message`) on a proxy WP_Error,
+ *   - state 'populated' non-computable zero when the query succeeds with no
+ *     usable value, and
+ *   - state 'error' with `bigquery_proxy_malformed_value` when the catalog
+ *     returns a non-numeric column.
+ *
+ * The 13 not-yet-wired methods (paid conversion / revenue / funnel /
+ * distribution / 3 perf tables) are pinned to the bridge envelope:
+ * state 'error' with `error_code: newspack_insights_prompts_not_yet_implemented`.
+ * Locks the bridge behavior so Tasks 3.2 / 3.3 can refactor with confidence.
  *
  * @package Newspack\Tests\Insights
  */
@@ -16,6 +22,7 @@ namespace Newspack\Tests\Insights;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Prompts_Metric;
 use WP_UnitTestCase;
 
@@ -27,152 +34,273 @@ use WP_UnitTestCase;
 class Test_Prompts_Metric extends WP_UnitTestCase {
 
 	/**
-	 * Subject under test.
-	 *
-	 * @var Prompts_Metric
-	 */
-	private $metric;
-
-	/**
-	 * Set up.
-	 */
-	public function set_up() {
-		parent::set_up();
-		$this->metric = new Prompts_Metric();
-	}
-
-	/**
 	 * Make a UTC DateTimeImmutable from a YYYY-MM-DD string.
 	 *
 	 * @param string $ymd Date string.
 	 * @return DateTimeImmutable
 	 */
-	private function make_date( string $ymd ): DateTimeImmutable {
+	protected function make_date( string $ymd ): DateTimeImmutable {
 		return new DateTimeImmutable( $ymd, new DateTimeZone( 'UTC' ) );
 	}
 
 	/**
-	 * Every scalar scorecard returns the Phase 1 placeholder envelope:
-	 * a non-computable, pending, zero value of the documented type.
-	 *
-	 * @dataProvider provide_scalar_methods
-	 * @param string $method           Method on Prompts_Metric to call.
-	 * @param string $placeholder_type Expected `placeholder_type`.
+	 * Window start convenience.
 	 */
-	public function test_scalar_returns_placeholder_envelope( string $method, string $placeholder_type ) {
-		$result = $this->metric->$method( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'value', $result );
-		$this->assertArrayHasKey( 'computable', $result );
-		$this->assertArrayHasKey( 'pending', $result );
-		$this->assertArrayHasKey( 'denominator', $result );
-		$this->assertArrayHasKey( 'placeholder_type', $result );
-
-		$this->assertTrue( $result['pending'], "$method should be pending in Phase 1" );
-		$this->assertFalse( $result['computable'], "$method should be non-computable in Phase 1" );
-		$this->assertNull( $result['denominator'] );
-		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
-
-		// Decimal placeholders are floats; everything else is an integer zero.
-		if ( 'decimal' === $placeholder_type ) {
-			$this->assertSame( 0.0, $result['value'] );
-		} else {
-			$this->assertSame( 0, $result['value'] );
-		}
+	protected function start(): DateTimeImmutable {
+		return $this->make_date( '2026-03-22' );
 	}
 
 	/**
-	 * Every scalar scorecard method, mapped to its expected placeholder type.
-	 * Mirrors the formulas-doc query set for Tab 5 Sections 1–5.
-	 *
-	 * @return array<string, array{0:string,1:string}>
+	 * Window end convenience.
 	 */
-	public function provide_scalar_methods(): array {
+	protected function end(): DateTimeImmutable {
+		return $this->make_date( '2026-04-21' );
+	}
+
+	/**
+	 * Build a Prompts_Metric with a proxy stub that returns the given value
+	 * from every `query()` call. Asserts the dispatched query name matches.
+	 *
+	 * @param string $expected_query_name The catalog name the orchestrator must dispatch.
+	 * @param mixed  $return              Value the mock client returns (rows array or WP_Error).
+	 * @return Prompts_Metric
+	 */
+	protected function make_metric_with_proxy_returning( string $expected_query_name, $return ): Prompts_Metric {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $expected_query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn( $return );
+		return new Prompts_Metric( $proxy );
+	}
+
+	/**
+	 * Build a Prompts_Metric with a proxy stub that fails the test if `query()`
+	 * is ever called. Used for the not-yet-implemented bridge smoke tests.
+	 */
+	protected function make_metric_with_unused_proxy(): Prompts_Metric {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+		return new Prompts_Metric( $proxy );
+	}
+
+	/**
+	 * Constructor accepts an injected proxy client (test seam).
+	 */
+	public function test_constructor_accepts_injected_proxy() {
+		$proxy  = $this->createMock( BigQuery_Proxy_Client::class );
+		$metric = new Prompts_Metric( $proxy );
+		$this->assertInstanceOf( Prompts_Metric::class, $metric );
+	}
+
+	// --- Section 1: Prompt exposure ------------------------------------
+
+	/**
+	 * Wired scalar metrics: dispatch the right query, read the right row key,
+	 * type-coerce per `placeholder_type`.
+	 *
+	 * @dataProvider provide_scalar_success_cases
+	 * @param string $method           Method on Prompts_Metric to call.
+	 * @param string $query_name       Catalog query name the orchestrator should dispatch.
+	 * @param string $row_key          Column the orchestrator reads from row 0.
+	 * @param mixed  $row_value        Value the mock client returns for that column.
+	 * @param string $placeholder_type Expected `placeholder_type` in the payload.
+	 * @param mixed  $expected_value   Expected `value` in the payload (already coerced).
+	 */
+	public function test_scalar_returns_populated_on_success( string $method, string $query_name, string $row_key, $row_value, string $placeholder_type, $expected_value ) {
+		$metric = $this->make_metric_with_proxy_returning( $query_name, [ [ $row_key => $row_value ] ] );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( $expected_value, $result['value'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertNull( $result['denominator'] );
+		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
+	}
+
+	/**
+	 * Wired scalar metrics: proxy WP_Error → state 'error' with code/message.
+	 *
+	 * @dataProvider provide_scalar_methods
+	 * @param string $method           Method on Prompts_Metric to call.
+	 * @param string $query_name       Catalog query name dispatched (unused but provided for symmetry).
+	 * @param string $row_key          Row key (unused but provided for symmetry).
+	 * @param string $placeholder_type Expected `placeholder_type` in the error payload.
+	 */
+	public function test_scalar_returns_error_state_on_proxy_error( string $method, string $query_name, string $row_key, string $placeholder_type ) {
+		unset( $row_key );
+		$metric = $this->make_metric_with_proxy_returning(
+			$query_name,
+			new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' )
+		);
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertNull( $result['denominator'] );
+		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
+		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
+		$this->assertSame( 'HTTP 500', $result['error_message'] );
+		// Value is a typed zero so React never crashes if it ignores `state`.
+		$this->assertSame( 'decimal' === $placeholder_type ? 0.0 : 0, $result['value'] );
+	}
+
+	/**
+	 * Wired scalar metrics: empty rows → state 'populated' non-computable zero.
+	 *
+	 * @dataProvider provide_scalar_methods
+	 * @param string $method           Method on Prompts_Metric to call.
+	 * @param string $query_name       Catalog query name dispatched.
+	 * @param string $row_key          Row key (unused but provided for symmetry).
+	 * @param string $placeholder_type Expected `placeholder_type` in the payload.
+	 */
+	public function test_scalar_returns_noncomputable_zero_on_empty( string $method, string $query_name, string $row_key, string $placeholder_type ) {
+		unset( $row_key );
+		$metric = $this->make_metric_with_proxy_returning( $query_name, [] );
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertNull( $result['denominator'] );
+		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
+		$this->assertSame( 'decimal' === $placeholder_type ? 0.0 : 0, $result['value'] );
+	}
+
+	/**
+	 * Data provider for scalar success cases. Real values, type-coerced.
+	 *
+	 * @return array
+	 */
+	public function provide_scalar_success_cases(): array {
 		return [
 			// Section 1 — exposure.
-			'total_prompt_impressions'                   => [ 'get_total_prompt_impressions', 'count' ],
-			'unique_readers_reached'                     => [ 'get_unique_readers_reached', 'count' ],
-			'avg_prompts_per_reader'                     => [ 'get_avg_prompts_per_reader', 'decimal' ],
+			'total_impressions'       => [ 'get_total_prompt_impressions', 'prompts_total_impressions', 'prompt_impressions', 12345, 'count', 12345 ],
+			'unique_viewers'          => [ 'get_unique_readers_reached', 'prompts_unique_viewers', 'unique_prompt_viewers', 678, 'count', 678 ],
+			'avg_prompts_per_reader'  => [ 'get_avg_prompts_per_reader', 'prompts_avg_prompts_per_reader', 'avg_prompts_per_reader', 3.5, 'decimal', 3.5 ],
 			// Section 2 — engagement.
-			'click_through_rate'                         => [ 'get_click_through_rate', 'rate' ],
-			'form_submission_rate'                       => [ 'get_form_submission_rate', 'rate' ],
-			'dismissal_rate'                             => [ 'get_dismissal_rate', 'rate' ],
-			// Section 3 — free reader conversion.
-			'registration_conversion_direct'             => [ 'get_registration_conversion_direct', 'rate' ],
-			'registration_conversion_influenced_7d'      => [ 'get_registration_conversion_influenced_7d', 'rate' ],
-			'newsletter_signup_conversion_direct'        => [ 'get_newsletter_signup_conversion_direct', 'rate' ],
-			'newsletter_signup_conversion_influenced_7d' => [ 'get_newsletter_signup_conversion_influenced_7d', 'rate' ],
-			// Section 4 — paid reader conversion.
-			'donation_conversion_direct'                 => [ 'get_donation_conversion_direct', 'rate' ],
-			'donation_conversion_influenced_14d'         => [ 'get_donation_conversion_influenced_14d', 'rate' ],
-			'subscription_conversion_direct'             => [ 'get_subscription_conversion_direct', 'rate' ],
-			'subscription_conversion_influenced_14d'     => [ 'get_subscription_conversion_influenced_14d', 'rate' ],
-			// Section 5 — revenue.
-			'donation_revenue_direct'                    => [ 'get_donation_revenue_direct', 'currency' ],
-			'donation_revenue_influenced_14d'            => [ 'get_donation_revenue_influenced_14d', 'currency' ],
-			'subscription_revenue_direct'                => [ 'get_subscription_revenue_direct', 'currency' ],
-			'subscription_revenue_influenced_14d'        => [ 'get_subscription_revenue_influenced_14d', 'currency' ],
+			'click_through_rate'      => [ 'get_click_through_rate', 'prompts_click_through_rate', 'click_through_rate', 0.12, 'rate', 0.12 ],
+			'form_submission_rate'    => [ 'get_form_submission_rate', 'prompts_form_submission_rate', 'form_submission_rate', 0.21, 'rate', 0.21 ],
+			'dismissal_rate'          => [ 'get_dismissal_rate', 'prompts_dismissal_rate', 'dismissal_rate', 0.07, 'rate', 0.07 ],
+			// Section 3 — free conversion.
+			'registration_direct'     => [ 'get_registration_conversion_direct', 'prompts_registration_conversion_direct', 'registration_conversion_direct', 0.18, 'rate', 0.18 ],
+			'registration_influenced' => [ 'get_registration_conversion_influenced_7d', 'prompts_registration_conversion_influenced_7d', 'registration_conversion_influenced', 0.31, 'rate', 0.31 ],
+			'newsletter_direct'       => [ 'get_newsletter_signup_conversion_direct', 'prompts_newsletter_signup_conversion_direct', 'newsletter_signup_conversion_direct', 0.09, 'rate', 0.09 ],
+			'newsletter_influenced'   => [ 'get_newsletter_signup_conversion_influenced_7d', 'prompts_newsletter_signup_conversion_influenced_7d', 'newsletter_signup_conversion_influenced', 0.14, 'rate', 0.14 ],
 		];
 	}
 
 	/**
-	 * The funnel returns a pending envelope with three ordered, zeroed stages.
-	 */
-	public function test_funnel_returns_three_zero_stages() {
-		$result = $this->metric->get_conversion_funnel( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertTrue( $result['pending'] );
-		$this->assertCount( 3, $result['stages'] );
-		foreach ( $result['stages'] as $stage ) {
-			$this->assertArrayHasKey( 'label', $stage );
-			$this->assertNotSame( '', $stage['label'] );
-			$this->assertSame( 0, $stage['count'] );
-			$this->assertSame( 0.0, $stage['pct_of_top'] );
-		}
-	}
-
-	/**
-	 * The distribution returns a pending envelope with four zeroed buckets.
-	 */
-	public function test_distribution_returns_four_zero_buckets() {
-		$result = $this->metric->get_exposures_distribution( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertTrue( $result['pending'] );
-		$this->assertCount( 4, $result['buckets'] );
-		foreach ( $result['buckets'] as $bucket ) {
-			$this->assertArrayHasKey( 'label', $bucket );
-			$this->assertNotSame( '', $bucket['label'] );
-			$this->assertSame( 0, $bucket['count'] );
-			$this->assertSame( 0.0, $bucket['pct'] );
-		}
-	}
-
-	/**
-	 * Each performance table returns a pending envelope with an empty
-	 * `rows` array, so the React layer renders the spec's empty-state row.
+	 * Data provider for scalar methods (no value column — used by error /
+	 * empty path tests where the column isn't returned at all).
 	 *
-	 * @dataProvider provide_table_methods
-	 * @param string $method Method on Prompts_Metric to call.
-	 */
-	public function test_performance_table_returns_empty_rows( string $method ) {
-		$result = $this->metric->$method( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertTrue( $result['pending'] );
-		$this->assertArrayHasKey( 'rows', $result );
-		$this->assertSame( [], $result['rows'] );
-	}
-
-	/**
-	 * The three Section 7 performance tables.
+	 * Tuple shape: [ method, query_name, row_key, placeholder_type ].
 	 *
-	 * @return array<string, array{0:string}>
+	 * @return array
 	 */
-	public function provide_table_methods(): array {
+	public function provide_scalar_methods(): array {
 		return [
-			'by_prompt'    => [ 'get_performance_by_prompt' ],
-			'by_intent'    => [ 'get_performance_by_intent' ],
-			'by_placement' => [ 'get_performance_by_placement' ],
+			'total_impressions'       => [ 'get_total_prompt_impressions', 'prompts_total_impressions', 'prompt_impressions', 'count' ],
+			'unique_viewers'          => [ 'get_unique_readers_reached', 'prompts_unique_viewers', 'unique_prompt_viewers', 'count' ],
+			'avg_prompts_per_reader'  => [ 'get_avg_prompts_per_reader', 'prompts_avg_prompts_per_reader', 'avg_prompts_per_reader', 'decimal' ],
+			'click_through_rate'      => [ 'get_click_through_rate', 'prompts_click_through_rate', 'click_through_rate', 'rate' ],
+			'form_submission_rate'    => [ 'get_form_submission_rate', 'prompts_form_submission_rate', 'form_submission_rate', 'rate' ],
+			'dismissal_rate'          => [ 'get_dismissal_rate', 'prompts_dismissal_rate', 'dismissal_rate', 'rate' ],
+			'registration_direct'     => [ 'get_registration_conversion_direct', 'prompts_registration_conversion_direct', 'registration_conversion_direct', 'rate' ],
+			'registration_influenced' => [ 'get_registration_conversion_influenced_7d', 'prompts_registration_conversion_influenced_7d', 'registration_conversion_influenced', 'rate' ],
+			'newsletter_direct'       => [ 'get_newsletter_signup_conversion_direct', 'prompts_newsletter_signup_conversion_direct', 'newsletter_signup_conversion_direct', 'rate' ],
+			'newsletter_influenced'   => [ 'get_newsletter_signup_conversion_influenced_7d', 'prompts_newsletter_signup_conversion_influenced_7d', 'newsletter_signup_conversion_influenced', 'rate' ],
+		];
+	}
+
+	/**
+	 * Malformed scalar value (non-numeric) → state 'error' with
+	 * `bigquery_proxy_malformed_value`. Single representative case — the
+	 * branch is shared across every scalar method via compute_metric_from_proxy.
+	 */
+	public function test_scalar_rejects_non_numeric_value() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_total_impressions',
+			[ [ 'prompt_impressions' => 'banana' ] ]
+		);
+		$result = $metric->get_total_prompt_impressions( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_value', $result['error_code'] );
+	}
+
+	// --- Section 4/5/6/7: not-yet-implemented bridge -------------------
+
+	/**
+	 * Placeholder methods return the bridge envelope:
+	 *   state 'error', error_code 'newspack_insights_prompts_not_yet_implemented'.
+	 * They must not touch the proxy.
+	 *
+	 * @dataProvider provide_placeholder_scalar_methods
+	 * @param string $method           Method on Prompts_Metric to call.
+	 * @param string $placeholder_type Expected `placeholder_type` in the payload.
+	 */
+	public function test_placeholder_scalar_returns_bridge_envelope( string $method, string $placeholder_type ) {
+		$metric = $this->make_metric_with_unused_proxy();
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( $placeholder_type, $result['placeholder_type'] );
+		$this->assertSame( 'newspack_insights_prompts_not_yet_implemented', $result['error_code'] );
+		$this->assertNotSame( '', $result['error_message'] );
+		// No `pending` key — bridge MUST NOT regress to the old shape.
+		$this->assertArrayNotHasKey( 'pending', $result );
+	}
+
+	/**
+	 * Data provider for the 8 not-yet-wired scalar methods.
+	 *
+	 * @return array
+	 */
+	public function provide_placeholder_scalar_methods(): array {
+		return [
+			'donation_direct'         => [ 'get_donation_conversion_direct', 'rate' ],
+			'donation_influenced'     => [ 'get_donation_conversion_influenced_14d', 'rate' ],
+			'subscription_direct'     => [ 'get_subscription_conversion_direct', 'rate' ],
+			'subscription_influenced' => [ 'get_subscription_conversion_influenced_14d', 'rate' ],
+			'donation_revenue_direct' => [ 'get_donation_revenue_direct', 'currency' ],
+			'donation_revenue_inf'    => [ 'get_donation_revenue_influenced_14d', 'currency' ],
+			'sub_revenue_direct'      => [ 'get_subscription_revenue_direct', 'currency' ],
+			'sub_revenue_inf'         => [ 'get_subscription_revenue_influenced_14d', 'currency' ],
+		];
+	}
+
+	/**
+	 * Placeholder collection methods (funnel, distribution, 3 perf tables)
+	 * return the bridge envelope with the proper rows-key and an empty list.
+	 *
+	 * @dataProvider provide_placeholder_collection_methods
+	 * @param string $method   Method on Prompts_Metric to call.
+	 * @param string $rows_key Key holding the (empty) collection: 'stages'|'buckets'|'rows'.
+	 */
+	public function test_placeholder_collection_returns_bridge_envelope( string $method, string $rows_key ) {
+		$metric = $this->make_metric_with_unused_proxy();
+		$result = $metric->$method( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'newspack_insights_prompts_not_yet_implemented', $result['error_code'] );
+		$this->assertNotSame( '', $result['error_message'] );
+		$this->assertSame( [], $result[ $rows_key ] );
+		$this->assertArrayNotHasKey( 'pending', $result );
+	}
+
+	/**
+	 * Data provider for the 5 not-yet-wired collection methods.
+	 *
+	 * @return array
+	 */
+	public function provide_placeholder_collection_methods(): array {
+		return [
+			'funnel'                => [ 'get_conversion_funnel', 'stages' ],
+			'distribution'          => [ 'get_exposures_distribution', 'buckets' ],
+			'performance_by_prompt' => [ 'get_performance_by_prompt', 'rows' ],
+			'performance_by_intent' => [ 'get_performance_by_intent', 'rows' ],
+			'performance_by_place'  => [ 'get_performance_by_placement', 'rows' ],
 		];
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -15,10 +15,12 @@
  * and share a per-window memoization cache (one proxy call per intent +
  * direction).
  *
- * The 5 not-yet-wired collection methods (funnel / distribution / 3 perf
- * tables) remain pinned to the bridge envelope:
- * state 'error' with `error_code: newspack_insights_prompts_not_yet_implemented`.
- * Locks the bridge behavior so Task 3.3 can refactor with confidence.
+ * The 5 collection methods are pinned (Task 3.3): funnel + distribution mirror
+ * the Gates state-envelope contract one-for-one; the per-prompt performance
+ * table additionally augments each row with per-popup Woo-completed donation
+ * and subscription counts and is asserted to degrade gracefully (engagement
+ * columns still render with zeros in the Woo columns) when the Woo-side proxy
+ * call fails.
  *
  * @package Newspack\Tests\Insights
  */
@@ -77,16 +79,6 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 			->method( 'query' )
 			->with( $expected_query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
 			->willReturn( $return );
-		return new Prompts_Metric( $proxy );
-	}
-
-	/**
-	 * Build a Prompts_Metric with a proxy stub that fails the test if `query()`
-	 * is ever called. Used for the not-yet-implemented bridge smoke tests.
-	 */
-	protected function make_metric_with_unused_proxy(): Prompts_Metric {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->never() )->method( 'query' );
 		return new Prompts_Metric( $proxy );
 	}
 
@@ -515,39 +507,567 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$metric->get_subscription_conversion_direct( $this->start(), $this->end() );
 	}
 
-	// --- Section 6/7: not-yet-implemented bridge (collections) ---------
+	// --- Section 6: Conversion funnel + exposures distribution ---------
 
 	/**
-	 * Placeholder collection methods (funnel, distribution, 3 perf tables)
-	 * return the bridge envelope with the proper rows-key and an empty list.
-	 *
-	 * @dataProvider provide_placeholder_collection_methods
-	 * @param string $method   Method on Prompts_Metric to call.
-	 * @param string $rows_key Key holding the (empty) collection: 'stages'|'buckets'|'rows'.
+	 * Funnel: maps the single BQ row to three React-ready stages with
+	 * pct_of_top normalized against step 1.
 	 */
-	public function test_placeholder_collection_returns_bridge_envelope( string $method, string $rows_key ) {
-		$metric = $this->make_metric_with_unused_proxy();
-		$result = $metric->$method( $this->start(), $this->end() );
+	public function test_funnel_maps_bq_rows_to_stages() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_funnel',
+			[
+				[
+					'step_1_impression' => 100,
+					'step_2_engagement' => 20,
+					'step_3_conversion' => 5,
+				],
+			]
+		);
+		$result = $metric->get_conversion_funnel( $this->start(), $this->end() );
 
-		$this->assertSame( 'error', $result['state'] );
-		$this->assertSame( 'newspack_insights_prompts_not_yet_implemented', $result['error_code'] );
-		$this->assertNotSame( '', $result['error_message'] );
-		$this->assertSame( [], $result[ $rows_key ] );
-		$this->assertArrayNotHasKey( 'pending', $result );
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 3, $result['stages'] );
+		$this->assertSame( 100, $result['stages'][0]['count'] );
+		$this->assertSame( 20, $result['stages'][1]['count'] );
+		$this->assertSame( 5, $result['stages'][2]['count'] );
+		$this->assertEqualsWithDelta( 1.0, $result['stages'][0]['pct_of_top'], 0.001 );
+		$this->assertEqualsWithDelta( 0.2, $result['stages'][1]['pct_of_top'], 0.001 );
+		$this->assertEqualsWithDelta( 0.05, $result['stages'][2]['pct_of_top'], 0.001 );
 	}
 
 	/**
-	 * Data provider for the 5 not-yet-wired collection methods.
+	 * Funnel: empty rows → state 'empty' with no stages.
+	 */
+	public function test_funnel_returns_empty_state_on_no_rows() {
+		$metric = $this->make_metric_with_proxy_returning( 'prompts_funnel', [] );
+		$result = $metric->get_conversion_funnel( $this->start(), $this->end() );
+
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['stages'] );
+	}
+
+	/**
+	 * Funnel: proxy WP_Error → state 'error' with code + empty stages.
+	 */
+	public function test_funnel_returns_error_state_on_proxy_error() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_funnel',
+			new \WP_Error( 'bigquery_query_failed', 'BQ down' )
+		);
+		$result = $metric->get_conversion_funnel( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_query_failed', $result['error_code'] );
+		$this->assertSame( [], $result['stages'] );
+	}
+
+	/**
+	 * Funnel: malformed shape (non-array row) → state 'error' with
+	 * `bigquery_proxy_malformed_rows`.
+	 */
+	public function test_funnel_returns_error_state_on_malformed_response() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_funnel',
+			[ 'not-a-row' ]
+		);
+		$result = $metric->get_conversion_funnel( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+	}
+
+	/**
+	 * Distribution: maps BQ rows to React-ready buckets in spec order
+	 * (1 / 2 / 3-5 / 6+).
+	 */
+	public function test_distribution_maps_bq_rows_to_buckets() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_exposures_before_conversion',
+			[
+				[
+					'bucket'               => '1',
+					'converters_in_bucket' => 50,
+					'pct_of_converters'    => 0.5,
+				],
+				[
+					'bucket'               => '2',
+					'converters_in_bucket' => 30,
+					'pct_of_converters'    => 0.3,
+				],
+				[
+					'bucket'               => '3-5',
+					'converters_in_bucket' => 15,
+					'pct_of_converters'    => 0.15,
+				],
+				[
+					'bucket'               => '6+',
+					'converters_in_bucket' => 5,
+					'pct_of_converters'    => 0.05,
+				],
+			]
+		);
+		$result = $metric->get_exposures_distribution( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 4, $result['buckets'] );
+		$this->assertSame( 50, $result['buckets'][0]['count'] );
+		$this->assertSame( 30, $result['buckets'][1]['count'] );
+		$this->assertSame( 15, $result['buckets'][2]['count'] );
+		$this->assertSame( 5, $result['buckets'][3]['count'] );
+	}
+
+	/**
+	 * Distribution: empty rows → state 'empty' with no buckets.
+	 */
+	public function test_distribution_returns_empty_state_on_no_rows() {
+		$metric = $this->make_metric_with_proxy_returning( 'prompts_exposures_before_conversion', [] );
+		$result = $metric->get_exposures_distribution( $this->start(), $this->end() );
+
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['buckets'] );
+	}
+
+	/**
+	 * Distribution: proxy WP_Error → state 'error' with empty buckets.
+	 */
+	public function test_distribution_returns_error_state_on_proxy_error() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_exposures_before_conversion',
+			new \WP_Error( 'bigquery_query_failed', 'BQ down' )
+		);
+		$result = $metric->get_exposures_distribution( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_query_failed', $result['error_code'] );
+		$this->assertSame( [], $result['buckets'] );
+	}
+
+	/**
+	 * Distribution: malformed shape (non-array) → state 'error' with
+	 * `bigquery_proxy_malformed_rows`.
+	 */
+	public function test_distribution_returns_error_state_on_malformed_response() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_exposures_before_conversion',
+			'not-an-array'
+		);
+		$result = $metric->get_exposures_distribution( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+	}
+
+	// --- Section 7: Performance breakdown ------------------------------
+
+	/**
+	 * Sample BQ row for the performance-by-prompt query. Columns mirror the
+	 * hub `prompts_performance_by_prompt` SELECT one-for-one.
 	 *
+	 * @param int    $popup_id    Popup ID for the row.
+	 * @param string $title       Prompt title.
+	 * @param string $intent      One of `donation`, `registration`, `newsletters_subscription`.
+	 * @param int    $impressions Impressions count (also used as ctr denominator on the publisher side).
 	 * @return array
 	 */
-	public function provide_placeholder_collection_methods(): array {
+	protected function performance_row( int $popup_id, string $title, string $intent, int $impressions ): array {
 		return [
-			'funnel'                => [ 'get_conversion_funnel', 'stages' ],
-			'distribution'          => [ 'get_exposures_distribution', 'buckets' ],
-			'performance_by_prompt' => [ 'get_performance_by_prompt', 'rows' ],
-			'performance_by_intent' => [ 'get_performance_by_intent', 'rows' ],
-			'performance_by_place'  => [ 'get_performance_by_placement', 'rows' ],
+			'popup_id'             => (string) $popup_id, // BQ emits string scalars.
+			'prompt_title'         => $title,
+			'intent'               => $intent,
+			'placement'            => 'overlay',
+			'impressions'          => $impressions,
+			'unique_viewers'       => (int) round( $impressions * 0.8 ),
+			'ctr'                  => 0.1,
+			'form_submission_rate' => 0.05,
+			'dismissal_rate'       => 0.02,
+			'registrations'        => 0,
+			'newsletter_signups'   => 0,
 		];
+	}
+
+	/**
+	 * Build a proxy mock that returns the performance-by-prompt rows on the
+	 * main query call and the given donation/subscription rows on the
+	 * augmentation queries (in dispatch order).
+	 *
+	 * @param array           $perf_rows         Rows for `prompts_performance_by_prompt`.
+	 * @param array|\WP_Error $donation_rows Rows for `prompts_donation_conversion_direct`.
+	 * @param array|\WP_Error $subscription_rows Rows for `prompts_subscription_conversion_direct`.
+	 * @return BigQuery_Proxy_Client
+	 */
+	protected function make_performance_proxy( array $perf_rows, $donation_rows, $subscription_rows ): BigQuery_Proxy_Client {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		// Dispatch order: perf table, donation augmentation, subscription augmentation.
+		$proxy->expects( $this->exactly( 3 ) )
+			->method( 'query' )
+			->willReturnCallback(
+				function ( $query_name ) use ( $perf_rows, $donation_rows, $subscription_rows ) {
+					switch ( $query_name ) {
+						case 'prompts_performance_by_prompt':
+							return $perf_rows;
+						case 'prompts_donation_conversion_direct':
+							return $donation_rows;
+						case 'prompts_subscription_conversion_direct':
+							return $subscription_rows;
+					}
+					return null;
+				}
+			);
+		return $proxy;
+	}
+
+	/**
+	 * Performance by prompt: maps BQ rows and intent-scopes Woo-completed
+	 * donation / subscription counts per popup.
+	 */
+	public function test_performance_by_prompt_augments_with_woo_counts() {
+		$perf_rows = [
+			$this->performance_row( 42, 'Donate now', 'donation', 1000 ),
+			$this->performance_row( 99, 'Join us', 'registration', 500 ),
+		];
+		$donation_attempts = [
+			[
+				'popup_id'       => '42',
+				'user_pseudo_id' => 'u1',
+				'session_id'     => 's1',
+				'attempt_ts'     => 1717000000000000,
+			],
+			[
+				'popup_id'       => '42',
+				'user_pseudo_id' => 'u2',
+				'session_id'     => 's2',
+				'attempt_ts'     => 1717001000000000,
+			],
+		];
+		$subscription_attempts = [
+			[
+				'popup_id'       => '99',
+				'user_pseudo_id' => 'u3',
+				'session_id'     => 's3',
+				'attempt_ts'     => 1717002000000000,
+			],
+		];
+
+		$proxy = $this->make_performance_proxy( $perf_rows, $donation_attempts, $subscription_attempts );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		// Each per-popup augmentation call gets its own scoped row subset; we
+		// stub a fixed return per call regardless of which subset arrived. The
+		// per-popup grouping itself is what the test exercises.
+		$resolver->method( 'count_completed_orders' )->willReturn( 5 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 2, $result['rows'] );
+
+		// Donation popup → donation columns populated, subscription columns zeroed.
+		$this->assertSame( 42, $result['rows'][0]['popup_id'] );
+		$this->assertSame( 'Donate now', $result['rows'][0]['prompt_title'] );
+		$this->assertSame( 'donation', $result['rows'][0]['intent'] );
+		$this->assertSame( 5, $result['rows'][0]['donation_conversions'] );
+		$this->assertEqualsWithDelta( 0.005, $result['rows'][0]['donation_conversion_rate'], 0.0001 );
+		$this->assertSame( 0, $result['rows'][0]['subscription_conversions'] );
+		$this->assertNull( $result['rows'][0]['subscription_conversion_rate'] );
+
+		// Registration popup → subscription columns populated, donation columns zeroed.
+		$this->assertSame( 99, $result['rows'][1]['popup_id'] );
+		$this->assertSame( 'registration', $result['rows'][1]['intent'] );
+		$this->assertSame( 0, $result['rows'][1]['donation_conversions'] );
+		$this->assertNull( $result['rows'][1]['donation_conversion_rate'] );
+		$this->assertSame( 5, $result['rows'][1]['subscription_conversions'] );
+		$this->assertEqualsWithDelta( 0.01, $result['rows'][1]['subscription_conversion_rate'], 0.0001 );
+
+		// Engagement columns flow through untouched.
+		$this->assertSame( 1000, $result['rows'][0]['impressions'] );
+		$this->assertSame( 0.1, $result['rows'][0]['ctr'] );
+		$this->assertSame( 0.05, $result['rows'][0]['form_submission_rate'] );
+	}
+
+	/**
+	 * Performance by prompt: locks the canonical row-key contract the React
+	 * layer consumes (`PromptPerformanceRow`). A column rename on either side
+	 * silently blanks the table, so assert the exact set + order.
+	 */
+	public function test_performance_by_prompt_row_schema_is_locked() {
+		$perf_rows = [ $this->performance_row( 42, 'Donate now', 'donation', 100 ) ];
+		$proxy     = $this->make_performance_proxy( $perf_rows, [], [] );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame(
+			[
+				'popup_id',
+				'prompt_title',
+				'intent',
+				'placement',
+				'impressions',
+				'unique_viewers',
+				'ctr',
+				'form_submission_rate',
+				'dismissal_rate',
+				'registrations',
+				'newsletter_signups',
+				'donation_conversions',
+				'donation_conversion_rate',
+				'subscription_conversions',
+				'subscription_conversion_rate',
+			],
+			array_keys( $result['rows'][0] )
+		);
+	}
+
+	/**
+	 * Performance by prompt: empty rows → state 'empty' with no augmentation
+	 * queries dispatched.
+	 */
+	public function test_performance_by_prompt_returns_empty_state_on_no_rows() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'prompts_performance_by_prompt' )
+			->willReturn( [] );
+
+		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * Performance by prompt: proxy WP_Error on the main query → state 'error'
+	 * with empty rows; augmentation queries are not dispatched.
+	 */
+	public function test_performance_by_prompt_returns_error_state_on_proxy_error() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'prompts_performance_by_prompt' )
+			->willReturn( new \WP_Error( 'bigquery_query_failed', 'BQ down' ) );
+
+		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_query_failed', $result['error_code'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * Performance by prompt: malformed shape (non-array) → state 'error' with
+	 * `bigquery_proxy_malformed_rows`.
+	 */
+	public function test_performance_by_prompt_returns_error_state_on_malformed_response() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'prompts_performance_by_prompt' )
+			->willReturn( 'not-an-array' );
+
+		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+	}
+
+	/**
+	 * Performance by prompt: when the donation-augmentation proxy call fails,
+	 * the table still renders with engagement columns intact; donation
+	 * columns degrade to 0 / null (no error envelope, no exception).
+	 */
+	public function test_performance_by_prompt_degrades_gracefully_on_woo_query_failure() {
+		$perf_rows = [ $this->performance_row( 42, 'Donate now', 'donation', 1000 ) ];
+
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->exactly( 3 ) )
+			->method( 'query' )
+			->willReturnCallback(
+				function ( $query_name ) use ( $perf_rows ) {
+					switch ( $query_name ) {
+						case 'prompts_performance_by_prompt':
+							return $perf_rows;
+						case 'prompts_donation_conversion_direct':
+							return new \WP_Error( 'bigquery_query_failed', 'donation BQ down' );
+						case 'prompts_subscription_conversion_direct':
+							return [];
+					}
+					return null;
+				}
+			);
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
+		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		// Table renders successfully — engagement data is load-bearing.
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 1000, $result['rows'][0]['impressions'] );
+		$this->assertSame( 0.1, $result['rows'][0]['ctr'] );
+		// Donation augmentation degraded to zero conversions; the rate stays
+		// computable (0/impressions = 0.0) since the intent matches and the
+		// engagement denominator is real — only the numerator is missing.
+		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
+		$this->assertEqualsWithDelta( 0.0, $result['rows'][0]['donation_conversion_rate'], 0.0001 );
+	}
+
+	/**
+	 * Performance by intent: maps BQ rows with title-cased intent labels per
+	 * `INTENT_LABELS` (including the special `newsletters_subscription` →
+	 * "Newsletter signup" mapping).
+	 */
+	public function test_performance_by_intent_maps_bq_rows_with_titlecased_labels() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_performance_by_intent',
+			[
+				[
+					'intent'               => 'donation',
+					'impressions'          => 5000,
+					'unique_viewers'       => 1200,
+					'ctr'                  => 0.1,
+					'form_submission_rate' => 0.05,
+					'dismissal_rate'       => 0.02,
+				],
+				[
+					'intent'               => 'registration',
+					'impressions'          => 3000,
+					'unique_viewers'       => 900,
+					'ctr'                  => 0.15,
+					'form_submission_rate' => 0.08,
+					'dismissal_rate'       => 0.03,
+				],
+				[
+					'intent'               => 'newsletters_subscription',
+					'impressions'          => 2000,
+					'unique_viewers'       => 600,
+					'ctr'                  => 0.2,
+					'form_submission_rate' => 0.1,
+					'dismissal_rate'       => 0.04,
+				],
+			]
+		);
+		$result = $metric->get_performance_by_intent( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 3, $result['rows'] );
+
+		$this->assertSame( 'donation', $result['rows'][0]['intent'] );
+		$this->assertSame( 'Donation', $result['rows'][0]['intent_label'] );
+		$this->assertSame( 5000, $result['rows'][0]['impressions'] );
+
+		$this->assertSame( 'registration', $result['rows'][1]['intent'] );
+		$this->assertSame( 'Registration', $result['rows'][1]['intent_label'] );
+
+		$this->assertSame( 'newsletters_subscription', $result['rows'][2]['intent'] );
+		$this->assertSame( 'Newsletter signup', $result['rows'][2]['intent_label'] );
+	}
+
+	/**
+	 * Performance by intent: empty rows → state 'empty'.
+	 */
+	public function test_performance_by_intent_returns_empty_state_on_no_rows() {
+		$metric = $this->make_metric_with_proxy_returning( 'prompts_performance_by_intent', [] );
+		$result = $metric->get_performance_by_intent( $this->start(), $this->end() );
+
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * Performance by intent: proxy WP_Error → state 'error'.
+	 */
+	public function test_performance_by_intent_returns_error_state_on_proxy_error() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_performance_by_intent',
+			new \WP_Error( 'bigquery_query_failed', 'BQ down' )
+		);
+		$result = $metric->get_performance_by_intent( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_query_failed', $result['error_code'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * Performance by placement: maps BQ rows with humanized placement labels
+	 * (`above-header` → "Above header") and no form_submission_rate column.
+	 */
+	public function test_performance_by_placement_maps_bq_rows_with_humanized_labels() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_performance_by_placement',
+			[
+				[
+					'placement'      => 'overlay',
+					'impressions'    => 5000,
+					'unique_viewers' => 1200,
+					'ctr'            => 0.1,
+					'dismissal_rate' => 0.02,
+				],
+				[
+					'placement'      => 'inline',
+					'impressions'    => 3000,
+					'unique_viewers' => 900,
+					'ctr'            => 0.15,
+					'dismissal_rate' => 0.03,
+				],
+				[
+					'placement'      => 'above-header',
+					'impressions'    => 2000,
+					'unique_viewers' => 600,
+					'ctr'            => 0.2,
+					'dismissal_rate' => 0.04,
+				],
+			]
+		);
+		$result = $metric->get_performance_by_placement( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 3, $result['rows'] );
+
+		$this->assertSame( 'overlay', $result['rows'][0]['placement'] );
+		$this->assertSame( 'Overlay', $result['rows'][0]['placement_label'] );
+		$this->assertSame( 'Inline', $result['rows'][1]['placement_label'] );
+		$this->assertSame( 'Above header', $result['rows'][2]['placement_label'] );
+
+		// No form_submission_rate column per spec.
+		$this->assertArrayNotHasKey( 'form_submission_rate', $result['rows'][0] );
+	}
+
+	/**
+	 * Performance by placement: empty rows → state 'empty'.
+	 */
+	public function test_performance_by_placement_returns_empty_state_on_no_rows() {
+		$metric = $this->make_metric_with_proxy_returning( 'prompts_performance_by_placement', [] );
+		$result = $metric->get_performance_by_placement( $this->start(), $this->end() );
+
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * Performance by placement: proxy WP_Error → state 'error'.
+	 */
+	public function test_performance_by_placement_returns_error_state_on_proxy_error() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_performance_by_placement',
+			new \WP_Error( 'bigquery_query_failed', 'BQ down' )
+		);
+		$result = $metric->get_performance_by_placement( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_query_failed', $result['error_code'] );
+		$this->assertSame( [], $result['rows'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -658,6 +658,23 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
 	}
 
+	/**
+	 * Distribution: top-level is an array but contains a non-array row (the
+	 * hub's contract is broken). Surface as malformed so a PHP-8 TypeError on
+	 * string-offset access can't crash the endpoint.
+	 */
+	public function test_distribution_returns_error_state_on_non_array_row() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_exposures_before_conversion',
+			[ 'not-a-row' ]
+		);
+		$result = $metric->get_exposures_distribution( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( [], $result['buckets'] );
+	}
+
 	// --- Section 7: Performance breakdown ------------------------------
 
 	/**
@@ -881,6 +898,23 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Performance by prompt: top-level is an array but contains a non-array row
+	 * (the hub's contract is broken). Surface as malformed so a PHP-8 TypeError
+	 * on string-offset access can't crash the endpoint.
+	 */
+	public function test_performance_by_prompt_returns_error_state_on_non_array_row() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [ 'not-a-row' ] );
+
+		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
 	 * Performance by prompt: when the donation-augmentation proxy call fails,
 	 * the table still renders with engagement columns intact; donation
 	 * columns degrade to 0 / null (no error envelope, no exception).
@@ -1001,6 +1035,23 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Performance by intent: top-level is an array but contains a non-array row.
+	 * Surface as malformed so a PHP-8 TypeError on string-offset access can't
+	 * crash the endpoint.
+	 */
+	public function test_performance_by_intent_returns_error_state_on_non_array_row() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_performance_by_intent',
+			[ 'not-a-row' ]
+		);
+		$result = $metric->get_performance_by_intent( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
 	 * Performance by placement: maps BQ rows with humanized placement labels
 	 * (`above-header` → "Above header") and no form_submission_rate column.
 	 */
@@ -1068,6 +1119,23 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'error', $result['state'] );
 		$this->assertSame( 'bigquery_query_failed', $result['error_code'] );
+		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * Performance by placement: top-level is an array but contains a non-array
+	 * row. Surface as malformed so a PHP-8 TypeError on string-offset access
+	 * can't crash the endpoint.
+	 */
+	public function test_performance_by_placement_returns_error_state_on_non_array_row() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_performance_by_placement',
+			[ 'not-a-row' ]
+		);
+		$result = $metric->get_performance_by_placement( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
 		$this->assertSame( [], $result['rows'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -226,6 +226,25 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'bigquery_proxy_malformed_value', $result['error_code'] );
 	}
 
+	/**
+	 * SAFE_DIVIDE returns NULL when the denominator is zero (BigQuery semantics).
+	 * That's a legitimate "no eligible events" case, not a malformed payload —
+	 * surface as `state: 'populated'` with a non-computable zero so the UI
+	 * renders "0%" instead of "Data temporarily unavailable".
+	 */
+	public function test_scalar_treats_null_safe_divide_result_as_non_computable_zero() {
+		$metric = $this->make_metric_with_proxy_returning(
+			'prompts_form_submission_rate',
+			[ [ 'form_submission_rate' => null ] ]
+		);
+		$result = $metric->get_form_submission_rate( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 0, $result['value'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 'rate', $result['placeholder_type'] );
+	}
+
 	// --- Section 4: Paid reader conversion (Woo join) -------------------
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * Test Prompts_REST_Controller (NPPD-1607, Phase 1).
+ * Test Prompts_REST_Controller (NPPD-1607, Phase 2).
  *
  * Exercises the Tab 5 endpoint's request lifecycle: a valid window
- * returns 200 with the placeholder envelope; comparison mode adds a
- * `previous` window; invalid / mismatched date params return 400.
+ * returns 200 with the state-envelope (Phase 2 replaces the Phase 1
+ * `tab_pending` placeholder with `tab_error`); comparison mode adds a
+ * `previous` window; invalid / mismatched date params return 400; the
+ * fixture-mode branch returns canned data when
+ * NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
  *
  * @package Newspack\Tests\Insights
  */
 
 namespace Newspack\Tests\Insights;
 
+use Newspack\Insights\Prompts_Metric;
 use Newspack\Insights\Prompts_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -84,8 +88,9 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A valid window returns 200 with the full placeholder envelope and a
-	 * null `previous` (no comparison requested).
+	 * A valid window returns 200 with the state envelope. In the test env the
+	 * proxy is unconfigured, so every metric surfaces `state: 'error'` and
+	 * the controller's `is_window_all_error` derives `tab_error: true`.
 	 */
 	public function test_valid_window_returns_200_envelope() {
 		$response = $this->dispatch(
@@ -98,8 +103,11 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 
-		$this->assertArrayHasKey( 'tab_pending', $data );
-		$this->assertTrue( $data['tab_pending'] );
+		// Phase 2 replaces `tab_pending` with `tab_error`; the Phase 1 key must
+		// not leak through to the wire format.
+		$this->assertArrayNotHasKey( 'tab_pending', $data );
+		$this->assertArrayHasKey( 'tab_error', $data );
+		$this->assertTrue( $data['tab_error'], 'Test env has an unconfigured proxy → every metric errors → tab_error: true.' );
 		$this->assertArrayHasKey( 'current', $data );
 		$this->assertNull( $data['previous'] );
 
@@ -127,14 +135,13 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		// A scalar carries the state-envelope (Phase 2). In the test env the proxy
 		// is unconfigured, so wired metrics surface as state 'error' (with
 		// `bigquery_proxy_not_configured`) — the envelope under test is the
-		// `state` + `placeholder_type` contract, not which `state` we got.
+		// `state` + `placeholder_type` contract.
 		$this->assertArrayHasKey( 'state', $current['total_prompt_impressions'] );
 		$this->assertArrayNotHasKey( 'pending', $current['total_prompt_impressions'] );
+		$this->assertSame( 'error', $current['total_prompt_impressions']['state'] );
 		$this->assertSame( 'count', $current['total_prompt_impressions']['placeholder_type'] );
-		// Tables ship a `rows` key for the empty-state UI; in the test env the
-		// proxy is unconfigured so wired collection metrics surface as state
-		// 'error' with `bigquery_proxy_not_configured`. The envelope under
-		// test is the `rows` + `state` contract, not which error code we got.
+		// Tables ship a `rows` key for the empty-state UI; wired collection
+		// metrics surface as state 'error' with `bigquery_proxy_not_configured`.
 		$this->assertSame( [], $current['performance_by_prompt']['rows'] );
 		$this->assertSame( 'error', $current['performance_by_prompt']['state'] );
 	}
@@ -229,5 +236,107 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 			]
 		);
 		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * The fixture closure (which the REST controller invokes via
+	 * `Prompts_Metric::get_fixture` when `NEWSPACK_INSIGHTS_FIXTURE_MODE` is on)
+	 * produces a populated payload with `tab_error: false` and every section
+	 * in state 'populated'.
+	 *
+	 * The controller's fixture-mode branch is a thin wrapper around this
+	 * static; exercising the static directly avoids redefining the
+	 * NEWSPACK_INSIGHTS_FIXTURE_MODE constant per test (PHP constants can't be
+	 * undefined once set, which would taint the rest of the suite).
+	 */
+	public function test_fixture_populated_variant() {
+		$payload = Prompts_Metric::get_fixture( 'populated', false );
+
+		$this->assertArrayHasKey( 'tab_error', $payload );
+		$this->assertFalse( $payload['tab_error'] );
+		$this->assertNull( $payload['previous'] );
+
+		$current = $payload['current'];
+		$this->assertSame( 'populated', $current['total_prompt_impressions']['state'] );
+		$this->assertSame( 'count', $current['total_prompt_impressions']['placeholder_type'] );
+		$this->assertTrue( $current['total_prompt_impressions']['computable'] );
+		$this->assertGreaterThan( 0, $current['total_prompt_impressions']['value'] );
+
+		$this->assertSame( 'populated', $current['conversion_funnel']['state'] );
+		$this->assertCount( 3, $current['conversion_funnel']['stages'] );
+		$this->assertSame( 'populated', $current['performance_by_prompt']['state'] );
+		$this->assertNotEmpty( $current['performance_by_prompt']['rows'] );
+
+		// Per-prompt rows honor the locked 15-key schema from Task 3.3.
+		$row = $current['performance_by_prompt']['rows'][0];
+		$this->assertSame(
+			[
+				'popup_id',
+				'prompt_title',
+				'intent',
+				'placement',
+				'impressions',
+				'unique_viewers',
+				'ctr',
+				'form_submission_rate',
+				'dismissal_rate',
+				'registrations',
+				'newsletter_signups',
+				'donation_conversions',
+				'donation_conversion_rate',
+				'subscription_conversions',
+				'subscription_conversion_rate',
+			],
+			array_keys( $row )
+		);
+	}
+
+	/**
+	 * The empty fixture variant reports collections as state 'empty' (queries
+	 * succeeded with zero rows) and `tab_error: false`.
+	 */
+	public function test_fixture_empty_variant() {
+		$payload = Prompts_Metric::get_fixture( 'empty', false );
+
+		$this->assertFalse( $payload['tab_error'] );
+		$current = $payload['current'];
+		$this->assertSame( 'empty', $current['conversion_funnel']['state'] );
+		$this->assertSame( [], $current['conversion_funnel']['stages'] );
+		$this->assertSame( 'empty', $current['exposures_distribution']['state'] );
+		$this->assertSame( 'empty', $current['performance_by_prompt']['state'] );
+		$this->assertSame( 'empty', $current['performance_by_intent']['state'] );
+		$this->assertSame( 'empty', $current['performance_by_placement']['state'] );
+
+		// Scalars in the empty variant report 'populated' with a non-computable
+		// zero — 'empty' has no meaning for a single scalar.
+		$this->assertSame( 'populated', $current['total_prompt_impressions']['state'] );
+		$this->assertFalse( $current['total_prompt_impressions']['computable'] );
+		$this->assertSame( 0, $current['total_prompt_impressions']['value'] );
+	}
+
+	/**
+	 * The error fixture variant reports every section in state 'error' and
+	 * `tab_error: true`.
+	 */
+	public function test_fixture_error_variant() {
+		$payload = Prompts_Metric::get_fixture( 'error', false );
+
+		$this->assertTrue( $payload['tab_error'] );
+		$current = $payload['current'];
+		$this->assertSame( 'error', $current['total_prompt_impressions']['state'] );
+		$this->assertSame( 'bigquery_proxy_http_error', $current['total_prompt_impressions']['error_code'] );
+		$this->assertSame( 'error', $current['conversion_funnel']['state'] );
+		$this->assertSame( 'error', $current['performance_by_prompt']['state'] );
+	}
+
+	/**
+	 * The fixture closure populates `previous` when comparison is requested.
+	 */
+	public function test_fixture_compare_populates_previous() {
+		$payload = Prompts_Metric::get_fixture( 'populated', true );
+
+		$this->assertIsArray( $payload['previous'] );
+		$this->assertArrayHasKey( 'total_prompt_impressions', $payload['previous'] );
+		$this->assertSame( 'populated', $payload['previous']['total_prompt_impressions']['state'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -131,10 +131,12 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'state', $current['total_prompt_impressions'] );
 		$this->assertArrayNotHasKey( 'pending', $current['total_prompt_impressions'] );
 		$this->assertSame( 'count', $current['total_prompt_impressions']['placeholder_type'] );
-		// Tables ship a `rows` key for the empty-state UI; not-yet-wired metrics
-		// also report `state: 'error'` with the bridge error code.
+		// Tables ship a `rows` key for the empty-state UI; in the test env the
+		// proxy is unconfigured so wired collection metrics surface as state
+		// 'error' with `bigquery_proxy_not_configured`. The envelope under
+		// test is the `rows` + `state` contract, not which error code we got.
 		$this->assertSame( [], $current['performance_by_prompt']['rows'] );
-		$this->assertSame( 'newspack_insights_prompts_not_yet_implemented', $current['performance_by_prompt']['error_code'] );
+		$this->assertSame( 'error', $current['performance_by_prompt']['state'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -14,6 +14,7 @@
 
 namespace Newspack\Tests\Insights;
 
+use Newspack\Insights\Cache;
 use Newspack\Insights\Prompts_Metric;
 use Newspack\Insights\Prompts_REST_Controller;
 use WP_REST_Request;
@@ -52,6 +53,9 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		$this->server   = new WP_REST_Server();
 		$wp_rest_server = $this->server;
 		do_action( 'rest_api_init' );
+
+		// Wipe transients + cooldown markers so cache state doesn't leak between tests.
+		Cache::purge( 'prompts' );
 	}
 
 	/**
@@ -70,6 +74,7 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		remove_action( 'rest_api_init', [ $this, 'register_prompts_route' ] );
 		global $wp_rest_server;
 		$wp_rest_server = null;
+		Cache::purge( 'prompts' );
 		parent::tear_down();
 	}
 
@@ -88,9 +93,10 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A valid window returns 200 with the state envelope. In the test env the
-	 * proxy is unconfigured, so every metric surfaces `state: 'error'` and
-	 * the controller's `is_window_all_error` derives `tab_error: true`.
+	 * A valid window returns 200 with the cache envelope wrapping the state
+	 * envelope. In the test env the proxy is unconfigured, so every metric
+	 * surfaces `state: 'error'` and the controller's `is_window_all_error`
+	 * derives `tab_error: true`.
 	 */
 	public function test_valid_window_returns_200_envelope() {
 		$response = $this->dispatch(
@@ -101,7 +107,16 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 200, $response->get_status() );
-		$data = $response->get_data();
+		$body = $response->get_data();
+
+		// Outer cache envelope shape ({ cache, data }).
+		$this->assertArrayHasKey( 'cache', $body );
+		$this->assertArrayHasKey( 'data', $body );
+		$this->assertSame( Cache::SOURCE_BIGQUERY, $body['cache']['source'] );
+		$this->assertNotEmpty( $body['cache']['computed_at'] );
+		$this->assertArrayHasKey( 'cooldown_until', $body['cache'] );
+
+		$data = $body['data'];
 
 		// Phase 2 replaces `tab_pending` with `tab_error`; the Phase 1 key must
 		// not leak through to the wire format.
@@ -161,7 +176,8 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 200, $response->get_status() );
-		$data = $response->get_data();
+		$body = $response->get_data();
+		$data = $body['data'];
 
 		$this->assertIsArray( $data['previous'] );
 		$this->assertSame( '2026-02-20', $data['previous']['window']['start'] );
@@ -236,6 +252,27 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 			]
 		);
 		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * The refresh route mirrors the GET route's envelope shape and is
+	 * registered alongside it. The route accepts POST (Cached_Controller_Trait
+	 * uses WP_REST_Server::CREATABLE).
+	 */
+	public function test_refresh_route_returns_cache_envelope() {
+		$request = new WP_REST_Request( 'POST', self::ROUTE . '/refresh' );
+		$request->set_param( 'start', '2026-03-22' );
+		$request->set_param( 'end', '2026-04-21' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$body = $response->get_data();
+		$this->assertArrayHasKey( 'cache', $body );
+		$this->assertArrayHasKey( 'data', $body );
+		$this->assertSame( Cache::SOURCE_BIGQUERY, $body['cache']['source'] );
+		// First refresh seeds the BQ cooldown stamp so the React layer can render the throttle UI.
+		$this->assertNotEmpty( $body['cache']['cooldown_until'] );
+		$this->assertArrayHasKey( 'tab_error', $body['data'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -124,11 +124,17 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 			$this->assertArrayHasKey( $key, $current, "Missing window key: $key" );
 		}
 
-		// A scalar carries the placeholder envelope.
-		$this->assertTrue( $current['total_prompt_impressions']['pending'] );
+		// A scalar carries the state-envelope (Phase 2). In the test env the proxy
+		// is unconfigured, so wired metrics surface as state 'error' (with
+		// `bigquery_proxy_not_configured`) — the envelope under test is the
+		// `state` + `placeholder_type` contract, not which `state` we got.
+		$this->assertArrayHasKey( 'state', $current['total_prompt_impressions'] );
+		$this->assertArrayNotHasKey( 'pending', $current['total_prompt_impressions'] );
 		$this->assertSame( 'count', $current['total_prompt_impressions']['placeholder_type'] );
-		// Tables ship empty rows for the empty-state UI.
+		// Tables ship a `rows` key for the empty-state UI; not-yet-wired metrics
+		// also report `state: 'error'` with the bridge error code.
 		$this->assertSame( [], $current['performance_by_prompt']['rows'] );
+		$this->assertSame( 'newspack_insights_prompts_not_yet_implemented', $current['performance_by_prompt']['error_code'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-woo-order-resolver.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-woo-order-resolver.php
@@ -53,7 +53,7 @@ class Test_Woo_Order_Resolver extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Build a row in the shape the BQ paywall queries return.
+	 * Build a row in the shape Gates BQ paywall queries return (back-compat `user_pseudo_id` key).
 	 *
 	 * @param int    $uid        Customer id used as user_pseudo_id.
 	 * @param string $session    Session identifier.
@@ -65,6 +65,26 @@ class Test_Woo_Order_Resolver extends WP_UnitTestCase {
 			'user_pseudo_id' => (string) $uid,
 			'session_id'     => $session,
 			'attempt_ts'     => (string) $attempt_ts,
+		];
+	}
+
+	/**
+	 * Build a row in the shape Prompts BQ paid attempt queries return (`uid` key).
+	 *
+	 * The hub's prompts catalog projects `COALESCE(user_id, user_pseudo_id) AS uid`
+	 * (renamed per Copilot review on newspack-manager-admin#457). The resolver
+	 * reads `uid` first and falls back to `user_pseudo_id` so both shapes work.
+	 *
+	 * @param int    $uid        Customer id used as uid.
+	 * @param string $session    Session identifier.
+	 * @param int    $attempt_ts GA4 microsecond timestamp.
+	 * @return array
+	 */
+	private function row_uid( int $uid, string $session, int $attempt_ts ): array {
+		return [
+			'uid'        => (string) $uid,
+			'session_id' => $session,
+			'attempt_ts' => (string) $attempt_ts,
 		];
 	}
 
@@ -172,6 +192,47 @@ class Test_Woo_Order_Resolver extends WP_UnitTestCase {
 		// One attempt = one conversion; revenue picks the first matching order.
 		$this->assertSame( 1, $resolver->count_completed_orders( $rows ) );
 		$this->assertSame( 25.00, $resolver->sum_completed_revenue( $rows ) );
+	}
+
+	/**
+	 * Rows with the Prompts-style `uid` key are matched the same as Gates-style
+	 * `user_pseudo_id` rows. Guards against a regression where the resolver
+	 * stopped reading the `uid` shape after the Copilot-driven hub-side rename.
+	 */
+	public function test_counts_completed_order_in_window_with_uid_field() {
+		$attempt_ts_micros = ( strtotime( '2026-04-15 12:00:00 UTC' ) * 1000000 );
+		$this->make_order( $this->customer_a, 'completed', '2026-04-15 12:10:00 UTC', 25.00 );
+
+		$rows = [ $this->row_uid( $this->customer_a, 'sess1', $attempt_ts_micros ) ];
+		$resolver = new Woo_Order_Resolver();
+
+		$this->assertSame( 1, $resolver->count_completed_orders( $rows ) );
+		$this->assertSame( 25.00, $resolver->sum_completed_revenue( $rows ) );
+		$this->assertSame( 1, $resolver->count_unique_completed_users( $rows ) );
+	}
+
+	/**
+	 * The `uid` field takes precedence over `user_pseudo_id` when both are present
+	 * on the same row. Documents the resolver's resolution order: read `uid` first,
+	 * fall back to `user_pseudo_id`. Customer B is the `uid` value (matches the
+	 * order). Customer A is the `user_pseudo_id` fallback (no matching order).
+	 */
+	public function test_uid_takes_precedence_over_user_pseudo_id() {
+		$attempt_ts_micros = ( strtotime( '2026-04-15 12:00:00 UTC' ) * 1000000 );
+		$this->make_order( $this->customer_b, 'completed', '2026-04-15 12:10:00 UTC', 42.00 );
+
+		$rows = [
+			[
+				'uid'            => (string) $this->customer_b,
+				'user_pseudo_id' => (string) $this->customer_a,
+				'session_id'     => 'sess1',
+				'attempt_ts'     => (string) $attempt_ts_micros,
+			],
+		];
+		$resolver = new Woo_Order_Resolver();
+
+		$this->assertSame( 1, $resolver->count_completed_orders( $rows ) );
+		$this->assertSame( 42.00, $resolver->sum_completed_revenue( $rows ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Wires the Insights Tab 5 (Prompts) UI to live BigQuery data via the Newspack Manager BigQuery proxy, replacing the Phase 1 `pending: true` placeholder layer with the state-envelope shape (`'error' | 'empty' | 'populated'`) used by Gates (Tab 4). Also brings Prompts to parity with the cache + refresh infrastructure that landed in #288 for every other Insights tab.

**Metric wiring** (publisher-side `Prompts_Metric`, mirroring `Gates_Metric`):

- **10 scalar metrics** — total impressions, unique viewers, avg prompts/reader, CTR, form submission rate, dismissal rate, plus registration + newsletter signup conversion (Direct + Influenced 7d). Pure BigQuery proxy dispatch.
- **8 paid conversion + revenue metrics** — donation/subscription × Direct/Influenced 14d × conversion/revenue. BigQuery proxy + `Woo_Order_Resolver` join; per-window memoization shared across rate/revenue pairs so one round-trip per intent + direction per request.
- **5 collection metrics** — funnel, exposures-before-conversion distribution, and three performance tables (per-prompt, per-intent, per-placement). The per-prompt table augments donation/subscription conversion columns via per-popup Woo joins, gracefully degrading to zeros if the Woo side fails.

**REST + envelope shape:**

- Drops `tab_pending`. Adds `tab_error: bool`, true only when every metric in the current window is `state: 'error'` (mirrors Gates).
- Fixture-mode short-circuit returns the three documented variants (`populated` / `empty` / `error`) via `NEWSPACK_INSIGHTS_FIXTURE_MODE` + `_fixture_state` param, with `Cache-Control: no-store, private`.
- Adopts `Cached_Controller_Trait` for `{ data, cache: { source, computed_at, cooldown_until } }` envelope; registers `/prompts/refresh` route.

**React UI:**

- Per-metric `state` field drives populated / empty / error treatments. New `SectionState` wrapper + `PromptsErrorBanner` mirror Gates' analogs.
- `usePromptsData` consumes `insightsCache` + registers with `refreshRegistry`.
- `PromptExposureSection` threads `LastUpdated` chrome (parity with `GateExposureSection`).

**Companion PR:** [Automattic/newspack-manager-admin#457](https://github.com/Automattic/newspack-manager-admin/pull/457) — adds the 19 `prompts_*` query builders + 4 conversion ↔ revenue aliases on the hub side. Stacked on a no-op refactor that extracts the existing 12 `gates_*` builders into a per-tab class so the catalog can scale as more tabs come online.

Closes NPPD-1607.

### How to test the changes in this Pull Request:

**Fixture mode (no hub deployment required — recommended first pass):**

1. Pull the branch and run `n build newspack-plugin` (or `npm run build` in `plugins/newspack-plugin` after `pnpm install` at the workspace root).
2. Enable fixture mode: `n wp config set NEWSPACK_INSIGHTS_FIXTURE_MODE true --raw`.
3. Visit `/wp-admin/admin.php?page=newspack-insights&tab=prompts&range=last-30`. Confirm:
   - All three top-level sections (Exposure / Engagement / Free reader conversion) render scorecards with realistic values.
   - Paid reader conversion + Revenue from prompts scorecards render.
   - The conversion funnel SVG shows visible drop-offs across the three stages.
   - The exposures-before-conversion distribution table renders four buckets.
   - The per-prompt table shows 5 rows with mixed donation / registration / newsletter intents; donation rows have non-zero `donation_conversions`; registration rows have non-zero `subscription_conversions`; newsletter rows have em-dashes in both paid columns.
   - The per-intent and per-placement tables aggregate matching the per-prompt rows.
   - The `LastUpdated` chrome and refresh menu render at the top of the Prompt Exposure section.
4. Test the empty variant: append `&_fixture_state=empty` to the URL. Confirm every scorecard renders as `0` / `0%` / `$0.00`; the funnel shows its empty-state message; tables show empty-state rows.
5. Test the error variant: append `&_fixture_state=error`. Confirm:
   - The top-level Prompts error banner renders.
   - Every section renders its error treatment with the section-error styling.
6. Test the comparison toggle: enable period-over-period comparison and confirm scorecards render deltas correctly across the populated + empty variants.
7. Disable fixture mode: `n wp config delete NEWSPACK_INSIGHTS_FIXTURE_MODE`.

**Live BigQuery (requires the companion hub PR deployed):**

8. Confirm the hub PR is deployed to a Manager Admin instance the publisher site is connected to.
9. Visit the Prompts tab without fixture mode. Confirm `tab_error` is false and scorecards populate (or render as `state: 'empty'` cleanly if the test site has no prompt events in the window).
10. Verify the refresh menu actually purges and refetches: click "Refresh now"; confirm `computed_at` updates and the cooldown notice appears.
11. Sanity check REST endpoint directly: \`curl -u admin:admin 'http://localhost/wp-json/newspack-insights/v1/prompts?start=2026-05-01&end=2026-05-31' | jq .\`. Confirm the envelope is \`{ data: { tab_error, current, previous }, cache: { source, computed_at, cooldown_until } }\`.

**Automated checks:**

12. From `plugins/newspack-plugin/`:
   - PHPUnit: \`docker exec newspack_dev sh -c "/var/scripts/test-php.sh newspack-plugin --filter Test_Prompts"\` (expect 90 passing).
   - Full plugin PHPUnit: \`docker exec newspack_dev sh -c "/var/scripts/test-php.sh newspack-plugin"\` (expect 1692 passing, 1 pre-existing skip).
   - PHPCS: \`vendor/bin/phpcs includes/wizards/insights/ tests/unit-tests/insights/\` clean.
   - Stylelint: \`npm run lint:scss\` clean.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?