### PR TITLE
feat: build theme.json from newsletter post meta

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
@@ -20,16 +20,16 @@ class Theme_Json_Builder {
 	 * @param \WP_Post $post Newsletter post.
 	 * @return array
 	 */
-	public static function build( $post ) {
-		$background = get_post_meta( $post->ID, 'background_color', true ) ?: '#ffffff';
-		$text       = get_post_meta( $post->ID, 'text_color', true ) ?: '#000000';
+	public static function build( \WP_Post $post ): array {
+		$background = \sanitize_hex_color( (string) \get_post_meta( $post->ID, 'background_color', true ) );
+		$text       = \sanitize_hex_color( (string) \get_post_meta( $post->ID, 'text_color', true ) );
 
 		return [
 			'version' => 3,
 			'styles'  => [
 				'color' => [
-					'background' => $background,
-					'text'       => $text,
+					'background' => $background ? $background : '#ffffff',
+					'text'       => $text ? $text : '#000000',
 				],
 			],
 		];

--- a/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Builds a per-newsletter theme.json array from existing post meta.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Translates Newspack per-newsletter theme post-meta into the theme.json shape
+ * the WC renderer consumes. Non-destructive: reads meta, never writes it.
+ */
+class Theme_Json_Builder {
+	/**
+	 * Build a theme.json-shaped array for a newsletter.
+	 *
+	 * @param \WP_Post $post Newsletter post.
+	 * @return array
+	 */
+	public static function build( $post ) {
+		$background = get_post_meta( $post->ID, 'background_color', true ) ?: '#ffffff';
+		$text       = get_post_meta( $post->ID, 'text_color', true ) ?: '#000000';
+
+		return [
+			'version' => 3,
+			'styles'  => [
+				'color' => [
+					'background' => $background,
+					'text'       => $text,
+				],
+			],
+		];
+	}
+}

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -69,6 +69,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscription-attempts.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-theme-json-builder.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/ads/class-ads.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-utils.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-pixel.php';

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
@@ -36,4 +36,18 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 		$this->assertSame( '#ffffff', $theme['styles']['color']['background'] );
 		$this->assertSame( '#000000', $theme['styles']['color']['text'] );
 	}
+
+	/**
+	 * Invalid or unsafe color meta is rejected and falls back to defaults.
+	 */
+	public function test_invalid_color_meta_falls_back_to_defaults() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'background_color', 'red; body{display:none}' );
+		update_post_meta( $post_id, 'text_color', 'not-a-hex' );
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertSame( '#ffffff', $theme['styles']['color']['background'] );
+		$this->assertSame( '#000000', $theme['styles']['color']['text'] );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Class Theme Json Builder Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Theme_Json_Builder;
+
+/**
+ * Theme Json Builder Test.
+ */
+class Test_Theme_Json_Builder extends WP_UnitTestCase {
+	/**
+	 * Background and text colors are mapped from post meta into theme.json styles.
+	 */
+	public function test_maps_background_and_text_color_from_meta() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'background_color', '#112233' );
+		update_post_meta( $post_id, 'text_color', '#445566' );
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertSame( '#112233', $theme['styles']['color']['background'] );
+		$this->assertSame( '#445566', $theme['styles']['color']['text'] );
+	}
+
+	/**
+	 * Missing color meta falls back to a white background and black text.
+	 */
+	public function test_defaults_when_meta_absent() {
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertSame( '#ffffff', $theme['styles']['color']['background'] );
+		$this->assertSame( '#000000', $theme['styles']['color']['text'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Adds `Newspack\Newsletters\Email_Renderers\Theme_Json_Builder`, which translates a newsletter's existing per-newsletter theme post-meta into the `theme.json`-shaped array the WooCommerce Email Editor renderer consumes. This is the **translate-on-read** layer: it reads `background_color` / `text_color` meta and never writes — no data migration, existing newsletters are untouched.

Scope here is intentionally limited to the background/text color mapping (with `#ffffff` / `#000000` defaults). Fonts, fluid typography, spacing presets, and custom CSS are deferred to a later plan (they depend on the impedance audit). No behaviour change yet — a later task injects this into the renderer via the `woocommerce_email_editor_theme_json` filter. Part of the `epic/editor-refactor` milestone.

### How to test the changes in this Pull Request:

1. Run `cd plugins/newspack-newsletters && n test-php --filter Test_Theme_Json_Builder` and confirm `OK (2 tests, 4 assertions)`.
2. For a newsletter post with `background_color` and `text_color` meta set, confirm `Theme_Json_Builder::build( $post )` returns `['version' => 3, 'styles' => ['color' => ['background' => <bg>, 'text' => <text>]]]`.
3. For a newsletter with no color meta, confirm it falls back to `#ffffff` background and `#000000` text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
