### PR TITLE
feat(insights): empty-state pattern for all-zero sections (NPPD-1694)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -300,10 +300,12 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	 */
 	private static function is_window_all_error( array $window ): bool {
 		foreach ( $window as $key => $value ) {
-			if ( 'window' === $key ) {
+			// Skip the date metadata and the scalar section-total fields
+			// (e.g. `paywall_attempts_total`, NPPD-1694) — neither is a metric.
+			if ( 'window' === $key || ! is_array( $value ) ) {
 				continue;
 			}
-			if ( ! is_array( $value ) || ! isset( $value['state'] ) || 'error' !== $value['state'] ) {
+			if ( ! isset( $value['state'] ) || 'error' !== $value['state'] ) {
 				return false;
 			}
 		}
@@ -319,30 +321,39 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	private function build_window( Gates_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
-		return [
-			'window'                             => [
-				'start' => $start->format( 'Y-m-d' ),
-				'end'   => $end->format( 'Y-m-d' ),
+		// Captured for the Paid-section totals below (NPPD-1694) — derived from
+		// these scalars, not re-queried.
+		$paywall_direct     = $metric->get_paywall_conversion_direct( $start, $end );
+		$paywall_influenced = $metric->get_paywall_conversion_influenced_14d( $start, $end );
+
+		return array_merge(
+			[
+				'window'                             => [
+					'start' => $start->format( 'Y-m-d' ),
+					'end'   => $end->format( 'Y-m-d' ),
+				],
+				// Section 1.
+				'total_gate_impressions'             => $metric->get_total_gate_impressions( $start, $end ),
+				'unique_readers_reached'             => $metric->get_unique_readers_reached( $start, $end ),
+				'avg_exposures_per_reader'           => $metric->get_avg_exposures_per_reader( $start, $end ),
+				'sessions_with_gate'                 => $metric->get_sessions_with_gate( $start, $end ),
+				// Section 2.
+				'regwall_conversion_direct'          => $metric->get_regwall_conversion_direct( $start, $end ),
+				'regwall_conversion_influenced_7d'   => $metric->get_regwall_conversion_influenced_7d( $start, $end ),
+				// Section 3.
+				'paywall_conversion_direct'          => $paywall_direct,
+				'paywall_conversion_influenced_14d'  => $paywall_influenced,
+				'total_paywall_revenue_direct'       => $metric->get_total_paywall_revenue_direct( $start, $end ),
+				'avg_revenue_per_paywall_conversion' => $metric->get_avg_revenue_per_paywall_conversion( $start, $end ),
+				// Section 4.
+				'conversion_funnel'                  => $metric->get_conversion_funnel( $start, $end ),
+				'exposures_distribution'             => $metric->get_exposures_distribution( $start, $end ),
+				// Section 5.
+				'performance_by_gate'                => $metric->get_performance_by_gate( $start, $end ),
 			],
-			// Section 1.
-			'total_gate_impressions'             => $metric->get_total_gate_impressions( $start, $end ),
-			'unique_readers_reached'             => $metric->get_unique_readers_reached( $start, $end ),
-			'avg_exposures_per_reader'           => $metric->get_avg_exposures_per_reader( $start, $end ),
-			'sessions_with_gate'                 => $metric->get_sessions_with_gate( $start, $end ),
-			// Section 2.
-			'regwall_conversion_direct'          => $metric->get_regwall_conversion_direct( $start, $end ),
-			'regwall_conversion_influenced_7d'   => $metric->get_regwall_conversion_influenced_7d( $start, $end ),
-			// Section 3.
-			'paywall_conversion_direct'          => $metric->get_paywall_conversion_direct( $start, $end ),
-			'paywall_conversion_influenced_14d'  => $metric->get_paywall_conversion_influenced_14d( $start, $end ),
-			'total_paywall_revenue_direct'       => $metric->get_total_paywall_revenue_direct( $start, $end ),
-			'avg_revenue_per_paywall_conversion' => $metric->get_avg_revenue_per_paywall_conversion( $start, $end ),
-			// Section 4.
-			'conversion_funnel'                  => $metric->get_conversion_funnel( $start, $end ),
-			'exposures_distribution'             => $metric->get_exposures_distribution( $start, $end ),
-			// Section 5.
-			'performance_by_gate'                => $metric->get_performance_by_gate( $start, $end ),
-		];
+			// Section 3 empty-state totals (NPPD-1694).
+			Gates_Metric::paywall_section_totals( $paywall_direct, $paywall_influenced )
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
@@ -236,6 +236,34 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		];
 	};
 
+	// --- Paid-section empty-state smoke variants (NPPD-1694). ---
+	if ( 'paid_no_conversions' === $variant ) {
+		// 17 paywall attempts, zero conversions → the section's `no_conversions`
+		// empty state with {N} = 17 (Richland Source's live scenario).
+		$current                              = $build( 1.0 );
+		$current['paywall_attempts_total']    = 17;
+		$current['paywall_conversions_total'] = 0;
+		return [
+			'tab_error' => false,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
+	if ( 'paid_zero_cards' === $variant ) {
+		// Section has data (Influenced converted) so the grid renders, but the
+		// Direct cards are zero → exercises the per-card count fallback:
+		// "0 of 320" (rate), "0 conversions" (currency total), "—" (currency avg).
+		$current                                       = $build( 1.0 );
+		$current['paywall_conversion_direct']          = $scalar( 0.0, 320, 'rate', 0 );
+		$current['total_paywall_revenue_direct']       = $scalar( 0.0, 0, 'currency' );
+		$current['avg_revenue_per_paywall_conversion'] = $scalar( 0.0, 0, 'currency' );
+		return [
+			'tab_error' => false,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
+
 	return [
 		'tab_error' => false,
 		'current'   => $build( 1.0 ),

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
@@ -53,11 +53,15 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'value'            => $zero_value( $type ),
 				'computable'       => false,
 				'denominator'      => null,
+				'numerator'        => null,
 				'placeholder_type' => $type,
 				'error_code'       => 'bigquery_proxy_http_error',
 				'error_message'    => 'HTTP 500',
 			];
 		}
+		// Scalar section-total metadata (NPPD-1694) — zero in the all-error window.
+		$current['paywall_attempts_total']    = 0;
+		$current['paywall_conversions_total'] = 0;
 		$collections = [
 			'conversion_funnel'      => 'stages',
 			'exposures_distribution' => 'buckets',
@@ -87,9 +91,13 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'value'            => $zero_value( $type ),
 				'computable'       => false,
 				'denominator'      => 'rate' === $type ? 0 : null,
+				'numerator'        => 'rate' === $type ? 0 : null,
 				'placeholder_type' => $type,
 			];
 		}
+		// Zero attempts → the Paid section renders its no_opportunity empty state.
+		$current['paywall_attempts_total']    = 0;
+		$current['paywall_conversions_total'] = 0;
 		$current['conversion_funnel']      = [
 			'state'  => 'empty',
 			'stages' => [],
@@ -110,12 +118,13 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 	}
 
 	// --- Populated variant (default). ---
-	$scalar = static function ( $value, $denominator, string $type ) {
+	$scalar = static function ( $value, $denominator, string $type, $numerator = null ) {
 		return [
 			'state'            => 'populated',
 			'value'            => $value,
 			'computable'       => true,
 			'denominator'      => $denominator,
+			'numerator'        => $numerator,
 			'placeholder_type' => $type,
 		];
 	};
@@ -131,11 +140,16 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			// Section 2 — Free reader conversion.
 			'regwall_conversion_direct'          => $scalar( round( 0.071 * $f, 3 ), null, 'rate' ),
 			'regwall_conversion_influenced_7d'   => $scalar( round( 0.123 * $f, 3 ), null, 'rate' ),
-			// Section 3 — Paid reader conversion.
-			'paywall_conversion_direct'          => $scalar( round( 0.021 * $f, 3 ), null, 'rate' ),
-			'paywall_conversion_influenced_14d'  => $scalar( round( 0.038 * $f, 3 ), null, 'rate' ),
+			// Section 3 — Paid reader conversion. Paywall rate cards carry both
+			// numerator (matched Woo orders) and denominator (attempts) so fixture
+			// mode exercises the NPPD-1694 count fallback.
+			'paywall_conversion_direct'          => $scalar( round( 0.021 * $f, 3 ), (int) round( 320 * $f ), 'rate', (int) round( 7 * $f ) ),
+			'paywall_conversion_influenced_14d'  => $scalar( round( 0.038 * $f, 3 ), (int) round( 290 * $f ), 'rate', (int) round( 11 * $f ) ),
 			'total_paywall_revenue_direct'       => $scalar( round( 4180.5 * $f, 2 ), (int) round( 47 * $f ), 'currency' ),
 			'avg_revenue_per_paywall_conversion' => $scalar( round( 88.95 * $f, 2 ), (int) round( 47 * $f ), 'currency' ),
+			// Section 3 empty-state totals (NPPD-1694).
+			'paywall_attempts_total'             => (int) round( 320 * $f ),
+			'paywall_conversions_total'          => (int) round( 11 * $f ),
 			// Section 4 — How readers convert. Funnel uses Richland Source's shape
 			// so both drop-off deltas exceed 20% and render in the error color.
 			'conversion_funnel'                  => [

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -34,6 +34,7 @@ use Newspack\Insights\Woo_Order_Resolver;
  *   value: int|float,
  *   computable: bool,
  *   denominator: int|null,
+ *   numerator: int|null,
  *   placeholder_type: string,
  *   error_code?: string,
  *   error_message?: string,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -119,6 +119,7 @@ final class Gates_Metric {
 			'value'            => 'decimal' === $placeholder_type ? 0.0 : 0,
 			'computable'       => false,
 			'denominator'      => null,
+			'numerator'        => null,
 			'placeholder_type' => $placeholder_type,
 			'error_code'       => $error->get_error_code(),
 			'error_message'    => $error->get_error_message(),
@@ -134,14 +135,20 @@ final class Gates_Metric {
 	 * @param bool      $computable       Whether the value is a real computed figure.
 	 * @param int|null  $denominator      Optional denominator.
 	 * @param string    $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @param int|null  $numerator        Optional numerator (NPPD-1694). Surfaced only
+	 *                                    for rate scorecards whose underlying count is
+	 *                                    computed locally (the paywall Woo join); null
+	 *                                    everywhere the count isn't available, e.g. the
+	 *                                    precomputed-rate regwall cards.
 	 * @return array
 	 */
-	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type ): array {
+	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type, ?int $numerator = null ): array {
 		return [
 			'state'            => 'populated',
 			'value'            => $value,
 			'computable'       => $computable,
 			'denominator'      => $denominator,
+			'numerator'        => $numerator,
 			'placeholder_type' => $placeholder_type,
 		];
 	}
@@ -243,12 +250,16 @@ final class Gates_Metric {
 			return $this->error_scalar( 'rate', $rows );
 		}
 		if ( ! is_array( $rows ) || empty( $rows ) ) {
-			// No paywall attempts in the window → a real 0% rate.
-			return $this->populated_scalar( 0.0, false, 0, 'rate' );
+			// No paywall attempts in the window → a real 0% rate. Numerator and
+			// denominator are both an explicit 0 so the card's count fallback can
+			// tell "no attempts" (denominator 0) from "0 of N" (NPPD-1694).
+			return $this->populated_scalar( 0.0, false, 0, 'rate', 0 );
 		}
 		$denominator = count( $rows );
 		$numerator   = $this->woo_resolver->count_completed_orders( $rows );
-		return $this->populated_scalar( $denominator > 0 ? $numerator / $denominator : 0.0, true, $denominator, 'rate' );
+		// Surface the numerator (matched Woo orders) alongside the denominator so
+		// the card can render "0 of {denominator}" when no attempt converted.
+		return $this->populated_scalar( $denominator > 0 ? $numerator / $denominator : 0.0, true, $denominator, 'rate', $numerator );
 	}
 
 	/**
@@ -424,6 +435,33 @@ final class Gates_Metric {
 			$conversions,
 			'currency'
 		);
+	}
+
+	/**
+	 * Paid-section totals for the empty-state gate (NPPD-1694).
+	 *
+	 * Pure derivation from already-computed scalars — no extra query. The
+	 * section component reads these to choose between the normal scorecard
+	 * render and an `<EmptyMetricSection>`:
+	 *   - `paywall_attempts_total` = the Direct rate denominator (sessions with a
+	 *     paywall impression; this is the {N} in the "no conversions" copy).
+	 *   - `paywall_conversions_total` = the most inclusive conversion count across
+	 *     attributions (max of Direct and Influenced numerators), so a section
+	 *     with Influenced-only conversions still renders its scorecards rather
+	 *     than hiding real data behind a "no conversions" empty state.
+	 *
+	 * @param array $direct     The `paywall_conversion_direct` scalar payload.
+	 * @param array $influenced The `paywall_conversion_influenced_14d` scalar payload.
+	 * @return array{paywall_attempts_total:int, paywall_conversions_total:int}
+	 */
+	public static function paywall_section_totals( array $direct, array $influenced ): array {
+		return [
+			'paywall_attempts_total'    => (int) ( $direct['denominator'] ?? 0 ),
+			'paywall_conversions_total' => max(
+				(int) ( $direct['numerator'] ?? 0 ),
+				(int) ( $influenced['numerator'] ?? 0 )
+			),
+		];
 	}
 
 	// --- Section 4: How readers convert ---------------------------------

--- a/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
@@ -151,6 +151,16 @@ const queryString = ( query: GatesQuery ): string => {
 		params.set( 'compare_start', query.compare_start );
 		params.set( 'compare_end', query.compare_end );
 	}
+	// Forward the `_fixture_state` URL param so fixture mode's render variants
+	// (empty / error / paid_no_conversions / paid_zero_cards) are reachable from
+	// the UI for smoke testing. A no-op in production: the server ignores it
+	// unless NEWSPACK_INSIGHTS_FIXTURE_MODE is enabled.
+	if ( typeof window !== 'undefined' ) {
+		const fixtureState = new URLSearchParams( window.location.search ).get( '_fixture_state' );
+		if ( fixtureState ) {
+			params.set( '_fixture_state', fixtureState );
+		}
+	}
 	return params.toString();
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
@@ -45,6 +45,13 @@ export interface GatesScalarMetric extends GatesErrorFields {
 	value: number;
 	computable: boolean;
 	denominator: number | null;
+	/**
+	 * Numerator behind a rate (NPPD-1694). A number (possibly 0) only on rate
+	 * scorecards whose count is computed locally — the paywall Woo join. Null
+	 * elsewhere, including the precomputed-rate regwall cards and currency cards
+	 * (whose conversions count rides on `denominator`).
+	 */
+	numerator: number | null;
 	placeholder_type: GatesPlaceholderType;
 }
 
@@ -105,6 +112,11 @@ export interface GatesWindow {
 	paywall_conversion_influenced_14d: GatesScalarMetric;
 	total_paywall_revenue_direct: GatesScalarMetric;
 	avg_revenue_per_paywall_conversion: GatesScalarMetric;
+	// Section 3 empty-state totals (NPPD-1694): drive the Paid section's
+	// no_opportunity / no_conversions / normal decision. Derived server-side from
+	// the scalars above — no extra query.
+	paywall_attempts_total: number;
+	paywall_conversions_total: number;
 	// Section 4 — How readers convert.
 	conversion_funnel: GatesFunnelData;
 	exposures_distribution: GatesDistributionData;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for EmptyMetricSection (NPPD-1694): the three `state` values, both
+ * branches of `{N}` interpolation, presence/absence of `caption`, and the
+ * non-dismissible callout.
+ *
+ * Body assertions check the rendered container (not `screen`): the callout's
+ * `Notice` announces its text via `@wordpress/a11y` `speak()`, which duplicates
+ * the copy into a global live-region outside the container — so a `screen`-level
+ * text query would match twice.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import EmptyMetricSection from './EmptyMetricSection';
+
+describe( 'EmptyMetricSection', () => {
+	it( 'renders the title and caption as the section identity', () => {
+		const { container } = render(
+			<EmptyMetricSection
+				title="Paid reader conversion"
+				caption="How effectively paywall gates convert visitors."
+				state="no_opportunity"
+				body="No paywall attempts in this window."
+			/>
+		);
+		expect( container ).toHaveTextContent( 'Paid reader conversion' );
+		expect( container ).toHaveTextContent( 'How effectively paywall gates convert visitors.' );
+		expect( container ).toHaveTextContent( 'No paywall attempts in this window.' );
+	} );
+
+	it( 'omits the caption when none is passed', () => {
+		const { container } = render(
+			<EmptyMetricSection title="Free reader conversion" state="no_opportunity" body="No registration impressions." />
+		);
+		expect( container ).not.toHaveTextContent( 'How effectively paywall gates convert visitors.' );
+	} );
+
+	it.each( [ 'no_opportunity', 'no_conversions', 'configuration_missing' ] as const )( 'exposes the %s state via the data attribute', state => {
+		const { container } = render( <EmptyMetricSection title="Section" state={ state } body="Body copy." /> );
+		expect( container.querySelector( `[data-empty-state="${ state }"]` ) ).toBeInTheDocument();
+	} );
+
+	it( 'is non-dismissible — renders no dismiss button', () => {
+		render( <EmptyMetricSection title="Section" state="no_conversions" body="Body copy." /> );
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+
+	describe( '{N} interpolation', () => {
+		it( 'substitutes {N} with the localized signalCount when provided', () => {
+			const { container } = render(
+				<EmptyMetricSection title="Section" state="no_conversions" body="Your paywall reached {N} readers." signalCount={ 1234567 } />
+			);
+			expect( container ).toHaveTextContent( 'Your paywall reached 1,234,567 readers.' );
+		} );
+
+		it( 'handles signalCount={0} gracefully', () => {
+			const { container } = render(
+				<EmptyMetricSection title="Section" state="no_conversions" body="Reached {N} readers." signalCount={ 0 } />
+			);
+			expect( container ).toHaveTextContent( 'Reached 0 readers.' );
+		} );
+
+		it( 'leaves {N} visible (not stripped) when signalCount is absent', () => {
+			const { container } = render( <EmptyMetricSection title="Section" state="no_conversions" body="Reached {N} readers." /> );
+			expect( container ).toHaveTextContent( 'Reached {N} readers.' );
+		} );
+
+		it( 'renders body verbatim when it has no placeholder, even with a signalCount', () => {
+			const { container } = render(
+				<EmptyMetricSection title="Section" state="no_opportunity" body="No attempts at all." signalCount={ 42 } />
+			);
+			expect( container ).toHaveTextContent( 'No attempts at all.' );
+		} );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.tsx
@@ -1,0 +1,81 @@
+/**
+ * EmptyMetricSection (NPPD-1694).
+ *
+ * Drop-in replacement for a scorecard section when the section would otherwise
+ * render as a row of zeros. Keeps the section's identity (title + caption, via
+ * the shared `SectionHeading`) and swaps the metric grid for a single
+ * callout-styled, NON-dismissible note explaining why there's no data.
+ *
+ * The callout chrome comes from the `@wordpress/components` `Notice` (info
+ * status, `isDismissible={ false }`) — the same primitive `InfoCallout` is built
+ * on, so empty states read as a deliberate part of the design system rather than
+ * a 404. We render the `Notice` directly rather than reuse `InfoCallout` because
+ * an empty state has no separate bold heading (its identity lives in the
+ * `SectionHeading` above) and never persists a dismissal.
+ *
+ * Distinct from `SectionEmpty`, which is the plain "no rows yet" paragraph for
+ * collection metrics (funnel / distribution / tables). `EmptyMetricSection` is
+ * the callout treatment for *scorecard* sections.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeading from './SectionHeading';
+import { formatNumber } from './format';
+
+export type EmptyMetricSectionState = 'no_opportunity' | 'no_conversions' | 'configuration_missing';
+
+export interface EmptyMetricSectionProps {
+	/** Matches the normal-data section header. */
+	title: string;
+	/** Matches the normal-data section caption. */
+	caption?: string;
+	/** Which empty-state this is — surfaced as a data attribute for styling/QA. */
+	state: EmptyMetricSectionState;
+	/** Empty-state copy; sections pass their own. May contain the literal `{N}` placeholder. */
+	body: string;
+	/** Optional integer for `{N}` interpolation in `body`. */
+	signalCount?: number;
+}
+
+/**
+ * Slugify the title into a stable id for `aria-labelledby` / the SectionHeading.
+ * Titles here are short fixed strings, so collisions aren't a concern in practice.
+ */
+const headingId = ( title: string ): string =>
+	'newspack-insights-empty-' +
+	title
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /^-+|-+$/g, '' );
+
+/**
+ * Interpolate `{N}` with the formatted signal count. Per spec: only substitute
+ * when a `signalCount` is actually provided AND the body contains `{N}`;
+ * otherwise render the body verbatim (we deliberately do NOT strip a stray
+ * `{N}` so a missing prop stays visible in QA rather than silently vanishing).
+ * `formatNumber` (the app's shared formatter) keeps large counts readable and
+ * consistent with every other count in the dashboard (1234567 → "1,234,567").
+ */
+const interpolate = ( body: string, signalCount?: number ): string =>
+	typeof signalCount === 'number' && body.includes( '{N}' ) ? body.split( '{N}' ).join( formatNumber( signalCount ) ) : body;
+
+const EmptyMetricSection = ( { title, caption, state, body, signalCount }: EmptyMetricSectionProps ) => {
+	const id = headingId( title );
+	return (
+		<section className="newspack-insights__section newspack-insights__empty-metric-section" aria-labelledby={ id } data-empty-state={ state }>
+			<SectionHeading id={ id } title={ title } description={ caption } />
+			<Notice status="info" isDismissible={ false } className="newspack-insights__empty-metric-section-callout">
+				<p>{ interpolate( body, signalCount ) }</p>
+			</Notice>
+		</section>
+	);
+};
+
+export default EmptyMetricSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -41,3 +41,120 @@ describe( 'MetricCard value tooltip', () => {
 		expect( value ).not.toHaveAttribute( 'title' );
 	} );
 } );
+
+describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
+	const PAYWALL = { attemptsLabel: 'paywall attempts', conversionsLabel: 'conversions' };
+
+	describe( 'rate card (format="percent")', () => {
+		it( 'renders "0 of N" (count, no % suffix) when numerator is 0 and denominator > 0', () => {
+			render(
+				<MetricCard
+					label="Paywall conversion (Direct)"
+					value={ 0 }
+					format="percent"
+					zeroFallback={ { numerator: 0, denominator: 17, ...PAYWALL } }
+				/>
+			);
+			expect( screen.getByText( '0 of 17' ) ).toBeInTheDocument();
+			// No percentage anywhere — neither a bare "0%" nor a "(0%)" parenthetical.
+			expect( screen.queryByText( /%/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'localizes a large denominator in the count format', () => {
+			render( <MetricCard label="Rate" value={ 0 } format="percent" zeroFallback={ { numerator: 0, denominator: 1234567, ...PAYWALL } } /> );
+			expect( screen.getByText( '0 of 1,234,567' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the em-dash + "No paywall attempts in this window" when denominator is 0', () => {
+			render( <MetricCard label="Rate" value={ 0 } format="percent" zeroFallback={ { numerator: 0, denominator: 0, ...PAYWALL } } /> );
+			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
+			expect( screen.getByText( 'No paywall attempts in this window' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls through to the normal percentage when numerator and denominator are both positive', () => {
+			render( <MetricCard label="Rate" value={ 0.5 } format="percent" zeroFallback={ { numerator: 3, denominator: 17, ...PAYWALL } } /> );
+			expect( screen.queryByText( /0 of/ ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( 'Not applicable' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'currency total card (currencyRole="total")', () => {
+		it( 'renders "0 conversions" when conversions are 0 and attempts > 0', () => {
+			render(
+				<MetricCard
+					label="Total paywall revenue (Direct)"
+					value={ 0 }
+					format="currency"
+					zeroFallback={ { numerator: 0, denominator: 17, currencyRole: 'total', ...PAYWALL } }
+				/>
+			);
+			expect( screen.getByText( '0 conversions' ) ).toBeInTheDocument();
+			expect( screen.queryByText( '$0.00' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders the em-dash + "No paywall attempts in this window" when attempts are 0', () => {
+			render(
+				<MetricCard
+					label="Total"
+					value={ 0 }
+					format="currency"
+					zeroFallback={ { numerator: 0, denominator: 0, currencyRole: 'total', ...PAYWALL } }
+				/>
+			);
+			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
+			expect( screen.getByText( 'No paywall attempts in this window' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'currency average card (currencyRole="average")', () => {
+		it( 'renders the em-dash + "No conversions in this window" when conversions are 0 but attempts > 0', () => {
+			render(
+				<MetricCard
+					label="Avg revenue per paywall conversion"
+					value={ 0 }
+					format="currency"
+					zeroFallback={ { numerator: 0, denominator: 17, currencyRole: 'average', ...PAYWALL } }
+				/>
+			);
+			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
+			expect( screen.getByText( 'No conversions in this window' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders "No paywall attempts in this window" when attempts are 0', () => {
+			render(
+				<MetricCard
+					label="Avg"
+					value={ 0 }
+					format="currency"
+					zeroFallback={ { numerator: 0, denominator: 0, currencyRole: 'average', ...PAYWALL } }
+				/>
+			);
+			expect( screen.getByText( 'No paywall attempts in this window' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders a custom plural opportunity label', () => {
+		render(
+			<MetricCard
+				label="Regwall conversion"
+				value={ 0 }
+				format="percent"
+				zeroFallback={ { numerator: 0, denominator: 0, attemptsLabel: 'registration gate impressions' } }
+			/>
+		);
+		expect( screen.getByText( 'No registration gate impressions in this window' ) ).toBeInTheDocument();
+	} );
+
+	it( 'suppresses the comparison delta when a fallback hero is shown', () => {
+		const { container } = render(
+			<MetricCard
+				label="Rate"
+				value={ 0 }
+				previousValue={ 0.4 }
+				format="percent"
+				zeroFallback={ { numerator: 0, denominator: 17, ...PAYWALL } }
+			/>
+		);
+		expect( container.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -38,6 +38,32 @@ export interface MetricCardOverlay {
 	dimensions?: string[];
 }
 
+/**
+ * Count-fallback inputs for zero scorecards (NPPD-1694). When a rate or
+ * currency card would otherwise render a bare `0%` / `$0.00`, these drive a
+ * count-based hero that conveys the real signal instead (`0 of 17`,
+ * `0 conversions`, or the `—` null glyph with an explanatory secondary line).
+ *
+ * Keyed on two counts, regardless of card `format`:
+ *   - `denominator` — the "opportunity" count (paywall attempts / regwall impressions)
+ *   - `numerator`   — the conversions count (for currency cards, the conversions companion)
+ *
+ * The decision is driven by these counts, NOT by `value`: a real $0 alongside N
+ * conversions still reads as data, while 0 conversions out of N attempts reads
+ * as an honest zero. `currencyRole` distinguishes the two currency behaviors
+ * (ticket: a total card shows `0 conversions`; an average card shows `—` with a
+ * "No conversions…" secondary). It is ignored for `format='percent'`.
+ */
+export interface MetricCardZeroFallback {
+	numerator?: number;
+	denominator?: number;
+	currencyRole?: 'total' | 'average';
+	/** Plural noun for the "No … in this window" line, e.g. "paywall attempts". */
+	attemptsLabel: string;
+	/** Plural noun for the conversions line, e.g. "conversions". */
+	conversionsLabel?: string;
+}
+
 export interface MetricCardProps {
 	label: string;
 	value?: number;
@@ -63,6 +89,8 @@ export interface MetricCardProps {
 	 * "$1.2M"). Overrides the title the currency formatter derives on its own.
 	 */
 	valueTitle?: string;
+	/** Count-fallback for zero rate/currency scorecards (NPPD-1694). */
+	zeroFallback?: MetricCardZeroFallback;
 }
 
 // Currency is handled by the caller (it needs both display + title from one
@@ -80,6 +108,13 @@ const formatValue = ( v: number, fmt: MetricFormat ): string => {
 	}
 };
 
+// Em-dash null glyph (U+2014). Matches the "Not applicable" treatment in the
+// Performance by gate table (PerformanceByGateSection's `NotApplicable`): same
+// glyph + same `aria-label`, so a null scorecard and a null table cell read as
+// one design system. The table's span is unstyled (inherits cell context); the
+// card renders it in the value region's own type scale.
+const EM_DASH = '—';
+
 const MetricCard = ( props: MetricCardProps ) => {
 	const {
 		label,
@@ -94,6 +129,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 		error,
 		notConfigured,
 		valueTitle,
+		zeroFallback,
 	} = props;
 
 	// Shared graceful-failure state (missing dimension / not configured / error).
@@ -109,7 +145,54 @@ const MetricCard = ( props: MetricCardProps ) => {
 		);
 	}
 
-	const hasComparison = ! pending && typeof previousValue === 'number';
+	// --- Zero-state count fallback (NPPD-1694) -----------------------------
+	// Resolve a count-based hero/secondary before the normal value+delta path.
+	// Driven by the conversions (numerator) and opportunity (denominator) counts
+	// on `zeroFallback`, never by `value`. `undefined === 0` is false, so a card
+	// passing partial counts simply falls through to the normal render.
+	let fallbackHero: string | null = null;
+	let fallbackSecondary: string | null = null;
+	if ( zeroFallback && ( format === 'percent' || format === 'currency' ) ) {
+		const { numerator, denominator, currencyRole, attemptsLabel, conversionsLabel } = zeroFallback;
+		const conversionsNoun = conversionsLabel ?? __( 'conversions', 'newspack-plugin' );
+		const noneInWindow = ( pluralNoun: string ) =>
+			sprintf(
+				/* translators: %s is a plural noun, e.g. "paywall attempts". */
+				__( 'No %s in this window', 'newspack-plugin' ),
+				pluralNoun
+			);
+		if ( denominator === 0 ) {
+			// Nothing happened at all → em-dash + "No <attempts> in this window".
+			fallbackHero = EM_DASH;
+			fallbackSecondary = noneInWindow( attemptsLabel );
+		} else if ( numerator === 0 && typeof denominator === 'number' && denominator > 0 ) {
+			if ( format === 'percent' ) {
+				// "0 of 17" — word "of", no "%" suffix and no "(0%)" parenthetical.
+				fallbackHero = sprintf(
+					/* translators: 1: numerator (always 0 here), 2: denominator. */
+					__( '%1$s of %2$s', 'newspack-plugin' ),
+					formatNumber( numerator ),
+					formatNumber( denominator )
+				);
+			} else if ( currencyRole === 'total' ) {
+				// Currency total → "0 conversions", symmetric with the rate card.
+				fallbackHero = sprintf(
+					/* translators: 1: conversions count (0 here), 2: plural "conversions". */
+					__( '%1$s %2$s', 'newspack-plugin' ),
+					formatNumber( numerator ),
+					conversionsNoun
+				);
+			} else {
+				// Currency average → em-dash + "No conversions in this window".
+				fallbackHero = EM_DASH;
+				fallbackSecondary = noneInWindow( conversionsNoun );
+			}
+		}
+	}
+
+	// Suppress the period-over-period delta whenever a fallback hero is shown — a
+	// "↓ 100%" against a real prior value would misread an honest zero.
+	const hasComparison = ! pending && ! fallbackHero && typeof previousValue === 'number';
 	// `delta` is null only when there's no comparison or previous is 0 (no ratio).
 	const delta = hasComparison ? formatDelta( value, previousValue as number ) : null;
 	const tone = hasComparison ? deltaTone( value, previousValue as number, lowerIsBetter ) : 'neutral';
@@ -147,14 +230,32 @@ const MetricCard = ( props: MetricCardProps ) => {
 	// as an override and still falls back to the formatter-derived full value.
 	const valueTooltip = valueTitle || currency?.title || undefined;
 
+	// Hero content: a count-fallback string, the em-dash null glyph (matched to
+	// the Performance by gate table's null cell — same glyph + aria-label), or
+	// the normal formatted value (optionally with a full-value tooltip).
+	let heroContent: React.ReactNode;
+	if ( fallbackHero === EM_DASH ) {
+		heroContent = (
+			<span className="newspack-insights__metric-card-na" aria-label={ __( 'Not applicable', 'newspack-plugin' ) }>
+				{ EM_DASH }
+			</span>
+		);
+	} else if ( fallbackHero !== null ) {
+		heroContent = fallbackHero;
+	} else if ( valueTooltip ) {
+		heroContent = <span title={ valueTooltip }>{ valueText }</span>;
+	} else {
+		heroContent = valueText;
+	}
+
 	return (
 		<Card __experimentalCoreCard className="newspack-insights__metric-card">
 			<div className="newspack-insights__metric-card-label">{ label }</div>
 			<div className="newspack-insights__metric-card-body">
-				<div className="newspack-insights__metric-card-value">
-					{ valueTooltip ? <span title={ valueTooltip }>{ valueText }</span> : valueText }
-				</div>
-				{ secondary && <div className="newspack-insights__metric-card-secondary">{ secondary }</div> }
+				<div className="newspack-insights__metric-card-value">{ heroContent }</div>
+				{ ( fallbackSecondary ?? secondary ) && (
+					<div className="newspack-insights__metric-card-secondary">{ fallbackSecondary ?? secondary }</div>
+				) }
 				{ magnitude !== null && (
 					<div
 						className={ `newspack-insights__metric-card-delta newspack-insights__metric-card-delta--${ tone }` }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -241,6 +241,8 @@ const MetricCard = ( props: MetricCardProps ) => {
 			</span>
 		);
 	} else if ( fallbackHero !== null ) {
+		// A count-fallback phrase ("0 of 17", "0 conversions") — flagged so the
+		// value region can render it smaller than the 44px number scale.
 		heroContent = fallbackHero;
 	} else if ( valueTooltip ) {
 		heroContent = <span title={ valueTooltip }>{ valueText }</span>;
@@ -252,7 +254,15 @@ const MetricCard = ( props: MetricCardProps ) => {
 		<Card __experimentalCoreCard className="newspack-insights__metric-card">
 			<div className="newspack-insights__metric-card-label">{ label }</div>
 			<div className="newspack-insights__metric-card-body">
-				<div className="newspack-insights__metric-card-value">{ heroContent }</div>
+				<div
+					className={
+						fallbackHero !== null && fallbackHero !== EM_DASH
+							? 'newspack-insights__metric-card-value newspack-insights__metric-card-value--count'
+							: 'newspack-insights__metric-card-value'
+					}
+				>
+					{ heroContent }
+				</div>
 				{ ( fallbackSecondary ?? secondary ) && (
 					<div className="newspack-insights__metric-card-secondary">{ fallbackSecondary ?? secondary }</div>
 				) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -182,6 +182,17 @@
 			text-align: left;
 		}
 
+		// Count-fallback heroes ("0 of 17", "0 conversions") are short phrases,
+		// not single numbers — the 44px number scale overflows the narrow card
+		// (NPPD-1694). Render them smaller and let them wrap so they stay inside
+		// the border. The em-dash null glyph keeps the full hero scale.
+		&-value--count {
+			font-size: 24px;
+			line-height: 1.2;
+			letter-spacing: 0;
+			overflow-wrap: break-word;
+		}
+
 		&-secondary {
 			margin: -4px 0 0;
 			font-size: 13px;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for PaidReaderConversionSection empty states (NPPD-1694): the render
+ * branches (no_opportunity / no_conversions / errored / normal) and the per-card
+ * count fallback surviving inside a normal section render.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PaidReaderConversionSection from './PaidReaderConversionSection';
+import type { GatesScalarMetric, GatesWindow } from '../../api/gates';
+
+const scalar = ( over: Partial< GatesScalarMetric > = {} ): GatesScalarMetric => ( {
+	state: 'populated',
+	value: 0,
+	computable: true,
+	denominator: null,
+	numerator: null,
+	placeholder_type: 'rate',
+	...over,
+} );
+
+const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
+	window: { start: '2026-03-01', end: '2026-03-31' },
+	total_gate_impressions: scalar( { placeholder_type: 'count', value: 100 } ),
+	unique_readers_reached: scalar( { placeholder_type: 'count' } ),
+	avg_exposures_per_reader: scalar( { placeholder_type: 'decimal' } ),
+	sessions_with_gate: scalar(),
+	regwall_conversion_direct: scalar(),
+	regwall_conversion_influenced_7d: scalar(),
+	paywall_conversion_direct: scalar(),
+	paywall_conversion_influenced_14d: scalar(),
+	total_paywall_revenue_direct: scalar( { placeholder_type: 'currency' } ),
+	avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency' } ),
+	paywall_attempts_total: 0,
+	paywall_conversions_total: 0,
+	conversion_funnel: { state: 'empty', stages: [] },
+	exposures_distribution: { state: 'empty', buckets: [] },
+	performance_by_gate: { state: 'empty', rows: [] },
+	...over,
+} );
+
+describe( 'PaidReaderConversionSection empty states', () => {
+	it( 'renders no_opportunity when there are no paywall attempts', () => {
+		const current = makeWindow( { paywall_attempts_total: 0, paywall_conversions_total: 0 } );
+		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		// Body is asserted on the container — the Notice's speak() duplicates it into a
+		// global live-region, so a screen-level text query would match twice.
+		expect( container ).toHaveTextContent( 'No paywall attempts in this window' );
+		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders no_conversions with the attempt count interpolated when attempts > 0 and conversions = 0', () => {
+		const current = makeWindow( { paywall_attempts_total: 17, paywall_conversions_total: 0 } );
+		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_conversions"]' ) ).toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'Your paywall reached 17 readers' );
+		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the four scorecards (no empty state) when the section has data', () => {
+		const current = makeWindow( {
+			paywall_attempts_total: 320,
+			paywall_conversions_total: 11,
+			paywall_conversion_direct: scalar( { value: 0.021, numerator: 7, denominator: 320 } ),
+			paywall_conversion_influenced_14d: scalar( { value: 0.038, numerator: 11, denominator: 290 } ),
+			total_paywall_revenue_direct: scalar( { placeholder_type: 'currency', value: 4180.5, denominator: 7 } ),
+			avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency', value: 88.95, denominator: 7 } ),
+		} );
+		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total Paywall Revenue (Direct)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does NOT show an empty state when the Direct scalar errored — renders the scorecards instead', () => {
+		// An errored Direct query leaves paywall_attempts_total at 0 (null denominator).
+		// That must not be mistaken for a genuine "no paywall attempts" empty state — the
+		// cards should render so the errored one surfaces its own error treatment.
+		const current = makeWindow( {
+			paywall_attempts_total: 0,
+			paywall_conversions_total: 0,
+			paywall_conversion_direct: scalar( { state: 'error', computable: false, error_message: 'BQ down' } ),
+		} );
+		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /No paywall attempts in this window/ ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'applies the per-card count fallback inside a normal section render', () => {
+		// Section has data (Influenced converted) so it renders scorecards, but the
+		// Direct rate card has 0 of 320 and the Direct revenue card has 0 conversions.
+		const current = makeWindow( {
+			paywall_attempts_total: 320,
+			paywall_conversions_total: 11,
+			paywall_conversion_direct: scalar( { value: 0, computable: true, numerator: 0, denominator: 320 } ),
+			paywall_conversion_influenced_14d: scalar( { value: 0.038, numerator: 11, denominator: 290 } ),
+			total_paywall_revenue_direct: scalar( { placeholder_type: 'currency', value: 0, denominator: 0 } ),
+			avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency', value: 0, denominator: 0 } ),
+		} );
+		render( <PaidReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( screen.getByText( '0 of 320' ) ).toBeInTheDocument();
+		expect( screen.getByText( '0 conversions' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -94,8 +94,28 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /No paywall attempts in this window/ ) ).not.toBeInTheDocument();
+		expect( container ).not.toHaveTextContent( 'No paywall attempts in this window' );
 		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does NOT show an empty state when the Influenced scalar errored — renders the scorecards instead', () => {
+		// Direct computes a genuine 0 conversions while Influenced errors independently
+		// (its null numerator coerces to 0 in paywall_section_totals). The section must
+		// not render the no_conversions empty state and hide the errored Influenced card.
+		const current = makeWindow( {
+			paywall_attempts_total: 17,
+			paywall_conversions_total: 0,
+			paywall_conversion_direct: scalar( { value: 0, numerator: 0, denominator: 17 } ),
+			paywall_conversion_influenced_14d: scalar( { state: 'error', computable: false, error_message: 'BQ down' } ),
+		} );
+		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		// Assert on the container, not `screen`: the Notice's speak() leaves the
+		// no_conversions copy in a global live-region from an earlier test.
+		expect( container ).not.toHaveTextContent( 'No paywall conversions in this window' );
+		// Scorecards render; the errored Influenced card shows the shared error note.
+		expect( screen.getByText( 'Paywall Conversion (Influenced, 14d)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'applies the per-card count fallback inside a normal section render', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -1,9 +1,16 @@
 /**
- * PaidReaderConversionSection (NPPD-1604, Section 3).
+ * PaidReaderConversionSection (NPPD-1604, Section 3; empty states NPPD-1694).
  *
  * Four scorecards in a single row covering paywall-gate conversion
  * (Direct attribution, Influenced 14-day lookback) plus revenue
  * from same-session paywall conversions.
+ *
+ * When the section would render as a row of zeros it swaps the grid for a
+ * single `<EmptyMetricSection>` (detection stays here, not in the orchestrator):
+ *   - no paywall attempts in the window → `no_opportunity`
+ *   - attempts but no conversions       → `no_conversions` (with the attempt count)
+ *   - otherwise the four scorecards, each carrying its count fallback so an
+ *     individual zero card reads as "0 of N" / "0 conversions" rather than 0%/$0.
  */
 
 /**
@@ -17,6 +24,7 @@ import { __ } from '@wordpress/i18n';
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
+import EmptyMetricSection from '../components/EmptyMetricSection';
 import { scalarToMetricCardProps } from './scalarToCard';
 
 export interface PaidReaderConversionSectionProps {
@@ -24,60 +32,133 @@ export interface PaidReaderConversionSectionProps {
 	previous: GatesWindow | null;
 }
 
-const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversionSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby="newspack-insights-gates-paid-heading">
-		<SectionHeading
-			id="newspack-insights-gates-paid-heading"
-			title={ __( 'Paid reader conversion', 'newspack-plugin' ) }
-			description={ __(
-				'How effectively paywall gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paywall impression. Influenced counts subscriptions that happened in a later session within 14 days of a paywall impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
-				'newspack-plugin'
-			) }
-		/>
-		<div className="newspack-insights__metric-grid">
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Paywall Conversion (Direct)', 'newspack-plugin' ),
-					description: __(
-						'Sessions with a subscription after a paywall impression ÷ sessions with a paywall impression',
-						'newspack-plugin'
-					),
-					current: current.paywall_conversion_direct,
-					previous: previous?.paywall_conversion_direct,
-				} ) }
+const HEADING_ID = 'newspack-insights-gates-paid-heading';
+
+const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversionSectionProps ) => {
+	const title = __( 'Paid reader conversion', 'newspack-plugin' );
+	const caption = __(
+		'How effectively paywall gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paywall impression. Influenced counts subscriptions that happened in a later session within 14 days of a paywall impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
+		'newspack-plugin'
+	);
+	const attemptsLabel = __( 'paywall attempts', 'newspack-plugin' );
+	const conversionsLabel = __( 'conversions', 'newspack-plugin' );
+
+	const attempts = current.paywall_attempts_total;
+	const conversions = current.paywall_conversions_total;
+
+	// The section totals are derived from the Direct scalar's denominator/numerator,
+	// which are null when that query errors — coercing both totals to 0. A zero total
+	// is only a *genuine* empty state when the Direct metric actually computed;
+	// otherwise we fall through to the scorecards so each card surfaces its own error
+	// treatment rather than a misleading "no paywall attempts" empty state.
+	const dataKnown = current.paywall_conversion_direct.state !== 'error';
+
+	// Empty states (NPPD-1694). Order matters: no opportunity before no conversions.
+	if ( dataKnown && attempts === 0 ) {
+		return (
+			<EmptyMetricSection
+				title={ title }
+				caption={ caption }
+				state="no_opportunity"
+				body={ __(
+					'No paywall attempts in this window. Your paywall gates may not be reaching readers — could be a placement question, a frequency question, or simply that the date range doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
+					'newspack-plugin'
+				) }
 			/>
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Paywall Conversion (Influenced, 14d)', 'newspack-plugin' ),
-					description: __(
-						'Readers who subscribed in a later session within 14 days of seeing a paywall ÷ readers who saw a paywall',
-						'newspack-plugin'
-					),
-					current: current.paywall_conversion_influenced_14d,
-					previous: previous?.paywall_conversion_influenced_14d,
-				} ) }
+		);
+	}
+	if ( dataKnown && conversions === 0 ) {
+		return (
+			<EmptyMetricSection
+				title={ title }
+				caption={ caption }
+				state="no_conversions"
+				signalCount={ attempts }
+				body={ __(
+					'No paywall conversions in this window. Your paywall reached {N} readers, but none completed a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
+					'newspack-plugin'
+				) }
 			/>
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Total Paywall Revenue (Direct)', 'newspack-plugin' ),
-					description: __(
-						'Sum of Woo order totals from subscriptions completed in the same session as a paywall impression',
-						'newspack-plugin'
-					),
-					current: current.total_paywall_revenue_direct,
-					previous: previous?.total_paywall_revenue_direct,
-				} ) }
-			/>
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Avg Revenue per Paywall Conversion', 'newspack-plugin' ),
-					description: __( 'Total paywall revenue ÷ paywall conversions', 'newspack-plugin' ),
-					current: current.avg_revenue_per_paywall_conversion,
-					previous: previous?.avg_revenue_per_paywall_conversion,
-				} ) }
-			/>
-		</div>
-	</section>
-);
+		);
+	}
+
+	return (
+		<section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby={ HEADING_ID }>
+			<SectionHeading id={ HEADING_ID } title={ title } description={ caption } />
+			<div className="newspack-insights__metric-grid">
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Paywall Conversion (Direct)', 'newspack-plugin' ),
+						description: __(
+							'Sessions with a subscription after a paywall impression ÷ sessions with a paywall impression',
+							'newspack-plugin'
+						),
+						current: current.paywall_conversion_direct,
+						previous: previous?.paywall_conversion_direct,
+						zeroFallback: {
+							numerator: current.paywall_conversion_direct.numerator ?? undefined,
+							denominator: current.paywall_conversion_direct.denominator ?? undefined,
+							attemptsLabel,
+						},
+					} ) }
+				/>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Paywall Conversion (Influenced, 14d)', 'newspack-plugin' ),
+						description: __(
+							'Readers who subscribed in a later session within 14 days of seeing a paywall ÷ readers who saw a paywall',
+							'newspack-plugin'
+						),
+						current: current.paywall_conversion_influenced_14d,
+						previous: previous?.paywall_conversion_influenced_14d,
+						zeroFallback: {
+							numerator: current.paywall_conversion_influenced_14d.numerator ?? undefined,
+							denominator: current.paywall_conversion_influenced_14d.denominator ?? undefined,
+							attemptsLabel,
+						},
+					} ) }
+				/>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Total Paywall Revenue (Direct)', 'newspack-plugin' ),
+						description: __(
+							'Sum of Woo order totals from subscriptions completed in the same session as a paywall impression',
+							'newspack-plugin'
+						),
+						current: current.total_paywall_revenue_direct,
+						previous: previous?.total_paywall_revenue_direct,
+						// Currency total: conversions ride on the scalar's `denominator`;
+						// attempts come from the section total — but only when the Direct
+						// scalar computed. Otherwise `attempts` is an unreliable 0, so pass
+						// undefined and let the card render its own value/error treatment
+						// instead of a misleading "No paywall attempts".
+						zeroFallback: {
+							numerator: current.total_paywall_revenue_direct.denominator ?? undefined,
+							denominator: dataKnown ? attempts : undefined,
+							currencyRole: 'total',
+							attemptsLabel,
+							conversionsLabel,
+						},
+					} ) }
+				/>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Avg Revenue per Paywall Conversion', 'newspack-plugin' ),
+						description: __( 'Total paywall revenue ÷ paywall conversions', 'newspack-plugin' ),
+						current: current.avg_revenue_per_paywall_conversion,
+						previous: previous?.avg_revenue_per_paywall_conversion,
+						zeroFallback: {
+							numerator: current.avg_revenue_per_paywall_conversion.denominator ?? undefined,
+							denominator: dataKnown ? attempts : undefined,
+							currencyRole: 'average',
+							attemptsLabel,
+							conversionsLabel,
+						},
+					} ) }
+				/>
+			</div>
+		</section>
+	);
+};
 
 export default PaidReaderConversionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -46,12 +46,14 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 	const attempts = current.paywall_attempts_total;
 	const conversions = current.paywall_conversions_total;
 
-	// The section totals are derived from the Direct scalar's denominator/numerator,
-	// which are null when that query errors — coercing both totals to 0. A zero total
-	// is only a *genuine* empty state when the Direct metric actually computed;
-	// otherwise we fall through to the scorecards so each card surfaces its own error
-	// treatment rather than a misleading "no paywall attempts" empty state.
-	const dataKnown = current.paywall_conversion_direct.state !== 'error';
+	// The section totals are derived from the Direct denominator and the Direct/
+	// Influenced numerators, all of which are null when their query errors —
+	// coercing the totals to 0. A zero total is only a *genuine* empty state when
+	// both source metrics actually computed; if either errored we fall through to
+	// the scorecards so each card surfaces its own error treatment rather than a
+	// misleading "no paywall attempts" / "no conversions" empty state. (Direct and
+	// Influenced are separate queries and can fail independently.)
+	const dataKnown = current.paywall_conversion_direct.state !== 'error' && current.paywall_conversion_influenced_14d.state !== 'error';
 
 	// Empty states (NPPD-1694). Order matters: no opportunity before no conversions.
 	if ( dataKnown && attempts === 0 ) {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
@@ -9,7 +9,7 @@
 import { __ } from '@wordpress/i18n';
 
 import type { GatesScalarMetric } from '../../api/gates';
-import type { MetricFormat } from '../components/MetricCard';
+import type { MetricFormat, MetricCardZeroFallback } from '../components/MetricCard';
 
 const formatFor = ( m: GatesScalarMetric ): MetricFormat => {
 	switch ( m.placeholder_type ) {
@@ -30,10 +30,16 @@ export interface ScalarCardProps {
 	description: string;
 	current: GatesScalarMetric;
 	previous?: GatesScalarMetric | null;
+	/**
+	 * Count-fallback for a zero card (NPPD-1694). The section builds it because
+	 * it owns the attempt/conversion copy and (for currency cards) the
+	 * section-level attempts count. Forwarded as-is; ignored in the error branch.
+	 */
+	zeroFallback?: MetricCardZeroFallback;
 }
 
 export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
-	const { label, description, current, previous } = props;
+	const { label, description, current, previous, zeroFallback } = props;
 	// A failed query renders MetricCard's shared error treatment rather than a
 	// misleading zero. The raw message stays server-side; the card shows generic
 	// copy keyed off the `error` prop.
@@ -50,5 +56,6 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 		// must not show a delta against a real prior value (that would read as a
 		// misleading "↓ 100%").
 		previousValue: current.computable && previous && previous.state !== 'error' && previous.computable ? previous.value : null,
+		...( zeroFallback ? { zeroFallback } : {} ),
 	};
 };

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -659,4 +659,131 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertCount( 1, $result['rows'] );
 		$this->assertStringContainsString( '999999', $result['rows'][0]['gate_name'] ); // Generic fallback.
 	}
+
+	// --- NPPD-1694: envelope additions for the empty-state pattern ----------
+
+	/**
+	 * A paywall rate scorecard surfaces both numerator (matched Woo orders) and
+	 * denominator (attempts) so the card can render "0 of N".
+	 */
+	public function test_paywall_rate_surfaces_numerator_and_denominator() {
+		$bq_rows = array_map(
+			static function ( $i ) {
+				return [
+					'user_pseudo_id' => (string) $i,
+					'session_id'     => 's' . $i,
+					'attempt_ts'     => (string) ( 1000000000000000 + $i ),
+				];
+			},
+			range( 1, 17 )
+		);
+
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( $bq_rows );
+
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_completed_orders' )->willReturn( 0 ); // 0 of 17 attempts converted.
+
+		$metric = new Gates_Metric( $proxy, $resolver );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 0, $result['numerator'] );
+		$this->assertSame( 17, $result['denominator'] );
+		$this->assertTrue( $result['computable'] );
+	}
+
+	/**
+	 * No paywall attempts → numerator and denominator are both an explicit 0 (not
+	 * null), so the card distinguishes "no attempts" (—) from "0 of N".
+	 */
+	public function test_paywall_rate_zero_attempts_sets_zero_counts() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [] );
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 0, $result['numerator'] );
+		$this->assertSame( 0, $result['denominator'] );
+		$this->assertFalse( $result['computable'] );
+	}
+
+	/**
+	 * The error scalar carries a null numerator alongside the null denominator.
+	 */
+	public function test_error_scalar_includes_null_numerator() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( new \WP_Error( 'bigquery_query_failed', 'BQ down' ) );
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertArrayHasKey( 'numerator', $result );
+		$this->assertNull( $result['numerator'] );
+	}
+
+	/**
+	 * Paid section totals: attempts come from the Direct denominator; conversions
+	 * are the inclusive max across Direct and Influenced numerators.
+	 */
+	public function test_paywall_section_totals_normal_data() {
+		$totals = Gates_Metric::paywall_section_totals(
+			[
+				'denominator' => 17,
+				'numerator'   => 2,
+			],
+			[
+				'denominator' => 290,
+				'numerator'   => 5,
+			]
+		);
+
+		$this->assertSame( 17, $totals['paywall_attempts_total'] );
+		// max( direct 2, influenced 5 ) — don't hide Influenced-only conversions.
+		$this->assertSame( 5, $totals['paywall_conversions_total'] );
+	}
+
+	/**
+	 * Paid section totals: attempts > 0 but zero conversions in either attribution
+	 * → the section's no_conversions trigger.
+	 */
+	public function test_paywall_section_totals_zero_conversions() {
+		$totals = Gates_Metric::paywall_section_totals(
+			[
+				'denominator' => 17,
+				'numerator'   => 0,
+			],
+			[
+				'denominator' => 290,
+				'numerator'   => 0,
+			]
+		);
+
+		$this->assertSame( 17, $totals['paywall_attempts_total'] );
+		$this->assertSame( 0, $totals['paywall_conversions_total'] );
+	}
+
+	/**
+	 * Paid section totals: zero attempts → no_opportunity. Missing/null keys
+	 * coerce to 0 rather than warning (e.g. an error scalar with null numerator).
+	 */
+	public function test_paywall_section_totals_zero_attempts_and_missing_keys() {
+		$zero = Gates_Metric::paywall_section_totals(
+			[
+				'denominator' => 0,
+				'numerator'   => 0,
+			],
+			[
+				'denominator' => 0,
+				'numerator'   => 0,
+			]
+		);
+		$this->assertSame( 0, $zero['paywall_attempts_total'] );
+		$this->assertSame( 0, $zero['paywall_conversions_total'] );
+
+		$missing = Gates_Metric::paywall_section_totals( [], [] );
+		$this->assertSame( 0, $missing['paywall_attempts_total'] );
+		$this->assertSame( 0, $missing['paywall_conversions_total'] );
+	}
 }


### PR DESCRIPTION
## Summary

The empty-state pattern for Gates tab sections that would otherwise render as a row of zeros, landing on `feat/insights-rsm`. Closes [[NPPD-1694](https://linear.app/a8c/issue/NPPD-1694)](https://linear.app/a8c/issue/NPPD-1694). It adds two reusable pieces, an `<EmptyMetricSection>` shared component and a `zeroFallback` count fallback on `MetricCard`, and wires the first and only consumer in this PR: the Gates tab's Paid reader conversion section. The trigger was test pubs 90-day window rendering Paid conversion as `0%`, `0%`, `$0.00`, `$0.00`, correct numbers (17 paywall attempts, zero conversions in the window) that read as a broken dashboard. That section now renders an honest, lightly diagnostic empty state, and individual zero cards read as `0 of 17` or `0 conversions` instead of `0%` or `$0.00`.

The Free reader conversion section is deferred to [[NPPD-1702](https://linear.app/a8c/issue/NPPD-1702)](https://linear.app/a8c/issue/NPPD-1702). It needs a hub-side BigQuery change (the regwall rates are a precomputed column with no underlying counts). The Paid side is fully self-contained and needs no hub changes.

### Pre-flight decisions

Surfaced before writing code, where the codebase disagreed with the original plan.

- Built on the current design-system primitives. This branch was reconciled onto the latest `feat/insights-rsm` after the design-system refactors landed. `<EmptyMetricSection>` renders its identity via the shared `SectionHeading` (the `SectionHeader` wrapper) and its callout via a non-dismissible `@wordpress/components` `Notice`, the same primitive `InfoCallout` now uses, rather than hand-rolled markup. The `zeroFallback` rendering re-fits onto the `Card`-based `MetricCard` with no change to its value or secondary regions.
- Free section deferred ([[NPPD-1702](https://linear.app/a8c/issue/NPPD-1702)](https://linear.app/a8c/issue/NPPD-1702)). The paywall numerator is computed locally via the Woo-order join, so the Paid section is buildable end to end here. The regwall (Free) rates come from a precomputed hub column with no underlying counts, and the BigQuery proxy only names an allowlisted query, so the SQL lives on the Newspack Manager hub. Rather than regress the working regwall percentages, Free lands with that hub change.
- `conversions_count` reuses the existing `denominator` field. The orchestrator already passes the conversions count into the envelope's `denominator` for both currency scorecards, so there is no redundant field. The only genuinely missing rate field was `numerator`, which was computed then discarded.
- The currency-total rule follows the ticket table. A currency-total card shows `0 conversions` when conversions equals 0 and attempts are greater than 0.
- `MetricCard` has no `'rate'` format. Rate scorecards render as `format='percent'`, and total-vs-average is not encoded on the card, so `zeroFallback` keys behavior off `format` plus a `currencyRole` discriminator plus the numerator and denominator counts.
- `zeroFallback` is built in the `scalarToCard` adapter path, not inline on `<MetricCard>`, since every Gates scorecard already flows through `scalarToMetricCardProps`.
- Error-state guard. The Paid section treats a zero total as a genuine empty state only when the Direct scalar actually computed (`state !== 'error'`). An errored Direct query leaves the totals at 0, which would otherwise mis-render as "no paywall attempts" instead of surfacing the card's error treatment.
- The null glyph is matched exactly to the Performance-by-gate table's null cell (same glyph and `aria-label`); counts use the app's shared `formatNumber`.

## What's in this PR

### `<EmptyMetricSection>`, shared component

`tabs/components/EmptyMetricSection.tsx` (new). `SectionHeading` (title plus caption) over a non-dismissible info `Notice`. The `{N}` body interpolation substitutes a `formatNumber`-formatted `signalCount` only when supplied and the placeholder is present; a stray `{N}` is left visible so a missing prop is caught in QA. Distinct from `SectionEmpty`, the plain "no rows" paragraph for collection metrics.

### `MetricCard` count fallback

`tabs/components/MetricCard.tsx` gains a `zeroFallback` prop, keyed on two counts (`denominator` = attempts, `numerator` = conversions) rather than on `value`. Rendering matches the ticket table: rate shows `0 of 17`; currency-total shows `0 conversions`; currency-average shows the null glyph plus "No conversions in this window"; and any zero opportunity count shows the null glyph plus "No {attempts} in this window". The comparison delta is suppressed under any fallback hero. Labels are pre-pluralized translatable nouns with no runtime string-munging.

### Gates envelope additions (PHP and TS)

`numerator` now rides alongside `denominator` on rate scalars, threaded from the already-computed paywall Woo join (null where the count is not computed locally). A pure, unit-tested `Gates_Metric::paywall_section_totals()` derives `paywall_attempts_total` (Direct denominator) and `paywall_conversions_total` (inclusive max across attributions) with no extra query. `is_window_all_error()` skips the new scalar totals. Mirrored in `api/gates.ts` and `gates-fixture.php`.

### Paid section, first consumer

`tabs/gates/PaidReaderConversionSection.tsx` detects state from the section totals in the component, not the orchestrator: `attempts === 0` gives `no_opportunity`; `conversions === 0` gives `no_conversions` (with `signalCount`); otherwise the four scorecards, each carrying its `zeroFallback`.

## How to test

1. Check out `feat/insights-empty-state` and run `n build newspack-plugin`.
2. Fixture mode (no BigQuery): with `NEWSPACK_INSIGHTS_FIXTURE_MODE` on, visit Insights → Gates. `?_fixture_state=empty` renders the Paid section's `no_opportunity` empty state; the default `populated` variant renders the four scorecards with the count fallback wired.
3. Test pub, 90-day (real data): the Paid reader conversion section renders the `no_conversions` empty state with `{N}` = 17.
4. A publisher with normal paywall data renders the four scorecards; an individual zero card shows `0 of N` or `0 conversions` rather than `0%` or `$0.00`.
5. `n test-php --filter Test_Gates_Metric`: 39 tests, 145 assertions green (existing plus 6 new). PHPCS clean.
6. `tsc --noEmit`, ESLint, the production build, and the 29 React tests across `EmptyMetricSection`, `MetricCard`, and `PaidReaderConversionSection` all pass. The `.tsx` tests are now collected by Jest ([[NPPD-1683](https://linear.app/a8c/issue/NPPD-1683)](https://linear.app/a8c/issue/NPPD-1683)'s `testMatch` fix has landed on this base).

## Heads-up

- Free reader conversion is a tracked follow-up ([[NPPD-1702](https://linear.app/a8c/issue/NPPD-1702)](https://linear.app/a8c/issue/NPPD-1702)). It needs the hub to return registration-impression and registration counts on the regwall queries. The in-repo wiring mirrors the Paid side and lands with the hub change.
- The `configuration_missing` `EmptyMetricSectionState` is defined but currently unused on Gates; no orchestrator path emits a "gates not configured" signal yet.