### PR TITLE
build: add woocommerce/email-editor via jetpack-autoloader

### DIFF
--- a/plugins/newspack-newsletters/composer.json
+++ b/plugins/newspack-newsletters/composer.json
@@ -3,7 +3,9 @@
 	"description": "Newsletter authoring plugin.",
 	"type": "wordpress-plugin",
 	"require": {
-		"campaignmonitor/createsend-php": "^7.0"
+		"campaignmonitor/createsend-php": "^7.0",
+		"automattic/jetpack-autoloader": "^5.0",
+		"woocommerce/email-editor": "2.14.0"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^3.0",
@@ -22,13 +24,16 @@
 			"XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html codecov"
 		]
 	},
-	"extra": {},
+	"extra": {
+		"autoloader-suffix": "Newspack_Newsletters"
+	},
 	"config": {
 		"platform": {
 			"php": "8.3"
 		},
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"automattic/jetpack-autoloader": true
 		}
 	},
 	"autoload": {

--- a/plugins/newspack-newsletters/composer.lock
+++ b/plugins/newspack-newsletters/composer.lock
@@ -4,8 +4,72 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2993ee5620d5077ad96573847bb808ff",
+    "content-hash": "d783a45ecd7e52575a0d7a6a35bd321e",
     "packages": [
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v5.0.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "b6abf43a9ea638d6a0edc02f0dd7575703f9c2a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/b6abf43a9ea638d6a0edc02f0dd7575703f9c2a1",
+                "reference": "b6abf43a9ea638d6a0edc02f0dd7575703f9c2a1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "^1.0.9",
+                "composer/composer": "^2.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "branch-alias": {
+                    "dev-trunk": "5.0.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "version-constants": {
+                    "::VERSION": "src/AutoloadGenerator.php"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                },
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "keywords": [
+                "autoload",
+                "autoloader",
+                "composer",
+                "jetpack",
+                "plugin",
+                "wordpress"
+            ],
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.20"
+            },
+            "time": "2026-06-15T12:15:05+00:00"
+        },
         {
             "name": "campaignmonitor/createsend-php",
             "version": "v7.1.1",
@@ -69,6 +133,63 @@
                 "source": "https://github.com/campaignmonitor/createsend-php/tree/v7.1.1"
             },
             "time": "2025-06-18T03:28:38+00:00"
