### PR TITLE
feat: add WC renderer feature flag

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-feature-flag.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-feature-flag.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Feature flag for the WooCommerce Email Editor renderer.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves whether the WC email-editor renderer is enabled for this site.
+ */
+class Feature_Flag {
+	const OPTION = 'newspack_newsletters_use_woo_renderer';
+
+	/**
+	 * Whether the WC renderer is enabled. Constant overrides option; filter wins last.
+	 *
+	 * @return boolean
+	 */
+	public static function is_enabled() {
+		$enabled = (bool) get_option( self::OPTION, false );
+		if ( defined( 'NEWSPACK_NEWSLETTERS_WOO_RENDERER' ) ) {
+			$enabled = (bool) constant( 'NEWSPACK_NEWSLETTERS_WOO_RENDERER' );
+		}
+		/**
+		 * Filters whether the WC email-editor renderer is enabled.
+		 *
+		 * @param boolean $enabled Whether enabled.
+		 */
+		return (bool) apply_filters( 'newspack_newsletters_use_woo_renderer', $enabled );
+	}
+}

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -37,6 +37,7 @@ if ( ! defined( 'NEWSPACK_NEWSLETTERS_LETTERHEAD_ENDPOINT' ) ) {
 // Include main plugin resources.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-logger.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-feature-flag.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider.php';

--- a/plugins/newspack-newsletters/tests/email-renderers/test-feature-flag.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-feature-flag.php
@@ -28,11 +28,24 @@ class Test_Feature_Flag extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the filter overrides the option value.
+	 * Test that the filter overrides the option value (filter wins over an enabled option).
 	 */
 	public function test_filter_overrides_option() {
-		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		update_option( 'newspack_newsletters_use_woo_renderer', '1' );
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+		$this->assertFalse( Feature_Flag::is_enabled() );
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+		delete_option( 'newspack_newsletters_use_woo_renderer' );
+	}
+
+	/**
+	 * Test that the NEWSPACK_NEWSLETTERS_WOO_RENDERER constant overrides the option.
+	 */
+	public function test_constant_overrides_option() {
+		if ( ! defined( 'NEWSPACK_NEWSLETTERS_WOO_RENDERER' ) ) {
+			define( 'NEWSPACK_NEWSLETTERS_WOO_RENDERER', true );
+		}
+		delete_option( 'newspack_newsletters_use_woo_renderer' );
 		$this->assertTrue( Feature_Flag::is_enabled() );
-		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-feature-flag.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-feature-flag.php
@@ -1,17 +1,35 @@
 <?php
+/**
+ * Class Feature Flag Test
+ *
+ * @package Newspack_Newsletters
+ */
+
 use Newspack\Newsletters\Email_Renderers\Feature_Flag;
 
+/**
+ * Feature Flag Test.
+ */
 class Test_Feature_Flag extends WP_UnitTestCase {
+	/**
+	 * Test that the Woo renderer feature flag is disabled by default.
+	 */
 	public function test_disabled_by_default() {
 		$this->assertFalse( Feature_Flag::is_enabled() );
 	}
 
+	/**
+	 * Test that the feature flag is enabled when the option is set.
+	 */
 	public function test_enabled_by_option() {
 		update_option( 'newspack_newsletters_use_woo_renderer', '1' );
 		$this->assertTrue( Feature_Flag::is_enabled() );
 		delete_option( 'newspack_newsletters_use_woo_renderer' );
 	}
 
+	/**
+	 * Test that the filter overrides the option value.
+	 */
 	public function test_filter_overrides_option() {
 		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
 		$this->assertTrue( Feature_Flag::is_enabled() );

--- a/plugins/newspack-newsletters/tests/email-renderers/test-feature-flag.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-feature-flag.php
@@ -1,0 +1,20 @@
+<?php
+use Newspack\Newsletters\Email_Renderers\Feature_Flag;
+
+class Test_Feature_Flag extends WP_UnitTestCase {
+	public function test_disabled_by_default() {
+		$this->assertFalse( Feature_Flag::is_enabled() );
+	}
+
+	public function test_enabled_by_option() {
+		update_option( 'newspack_newsletters_use_woo_renderer', '1' );
+		$this->assertTrue( Feature_Flag::is_enabled() );
+		delete_option( 'newspack_newsletters_use_woo_renderer' );
+	}
+
+	public function test_filter_overrides_option() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		$this->assertTrue( Feature_Flag::is_enabled() );
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Adds the feature flag that will gate the new WooCommerce-Email-Editor-based newsletter renderer during its controlled rollout. `Newspack\Newsletters\Email_Renderers\Feature_Flag::is_enabled()` resolves whether the new engine is active for the site, in this precedence: the `NEWSPACK_NEWSLETTERS_WOO_RENDERER` constant overrides the `newspack_newsletters_use_woo_renderer` option, and the `newspack_newsletters_use_woo_renderer` filter wins last.

It is **off by default**, so this PR changes no behaviour on its own — subsequent tasks (the render dispatch, the editor preview, the send-time stamp) consume this flag. Part of the `epic/editor-refactor` milestone.

### How to test the changes in this Pull Request:

1. Run `cd plugins/newspack-newsletters && n test-php --filter Test_Feature_Flag` and confirm `OK (3 tests, 3 assertions)`.
2. Confirm `Feature_Flag::is_enabled()` returns `false` by default.
3. Set the option (`update_option( 'newspack_newsletters_use_woo_renderer', '1' )`) and confirm it returns `true`.
4. Add a filter returning `false` and confirm the filter wins (returns `false`) even with the option set; define the `NEWSPACK_NEWSLETTERS_WOO_RENDERER` constant and confirm it overrides the option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
