### PR TITLE
feat(segmentation): segment donors arriving from newsletter links

### DIFF
--- a/plugins/newspack-newsletters/includes/tracking/class-utils.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-utils.php
@@ -33,4 +33,44 @@ final class Utils {
 				return '';
 		}
 	}
+
+	/**
+	 * Get the ESP merge tag for an arbitrary merge field.
+	 *
+	 * The counterpart to get_email_address_tag() for any field: callers embed
+	 * the returned tag in newsletter content and the ESP substitutes the
+	 * recipient's value at send time. Used to carry a per-recipient field value
+	 * (e.g. a donor-status flag) into a link without Newspack needing to know
+	 * the recipient at render time.
+	 *
+	 * The field name is used verbatim, so callers must pass the exact ESP merge
+	 * tag (e.g. the Mailchimp merge field's tag, not its display label).
+	 *
+	 * @param string $field The ESP merge field tag.
+	 *
+	 * @return string The merge tag (e.g. '*|DONORSTATUS|*'), or '' when there is
+	 *                no provider, the field is empty, or the provider is unsupported.
+	 */
+	public static function get_merge_tag( $field ) {
+		$field = trim( (string) $field );
+		if ( '' === $field ) {
+			return '';
+		}
+		$provider = \Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return '';
+		}
+		switch ( $provider->service ) {
+			case 'mailchimp':
+				return '*|' . $field . '|*';
+			case 'campaign_monitor':
+				return '[' . $field . ']';
+			case 'constant_contact':
+				return '[[' . $field . ']]';
+			case 'active_campaign':
+				return '%' . $field . '%';
+			default:
+				return '';
+		}
+	}
 }

