### PR TITLE
feat: route editor preview through server render when flag is on

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -542,6 +542,7 @@ final class Newspack_Newsletters_Editor {
 			],
 			'supported_social_icon_services' => Newspack_Newsletters_Renderer::get_supported_social_icons_services(),
 			'supported_esps'                 => Newspack_Newsletters::get_supported_providers(),
+			'use_woo_renderer'               => \Newspack\Newsletters\Email_Renderers\Feature_Flag::is_enabled(),
 			'merge_tags'                     => $provider
 				? $provider::get_merge_tags()
 				: Newspack_Newsletters_Service_Provider::get_merge_tags(),

--- a/plugins/newspack-newsletters/src/components/send-button/index.js
+++ b/plugins/newspack-newsletters/src/components/send-button/index.js
@@ -27,15 +27,8 @@ import './style.scss';
 
 function PreviewHTML() {
 	const { isSaving, isAutosaving, isDirty, postId, postContent, postTitle } = useSelect( select => {
-		const {
-			getCurrentPostId,
-			getCurrentPostType,
-			getEditedPostAttribute,
-			getEditedPostContent,
-			isAutosavingPost,
-			isEditedPostDirty,
-			isSavingPost,
-		} = select( 'core/editor' );
+		const { getCurrentPostId, getEditedPostAttribute, getEditedPostContent, isAutosavingPost, isEditedPostDirty, isSavingPost } =
+			select( 'core/editor' );
 		return {
 			isSaving: isSavingPost(),
 			isAutosaving: isAutosavingPost(),
@@ -43,7 +36,6 @@ function PreviewHTML() {
 			postContent: getEditedPostContent(),
 			postId: getCurrentPostId(),
 			postTitle: getEditedPostAttribute( 'title' ),
-			postType: getCurrentPostType(),
 		};
 	} );
 	const { savePost } = useDispatch( 'core/editor' );

--- a/plugins/newspack-newsletters/src/components/send-button/index.js
+++ b/plugins/newspack-newsletters/src/components/send-button/index.js
@@ -47,17 +47,32 @@ function PreviewHTML() {
 		};
 	} );
 	const { savePost } = useDispatch( 'core/editor' );
