### PR TITLE
fix(content-gate): try all utm_source values for newsletter bypass

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-newsletters-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-newsletters-access.php
@@ -573,8 +573,18 @@ class Newsletters_Access {
 	 *                known send list.
 	 */
 	private static function resolve_utm_source_list_id() {
-		$raw = isset( $_SERVER['QUERY_STRING'] ) ? wp_unslash( $_SERVER['QUERY_STRING'] ) : '';
-		if ( ! is_string( $raw ) || '' === $raw ) {
+		// Read the request URI rather than QUERY_STRING directly: WP's
+		// WP_UnitTestCase::go_to() populates REQUEST_URI but not
+		// QUERY_STRING, so QUERY_STRING-based parsing breaks the existing
+		// UTM-fallback test suite. Real requests have both. wp_parse_url
+		// then gives the raw query untouched by PHP's $_GET de-duplication.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- each candidate value is sanitize_text_field()'d below before any use.
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		if ( ! is_string( $request_uri ) || '' === $request_uri ) {
+			return '';
+		}
+		$raw = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
+		if ( '' === $raw ) {
 			return '';
 		}
 		// Hard cap on the candidate count so a query string stuffed with

--- a/plugins/newspack-plugin/includes/content-gate/class-newsletters-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-newsletters-access.php
@@ -511,9 +511,17 @@ class Newsletters_Access {
 			return [ 'action' => 'skipped' ];
 		}
 
-		$list_id = sanitize_text_field( wp_unslash( $_GET['utm_source'] ?? '' ) );
 		// phpcs:enable
-		if ( empty( $list_id ) || ! self::is_valid_send_list_id( $list_id ) ) {
+		// A URL can carry multiple `utm_source` values when more than one
+		// system decorates the link (e.g. Newspack Newsletters writes one
+		// at send time and Mailchimp's audience-level Google Analytics
+		// option appends another on top). PHP's $_GET keeps only the last
+		// occurrence per key, so reading $_GET['utm_source'] discards the
+		// Newspack-issued list ID whenever a second utm_source follows.
+		// Walk the raw query string and accept the first value that
+		// resolves to a known send list.
+		$list_id = self::resolve_utm_source_list_id();
+		if ( '' === $list_id ) {
 			return [ 'action' => 'invalid' ];
 		}
 
@@ -547,6 +555,56 @@ class Newsletters_Access {
 	public static function is_verification_enabled() {
 		$settings = \Newspack\Content_Gate_Advanced_Settings::get_settings();
 		return ! empty( $settings['newsletter_link_bypass_enabled'] );
+	}
+
+	/**
+	 * Walk the raw query string and return the first `utm_source` value
+	 * that `is_valid_send_list_id()` accepts. Returns an empty string when
+	 * no candidate matches.
+	 *
+	 * Necessary because $_GET only retains the last occurrence per key:
+	 * URLs like `?utm_source=51fd819e60&utm_source=Brand.example` (which
+	 * appear in the wild whenever Mailchimp's audience-level UTM tagging
+	 * is enabled on top of Newspack Newsletters' own link decoration)
+	 * would otherwise hand the wrong value to the registry check and
+	 * the bypass would silently fail.
+	 *
+	 * @return string Empty string when no utm_source value resolves to a
+	 *                known send list.
+	 */
+	private static function resolve_utm_source_list_id() {
+		$raw = isset( $_SERVER['QUERY_STRING'] ) ? wp_unslash( $_SERVER['QUERY_STRING'] ) : '';
+		if ( ! is_string( $raw ) || '' === $raw ) {
+			return '';
+		}
+		// Hard cap on the candidate count so a query string stuffed with
+		// `?utm_source=&utm_source=&...` can't drive thousands of registry
+		// lookups. 32 is generous — real URLs have 1 or 2.
+		$max_candidates = 32;
+		$seen           = [];
+		$count          = 0;
+		foreach ( explode( '&', $raw ) as $pair ) {
+			if ( $count >= $max_candidates ) {
+				break;
+			}
+			$parts = explode( '=', $pair, 2 );
+			if ( 2 !== count( $parts ) ) {
+				continue;
+			}
+			if ( 'utm_source' !== rawurldecode( $parts[0] ) ) {
+				continue;
+			}
+			++$count;
+			$candidate = sanitize_text_field( rawurldecode( $parts[1] ) );
+			if ( '' === $candidate || isset( $seen[ $candidate ] ) ) {
+				continue;
+			}
+			$seen[ $candidate ] = true;
+			if ( self::is_valid_send_list_id( $candidate ) ) {
+				return $candidate;
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-newsletters-access.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-newsletters-access.php
@@ -425,6 +425,65 @@ class Test_Newsletters_Access extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that process_utm_fallback_request() grants a bypass even when the
+	 * URL carries multiple utm_source values — only one of them needs to be
+	 * a valid send list ID.
+	 *
+	 * Real-world scenario: Newspack Newsletters writes utm_source=<list_id>
+	 * at send time, then Mailchimp's audience-level Google Analytics option
+	 * appends a second utm_source=<audience-friendly-name> on top of it.
+	 * PHP's $_GET keeps only the last occurrence, so we have to walk the
+	 * raw query string to recover the Newspack-issued list ID.
+	 */
+	public function test_utm_fallback_grants_bypass_when_one_of_multiple_utm_sources_is_valid() {
+		update_option( 'newspack_content_gate_newsletter_link_bypass_enabled', 1, false );
+
+		$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+		$url     = get_permalink( $post_id );
+		$this->create_sent_newsletter_with_link( 'list_abc', $url );
+
+		// String-concat the query so the duplicate utm_source survives —
+		// add_query_arg would collapse them.
+		$separator   = false === strpos( $url, '?' ) ? '?' : '&';
+		$request_url = $url . $separator . 'utm_medium=email&utm_source=list_abc&utm_source=brand.example';
+		$this->go_to( $request_url );
+
+		add_filter(
+			'newspack_newsletters_access_is_valid_send_list_id',
+			function( $valid, $list_id ) {
+				return 'list_abc' === $list_id ? true : null;
+			},
+			10,
+			2
+		);
+
+		$result = Newsletters_Access::process_utm_fallback_request( false );
+
+		unset( $_GET['utm_medium'], $_GET['utm_source'] );
+		$this->assertSame( 'verified', $result['action'] );
+		$this->assertSame( $post_id, $result['post_id'] );
+	}
+
+	/**
+	 * Test that process_utm_fallback_request() still rejects when NONE of the
+	 * stacked utm_source values matches a known send list.
+	 */
+	public function test_utm_fallback_rejects_when_no_utm_source_is_valid() {
+		update_option( 'newspack_content_gate_newsletter_link_bypass_enabled', 1, false );
+
+		$post_id     = $this->factory->post->create( [ 'post_type' => 'post' ] );
+		$url         = get_permalink( $post_id );
+		$separator   = false === strpos( $url, '?' ) ? '?' : '&';
+		$request_url = $url . $separator . 'utm_medium=email&utm_source=fake_xyz&utm_source=brand.example';
+		$this->go_to( $request_url );
+
+		$result = Newsletters_Access::process_utm_fallback_request( false );
+
+		unset( $_GET['utm_medium'], $_GET['utm_source'] );
+		$this->assertSame( 'invalid', $result['action'] );
+	}
+
+	/**
 	 * Test that process_utm_fallback_request() returns 'skipped' for a logged-in
 	 * editor, who bypasses the gate via capability checks.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hotfix for the newsletter-link-bypass UTM fallback (shipped in #136). On real Newspack + Mailchimp sites, the bypass returns `'invalid'` for legitimately-signed links and the reader still sees the content gate, because Mailchimp's audience-level Google Analytics option appends a *second* `utm_source` on top of the Newspack-issued one. PHP's `$_GET` keeps only the last occurrence per key, so reading `$_GET['utm_source']` silently discards the list ID the registry would have recognised.

`process_utm_fallback_request()` now walks the raw `$_SERVER['QUERY_STRING']` and grants the bypass on the first `utm_source` value that resolves to a known send list. Behaviour for single-utm URLs is unchanged. Capped at 32 candidates and de-duped so a hostile query can't drive arbitrary registry lookups.

This will affect any Newspack Newsletters site using Mailchimp with audience-level UTM tagging enabled (the default for most publishers), so the fix is needed on the `release` line before the next stable push reaches more publishers.

### How to test the changes in this Pull Request:

1. On a site with `release` checked out (or this branch), enable the newsletter-link-bypass content-gate setting and confirm a reader-gated post is restricted for an anonymous visitor.
2. Send a Newspack Newsletters campaign via Mailchimp **with the audience-level Google Analytics tracking option enabled** (Mailchimp Audience → Settings → Audience name and campaign defaults → Google Analytics tracking).
3. In the inbox, click any link that points to a gated post on the site. The resulting URL should have **two** `utm_source` params — one is the Mailchimp list ID, one is the audience-friendly name.
4. **Before this fix**: the gate is still shown. **After this fix**: the gate is bypassed and the article renders.
5. Confirm single-utm URLs (e.g. paste a clean `?utm_medium=email&utm_source=<known_list_id>` directly) still grant the bypass — no regression.
6. Confirm URLs whose every `utm_source` is unknown still return `'invalid'` and show the gate.
7. Run `n test-php --filter test_utm_fallback` from `plugins/newspack-plugin/` — the two new tests (`test_utm_fallback_grants_bypass_when_one_of_multiple_utm_sources_is_valid`, `test_utm_fallback_rejects_when_no_utm_source_is_valid`) should pass, plus the existing UTM-fallback suite.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally? — PHPUnit runs in CI; local test env is unavailable.

> [!NOTE]
> Targets `release` directly since #136 has already been merged there. Does not need to land on `main`/`alpha` first — `release → alpha` will pick it up via the standard branch promotion.
