### PR TITLE
chore(release): back-merge release into main (post-release recovery)

### DIFF
--- a/plugins/newspack-network/CHANGELOG.md
+++ b/plugins/newspack-network/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-network [2.20.3](https://github.com/Automattic/newspack-workspace/compare/newspack-network@2.20.2...newspack-network@2.20.3) (2026-06-11)
+
+
+### Bug Fixes
+
+* **network:** preserve node future schedule on origin publish re-sync ([#222](https://github.com/Automattic/newspack-workspace/issues/222)) ([888b5d8](https://github.com/Automattic/newspack-workspace/commit/888b5d82f2dd2fdf9a989d0017fdc9be69208f61))
+
 ## newspack-network [2.20.2](https://github.com/Automattic/newspack-workspace/compare/newspack-network@2.20.1...newspack-network@2.20.2) (2026-06-01)
 
 

--- a/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
@@ -722,6 +722,36 @@ class Incoming_Post {
 				$postarr['post_status'] = $post_data['post_status'];
 			}
 
+			/**
+			 * Preserve a node's local future schedule.
+			 *
+			 * If the linked node post has been locally scheduled (`future`) and
+			 * the origin re-syncs an edit while still `publish`, do not let the
+			 * sync overwrite the node's schedule. Overwriting `post_date_gmt`
+			 * with the origin's (past) date trips WP core's future-with-past-date
+			 * check and auto-publishes the node post ahead of its intended time,
+			 * while the public permalink keeps the future local `post_date`.
+			 * Content/title/taxonomy/meta still flow.
+			 *
+			 * Scoped to incoming `publish` only: origin-side removal or
+			 * unpublishing (`trash`/`draft`/`pending`/`private`) still propagates
+			 * so a retracted story doesn't stay scheduled to publish on the node.
+			 *
+			 * A node's local schedule deliberately takes precedence over any
+			 * `status_on_publish` hold applied above: manually scheduling the
+			 * node post is the more recent, explicit editor intent.
+			 */
+			if (
+				! $is_new_post
+				&& $this->post instanceof WP_Post
+				&& 'future' === $this->post->post_status
+				&& 'publish' === $post_data['post_status']
+			) {
+				$postarr['post_status']   = 'future';
+				$postarr['post_date']     = $this->post->post_date;
+				$postarr['post_date_gmt'] = $this->post->post_date_gmt;
+			}
+
 			$postarr['post_author'] = 0;
 			if ( ! empty( $post_data['author'] ) ) {
 				$post_author = self::get_incoming_wp_user_author( $this->get_original_site_url(), $post_data['author'] );

--- a/plugins/newspack-network/newspack-network.php
+++ b/plugins/newspack-network/newspack-network.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Network
  * Description: The Newspack Network plugin.
- * Version: 2.20.2
+ * Version: 2.20.3
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL3

--- a/plugins/newspack-network/package.json
+++ b/plugins/newspack-network/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-network",
-	"version": "2.20.2",
+	"version": "2.20.3",
 	"description": "The Newspack Network plugin.",
 	"license": "GPL-2.0-or-later",
 	"repository": {

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -387,6 +387,102 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPM-2871: An origin `publish` re-sync must not unschedule a node post
+	 * that has been locally rescheduled to `future`. Content still flows.
+	 */
+	public function test_origin_publish_preserves_node_future_schedule() {
+		// Linked post arrives and is created (sample payload is post_status=publish, status_on_publish=draft → draft).
+		$post_id = $this->incoming_post->insert();
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+
+		// Node editor reschedules locally to a future date.
+		$future_gmt = '2099-12-31 10:16:00';
+		wp_update_post(
+			[
+				'ID'            => $post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_gmt,
+				'post_date_gmt' => $future_gmt,
+			]
+		);
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+
+		// Origin edits and re-syncs as `publish` with its own (past) date_gmt.
+		$payload = $this->get_sample_payload();
+		$payload['post_data']['post_status'] = 'publish';
+		$payload['post_data']['title']       = 'Edited By Origin';
+		$payload['post_data']['date_gmt']    = '2021-01-01 00:00:00';
+		$this->incoming_post->insert( $payload );
+
+		// Node schedule must be preserved (status + both date fields coherent).
+		$this->assertSame( 'future', get_post_status( $post_id ), 'Node post must stay scheduled.' );
+		$this->assertSame( $future_gmt, get_post_field( 'post_date_gmt', $post_id ), 'Node GMT date must be preserved.' );
+		$this->assertSame( $future_gmt, get_post_field( 'post_date', $post_id ), 'Node local date must be preserved.' );
+
+		// Content still flows through.
+		$this->assertSame( 'Edited By Origin', get_the_title( $post_id ) );
+	}
+
+	/**
+	 * NPPM-2871: The future-schedule guard is scoped to incoming `publish`.
+	 * An origin-side removal (`trash`) must still propagate to a locally
+	 * scheduled node post — a retracted story must not stay scheduled.
+	 */
+	public function test_origin_trash_still_propagates_to_scheduled_node() {
+		$post_id = $this->incoming_post->insert();
+
+		// Node editor reschedules locally to a future date.
+		$future_gmt = '2099-12-31 10:16:00';
+		wp_update_post(
+			[
+				'ID'            => $post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_gmt,
+				'post_date_gmt' => $future_gmt,
+			]
+		);
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+
+		// Origin trashes the story.
+		$payload = $this->get_sample_payload();
+		$payload['post_data']['post_status'] = 'trash';
+		$this->incoming_post->insert( $payload );
+
+		// Removal propagates despite the local schedule.
+		$this->assertSame( 'trash', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * NPPM-2871: An origin-side unpublish to `draft` must also reach a locally
+	 * scheduled node post. `draft` takes a different WP path than `trash`
+	 * (a `future`→`draft` transition through `wp_update_post`), so cover it
+	 * explicitly to lock the guard's `publish`-only scope.
+	 */
+	public function test_origin_draft_unpublish_propagates_to_scheduled_node() {
+		$post_id = $this->incoming_post->insert();
+
+		// Node editor reschedules locally to a future date.
+		$future_gmt = '2099-12-31 10:16:00';
+		wp_update_post(
+			[
+				'ID'            => $post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_gmt,
+				'post_date_gmt' => $future_gmt,
+			]
+		);
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+
+		// Origin unpublishes the story back to draft.
+		$payload = $this->get_sample_payload();
+		$payload['post_data']['post_status'] = 'draft';
+		$this->incoming_post->insert( $payload );
+
+		// Unpublish propagates despite the local schedule.
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+	}
+
+	/**
 	 * Test delete.
 	 */
 	public function test_delete() {

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.42.7](https://github.com/Automattic/newspack-workspace/compare/newspack@6.42.6...newspack@6.42.7) (2026-06-11)
+
+
+### Bug Fixes
+
+* **co-authors-plus:** dedup count_user_posts for linked guest authors ([#149](https://github.com/Automattic/newspack-workspace/issues/149)) ([3e577bf](https://github.com/Automattic/newspack-workspace/commit/3e577bff6b1a92277d42a8afb3085e803f8b1503))
+
 ## newspack [6.42.6](https://github.com/Automattic/newspack-workspace/compare/newspack@6.42.5...newspack@6.42.6) (2026-06-09)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.42.6](https://github.com/Automattic/newspack-workspace/compare/newspack@6.42.5...newspack@6.42.6) (2026-06-09)
+
+
+### Bug Fixes
+
+* **access-control:** make email domain matching case-insensitive ([#255](https://github.com/Automattic/newspack-workspace/issues/255)) ([c410158](https://github.com/Automattic/newspack-workspace/commit/c4101587227801514f4e078652876677e5bde7b8))
+
 ## newspack [6.42.5](https://github.com/Automattic/newspack-workspace/compare/newspack@6.42.4...newspack@6.42.5) (2026-06-09)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.42.5](https://github.com/Automattic/newspack-workspace/compare/newspack@6.42.4...newspack@6.42.5) (2026-06-09)
+
+
+### Bug Fixes
+
+* **access-control:** populate GA4 group metadata for anonymous readers ([#254](https://github.com/Automattic/newspack-workspace/issues/254)) ([b7adf8f](https://github.com/Automattic/newspack-workspace/commit/b7adf8f0ecc3fbe8660e0c2125c419331d0dc8c5))
+
 ## newspack [6.42.4](https://github.com/Automattic/newspack-workspace/compare/newspack@6.42.3...newspack@6.42.4) (2026-06-04)
 
 

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -229,6 +229,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change-ui.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-co-authors-plus-rss-feed.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-co-authors-plus-count-user-posts-fix.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-complianz.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -426,6 +426,7 @@ class Access_Rules {
 		$domains = str_replace( PHP_EOL, ',', $domains );
 		$domains = explode( ',', $domains );
 		$domains = array_map( 'trim', $domains );
+		$domains = array_map( 'strtolower', $domains );
 		$user    = \get_userdata( $user_id );
 		if ( ! $user ) {
 			return false;
@@ -437,7 +438,7 @@ class Access_Rules {
 		if ( Reader_Activation::is_reader_verified( $user ) === false ) {
 			return false;
 		}
-		$email_domain = substr( $email, strrpos( $email, '@' ) + 1 );
+		$email_domain = strtolower( substr( $email, strrpos( $email, '@' ) + 1 ) );
 		return in_array( $email_domain, $domains, true );
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-co-authors-plus-count-user-posts-fix.php
+++ b/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-co-authors-plus-count-user-posts-fix.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Co-Authors Plus count_user_posts dedup integration.
+ *
+ * CAP's filter_count_user_posts adds a user's own post_author count to the
+ * count of posts attached to a linked guest author's taxonomy term without
+ * deduplication. On sites where the editorial workflow tags the same posts
+ * with both attribution paths (e.g. MinnPost), this inflates the wp-admin
+ * Users-list "Posts" column.
+ *
+ * This filter recomputes count_user_posts as COUNT(DISTINCT) over the union
+ * of (post_author = user) and (attached to GA term), so the same post is
+ * counted once regardless of how it's attributed.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deduplicates count_user_posts for WP users linked to a CAP guest author.
+ */
+class Co_Authors_Plus_Count_User_Posts_Fix {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		// Priority 11 runs after CAP's own filter_count_user_posts at priority 10.
+		add_filter( 'get_usernumposts', [ __CLASS__, 'dedup_linked_author_count' ], 11, 4 );
+	}
+
+	/**
+	 * Replace the count CAP produced with a deduplicated union count.
+	 *
+	 * @param int|string      $count       The count value from previous filters (CAP at priority 10).
+	 * @param int             $user_id     The user ID.
+	 * @param string|string[] $post_type   The post type(s) to count. WP's count_user_posts accepts
+	 *                                     a string or an array; the WP_Query 'any' sentinel is honored.
+	 * @param bool            $public_only Whether to restrict the count to public-status posts.
+	 * @return int|string The deduplicated count, or the original $count if no linked GA.
+	 */
+	public static function dedup_linked_author_count( $count, $user_id, $post_type, $public_only ) {
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			return $count;
+		}
+
+		$ga_term_taxonomy_ids = self::get_linked_guest_author_term_taxonomy_ids( $user->user_login );
+		if ( empty( $ga_term_taxonomy_ids ) ) {
+			return $count;
+		}
+
+		return self::count_distinct_attributed_posts( $count, $user_id, $ga_term_taxonomy_ids, $post_type, (bool) $public_only );
+	}
+
+	/**
+	 * Find every author term_taxonomy_id belonging to guest authors whose
+	 * `cap-linked_account` meta matches the given user_login.
+	 *
+	 * CAP's data model treats this as a 1:1 link, but data corruption, manual
+	 * term edits, or in-progress migrations can leave a user pointed at by more
+	 * than one GA (and a GA can carry more than one author term). Collecting
+	 * all of them prevents silent undercount in the dedup query.
+	 *
+	 * @param string $user_login The WP user's user_login value.
+	 * @return int[] Unique term_taxonomy_ids across all linked GAs (empty if none).
+	 */
+	private static function get_linked_guest_author_term_taxonomy_ids( $user_login ) {
+		if ( ! post_type_exists( 'guest-author' ) || ! taxonomy_exists( 'author' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		// Find every GA CPT post whose cap-linked_account meta matches the user's login.
+		// SELECT DISTINCT guards against duplicate cap-linked_account meta rows on a single
+		// GA post returning the same ID twice, which would cause redundant term lookups below.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery -- WP_Query + meta_query would be markedly slower; this fires per count_user_posts call.
+		$ga_post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = 'cap-linked_account'
+				WHERE p.post_type = 'guest-author'
+				AND p.post_status != 'trash'
+				AND pm.meta_value = %s",
+				$user_login
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery
+
+		if ( empty( $ga_post_ids ) ) {
+			return [];
+		}
+
+		$tt_ids = [];
+		foreach ( $ga_post_ids as $ga_post_id ) {
+			$terms = wp_get_object_terms( (int) $ga_post_id, 'author', [ 'fields' => 'tt_ids' ] );
+			if ( is_wp_error( $terms ) ) {
+				continue;
+			}
+			foreach ( $terms as $tt_id ) {
+				$tt_ids[] = (int) $tt_id;
+			}
+		}
+
+		return array_values( array_unique( $tt_ids ) );
+	}
+
+	/**
+	 * Run a COUNT(DISTINCT) over the union of (post_author = user) and
+	 * (attached to any of the GA's author terms), honoring post type and
+	 * public-only filters.
+	 *
+	 * @param int|string      $count                 The upstream count, returned cast to int when no post types resolve.
+	 * @param int             $user_id               The user ID.
+	 * @param int[]           $ga_term_taxonomy_ids  Author term_taxonomy_ids for all linked GAs.
+	 * @param string|string[] $post_type             The post type(s) to count (WP's count_user_posts accepts either).
+	 * @param bool            $public_only           Restrict to public-status posts.
+	 * @return int The deduplicated count.
+	 */
+	private static function count_distinct_attributed_posts( $count, $user_id, $ga_term_taxonomy_ids, $post_type, $public_only ) {
+		global $wpdb;
+
+		$types = self::resolve_post_types( $post_type );
+		// Guard: an empty post-type set (e.g. a publisher filtering
+		// `coauthors_count_published_post_types` down to []) would build a
+		// malformed `post_type IN ()`. Fall back to the upstream count rather
+		// than running a broken query and silently returning 0.
+		if ( empty( $types ) ) {
+			return (int) $count;
+		}
+
+		$statuses            = self::resolve_post_statuses( $public_only, $types );
+		$tt_placeholders     = implode( ',', array_fill( 0, count( $ga_term_taxonomy_ids ), '%d' ) );
+		$type_placeholders   = implode( ',', array_fill( 0, count( $types ), '%s' ) );
+		$status_placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$prepare_args        = array_merge( $ga_term_taxonomy_ids, $types, $statuses, [ $user_id ] );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $tt_placeholders / $type_placeholders / $status_placeholders are %d/%s-only fragments built from count() of the resolved arrays; the actual values flow through prepare() in $prepare_args. Direct query needed for COUNT(DISTINCT) over the union (loses index-friendly form as WP_Query meta/tax_query).
+		$count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p
+				LEFT JOIN {$wpdb->term_relationships} tr
+					ON tr.object_id = p.ID AND tr.term_taxonomy_id IN ({$tt_placeholders})
+				WHERE p.post_type IN ({$type_placeholders})
+				AND p.post_status IN ({$status_placeholders})
+				AND ( p.post_author = %d OR tr.object_id IS NOT NULL )",
+				$prepare_args
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return (int) $count;
+	}
+
+	/**
+	 * Resolve the post statuses to count over, matching CAP's `get_post_count_for_author_term`
+	 * and WP core's `count_user_posts` behavior: `publish` only when restricted to public,
+	 * `publish` + `private` otherwise — but `private` is only included when the current viewer
+	 * may actually read private posts, mirroring WP core's `get_posts_by_author_sql()` gate.
+	 * Notably excludes drafts, pending, trash, auto-draft, and other transient/internal statuses
+	 * that would inflate the count over time.
+	 *
+	 * @param bool     $public_only Restrict to public statuses when true.
+	 * @param string[] $types       Resolved post types, used to gate the private-status capability.
+	 * @return string[] Post status names.
+	 */
+	private static function resolve_post_statuses( $public_only, $types ) {
+		if ( $public_only ) {
+			return [ 'publish' ];
+		}
+		return self::viewer_can_read_private_posts( $types )
+			? [ 'publish', 'private' ]
+			: [ 'publish' ];
+	}
+
+	/**
+	 * Whether the current viewer may read private posts for every resolved post type.
+	 *
+	 * Mirrors WP core's `get_posts_by_author_sql()` capability gate so a low-cap or
+	 * unauthenticated viewer (e.g. the public REST `users` endpoint) never sees a
+	 * private-inflated count. Conservative by design: `private` is counted only when
+	 * the viewer can read private posts for ALL resolved types — for the common
+	 * single-`post` case this is identical to core. Core's narrower "own private posts
+	 * when logged in" branch is intentionally not replicated; this filter only runs for
+	 * linked-guest-author users, where that edge does not meaningfully apply.
+	 *
+	 * @param string[] $types Resolved post type names.
+	 * @return bool True if the viewer can read private posts for every type.
+	 */
+	private static function viewer_can_read_private_posts( $types ) {
+		foreach ( $types as $type ) {
+			$post_type_object = get_post_type_object( $type );
+			if ( ! $post_type_object || ! current_user_can( $post_type_object->cap->read_private_posts ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Resolve the post types to count over, mirroring the upstream behaviors this filter
+	 * runs after:
+	 *
+	 * - WP_Query's `'any'` sentinel expands to every post type whose `exclude_from_search`
+	 *   is `false`. Without this, `IN ('any')` would match zero rows — a real regression
+	 *   for callers like newspack-blocks' Author List controller which passes `['any']`.
+	 * - When the default `'post'` is passed (string or `['post']`), CAP's
+	 *   `coauthors_count_published_post_types` filter lets publishers expand the set
+	 *   (e.g. include `newsletter`). CAP applies this at priority 10; we mirror it here
+	 *   so the dedup'd count matches the surface area CAP counted.
+	 *
+	 * @param string|string[] $post_type The post type argument passed to count_user_posts.
+	 * @return string[] Resolved list of post type names.
+	 */
+	private static function resolve_post_types( $post_type ) {
+		if ( 'any' === $post_type || ( is_array( $post_type ) && in_array( 'any', $post_type, true ) ) ) {
+			return array_values( get_post_types( [ 'exclude_from_search' => false ], 'names' ) );
+		}
+
+		$is_default = ( 'post' === $post_type || ( is_array( $post_type ) && [ 'post' ] === $post_type ) );
+		if ( $is_default ) {
+			return (array) apply_filters( 'coauthors_count_published_post_types', [ 'post' ] );
+		}
+
+		return is_array( $post_type ) ? $post_type : [ $post_type ];
+	}
+}
+Co_Authors_Plus_Count_User_Posts_Fix::init();

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -297,22 +297,22 @@ class GoogleSiteKit {
 	 * @return string[] Sorted, deduplicated anonymized labels.
 	 */
 	private static function get_user_group_labels( $user ) {
+		$labels = [];
+		// Non-logged-in users can still match institutions via IP-based access rules.
+		foreach ( Institution::get_matching_ids_for_user( $user->ID ?? 0 ) as $inst_id ) {
+			$labels[] = 'Institution ' . $inst_id;
+		}
 		if ( ! $user || ! $user->ID ) {
-			return [];
+			return $labels;
 		}
 		// Match the framing of the surrounding params (`is_reader`, `is_subscriber`):
 		// only attribute groups to actual readers, not admins/editors.
 		if ( ! Reader_Activation::is_user_reader( $user ) ) {
-			return [];
+			return $labels;
 		}
 		$user_id = (int) $user->ID;
-
-		$labels = [];
 		foreach ( Group_Subscription::get_group_ids_for_user( $user_id ) as $sub_id ) {
 			$labels[] = 'Group ' . $sub_id;
-		}
-		foreach ( Institution::get_matching_ids_for_user( $user_id ) as $inst_id ) {
-			$labels[] = 'Institution ' . $inst_id;
 		}
 		sort( $labels, SORT_NATURAL | SORT_FLAG_CASE );
 		return $labels;

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.42.6
+ * Version: 6.42.7
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.42.6' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.42.7' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.42.4
+ * Version: 6.42.5
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.42.4' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.42.5' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.42.5
+ * Version: 6.42.6
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.42.5' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.42.6' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.42.5",
+	"version": "6.42.6",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.42.4",
+	"version": "6.42.5",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.42.6",
+	"version": "6.42.7",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -262,6 +262,25 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test user passing email domain rule with case insensitivity.
+	 */
+	public function test_email_domain_pass_case_insensitive() {
+		$rules = [
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'Example.com',
+				],
+			],
+		];
+		$this->create_gate_with_rules( 'Domain Gate', $rules );
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'User with matching domain but non-matching case should have access.' );
+	}
+
+	/**
 	 * Test user failing email domain rule.
 	 */
 	public function test_email_domain_fail() {

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/co-authors-plus-count-user-posts-fix.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/co-authors-plus-count-user-posts-fix.php
@@ -1,0 +1,537 @@
+<?php
+/**
+ * Tests for the Co_Authors_Plus_Count_User_Posts_Fix integration.
+ *
+ * The integration filters get_usernumposts so that a WP user with a linked
+ * Co-Authors Plus guest author is credited with the count of distinct posts
+ * across (post_author = user) UNION (attached to the GA's author term), rather
+ * than CAP's default behavior of summing the two without deduplication.
+ *
+ * @package Newspack\Tests
+ */
+
+/**
+ * Tests the CAP count_user_posts dedup filter.
+ */
+class Newspack_Test_CAP_Count_User_Posts_Fix extends WP_UnitTestCase {
+
+	/**
+	 * Register the CAP-owned post type and taxonomy before each test.
+	 *
+	 * CAP isn't loaded in the test environment, so we register just enough
+	 * of its data model for the filter to exercise its lookups.
+	 */
+	public function set_up() {
+		parent::set_up();
+		register_post_type(
+			'guest-author',
+			[
+				'public'   => false,
+				'supports' => [ 'title' ],
+			]
+		);
+		register_taxonomy( 'author', 'post', [ 'public' => false ] );
+	}
+
+	/**
+	 * Tear down the CAP-owned post type and taxonomy after each test.
+	 */
+	public function tear_down() {
+		// Several tests set the current user to exercise the read_private_posts
+		// gate; reset to 0 so viewer state can't leak into later tests.
+		wp_set_current_user( 0 );
+		unregister_taxonomy( 'author' );
+		unregister_post_type( 'guest-author' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a guest author CPT linked to a WP user and return its IDs.
+	 *
+	 * @param string $user_login The WP user's user_login value to link.
+	 * @return array { 'ga_id' => int, 'term_id' => int }
+	 */
+	private function create_linked_ga( $user_login ) {
+		$ga_id = self::factory()->post->create(
+			[
+				'post_type'   => 'guest-author',
+				'post_status' => 'publish',
+				'post_title'  => 'Guest ' . $user_login,
+			]
+		);
+		update_post_meta( $ga_id, 'cap-linked_account', $user_login );
+		update_post_meta( $ga_id, 'cap-user_login', $user_login );
+
+		$term = wp_insert_term( 'cap-' . $user_login, 'author', [ 'slug' => 'cap-' . $user_login ] );
+		wp_set_object_terms( $ga_id, [ $term['term_id'] ], 'author' );
+
+		return [
+			'ga_id'   => $ga_id,
+			'term_id' => (int) $term['term_id'],
+		];
+	}
+
+	/**
+	 * Create a published post authored by a given user, optionally attached
+	 * to an author term. Returns the post ID.
+	 *
+	 * @param int      $author_id The post_author user ID.
+	 * @param int|null $term_id   Optional author term ID to attach.
+	 * @return int
+	 */
+	private function create_authored_post( $author_id, $term_id = null ) {
+		$post_id = self::factory()->post->create(
+			[
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			]
+		);
+		if ( $term_id ) {
+			wp_set_object_terms( $post_id, [ $term_id ], 'author' );
+		}
+		return $post_id;
+	}
+
+	/**
+	 * Mirrors the MinnPost scenario: user's own post_author posts are 100%
+	 * overlapped with posts attributed via the linked GA's author term.
+	 * Without the fix, CAP returns (post_author count + GA term count) with
+	 * no deduplication.
+	 */
+	public function test_dedups_count_with_full_overlap() {
+		$user_id       = self::factory()->user->create( [ 'user_login' => 'testauthor1' ] );
+		$other_user_id = self::factory()->user->create();
+		$ga            = $this->create_linked_ga( 'testauthor1' );
+
+		// 3 posts authored by the user, all tagged with the GA term.
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		// 2 posts authored by other staff, attached to the same GA term
+		// (typical CAP editorial workflow where staff publishes under the columnist's byline).
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $other_user_id, $ga['term_id'] );
+		}
+
+		// Distinct posts attributed to the user: 3 own + 2 via GA term = 5.
+		$this->assertEquals( 5, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * When the user has post_author posts that are NOT all tagged with the GA
+	 * term, the dedup'd count is the union (user's posts plus GA-term posts
+	 * authored by others), not a simple sum.
+	 */
+	public function test_dedups_count_with_partial_overlap() {
+		$user_id       = self::factory()->user->create( [ 'user_login' => 'partial' ] );
+		$other_user_id = self::factory()->user->create();
+		$ga            = $this->create_linked_ga( 'partial' );
+
+		// 3 user-authored posts; only 1 carries the GA term.
+		$user_posts = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$user_posts[] = $this->create_authored_post( $user_id );
+		}
+		wp_set_object_terms( $user_posts[0], [ $ga['term_id'] ], 'author' );
+
+		// 4 other-authored posts attached to the GA term.
+		for ( $i = 0; $i < 4; $i++ ) {
+			$this->create_authored_post( $other_user_id, $ga['term_id'] );
+		}
+
+		// Union: 3 (user's own) + 4 (others via GA term) = 7. The 1 overlap is naturally dedup'd.
+		$this->assertEquals( 7, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * No linked guest author → the filter must no-op and return WP's default count.
+	 */
+	public function test_returns_original_count_when_no_linked_ga() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'unlinked' ] );
+		for ( $i = 0; $i < 4; $i++ ) {
+			$this->create_authored_post( $user_id );
+		}
+		$this->assertEquals( 4, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * A GA exists with a different linked_account → not this user's GA.
+	 * Filter must no-op.
+	 */
+	public function test_no_op_when_ga_links_to_different_user() {
+		$user_id        = self::factory()->user->create( [ 'user_login' => 'notlinked' ] );
+		$linked_user_id = self::factory()->user->create( [ 'user_login' => 'isLinked' ] );
+
+		// GA links to a different user.
+		$ga = $this->create_linked_ga( 'isLinked' );
+
+		// notlinked has 2 posts of their own; not attached to the other user's GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id );
+		}
+		// linkedUser has 3 posts attached to their GA term.
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->create_authored_post( $linked_user_id, $ga['term_id'] );
+		}
+
+		// The filter must NOT pull in the other user's GA-term posts for this user.
+		$this->assertEquals( 2, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * A linked GA exists but the GA term is attached to no posts other than the
+	 * GA CPT itself. Result is just the user's own post_author count.
+	 */
+	public function test_returns_user_post_count_when_ga_term_empty() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'lonely' ] );
+		$this->create_linked_ga( 'lonely' );
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->create_authored_post( $user_id );
+		}
+
+		$this->assertEquals( 5, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * Respects the $public_only param — non-published posts excluded when true.
+	 */
+	public function test_respects_public_only_filter() {
+		$user_id       = self::factory()->user->create( [ 'user_login' => 'drafts' ] );
+		$other_user_id = self::factory()->user->create();
+		$ga            = $this->create_linked_ga( 'drafts' );
+
+		// 2 published, 1 draft for the user (all tagged with GA term).
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		$draft = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			]
+		);
+		wp_set_object_terms( $draft, [ $ga['term_id'] ], 'author' );
+
+		// 1 published other-authored post on the GA term.
+		$this->create_authored_post( $other_user_id, $ga['term_id'] );
+
+		// public_only = true → 2 + 1 = 3 distinct published. Drafts excluded.
+		$this->assertEquals( 3, count_user_posts( $user_id, 'post', true ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * Drafts and trashed posts must NOT be counted even when the default $public_only=false
+	 * is passed. WP core's count_user_posts and CAP's filter both restrict to publish (+ private)
+	 * in this branch; including every registered status would inflate the Users-list column
+	 * as drafts accumulate over time.
+	 */
+	public function test_excludes_drafts_and_trash_when_public_only_false() {
+		$user_id       = self::factory()->user->create( [ 'user_login' => 'drafty' ] );
+		$other_user_id = self::factory()->user->create();
+		$ga            = $this->create_linked_ga( 'drafty' );
+
+		// 2 published posts authored by the user, all tagged with the GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		// 1 draft authored by the user, also tagged with the GA term.
+		$draft = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			]
+		);
+		wp_set_object_terms( $draft, [ $ga['term_id'] ], 'author' );
+		// 1 trashed post authored by the user, also tagged with the GA term.
+		$trash = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'trash',
+				'post_type'   => 'post',
+			]
+		);
+		wp_set_object_terms( $trash, [ $ga['term_id'] ], 'author' );
+		// 1 published other-authored post on the GA term.
+		$this->create_authored_post( $other_user_id, $ga['term_id'] );
+
+		// Default $public_only=false should still exclude drafts/trash.
+		// Distinct published attributed to the user: 2 + 1 = 3.
+		$this->assertEquals( 3, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * Private posts must be included when $public_only=false AND the viewer can
+	 * read private posts — matching WP core's get_posts_by_author_sql() capability
+	 * gate. Here the viewer is an administrator, so private posts count.
+	 */
+	public function test_includes_private_posts_when_viewer_can_read_private() {
+		$user_id  = self::factory()->user->create( [ 'user_login' => 'privposts' ] );
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$ga       = $this->create_linked_ga( 'privposts' );
+
+		// 2 published, 1 private, all by the user and all tagged with the GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		$private = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'private',
+				'post_type'   => 'post',
+			]
+		);
+		wp_set_object_terms( $private, [ $ga['term_id'] ], 'author' );
+
+		// Viewer can read private posts → publish + private = 3.
+		wp_set_current_user( $admin_id );
+		$this->assertEquals( 3, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * Private posts must be EXCLUDED when the viewer cannot read private posts,
+	 * even with $public_only=false. WP core's get_posts_by_author_sql() only adds
+	 * `post_status = 'private'` when the viewer has read_private_posts; an
+	 * anonymous viewer (e.g. the public REST `users` endpoint) would otherwise see
+	 * a private-inflated count where core returns the published-only figure.
+	 */
+	public function test_excludes_private_posts_when_viewer_cannot_read_private() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'privhidden' ] );
+		$ga      = $this->create_linked_ga( 'privhidden' );
+
+		// 2 published, 1 private, all by the user and all tagged with the GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		$private = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'private',
+				'post_type'   => 'post',
+			]
+		);
+		wp_set_object_terms( $private, [ $ga['term_id'] ], 'author' );
+
+		// Anonymous viewer (no read_private_posts) → private excluded, publish only = 2.
+		wp_set_current_user( 0 );
+		$this->assertEquals( 2, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * The capability gate is a conjunction: private posts are counted only when the
+	 * viewer can read private posts for EVERY resolved type. Here an editor (who CAN
+	 * read private `post`) counts across `['post', <cpt>]` where the CPT's
+	 * read-private cap they lack — so private must be excluded for ALL types, not just
+	 * the one that fails. Guards against a regression that loosens the gate to "any type".
+	 */
+	public function test_private_gate_requires_capability_for_all_resolved_types() {
+		$user_id   = self::factory()->user->create( [ 'user_login' => 'multitype' ] );
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		$ga        = $this->create_linked_ga( 'multitype' );
+
+		// A CPT whose read-private capability the editor does NOT hold.
+		register_post_type(
+			'gated_thing',
+			[
+				'public'          => false,
+				'capability_type' => 'gated_thing',
+				'map_meta_cap'    => true,
+			]
+		);
+
+		// 2 published + 1 private `post`, all by the user and tagged with the GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		$private = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'private',
+				'post_type'   => 'post',
+			]
+		);
+		wp_set_object_terms( $private, [ $ga['term_id'] ], 'author' );
+
+		// Editor can read private `post` but NOT `gated_thing`; the conjunction fails,
+		// so private is excluded across the union → 2 published only.
+		wp_set_current_user( $editor_id );
+		try {
+			$this->assertEquals( 2, count_user_posts( $user_id, [ 'post', 'gated_thing' ] ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+		} finally {
+			unregister_post_type( 'gated_thing' );
+		}
+	}
+
+	/**
+	 * Defensive guard: if the resolved post-type set comes up empty (e.g. a
+	 * publisher filters `coauthors_count_published_post_types` down to []), the
+	 * dedup query would build a malformed `post_type IN ()`. The filter must
+	 * instead no-op and return the upstream count rather than silently yielding 0.
+	 */
+	public function test_returns_upstream_count_when_post_types_resolve_empty() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'emptytypes' ] );
+		$ga      = $this->create_linked_ga( 'emptytypes' );
+
+		// 3 published posts authored by the user, all tagged with the GA term.
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+
+		// Collapse the countable post types to an empty set.
+		$filter = function () {
+			return [];
+		};
+		add_filter( 'coauthors_count_published_post_types', $filter );
+
+		try {
+			// Guard returns the upstream count (3) instead of a malformed IN () → 0.
+			$this->assertEquals( 3, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+		} finally {
+			remove_filter( 'coauthors_count_published_post_types', $filter );
+		}
+	}
+
+	/**
+	 * WP_Query's 'any' post_type sentinel must be honored — `IN ('any')` would match
+	 * zero rows. Caller in the wild: newspack-blocks Author List controller calls
+	 * count_user_posts($id, ['any'], true) and drops authors with count=0 from the
+	 * API response when exclude_empty is set.
+	 */
+	public function test_honors_any_post_type_sentinel() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'manytype' ] );
+		$ga      = $this->create_linked_ga( 'manytype' );
+
+		// Author taxonomy needs to apply to pages for this test's fixtures.
+		register_taxonomy_for_object_type( 'author', 'page' );
+
+		// 2 published posts + 1 published page, all authored by the user and tagged with the GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		$page = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			]
+		);
+		wp_set_object_terms( $page, [ $ga['term_id'] ], 'author' );
+
+		// 'any' should expand to all searchable post types (post + page here) and return 3.
+		$this->assertEquals( 3, count_user_posts( $user_id, 'any' ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * The newspack-blocks Author List controller calls count_user_posts with the array form
+	 * `['any']` (not the bare string). The filter must honor both forms.
+	 */
+	public function test_honors_array_form_any_sentinel() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'arrayany' ] );
+		$ga      = $this->create_linked_ga( 'arrayany' );
+
+		register_taxonomy_for_object_type( 'author', 'page' );
+
+		// 2 published posts + 1 published page, all authored by the user and tagged with the GA term.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$this->create_authored_post( $user_id, $ga['term_id'] );
+		}
+		$page = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			]
+		);
+		wp_set_object_terms( $page, [ $ga['term_id'] ], 'author' );
+
+		// ['any'] (array form, public_only=true) — the call shape used by newspack-blocks Author List.
+		$this->assertEquals( 3, count_user_posts( $user_id, [ 'any' ], true ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * Data-corruption / migration edge case: more than one guest author with
+	 * `cap-linked_account` pointing at the same WP user. The filter must aggregate
+	 * across ALL linked GAs (and their author terms), not silently pick one and
+	 * undercount.
+	 */
+	public function test_dedups_across_multiple_linked_guest_authors() {
+		$user_id       = self::factory()->user->create( [ 'user_login' => 'multilink' ] );
+		$other_user_id = self::factory()->user->create();
+
+		// GA #1 linked to the user.
+		$ga1_id = self::factory()->post->create(
+			[
+				'post_type'   => 'guest-author',
+				'post_status' => 'publish',
+				'post_title'  => 'Multilink A',
+			]
+		);
+		update_post_meta( $ga1_id, 'cap-linked_account', 'multilink' );
+		update_post_meta( $ga1_id, 'cap-user_login', 'multilink-a' );
+		$term1 = wp_insert_term( 'cap-multilink-a', 'author', [ 'slug' => 'cap-multilink-a' ] );
+		wp_set_object_terms( $ga1_id, [ $term1['term_id'] ], 'author' );
+
+		// GA #2 ALSO linked to the same user.
+		$ga2_id = self::factory()->post->create(
+			[
+				'post_type'   => 'guest-author',
+				'post_status' => 'publish',
+				'post_title'  => 'Multilink B',
+			]
+		);
+		update_post_meta( $ga2_id, 'cap-linked_account', 'multilink' );
+		update_post_meta( $ga2_id, 'cap-user_login', 'multilink-b' );
+		$term2 = wp_insert_term( 'cap-multilink-b', 'author', [ 'slug' => 'cap-multilink-b' ] );
+		wp_set_object_terms( $ga2_id, [ $term2['term_id'] ], 'author' );
+
+		// 1 post by the user, attached to term1.
+		$this->create_authored_post( $user_id, $term1['term_id'] );
+		// 1 post by other user, attached to term1 only.
+		$this->create_authored_post( $other_user_id, $term1['term_id'] );
+		// 1 post by other user, attached to term2 only — would be silently dropped if only term1 were aggregated.
+		$this->create_authored_post( $other_user_id, $term2['term_id'] );
+
+		// Distinct: 1 (user own + in term1) + 1 (other in term1) + 1 (other in term2) = 3.
+		$this->assertEquals( 3, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+	}
+
+	/**
+	 * When the default 'post' is passed, the filter must honor CAP's
+	 * `coauthors_count_published_post_types` hook so third-party CPT additions
+	 * (e.g. newsletters) are included.
+	 */
+	public function test_applies_coauthors_count_published_post_types_filter() {
+		$user_id = self::factory()->user->create( [ 'user_login' => 'expanded' ] );
+		$ga      = $this->create_linked_ga( 'expanded' );
+
+		register_post_type( 'newsletter', [ 'public' => false ] );
+		register_taxonomy_for_object_type( 'author', 'newsletter' );
+
+		// 1 'post' + 1 'newsletter', both by the user, both tagged with the GA term.
+		$this->create_authored_post( $user_id, $ga['term_id'] );
+		$nl = self::factory()->post->create(
+			[
+				'post_author' => $user_id,
+				'post_status' => 'publish',
+				'post_type'   => 'newsletter',
+			]
+		);
+		wp_set_object_terms( $nl, [ $ga['term_id'] ], 'author' );
+
+		$filter = function ( $types ) {
+			return array_merge( $types, [ 'newsletter' ] );
+		};
+		add_filter( 'coauthors_count_published_post_types', $filter );
+
+		try {
+			// Default 'post' + the filter should include 'newsletter' → 2 distinct.
+			$this->assertEquals( 2, count_user_posts( $user_id ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts
+		} finally {
+			remove_filter( 'coauthors_count_published_post_types', $filter );
+			unregister_post_type( 'newsletter' );
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
@@ -10,6 +10,7 @@ use Newspack\Group_Subscription;
 use Newspack\Group_Subscription_Settings;
 use Newspack\Institution;
 use Newspack\Reader_Activation;
+use Newspack\Content_Gate\IP_Access_Rule;
 
 /**
  * Test the `group` GA4 custom event parameter.
@@ -186,6 +187,30 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 		$params = GoogleSiteKit::get_custom_event_parameters();
 
 		$this->assertEquals( 'Institution ' . $inst_id, $params['group'] );
+	}
+
+	/**
+	 * Matching institution (via IP-based access rules) contributes the anonymized ID label
+	 * for logged-out users, too.
+	 */
+	public function test_group_includes_matching_institution_while_logged_out() {
+		// Ensure logged-out user.
+		wp_set_current_user( 0 );
+		$inst_id = $this->create_institution( 'Test University', [ 'ip_range' => '192.168.1.0/24' ] );
+
+		// Mock a session in the whitelisted IP range.
+		$_SERVER['REMOTE_ADDR'] = '192.168.1.50'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$_COOKIE[ IP_Access_Rule::COOKIE_NAME ] = '1'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		$this->assertTrue( IP_Access_Rule::is_cookie_set() );
+
+		$params = GoogleSiteKit::get_custom_event_parameters();
+
+		$this->assertEquals( 'Institution ' . $inst_id, $params['group'] );
+
+		// Unset whitelisted IP and cookie.
+		unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Recovers the failed post-release back-merge of `release` into `main`. The *Post-release branch sync* job (`.github/scripts/post-release.sh`) aborts and only pings Slack when its `release` → `main` / `alpha` merge hits a conflict, then exits 0 — so the failures were silent and `main`/`alpha` drifted behind `release` across several consecutive hotfix releases.

This brings `main` up to date with the hotfixes that had only landed on `release`:

- `fix(network)` preserve node future schedule on origin publish re-sync (→ newspack-network 2.20.3)
- `fix(co-authors-plus)` dedup count_user_posts for linked guest authors (→ newspack 6.42.7)
- `fix(access-control)` make email domain matching case-insensitive (→ 6.42.6)
- `fix(access-control)` populate GA4 group metadata for anonymous readers (→ 6.42.5)

The only merge conflict was the `newspack-network.php` version header (`main` had a stale `2.20.1`, out of sync with its own `package.json`); resolved to `2.20.3` to match the merged `package.json` and CHANGELOG. All other conflicts were version/changelog metadata that auto-merged. No code conflicts.

The companion `release` → `alpha` back-merge was already applied directly (`alpha` is not PR-gated).

**Merge with a merge commit, not squash** — preserving `release`'s commits as ancestors of `main` is what keeps the *next* automated back-merge from re-conflicting on these same version/changelog files.

### How to test the changes in this Pull Request:

1. Confirm `main` after merge contains the four hotfix commits above (`git log --oneline origin/main | grep -E 'preserve node future schedule|dedup count_user_posts|case-insensitive|GA4 group metadata'`).
2. Confirm versions are consistent: newspack 6.42.7, newspack-network 2.20.3 across `package.json`, plugin header, and CHANGELOG.
3. CI ("CI OK") passes.

### Other information:

Investigated from run https://github.com/Automattic/newspack-workspace/actions/runs/27352522087/job/80818961398.