### PR TITLE
fix(insights): give info callout consistent self-contained chrome

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -228,6 +228,32 @@
 	&__cooldown-notice {
 		margin: 0 0 16px;
 	}
+
+	// Shared info callout (NPPD-1618). Self-contained box chrome — background +
+	// uniform border — defined here in the wizard's global stylesheet (imported
+	// by `insights/index.tsx`, so it loads on EVERY Insights view) rather than in
+	// a per-tab partial. This guarantees the callout looks identical on every tab
+	// and component regardless of which lazy tab-chunk CSS is loaded.
+	//
+	// We paint the full box explicitly instead of leaning on `@wordpress/components`
+	// Notice: its `status="info"` variant ships NO `.is-info` rule, so a bare
+	// `.components-notice` is just a white box with a 4px left accent border — no
+	// background, no full border. The compound `&.components-notice` selector
+	// (0,2,0) outranks WP's `.components-notice` (0,1,0) regardless of load order,
+	// so the custom chrome can't be lost to the cascade. Variant skins (e.g.
+	// `--preview`) override only the background on top of this shared box.
+	&__info-callout.components-notice {
+		margin: 0;
+		background-color: wp-colors.$gray-100;
+		border: 1px solid wp-colors.$gray-300;
+		border-radius: 4px;
+		color: wp-colors.$gray-900;
+	}
+
+	&__info-callout-title {
+		margin: 0;
+		font-size: 14px;
+	}
 }
 
 // Suppress the generic wizard chunk-loading message ("Loading Insights…")

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -475,21 +475,11 @@
 	background: rgba( 255, 255, 255, 0.35 );
 }
 
-// Shared info callout (NPPD-1618) — bold heading + free-form body in a muted
-// box. Background, padding, and the dismiss button all come from
-// `@wordpress/components` Notice (rendered as `.components-notice`); we only
-// override the title typography and neutralize Notice's default margins so
-// the callout sits cleanly in the Insights tabs' gap-based flex layouts.
-.newspack-insights__info-callout {
-	&.components-notice {
-		margin: 0;
-	}
-
-	.newspack-insights__info-callout-title {
-		font-size: 14px;
-		margin: 0;
-	}
-}
+// Shared info callout (NPPD-1618) chrome — background, uniform border, margin
+// reset, and title typography — now lives in the wizard's global `style.scss`
+// (`.newspack-insights__info-callout`), which loads on every Insights view. It
+// is intentionally NOT defined in this per-tab partial so the callout can't
+// look different depending on which tab-chunk CSS happens to be loaded.
 
 // Per-section grid column modifiers. Compound selectors (0,2,0) so they win
 // over the single-class base rules regardless of stylesheet load order. Max 4

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -28,11 +28,11 @@
 	}
 
 	// Phase 1 preview banner — a light-blue variant of the shared
-	// `__info-callout`. The base chrome comes from `@wordpress/components`
-	// Notice (rendered as `.components-notice`); this override re-skins the
-	// background, distinguishing the preview banner from the gray freshness
-	// note below it. (`@wordpress/components` Notice renders no icon for
-	// `status="info"`, so there's nothing to tint.) Removed entirely in Phase 2.
+	// `__info-callout`. The box chrome (border, radius, margin reset) comes from
+	// the shared `.newspack-insights__info-callout` rule in the wizard's global
+	// `style.scss`; this higher-specificity (0,3,0) selector re-skins only the
+	// background, distinguishing the preview banner from the gray freshness note
+	// below it while keeping the same border. Removed entirely in Phase 2.
 	&__info-callout--preview.newspack-insights__info-callout.components-notice {
 		background-color: #e6f1fb;
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/gates.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/gates.scss
@@ -18,9 +18,9 @@
 		gap: 32px;
 	}
 
-	// The Direct vs Influenced explainer chrome moved to the shared
-	// `.newspack-insights__info-callout` (components/_insights-charts.scss) —
-	// see DirectVsInfluencedCallout / InfoCallout (NPPD-1618).
+	// The Direct vs Influenced explainer chrome comes from the shared
+	// `.newspack-insights__info-callout` rule in the wizard's global
+	// `style.scss` — see DirectVsInfluencedCallout / InfoCallout (NPPD-1618).
 
 	// Two-card row (Section 2). The shared metric-grid is auto-fill
 	// with a 220px minimum; for the dedicated two-card sections we


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Insights info callouts (`.newspack-insights__info-callout`, rendered via the `@wordpress/components` `Notice`) now have a consistent border and background on every Insights tab and view.

Previously the callout's box styling lived only in a per-tab chart partial that just four tabs imported, so the same shared callout looked different depending on which tab it appeared on — most visibly on the **Gates** and **Prompts** tabs, where it fell back to WordPress core's bare `info` notice (which ships no background and only a thin left accent border). The inconsistency was especially apparent under `NEWSPACK_INSIGHTS_FIXTURE_MODE`, where more tabs render populated callouts.

The callout chrome is now defined once in the wizard's global stylesheet — which loads on every Insights view — as a self-contained box (gray background, uniform 1px border, rounded corners) that no longer depends on WordPress core notice styling winning the cascade. Variant skins such as the Conversion preview banner continue to override only the background on top of the shared box.

Related to the shared InfoCallout work in NPPD-1618.

### How to test the changes in this Pull Request:

1. On a Newspack site, enable Insights with fixture mode and the preview tabs by adding these constants to `wp-config.php`:
   - `define( 'NEWSPACK_INSIGHTS_ENABLED', true );`
   - `define( 'NEWSPACK_INSIGHTS_FIXTURE_MODE', true );`
   - `define( 'NEWSPACK_INSIGHTS_GATES_PREVIEW', true );`
   - `define( 'NEWSPACK_INSIGHTS_ADVERTISING_ENABLED', true );`
2. Go to **Newspack › Insights** (`admin.php?page=newspack-insights`).
3. Visit the **Gates** and **Prompts** tabs and locate the "About Direct vs Influenced conversion" info callout near the top of each.
4. Confirm each callout renders as a defined box: light gray background, a uniform 1px border on all four sides, and rounded corners.
5. Visit the **Conversion** tab (preview banner + cohort-retention-freshness note) and the **Advertising** tab ("About this data" note). Confirm those callouts share the exact same box treatment — the Gates/Prompts callouts should be visually identical to these.
6. Confirm the Conversion **preview** banner keeps its light-blue background but now carries the same border as the other callouts.
7. Optionally toggle `NEWSPACK_INSIGHTS_FIXTURE_MODE` off and back on; the callout styling should remain consistent in both states.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (CSS-only change; no behavioral/unit surface. Verified via SCSS lint, compiled-output inspection, and manual testing across all callout-bearing tabs.)
* [x] Have you successfully run tests with your changes locally?
