### PR TITLE
feat(redirection): disable Redirection plugin logging by default

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -235,6 +235,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-redirection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-author-rest-fields.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -136,3 +136,4 @@ class Redirection {
 	 */
 	public static function maybe_render_drift_notice() {}
 }
+Redirection::init();

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -126,7 +126,7 @@ class Redirection {
 
 	/**
 	 * Layer 3: enqueue the admin script that hides the log-retention controls,
-	 * only on Redirection's options screen.
+	 * only on the Redirection admin screen (Tools → Redirection).
 	 *
 	 * @param string $hook_suffix Current admin screen hook suffix.
 	 */

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -162,8 +162,48 @@ class Redirection {
 	}
 
 	/**
-	 * Durability notice — implemented in a later task.
+	 * Pure detector: is Redirection's expected logging surface missing?
+	 *
+	 * Our Layer 1 suppression hooks Redirection's own log classes' filters; if a
+	 * future Redirection release renames/removes those classes, our filters would
+	 * silently no-op. This detects that drift so we can surface a warning.
+	 *
+	 * @param bool $has_redirect_log Whether Red_Redirect_Log exists.
+	 * @param bool $has_404_log      Whether Red_404_Log exists.
+	 * @return bool
 	 */
-	public static function maybe_render_drift_notice() {}
+	public static function is_logging_surface_missing( $has_redirect_log, $has_404_log ) {
+		return ! $has_redirect_log || ! $has_404_log;
+	}
+
+	/**
+	 * Build the drift-notice HTML (empty string when no drift).
+	 *
+	 * @return string
+	 */
+	public static function get_drift_notice_html() {
+		$missing = self::is_logging_surface_missing(
+			class_exists( 'Red_Redirect_Log' ),
+			class_exists( 'Red_404_Log' )
+		);
+		if ( ! $missing ) {
+			return '';
+		}
+		return '<div class="notice notice-warning"><p>'
+			. esc_html__( 'Newspack expected to disable Redirection logging, but this version of Redirection no longer exposes the expected log classes. Please report this so Newspack can update the integration.', 'newspack' )
+			. '</p></div>';
+	}
+
+	/**
+	 * Durability: warn admins if Redirection's log surface has drifted out from
+	 * under our suppression filters. Rendered only on the Redirection screen.
+	 */
+	public static function maybe_render_drift_notice() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'tools_page_redirection' !== $screen->id ) {
+			return;
+		}
+		echo self::get_drift_notice_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 }
 Redirection::init();

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Redirection plugin integration.
+ *
+ * Forces the third-party Redirection plugin's redirect/404 logging off
+ * (with a code-level escape hatch) and optionally suppresses its hit counter.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Redirection {
+	/**
+	 * Whether Redirection's redirect/404 logging is enabled.
+	 *
+	 * Default: false (Newspack forces logging off). Precedence:
+	 * constant NEWSPACK_REDIRECTION_LOGGING_ENABLED wins, then the
+	 * `newspack_redirection_logging_enabled` filter, then the default.
+	 *
+	 * @return bool
+	 */
+	public static function is_logging_enabled() {
+		if ( defined( 'NEWSPACK_REDIRECTION_LOGGING_ENABLED' ) ) {
+			return (bool) NEWSPACK_REDIRECTION_LOGGING_ENABLED;
+		}
+		/**
+		 * Filters whether the Redirection plugin's redirect/404 logging is enabled.
+		 *
+		 * @param bool $enabled Default false (Newspack forces logging off).
+		 */
+		return (bool) apply_filters( 'newspack_redirection_logging_enabled', false );
+	}
+
+	/**
+	 * Whether Redirection's per-redirect hit counter is enabled.
+	 *
+	 * Default: true (left unchanged). Precedence:
+	 * constant NEWSPACK_REDIRECTION_HIT_TRACKING_ENABLED wins, then the
+	 * `newspack_redirection_hit_tracking_enabled` filter, then the default.
+	 *
+	 * @return bool
+	 */
+	public static function is_hit_tracking_enabled() {
+		if ( defined( 'NEWSPACK_REDIRECTION_HIT_TRACKING_ENABLED' ) ) {
+			return (bool) NEWSPACK_REDIRECTION_HIT_TRACKING_ENABLED;
+		}
+		/**
+		 * Filters whether the Redirection plugin's per-redirect hit counter is enabled.
+		 *
+		 * @param bool $enabled Default true (left unchanged).
+		 */
+		return (bool) apply_filters( 'newspack_redirection_hit_tracking_enabled', true );
+	}
+}

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -168,6 +168,13 @@ class Redirection {
 	 * future Redirection release renames/removes those classes, our filters would
 	 * silently no-op. This detects that drift so we can surface a warning.
 	 *
+	 * Note: this is an intentionally loose proxy. Suppression rides on the log
+	 * *filters*; we check the log *classes* (whose create() methods carry those
+	 * filters) as a cheap stand-in. They can diverge — Redirection could keep the
+	 * classes but rename/relocate the filters — so this catches class-level removal,
+	 * not every possible filter drift. The live "logs actually stop" check (the PR
+	 * test plan) is the authoritative verification.
+	 *
 	 * @param bool $has_redirect_log Whether Red_Redirect_Log exists.
 	 * @param bool $has_404_log      Whether Red_404_Log exists.
 	 * @return bool

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -102,12 +102,25 @@ class Redirection {
 	}
 
 	/**
-	 * Layer 2 callback — implemented in a later task.
+	 * Layer 2: force the stored log-retention values to "off" on read.
 	 *
-	 * @param mixed $value Stored option value.
+	 * Read-only (we never write the row), non-destructive, and fully reversible —
+	 * deactivating Newspack reverts the site to its prior settings. Makes the
+	 * Redirection options screen show logging disabled and prevents re-enabling
+	 * from the UI (the value reverts on next read).
+	 *
+	 * Must pass a non-array value through untouched: get_option() returns false
+	 * on a fresh site with no saved row.
+	 *
+	 * @param mixed $value Stored redirection_options value.
 	 * @return mixed
 	 */
 	public static function force_logging_off_in_options( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		$value['expire_redirect'] = -1;
+		$value['expire_404']      = -1;
 		return $value;
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -17,6 +17,49 @@ defined( 'ABSPATH' ) || exit;
  */
 class Redirection {
 	/**
+	 * Initialize. Registration is deferred to plugins_loaded so Redirection's
+	 * classes are loaded before we guard on them.
+	 */
+	public static function init() {
+		add_action( 'plugins_loaded', [ __CLASS__, 'register' ], 11 );
+	}
+
+	/**
+	 * Register hooks, but only when the Redirection plugin is present.
+	 *
+	 * Guards on function_exists( 'red_get_options' ) — a stable symbol in the
+	 * released Redirection (5.5.2). Load-context-independent, unlike
+	 * is_plugin_active() (undefined on front-end requests). NOT class_exists(
+	 * 'Red_Options' ): that class exists only on Redirection's trunk, so it would
+	 * make this a silent no-op on every site running a released version.
+	 */
+	public static function register() {
+		if ( ! function_exists( 'red_get_options' ) ) {
+			return;
+		}
+
+		if ( ! self::is_logging_enabled() ) {
+			// Layer 1: hard-stop both log writes at the source (independent of stored options).
+			add_filter( 'redirection_log_data', '__return_false' );
+			add_filter( 'redirection_404_data', '__return_false' );
+			add_filter( 'redirection_log_404', '__return_false' );
+
+			// Layer 2: read-only neutralize + honest UI (see force_logging_off_in_options()).
+			add_filter( 'option_redirection_options', [ __CLASS__, 'force_logging_off_in_options' ] );
+
+			// Layer 3: hide the log-retention controls on Redirection's options screen.
+			add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_assets' ] );
+
+			// Durability: structural-drift notice if Redirection's log classes are gone.
+			add_action( 'admin_notices', [ __CLASS__, 'maybe_render_drift_notice' ] );
+		}
+
+		if ( ! self::is_hit_tracking_enabled() ) {
+			add_filter( 'redirection_redirect_counter', '__return_false' );
+		}
+	}
+
+	/**
 	 * Whether Redirection's redirect/404 logging is enabled.
 	 *
 	 * Default: false (Newspack forces logging off). Precedence:
@@ -57,4 +100,26 @@ class Redirection {
 		 */
 		return (bool) apply_filters( 'newspack_redirection_hit_tracking_enabled', true );
 	}
+
+	/**
+	 * Layer 2 callback — implemented in a later task.
+	 *
+	 * @param mixed $value Stored option value.
+	 * @return mixed
+	 */
+	public static function force_logging_off_in_options( $value ) {
+		return $value;
+	}
+
+	/**
+	 * Layer 3 enqueue — implemented in a later task.
+	 *
+	 * @param string $hook_suffix Current admin screen hook suffix.
+	 */
+	public static function enqueue_admin_assets( $hook_suffix ) {}
+
+	/**
+	 * Durability notice — implemented in a later task.
+	 */
+	public static function maybe_render_drift_notice() {}
 }

--- a/plugins/newspack-plugin/includes/plugins/class-redirection.php
+++ b/plugins/newspack-plugin/includes/plugins/class-redirection.php
@@ -125,11 +125,41 @@ class Redirection {
 	}
 
 	/**
-	 * Layer 3 enqueue — implemented in a later task.
+	 * Layer 3: enqueue the admin script that hides the log-retention controls,
+	 * only on Redirection's options screen.
 	 *
 	 * @param string $hook_suffix Current admin screen hook suffix.
 	 */
-	public static function enqueue_admin_assets( $hook_suffix ) {}
+	public static function enqueue_admin_assets( $hook_suffix ) {
+		// Redirection's menu lives under Tools → Redirection (slug `redirection.php`).
+		if ( 'tools_page_redirection' !== $hook_suffix ) {
+			return;
+		}
+
+		$path = NEWSPACK_ABSPATH . 'dist/other-scripts/redirection-admin.js';
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+
+		$asset  = include NEWSPACK_ABSPATH . 'dist/other-scripts/redirection-admin.asset.php';
+		$handle = 'newspack-redirection-admin';
+		wp_enqueue_script(
+			$handle,
+			plugins_url( 'dist/other-scripts/redirection-admin.js', NEWSPACK_PLUGIN_FILE ),
+			$asset['dependencies'] ?? [],
+			$asset['version'] ?? false,
+			true
+		);
+
+		// Translated note text, ready for the disable+note fallback.
+		wp_localize_script(
+			$handle,
+			'newspackRedirection',
+			[
+				'noteText' => __( 'Logging is disabled for performance reasons on Newspack.', 'newspack' ),
+			]
+		);
+	}
 
 	/**
 	 * Durability notice — implemented in a later task.

--- a/plugins/newspack-plugin/src/other-scripts/redirection-admin/index.js
+++ b/plugins/newspack-plugin/src/other-scripts/redirection-admin/index.js
@@ -1,0 +1,43 @@
+/**
+ * Hides Redirection's log-retention controls on its options screen.
+ *
+ * Redirection's options page is a React SPA that renders asynchronously and on
+ * hash navigation, so we watch for the two log-retention <select>s and hide
+ * only their rows (not the "Logs" section header — track_hits / log_header live
+ * under it and remain active). This is cosmetic: server-side filters are the
+ * real enforcement, so if Redirection's markup changes this degrades to a no-op
+ * (logging stays off regardless).
+ *
+ * Fallback (apply if hiding proves brittle in testing): instead of hiding the
+ * row, set `select.disabled = true` and append a note element with
+ * window.newspackRedirection.noteText. See the design doc, Layer 3.
+ */
+( function () {
+	const SELECTORS = [ 'select[name="expire_redirect"]', 'select[name="expire_404"]' ];
+
+	function hideLogRows() {
+		SELECTORS.forEach( function ( selector ) {
+			const control = document.querySelector( selector );
+			if ( ! control ) {
+				return;
+			}
+			const row = control.closest( 'tr' );
+			if ( row && ! row.dataset.newspackHidden ) {
+				row.style.display = 'none';
+				row.dataset.newspackHidden = '1';
+			}
+		} );
+	}
+
+	function start() {
+		hideLogRows();
+		const observer = new MutationObserver( hideLogRows );
+		observer.observe( document.body, { childList: true, subtree: true } );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', start );
+	} else {
+		start();
+	}
+} )();

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
@@ -13,7 +13,8 @@ use Newspack\Redirection;
 class Newspack_Test_Redirection extends WP_UnitTestCase {
 
 	/**
-	 * Remove our filters between tests so registrations don't leak.
+	 * Remove the filters and actions register() adds, so registrations don't leak
+	 * across tests in the same process.
 	 */
 	public function tear_down() {
 		parent::tear_down();
@@ -24,6 +25,8 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 		remove_all_filters( 'option_redirection_options' );
 		remove_all_filters( 'newspack_redirection_logging_enabled' );
 		remove_all_filters( 'newspack_redirection_hit_tracking_enabled' );
+		remove_all_actions( 'admin_enqueue_scripts' );
+		remove_all_actions( 'admin_notices' );
 	}
 
 	/**
@@ -72,6 +75,12 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 	/**
 	 * With logging disabled (default), register() adds the three hard-stop filters,
 	 * and each returns false (suppressing the log write).
+	 *
+	 * Note: unit coverage stops at registration + the filters' return value. That
+	 * Redirection actually *honors* a false return to skip the DB insert is the
+	 * load-bearing contract, but it can't be exercised here (no Redirection in the
+	 * test container) — it's verified live against a real install in the PR's test
+	 * plan (logs stop accruing while the integration is active).
 	 */
 	public function test_register_adds_log_suppression_filters() {
 		$this->stub_redirection_present();

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
@@ -55,4 +55,63 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 		add_filter( 'newspack_redirection_hit_tracking_enabled', '__return_false' );
 		$this->assertFalse( Redirection::is_hit_tracking_enabled() );
 	}
+
+	/**
+	 * Define a red_get_options() stub so the guard passes.
+	 *
+	 * Matches the released Redirection (5.5.2), which exposes the
+	 * red_get_options() function rather than a Red_Options class (trunk-only).
+	 * Note: the stubbed symbol persists process-wide (PHP can't undefine it).
+	 */
+	private function stub_redirection_present() {
+		if ( ! function_exists( 'red_get_options' ) ) {
+			eval( 'function red_get_options() { return []; }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
+		}
+	}
+
+	/**
+	 * With logging disabled (default), register() adds the three hard-stop filters,
+	 * and each returns false (suppressing the log write).
+	 */
+	public function test_register_adds_log_suppression_filters() {
+		$this->stub_redirection_present();
+		Redirection::register();
+
+		$this->assertSame( 10, has_filter( 'redirection_log_data', '__return_false' ) );
+		$this->assertSame( 10, has_filter( 'redirection_404_data', '__return_false' ) );
+		$this->assertSame( 10, has_filter( 'redirection_log_404', '__return_false' ) );
+
+		$this->assertFalse( apply_filters( 'redirection_log_data', [ 'url' => '/x' ] ) );
+		$this->assertFalse( apply_filters( 'redirection_404_data', [ 'url' => '/x' ] ) );
+	}
+
+	/**
+	 * Hit tracking is NOT suppressed by default.
+	 */
+	public function test_register_leaves_hit_tracking_alone_by_default() {
+		$this->stub_redirection_present();
+		Redirection::register();
+		$this->assertFalse( has_filter( 'redirection_redirect_counter', '__return_false' ) );
+	}
+
+	/**
+	 * Opting hit tracking out adds the counter-suppression filter.
+	 */
+	public function test_register_suppresses_hit_tracking_when_opted_out() {
+		add_filter( 'newspack_redirection_hit_tracking_enabled', '__return_false' );
+		$this->stub_redirection_present();
+		Redirection::register();
+		$this->assertSame( 10, has_filter( 'redirection_redirect_counter', '__return_false' ) );
+	}
+
+	/**
+	 * When logging is re-enabled, no log-suppression filters are added.
+	 */
+	public function test_register_skips_suppression_when_logging_enabled() {
+		add_filter( 'newspack_redirection_logging_enabled', '__return_true' );
+		$this->stub_redirection_present();
+		Redirection::register();
+		$this->assertFalse( has_filter( 'redirection_log_data', '__return_false' ) );
+		$this->assertFalse( has_filter( 'option_redirection_options', [ Redirection::class, 'force_logging_off_in_options' ] ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
@@ -114,4 +114,30 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 		$this->assertFalse( has_filter( 'redirection_log_data', '__return_false' ) );
 		$this->assertFalse( has_filter( 'option_redirection_options', [ Redirection::class, 'force_logging_off_in_options' ] ) );
 	}
+
+	/**
+	 * The option override forces both expiries to -1 and preserves other keys.
+	 */
+	public function test_option_override_forces_expiries_and_preserves_keys() {
+		$value = [
+			'expire_redirect' => 7,
+			'expire_404'      => 30,
+			'track_hits'      => true,
+			'monitor_post'    => 5,
+		];
+		$result = Redirection::force_logging_off_in_options( $value );
+
+		$this->assertSame( -1, $result['expire_redirect'] );
+		$this->assertSame( -1, $result['expire_404'] );
+		$this->assertTrue( $result['track_hits'] );   // untouched
+		$this->assertSame( 5, $result['monitor_post'] ); // untouched
+	}
+
+	/**
+	 * A non-array value (fresh site, no saved row) is returned untouched.
+	 */
+	public function test_option_override_passes_non_array_through() {
+		$this->assertFalse( Redirection::force_logging_off_in_options( false ) );
+		$this->assertSame( '', Redirection::force_logging_off_in_options( '' ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
@@ -119,7 +119,7 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 	 * The option override forces both expiries to -1 and preserves other keys.
 	 */
 	public function test_option_override_forces_expiries_and_preserves_keys() {
-		$value = [
+		$value  = [
 			'expire_redirect' => 7,
 			'expire_404'      => 30,
 			'track_hits'      => true,
@@ -129,8 +129,8 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 
 		$this->assertSame( -1, $result['expire_redirect'] );
 		$this->assertSame( -1, $result['expire_404'] );
-		$this->assertTrue( $result['track_hits'] );   // untouched
-		$this->assertSame( 5, $result['monitor_post'] ); // untouched
+		$this->assertTrue( $result['track_hits'] );   // Untouched.
+		$this->assertSame( 5, $result['monitor_post'] ); // Untouched.
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests the Redirection integration.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Redirection;
+
+/**
+ * Test the Redirection integration class.
+ */
+class Newspack_Test_Redirection extends WP_UnitTestCase {
+
+	/**
+	 * Remove our filters between tests so registrations don't leak.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		remove_all_filters( 'redirection_log_data' );
+		remove_all_filters( 'redirection_404_data' );
+		remove_all_filters( 'redirection_log_404' );
+		remove_all_filters( 'redirection_redirect_counter' );
+		remove_all_filters( 'option_redirection_options' );
+		remove_all_filters( 'newspack_redirection_logging_enabled' );
+		remove_all_filters( 'newspack_redirection_hit_tracking_enabled' );
+	}
+
+	/**
+	 * Logging is disabled by default (filter resolves false).
+	 */
+	public function test_logging_disabled_by_default() {
+		$this->assertFalse( Redirection::is_logging_enabled() );
+	}
+
+	/**
+	 * Hit tracking is left enabled by default (filter resolves true).
+	 */
+	public function test_hit_tracking_enabled_by_default() {
+		$this->assertTrue( Redirection::is_hit_tracking_enabled() );
+	}
+
+	/**
+	 * The logging filter can re-enable logging.
+	 */
+	public function test_logging_filter_can_reenable() {
+		add_filter( 'newspack_redirection_logging_enabled', '__return_true' );
+		$this->assertTrue( Redirection::is_logging_enabled() );
+	}
+
+	/**
+	 * The hit-tracking filter can opt into suppression.
+	 */
+	public function test_hit_tracking_filter_can_disable() {
+		add_filter( 'newspack_redirection_hit_tracking_enabled', '__return_false' );
+		$this->assertFalse( Redirection::is_hit_tracking_enabled() );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/redirection.php
@@ -140,4 +140,28 @@ class Newspack_Test_Redirection extends WP_UnitTestCase {
 		$this->assertFalse( Redirection::force_logging_off_in_options( false ) );
 		$this->assertSame( '', Redirection::force_logging_off_in_options( '' ) );
 	}
+
+	/**
+	 * No drift notice when Redirection's log classes are present.
+	 */
+	public function test_no_drift_notice_when_log_classes_present() {
+		if ( ! class_exists( 'Red_Redirect_Log' ) ) {
+			eval( 'class Red_Redirect_Log {}' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
+		}
+		if ( ! class_exists( 'Red_404_Log' ) ) {
+			eval( 'class Red_404_Log {}' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
+		}
+		$this->assertSame( '', Redirection::get_drift_notice_html() );
+	}
+
+	/**
+	 * The drift detector reports drift when the log classes are missing.
+	 * (Tested via the pure detector, since the stub classes can't be unloaded.)
+	 */
+	public function test_drift_detected_when_log_classes_missing() {
+		$this->assertTrue( Redirection::is_logging_surface_missing( false, false ) );
+		$this->assertTrue( Redirection::is_logging_surface_missing( true, false ) );
+		$this->assertTrue( Redirection::is_logging_surface_missing( false, true ) );
+		$this->assertFalse( Redirection::is_logging_surface_missing( true, true ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The third-party **Redirection** plugin can be configured to log redirects and 404s.  This can have a serious performance impact on sites with even moderate traffic.  

This PR disables the third-party **Redirection** plugin's redirect and 404 request logging and hides the controls.  It also provides a method to disable per-redirect hit-counting, which hasn't been specifically identified as a site-killer--but now we've got a handle to test that theory out. 

Configuration is done through constants:

* Re-enable logging on a specific site: `define( 'NEWSPACK_REDIRECTION_LOGGING_ENABLED', true );` (or return `true` from the `newspack_redirection_logging_enabled` filter).
* Disable the hit counter: `define( 'NEWSPACK_REDIRECTION_HIT_TRACKING_ENABLED', false );` (or return `false` from the `newspack_redirection_hit_tracking_enabled` filter).

If Redirection is not active, the integration is inert. If a future Redirection release moves the log classes the suppression relies on, an admin notice surfaces so the regression is caught.

_Notes for reviewers:_ Verified against Redirection **5.5.2 and 5.7.5** — the activation guard uses `function_exists( 'red_get_options' )` because 5.5.2 has no `Red_Options` class. The option override is read-time only; Redirection's REST-driven options SPA still *reads* the stored value, but the controls are hidden and logging is suppressed regardless, so the displayed value is immaterial.

Closes NPPM-2811.

### How to test the changes in this Pull Request:

1. On a site with the Newspack plugin and **Redirection** plugin active, go to **Tools → Redirection → Options**. Confirm the "Redirect Logs" and "404 Logs" (time-to-keep) rows are **hidden**, while "Track redirect hits…", IP logging, and the other options remain visible.
2. Trigger several 404s (visit non-existent URLs) and at least one redirect. Go to **Tools → Redirection → 404s** and **Logs** and confirm **no new rows** are recorded.
3. Add `define( 'NEWSPACK_REDIRECTION_LOGGING_ENABLED', true );` to `wp-config.php`, repeat step 2, and confirm logging **resumes** (rows appear). Remove the constant afterward.
4. Confirm a redirect's hit count increments by default; then add `define( 'NEWSPACK_REDIRECTION_HIT_TRACKING_ENABLED', false );` and confirm the per-redirect hit count stops incrementing.
5. Deactivate the Newspack plugin and confirm Redirection returns to its normal behavior (the override is read-only — no publisher data is mutated).
6. With Redirection **inactive**, confirm the Newspack plugin loads normally and adds none of these hooks.
7. Run `n test-php --filter Newspack_Test_Redirection` and confirm 12 tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
