### PR TITLE
ci(release): author changelog/version stamps only on the release branch (cherry-pick #308)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,13 +84,16 @@ jobs:
       # The [skip ci] commit won't re-trigger this workflow, and post-release.sh's
       # ancestry check is unaffected by the extra commit.
       #
-      # Skipped on hotfix/* and epic/* branches: those are out-of-schedule
-      # prereleases whose bumped files are deliberately kept off the branch (the
-      # release configs drop their @semantic-release/git commit there too), so
-      # the hotfix PR diff stays clean. The prerelease zip is built from the
+      # Runs only on the `release` branch. Version/changelog stamps are authored
+      # on a single channel (see config/release-helpers.js): prerelease channels
+      # (alpha, hotfix/*, epic/*) build their zip/tag from the working-tree bump
+      # but never commit it, so only `release` ever edits the version-stamp
+      # lines. That keeps the committed CHANGELOG free of prerelease noise and
+      # stops post-release.sh's release -> alpha / default-branch sync from
+      # colliding on version headers. The prerelease zip is built from the
       # working tree regardless, so nothing downstream needs this commit.
       - name: Sync package.json versions
-        if: ${{ !startsWith( github.ref_name, 'hotfix/' ) && !startsWith( github.ref_name, 'epic/' ) }}
+        if: ${{ github.ref_name == 'release' }}
         run: |
           node .github/scripts/finalize-package-versions.cjs
           # The release is already published by this point, so the branch must not

--- a/config/release-helpers.js
+++ b/config/release-helpers.js
@@ -1,37 +1,47 @@
 /**
- * Whether the release is running on a `hotfix/*` or `epic/*` branch.
+ * Whether the current release run is on the stable `release` branch.
  *
  * The branch name is read from GITHUB_REF_NAME (set by GitHub Actions). Outside
  * CI it is undefined and this returns false, so local config evaluation is a
  * no-op.
  *
- * @return {boolean} True on a hotfix/* or epic/* branch.
+ * @return {boolean} True only on the `release` branch.
  */
-function isHotfixOrEpicBranch() {
-	const branch = process.env.GITHUB_REF_NAME || '';
-	return /^(hotfix|epic)\//.test( branch );
+function isReleaseBranch() {
+	return ( process.env.GITHUB_REF_NAME || '' ) === 'release';
 }
 
 /**
  * The `@semantic-release/git` prepare step that commits a release's version
- * bumps back to the branch — or nothing at all on `hotfix/*` and `epic/*`.
+ * bumps back to the branch — but ONLY on the stable `release` branch.
  *
- * Out-of-schedule hotfix/epic prereleases build their zip and tag from the
- * working-tree bump, so committing the bumped files (PHP/CSS version headers,
- * CHANGELOG.md) back to the branch would only add `chore(release)` bot commits
- * and version churn to the hotfix PR diff. Legacy newspack-scripts skipped the
- * commit step on these branches for the same reason. (package.json is committed
- * separately by .github/scripts/finalize-package-versions.cjs, which release.yml
- * likewise skips on these branches.)
+ * Version and changelog stamps are authored on a single channel. The `release`
+ * branch is the source of truth for CHANGELOG.md and the committed version
+ * headers; prerelease channels (`alpha`, `hotfix/*`, `epic/*`) still compute
+ * their version and build their zip/tag from the working-tree bump, but they do
+ * NOT commit it back to the branch. This buys two things:
+ *
+ *   1. The committed CHANGELOG.md only ever contains stable release sections —
+ *      no `-alpha.N` / hotfix prerelease entries leak in as cross-channel noise.
+ *      Individual `fix:` / `feat:` commits are not lost: they roll up into the
+ *      next stable version's notes when promoted to `release`.
+ *   2. Only one branch ever edits the version-stamp lines, so syncing `release`
+ *      back into `alpha` / the default branch (post-release.sh) no longer
+ *      collides on CHANGELOG.md / version headers — the recurring post-release
+ *      merge conflict is eliminated at the source.
+ *
+ * (package.json is committed separately by
+ * .github/scripts/finalize-package-versions.cjs, which release.yml likewise
+ * runs only on the `release` branch.)
  *
  * Spread the result into a `prepare` array:
  *   prepare: [ ...otherSteps, ...gitCommitStep( [ phpFile, 'CHANGELOG.md' ] ) ]
  *
  * @param {string[]} assets Files to include in the release commit.
- * @return {Array} `[]` on hotfix/epic branches, otherwise `[ gitStep ]`.
+ * @return {Array} `[ gitStep ]` on the `release` branch, otherwise `[]`.
  */
 function gitCommitStep( assets ) {
-	if ( isHotfixOrEpicBranch() ) {
+	if ( ! isReleaseBranch() ) {
 		return [];
 	}
 	return [


### PR DESCRIPTION
Cherry-picks `ed32613ca` (#308, merged to `main`) onto `release` so the fix is **active on the release channel** — on `main` alone it's dormant, since `main` isn't a release branch.

See #308 for the full rationale. In short: version/changelog stamps are now authored only on `release`; prerelease channels (`alpha`, `hotfix/*`, `epic/*`) build their zip/tag from the working-tree bump but don't commit it. This stops the recurring `post-release.sh` version-stamp conflict when `release` syncs into `alpha`/`main`, and keeps the committed CHANGELOG free of prerelease noise.

Companion PR cherry-picks the same commit onto `alpha`.

### How to test

```sh
GITHUB_REF_NAME=alpha   node -e "console.log(require('./config/release-helpers').gitCommitStep(['x']).length)"   # → 0
GITHUB_REF_NAME=release node -e "console.log(require('./config/release-helpers').gitCommitStep(['x']).length)"   # → 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)