### PR TITLE
test: harden CAP and GoogleSiteKit test isolation

### DIFF
--- a/plugins/newspack-plugin/tests/unit-tests/plugins/co-authors-plus-count-user-posts-fix.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/co-authors-plus-count-user-posts-fix.php
@@ -30,7 +30,9 @@ class Newspack_Test_CAP_Count_User_Posts_Fix extends WP_UnitTestCase {
 				'supports' => [ 'title' ],
 			]
 		);
-		register_taxonomy( 'author', 'post', [ 'public' => false ] );
+		// CAP attaches 'author' terms to the guest-author CPT, so register the
+		// taxonomy for that object type as well as 'post'.
+		register_taxonomy( 'author', [ 'post', 'guest-author' ], [ 'public' => false ] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
@@ -41,6 +41,20 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 	private $institution_ids = [];
 
 	/**
+	 * Original $_SERVER['REMOTE_ADDR'] captured in set_up, restored in tear_down.
+	 *
+	 * @var string|null
+	 */
+	private $original_remote_addr;
+
+	/**
+	 * Original IP-access cookie value captured in set_up, restored in tear_down.
+	 *
+	 * @var string|null
+	 */
+	private $original_ip_cookie;
+
+	/**
 	 * Enable the content gating feature flag and load WC mocks.
 	 */
 	public static function set_up_before_class() {
@@ -56,6 +70,11 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		// Capture request globals that IP-based tests mutate, so tear_down can
+		// restore them even if an assertion fails mid-test.
+		$this->original_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$this->original_ip_cookie   = $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ?? null; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 
 		// Reset mock WC databases.
 		global $subscriptions_database, $products_database;
@@ -102,6 +121,20 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 		Group_Subscription::reset_cache();
 		Institution::reset_matching_cache();
 		wp_set_current_user( 0 );
+
+		// Restore request globals to their pre-test values so IP-based tests
+		// can't leak state into later tests in the same process.
+		if ( null === $this->original_remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->original_remote_addr; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		}
+		if ( null === $this->original_ip_cookie ) {
+			unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		} else {
+			$_COOKIE[ IP_Access_Rule::COOKIE_NAME ] = $this->original_ip_cookie; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		}
+
 		parent::tear_down();
 	}
 
@@ -208,9 +241,7 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 
 		$this->assertEquals( 'Institution ' . $inst_id, $params['group'] );
 
-		// Unset whitelisted IP and cookie.
-		unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		// The whitelisted IP and cookie are restored in tear_down().
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit.php
@@ -73,8 +73,8 @@ class Newspack_Test_GoogleSiteKit_Group_Param extends WP_UnitTestCase {
 
 		// Capture request globals that IP-based tests mutate, so tear_down can
 		// restore them even if an assertion fails mid-test.
-		$this->original_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-		$this->original_ip_cookie   = $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ?? null; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$this->original_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput, WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$this->original_ip_cookie   = $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 
 		// Reset mock WC databases.
 		global $subscriptions_database, $products_database;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses the two test-isolation findings Copilot raised on #305. They are kept out of #305 so that PR stays a pure `release` → `main` back-merge. Both are test-only changes — no production code, no release trigger.

The flagged tests arrived via the hotfix releases (so they already live on `release`/`alpha`); this hardens them on the trunk.

1. **`google-site-kit.php`** (valid): `test_group_includes_matching_institution_while_logged_out()` set `$_SERVER['REMOTE_ADDR']` and the IP-access cookie, then only `unset()` them at the end of the test body. That clobbered any pre-existing value instead of restoring it, and skipped cleanup entirely if an assertion threw. Originals are now captured in `set_up()` and restored in `tear_down()`, so the suite stays order-independent.

2. **`co-authors-plus-count-user-posts-fix.php`** (hardening): the `author` taxonomy was registered only for `post`, while fixtures attach `author` terms to the `guest-author` CPT. `wp_set_object_terms()` only needs `taxonomy_exists()`, so the tests already passed (CI on #305 is green) — but registering the taxonomy for `guest-author` too makes the data model correct and satisfies the reviewer.

### How to test the changes in this Pull Request:

1. `PHPUnit / newspack` passes (the suite this touches).
2. Run repeatedly / in different orders; no `$_SERVER`/`$_COOKIE` leakage between tests.

### Other information:

Stacked on #305; GitHub will retarget this to `main` automatically once #305 merges. Follow-up from the Copilot review on #305.