### PR TITLE
feat(settings): add Jetpack AI Assistant toggle (off by default)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,0 +1,11 @@
+# newspack-components [4.4.0-hotfix-nppm-2915-jetpack-ai-toggle.1](https://github.com/Automattic/newspack-workspace/compare/newspack-components@4.3.0...newspack-components@4.4.0-hotfix-nppm-2915-jetpack-ai-toggle.1) (2026-06-12)
+
+
+### Bug Fixes
+
+* **components:** restore className and disabled props on CardSettingsGroup ([226762e](https://github.com/Automattic/newspack-workspace/commit/226762e51e8de85058af7414c4eed839c3805c98))
+
+
+### Features
+
+* **reader-activation:** replace RAS auto-enable with manual toggle ([#196](https://github.com/Automattic/newspack-workspace/issues/196)) ([71d2165](https://github.com/Automattic/newspack-workspace/commit/71d216515c9f15711becbbe2bc212eb6662b6a9a))

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-components",
-	"version": "4.3.0",
+	"version": "4.4.0-hotfix-nppm-2915-jetpack-ai-toggle.1",
 	"description": "Newspack design system components",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -185,6 +185,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-recirculation-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-collections-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-privacy-section.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-jetpack-ai-section.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -59,6 +59,7 @@ class Wizards {
 						'nextdoor'         => 'Newspack\Wizards\Newspack\Nextdoor_Section',
 						'primary-category' => 'Newspack\Wizards\Newspack\Primary_Category_Section',
 						'privacy'          => 'Newspack\Wizards\Newspack\Privacy_Section',
+						'jetpack-ai'       => 'Newspack\Wizards\Newspack\Jetpack_AI_Section',
 					],
 				]
 			),

--- a/plugins/newspack-plugin/includes/optional-modules/class-optional-modules.php
+++ b/plugins/newspack-plugin/includes/optional-modules/class-optional-modules.php
@@ -63,6 +63,15 @@ class Optional_Modules {
 	/**
 	 * Get the list of available optional modules.
 	 *
+	 * Note: this list is consumed by the Syndication settings batch-writer
+	 * (`Syndication::api_update_settings()` overwrites every listed module from
+	 * the request, and the route marks each one `required`). Modules managed by
+	 * their own dedicated section/endpoint must NOT be added here, or an
+	 * unrelated Syndication save would clobber/422 them. `jetpack-ai` is one such
+	 * module — it has a default in `get_settings()` and its own
+	 * `Jetpack_AI_Section` REST endpoint (Settings → Connections), so it is
+	 * intentionally excluded from this list.
+	 *
 	 * @return array List of available optional modules.
 	 */
 	public static function get_available_optional_modules(): array {

--- a/plugins/newspack-plugin/includes/optional-modules/class-optional-modules.php
+++ b/plugins/newspack-plugin/includes/optional-modules/class-optional-modules.php
@@ -40,6 +40,7 @@ class Optional_Modules {
 			self::MODULE_ENABLED_PREFIX . 'collections'    => false,
 			self::MODULE_ENABLED_PREFIX . 'indesign-export' => false,
 			self::MODULE_ENABLED_PREFIX . 'nextdoor'       => false,
+			self::MODULE_ENABLED_PREFIX . 'jetpack-ai'     => false,
 		];
 		return wp_parse_args( get_option( self::OPTION_NAME ), $default_settings );
 	}

--- a/plugins/newspack-plugin/includes/plugins/class-jetpack.php
+++ b/plugins/newspack-plugin/includes/plugins/class-jetpack.php
@@ -168,6 +168,25 @@ class Jetpack {
 
 		// Disable Jetpack Image Studio as late as possible so dequeues cannot be overridden.
 		add_action( 'admin_print_scripts', [ __CLASS__, 'disable_image_studio' ], 999 );
+
+		// Disable Jetpack AI Assistant unless the publisher has opted in (NPPM-2915). Off by default fleet-wide.
+		add_filter( 'jetpack_ai_enabled', [ __CLASS__, 'maybe_disable_ai_assistant' ] );
+	}
+
+	/**
+	 * Disable Jetpack AI Assistant unless the publisher has explicitly opted in.
+	 *
+	 * Jetpack AI is off by default across Newspack sites; publishers opt back in via
+	 * Settings → Connections (the `jetpack-ai` optional module). See NPPM-2915.
+	 *
+	 * @param bool $enabled Whether Jetpack AI is enabled (incoming filter value).
+	 * @return bool False when the site has not opted in; the unchanged value otherwise.
+	 */
+	public static function maybe_disable_ai_assistant( $enabled ) {
+		if ( ! Optional_Modules::is_optional_module_active( 'jetpack-ai' ) ) {
+			return false;
+		}
+		return $enabled;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-jetpack-ai-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-jetpack-ai-section.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Jetpack AI Section Object.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Optional_Modules;
+use WP_REST_Server;
+
+use Newspack\Wizards\Wizard_Section;
+
+/**
+ * Jetpack AI Section Object.
+ *
+ * Toggles the `jetpack-ai` optional module, which gates Jetpack AI Assistant
+ * (off by default fleet-wide; publishers opt in). See NPPM-2915.
+ *
+ * @package Newspack\Wizards\Newspack
+ */
+class Jetpack_AI_Section extends Wizard_Section {
+
+	/**
+	 * Optional-module slug backing this toggle.
+	 *
+	 * Hyphenated to match the other optional-module slugs; the REST/JS contract
+	 * exposes the underscore form `module_enabled_jetpack_ai` (a JS property
+	 * cannot contain a hyphen).
+	 *
+	 * @var string
+	 */
+	const MODULE_NAME = 'jetpack-ai';
+
+	/**
+	 * REST/JS property name for the toggle.
+	 *
+	 * @var string
+	 */
+	const REST_KEY = 'module_enabled_jetpack_ai';
+
+	/**
+	 * Containing wizard slug.
+	 *
+	 * @var string
+	 */
+	protected $wizard_slug = 'newspack-settings';
+
+	/**
+	 * Register Wizard Section specific endpoints.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->wizard_slug . '/jetpack-ai',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->wizard_slug . '/jetpack-ai',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					self::REST_KEY => [
+						'required' => true,
+						'type'     => 'boolean',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get Jetpack AI settings.
+	 *
+	 * @return array
+	 */
+	public function api_get_settings() {
+		return [
+			self::REST_KEY => Optional_Modules::is_optional_module_active( self::MODULE_NAME ),
+		];
+	}
+
+	/**
+	 * Update Jetpack AI settings.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return array|\WP_Error
+	 */
+	public function api_update_settings( $request ) {
+		$enabled = $request->get_param( self::REST_KEY );
+		if ( ! is_bool( $enabled ) ) {
+			return new \WP_Error( 'invalid_param', __( 'Invalid parameter for module_enabled_jetpack_ai.', 'newspack' ), [ 'status' => 400 ] );
+		}
+
+		if ( $enabled ) {
+			Optional_Modules::activate_optional_module( self::MODULE_NAME );
+		} else {
+			Optional_Modules::deactivate_optional_module( self::MODULE_NAME );
+		}
+
+		return [
+			self::REST_KEY => $enabled,
+		];
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/index.tsx
@@ -16,6 +16,7 @@ import Webhooks from './webhooks';
 import Analytics from './analytics';
 import Recaptcha from './recaptcha';
 import JetpackSSO from './jetpack-sso';
+import JetpackAI from './jetpack-ai';
 import Mailchimp from './mailchimp';
 import GoogleOAuth from './google-oauth';
 import CustomEvents from './custom-events';
@@ -45,6 +46,11 @@ function Connections() {
 					<JetpackSSO />
 				</WizardSection>
 			) : null }
+
+			{ /* Jetpack AI Assistant */ }
+			<WizardSection title={ __( 'Jetpack AI Assistant', 'newspack-plugin' ) }>
+				<JetpackAI />
+			</WizardSection>
 
 			{ /* reCAPTCHA */ }
 			<WizardSection scrollToAnchor="newspack-settings-recaptcha" title={ __( 'reCAPTCHA', 'newspack-plugin' ) }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-ai.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-ai.tsx
@@ -1,0 +1,42 @@
+/**
+ * Settings Wizard: Connections > Jetpack AI Assistant
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import WizardsActionCard from '../../../../wizards-action-card';
+import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
+
+function JetpackAI() {
+	const { description, apiData, isFetching, actionText, apiFetchToggle, errorMessage } = useWizardApiFetchToggle< JetpackAiData >( {
+		path: '/newspack/v1/wizard/newspack-settings/jetpack-ai',
+		apiNamespace: 'newspack-settings/jetpack-ai',
+		data: {
+			module_enabled_jetpack_ai: false,
+		},
+		description: __(
+			"Enables Jetpack's AI features, such as the AI Assistant block. Off by default; turn on to let editors use Jetpack AI on this site.",
+			'newspack-plugin'
+		),
+	} );
+
+	return (
+		<WizardsActionCard
+			title={ __( 'Enable Jetpack AI Assistant', 'newspack-plugin' ) }
+			description={ description }
+			disabled={ isFetching }
+			actionText={ actionText }
+			error={ errorMessage }
+			toggleChecked={ apiData.module_enabled_jetpack_ai }
+			toggleOnChange={ ( value: boolean ) => apiFetchToggle( { ...apiData, module_enabled_jetpack_ai: value }, true ) }
+		/>
+	);
+}
+
+export default JetpackAI;

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/types.d.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/types.d.ts
@@ -107,3 +107,10 @@ type JetpackSSOSettings = Partial< {
 type PrintData = {
 	module_enabled_print: boolean;
 };
+
+/**
+ * Jetpack AI API data
+ */
+type JetpackAiData = {
+	module_enabled_jetpack_ai: boolean;
+};

--- a/plugins/newspack-plugin/tests/unit-tests/jetpack-ai-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/jetpack-ai-section.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests the Jetpack_AI_Section REST section.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Wizards\Newspack\Jetpack_AI_Section;
+use Newspack\Optional_Modules;
+
+/**
+ * Tests the Jetpack_AI_Section REST section.
+ */
+class Newspack_Test_Jetpack_AI_Section extends WP_UnitTestCase {
+	/**
+	 * Reset settings before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Optional_Modules::OPTION_NAME );
+	}
+
+	/**
+	 * GET returns the flag (underscore key), default false.
+	 */
+	public function test_get_settings_default() {
+		$section = new Jetpack_AI_Section();
+		$result  = $section->api_get_settings();
+		self::assertIsArray( $result );
+		self::assertArrayHasKey( 'module_enabled_jetpack_ai', $result );
+		self::assertFalse( $result['module_enabled_jetpack_ai'] );
+	}
+
+	/**
+	 * POST true activates the module; POST false deactivates it.
+	 */
+	public function test_update_settings_toggles_module() {
+		$section = new Jetpack_AI_Section();
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'module_enabled_jetpack_ai', true );
+		$result = $section->api_update_settings( $request );
+		self::assertTrue( $result['module_enabled_jetpack_ai'] );
+		self::assertTrue( Optional_Modules::is_optional_module_active( 'jetpack-ai' ) );
+
+		$request->set_param( 'module_enabled_jetpack_ai', false );
+		$result = $section->api_update_settings( $request );
+		self::assertFalse( $result['module_enabled_jetpack_ai'] );
+		self::assertFalse( Optional_Modules::is_optional_module_active( 'jetpack-ai' ) );
+	}
+
+	/**
+	 * POST with a non-boolean param returns a 400 error.
+	 */
+	public function test_update_settings_rejects_non_boolean() {
+		$section = new Jetpack_AI_Section();
+		$request = new WP_REST_Request();
+		$request->set_param( 'module_enabled_jetpack_ai', 'not-a-bool' );
+		$result = $section->api_update_settings( $request );
+		self::assertInstanceOf( WP_Error::class, $result );
+		self::assertEquals( 400, $result->get_error_data()['status'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/jetpack-ai.php
+++ b/plugins/newspack-plugin/tests/unit-tests/jetpack-ai.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests the Jetpack AI Assistant runtime gate.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Jetpack;
+use Newspack\Optional_Modules;
+
+/**
+ * Tests the Jetpack AI Assistant runtime gate.
+ */
+class Newspack_Test_Jetpack_AI extends WP_UnitTestCase {
+	/**
+	 * Reset settings before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Optional_Modules::OPTION_NAME );
+	}
+
+	/**
+	 * By default (not opted in), the gate disables Jetpack AI.
+	 */
+	public function test_ai_disabled_by_default() {
+		self::assertFalse(
+			Jetpack::maybe_disable_ai_assistant( true ),
+			'Gate returns false when the publisher has not opted in.'
+		);
+		self::assertFalse(
+			apply_filters( 'jetpack_ai_enabled', true ),
+			'jetpack_ai_enabled filters to false by default.'
+		);
+	}
+
+	/**
+	 * When opted in, the gate passes the incoming value through.
+	 */
+	public function test_ai_enabled_when_opted_in() {
+		Optional_Modules::activate_optional_module( 'jetpack-ai' );
+		self::assertTrue(
+			Jetpack::maybe_disable_ai_assistant( true ),
+			'Gate passes through when the publisher has opted in.'
+		);
+		self::assertTrue(
+			apply_filters( 'jetpack_ai_enabled', true ),
+			'jetpack_ai_enabled is unchanged when opted in.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/optional-modules.php
+++ b/plugins/newspack-plugin/tests/unit-tests/optional-modules.php
@@ -32,6 +32,7 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_collections'           => false,
 				'module_enabled_indesign-export'       => false,
 				'module_enabled_nextdoor'              => false,
+				'module_enabled_jetpack-ai'            => false,
 			],
 			'Default settings are as expected.'
 		);
@@ -53,6 +54,7 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_collections'           => false,
 				'module_enabled_indesign-export'       => false,
 				'module_enabled_nextdoor'              => false,
+				'module_enabled_jetpack-ai'            => false,
 			],
 			'Settings is updated.'
 		);
@@ -68,6 +70,7 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_collections'           => true,
 				'module_enabled_indesign-export'       => false,
 				'module_enabled_nextdoor'              => false,
+				'module_enabled_jetpack-ai'            => false,
 			],
 			'Settings is updated.'
 		);
@@ -83,6 +86,7 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_collections'           => true,
 				'module_enabled_indesign-export'       => false,
 				'module_enabled_nextdoor'              => false,
+				'module_enabled_jetpack-ai'            => false,
 			],
 			'A non-existent setting is not saved.'
 		);
@@ -132,6 +136,27 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 			Optional_Modules::is_optional_module_active( 'collections' ),
 			false,
 			'Collections module is deactivated.'
+		);
+
+		// Test Jetpack AI module activation.
+		self::assertEquals(
+			Optional_Modules::is_optional_module_active( 'jetpack-ai' ),
+			false,
+			'Jetpack AI module is not active by default.'
+		);
+
+		Optional_Modules::activate_optional_module( 'jetpack-ai' );
+		self::assertEquals(
+			Optional_Modules::is_optional_module_active( 'jetpack-ai' ),
+			true,
+			'Jetpack AI module is active after being activated.'
+		);
+
+		Optional_Modules::deactivate_optional_module( 'jetpack-ai' );
+		self::assertEquals(
+			Optional_Modules::is_optional_module_active( 'jetpack-ai' ),
+			false,
+			'Jetpack AI module is deactivated.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a **Jetpack AI Assistant** toggle under **Settings → Connections**. Jetpack AI is now **disabled by default across all Newspack sites**; publishers opt in per site via the toggle.

Per the support team's request, the default is off so publications can evaluate Jetpack's AI features deliberately before enabling them. This brings the per-site [`jetpack-ai-assistant-off`](https://github.com/Automattic/newspack-custom-code/tree/trunk/plugins/jetpack-ai-assistant-off) plugin (currently on ~15 sites) into Newspack as a first-class, publisher-controllable setting.

**⚠️ Rollout notes (read before release):**

* **Fleet-wide, no grandfathering:** on update, Jetpack AI turns off for every Newspack site until a publisher opts in.
* **Publisher comms required** — coordinate with support before release.
* **Retire the standalone `jetpack-ai-assistant-off` plugin** on the affected sites (Embarcadero, Colorado Sun, Noisy Creek, Yubanet, Austin Chronicle) — its hard-coded filter would otherwise override this toggle there.
* **Impact review:** no code-level cross-repo coupling — nothing in the ecosystem hooks `jetpack_ai_enabled` or references `Newspack\Jetpack`; the change is additive.

Closes [NPPM-2915: Add a toggleable option to manage Jetpack AI preference](https://linear.app/a8c/issue/NPPM-2915/add-a-toggleable-option-to-manage-jetpack-ai-preference).

### How to test the changes in this Pull Request:

1. On a site with newspack-plugin active, confirm AI is off by default: `wp eval 'var_dump( apply_filters( "jetpack_ai_enabled", true ) );'` → `bool(false)`.
2. Go to **Newspack → Settings → Connections**; confirm a "Jetpack AI Assistant" section with an "Enable Jetpack AI Assistant" toggle, off by default.
3. Toggle it on, reload the page, confirm it persists on.
4. Confirm AI is now enabled: same `wp eval` → `bool(true)`. With a connected Jetpack, the AI Assistant block/features become available in the editor.
5. Toggle off, reload, confirm it persists and the filter returns `bool(false)`.
6. Run `n test-php` — all pass (new tests: `optional-modules.php`, `jetpack-ai.php`, `jetpack-ai-section.php`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
