### PR TITLE
chore(env): bind worktrees to workspace path for JS build/test

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -153,8 +153,18 @@ case $1 in
                         wt_container_path="/newspack-plugins/$wt_repo"
                     fi
                     worktree_dir="./worktrees/$safe_branch/$wt_host_path"
-                    worktree_volumes="$worktree_volumes      - $worktree_dir:$wt_container_path
-"
+                    # Mount the worktree subdir at BOTH container roots:
+                    #   - the site-serving path (/newspack-plugins|themes/<repo>), and
+                    #   - the pnpm-workspace path (/newspack-monorepo/<host_path>).
+                    # The site reads the first; the JS toolchain (n build / n test-js /
+                    # jest, all resolved under /newspack-monorepo) reads the second. Without
+                    # the workspace mount the toolchain builds/tests the *main* checkout's
+                    # source, never the worktree's, and the worktree's own node_modules has
+                    # relative pnpm symlinks (../../../packages/*) that only resolve when the
+                    # plugin sits at its real workspace location. Mounting here makes both
+                    # work, so builds land in the worktree's dist and are served immediately.
+                    worktree_volumes+="      - $worktree_dir:$wt_container_path"$'\n'
+                    worktree_volumes+="      - $worktree_dir:/newspack-monorepo/$wt_host_path"$'\n'
                     shift 2
                     ;;
                 --domain)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Isolated environments created with `n env create --worktree <repo>:<branch>` only mounted the worktree's plugin/theme onto the **site-serving** path (`/newspack-plugins/<repo>`, `/newspack-themes/<repo>`). The JS toolchain — `n build`, `n test-js`, and jest — resolves projects under the **pnpm-workspace** path (`/newspack-monorepo/...`), which was still the main checkout. The result: worktree JS was *served* by the site but silently *built and tested against `main`'s source*, never the branch's. PHP was unaffected (it runs against the site mount directly).

It also couldn't be worked around by running `npm`/`jest` directly in the worktree dir: the worktree's own `node_modules` uses pnpm's relative symlinks (`../../../packages/*`) that only resolve when the plugin sits at its real workspace location, so a flat overlay leaves every dependency dangling (`MODULE_NOT_FOUND`).

This makes `n env create` emit a second bind for every `--worktree`, onto the workspace path, alongside the existing site mount. Both container roots now point at the same worktree directory, so the toolchain builds/tests the actual branch source and build output lands in the worktree's `dist`, served immediately. No copy-step, no per-env compose patching.

Affects newly created environments. Pre-existing environments need recreation (or a manual mount line) to pick up the second bind.

### How to test the changes in this Pull Request:

1. Create an env with a plugin worktree: `n env create jstest --worktree newspack-popups:some-branch` (use any branch with a JS change, or create one).
2. Inspect the generated compose: `grep newspack-monorepo/plugins docker-compose.env-jstest.yml` — confirm a `.../plugins/newspack-popups:/newspack-monorepo/plugins/newspack-popups` line now exists alongside the `/newspack-plugins/...` one. Repeat with a `--worktree newspack-theme:...` and confirm the `themes/` equivalent.
3. `n env up jstest --build`.
4. In the worktree's `plugins/newspack-popups/src`, make a visible JS change (e.g. add a unique string).
5. From the worktree's plugin dir, run `n test-js` — confirm test files added in the worktree are discovered and run (not just `main`'s).
6. Run `n build` — confirm the worktree's `dist/` is regenerated containing your change (`grep <unique-string> dist/*.js`), and the running site serves it.
7. Sanity-check PHP is unaffected: `n test-php` still runs against the worktree as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (Shell tooling change; verified manually per the steps above.)
* [x] Have you successfully run tests with your changes locally?