### PR TITLE
fix(separator): restore Default separator width on WP 7.0

### DIFF
--- a/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
+++ b/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
@@ -1097,6 +1097,17 @@ hr {
 	}
 }
 
+// Default-width separators need a short max-width. Historically WordPress core
+// pinned this with `.wp-block-separator { width: 100px }` (the separator block's
+// theme.css). WordPress 7.0 stopped enqueuing that rule in separate-block-assets
+// mode, exposing that inside post content `.entry .entry-content > *` (0,2,0)
+// out-specifies the base `.wp-block-separator` (0,1,0) max-width above, so a
+// Default separator stretched to full width. Re-assert the short width for the
+// default style with a higher-specificity selector (0,3,0). See NPPM-2930.
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	max-width: #{5 * structure.$size__spacing-unit};
+}
+
 .entry .entry-content,
 [id="pico"] {
 	> .wp-block-separator,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On WordPress 7.0, `core/separator` blocks set to the **Default** width render full-width instead of short on the classic `newspack-theme` and its variations.

WordPress 7.0 stopped enqueuing the separator block's `theme.css` (which had pinned the default width with `width: 100px`). Inside post content, the theme's own `.entry .entry-content > *` content-width rule (specificity 0,2,0) out-specifies the base `.wp-block-separator { max-width }` (0,1,0), so once core's width pin disappeared the Default separator stretched to full content width.

This re-asserts the short default width with a higher-specificity selector (0,3,0) scoped to the default style, so Default separators render short again. Wide and Dots styles are unaffected. CSS-only change; affects all classic theme variations via the shared base styles.

Closes [NPPM-2930: Default width separators are full width in WordPress 7.0](https://linear.app/a8c/issue/NPPM-2930).

### How to test the changes in this Pull Request:

1. On a site running WordPress 7.0 with a classic Newspack theme active (e.g. `newspack-theme` or `newspack-scott`), edit a post and add two Separator blocks in the content: leave one at the **Default** style and set the other to **Wide Line**. Publish.
2. View the post on the front end in an incognito window. Confirm the **Default** separator renders as a short, centered line (~100px) and the **Wide** separator spans the full content width. (Before this change, both were full width.)
3. Confirm the **Dots** style separator still renders centered, and that a Default separator placed inside a Group/constrained container is unaffected.
4. Repeat with a child theme variation (`newspack-sacha`/`joseph`/`katharine`/`nelson`) to confirm the fix applies across variations.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (N/A — CSS-only; no theme CSS test harness)
* [x] Have you successfully run tests with your changes locally? (`lint:scss` passes; verified via in-container `n build newspack-theme` + real front-end render: Default 100px, Wide full-width)