+        },
+        {
+            "name": "woocommerce/email-editor",
+            "version": "2.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/email-editor.git",
+                "reference": "e6ab4c31c5223fa2c28267a3cc4514199a1981e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/e6ab4c31c5223fa2c28267a3cc4514199a1981e6",
+                "reference": "e6ab4c31c5223fa2c28267a3cc4514199a1981e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "3.3.0",
+                "phpunit/phpunit": "^9.6",
+                "woocommerce/woocommerce-sniffs": "1.0.0",
+                "yoast/phpunit-polyfills": "^4.0"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "changelogger": {
+                    "types": {
+                        "add": "Adds functionality",
+                        "dev": "Development related task",
+                        "fix": "Fixes an existing bug",
+                        "tweak": "A minor adjustment to the codebase",
+                        "update": "Update existing functionality",
+                        "enhancement": "Improve existing functionality",
+                        "performance": "Address performance issues"
+                    },
+                    "changelog": "changelog.md",
+                    "formatter": {
+                        "filename": "../../../tools/changelogger/class-php-package-formatter.php"
+                    }
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/",
+                    "vendor-prefixed/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Email editor based on WordPress Gutenberg package.",
+            "support": {
+                "source": "https://github.com/woocommerce/email-editor/tree/2.14.0"
+            },
+            "time": "2026-06-15T09:32:46+00:00"
         }
     ],
     "packages-dev": [

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -35,7 +35,7 @@ if ( ! defined( 'NEWSPACK_NEWSLETTERS_LETTERHEAD_ENDPOINT' ) ) {
 	define( 'NEWSPACK_NEWSLETTERS_LETTERHEAD_ENDPOINT', 'https://api.tryletterhead.com' );
 }
 // Include main plugin resources.
-require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-logger.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -34,8 +34,25 @@ if ( ! defined( 'NEWSPACK_NEWSLETTERS_PLUGIN_FILE' ) ) {
 if ( ! defined( 'NEWSPACK_NEWSLETTERS_LETTERHEAD_ENDPOINT' ) ) {
 	define( 'NEWSPACK_NEWSLETTERS_LETTERHEAD_ENDPOINT', 'https://api.tryletterhead.com' );
 }
+// Load the Composer autoloader. Prefer the jetpack-autoloader package loader
+// (which negotiates shared package versions across plugins); fall back to the
+// plain Composer autoloader if it is unavailable.
+if ( file_exists( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.php' ) ) {
+	require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.php';
+} elseif ( file_exists( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php' ) ) {
+	require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php';
+} else {
+	add_action(
+		'admin_notices',
+		function() {
+			echo '<div class="notice notice-error"><p>';
+			echo esc_html__( 'Newspack Newsletters is missing its Composer dependencies. Please run "composer install" in the plugin directory.', 'newspack-newsletters' );
+			echo '</p></div>';
+		}
+	);
+	return;
+}
 // Include main plugin resources.
-require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-logger.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';

--- a/plugins/newspack-newsletters/tests/bootstrap.php
+++ b/plugins/newspack-newsletters/tests/bootstrap.php
@@ -27,11 +27,31 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-// Load the composer autoloader.
-require_once __DIR__ . '/../vendor/autoload.php';
+// Tell the WP test bootstrap where to find PHPUnit Polyfills directly. The plugin
+// loads its dependencies through the jetpack-autoloader (autoload_packages.php),
+// which cannot be required this early because it relies on WordPress functions
+// (e.g. wp_normalize_path()) that are not defined until WP boots below. Pointing
+// the WP bootstrap at Polyfills avoids needing the plain Composer autoloader here.
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', __DIR__ . '/../vendor/yoast/phpunit-polyfills' );
+}
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+// Load the Composer autoloader. Prefer the jetpack-autoloader package loader
+// (which negotiates shared package versions across plugins) to mirror the
+// plugin's runtime bootstrap; fall back to the plain Composer autoloader.
+// Loaded after the WP test environment boots because the jetpack-autoloader
+// relies on WordPress functions (e.g. wp_normalize_path()).
+if ( file_exists( __DIR__ . '/../vendor/autoload_packages.php' ) ) {
+	require_once __DIR__ . '/../vendor/autoload_packages.php';
+} elseif ( file_exists( __DIR__ . '/../vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/../vendor/autoload.php';
+} else {
+	echo 'Could not find the Composer autoloader, have you run "composer install" in the plugin directory?' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
 
 // Trait used to test Subscription Lists.
 require_once 'trait-lists-setup.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Foundation for the newsletter renderer modernisation (MJML to the WooCommerce Email Editor). This adds the `woocommerce/email-editor` package (Packagist) as a dependency of `newspack-newsletters`, loaded through the **jetpack-autoloader** so it coexists safely with WooCommerce's own bundled copy of the same package.

Why jetpack-autoloader: the package ships under the unscoped `Automattic\WooCommerce\EmailEditor\*` namespace. On sites running both WooCommerce and Newspack, two plain Composer classmaps providing the same FQCNs would risk an order-dependent fatal "Cannot redeclare class" or silent version skew. jetpack-autoloader negotiates a single version across plugins, which is the same mechanism WooCommerce itself uses.

`woocommerce/email-editor` is pinned (`2.14.0`) so version negotiation never downgrades WooCommerce's bundled copy. No renderer behaviour changes yet — this PR only wires up the dependency and switches the plugin bootstrap to `vendor/autoload_packages.php`.

Part of the `epic/editor-refactor` milestone.

### How to test the changes in this Pull Request:

1. Check out this branch and run `cd plugins/newspack-newsletters && n composer install`.
2. Confirm `vendor/autoload_packages.php`, `vendor/woocommerce/email-editor/`, and `vendor/automattic/jetpack-autoloader/` exist.
3. Confirm `vendor/woocommerce/email-editor/vendor-prefixed/` ships the prefixed runtime deps (Emogrifier/Sabberworm under `Automattic\WooCommerce\EmailEditorVendor\`).
4. With **WooCommerce active** alongside Newspack Newsletters, load any wp-admin page and confirm there is no `Cannot redeclare class` fatal.
5. Run `wp eval 'echo class_exists( "Automattic\\WooCommerce\\EmailEditor\\Engine\\Renderer\\Renderer" ) ? "OK" : "MISSING";' --allow-root` and confirm it prints `OK`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (Dependency/bootstrap change — verified via class-load smoke check; unit tests land in subsequent tasks.)
* [x] Have you successfully run tests with your changes locally?
