### PR TITLE
fix(theme): allow wide/full alignment inside content wrappers like .everlit-audio

### DIFF
--- a/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
+++ b/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
@@ -1691,6 +1691,11 @@ $colors: (
 .page-template-single-feature,
 .page-template-no-header-footer {
 	.entry .entry-content > *,
+	// Some plugins (e.g. Everlit) wrap the_content in a span/div at render
+	// time, which interposes a parent between .entry-content and the aligned
+	// block and breaks the direct-child match above. Allow one level of such
+	// wrapping so wide/full alignment continues to work.
+	.entry .entry-content > .everlit-audio > *,
 	.newspack-content-gate__inline-gate > *,
 	[id="pico"] > * {
 		&.alignwide {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hotfix to bring the `.everlit-audio` wide/full-alignment fix into a monorepo release.

This is a re-application of legacy `newspack-theme` hotfix [Automattic/newspack-theme#2710](https://github.com/Automattic/newspack-theme/pull/2710), which was merged to the legacy `release` branch on 2026-06-10 – **after** the monorepo cutover. That PR's change synced into monorepo `main` (commit `3ee93dcd0`), but `main` had already diverged from the live release line, so the fix never reached `alpha`/`release` and has not shipped in any stable monorepo theme release. The latest stable `newspack-theme@2.23.1` (2026-06-03) predates it. This branch puts the fix back on the `release` line so it actually goes out to publishers.

The fix itself: the `single-feature` alignment rules in `sass/blocks/_blocks.scss` gate the negative-margin "escape" for `.alignwide` / `.alignfull` behind a direct-child selector. When a plugin (Everlit's text-to-speech, hit in the wild on inewsource.org) wraps `the_content` in a `<span class="everlit-audio">` at render time, the aligned block is no longer a direct child of `.entry-content` and the rule stops matching, so wide-width images stay clamped to the column width on the front end (they still render correctly in the editor, which doesn't run the filter).

This adds one selector to the existing allow-list – `.entry .entry-content > .everlit-audio > *` – permitting exactly one level of wrapping for the known case, without broadening to a generic descendant selector (which would incorrectly let nested blocks like columns/groups escape).

Closes [Automattic/newspack-theme#2710](https://github.com/Automattic/newspack-theme/pull/2710) (re-applied on the monorepo release line).

### How to test the changes in this Pull Request:

1. Activate the Everlit plugin (or any plugin that wraps `the_content` in a `<span class="everlit-audio">`). To simulate locally, add a `wp:html` block opening `<span class="everlit-audio">` at the top of a post and a closing `</span>` at the bottom.
2. Create a post with template = `single-feature.php` and any `newspack_featured_image_position` (`above`, `behind`, or `beside`; `beside` matches the original report).
3. Insert a wide-width image block in the body.
4. View the published post on the front end at a viewport ≥ tablet.

**Before:** the figure width equals `.entry-content` width (~780px on a 1400px viewport, no negative-margin escape).
**After:** the figure escapes via the existing alignwide rule (~1090px with `margin: 0 -155px`). No horizontal scrollbar – `overflow: clip` still applies. An unwrapped post is unchanged (regression check).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? – CSS-only change; visual verification covered in #2710.
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)