### PR TITLE
fix(audience): gate Group labels settings behind Content_Gate feature flag

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -116,9 +116,20 @@ class Content_Gate {
 	/**
 	 * Whether the first-party Newspack feature is enabled.
 	 *
+	 * Memoized per request — the underlying constant is immutable for the
+	 * lifetime of a request, and call sites (admin menu, REST registration,
+	 * wizard data, gated callbacks across Group_Subscription_*) consult this
+	 * many times per page. The cache keeps that footprint flat if the check
+	 * grows beyond a constant lookup in the future (license, remote call,
+	 * etc.).
+	 *
 	 * @return bool
 	 */
 	public static function is_newspack_feature_enabled() {
+		static $enabled = null;
+		if ( null !== $enabled ) {
+			return $enabled;
+		}
 		/**
 		 * Enables the content gating feature which allows restricting
 		 * content access based on membership, donations, or other criteria.
@@ -130,7 +141,8 @@ class Content_Gate {
 		 *
 		 * @example define( 'NEWSPACK_CONTENT_GATES', true );
 		 */
-		return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		$enabled = defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		return $enabled;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -123,13 +123,13 @@ class Content_Gate {
 	 * grows beyond a constant lookup in the future (license, remote call,
 	 * etc.).
 	 *
+	 * Tests under PHPUnit boot the plugin once and `define()` the constant
+	 * later in per-suite `setUp()` calls. To keep those defines effective,
+	 * skip the cache when `IS_TEST_ENV` is on.
+	 *
 	 * @return bool
 	 */
 	public static function is_newspack_feature_enabled() {
-		static $enabled = null;
-		if ( null !== $enabled ) {
-			return $enabled;
-		}
 		/**
 		 * Enables the content gating feature which allows restricting
 		 * content access based on membership, donations, or other criteria.
@@ -141,7 +141,13 @@ class Content_Gate {
 		 *
 		 * @example define( 'NEWSPACK_CONTENT_GATES', true );
 		 */
-		$enabled = defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		}
+		static $enabled = null;
+		if ( null === $enabled ) {
+			$enabled = defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		}
 		return $enabled;
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -857,6 +857,9 @@ class Group_Subscription_Settings {
 	 * Register the publisher-configurable group label settings.
 	 */
 	public static function register_label_settings() {
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return;
+		}
 		// Group name is unused (no settings_fields() form); registers sanitize_callback via update_option().
 		\register_setting(
 			'newspack_group_subscription',

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
@@ -114,6 +114,8 @@ class Audience_Wizard extends Wizard {
 			'has_metering'    => Content_Gate::is_metering_enabled( Memberships::GATE_CPT ),
 		];
 
+		$data['is_newspack_feature_enabled'] = Content_Gate::is_newspack_feature_enabled();
+
 		wp_enqueue_script( 'newspack-wizards' );
 
 		wp_localize_script(
@@ -381,34 +383,38 @@ class Audience_Wizard extends Wizard {
 		);
 
 		// Group label settings (publisher-overridable singular/plural for group subscriptions).
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/group-labels',
-			[
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_get_group_labels' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/group-labels',
-			[
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_group_labels' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'label_singular' => [
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
+		// Gated on the Newspack Content Gate feature flag — these endpoints are
+		// only relevant when the group subscriptions / access control feature is on.
+		if ( Content_Gate::is_newspack_feature_enabled() ) {
+			register_rest_route(
+				NEWSPACK_API_NAMESPACE,
+				'/wizard/' . $this->slug . '/group-labels',
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'api_get_group_labels' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+				]
+			);
+			register_rest_route(
+				NEWSPACK_API_NAMESPACE,
+				'/wizard/' . $this->slug . '/group-labels',
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'api_update_group_labels' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+					'args'                => [
+						'label_singular' => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'label_plural'   => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						],
 					],
-					'label_plural'   => [
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-				],
-			]
-		);
+				]
+			);
+		}
 
 		// Cover fees settings.
 		register_rest_route(

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
@@ -383,38 +383,37 @@ class Audience_Wizard extends Wizard {
 		);
 
 		// Group label settings (publisher-overridable singular/plural for group subscriptions).
-		// Gated on the Newspack Content Gate feature flag — these endpoints are
-		// only relevant when the group subscriptions / access control feature is on.
-		if ( Content_Gate::is_newspack_feature_enabled() ) {
-			register_rest_route(
-				NEWSPACK_API_NAMESPACE,
-				'/wizard/' . $this->slug . '/group-labels',
-				[
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $this, 'api_get_group_labels' ],
-					'permission_callback' => [ $this, 'api_permissions_check' ],
-				]
-			);
-			register_rest_route(
-				NEWSPACK_API_NAMESPACE,
-				'/wizard/' . $this->slug . '/group-labels',
-				[
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => [ $this, 'api_update_group_labels' ],
-					'permission_callback' => [ $this, 'api_permissions_check' ],
-					'args'                => [
-						'label_singular' => [
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						],
-						'label_plural'   => [
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						],
+		// The callbacks short-circuit on Content_Gate::is_newspack_feature_enabled() so
+		// stale clients hitting the route after a flag flip get a descriptive error
+		// instead of reading or writing the option directly.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/group-labels',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_group_labels' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/group-labels',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_group_labels' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'label_singular' => [
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
 					],
-				]
-			);
-		}
+					'label_plural'   => [
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
 
 		// Cover fees settings.
 		register_rest_route(
@@ -1057,9 +1056,13 @@ class Audience_Wizard extends Wizard {
 	 * Get the publisher-configurable group subscription labels. Empty values fall back
 	 * to the defaults baked into Group_Subscription::get_label().
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function api_get_group_labels() {
+		$disabled = self::group_labels_feature_disabled_error();
+		if ( $disabled ) {
+			return $disabled;
+		}
 		return rest_ensure_response(
 			[
 				'label_singular'         => (string) get_option( 'newspack_group_subscription_label_singular', '' ),
@@ -1075,9 +1078,13 @@ class Audience_Wizard extends Wizard {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function api_update_group_labels( $request ) {
+		$disabled = self::group_labels_feature_disabled_error();
+		if ( $disabled ) {
+			return $disabled;
+		}
 		$params = $request->get_params();
 		foreach ( [ 'label_singular', 'label_plural' ] as $field ) {
 			if ( ! array_key_exists( $field, $params ) ) {
@@ -1091,6 +1098,23 @@ class Audience_Wizard extends Wizard {
 			}
 		}
 		return $this->api_get_group_labels();
+	}
+
+	/**
+	 * Shared guard for the /group-labels callbacks: returns a 403 WP_Error when
+	 * the Newspack Content Gate feature flag is off, or null when it's on.
+	 *
+	 * @return WP_Error|null
+	 */
+	private static function group_labels_feature_disabled_error() {
+		if ( Content_Gate::is_newspack_feature_enabled() ) {
+			return null;
+		}
+		return new WP_Error(
+			'newspack_content_gate_disabled',
+			__( 'Group subscription label settings are unavailable: the Newspack Content Gate feature is not enabled on this site.', 'newspack-plugin' ),
+			[ 'status' => 403 ]
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
@@ -111,7 +111,9 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 			label: __( 'Checkout & Payment', 'newspack-plugin' ),
 			path: '/payment',
 		},
-		{
+		// "Advanced settings" hosts the Group labels override, which only makes
+		// sense when the Newspack Content Gate / Group subscriptions feature is on.
+		newspackAudience.is_newspack_feature_enabled && {
 			label: __( 'Advanced settings', 'newspack-plugin' ),
 			path: '/groups',
 		},
@@ -163,7 +165,7 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 					<Route path="/" exact render={ () => <Setup { ...props } /> } />
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
-					<Route path="/groups" render={ () => <Groups { ...props } /> } />
+					{ newspackAudience.is_newspack_feature_enabled && <Route path="/groups" render={ () => <Groups { ...props } /> } /> }
 					<Route path="/campaign" render={ () => <Campaign { ...props } /> } />
 					<Route path="/complete" render={ () => <Complete { ...props } /> } />
 					<Redirect to="/" />


### PR DESCRIPTION
## Summary

[#148](https://github.com/Automattic/newspack-workspace/pull/148) introduced a publisher-overridable Group labels override (Audience → Setup → Advanced settings) plus a `/group-labels` REST endpoint and an `admin_init` `register_label_settings` hook. All three were registered unconditionally, so sites with the Newspack group subscriptions / access control feature **off** still see the new "Advanced settings" tab — flagged by @mpeixe on a fresh env in [#newspack-engineering-public](https://a8c.slack.com/archives/C055SRT7WN4/p1781028932123569).

This hotfix wraps every surface that pertains to the new group-labels feature in `Newspack\Content_Gate::is_newspack_feature_enabled()`, matching the gating that the rest of the Group subscription stack (product options, meta box, content gates, premium newsletters, etc.) already uses. It also memoizes the helper so the per-request footprint stays flat as the wizard consults it on every gated surface.

### Changes

- **`includes/wizards/audience/class-audience-wizard.php`**
  - `enqueue_scripts_and_styles()`: expose `is_newspack_feature_enabled` on the `newspackAudience` localized data so the React layer can gate UI off it.
  - `register_api_endpoints()`: the two `/wizard/newspack-audience/group-labels` REST routes register **unconditionally** — gating happens inside the callbacks.
  - `api_get_group_labels()` / `api_update_group_labels()`: short-circuit with a descriptive `403 newspack_content_gate_disabled` `WP_Error` via a shared private helper when the feature is off, so a stale client (or a developer manually hitting the route after a flag flip) gets a clean error rather than a silent 404.
- **`src/wizards/audience/views/setup/index.js`**: conditionally append the "Advanced settings" tab and the `/groups` `<Route>` based on `newspackAudience.is_newspack_feature_enabled`. The tab disappears _and_ direct-nav to `#/groups` falls through to the catch-all redirect when the feature is off.
- **`includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php`**: early-return `register_label_settings()` when the feature is off, mirroring the existing per-callback guards on `add_custom_product_options()`, `add_custom_product_pricing_options()`, and the meta box.
- **`includes/content-gate/class-content-gate.php`**: memoize `Content_Gate::is_newspack_feature_enabled()` with a function-local static cache. The wizard surface consults this helper on every gated call (REST registration, localized data, every `Group_Subscription_*` callback) — the cache keeps that footprint flat if the check ever grows beyond a constant lookup (license, remote call, etc.). The cache is skipped under `IS_TEST_ENV` so PHPUnit suites that `define( 'NEWSPACK_CONTENT_GATES', true )` in `setUp()` still see the new value.

### Scope note

Other Group_Subscription* hooks (`Group_Subscription_MyAccount` endpoints, `admin_post` handlers, `Group_Subscription_Invite` template_redirect handlers) were also re-audited. They predate #148 or are gated through downstream guards (e.g. `Group_Subscription::is_group_subscription()` short-circuits the My Account UI). Bringing them under a uniform `init()`-level guard is a worthwhile cleanup but out of scope for this hotfix.

## Test plan

- [ ] On a fresh env with **Content Gate / Access Control disabled** (default), Audience → Setup shows only Setup, Checkout & Payment — no "Advanced settings" tab. An authenticated REST request to `/newspack/v1/wizard/newspack-audience/group-labels` returns **403** with code `newspack_content_gate_disabled` (rather than a silent 404), and the body explains why.
- [ ] Enable Access Control (`define( 'NEWSPACK_CONTENT_GATES', true );` in `wp-config.php` or however the feature is toggled on this env). Hard refresh Audience → Setup: the "Advanced settings" tab appears, GroupLabels component renders, REST GET/POST round-trip on `/group-labels` works (e.g. POST `{ label_singular: "Cohort", label_plural: "Cohorts" }` → 200, payload echoed back, `get_option( 'newspack_group_subscription_label_singular' )` returns `"Cohort"`).
- [ ] Toggle the feature back off: tab disappears, direct-nav to `#/groups` redirects to `/`. REST routes still register but return the 403 again.
- [ ] As an admin on the unguarded state, browse to `wp-admin/options.php` and confirm `newspack_group_subscription_label_singular` / `_plural` are NOT in `$wp_registered_settings` (settings list does not include them); flip the feature on, reload — they do.
- [ ] `Content_Gate::is_newspack_feature_enabled()` returns the same value on a second call within a single request (memoization). Under PHPUnit (`IS_TEST_ENV` defined), a per-suite `setUp()` that `define()`s `NEWSPACK_CONTENT_GATES` after the plugin has already loaded still takes effect on the next call.
- [ ] PHPCS + ESLint pass (`npm run lint`); PHPUnit passes (`n test-php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
