### PR TITLE
fix(release): fail post-release job when a branch sync conflicts

### DIFF
--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -105,6 +105,11 @@ notify_slack() {
     -s > /dev/null
 }
 
+# Tracks whether any release -> branch sync hit a conflict. We attempt every
+# sync (so each gets its own Slack ping) but exit non-zero at the end if any
+# failed, so the job goes red instead of silently passing on an aborted merge.
+sync_failed=0
+
 git pull origin release
 git checkout alpha
 
@@ -123,6 +128,7 @@ else
     git merge --abort
     echo "[post-release] Post-release merge to alpha failed."
     notify_slack alpha
+    sync_failed=1
   fi
 fi
 
@@ -135,4 +141,10 @@ else
   git merge --abort
   echo "[post-release] Post-release merge to $DEFAULT_BRANCH failed."
   notify_slack "$DEFAULT_BRANCH"
+  sync_failed=1
+fi
+
+if [ "$sync_failed" -ne 0 ]; then
+  echo "[post-release] One or more post-release syncs hit conflicts (see above); failing the job."
+  exit 1
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`post-release.sh` notifies Slack on a conflicted `release` → `alpha`/`main` back-merge but `exit 0`s, so the **Post-release branch sync** job shows green even when the back-merge aborted. The failure is only visible if someone reads the Slack ping — and over time the un-synced commits compound the divergence ([run 27583448880](https://github.com/Automattic/newspack-workspace/actions/runs/27583448880) is the case in point: `release` → `main` aborted on conflicts, job passed).

This tracks a `sync_failed` flag, sets it on either the `alpha` or `main` conflict path (each still pings Slack), and `exit 1`s at the end so the job goes red. Both syncs are still attempted before failing.

### How to test the changes in this Pull Request:

1. `bash -n .github/scripts/post-release.sh` passes.
2. On the next release where `release` → `main` conflicts, the Post-release branch sync job now fails (red) instead of passing silently, in addition to the Slack ping.

### Other information:

* The recurring back-merge conflicts themselves are a separate issue (genuine `release`/`main` divergence); this PR only makes the failure visible.