### PR TITLE
feat: render newsletters via WC engine behind controller

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -63,6 +63,24 @@ class Editor_Bootstrap {
 		// rendering mode) with the package's email defaults. Re-assert the canonical
 		// definition at a later priority so Newspack's registration stays authoritative.
 		add_action( 'init', [ \Newspack_Newsletters::class, 'register_cpt' ], 11 );
+
+		// Inject per-newsletter theme colors at render time. ThemeController applies
+		// this filter with no post argument, so resolve the render post from
+		// Renderer_Controller first (set during render_wc), falling back to the
+		// global $post only when not actively rendering.
+		add_filter(
+			'woocommerce_email_editor_theme_json',
+			function ( $theme ) {
+				$post = Renderer_Controller::get_rendering_post();
+				if ( ! $post ) {
+					$post = get_post();
+				}
+				if ( $post && \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $post->post_type ) {
+					$theme->merge( new \WP_Theme_JSON( Theme_Json_Builder::build( $post ), 'default' ) );
+				}
+				return $theme;
+			}
+		);
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -64,23 +64,43 @@ class Editor_Bootstrap {
 		// definition at a later priority so Newspack's registration stays authoritative.
 		add_action( 'init', [ \Newspack_Newsletters::class, 'register_cpt' ], 11 );
 
-		// Inject per-newsletter theme colors at render time. ThemeController applies
-		// this filter with no post argument, so resolve the render post from
-		// Renderer_Controller first (set during render_wc), falling back to the
-		// global $post only when not actively rendering.
-		add_filter(
-			'woocommerce_email_editor_theme_json',
-			function ( $theme ) {
-				$post = Renderer_Controller::get_rendering_post();
-				if ( ! $post ) {
-					$post = get_post();
-				}
-				if ( $post && \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $post->post_type ) {
-					$theme->merge( new \WP_Theme_JSON( Theme_Json_Builder::build( $post ), 'default' ) );
-				}
-				return $theme;
-			}
-		);
+		// Inject per-newsletter theme colors at render time. See merge_theme_json().
+		add_filter( 'woocommerce_email_editor_theme_json', [ __CLASS__, 'merge_theme_json' ] );
+	}
+
+	/**
+	 * Merge per-newsletter theme colors into the editor theme at render time.
+	 *
+	 * ThemeController applies the `woocommerce_email_editor_theme_json` filter
+	 * with no post argument, so resolve the render post from Renderer_Controller
+	 * first (set during render_wc), falling back to the global $post only when not
+	 * actively rendering.
+	 *
+	 * The built WP_Theme_JSON is memoized per post: get_theme() — and therefore
+	 * this filter — fires several times during one render, and WP_Theme_JSON::merge()
+	 * reads but never mutates its argument, so the cached instance is safe to reuse.
+	 * The cache is request-scoped (static) and a newsletter's color meta is stable
+	 * within a single render.
+	 *
+	 * @param \WP_Theme_JSON $theme The editor theme being assembled.
+	 * @return \WP_Theme_JSON The theme with per-newsletter colors merged in.
+	 */
+	public static function merge_theme_json( $theme ) {
+		$post = Renderer_Controller::get_rendering_post();
+		if ( ! $post ) {
+			$post = get_post();
+		}
+		if ( ! $post || \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
+			return $theme;
+		}
+
+		static $cache = [];
+		if ( ! isset( $cache[ $post->ID ] ) ) {
+			$cache[ $post->ID ] = new \WP_Theme_JSON( Theme_Json_Builder::build( $post ), 'default' );
+		}
+
+		$theme->merge( $cache[ $post->ID ] );
+		return $theme;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -83,17 +83,23 @@ class Renderer_Controller {
 	 * renderer so the theme.json filter can apply per-newsletter colors, then
 	 * clears it in a finally block so it is reset even if rendering throws.
 	 *
+	 * Returns an empty string (never fatals) when the post is invalid, the WC
+	 * email-editor package is unavailable, or the renderer throws.
+	 *
 	 * @param \WP_Post $post Newsletter post to render.
 	 * @return string Rendered email HTML, or an empty string when unavailable.
 	 */
 	public static function render_wc( $post ) {
-		$container = \Automattic\WooCommerce\EmailEditor\Email_Editor_Container::container();
-		$renderer  = $container->get( \Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer::class );
-		$preheader = (string) get_post_meta( $post->ID, 'preview_text', true );
+		if ( ! $post instanceof \WP_Post || ! class_exists( \Automattic\WooCommerce\EmailEditor\Email_Editor_Container::class ) ) {
+			return '';
+		}
 
 		self::$rendering_post = $post;
 		try {
-			$result = $renderer->render(
+			$container = \Automattic\WooCommerce\EmailEditor\Email_Editor_Container::container();
+			$renderer  = $container->get( \Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer::class );
+			$preheader = (string) get_post_meta( $post->ID, 'preview_text', true );
+			$result    = $renderer->render(
 				$post,
 				(string) $post->post_title,
 				$preheader,
@@ -101,11 +107,13 @@ class Renderer_Controller {
 				'',
 				Editor_Bootstrap::TEMPLATE_SLUG
 			);
+			return isset( $result['html'] ) ? (string) $result['html'] : '';
+		} catch ( \Throwable $e ) {
+			\Newspack_Newsletters_Logger::log( 'Email editor: WC render failed — ' . $e->getMessage() );
+			return '';
 		} finally {
 			self::$rendering_post = null;
 		}
-
-		return isset( $result['html'] ) ? (string) $result['html'] : '';
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -72,7 +72,7 @@ class Renderer_Controller {
 	 *
 	 * @return \WP_Post|null The render post, or null when not rendering.
 	 */
-	public static function get_rendering_post() {
+	public static function get_rendering_post(): ?\WP_Post {
 		return self::$rendering_post;
 	}
 
@@ -86,14 +86,17 @@ class Renderer_Controller {
 	 * Returns an empty string (never fatals) when the post is invalid, the WC
 	 * email-editor package is unavailable, or the renderer throws.
 	 *
-	 * @param \WP_Post $post Newsletter post to render.
+	 * @param \WP_Post|null $post Newsletter post to render.
 	 * @return string Rendered email HTML, or an empty string when unavailable.
 	 */
-	public static function render_wc( $post ) {
+	public static function render_wc( ?\WP_Post $post ): string {
 		if ( ! $post instanceof \WP_Post || ! class_exists( \Automattic\WooCommerce\EmailEditor\Email_Editor_Container::class ) ) {
 			return '';
 		}
 
+		// Save/restore rather than clear so a nested render_wc() (post B mid-render
+		// of post A) leaves the outer render's post intact when the inner one returns.
+		$previous             = self::$rendering_post;
 		self::$rendering_post = $post;
 		try {
 			$container = \Automattic\WooCommerce\EmailEditor\Email_Editor_Container::container();
@@ -103,7 +106,7 @@ class Renderer_Controller {
 				$post,
 				(string) $post->post_title,
 				$preheader,
-				'en',
+				(string) get_bloginfo( 'language' ),
 				'',
 				Editor_Bootstrap::TEMPLATE_SLUG
 			);
@@ -112,7 +115,7 @@ class Renderer_Controller {
 			\Newspack_Newsletters_Logger::log( 'Email editor: WC render failed — ' . $e->getMessage() );
 			return '';
 		} finally {
-			self::$rendering_post = null;
+			self::$rendering_post = $previous;
 		}
 	}
 
@@ -121,7 +124,7 @@ class Renderer_Controller {
 	 *
 	 * @return string self::ENGINE_WC when the WC renderer flag is on, else self::ENGINE_MJML.
 	 */
-	public static function active_engine() {
+	public static function active_engine(): string {
 		return Feature_Flag::is_enabled() ? self::ENGINE_WC : self::ENGINE_MJML;
 	}
 }

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -29,6 +29,19 @@ class Renderer_Controller {
 	const ENGINE_WC = 'wc';
 
 	/**
+	 * The newsletter currently being rendered by render_wc().
+	 *
+	 * Made available to the `woocommerce_email_editor_theme_json` filter so it can
+	 * apply per-newsletter colors. The package's ThemeController applies that
+	 * filter with no post argument and Renderer::render() does not set up the
+	 * global $post, so a filter resolving the post via get_post() would get null
+	 * during a REST round-trip. This static carries the post explicitly instead.
+	 *
+	 * @var \WP_Post|null
+	 */
+	private static $rendering_post = null;
+
+	/**
 	 * Resolve which engine a post's stored HTML was produced by.
 	 * Absence of a stamp means the newsletter predates this feature, so it is MJML.
 	 *
@@ -49,5 +62,58 @@ class Renderer_Controller {
 	 */
 	public static function stamp_renderer( $post_id, $engine ) {
 		update_post_meta( $post_id, self::RENDERER_META, self::ENGINE_WC === $engine ? self::ENGINE_WC : self::ENGINE_MJML );
+	}
+
+	/**
+	 * The post currently being rendered by render_wc(), or null when idle.
+	 *
+	 * The `woocommerce_email_editor_theme_json` filter reads this to apply
+	 * per-newsletter colors without depending on the global $post.
+	 *
+	 * @return \WP_Post|null The render post, or null when not rendering.
+	 */
+	public static function get_rendering_post() {
+		return self::$rendering_post;
+	}
+
+	/**
+	 * Render a newsletter to email-safe HTML via the WC email-editor engine.
+	 *
+	 * Sets the render post on a static accessor before delegating to the package
+	 * renderer so the theme.json filter can apply per-newsletter colors, then
+	 * clears it in a finally block so it is reset even if rendering throws.
+	 *
+	 * @param \WP_Post $post Newsletter post to render.
+	 * @return string Rendered email HTML, or an empty string when unavailable.
+	 */
+	public static function render_wc( $post ) {
+		$container = \Automattic\WooCommerce\EmailEditor\Email_Editor_Container::container();
+		$renderer  = $container->get( \Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer::class );
+		$preheader = (string) get_post_meta( $post->ID, 'preview_text', true );
+
+		self::$rendering_post = $post;
+		try {
+			$result = $renderer->render(
+				$post,
+				(string) $post->post_title,
+				$preheader,
+				'en',
+				'',
+				Editor_Bootstrap::TEMPLATE_SLUG
+			);
+		} finally {
+			self::$rendering_post = null;
+		}
+
+		return isset( $result['html'] ) ? (string) $result['html'] : '';
+	}
+
+	/**
+	 * Resolve which engine should render new newsletters right now.
+	 *
+	 * @return string self::ENGINE_WC when the WC renderer flag is on, else self::ENGINE_MJML.
+	 */
+	public static function active_engine() {
+		return Feature_Flag::is_enabled() ? self::ENGINE_WC : self::ENGINE_MJML;
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -98,4 +98,12 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'wc', Renderer_Controller::active_engine() );
 		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
 	}
+
+	/**
+	 * Renders to an empty string for an invalid post instead of fataling on a
+	 * non-WP_Post argument, honoring the documented render_wc() contract.
+	 */
+	public function test_render_wc_returns_empty_string_for_invalid_post() {
+		$this->assertSame( '', Renderer_Controller::render_wc( null ) );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -106,4 +106,29 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 	public function test_render_wc_returns_empty_string_for_invalid_post() {
 		$this->assertSame( '', Renderer_Controller::render_wc( null ) );
 	}
+
+	/**
+	 * A failure raised inside the package renderer is swallowed: render_wc() logs
+	 * and returns an empty string instead of letting the \Throwable escape, and the
+	 * render post is still cleared by the finally block.
+	 *
+	 * Forces the failure by hooking the theme.json filter (which fires inside the
+	 * render) to throw, exercising the catch ( \Throwable ) branch directly.
+	 */
+	public function test_render_wc_returns_empty_string_when_renderer_throws() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$post_id = $this->create_newsletter_with_paragraph( 'Boom' );
+
+		$thrower = function () {
+			throw new \RuntimeException( 'forced render failure' );
+		};
+		add_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		remove_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
+
+		$this->assertSame( '', $html );
+		$this->assertNull( Renderer_Controller::get_rendering_post(), 'render post is cleared even when rendering throws' );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -36,4 +36,66 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 		Renderer_Controller::stamp_renderer( $post_id, 'something-else' );
 		$this->assertSame( 'mjml', Renderer_Controller::get_post_renderer( $post_id ) );
 	}
+
+	/**
+	 * Create a newsletter CPT post carrying a single core paragraph block.
+	 *
+	 * @param string $body Paragraph body text.
+	 * @return int Created post ID.
+	 */
+	private function create_newsletter_with_paragraph( $body ) {
+		return self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Test newsletter',
+				'post_content' => '<!-- wp:paragraph --><p>' . $body . '</p><!-- /wp:paragraph -->',
+			]
+		);
+	}
+
+	/**
+	 * The WC render path produces email-safe HTML containing the post body.
+	 *
+	 * The WC engine wraps content in tables for email-client compatibility, so a
+	 * successful render both echoes the body text and emits at least one table.
+	 */
+	public function test_render_wc_returns_html_with_content() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$post_id = $this->create_newsletter_with_paragraph( 'Hello from the WC engine' );
+		$html    = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		$this->assertStringContainsString( 'Hello from the WC engine', $html );
+		$this->assertStringContainsString( '<table', $html );
+	}
+
+	/**
+	 * The WC render path injects the per-newsletter background color into the output.
+	 *
+	 * This proves the static-post plumbing: the theme filter resolves the render
+	 * post from Renderer_Controller::get_rendering_post() rather than the global
+	 * $post (which is never set here, simulating the REST round-trip path).
+	 */
+	public function test_render_wc_applies_per_newsletter_background() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$post_id = $this->create_newsletter_with_paragraph( 'Colored newsletter' );
+		update_post_meta( $post_id, 'background_color', '#123456' );
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		$this->assertStringContainsString( '123456', $html );
+	}
+
+	/**
+	 * The active engine follows the WC renderer feature flag.
+	 */
+	public function test_active_engine_follows_flag() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+		$this->assertSame( 'mjml', Renderer_Controller::active_engine() );
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		$this->assertSame( 'wc', Renderer_Controller::active_engine() );
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Wires the WooCommerce render path behind `Renderer_Controller` and injects per-newsletter colors at render time (Task 6 of `epic/editor-refactor`). It:

- Adds `Renderer_Controller::render_wc( $post )` — renders a newsletter to email HTML via the WC Email Editor `Renderer` (verified signature: `render( WP_Post, subject, pre_header, language, meta_robots, template_slug ): array`), returning the `html` payload.
- Adds `Renderer_Controller::active_engine()` — resolves `wc`/`mjml` from `Feature_Flag::is_enabled()`.
- Registers the `woocommerce_email_editor_theme_json` filter in `Editor_Bootstrap::init()` to merge each newsletter's `Theme_Json_Builder` output (background/text color) into the editor theme.

**Render post-context (the important bit):** `ThemeController::get_theme()` applies the theme.json filter with no post argument, and `Renderer::render( $post )` does not set up the global `$post`. Resolving the newsletter via `get_post()` would therefore return `null` in a REST round-trip (Task 7) and silently drop per-newsletter colors. So `render_wc()` stashes the post being rendered on `Renderer_Controller::$rendering_post` (reset in a `finally`), and the filter reads that via `get_rendering_post()`, only falling back to `get_post()`. A test proves the color lands in the output **with no global post set**.

No behavior change for the legacy path — MJML rendering and the flag default (off) are untouched. The REST endpoint that calls `render_wc()` is Task 7; the editor preview branch is Task 8.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-newsletters && n test-php --filter Test_Renderer_Controller` → `OK (6 tests, 8 assertions)`.
2. Full suite stays green: `n test-php` → `OK (440 tests, 2311 assertions)`.
3. With a newsletter post that has `background_color` meta set, `Renderer_Controller::render_wc( $post )` returns email-safe HTML (`<table…>`) containing the post content and the background color (e.g. `#123456`) — even when no global `$post` is set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
