### PR TITLE
feat: add post-html REST endpoint for server-side preview

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -878,6 +878,21 @@ final class Newspack_Newsletters {
 				],
 			]
 		);
+		\register_rest_route(
+			self::API_NAMESPACE,
+			'post-html',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_get_post_html' ],
+				'permission_callback' => [ __CLASS__, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'post_id' => [
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -909,6 +924,33 @@ final class Newspack_Newsletters {
 		}
 		$post->post_content = $request['content'];
 		return \rest_ensure_response( Newspack_Newsletters_Renderer::render_post_to_mjml( $post ) );
+	}
+
+	/**
+	 * Render a newsletter to final email HTML via the WC engine.
+	 *
+	 * Mirrors the `post-mjml` route but produces email-safe HTML through the
+	 * block-based WC email-editor engine for the editor preview. Renders the
+	 * newsletter's saved content: unlike api_get_mjml(), this endpoint does not
+	 * accept a live `content` override because the WC engine re-fetches the post
+	 * from the database by ID at render time (see Post_Content::render_stateless
+	 * in the email-editor package), so an in-memory override would be ignored.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|WP_Error Response carrying the rendered HTML, or a
+	 *                                   404 error when the post does not exist.
+	 */
+	public static function api_get_post_html( $request ) {
+		$post = get_post( $request['post_id'] );
+		if ( ! $post instanceof \WP_Post ) {
+			return new \WP_Error(
+				'newspack_newsletters_no_post',
+				__( 'Newsletter not found.', 'newspack-newsletters' ),
+				[ 'status' => 404 ]
+			);
+		}
+		$html = \Newspack\Newsletters\Email_Renderers\Renderer_Controller::render_wc( $post );
+		return \rest_ensure_response( [ 'html' => $html ] );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -882,12 +882,13 @@ final class Newspack_Newsletters {
 			self::API_NAMESPACE,
 			'post-html',
 			[
-				'methods'             => \WP_REST_Server::EDITABLE,
+				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_post_html' ],
 				'permission_callback' => [ __CLASS__, 'api_authoring_permissions_check' ],
 				'args'                => [
 					'post_id' => [
 						'required'          => true,
+						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 					],
 				],
@@ -929,20 +930,21 @@ final class Newspack_Newsletters {
 	/**
 	 * Render a newsletter to final email HTML via the WC engine.
 	 *
-	 * Mirrors the `post-mjml` route but produces email-safe HTML through the
-	 * block-based WC email-editor engine for the editor preview. Renders the
-	 * newsletter's saved content: unlike api_get_mjml(), this endpoint does not
-	 * accept a live `content` override because the WC engine re-fetches the post
-	 * from the database by ID at render time (see Post_Content::render_stateless
-	 * in the email-editor package), so an in-memory override would be ignored.
+	 * Produces email-safe HTML through the block-based WC email-editor engine for
+	 * the editor preview. This is a read-only endpoint: it renders the
+	 * newsletter's saved content and, unlike api_get_mjml(), does not accept a
+	 * live `content` override, because the WC engine re-fetches the post from the
+	 * database by ID at render time (see Post_Content::render_stateless in the
+	 * email-editor package), so an in-memory override would be ignored.
 	 *
 	 * @param WP_REST_Request $request API request object.
-	 * @return WP_REST_Response|WP_Error Response carrying the rendered HTML, or a
-	 *                                   404 error when the post does not exist.
+	 * @return WP_REST_Response|WP_Error Response carrying the rendered HTML; a 404
+	 *                                   error when the post is not a newsletter, or
+	 *                                   a 500 error when rendering fails.
 	 */
 	public static function api_get_post_html( $request ) {
 		$post = get_post( $request['post_id'] );
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof \WP_Post || ! self::validate_newsletter_id( $post->ID ) ) {
 			return new \WP_Error(
 				'newspack_newsletters_no_post',
 				__( 'Newsletter not found.', 'newspack-newsletters' ),
@@ -950,6 +952,13 @@ final class Newspack_Newsletters {
 			);
 		}
 		$html = \Newspack\Newsletters\Email_Renderers\Renderer_Controller::render_wc( $post );
+		if ( '' === $html ) {
+			return new \WP_Error(
+				'newspack_newsletters_render_failed',
+				__( 'Failed to render the newsletter.', 'newspack-newsletters' ),
+				[ 'status' => 500 ]
+			);
+		}
 		return \rest_ensure_response( [ 'html' => $html ] );
 	}
 

--- a/plugins/newspack-newsletters/tests/email-renderers/test-rest-post-html.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-rest-post-html.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Class REST post-html Endpoint Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests for the `post-html` REST route that renders a newsletter to final
+ * email HTML via the WC engine.
+ */
+class Test_REST_Post_Html extends WP_UnitTestCase {
+	/**
+	 * The full route path under the plugin's REST namespace.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/' . \Newspack_Newsletters::API_NAMESPACE . '/post-html';
+
+	/**
+	 * Enable the WC renderer flag and ensure the REST routes are registered.
+	 *
+	 * The test bootstrap fires `init` once already; here we boot the WC editor
+	 * so render_wc() can run and fire `rest_api_init` (the established pattern in
+	 * this plugin's REST tests) to register the plugin's routes into the server.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Remove the WC renderer flag.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a newsletter CPT post carrying a single core paragraph block.
+	 *
+	 * @param string $body Paragraph body text.
+	 * @return int Created post ID.
+	 */
+	private function create_newsletter_with_paragraph( $body ) {
+		return self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Test newsletter',
+				'post_content' => '<!-- wp:paragraph --><p>' . $body . '</p><!-- /wp:paragraph -->',
+			]
+		);
+	}
+
+	/**
+	 * An authorized request returns 200 with email-safe HTML containing the body.
+	 *
+	 * The WC engine wraps content in tables for email-client compatibility, so a
+	 * successful render both echoes the body text and emits at least one table.
+	 *
+	 * @return void
+	 */
+	public function test_post_html_route_returns_rendered_html() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$post_id = $this->create_newsletter_with_paragraph( 'Hello from the WC endpoint' );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'html', $data );
+		$this->assertStringContainsString( 'Hello from the WC endpoint', $data['html'] );
+		$this->assertStringContainsString( '<table', $data['html'] );
+	}
+
+	/**
+	 * A request for a non-existent post returns a 404.
+	 *
+	 * @return void
+	 */
+	public function test_post_html_route_404_for_missing_post() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'post_id', 99999999 );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * A request from an unauthorized (logged-out) user is rejected, confirming
+	 * the route is gated by api_authoring_permissions_check.
+	 *
+	 * @return void
+	 */
+	public function test_post_html_route_requires_authorization() {
+		wp_set_current_user( 0 );
+		$post_id = $this->create_newsletter_with_paragraph( 'Should be gated' );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+
+		$this->assertNotSame( 200, $response->get_status() );
+		$this->assertContains( $response->get_status(), [ 401, 403 ] );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-rest-post-html.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-rest-post-html.php
@@ -147,11 +147,15 @@ class Test_REST_Post_Html extends WP_UnitTestCase {
 		};
 		add_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
 
-		$request = new WP_REST_Request( 'GET', self::ROUTE );
-		$request->set_param( 'post_id', $post_id );
-		$response = rest_do_request( $request );
-
-		remove_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
+		// try/finally so the throwing filter is always removed, even if the
+		// request errors — otherwise it would leak into subsequent tests.
+		try {
+			$request = new WP_REST_Request( 'GET', self::ROUTE );
+			$request->set_param( 'post_id', $post_id );
+			$response = rest_do_request( $request );
+		} finally {
+			remove_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
+		}
 
 		$this->assertSame( 500, $response->get_status() );
 	}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-rest-post-html.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-rest-post-html.php
@@ -18,27 +18,33 @@ class Test_REST_Post_Html extends WP_UnitTestCase {
 	const ROUTE = '/' . \Newspack_Newsletters::API_NAMESPACE . '/post-html';
 
 	/**
-	 * Enable the WC renderer flag and ensure the REST routes are registered.
+	 * Enable the WC renderer flag and register the plugin's REST routes against a
+	 * fresh server instance.
 	 *
-	 * The test bootstrap fires `init` once already; here we boot the WC editor
-	 * so render_wc() can run and fire `rest_api_init` (the established pattern in
-	 * this plugin's REST tests) to register the plugin's routes into the server.
+	 * A dedicated `WP_REST_Server` is created before `rest_api_init` (the
+	 * established pattern in this plugin's REST tests) to avoid order-dependent
+	 * route registration and global state leaking between tests. `Editor_Bootstrap`
+	 * is already booted (idempotently) at plugin load, so the WC render path is
+	 * available without re-initializing it here.
 	 *
 	 * @return void
 	 */
 	public function set_up() {
 		parent::set_up();
 		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
-		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
 		do_action( 'rest_api_init' );
 	}
 
 	/**
-	 * Remove the WC renderer flag.
+	 * Reset the REST server and remove the WC renderer flag.
 	 *
 	 * @return void
 	 */
 	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
 		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
 		parent::tear_down();
 	}
@@ -72,7 +78,7 @@ class Test_REST_Post_Html extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$post_id = $this->create_newsletter_with_paragraph( 'Hello from the WC endpoint' );
 
-		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
 		$request->set_param( 'post_id', $post_id );
 		$response = rest_do_request( $request );
 
@@ -91,11 +97,63 @@ class Test_REST_Post_Html extends WP_UnitTestCase {
 	public function test_post_html_route_404_for_missing_post() {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
 		$request->set_param( 'post_id', 99999999 );
 		$response = rest_do_request( $request );
 
 		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * A request for an existing post that is not a newsletter returns a 404,
+	 * confirming the endpoint only renders the newsletter CPT and not arbitrary
+	 * post types.
+	 *
+	 * @return void
+	 */
+	public function test_post_html_route_404_for_non_newsletter_post() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Not a newsletter</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'post_id', $page_id );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * When the WC engine fails to render (returns an empty string), the endpoint
+	 * surfaces a 500 rather than a misleading 200 with empty HTML.
+	 *
+	 * The render failure is simulated by forcing the email-editor's theme.json
+	 * filter to throw; render_wc() swallows the throwable into an empty string,
+	 * which is exactly the failure mode the endpoint must report as an error.
+	 *
+	 * @return void
+	 */
+	public function test_post_html_route_500_when_render_fails() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$post_id = $this->create_newsletter_with_paragraph( 'Will fail to render' );
+
+		$thrower = static function () {
+			throw new \RuntimeException( 'Simulated render failure' );
+		};
+		add_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
+
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+
+		remove_filter( 'woocommerce_email_editor_theme_json', $thrower, 99 );
+
+		$this->assertSame( 500, $response->get_status() );
 	}
 
 	/**
@@ -108,7 +166,7 @@ class Test_REST_Post_Html extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 		$post_id = $this->create_newsletter_with_paragraph( 'Should be gated' );
 
-		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
 		$request->set_param( 'post_id', $post_id );
 		$response = rest_do_request( $request );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Adds a `post-html` REST endpoint that renders a newsletter to final email HTML via the WC engine — the server round-trip the editor preview will call when the WC renderer flag is on (Task 7 of `epic/editor-refactor`).

The route is registered under `self::API_NAMESPACE` (`newspack-newsletters/v1`) as a **read-only** `\WP_REST_Server::READABLE` (GET) route, with the static `[ __CLASS__, 'api_get_post_html' ]` callback gated by `api_authoring_permissions_check`. It takes a single `post_id` (typed `integer`, `absint`-sanitized) and produces no side effects, so — unlike `post-mjml`, which carries the editor's live `content` payload and mutates the post before rendering — it doesn't need a write verb.

The handler:

* returns `{ html }` from `Renderer_Controller::render_wc()` on success;
* returns a `404` `WP_Error` when the `post_id` is missing **or is not a newsletter** — the endpoint is scoped to the newsletter CPT (via `validate_newsletter_id()`), so it won't render arbitrary post types and the "Newsletter not found" message stays accurate;
* returns a `500` `WP_Error` when the WC engine fails to render (i.e. `render_wc()` returns an empty string), so a genuine render failure is surfaced instead of a misleading `200` with empty HTML.

**Important — renders saved content, not editor-unsaved content.** Unlike `post-mjml` (which applies the editor's live `content` before rendering), the WC package's `Post_Content::render_stateless()` re-fetches the post from the database by ID and ignores any in-memory `post_content` override (verified by reading `vendor/woocommerce/email-editor/.../Renderer/Blocks/class-post-content.php` and an empirical probe). So this endpoint intentionally takes `post_id` only — adding a `content` param would be misleading. **Implication for Task 8:** in-editor live preview must persist the draft (autosave/revision) before calling `post-html`; it cannot pass unsaved content through.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-newsletters && n test-php --filter Test_REST_Post_Html` → `OK (5 tests, 9 assertions)`.
2. Full suite stays green: `n test-php` → `OK (447 tests, 2323 assertions)`.
3. As an authenticated author, `GET /newspack-newsletters/v1/post-html?post_id=<id>` for a saved newsletter returns `200` and `{ html }` containing email-safe `<table>` markup; a non-existent **or non-newsletter** `post_id` returns `404`; a post that fails to render returns `500`; an unauthenticated request is rejected (`403`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