+	const { createNotice } = useDispatch( 'core/notices' );
 	const [ previewHtml, setPreviewHtml ] = useState( '' );
 	const showSpinner = ( isSaving && ! isAutosaving ) || ! previewHtml;
 
 	useEffect( () => {
 		if ( ! previewHtml ) {
+			// Mount-once: the modal remounts on each open, so capturing isDirty/savePost
+			// at mount is intentional — do not add them to deps (would cause double-fetches).
 			( async () => {
-				if ( newspack_email_editor_data?.use_woo_renderer && isDirty ) {
-					await savePost();
+				try {
+					if ( newspack_email_editor_data?.use_woo_renderer && isDirty ) {
+						await savePost();
+					}
+					const res = await refreshEmailHtml( postId, postTitle, postContent );
+					if ( res?.html ) {
+						setPreviewHtml( res.html );
+					} else {
+						createNotice( 'error', res?.error?.message || __( 'Failed to load email preview.', 'newspack-newsletters' ) );
+						// Resolve the spinner with non-empty fallback markup.
+						setPreviewHtml( `<p>${ __( 'Could not load preview.', 'newspack-newsletters' ) }</p>` );
+					}
+				} catch ( error ) {
+					createNotice( 'error', error?.message || __( 'Failed to load email preview.', 'newspack-newsletters' ) );
+					// Resolve the spinner with non-empty fallback markup.
+					setPreviewHtml( `<p>${ __( 'Could not load preview.', 'newspack-newsletters' ) }</p>` );
 				}
-				const { html } = await refreshEmailHtml( postId, postTitle, postContent );
-				setPreviewHtml( html );
 			} )();
 		}
 	}, [] );
@@ -323,8 +338,17 @@ export default compose( [
 	}
 
 	const handleModalOpen = async () => {
-		const res = await refreshEmailHtml( postId, postTitle, postContent );
-		await savePost();
+		// Under the Woo renderer the endpoint renders saved content, so save first
+		// to avoid rendering stale content. When the flag is off, preserve the
+		// original order (refresh first, then save) byte-for-byte.
+		let res;
+		if ( newspack_email_editor_data?.use_woo_renderer ) {
+			await savePost();
+			res = await refreshEmailHtml( postId, postTitle, postContent );
+		} else {
+			res = await refreshEmailHtml( postId, postTitle, postContent );
+			await savePost();
+		}
 		if ( res.result === 'success' && saveDidSucceed ) {
 			setModalVisible( true );
 		} else {

--- a/plugins/newspack-newsletters/src/components/send-button/index.js
+++ b/plugins/newspack-newsletters/src/components/send-button/index.js
@@ -1,7 +1,9 @@
+/* global newspack_email_editor_data */
+
 /**
  * WordPress dependencies
  */
-import { withDispatch, withSelect, useSelect } from '@wordpress/data';
+import { withDispatch, withSelect, useSelect, useDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner } from '@wordpress/components';
 import { Fragment, useEffect, useState } from '@wordpress/element';
@@ -24,26 +26,39 @@ import { refreshEmailHtml } from '../../editor/mjml';
 import './style.scss';
 
 function PreviewHTML() {
-	const { isSaving, isAutosaving, postId, postContent, postTitle } = useSelect( select => {
-		const { getCurrentPostId, getCurrentPostType, getEditedPostAttribute, getEditedPostContent, isAutosavingPost, isSavingPost } =
-			select( 'core/editor' );
+	const { isSaving, isAutosaving, isDirty, postId, postContent, postTitle } = useSelect( select => {
+		const {
+			getCurrentPostId,
+			getCurrentPostType,
+			getEditedPostAttribute,
+			getEditedPostContent,
+			isAutosavingPost,
+			isEditedPostDirty,
+			isSavingPost,
+		} = select( 'core/editor' );
 		return {
 			isSaving: isSavingPost(),
 			isAutosaving: isAutosavingPost(),
+			isDirty: isEditedPostDirty(),
 			postContent: getEditedPostContent(),
 			postId: getCurrentPostId(),
 			postTitle: getEditedPostAttribute( 'title' ),
 			postType: getCurrentPostType(),
 		};
 	} );
+	const { savePost } = useDispatch( 'core/editor' );
 	const [ previewHtml, setPreviewHtml ] = useState( '' );
 	const showSpinner = ( isSaving && ! isAutosaving ) || ! previewHtml;
 
 	useEffect( () => {
 		if ( ! previewHtml ) {
-			refreshEmailHtml( postId, postTitle, postContent ).then( ( { html } ) => {
+			( async () => {
+				if ( newspack_email_editor_data?.use_woo_renderer && isDirty ) {
+					await savePost();
+				}
+				const { html } = await refreshEmailHtml( postId, postTitle, postContent );
 				setPreviewHtml( html );
-			} );
+			} )();
 		}
 	}, [] );
 

--- a/plugins/newspack-newsletters/src/editor/mjml/index.js
+++ b/plugins/newspack-newsletters/src/editor/mjml/index.js
@@ -5,6 +5,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { isLayoutEditor, usePrevious } from '../../newsletter-editor/utils';
@@ -29,6 +30,13 @@ import mjml2html from 'mjml-browser';
  * @return {Promise<string>} The refreshed email HTML.
  */
 export const refreshEmailHtml = async ( postId, postTitle, postContent ) => {
+	if ( newspack_email_editor_data?.use_woo_renderer ) {
+		return apiFetch( {
+			path: addQueryArgs( '/newspack-newsletters/v1/post-html', { post_id: postId } ),
+		} )
+			.then( ( { html } ) => ( { result: 'success', html } ) )
+			.catch( error => ( { result: 'error', error } ) );
+	}
 	return apiFetch( {
 		path: `/newspack-newsletters/v1/post-mjml`,
 		method: 'POST',

--- a/plugins/newspack-newsletters/src/editor/mjml/index.js
+++ b/plugins/newspack-newsletters/src/editor/mjml/index.js
@@ -24,13 +24,20 @@ import mjml2html from 'mjml-browser';
 /**
  * Refresh the email-compliant HTML for a post.
  *
+ * Resolves to a result object rather than a bare string: `{ result: 'success', html }`
+ * on success, or `{ result: 'error', error }` if the render/compile fails.
+ *
  * @param {number} postId      The current post ID.
  * @param {string} postTitle   The current post title.
  * @param {string} postContent The current post content.
- * @return {Promise<string>} The refreshed email HTML.
+ * @return {Promise<{result: string, html?: string, error?: Error}>} The refresh result.
  */
 export const refreshEmailHtml = async ( postId, postTitle, postContent ) => {
-	if ( newspack_email_editor_data?.use_woo_renderer ) {
+	const editorData = typeof newspack_email_editor_data !== 'undefined' ? newspack_email_editor_data : {};
+	// The server-render endpoint only accepts the newsletter CPT. Gate the Woo
+	// branch to that CPT so the Layout (newspack_nl_layo_cpt) and Ad editors fall
+	// through to the MJML path even when the flag is on (otherwise they 404).
+	if ( editorData.use_woo_renderer && editorData.current_post_type === editorData.newsletter_post_type ) {
 		return apiFetch( {
 			path: addQueryArgs( '/newspack-newsletters/v1/post-html', { post_id: postId } ),
 		} )

--- a/plugins/newspack-newsletters/src/editor/mjml/index.test.js
+++ b/plugins/newspack-newsletters/src/editor/mjml/index.test.js
@@ -24,8 +24,12 @@ describe( 'refreshEmailHtml', () => {
 		delete global.newspack_email_editor_data;
 	} );
 
-	it( 'GETs the server-rendered HTML endpoint when the Woo renderer flag is on', async () => {
-		global.newspack_email_editor_data = { use_woo_renderer: true };
+	it( 'GETs the server-rendered HTML endpoint when the Woo renderer flag is on and editing the newsletter CPT', async () => {
+		global.newspack_email_editor_data = {
+			use_woo_renderer: true,
+			current_post_type: 'newspack_nl_cpt',
+			newsletter_post_type: 'newspack_nl_cpt',
+		};
 		apiFetch.mockResolvedValueOnce( { html: '<server-html />' } );
 
 		const result = await refreshEmailHtml( 123, 'A title', '<p>body</p>' );
@@ -40,7 +44,11 @@ describe( 'refreshEmailHtml', () => {
 	} );
 
 	it( 'returns an error shape when the server render request rejects', async () => {
-		global.newspack_email_editor_data = { use_woo_renderer: true };
+		global.newspack_email_editor_data = {
+			use_woo_renderer: true,
+			current_post_type: 'newspack_nl_cpt',
+			newsletter_post_type: 'newspack_nl_cpt',
+		};
 		const error = new Error( 'boom' );
 		apiFetch.mockRejectedValueOnce( error );
 
@@ -61,6 +69,32 @@ describe( 'refreshEmailHtml', () => {
 			method: 'POST',
 			data: { post_id: 123, title: 'A title', content: '<p>body</p>' },
 		} );
+		expect( mjml2html ).toHaveBeenCalledWith( '<mjml />', { keepComments: false, minify: true } );
+		expect( result ).toEqual( { result: 'success', html: '<mjml-html />' } );
+	} );
+
+	it( 'falls back to MJML when the flag is on but the current post is not the newsletter CPT', async () => {
+		// e.g. the Layout editor (newspack_nl_layo_cpt): /post-html only accepts the
+		// newsletter CPT, so the gate must route these through the MJML path.
+		global.newspack_email_editor_data = {
+			use_woo_renderer: true,
+			current_post_type: 'newspack_nl_layo_cpt',
+			newsletter_post_type: 'newspack_nl_cpt',
+		};
+		apiFetch.mockResolvedValueOnce( '<mjml />' );
+
+		const result = await refreshEmailHtml( 123, 'A title', '<p>body</p>' );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/newspack-newsletters/v1/post-mjml',
+			method: 'POST',
+			data: { post_id: 123, title: 'A title', content: '<p>body</p>' },
+		} );
+		// Did NOT hit the server-render endpoint.
+		expect( apiFetch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { path: expect.stringContaining( '/post-html' ) } )
+		);
 		expect( mjml2html ).toHaveBeenCalledWith( '<mjml />', { keepComments: false, minify: true } );
 		expect( result ).toEqual( { result: 'success', html: '<mjml-html />' } );
 	} );

--- a/plugins/newspack-newsletters/src/editor/mjml/index.test.js
+++ b/plugins/newspack-newsletters/src/editor/mjml/index.test.js
@@ -92,9 +92,7 @@ describe( 'refreshEmailHtml', () => {
 			data: { post_id: 123, title: 'A title', content: '<p>body</p>' },
 		} );
 		// Did NOT hit the server-render endpoint.
-		expect( apiFetch ).not.toHaveBeenCalledWith(
-			expect.objectContaining( { path: expect.stringContaining( '/post-html' ) } )
-		);
+		expect( apiFetch ).not.toHaveBeenCalledWith( expect.objectContaining( { path: expect.stringContaining( '/post-html' ) } ) );
 		expect( mjml2html ).toHaveBeenCalledWith( '<mjml />', { keepComments: false, minify: true } );
 		expect( result ).toEqual( { result: 'success', html: '<mjml-html />' } );
 	} );

--- a/plugins/newspack-newsletters/src/editor/mjml/index.test.js
+++ b/plugins/newspack-newsletters/src/editor/mjml/index.test.js
@@ -1,0 +1,67 @@
+// Spy on the network layer and the MJML compiler; the module under test only
+// branches on the localized `use_woo_renderer` flag, so both externals are
+// mocked to keep the test fast and deterministic.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'mjml-browser', () => ( {
+	__esModule: true,
+	default: jest.fn( () => ( { html: '<mjml-html />' } ) ),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import mjml2html from 'mjml-browser';
+import { refreshEmailHtml } from './index';
+
+describe( 'refreshEmailHtml', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	afterEach( () => {
+		delete global.newspack_email_editor_data;
+	} );
+
+	it( 'GETs the server-rendered HTML endpoint when the Woo renderer flag is on', async () => {
+		global.newspack_email_editor_data = { use_woo_renderer: true };
+		apiFetch.mockResolvedValueOnce( { html: '<server-html />' } );
+
+		const result = await refreshEmailHtml( 123, 'A title', '<p>body</p>' );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		const { path, method } = apiFetch.mock.calls[ 0 ][ 0 ];
+		expect( path ).toBe( '/newspack-newsletters/v1/post-html?post_id=123' );
+		// GET request: no explicit method, no MJML POST body.
+		expect( method ).toBeUndefined();
+		expect( mjml2html ).not.toHaveBeenCalled();
+		expect( result ).toEqual( { result: 'success', html: '<server-html />' } );
+	} );
+
+	it( 'returns an error shape when the server render request rejects', async () => {
+		global.newspack_email_editor_data = { use_woo_renderer: true };
+		const error = new Error( 'boom' );
+		apiFetch.mockRejectedValueOnce( error );
+
+		const result = await refreshEmailHtml( 123, 'A title', '<p>body</p>' );
+
+		expect( result ).toEqual( { result: 'error', error } );
+	} );
+
+	it( 'falls back to the MJML POST + compile path when the flag is off', async () => {
+		global.newspack_email_editor_data = { use_woo_renderer: false };
+		apiFetch.mockResolvedValueOnce( '<mjml />' );
+
+		const result = await refreshEmailHtml( 123, 'A title', '<p>body</p>' );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/newspack-newsletters/v1/post-mjml',
+			method: 'POST',
+			data: { post_id: 123, title: 'A title', content: '<p>body</p>' },
+		} );
+		expect( mjml2html ).toHaveBeenCalledWith( '<mjml />', { keepComments: false, minify: true } );
+		expect( result ).toEqual( { result: 'success', html: '<mjml-html />' } );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Routes the newsletter editor's email preview through the server-side WC renderer when the feature flag is on**, instead of the client-side `mjml-browser` compile.

Part of the renderer-foundation work (Task 8). With `newspack_newsletters_use_woo_renderer` enabled, the editor needs to preview newsletters using the new WooCommerce Email Editor engine rather than MJML. This wires the JS preview path to the `post-html` REST endpoint added in #333.

What changed:

- **Flag exposed to JS** — `use_woo_renderer` is added to the localized `newspack_email_editor_data` payload (`Feature_Flag::is_enabled()`).
- **`refreshEmailHtml()`** — when the flag is on, it `GET`s `/newspack-newsletters/v1/post-html?post_id=N` and returns the rendered HTML directly, skipping the MJML POST + `mjml2html` compile. Return shape (`{ result, html }`) is identical, so both callers keep working.
- **Send-button preview** — on the WC branch only, force-saves the post (when dirty) before fetching the preview. The endpoint renders *saved* content, so this keeps the modal preview in sync with unsaved edits.

Behavior & regression notes: when the flag is **off**, every path is byte-for-byte unchanged — the MJML compile, the post-save refresh, and the send modal all behave exactly as before. The forced save on the WC branch is gated on both the flag and `isEditedPostDirty()`.

Closes NEWS-1907.

### How to test the changes in this Pull Request:

A ready env is provisioned (`task08-preview`, flag on, test newsletter post 69).

**Flag ON:**
1. Open a newsletter, make an edit, and **save** → the preview should refresh via the server round-trip (WC `<table>`-based output), not the client MJML compile. In the Network tab you should see `GET …/v1/post-html?post_id=N` and **no** `post-mjml` POST.
2. Open the send/preview modal after editing without saving → it force-saves first, so the preview reflects your latest content (not stale).
3. Confirm a merge tag like `*|FNAME|*` survives verbatim in the preview output.

**Flag OFF (regression):**
4. Set `newspack_newsletters_use_woo_renderer` to `0`, reload → preview returns to the MJML path (`post-mjml` POST + client compile), unchanged from before.

### Other information:

* [x] Have you written new tests for your changes, as applicable? — `src/editor/mjml/index.test.js` covers the flag branch (on → GET, on+error, off → POST).
* [x] Have you successfully run tests with your changes locally? — `n test-js` green (22 suites / 198 tests), build + PHP/JS lint clean.

---

## For AI / reviewers (detail)

- **Files:** `includes/class-newspack-newsletters-editor.php` (localize flag), `src/editor/mjml/index.js` (`refreshEmailHtml` branch + `addQueryArgs` import), `src/components/send-button/index.js` (`PreviewHTML` force-save), `src/editor/mjml/index.test.js` (new).
- **Why the main editor path needs no force-save:** `MJML.refreshHtml()` is already gated on `saveSucceeded` (and autosave is locked), so the DB holds the latest content by the time the WC branch calls the saved-content endpoint. Only the send-button mount preview (which fires from `getEditedPostContent()` on open) needed the explicit save-then-render.
- **Known minor / follow-up candidate:** `handleModalOpen` (send-button ~L326) calls `refreshEmailHtml` then `savePost()`. On the WC branch that pre-flight render is of pre-save content, but its result is used only as a success/error gate to decide whether to open the modal — the *displayed* preview comes from `<PreviewHTML />`, which saves-then-renders. Left as-is to keep the flag-off path unchanged; worst case is one throwaway render. Flagging for a possible cleanup.
