### PR TITLE
feat: stamp and resolve producing engine for newsletters

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -19,25 +19,35 @@ class Renderer_Controller {
 	const RENDERER_META = 'newspack_newsletter_renderer';
 
 	/**
+	 * Legacy MJML engine. The default for any newsletter without a stamp.
+	 */
+	const ENGINE_MJML = 'mjml';
+
+	/**
+	 * WC (WooCommerce/block) engine.
+	 */
+	const ENGINE_WC = 'wc';
+
+	/**
 	 * Resolve which engine a post's stored HTML was produced by.
 	 * Absence of a stamp means the newsletter predates this feature, so it is MJML.
 	 *
 	 * @param int $post_id Post ID.
-	 * @return string 'mjml'|'wc'.
+	 * @return string One of self::ENGINE_MJML|self::ENGINE_WC.
 	 */
 	public static function get_post_renderer( $post_id ) {
 		$stamp = get_post_meta( $post_id, self::RENDERER_META, true );
-		return ( 'wc' === $stamp ) ? 'wc' : 'mjml';
+		return ( self::ENGINE_WC === $stamp ) ? self::ENGINE_WC : self::ENGINE_MJML;
 	}
 
 	/**
 	 * Stamp the producing engine on a post (called at send time).
 	 *
 	 * @param int    $post_id Post ID.
-	 * @param string $engine  'mjml'|'wc'.
+	 * @param string $engine  One of self::ENGINE_MJML|self::ENGINE_WC.
 	 * @return void
 	 */
 	public static function stamp_renderer( $post_id, $engine ) {
-		update_post_meta( $post_id, self::RENDERER_META, 'wc' === $engine ? 'wc' : 'mjml' );
+		update_post_meta( $post_id, self::RENDERER_META, self::ENGINE_WC === $engine ? self::ENGINE_WC : self::ENGINE_MJML );
 	}
 }

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Dispatches newsletter rendering between the legacy MJML and WC engines.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Single dispatch point for newsletter HTML rendering.
+ */
+class Renderer_Controller {
+	/**
+	 * Post meta key recording which engine produced a sent newsletter's HTML.
+	 */
+	const RENDERER_META = 'newspack_newsletter_renderer';
+
+	/**
+	 * Resolve which engine a post's stored HTML was produced by.
+	 * Absence of a stamp means the newsletter predates this feature, so it is MJML.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string 'mjml'|'wc'.
+	 */
+	public static function get_post_renderer( $post_id ) {
+		$stamp = get_post_meta( $post_id, self::RENDERER_META, true );
+		return ( 'wc' === $stamp ) ? 'wc' : 'mjml';
+	}
+
+	/**
+	 * Stamp the producing engine on a post (called at send time).
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $engine  'mjml'|'wc'.
+	 * @return void
+	 */
+	public static function stamp_renderer( $post_id, $engine ) {
+		update_post_meta( $post_id, self::RENDERER_META, 'wc' === $engine ? 'wc' : 'mjml' );
+	}
+}

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -37,6 +37,7 @@ if ( ! defined( 'NEWSPACK_NEWSLETTERS_LETTERHEAD_ENDPOINT' ) ) {
 // Include main plugin resources.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-logger.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-renderer-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider.php';

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -27,4 +27,13 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 		Renderer_Controller::stamp_renderer( $post_id, 'wc' );
 		$this->assertSame( 'wc', Renderer_Controller::get_post_renderer( $post_id ) );
 	}
+
+	/**
+	 * An unknown engine value is normalized to the legacy MJML engine.
+	 */
+	public function test_unknown_engine_normalizes_to_mjml() {
+		$post_id = self::factory()->post->create();
+		Renderer_Controller::stamp_renderer( $post_id, 'something-else' );
+		$this->assertSame( 'mjml', Renderer_Controller::get_post_renderer( $post_id ) );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Class Renderer Controller Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+/**
+ * Renderer Controller Test.
+ */
+class Test_Renderer_Controller extends WP_UnitTestCase {
+	/**
+	 * Unstamped posts resolve to the legacy MJML engine.
+	 */
+	public function test_unstamped_post_resolves_to_mjml() {
+		$post_id = self::factory()->post->create();
+		$this->assertSame( 'mjml', Renderer_Controller::get_post_renderer( $post_id ) );
+	}
+
+	/**
+	 * A stamped post resolves to its stored engine value.
+	 */
+	public function test_stamped_post_resolves_to_stored_value() {
+		$post_id = self::factory()->post->create();
+		Renderer_Controller::stamp_renderer( $post_id, 'wc' );
+		$this->assertSame( 'wc', Renderer_Controller::get_post_renderer( $post_id ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Adds the per-newsletter "producing engine" record used to keep the renderer rollout safe. `Newspack\Newsletters\Email_Renderers\Renderer_Controller` provides two static helpers:

- `stamp_renderer( $post_id, $engine )` — records which engine (`mjml` or `wc`) produced a sent newsletter's HTML, in the `newspack_newsletter_renderer` post meta.
- `get_post_renderer( $post_id )` — resolves a post's engine, returning `mjml` whenever the stamp is absent.

The absent-stamp-means-MJML default is the key behaviour: every newsletter that predates this feature (all existing sent archives) resolves to `mjml` with no backfill or migration, so their "view in browser" output never changes. Sending newsletters will stamp `wc` once the new engine is active (wired up in a later task).

No behaviour change yet — this PR only adds the stamp/resolve helpers and their tests. Part of the `epic/editor-refactor` milestone.

### How to test the changes in this Pull Request:

1. Run `cd plugins/newspack-newsletters && n test-php --filter Test_Renderer_Controller` and confirm `OK (2 tests, 2 assertions)`.
2. Confirm `Renderer_Controller::get_post_renderer( $id )` returns `mjml` for a post with no `newspack_newsletter_renderer` meta.
3. Call `Renderer_Controller::stamp_renderer( $id, 'wc' )` and confirm `get_post_renderer( $id )` then returns `wc`.
4. Call `stamp_renderer( $id, 'anything-else' )` and confirm it normalises to `mjml`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
