### PR TITLE
fix(woocommerce): scope payment notice to recoverable statuses

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -18,6 +18,16 @@ class WooCommerce_Update_Payment_Notice {
 	const NOTICE_INTERVAL = 60 * 60 * 24; // 24 hours.
 
 	/**
+	 * Subscription statuses for which the "needs payment" notice is actionable.
+	 * Only states where paying actually restores the subscription. Terminal
+	 * statuses (expired, cancelled, switched) and states where the reader still
+	 * has access (active, pending-cancel) are intentionally excluded. NPPM-2926.
+	 *
+	 * @var string[]
+	 */
+	const NOTICE_SUBSCRIPTION_STATUSES = [ 'on-hold', 'pending' ];
+
+	/**
 	 * Initialize the class.
 	 */
 	public static function init() {
@@ -137,7 +147,10 @@ class WooCommerce_Update_Payment_Notice {
 		$notices = [];
 
 		foreach ( $subscriptions as $subscription ) {
-			if ( 'cancelled' === $subscription->get_status() ) {
+			// Only nag for statuses where paying actually restores the subscription.
+			// Terminal/ended statuses (e.g. expired) can carry a stale unpaid renewal
+			// order that trips needs_payment() with no live payment to resolve. NPPM-2926.
+			if ( ! $subscription->has_status( self::NOTICE_SUBSCRIPTION_STATUSES ) ) {
 				continue;
 			}
 			if ( ! $subscription->needs_payment() ) {

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -23,6 +23,12 @@ class WooCommerce_Update_Payment_Notice {
 	 * statuses (expired, cancelled, switched) and states where the reader still
 	 * has access (active, pending-cancel) are intentionally excluded. NPPM-2926.
 	 *
+	 * Closed set of core WCS statuses. A publisher's custom "recoverable but
+	 * unpaid" status would not match, so readers in it would silently miss the
+	 * notice; both callers fail closed, so the only effect is a missed nudge,
+	 * never a wrong action. Extend this constant (or add a filter) only if such
+	 * a status is found in the field.
+	 *
 	 * @var string[]
 	 */
 	const NOTICE_RECOVERABLE_STATUSES = [ 'on-hold', 'pending' ];

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -25,7 +25,7 @@ class WooCommerce_Update_Payment_Notice {
 	 *
 	 * @var string[]
 	 */
-	const NOTICE_SUBSCRIPTION_STATUSES = [ 'on-hold', 'pending' ];
+	const NOTICE_RECOVERABLE_STATUSES = [ 'on-hold', 'pending' ];
 
 	/**
 	 * Initialize the class.
@@ -147,10 +147,9 @@ class WooCommerce_Update_Payment_Notice {
 		$notices = [];
 
 		foreach ( $subscriptions as $subscription ) {
-			// Only nag for statuses where paying actually restores the subscription.
-			// Terminal/ended statuses (e.g. expired) can carry a stale unpaid renewal
-			// order that trips needs_payment() with no live payment to resolve. NPPM-2926.
-			if ( ! $subscription->has_status( self::NOTICE_SUBSCRIPTION_STATUSES ) ) {
+			// Only nag for statuses where paying can restore the subscription (NPPM-2926);
+			// see NOTICE_RECOVERABLE_STATUSES for why terminal/has-access statuses are excluded.
+			if ( ! $subscription->has_status( self::NOTICE_RECOVERABLE_STATUSES ) ) {
 				continue;
 			}
 			if ( ! $subscription->needs_payment() ) {

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -432,6 +432,12 @@ class WC_Subscription {
 		}
 		return (float) ( $wcs_mock_items_sign_up_fee ?? 0 );
 	}
+	public function needs_payment() {
+		return ! empty( $this->data['needs_payment'] );
+	}
+	public function get_view_order_url() {
+		return $this->data['view_order_url'] ?? 'https://example.test/my-account/view-order/' . $this->get_id();
+	}
 	public function save() {
 		return true;
 	}
@@ -635,6 +641,17 @@ function wcs_get_users_subscriptions( $user_id ) {
 	// subs the user is only a member of). Tests that need ownership semantics
 	// must guard against this just like production code.
 	return apply_filters( 'wcs_get_users_subscriptions', $user_subscriptions, $user_id );
+}
+function wcs_get_subscriptions( $args = [] ) {
+	global $subscriptions_database;
+	$customer_id = $args['customer_id'] ?? null;
+	$matches     = [];
+	foreach ( $subscriptions_database as $id => $subscription ) {
+		if ( null === $customer_id || $subscription->get_customer_id() === $customer_id ) {
+			$matches[ $id ] = $subscription;
+		}
+	}
+	return $matches;
 }
 function wcs_get_canonical_product_id( $item ) {
 	if ( is_object( $item ) && method_exists( $item, 'get_product_id' ) ) {

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -643,6 +643,10 @@ function wcs_get_users_subscriptions( $user_id ) {
 	return apply_filters( 'wcs_get_users_subscriptions', $user_subscriptions, $user_id );
 }
 function wcs_get_subscriptions( $args = [] ) {
+	// Minimal mock: implements only the `customer_id` filter, the sole arg the code
+	// under test passes. If a future test needs status/paging args
+	// (subscription_status, subscriptions_per_page, paged, offset), extend the filter
+	// here rather than relying on this returning the full set.
 	global $subscriptions_database;
 	$customer_id = $args['customer_id'] ?? null;
 	$matches     = [];

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
@@ -166,4 +166,25 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 
 		$this->assertSame( [], $this->get_notices(), 'No notice when the subscription does not need payment.' );
 	}
+
+	/**
+	 * Pin the allowlist against the full set of WCS statuses known at authoring
+	 * time. If WCS adds a status, this fails so a human decides whether it is a
+	 * recoverable (notice-worthy) state rather than silently skipping it. NPPM-2926.
+	 */
+	public function test_allowlist_is_pinned_against_known_wcs_statuses() {
+		$known_wcs_statuses = [ 'pending', 'active', 'on-hold', 'cancelled', 'switched', 'expired', 'pending-cancel' ];
+
+		$reflection = new ReflectionClass( \Newspack\WooCommerce_Update_Payment_Notice::class );
+		$allowlist  = $reflection->getConstant( 'NOTICE_SUBSCRIPTION_STATUSES' );
+
+		$unknown = array_diff( $allowlist, $known_wcs_statuses );
+		$this->assertSame( [], array_values( $unknown ), 'Allowlist contains a status not in the known WCS set.' );
+
+		$this->assertEqualSets(
+			[ 'on-hold', 'pending' ],
+			$allowlist,
+			'Allowlist changed. Confirm any new status is genuinely recoverable before updating this guard.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
@@ -10,6 +10,8 @@ use Newspack\WooCommerce_Update_Payment_Notice;
 require_once __DIR__ . '/../../mocks/wc-mocks.php';
 
 /**
+ * Tests for WooCommerce_Update_Payment_Notice status allowlist logic.
+ *
  * @group update_payment_notice
  */
 class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
@@ -54,13 +56,36 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	 */
 	private function make_line_item( $product_id ) {
 		return new class( $product_id ) {
+			/**
+			 * Product ID this line item refers to.
+			 *
+			 * @var int
+			 */
 			private $product_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $product_id Product ID.
+			 */
 			public function __construct( $product_id ) {
 				$this->product_id = $product_id;
 			}
+
+			/**
+			 * Return the product ID.
+			 *
+			 * @return int
+			 */
 			public function get_product_id() {
 				return $this->product_id;
 			}
+
+			/**
+			 * Return the WC_Product object for this line item.
+			 *
+			 * @return WC_Product|false
+			 */
 			public function get_product() {
 				return wc_get_product( $this->product_id );
 			}
@@ -103,13 +128,20 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Non-recoverable statuses must not produce a payment notice even if needs_payment() is true.
+	 *
 	 * @dataProvider terminal_status_provider
 	 *
 	 * @param string $status Subscription status.
 	 */
 	public function test_no_notice_for_non_recoverable_status( $status ) {
 		$customer_id = $this->make_current_customer();
-		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			] 
+		);
 		$this->make_needs_payment_subscription( $customer_id, $status, $product->get_id() );
 
 		$this->assertSame( [], $this->get_notices(), "Status '$status' must not produce a payment notice." );
@@ -120,7 +152,12 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	 */
 	public function test_no_notice_for_expired_with_stale_unpaid_order() {
 		$customer_id = $this->make_current_customer();
-		$product     = wc_create_mock_product( [ 'id' => 54427, 'name' => 'Newsroom Pro – Monthly' ] );
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 54427,
+				'name' => 'Newsroom Pro – Monthly',
+			] 
+		);
 		// needs_payment() true models the stale unpaid failed-renewal order still attached.
 		$this->make_needs_payment_subscription( $customer_id, 'expired', $product->get_id() );
 
@@ -132,7 +169,12 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	 */
 	public function test_notice_fires_for_on_hold() {
 		$customer_id = $this->make_current_customer();
-		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			] 
+		);
 		$this->make_needs_payment_subscription( $customer_id, 'on-hold', $product->get_id() );
 
 		$notices = $this->get_notices();
@@ -140,9 +182,17 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Newsroom Pro', $notices[0] );
 	}
 
+	/**
+	 * A pending subscription that needs payment fires a notice (regression guard).
+	 */
 	public function test_notice_fires_for_pending() {
 		$customer_id = $this->make_current_customer();
-		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			] 
+		);
 		$this->make_needs_payment_subscription( $customer_id, 'pending', $product->get_id() );
 
 		$this->assertCount( 1, $this->get_notices(), 'A pending subscription that needs payment must produce a notice.' );
@@ -153,7 +203,12 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	 */
 	public function test_no_notice_when_payment_not_needed() {
 		$customer_id = $this->make_current_customer();
-		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			] 
+		);
 		wcs_create_subscription(
 			[
 				'customer_id'   => $customer_id,

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
@@ -117,7 +117,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	 *
 	 * @return array<string,array{0:string}>
 	 */
-	public function terminal_status_provider() {
+	public function non_recoverable_status_provider() {
 		return [
 			'expired'        => [ 'expired' ],
 			'switched'       => [ 'switched' ],
@@ -130,7 +130,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	/**
 	 * Non-recoverable statuses must not produce a payment notice even if needs_payment() is true.
 	 *
-	 * @dataProvider terminal_status_provider
+	 * @dataProvider non_recoverable_status_provider
 	 *
 	 * @param string $status Subscription status.
 	 */
@@ -140,7 +140,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 			[
 				'id'   => 4242,
 				'name' => 'Newsroom Pro',
-			] 
+			]
 		);
 		$this->make_needs_payment_subscription( $customer_id, $status, $product->get_id() );
 
@@ -156,7 +156,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 			[
 				'id'   => 54427,
 				'name' => 'Newsroom Pro – Monthly',
-			] 
+			]
 		);
 		// needs_payment() true models the stale unpaid failed-renewal order still attached.
 		$this->make_needs_payment_subscription( $customer_id, 'expired', $product->get_id() );
@@ -173,7 +173,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 			[
 				'id'   => 4242,
 				'name' => 'Newsroom Pro',
-			] 
+			]
 		);
 		$this->make_needs_payment_subscription( $customer_id, 'on-hold', $product->get_id() );
 
@@ -191,7 +191,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 			[
 				'id'   => 4242,
 				'name' => 'Newsroom Pro',
-			] 
+			]
 		);
 		$this->make_needs_payment_subscription( $customer_id, 'pending', $product->get_id() );
 
@@ -207,7 +207,7 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 			[
 				'id'   => 4242,
 				'name' => 'Newsroom Pro',
-			] 
+			]
 		);
 		wcs_create_subscription(
 			[
@@ -223,15 +223,17 @@ class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Pin the allowlist against the full set of WCS statuses known at authoring
-	 * time. If WCS adds a status, this fails so a human decides whether it is a
-	 * recoverable (notice-worthy) state rather than silently skipping it. NPPM-2926.
+	 * Pin the recoverable-status allowlist to its reviewed value. This does NOT
+	 * auto-detect new WooCommerce Subscriptions statuses — the known set is listed
+	 * here, not queried. It fails when the allowlist itself changes, or gains a
+	 * status outside the known set, forcing a human to confirm a new status is
+	 * genuinely recoverable before it ships. NPPM-2926.
 	 */
 	public function test_allowlist_is_pinned_against_known_wcs_statuses() {
 		$known_wcs_statuses = [ 'pending', 'active', 'on-hold', 'cancelled', 'switched', 'expired', 'pending-cancel' ];
 
 		$reflection = new ReflectionClass( \Newspack\WooCommerce_Update_Payment_Notice::class );
-		$allowlist  = $reflection->getConstant( 'NOTICE_SUBSCRIPTION_STATUSES' );
+		$allowlist  = $reflection->getConstant( 'NOTICE_RECOVERABLE_STATUSES' );
 
 		$unknown = array_diff( $allowlist, $known_wcs_statuses );
 		$this->assertSame( [], array_values( $unknown ), 'Allowlist contains a status not in the known WCS set.' );

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Tests the WooCommerce Update Payment Notice status gate (NPPM-2926, Gap B).
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Update_Payment_Notice;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * @group update_payment_notice
+ */
+class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
+	/**
+	 * Reset the mock subscription registry before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database, $orders_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$orders_database        = [];
+	}
+
+	/**
+	 * Call the private get_notices() via reflection.
+	 *
+	 * @return string[]
+	 */
+	private function get_notices() {
+		$method = new ReflectionMethod( WooCommerce_Update_Payment_Notice::class, 'get_notices' );
+		$method->setAccessible( true );
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Register a logged-in customer and return its ID.
+	 *
+	 * @return int
+	 */
+	private function make_current_customer() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Build a minimal line item exposing the methods the notice path uses.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return object
+	 */
+	private function make_line_item( $product_id ) {
+		return new class( $product_id ) {
+			private $product_id;
+			public function __construct( $product_id ) {
+				$this->product_id = $product_id;
+			}
+			public function get_product_id() {
+				return $this->product_id;
+			}
+			public function get_product() {
+				return wc_get_product( $this->product_id );
+			}
+		};
+	}
+
+	/**
+	 * Register a subscription that needs payment, owned by the current customer.
+	 *
+	 * @param int    $customer_id Customer ID.
+	 * @param string $status      Subscription status.
+	 * @param int    $product_id  Product ID granted by the subscription.
+	 * @return WC_Subscription
+	 */
+	private function make_needs_payment_subscription( $customer_id, $status, $product_id ) {
+		return wcs_create_subscription(
+			[
+				'customer_id'   => $customer_id,
+				'status'        => $status,
+				'needs_payment' => true,
+				'products'      => [ $product_id ],
+				'items'         => [ $this->make_line_item( $product_id ) ],
+			]
+		);
+	}
+
+	/**
+	 * Statuses that must NOT produce a notice even when needs_payment() is true.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function terminal_status_provider() {
+		return [
+			'expired'        => [ 'expired' ],
+			'switched'       => [ 'switched' ],
+			'active'         => [ 'active' ],
+			'pending-cancel' => [ 'pending-cancel' ],
+			'cancelled'      => [ 'cancelled' ],
+		];
+	}
+
+	/**
+	 * @dataProvider terminal_status_provider
+	 *
+	 * @param string $status Subscription status.
+	 */
+	public function test_no_notice_for_non_recoverable_status( $status ) {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$this->make_needs_payment_subscription( $customer_id, $status, $product->get_id() );
+
+		$this->assertSame( [], $this->get_notices(), "Status '$status' must not produce a payment notice." );
+	}
+
+	/**
+	 * The documented incident: an expired subscription with a stale unpaid renewal order.
+	 */
+	public function test_no_notice_for_expired_with_stale_unpaid_order() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product( [ 'id' => 54427, 'name' => 'Newsroom Pro – Monthly' ] );
+		// needs_payment() true models the stale unpaid failed-renewal order still attached.
+		$this->make_needs_payment_subscription( $customer_id, 'expired', $product->get_id() );
+
+		$this->assertSame( [], $this->get_notices(), 'An expired subscription with a stale unpaid order must not nag.' );
+	}
+
+	/**
+	 * Recoverable statuses still fire (regression guard).
+	 */
+	public function test_notice_fires_for_on_hold() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$this->make_needs_payment_subscription( $customer_id, 'on-hold', $product->get_id() );
+
+		$notices = $this->get_notices();
+		$this->assertCount( 1, $notices, 'An on-hold subscription that needs payment must produce a notice.' );
+		$this->assertStringContainsString( 'Newsroom Pro', $notices[0] );
+	}
+
+	public function test_notice_fires_for_pending() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		$this->make_needs_payment_subscription( $customer_id, 'pending', $product->get_id() );
+
+		$this->assertCount( 1, $this->get_notices(), 'A pending subscription that needs payment must produce a notice.' );
+	}
+
+	/**
+	 * A recoverable status that does NOT need payment produces nothing.
+	 */
+	public function test_no_notice_when_payment_not_needed() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product( [ 'id' => 4242, 'name' => 'Newsroom Pro' ] );
+		wcs_create_subscription(
+			[
+				'customer_id'   => $customer_id,
+				'status'        => 'on-hold',
+				'needs_payment' => false,
+				'products'      => [ $product->get_id() ],
+				'items'         => [ $this->make_line_item( $product->get_id() ) ],
+			]
+		);
+
+		$this->assertSame( [], $this->get_notices(), 'No notice when the subscription does not need payment.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Users continued to see the My Account / snackbar **"Your '…' subscription is not active. Please update your payment method."** notice following previous efforts to limit where it appeared.  

This PR further limits that notice to subscriptions in a status where paying can actually restore them — `on-hold` (failed renewal) and `pending` (awaiting initial payment).

Previously we skipped only `cancelled` items and otherwise trusted `needs_payment()`. An **expired** (or otherwise terminal) subscription that still carries a stale, unpaid failed-renewal order trips `needs_payment()`, so finished subscriptions kept firing a notice the reader had no way to resolve — telling active subscribers they were "not active."

This replaces the `cancelled`-only skip with an explicit recoverable-status allowlist. `expired` / `cancelled` / `switched` (terminal) and `active` / `pending-cancel` (reader still has access) are intentionally excluded. A guard test pins the allowlist against the known WooCommerce Subscriptions status set so any future/custom status surfaces for a human decision rather than being silently skipped.

**Scope:** This is a **hotfix** that fully resolves the reported incident. A broader preventative adjustment that will suppress the notice when an active subscription grants the *same membership* through a *different product* (the "same product was too narrow" follow-up) will ship separately on our typical release cadence and is **not** included here.

Closes [NPPM-2926: Update Payment Notice still fires for subscribers holding both active and expired subscriptions](https://linear.app/a8c/issue/NPPM-2926/update-payment-notice-still-fires-for-subscribers-holding-both-active).

### How to test the changes in this Pull Request:

1. On a site with WooCommerce Subscriptions, take a reader who has both (a) an **active** subscription and (b) an **expired** subscription that still has an unpaid failed-renewal order (the newsroom.co.nz repro: expired sub #190664). Before this change, browsing the front end / My Account shows the "subscription is not active / update your payment method" notice.
2. With this change applied, log in as (or impersonate) that reader and browse the front end and the My Account page → **no notice** appears.
3. Confirm a genuinely recoverable subscription still nags: put a subscription `on-hold` with a payment due → the notice **does** appear with an "update your payment method" link.
4. Confirm `pending` (initial payment not completed) also still shows the notice.
5. Automated: from `plugins/newspack-plugin`, run `n test-php --group update_payment_notice` → **OK (10 tests)**. The suite covers each excluded status (incl. the expired-with-stale-order incident), the `on-hold`/`pending` fire paths, the not-needs-payment case, and the allowlist-vs-WCS-status-registry guard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

---

Cross-publisher impact was reviewed (reader-revenue / third-party-integrations surface): no Newspack repo references this class, the new constant, or the touched filter; the change only ever *narrows* when the notice shows, so there is no silent-breakage vector. Production diff is one new constant plus the allowlist gate; the rest is tests + test mocks.