--- a/plugins/newspack-newsletters/includes/tracking/class-utils.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-utils.php
@@ -19,19 +19,13 @@ final class Utils {
 		if ( empty( $provider ) ) {
 			return '';
 		}
-		$provider_name = $provider->service;
-		switch ( $provider_name ) {
-			case 'mailchimp':
-				return '*|EMAIL|*';
-			case 'campaign_monitor':
-				return '[email]';
-			case 'constant_contact':
-				return '[[emailAddress]]';
-			case 'active_campaign':
-				return '%EMAIL%';
-			default:
-				return '';
-		}
+		return match ( $provider->service ) {
+			'mailchimp'        => '*|EMAIL|*',
+			'campaign_monitor' => '[email]',
+			'constant_contact' => '[[emailAddress]]',
+			'active_campaign'  => '%EMAIL%',
+			default            => '',
+		};
 	}
 
 	/**
@@ -60,17 +54,12 @@ final class Utils {
 		if ( empty( $provider ) ) {
 			return '';
 		}
-		switch ( $provider->service ) {
-			case 'mailchimp':
-				return '*|' . $field . '|*';
-			case 'campaign_monitor':
-				return '[' . $field . ']';
-			case 'constant_contact':
-				return '[[' . $field . ']]';
-			case 'active_campaign':
-				return '%' . $field . '%';
-			default:
-				return '';
-		}
+		return match ( $provider->service ) {
+			'mailchimp'        => '*|' . $field . '|*',
+			'campaign_monitor' => '[' . $field . ']',
+			'constant_contact' => '[[' . $field . ']]',
+			'active_campaign'  => '%' . $field . '%',
+			default            => '',
+		};
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-tracking-utils.php
+++ b/plugins/newspack-newsletters/tests/test-tracking-utils.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tests for the Tracking\Utils merge-tag helpers.
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack_Newsletters\Tracking\Utils;
+
+/**
+ * Tracking Utils Test.
+ */
+class Newsletters_Tracking_Utils_Test extends WP_UnitTestCase {
+	/**
+	 * Wraps a field in the active ESP's merge-tag delimiters.
+	 */
+	public function test_get_merge_tag_uses_active_provider_syntax() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$this->assertSame( '*|HUB-MEMBER|*', Utils::get_merge_tag( 'HUB-MEMBER' ) );
+
+		\Newspack_Newsletters::set_service_provider( 'active_campaign' );
+		$this->assertSame( '%HUB-MEMBER%', Utils::get_merge_tag( 'HUB-MEMBER' ) );
+
+		\Newspack_Newsletters::set_service_provider( 'constant_contact' );
+		$this->assertSame( '[[HUB-MEMBER]]', Utils::get_merge_tag( 'HUB-MEMBER' ) );
+	}
+
+	/**
+	 * An empty field name yields no tag, so callers can append unconditionally
+	 * and skip on an empty return.
+	 */
+	public function test_get_merge_tag_returns_empty_for_empty_field() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$this->assertSame( '', Utils::get_merge_tag( '' ) );
+		$this->assertSame( '', Utils::get_merge_tag( '   ' ) );
+	}
+}

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -254,7 +254,14 @@ final class Newspack_Popups_Segmentation {
 		if ( empty( $merge_tag ) ) {
 			return $url;
 		}
-		return add_query_arg( self::DONOR_SEGMENT_QUERY_PARAM, $merge_tag, $url );
+		$url = add_query_arg( self::DONOR_SEGMENT_QUERY_PARAM, $merge_tag, $url );
+		// add_query_arg() URL-encodes the value, but ESPs substitute only the raw
+		// merge-tag syntax — Mailchimp leaves the percent-encoded form (e.g.
+		// %2A%7C…%7C%2A) untouched, verified against a live send — so the tag would
+		// never resolve. Restore the raw tag so the ESP substitutes the recipient's
+		// value at send time. (The reader lands on the substituted value; an
+		// unsubstituted literal is ignored client-side, so this stays fail-safe.)
+		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -26,6 +26,20 @@ final class Newspack_Popups_Segmentation {
 	const SEGMENTS_OPTION_NAME = 'newspack_popups_segments';
 
 	/**
+	 * Query param appended to newsletter links carrying the reader's donor
+	 * status. Its value is the ESP merge tag for the configured donor merge
+	 * field (e.g. Mailchimp's *|HUB-MEMBER|*), which the ESP substitutes with
+	 * the recipient's actual value at send time. The view script reads the
+	 * substituted value on the inbound click to flag the reader as a donor for
+	 * segmentation — no login required.
+	 *
+	 * This is an unsigned, reader-visible, forgeable signal: it must only ever
+	 * drive prompt segmentation, never content access. Restricted content stays
+	 * behind the HMAC-signed newsletter pass (see Newspack\Newsletters_Access).
+	 */
+	const DONOR_SEGMENT_QUERY_PARAM = 'np_seg_donor';
+
+	/**
 	 * Installed version number of the custom table.
 	 */
 	const TABLE_VERSION = '1.0';
@@ -66,6 +80,12 @@ final class Newspack_Popups_Segmentation {
 		) {
 			\Newspack\Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
 		}
+
+		// Append the donor-status segment param to newsletter links so readers
+		// arriving from a newsletter are segmented as donors without a login.
+		// The handler self-guards on the donor merge field being configured and
+		// the ESP being supported, so it's cheap to register unconditionally.
+		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_donor_segment_param' ], 30, 3 );
 	}
 
 	/**
@@ -183,6 +203,85 @@ final class Newspack_Popups_Segmentation {
 	 */
 	public static function reindex_segments( $segments ) {
 		return Newspack_Segments_Model::reindex_segments( $segments );
+	}
+
+	/**
+	 * Filter callback: append the donor-status segment param to first-party
+	 * newsletter links.
+	 *
+	 * The appended value is the ESP merge tag for the configured donor merge
+	 * field; the ESP substitutes the recipient's value at send time so the
+	 * inbound click carries e.g. `?np_seg_donor=true`. Skips when the Newsletters
+	 * tracking helper is unavailable, the post isn't a newsletter (ad links are
+	 * proxied separately and wouldn't forward the param), the link is
+	 * third-party, no donor merge field is configured, or the ESP is unsupported.
+	 *
+	 * @param string        $url          Processed URL (may already carry other params).
+	 * @param string        $original_url Original URL before processing.
+	 * @param \WP_Post|null $post         Newsletter post object, or null.
+	 *
+	 * @return string
+	 */
+	public static function append_donor_segment_param( $url, $original_url, $post ) {
+		if ( ! class_exists( '\Newspack_Newsletters\Tracking\Utils' ) ) {
+			return $url;
+		}
+		if ( ! self::is_newsletter_post( $post ) ) {
+			return $url;
+		}
+		if ( ! self::is_first_party_url( $url ) ) {
+			return $url;
+		}
+		// Read the option directly rather than via Newspack_Popups_Settings::get_setting(),
+		// which builds the whole settings array (including a WP_Query over all pages)
+		// on every call — wasteful here since this filter fires once per newsletter link.
+		$donor_merge_field = get_option( 'newspack_popups_mc_donor_merge_field', 'DONAT' );
+		if ( empty( $donor_merge_field ) ) {
+			return $url;
+		}
+		$merge_tag = \Newspack_Newsletters\Tracking\Utils::get_merge_tag( $donor_merge_field );
+		if ( empty( $merge_tag ) ) {
+			return $url;
+		}
+		return add_query_arg( self::DONOR_SEGMENT_QUERY_PARAM, $merge_tag, $url );
+	}
+
+	/**
+	 * Whether the given post is a Newspack newsletter.
+	 *
+	 * @param \WP_Post|null $post Post object.
+	 *
+	 * @return bool
+	 */
+	private static function is_newsletter_post( $post ) {
+		if ( ! $post instanceof \WP_Post ) {
+			return false;
+		}
+		if ( ! defined( '\Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT' ) ) {
+			return false;
+		}
+		return \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $post->post_type;
+	}
+
+	/**
+	 * Whether the given URL points to this site, by host comparison.
+	 *
+	 * The donor flag is appended only to first-party links: pushing it onto
+	 * third-party URLs would leak the reader's donor status into external logs,
+	 * analytics, and Referer headers for no benefit, since only this site reads
+	 * the param. Relative URLs are first-party by definition.
+	 *
+	 * @param string $url URL to test.
+	 *
+	 * @return bool
+	 */
+	private static function is_first_party_url( $url ) {
+		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( empty( $url_host ) ) {
+			return true;
+		}
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		return strcasecmp( $url_host, (string) $site_host ) === 0;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -256,11 +256,10 @@ final class Newspack_Popups_Segmentation {
 		}
 		$url = add_query_arg( self::DONOR_SEGMENT_QUERY_PARAM, $merge_tag, $url );
 		// add_query_arg() URL-encodes the value, but ESPs substitute only the raw
-		// merge-tag syntax — Mailchimp leaves the percent-encoded form (e.g.
-		// %2A%7C…%7C%2A) untouched, verified against a live send — so the tag would
-		// never resolve. Restore the raw tag so the ESP substitutes the recipient's
-		// value at send time. (The reader lands on the substituted value; an
-		// unsubstituted literal is ignored client-side, so this stays fail-safe.)
+		// merge-tag syntax: Mailchimp leaves the percent-encoded form (%2A%7C...%7C%2A)
+		// untouched, as verified against a live send, so the tag would never resolve.
+		// Restore the raw tag so the ESP substitutes the recipient's value at send
+		// time. An unsubstituted literal is ignored client-side, so this stays fail-safe.
 		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
 	}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -223,7 +223,12 @@ final class Newspack_Popups_Segmentation {
 	 * @return string
 	 */
 	public static function append_donor_segment_param( $url, $original_url, $post ) {
-		if ( ! class_exists( '\Newspack_Newsletters\Tracking\Utils' ) ) {
+		// Guard on the method, not just the class: the Tracking\Utils class predates
+		// get_merge_tag(), so an older newspack-newsletters can satisfy a class_exists()
+		// check while lacking the method — calling it would fatal mid-render, breaking
+		// every newsletter on the site. method_exists() also returns false when the
+		// class is absent, so this covers both the missing-class and version-skew cases.
+		if ( ! method_exists( '\Newspack_Newsletters\Tracking\Utils', 'get_merge_tag' ) ) {
 			return $url;
 		}
 		if ( ! self::is_newsletter_post( $post ) ) {
@@ -235,7 +240,13 @@ final class Newspack_Popups_Segmentation {
 		// Read the option directly rather than via Newspack_Popups_Settings::get_setting(),
 		// which builds the whole settings array (including a WP_Query over all pages)
 		// on every call — wasteful here since this filter fires once per newsletter link.
-		$donor_merge_field = get_option( 'newspack_popups_mc_donor_merge_field', 'DONAT' );
+		$donor_merge_field = get_option( 'newspack_popups_mc_donor_merge_field', Newspack_Popups_Settings::DEFAULT_DONOR_MERGE_FIELD );
+		// This setting is a comma-delimited list of name fragments used for substring
+		// matching at login (see reader_logged_in()). Building a query-param merge tag
+		// instead needs a single exact ESP merge tag — a multi-value list can't map to
+		// one — so use the first entry. The value must be the exact merge tag (not a
+		// display label or partial name) for the ESP to substitute it.
+		$donor_merge_field = trim( explode( ',', (string) $donor_merge_field )[0] );
 		if ( empty( $donor_merge_field ) ) {
 			return $url;
 		}

--- a/plugins/newspack-popups/includes/class-newspack-popups-settings.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-settings.php
@@ -14,6 +14,14 @@ class Newspack_Popups_Settings {
 	const NEWSPACK_POPUPS_SETTINGS_PAGE = 'newspack-popups-settings-admin';
 
 	/**
+	 * Default value for the `newspack_popups_mc_donor_merge_field` option.
+	 *
+	 * Referenced both here and by Newspack_Popups_Segmentation (which reads the
+	 * option directly), so the default stays in one place.
+	 */
+	const DEFAULT_DONOR_MERGE_FIELD = 'DONAT';
+
+	/**
 	 * Set up hooks.
 	 */
 	public static function init() {
@@ -269,8 +277,8 @@ class Newspack_Popups_Settings {
 				'section'     => 'donor_settings',
 				'key'         => 'newspack_popups_mc_donor_merge_field',
 				'type'        => 'string',
-				'value'       => get_option( 'newspack_popups_mc_donor_merge_field', 'DONAT' ),
-				'default'     => 'DONAT',
+				'value'       => get_option( 'newspack_popups_mc_donor_merge_field', self::DEFAULT_DONOR_MERGE_FIELD ),
+				'default'     => self::DEFAULT_DONOR_MERGE_FIELD,
 				'description' => __( 'Mailchimp donor merge fields', 'newspack-popups' ),
 				'help'        => __(
 					'A comma-delimited list of strings to match against Mailchimp merge field names. If a Mailchimp merge field name contains one of these strings and a subscriber has a true value in this field, the subscriber will be considered a donor for segmentation purposes.',

--- a/plugins/newspack-popups/src/criteria/default/donation.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.js
@@ -1,12 +1,110 @@
 import { setMatchingFunction } from '../utils';
 
-setMatchingFunction( 'donation', ( config, { store } ) => {
+/**
+ * Query param carrying the reader's donor status, substituted per-recipient by
+ * the ESP from the configured donor merge field (e.g. `?np_seg_donor=true`).
+ */
+const DONOR_PARAM = 'np_seg_donor';
+
+/**
+ * Session-storage key used to remember that the reader arrived from a newsletter
+ * email carrying a positive donor status during the current browsing session.
+ */
+const FROM_EMAIL_DONOR_KEY = 'newspack-popups-donor-from-email';
+
+/**
+ * Whether a donor merge-field value counts as a positive donor indicator.
+ *
+ * Mirrors Newspack_Popups_Segmentation::is_donor_merge_field_value() in PHP —
+ * keep the falsy list in sync.
+ *
+ * @param {string} value The merge-tag value from the inbound link.
+ * @return {boolean} Whether the value indicates the reader is a donor.
+ */
+const isDonorValue = value => ! [ 'no', 'none', 'false', '0', '' ].includes( String( value ).toLowerCase() );
+
+/**
+ * Whether a query-param value still contains unsubstituted ESP merge-tag syntax
+ * — i.e. the sending service failed to replace it with the actual per-recipient
+ * value. Such a value must be ignored, or every recipient of a misconfigured
+ * send would be flagged as a donor from the raw template string.
+ *
+ * Covers three of the four ESPs supported by Newspack Newsletters:
+ *   Mailchimp        *|FIELD|*
+ *   Constant Contact [[FIELD]]
+ *   ActiveCampaign   %FIELD%
+ *
+ * Campaign Monitor uses [FIELD], but bare square brackets are too common in
+ * query values to guard against reliably.
+ *
+ * @param {string} value The decoded query-param value.
+ * @return {boolean} True when the value contains raw merge-tag syntax.
+ */
+const isUnsubstitutedMergeTag = value =>
+	/^\*\|[^|]+\|\*$/.test( value ) || // Mailchimp
+	/^\[\[[^\]]+\]\]$/.test( value ) || // Constant Contact
+	/^%[^%]+%$/.test( value ); // ActiveCampaign
+
+/**
+ * Whether the reader arrived from a newsletter email flagged as a donor.
+ *
+ * A reader clicking a link in a newsletter lands on a URL carrying
+ * `np_seg_donor`, whose value the ESP substitutes per recipient from the
+ * publisher's donor merge field. The URL param is authoritative on the landing
+ * page, so it is honored even when the arrival cannot be persisted. When a
+ * positive donor value is detected, the arrival is also remembered for the rest
+ * of the browsing session via sessionStorage so the reader keeps matching donor
+ * segments as they navigate to clean URLs.
+ *
+ * This is segmentation-only and transient — it is never written to the persisted
+ * reader data store, so it cannot grant content access, does not affect
+ * analytics or ad targeting, and never persists across sessions. Mirrors the
+ * `isFromEmail()` pattern in newsletter.js.
+ *
+ * @return {boolean} True if the reader arrived this session as a flagged donor.
+ */
+export function isDonorFromEmail() {
+	const value = new URLSearchParams( window.location.search ).get( DONOR_PARAM );
+	// The URL param is authoritative on the landing page, even if nothing can be
+	// persisted. An unsubstituted merge tag means the send was misconfigured, so
+	// it is ignored rather than treated as a donor value.
+	if ( value !== null && ! isUnsubstitutedMergeTag( value ) && isDonorValue( value ) ) {
+		// Remember the arrival for the rest of the session so the reader keeps
+		// matching after navigating to clean URLs. A write failure (e.g. private
+		// mode) only costs the cross-navigation memory, not this detection.
+		try {
+			window.sessionStorage.setItem( FROM_EMAIL_DONOR_KEY, '1' );
+		} catch ( e ) {
+			// sessionStorage unavailable; the URL signal still stands.
+		}
+		return true;
+	}
+	// No positive param on this page — fall back to whatever was remembered earlier.
+	try {
+		return window.sessionStorage.getItem( FROM_EMAIL_DONOR_KEY ) === '1';
+	} catch ( e ) {
+		// sessionStorage unavailable. Fail closed.
+		return false;
+	}
+}
+
+/**
+ * Matching function for the 'donation' criteria.
+ *
+ * @param {Object} config    The segment criteria config.
+ * @param {Object} ras       The reader activation object.
+ * @param {Object} ras.store The reader data library store.
+ * @return {boolean} Whether the criteria matches.
+ */
+export function matchDonation( config, { store } ) {
 	switch ( config.value ) {
 		case 'donors':
-			return store.get( 'is_donor' );
+			return store.get( 'is_donor' ) || isDonorFromEmail();
 		case 'non-donors':
-			return ! store.get( 'is_donor' );
+			return ! ( store.get( 'is_donor' ) || isDonorFromEmail() );
 		case 'formers-donors':
 			return store.get( 'is_former_donor' );
 	}
-} );
+}
+
+setMatchingFunction( 'donation', matchDonation );

--- a/plugins/newspack-popups/src/criteria/default/donation.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.js
@@ -1,4 +1,5 @@
 import { setMatchingFunction } from '../utils';
+import { rememberSessionSignal } from './session-signal';
 
 /**
  * Query param carrying the reader's donor status, substituted per-recipient by
@@ -50,42 +51,20 @@ const isUnsubstitutedMergeTag = value =>
  *
  * A reader clicking a link in a newsletter lands on a URL carrying
  * `np_seg_donor`, whose value the ESP substitutes per recipient from the
- * publisher's donor merge field. The URL param is authoritative on the landing
- * page, so it is honored even when the arrival cannot be persisted. When a
- * positive donor value is detected, the arrival is also remembered for the rest
- * of the browsing session via sessionStorage so the reader keeps matching donor
- * segments as they navigate to clean URLs.
- *
- * This is segmentation-only and transient — it is never written to the persisted
- * reader data store, so it cannot grant content access, does not affect
- * analytics or ad targeting, and never persists across sessions. Mirrors the
- * `isFromEmail()` pattern in newsletter.js.
+ * publisher's donor merge field. A positive value is detected and remembered
+ * for the rest of the browsing session so the reader keeps matching donor
+ * segments as they navigate to clean URLs. An unsubstituted merge tag means the
+ * send was misconfigured, so it is ignored rather than treated as a donor value.
+ * See rememberSessionSignal() for the segmentation-only, transient guarantees.
  *
  * @return {boolean} True if the reader arrived this session as a flagged donor.
  */
 export function isDonorFromEmail() {
-	const value = new URLSearchParams( window.location.search ).get( DONOR_PARAM );
-	// The URL param is authoritative on the landing page, even if nothing can be
-	// persisted. An unsubstituted merge tag means the send was misconfigured, so
-	// it is ignored rather than treated as a donor value.
-	if ( value !== null && ! isUnsubstitutedMergeTag( value ) && isDonorValue( value ) ) {
-		// Remember the arrival for the rest of the session so the reader keeps
-		// matching after navigating to clean URLs. A write failure (e.g. private
-		// mode) only costs the cross-navigation memory, not this detection.
-		try {
-			window.sessionStorage.setItem( FROM_EMAIL_DONOR_KEY, '1' );
-		} catch ( e ) {
-			// sessionStorage unavailable; the URL signal still stands.
-		}
-		return true;
-	}
-	// No positive param on this page — fall back to whatever was remembered earlier.
-	try {
-		return window.sessionStorage.getItem( FROM_EMAIL_DONOR_KEY ) === '1';
-	} catch ( e ) {
-		// sessionStorage unavailable. Fail closed.
-		return false;
-	}
+	return rememberSessionSignal( {
+		param: DONOR_PARAM,
+		sessionKey: FROM_EMAIL_DONOR_KEY,
+		isPositive: value => ! isUnsubstitutedMergeTag( value ) && isDonorValue( value ),
+	} );
 }
 
 /**

--- a/plugins/newspack-popups/src/criteria/default/donation.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.js
@@ -30,13 +30,17 @@ const isDonorValue = value => ! [ 'no', 'none', 'false', '0', '' ].includes( Str
  * value. Such a value must be ignored, or every recipient of a misconfigured
  * send would be flagged as a donor from the raw template string.
  *
- * Covers three of the four ESPs supported by Newspack Newsletters:
+ * Covers all four ESPs supported by Newspack Newsletters:
  *   Mailchimp        *|FIELD|*
  *   Constant Contact [[FIELD]]
  *   ActiveCampaign   %FIELD%
+ *   Campaign Monitor [FIELD]
  *
- * Campaign Monitor uses [FIELD], but bare square brackets are too common in
- * query values to guard against reliably.
+ * Rejecting the bare-bracket Campaign Monitor form would be risky for an
+ * arbitrary query value, but `np_seg_donor` only ever carries a donor-status
+ * value (e.g. `true`, `monthly`, `$50.00`) — never a `[…]`-wrapped string — so
+ * matching it here is safe and keeps the inbound guard symmetric with every tag
+ * get_merge_tag() can emit.
  *
  * @param {string} value The decoded query-param value.
  * @return {boolean} True when the value contains raw merge-tag syntax.
@@ -44,7 +48,8 @@ const isDonorValue = value => ! [ 'no', 'none', 'false', '0', '' ].includes( Str
 const isUnsubstitutedMergeTag = value =>
 	/^\*\|[^|]+\|\*$/.test( value ) || // Mailchimp
 	/^\[\[[^\]]+\]\]$/.test( value ) || // Constant Contact
-	/^%[^%]+%$/.test( value ); // ActiveCampaign
+	/^%[^%]+%$/.test( value ) || // ActiveCampaign
+	/^\[[^\][]+\]$/.test( value ); // Campaign Monitor
 
 /**
  * Whether the reader arrived from a newsletter email flagged as a donor.
@@ -69,6 +74,11 @@ export function isDonorFromEmail() {
 
 /**
  * Matching function for the 'donation' criteria.
+ *
+ * Readers arriving from a newsletter flagged as donors (`np_seg_donor`) match
+ * `donors`; a falsy or absent signal leaves them matching `non-donors`, the same
+ * as a reader who never clicked — the inbound flag only ever adds donors, there
+ * is no separate "unknown" state.
  *
  * @param {Object} config    The segment criteria config.
  * @param {Object} ras       The reader activation object.

--- a/plugins/newspack-popups/src/criteria/default/donation.test.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.test.js
@@ -1,0 +1,96 @@
+import { matchDonation, isDonorFromEmail } from './donation';
+
+/**
+ * Build the second argument the matching function receives, with a stubbed
+ * reader data library store returning the given values.
+ *
+ * @param {Object}  values            Store values.
+ * @param {boolean} values.isDonor       Value returned by store.get( 'is_donor' ).
+ * @param {boolean} values.isFormerDonor Value returned by store.get( 'is_former_donor' ).
+ * @return {Object} Stubbed reader activation object.
+ */
+const ras = ( { isDonor = false, isFormerDonor = false } = {} ) => ( {
+	store: { get: key => ( 'is_former_donor' === key ? isFormerDonor : isDonor ) },
+} );
+
+describe( 'donation criteria matching', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'treats a non-donor arriving with no donor param as a non-donor', () => {
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( false );
+		expect( matchDonation( { value: 'non-donors' }, ras() ) ).toBe( true );
+	} );
+
+	it( 'treats a reader with the stored is_donor flag as a donor', () => {
+		expect( matchDonation( { value: 'donors' }, ras( { isDonor: true } ) ) ).toBe( true );
+		expect( matchDonation( { value: 'non-donors' }, ras( { isDonor: true } ) ) ).toBe( false );
+	} );
+
+	it( 'matches the former-donors value from the store', () => {
+		expect( matchDonation( { value: 'formers-donors' }, ras( { isFormerDonor: true } ) ) ).toBe( true );
+		expect( matchDonation( { value: 'formers-donors' }, ras() ) ).toBe( false );
+	} );
+
+	it.each( [ 'true', 'Yes', '1', 'monthly', '$50.00' ] )(
+		'treats a reader arriving with np_seg_donor=%s as a donor',
+		value => {
+			window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+			expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+			expect( matchDonation( { value: 'non-donors' }, ras() ) ).toBe( false );
+		}
+	);
+
+	it.each( [ 'false', 'no', 'none', '0' ] )(
+		'does not treat a reader arriving with falsy np_seg_donor=%s as a donor',
+		value => {
+			window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+			expect( isDonorFromEmail() ).toBe( false );
+		}
+	);
+
+	it( 'remembers a donor email arrival for the rest of the session', () => {
+		// Landing page carries the param and sets the session flag.
+		window.history.replaceState( {}, '', '/?np_seg_donor=true' );
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+		// Subsequent navigation to a clean URL still matches donors.
+		window.history.replaceState( {}, '', '/some-article' );
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+	} );
+
+	it.each( [
+		[ 'Mailchimp', '*|HUB-MEMBER|*' ],
+		[ 'Constant Contact', '[[DONOR]]' ],
+		[ 'ActiveCampaign', '%DONOR%' ],
+	] )( 'ignores an unsubstituted %s merge tag so every recipient is not flagged', ( _esp, value ) => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+		expect( isDonorFromEmail() ).toBe( false );
+	} );
+
+	it( 'still matches donors on an email arrival when sessionStorage writes are blocked', () => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=true' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		// The URL param is authoritative; a failed write only costs cross-navigation memory.
+		expect( () => matchDonation( { value: 'donors' }, ras() ) ).not.toThrow();
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+		setSpy.mockRestore();
+	} );
+
+	it( 'does not throw when sessionStorage is fully unavailable', () => {
+		window.history.replaceState( {}, '', '/some-article' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		const getSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => isDonorFromEmail() ).not.toThrow();
+		expect( isDonorFromEmail() ).toBe( false );
+		setSpy.mockRestore();
+		getSpy.mockRestore();
+	} );
+} );

--- a/plugins/newspack-popups/src/criteria/default/donation.test.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.test.js
@@ -4,7 +4,7 @@ import { matchDonation, isDonorFromEmail } from './donation';
  * Build the second argument the matching function receives, with a stubbed
  * reader data library store returning the given values.
  *
- * @param {Object}  values            Store values.
+ * @param {Object}  values               Store values.
  * @param {boolean} values.isDonor       Value returned by store.get( 'is_donor' ).
  * @param {boolean} values.isFormerDonor Value returned by store.get( 'is_former_donor' ).
  * @return {Object} Stubbed reader activation object.
@@ -34,22 +34,16 @@ describe( 'donation criteria matching', () => {
 		expect( matchDonation( { value: 'formers-donors' }, ras() ) ).toBe( false );
 	} );
 
-	it.each( [ 'true', 'Yes', '1', 'monthly', '$50.00' ] )(
-		'treats a reader arriving with np_seg_donor=%s as a donor',
-		value => {
-			window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
-			expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
-			expect( matchDonation( { value: 'non-donors' }, ras() ) ).toBe( false );
-		}
-	);
+	it.each( [ 'true', 'Yes', '1', 'monthly', '$50.00' ] )( 'treats a reader arriving with np_seg_donor=%s as a donor', value => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+		expect( matchDonation( { value: 'non-donors' }, ras() ) ).toBe( false );
+	} );
 
-	it.each( [ 'false', 'no', 'none', '0' ] )(
-		'does not treat a reader arriving with falsy np_seg_donor=%s as a donor',
-		value => {
-			window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
-			expect( isDonorFromEmail() ).toBe( false );
-		}
-	);
+	it.each( [ 'false', 'no', 'none', '0' ] )( 'does not treat a reader arriving with falsy np_seg_donor=%s as a donor', value => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+		expect( isDonorFromEmail() ).toBe( false );
+	} );
 
 	it( 'remembers a donor email arrival for the rest of the session', () => {
 		// Landing page carries the param and sets the session flag.

--- a/plugins/newspack-popups/src/criteria/default/donation.test.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.test.js
@@ -58,6 +58,7 @@ describe( 'donation criteria matching', () => {
 		[ 'Mailchimp', '*|HUB-MEMBER|*' ],
 		[ 'Constant Contact', '[[DONOR]]' ],
 		[ 'ActiveCampaign', '%DONOR%' ],
+		[ 'Campaign Monitor', '[HUB-MEMBER]' ],
 	] )( 'ignores an unsubstituted %s merge tag so every recipient is not flagged', ( _esp, value ) => {
 		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
 		expect( isDonorFromEmail() ).toBe( false );

--- a/plugins/newspack-popups/src/criteria/default/index.php
+++ b/plugins/newspack-popups/src/criteria/default/index.php
@@ -135,7 +135,7 @@ $criteria = [
 	],
 	'donation'                 => [
 		'name'        => __( 'Donation', 'newspack-popups' ),
-		'description' => __( 'If the reader has completed an onsite donation.', 'newspack-popups' ),
+		'description' => __( 'If the reader has completed an onsite donation. Readers arriving from a newsletter email flagged as a donor are also matched as donors, for the rest of their browsing session.', 'newspack-popups' ),
 		'category'    => 'reader_revenue',
 		'options'     => [
 			[

--- a/plugins/newspack-popups/src/criteria/default/newsletter.js
+++ b/plugins/newspack-popups/src/criteria/default/newsletter.js
@@ -1,4 +1,5 @@
 import { setMatchingFunction } from '../utils';
+import { rememberSessionSignal } from './session-signal';
 
 /**
  * Session-storage key used to remember that the reader arrived from a
@@ -10,39 +11,20 @@ const FROM_EMAIL_KEY = 'newspack-popups-from-email';
  * Whether the reader is visiting from a newsletter email.
  *
  * A reader clicking a link in a Newspack newsletter lands on a URL carrying
- * `utm_medium=email` (appended by the newsletter renderer). The URL param is an
- * authoritative signal on the landing page, so it is honored even when the
- * arrival cannot be persisted. When detected, the arrival is also remembered
- * for the rest of the browsing session via sessionStorage so the reader keeps
- * matching "subscribers" segments as they navigate to clean URLs. This is
- * segmentation-only and transient — it is never written to the persisted reader
- * data store, so it does not affect analytics or ad targeting, and never
- * persists across sessions.
+ * `utm_medium=email` (appended by the newsletter renderer). The arrival is
+ * detected from the param and remembered for the rest of the browsing session
+ * so the reader keeps matching "subscribers" segments as they navigate to clean
+ * URLs. See rememberSessionSignal() for the segmentation-only, transient
+ * guarantees.
  *
  * @return {boolean} True if the reader arrived from a newsletter email this session.
  */
 export function isFromEmail() {
-	// The URL param is authoritative on the landing page, even if nothing can
-	// be persisted.
-	const medium = new URLSearchParams( window.location.search ).get( 'utm_medium' );
-	if ( medium?.toLowerCase() === 'email' ) {
-		// Remember the arrival for the rest of the session so the reader keeps
-		// matching after navigating to clean URLs. A write failure (e.g. private
-		// mode) only costs the cross-navigation memory, not this detection.
-		try {
-			window.sessionStorage.setItem( FROM_EMAIL_KEY, '1' );
-		} catch ( e ) {
-			// sessionStorage unavailable; the URL signal still stands.
-		}
-		return true;
-	}
-	// No param on this page — fall back to whatever was remembered earlier.
-	try {
-		return window.sessionStorage.getItem( FROM_EMAIL_KEY ) === '1';
-	} catch ( e ) {
-		// sessionStorage unavailable. Fail closed.
-		return false;
-	}
+	return rememberSessionSignal( {
+		param: 'utm_medium',
+		sessionKey: FROM_EMAIL_KEY,
+		isPositive: value => value.toLowerCase() === 'email',
+	} );
 }
 
 /**

--- a/plugins/newspack-popups/src/criteria/default/session-signal.js
+++ b/plugins/newspack-popups/src/criteria/default/session-signal.js
@@ -1,0 +1,42 @@
+/**
+ * Detect a URL-param arrival signal and remember it for the browsing session.
+ *
+ * Several segmentation signals are delivered as a query param on the page a
+ * reader lands on from a newsletter email (e.g. `utm_medium=email`,
+ * `np_seg_donor`). The param is authoritative on the landing page; once a
+ * positive value is seen it is remembered in sessionStorage so the reader keeps
+ * matching as they navigate on to clean URLs.
+ *
+ * The flag is segmentation-only and transient: it is never written to the
+ * persisted reader data store (so it cannot grant content access and does not
+ * affect analytics or ad targeting) and never survives the browsing session.
+ *
+ * @param {Object}   options
+ * @param {string}   options.param      Query-param name to read.
+ * @param {string}   options.sessionKey sessionStorage key under which a positive arrival is remembered.
+ * @param {Function} options.isPositive Predicate receiving the decoded (non-null) param value; returns whether it is a positive signal.
+ * @return {boolean} Whether the signal is active for this browsing session.
+ */
+export function rememberSessionSignal( { param, sessionKey, isPositive } ) {
+	// The URL param is authoritative on the landing page, even if nothing can be
+	// persisted.
+	const value = new URLSearchParams( window.location.search ).get( param );
+	if ( value !== null && isPositive( value ) ) {
+		// Remember the arrival for the rest of the session so the reader keeps
+		// matching after navigating to clean URLs. A write failure (e.g. private
+		// mode) only costs the cross-navigation memory, not this detection.
+		try {
+			window.sessionStorage.setItem( sessionKey, '1' );
+		} catch ( e ) {
+			// sessionStorage unavailable; the URL signal still stands.
+		}
+		return true;
+	}
+	// No positive param on this page — fall back to whatever was remembered earlier.
+	try {
+		return window.sessionStorage.getItem( sessionKey ) === '1';
+	} catch ( e ) {
+		// sessionStorage unavailable. Fail closed.
+		return false;
+	}
+}

--- a/plugins/newspack-popups/src/criteria/default/session-signal.test.js
+++ b/plugins/newspack-popups/src/criteria/default/session-signal.test.js
@@ -1,0 +1,60 @@
+import { rememberSessionSignal } from './session-signal';
+
+const KEY = 'newspack-popups-test-signal';
+
+/**
+ * Invoke the helper for a `flag` param that is positive when its value is `1`.
+ *
+ * @return {boolean} The helper result.
+ */
+const detect = () => rememberSessionSignal( { param: 'flag', sessionKey: KEY, isPositive: value => '1' === value } );
+
+describe( 'rememberSessionSignal', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'returns false when the param is absent and nothing is remembered', () => {
+		expect( detect() ).toBe( false );
+	} );
+
+	it( 'returns true and remembers a positive param for the session', () => {
+		window.history.replaceState( {}, '', '/?flag=1' );
+		expect( detect() ).toBe( true );
+		// Subsequent navigation to a clean URL still matches via the remembered flag.
+		window.history.replaceState( {}, '', '/some-article' );
+		expect( detect() ).toBe( true );
+	} );
+
+	it( 'returns false for a non-positive param value and does not remember it', () => {
+		window.history.replaceState( {}, '', '/?flag=0' );
+		expect( detect() ).toBe( false );
+		window.history.replaceState( {}, '', '/some-article' );
+		expect( detect() ).toBe( false );
+	} );
+
+	it( 'still detects a positive param when the sessionStorage write is blocked', () => {
+		window.history.replaceState( {}, '', '/?flag=1' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => detect() ).not.toThrow();
+		expect( detect() ).toBe( true );
+		setSpy.mockRestore();
+	} );
+
+	it( 'fails closed when sessionStorage is fully unavailable and no param is present', () => {
+		window.history.replaceState( {}, '', '/some-article' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		const getSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => detect() ).not.toThrow();
+		expect( detect() ).toBe( false );
+		setSpy.mockRestore();
+		getSpy.mockRestore();
+	} );
+} );

--- a/plugins/newspack-popups/tests/mocks/class-newspack-newsletters.php
+++ b/plugins/newspack-popups/tests/mocks/class-newspack-newsletters.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Mock of the newspack-newsletters main class for popups tests.
+ *
+ * The popups test suite loads only newspack-popups, so cross-plugin classes
+ * the code guards on are absent. This stand-in exposes just the newsletter CPT
+ * slug used by Newspack_Popups_Segmentation::append_donor_segment_param().
+ *
+ * @package Newspack_Popups
+ */
+
+if ( ! class_exists( 'Newspack_Newsletters' ) ) {
+	/**
+	 * Minimal stand-in for the newspack-newsletters main class.
+	 */
+	class Newspack_Newsletters {
+		const NEWSPACK_NEWSLETTERS_CPT = 'newspack_nl_cpt';
+	}
+}

--- a/plugins/newspack-popups/tests/mocks/class-utils.php
+++ b/plugins/newspack-popups/tests/mocks/class-utils.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Mock of the newspack-newsletters Tracking\Utils helper for popups tests.
+ *
+ * Mirrors the real helper's Mailchimp merge-tag syntax so the donor-segment
+ * link handler can be tested without the newspack-newsletters plugin loaded.
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+if ( ! class_exists( __NAMESPACE__ . '\Utils' ) ) {
+	/**
+	 * Minimal stand-in for the newspack-newsletters tracking helper.
+	 */
+	class Utils {
+		/**
+		 * Wrap a field in Mailchimp merge-tag delimiters.
+		 *
+		 * @param string $field Merge field tag.
+		 * @return string
+		 */
+		public static function get_merge_tag( $field ) {
+			$field = trim( (string) $field );
+			return '' === $field ? '' : '*|' . $field . '|*';
+		}
+	}
+}

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests for the donor-status segment param appended to newsletter links by
+ * Newspack_Popups_Segmentation::append_donor_segment_param().
+ *
+ * @package Newspack_Popups
+ */
+
+// Stand-ins for the newspack-newsletters classes the handler guards on; the
+// popups test suite loads only newspack-popups.
+require_once __DIR__ . '/mocks/class-newspack-newsletters.php';
+require_once __DIR__ . '/mocks/class-utils.php';
+
+/**
+ * Test appending segment params to newsletter links.
+ */
+class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
+	const DONOR_FIELD = 'HUB-MEMBER';
+
+	/**
+	 * Set up: configure a donor merge field.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( 'newspack_popups_mc_donor_merge_field', self::DONOR_FIELD );
+	}
+
+	/**
+	 * Make a newsletter post.
+	 *
+	 * @return WP_Post
+	 */
+	private function make_newsletter() {
+		return self::factory()->post->create_and_get(
+			[ 'post_type' => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ]
+		);
+	}
+
+	/**
+	 * A first-party link in a newsletter gets the donor merge tag appended,
+	 * which the ESP substitutes per recipient at send time.
+	 */
+	public function test_appends_merge_tag_to_first_party_newsletter_link() {
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertArrayHasKey( 'np_seg_donor', $args );
+		$this->assertSame( '*|' . self::DONOR_FIELD . '|*', $args['np_seg_donor'] );
+	}
+
+	/**
+	 * Third-party links are left untouched so the donor flag never leaks into
+	 * external logs / Referer headers.
+	 */
+	public function test_skips_external_link() {
+		$url = 'https://example.com/elsewhere/';
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * With no donor merge field configured there's nothing to segment on.
+	 */
+	public function test_skips_when_no_donor_field_configured() {
+		update_option( 'newspack_popups_mc_donor_merge_field', '' );
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Non-newsletter posts (e.g. newsletter ads, which are proxied separately)
+	 * are not touched.
+	 */
+	public function test_skips_non_newsletter_post() {
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'post' ] );
+		$url  = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $post )
+		);
+	}
+}

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -85,4 +85,29 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $post )
 		);
 	}
+
+	/**
+	 * Relative (host-less) links are first-party by definition and get the param.
+	 */
+	public function test_appends_to_relative_link() {
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( '/some-article/', '/some-article/', $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertArrayHasKey( 'np_seg_donor', $args );
+		$this->assertSame( '*|' . self::DONOR_FIELD . '|*', $args['np_seg_donor'] );
+	}
+
+	/**
+	 * The donor-merge-field setting is a comma-delimited substring list (used for
+	 * login matching); a query-param merge tag needs a single exact tag, so only
+	 * the first entry is used and surrounding whitespace is trimmed.
+	 */
+	public function test_uses_first_entry_of_comma_delimited_field() {
+		update_option( 'newspack_popups_mc_donor_merge_field', ' HUB-MEMBER , MEMBER ' );
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertSame( '*|HUB-MEMBER|*', $args['np_seg_donor'] );
+	}
 }

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -47,6 +47,13 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
 		$this->assertArrayHasKey( 'np_seg_donor', $args );
 		$this->assertSame( '*|' . self::DONOR_FIELD . '|*', $args['np_seg_donor'] );
+
+		// The merge tag must appear RAW (unencoded) in the URL: ESPs substitute only
+		// the literal *|FIELD|* syntax and leave the percent-encoded form (%2A%7C…)
+		// untouched (verified against a live Mailchimp send). add_query_arg() encodes
+		// by default, so this guards the str_replace that restores the raw tag.
+		$this->assertStringContainsString( 'np_seg_donor=*|' . self::DONOR_FIELD . '|*', $result );
+		$this->assertStringNotContainsString( '%2A%7C', $result );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Lets readers who arrive from a newsletter be segmented as **donors** for prompt/campaign targeting, without requiring a reader account or login. This solves the case where a publisher on an off-site donation platform (e.g. NRH) sends via an ESP and wants donor-targeted prompts to fire for donors clicking through from the email.

**How it works:**

- `newspack-newsletters` appends `?np_seg_donor=*|MERGE_FIELD|*` to first-party links in newsletters (via `newspack_newsletters_process_link`). The ESP substitutes the merge tag per recipient at send time, so each reader's link carries their actual donor status (e.g. `?np_seg_donor=true`). A new `Newspack_Newsletters\Tracking\Utils::get_merge_tag()` produces the correct merge-tag syntax for each supported ESP (Mailchimp, ActiveCampaign, Constant Contact, Campaign Monitor).
- On inbound, the **donation** segmentation criterion (`donation.js`) treats the reader as a donor when `np_seg_donor` carries a positive value, and remembers it for the rest of the browsing session via `sessionStorage`.

**Key properties (mirrors the `utm_medium=email` subscriber work in #312):**

- **Segmentation-only and transient.** The arrival is remembered in `sessionStorage`, **never** written to the persisted reader data store. It cannot grant content access, does not affect GA4 / ad targeting / Site Kit, and never persists across sessions.
- **Misconfiguration-safe.** If the ESP fails to substitute the merge tag, the raw `*|FIELD|*` / `[[FIELD]]` / `%FIELD%` value is detected and ignored, so a broken send doesn't flag every recipient as a donor.
- **First-party links only.** The param is never appended to third-party URLs, so donor status doesn't leak into external logs / Referer headers.

> [!NOTE]
> This is the **donor** half of the original scope. The newsletter-**subscriber** half is handled by #312 (`utm_medium=email`), which Newspack Newsletters already appends to every link — so no separate subscriber param is needed here. The two PRs are independent (separate criterion files) and apply the same sessionStorage pattern.

Closes NPPM-2876.

### How to test the changes in this Pull Request:

1. On a site running newspack-popups + newspack-newsletters, build this branch (`n build newspack-popups`, `n build newspack-newsletters`).
2. In Newspack → Campaigns → Settings, set the **donor merge field** to your ESP donor merge field (e.g. `HUB-MEMBER`).
3. Create **Prompt A** on a segment whose only criterion is **Donation → Donors**, and **Prompt B** on **Donation → Non-donors**.
4. As a fresh, logged-out reader (new private window), visit a post with no params. Confirm **Prompt B** shows and **Prompt A** does not.
5. In the same session, visit a post with `?np_seg_donor=true`. Confirm **Prompt A** (donors) now shows and **Prompt B** does not.
6. Navigate to another post with no params in the same session. Confirm the reader is still treated as a donor (the arrival is remembered for the session).
7. Start a new session (reopen the tab / new private window) and visit with no params. Confirm the reader is a non-donor again (the flag never persists across sessions).
8. Edge case: visit with `?np_seg_donor=no` (or `false`/`0`) and confirm the reader is NOT treated as a donor.
9. Edge case: visit with the raw unsubstituted tag `?np_seg_donor=*|HUB-MEMBER|*` and confirm the reader is NOT treated as a donor (misconfigured send is ignored).
10. Confirm a genuine donor (persisted `is_donor`) is unaffected — **Prompt A** shows regardless of params.
11. Inspect a rendered newsletter's first-party links and confirm they carry `np_seg_donor=*|HUB-MEMBER|*`; third-party links do not.
12. Automated: from `plugins/newspack-popups` run the JS suite (`donation.test.js`) and `n test-php --filter SegmentationNewsletterLink`; from `plugins/newspack-newsletters` run `n test-php --filter test_get_merge_tag`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?