### PR TITLE
feat: bootstrap WC email-editor for newsletters

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -40,7 +40,7 @@ class Editor_Bootstrap {
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! class_exists( Email_Editor_Container::class ) ) {
+		if ( ! class_exists( Email_Editor_Container::class ) || ! class_exists( Bootstrap::class ) ) {
 			return;
 		}
 
@@ -76,7 +76,10 @@ class Editor_Bootstrap {
 	 * @return Templates_Registry The templates registry instance.
 	 */
 	public static function register_template( $registry ) {
-		$content = (string) file_get_contents( __DIR__ . '/templates/newspack-newsletter.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled plugin template file, not a remote resource.
+		$content = file_get_contents( __DIR__ . '/templates/newspack-newsletter.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled plugin template file, not a remote resource.
+		if ( false === $content ) {
+			return $registry;
+		}
 
 		$template = new Template(
 			self::TEMPLATE_NAMESPACE,

--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Boots the WooCommerce Email Editor package for the newsletters CPT.
+ *
+ * Initializes the email-editor package container, opts the newsletters CPT
+ * into the editor, and registers a wrapping block template that locks the
+ * newsletter content into a constrained group. No renderer wiring yet — this
+ * only bootstraps the package and registers the template.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+use Automattic\WooCommerce\EmailEditor\Bootstrap;
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Templates\Template;
+use Automattic\WooCommerce\EmailEditor\Engine\Templates\Templates_Registry;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bootstraps the WC email-editor package and registers the wrapping template.
+ */
+class Editor_Bootstrap {
+	/**
+	 * Plugin namespace used as the prefix of the registered template id.
+	 * The package composes the template id as "{namespace}//{slug}".
+	 */
+	const TEMPLATE_NAMESPACE = 'newspack';
+
+	/**
+	 * Slug of the wrapping block template.
+	 */
+	const TEMPLATE_SLUG = 'newspack-newsletter';
+
+	/**
+	 * Boot the package and register the editor hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! class_exists( Email_Editor_Container::class ) ) {
+			return;
+		}
+
+		Email_Editor_Container::container()->get( Bootstrap::class )->init();
+
+		add_filter( 'woocommerce_email_editor_post_types', [ __CLASS__, 'add_post_type' ] );
+		add_filter( 'woocommerce_email_editor_register_templates', [ __CLASS__, 'register_template' ] );
+	}
+
+	/**
+	 * Opt the newsletters CPT into the email editor.
+	 *
+	 * The package expects each entry to be an array with `name` and `args`
+	 * keys. We pass empty `args` so the canonical CPT definition registered by
+	 * Newspack_Newsletters remains authoritative; this entry only opts the CPT
+	 * into the editor's post-type-aware features (templates, REST fields).
+	 *
+	 * @param array $post_types List of email editor post types.
+	 * @return array Modified list of post types.
+	 */
+	public static function add_post_type( $post_types ) {
+		$post_types[] = [
+			'name' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			'args' => [],
+		];
+		return $post_types;
+	}
+
+	/**
+	 * Register the wrapping block template with the package registry.
+	 *
+	 * @param Templates_Registry $registry The templates registry instance.
+	 * @return Templates_Registry The templates registry instance.
+	 */
+	public static function register_template( $registry ) {
+		$content = (string) file_get_contents( __DIR__ . '/templates/newspack-newsletter.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled plugin template file, not a remote resource.
+
+		$template = new Template(
+			self::TEMPLATE_NAMESPACE,
+			self::TEMPLATE_SLUG,
+			__( 'Newsletter', 'newspack-newsletters' ),
+			__( 'Newspack newsletter email template.', 'newspack-newsletters' ),
+			$content,
+			[ \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ]
+		);
+
+		$registry->register( $template );
+
+		return $registry;
+	}
+}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -62,7 +62,7 @@ class Editor_Bootstrap {
 		// the canonical CPT's scalar args (public, labels, rewrite, menu_icon,
 		// rendering mode) with the package's email defaults. Re-assert the canonical
 		// definition at a later priority so Newspack's registration stays authoritative.
-		add_action( 'init', [ '\Newspack_Newsletters', 'register_cpt' ], 11 );
+		add_action( 'init', [ \Newspack_Newsletters::class, 'register_cpt' ], 11 );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -25,7 +25,9 @@ defined( 'ABSPATH' ) || exit;
 class Editor_Bootstrap {
 	/**
 	 * Plugin namespace used as the prefix of the registered template id.
-	 * The package composes the template id as "{namespace}//{slug}".
+	 * The package composes the template id as "{namespace}//{slug}", so the
+	 * full id is "newspack//newspack-newsletter" — unique to this plugin's
+	 * wrapping template (the slug below is newsletters-specific).
 	 */
 	const TEMPLATE_NAMESPACE = 'newspack';
 
@@ -40,23 +42,38 @@ class Editor_Bootstrap {
 	 * @return void
 	 */
 	public static function init() {
+		static $did_init = false;
+		if ( $did_init ) {
+			return;
+		}
 		if ( ! class_exists( Email_Editor_Container::class ) || ! class_exists( Bootstrap::class ) ) {
 			return;
 		}
+		$did_init = true;
 
 		Email_Editor_Container::container()->get( Bootstrap::class )->init();
 
 		add_filter( 'woocommerce_email_editor_post_types', [ __CLASS__, 'add_post_type' ] );
 		add_filter( 'woocommerce_email_editor_register_templates', [ __CLASS__, 'register_template' ] );
+
+		// The package re-registers every opted-in post type on `init` (priority 10)
+		// via register_post_type(). Its callback runs after
+		// Newspack_Newsletters::register_cpt(), so without this it would overwrite
+		// the canonical CPT's scalar args (public, labels, rewrite, menu_icon,
+		// rendering mode) with the package's email defaults. Re-assert the canonical
+		// definition at a later priority so Newspack's registration stays authoritative.
+		add_action( 'init', [ '\Newspack_Newsletters', 'register_cpt' ], 11 );
 	}
 
 	/**
 	 * Opt the newsletters CPT into the email editor.
 	 *
 	 * The package expects each entry to be an array with `name` and `args`
-	 * keys. We pass empty `args` so the canonical CPT definition registered by
-	 * Newspack_Newsletters remains authoritative; this entry only opts the CPT
-	 * into the editor's post-type-aware features (templates, REST fields).
+	 * keys. We pass empty `args` and opt the CPT in only for the editor's
+	 * post-type-aware features (templates, REST fields). The package re-registers
+	 * opted-in post types, so `init()` re-asserts the canonical
+	 * Newspack_Newsletters CPT definition at a later priority to keep it
+	 * authoritative (see init()).
 	 *
 	 * @param array $post_types List of email editor post types.
 	 * @return array Modified list of post types.
@@ -78,6 +95,7 @@ class Editor_Bootstrap {
 	public static function register_template( $registry ) {
 		$content = file_get_contents( __DIR__ . '/templates/newspack-newsletter.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled plugin template file, not a remote resource.
 		if ( false === $content ) {
+			\Newspack_Newsletters_Logger::log( 'Email editor: could not read the wrapping template file; skipping template registration.' );
 			return $registry;
 		}
 

--- a/plugins/newspack-newsletters/includes/email-renderers/templates/newspack-newsletter.html
+++ b/plugins/newspack-newsletters/includes/email-renderers/templates/newspack-newsletter.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:post-content {"lock":{"move":true,"remove":true},"layout":{"type":"default"}} /-->
+</div>
+<!-- /wp:group -->

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -56,6 +56,7 @@ if ( file_exists( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-logger.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-feature-flag.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-renderer-controller.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-editor-bootstrap.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider.php';
@@ -115,6 +116,10 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-she
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-assets.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.php';
+
+// Boot the WooCommerce Email Editor package. Must run before the `init` hook
+// so the editor's own `init` callbacks (CPT, templates) are registered in time.
+\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
 
 // This MUST be initialized after Newspack_Newsletter class.
 \Newspack\Newsletters\Subscription_Lists::init();

--- a/plugins/newspack-newsletters/tests/email-renderers/test-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-editor-bootstrap.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Class Editor Bootstrap Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+
+/**
+ * Editor Bootstrap Test.
+ *
+ * Verifies that booting the WooCommerce Email Editor package registers the
+ * wrapping block template for the newsletters CPT.
+ */
+class Test_Editor_Bootstrap extends WP_UnitTestCase {
+	/**
+	 * The wrapping block template is registered under the package's
+	 * "{plugin_uri}//{slug}" identifier once the editor is bootstrapped.
+	 */
+	public function test_wrapping_template_is_registered() {
+		$template_id = Editor_Bootstrap::TEMPLATE_NAMESPACE . '//' . Editor_Bootstrap::TEMPLATE_SLUG;
+		$template    = get_block_template( $template_id );
+		$this->assertNotNull( $template, 'Expected the Newspack newsletter wrapping template to be registered.' );
+		$this->assertSame( Editor_Bootstrap::TEMPLATE_SLUG, $template->slug, 'Registered template slug should match the bootstrap slug.' );
+	}
+
+	/**
+	 * The registered template opts the newsletters CPT in via its post_types.
+	 */
+	public function test_template_targets_newsletters_cpt() {
+		$template_id = Editor_Bootstrap::TEMPLATE_NAMESPACE . '//' . Editor_Bootstrap::TEMPLATE_SLUG;
+		$template    = get_block_template( $template_id );
+		$this->assertNotNull( $template );
+		$this->assertContains(
+			\Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			$template->post_types,
+			'The wrapping template should be associated with the newsletters CPT.'
+		);
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-editor-bootstrap.php
@@ -38,4 +38,17 @@ class Test_Editor_Bootstrap extends WP_UnitTestCase {
 			'The wrapping template should be associated with the newsletters CPT.'
 		);
 	}
+
+	/**
+	 * The canonical newsletters CPT definition stays authoritative after the
+	 * editor bootstraps. The email-editor package re-registers every opted-in
+	 * post type on `init`, so this guards against it clobbering Newspack's
+	 * registration (public flag, labels, etc.) with the package's email defaults.
+	 */
+	public function test_canonical_cpt_args_remain_authoritative() {
+		$post_type = get_post_type_object( \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$this->assertNotNull( $post_type, 'Newsletters CPT should be registered.' );
+		$this->assertTrue( (bool) $post_type->public, 'Newsletters CPT should remain public after the editor bootstraps.' );
+		$this->assertSame( 'Newsletters', $post_type->labels->name, 'Newsletters CPT labels should remain authoritative after the editor bootstraps.' );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-editor-bootstrap.php
@@ -49,6 +49,7 @@ class Test_Editor_Bootstrap extends WP_UnitTestCase {
 		$post_type = get_post_type_object( \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 		$this->assertNotNull( $post_type, 'Newsletters CPT should be registered.' );
 		$this->assertTrue( (bool) $post_type->public, 'Newsletters CPT should remain public after the editor bootstraps.' );
-		$this->assertSame( 'Newsletters', $post_type->labels->name, 'Newsletters CPT labels should remain authoritative after the editor bootstraps.' );
+		$expected_label = _x( 'Newsletters', 'post type general name', 'newspack-newsletters' );
+		$this->assertSame( $expected_label, $post_type->labels->name, 'Newsletters CPT labels should remain authoritative after the editor bootstraps.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Bootstraps the **WooCommerce Email Editor** package for the newsletters CPT (Task 4 of the `epic/editor-refactor` renderer foundation). It:

- Adds `Newspack\Newsletters\Email_Renderers\Editor_Bootstrap`, which initialises the package container/bootstrap, opts the newsletter CPT (`Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT`) into the editor via `woocommerce_email_editor_post_types`, and registers a wrapping block template via `woocommerce_email_editor_register_templates`.
- Adds the wrapping block template `includes/email-renderers/templates/newspack-newsletter.html` (a constrained group wrapping locked `post-content`).
- Boots it from `newspack-newsletters.php` (require_once + `Editor_Bootstrap::init()` on/before `init`), with a defensive `class_exists` guard so the plugin degrades gracefully if the package autoloader is absent.

No renderer wiring yet — registering `render()` and the `theme.json` filter is **Task 6** (depends on #320). This PR only stands up the container, CPT opt-in and template registration, proven by a test.

**API notes (verified against the installed `woocommerce/email-editor` 2.x):**
- `woocommerce_email_editor_post_types` entries must be `[ 'name' => <cpt>, 'args' => [] ]`, not bare strings (the package reads `$post_type['name']`/`['args']`). `args` is left empty so the canonical CPT registration stays authoritative.
- The template lookup key is `newspack//newspack-newsletter`; WP rebuilds the resolved `WP_Block_Template->id` with the active theme stylesheet prefix, so the test asserts on the lookup key + slug.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-newsletters && n test-php --filter Test_Editor_Bootstrap` → `OK (2 tests, 4 assertions)`.
2. Full suite stays green: `n test-php` → `OK (433 tests, 2297 assertions)`.
3. Confirm `get_block_template( 'newspack//newspack-newsletter' )` returns a template with slug `newspack-newsletter` once the plugin is loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
