### PR TITLE
fix(posts-inserter): show featured images for all post types

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -889,7 +889,11 @@ final class Newspack_Newsletters_Editor {
 
 
 		if ( function_exists( 'get_coauthors' ) ) {
-			$authors = get_coauthors();
+			// Pass the post ID explicitly: this runs as a REST collection callback
+			// without setup_postdata(), so get_coauthors() has no reliable global
+			// $post to fall back on. Now that the field is registered for Pages,
+			// Newsletters, Events, etc. (NPPM-2756), the global is unset here.
+			$authors = get_coauthors( $post['id'] );
 
 			foreach ( $authors as $author ) {
 				$author_link = null;

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -881,8 +881,8 @@ final class Newspack_Newsletters_Editor {
 	/**
 	 * Append author data to the REST /posts response, so we can include Coauthors, link and display names.
 	 *
-	 * @param object $post Post object for the post being returned.
-	 * @return object Formatted data for all authors associated with the post.
+	 * @param array $post Prepared REST response data for the post being returned.
+	 * @return array Formatted data for all authors associated with the post.
 	 */
 	public static function newspack_get_author_info( $post ) {
 		$author_data = [];
@@ -932,7 +932,7 @@ final class Newspack_Newsletters_Editor {
 	/**
 	 * Get custom byline for the REST /posts response.
 	 *
-	 * @param object $post Post object for the post being returned.
+	 * @param array $post Prepared REST response data for the post being returned.
 	 * @return string|null Formatted custom byline HTML or null if not active.
 	 */
 	public static function newspack_get_custom_byline( $post ) {
@@ -946,7 +946,7 @@ final class Newspack_Newsletters_Editor {
 	/**
 	 * Append sponsor data to the REST /posts response.
 	 *
-	 * @param object $post Post object for the post being returned.
+	 * @param array $post Prepared REST response data for the post being returned.
 	 * @return array Formatted data for all sponsors associated with the post.
 	 */
 	public static function newspack_get_sponsors_info( $post ) {
@@ -956,7 +956,7 @@ final class Newspack_Newsletters_Editor {
 	/**
 	 * Get featured media info for the REST /posts response.
 	 *
-	 * @param object $post Post object for the post being returned.
+	 * @param array $post Prepared REST response data for the post being returned.
 	 * @return object Formatted data for the featured media associated with the post.
 	 */
 	public static function newspack_get_featured_media_info( $post ) {

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -769,7 +769,7 @@ final class Newspack_Newsletters_Editor {
 					'context' => [
 						'edit',
 					],
-					'type'    => 'string',
+					'type'    => [ 'string', 'null' ],
 				],
 			]
 		);
@@ -950,7 +950,9 @@ final class Newspack_Newsletters_Editor {
 	 * @return array Formatted data for all sponsors associated with the post.
 	 */
 	public static function newspack_get_sponsors_info( $post ) {
-		return \Newspack_Sponsors\get_all_sponsors( $post['id'], null, 'post' );
+		// Cast to array: get_all_sponsors() returns false when none exist, but the
+		// REST schema (and callers) expect an array.
+		return (array) \Newspack_Sponsors\get_all_sponsors( $post['id'], null, 'post' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -90,6 +90,7 @@ final class Newspack_Newsletters_Editor {
 		$email_cpts = [
 			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			Newspack_Newsletters\Ads::CPT,
+			Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
 		];
 		return apply_filters( 'newspack_newsletters_email_editor_cpts', $email_cpts );
 	}
@@ -510,23 +511,23 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Load up common JS/CSS for newsletter editor.
+	 * Build the `newspack_email_editor_data` payload shared by the editor and any
+	 * surface that previews newsletter blocks (e.g. the admin-shell layouts list).
+	 *
+	 * @return array
 	 */
-	public static function enqueue_block_assets() {
-		if ( ! is_admin() ) {
-			return;
-		}
+	public static function get_email_editor_data() {
 		// Remove the Ads CPT - it does not need MJML handling since ads
 		// will be injected into email content before it's converted to MJML.
 		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters\Ads::CPT ] ) );
 		$provider                 = Newspack_Newsletters::get_service_provider();
 		$conditional_tag_support  = false;
 
-		if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() ) ) {
+		if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() || self::is_editing_layout() ) ) {
 			$conditional_tag_support = $provider::get_conditional_tag_support();
 		}
 
-		$email_editor_data = [
+		return [
 			'email_html_meta'                => Newspack_Newsletters::EMAIL_HTML_META,
 			'mjml_handling_post_types'       => $mjml_handling_post_types,
 			'newsletter_post_type'           => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
@@ -541,7 +542,22 @@ final class Newspack_Newsletters_Editor {
 			],
 			'supported_social_icon_services' => Newspack_Newsletters_Renderer::get_supported_social_icons_services(),
 			'supported_esps'                 => Newspack_Newsletters::get_supported_providers(),
+			'merge_tags'                     => $provider
+				? $provider::get_merge_tags()
+				: Newspack_Newsletters_Service_Provider::get_merge_tags(),
+			'sample_assets_url'              => plugins_url( '../assets/sample-posts/', __FILE__ ),
 		];
+	}
+
+	/**
+	 * Load up common JS/CSS for newsletter editor.
+	 */
+	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$email_editor_data = self::get_email_editor_data();
 
 		if ( self::is_editing_email() ) {
 			wp_register_style(
@@ -578,7 +594,7 @@ final class Newspack_Newsletters_Editor {
 			);
 		}
 
-		if ( self::is_editing_newsletter() ) {
+		if ( self::is_editing_newsletter() || self::is_editing_layout() ) {
 			wp_localize_script(
 				'newspack-newsletters-editor',
 				'newspack_newsletters_data',
@@ -662,6 +678,13 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
+	 * Is editing a layout?
+	 */
+	private static function is_editing_layout() {
+		return Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type();
+	}
+
+	/**
 	 * If excerpt length is set in Post Inserter block attributes, override the site's excerpt length using the setting.
 	 *
 	 * @param array           $args Request arguments.
@@ -723,15 +746,25 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Append author info to the posts REST response so we can append Coauthors, if they exist.
+	 * Register the Posts Inserter's extra REST fields — author info, custom byline,
+	 * sponsor info and featured-media URLs — for every post type the inserter can offer.
 	 */
 	public static function add_newspack_extra_info() {
-		// Register on every post type the Posts Inserter can offer — it mirrors
-		// the inserter's own /wp/v2/types filter (viewable + show_ui) — so featured
-		// images, author info, custom bylines and sponsor data resolve for Pages,
-		// Newsletters, Events, etc., not just `post`. Regression fix: NPPM-2756 (#1969).
+		// Register on every post type the Posts Inserter can offer — it mirrors the
+		// inserter's own /wp/v2/types filter (REST-exposed + viewable + show_ui) — so
+		// featured images, author info, custom bylines and sponsor data resolve for
+		// Pages, Newsletters, Events, etc., not just `post`. Regression fix: NPPM-2756 (#1969).
 		$post_types = array_values(
-			array_filter( get_post_types( [ 'show_ui' => true ], 'names' ), 'is_post_type_viewable' )
+			array_filter(
+				get_post_types(
+					[
+						'show_ui'      => true,
+						'show_in_rest' => true,
+					],
+					'names' 
+				),
+				'is_post_type_viewable'
+			)
 		);
 
 		// Add author info source.

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -726,9 +726,17 @@ final class Newspack_Newsletters_Editor {
 	 * Append author info to the posts REST response so we can append Coauthors, if they exist.
 	 */
 	public static function add_newspack_extra_info() {
+		// Register on every post type the Posts Inserter can offer — it mirrors
+		// the inserter's own /wp/v2/types filter (viewable + show_ui) — so featured
+		// images, author info, custom bylines and sponsor data resolve for Pages,
+		// Newsletters, Events, etc., not just `post`. Regression fix: NPPM-2756 (#1969).
+		$post_types = array_values(
+			array_filter( get_post_types( [ 'show_ui' => true ], 'names' ), 'is_post_type_viewable' )
+		);
+
 		// Add author info source.
 		register_rest_field(
-			'post',
+			$post_types,
 			'newspack_author_info',
 			[
 				'get_callback' => [ __CLASS__, 'newspack_get_author_info' ],
@@ -743,7 +751,7 @@ final class Newspack_Newsletters_Editor {
 
 		// Add custom byline info.
 		register_rest_field(
-			'post',
+			$post_types,
 			'newspack_custom_byline',
 			[
 				'get_callback' => [ __CLASS__, 'newspack_get_custom_byline' ],
@@ -759,7 +767,7 @@ final class Newspack_Newsletters_Editor {
 		// Add sponsor info.
 		if ( function_exists( '\Newspack_Sponsors\get_all_sponsors' ) ) {
 			register_rest_field(
-				'post',
+				$post_types,
 				'newspack_sponsors_info',
 				[
 					'get_callback' => [ __CLASS__, 'newspack_get_sponsors_info' ],
@@ -775,7 +783,7 @@ final class Newspack_Newsletters_Editor {
 
 		// Add featured media thumbnail URLs.
 		register_rest_field(
-			'post',
+			$post_types,
 			'featured_media_info',
 			[
 				'get_callback' => [ __CLASS__, 'newspack_get_featured_media_info' ],

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -90,7 +90,6 @@ final class Newspack_Newsletters_Editor {
 		$email_cpts = [
 			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			Newspack_Newsletters\Ads::CPT,
-			Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
 		];
 		return apply_filters( 'newspack_newsletters_email_editor_cpts', $email_cpts );
 	}
@@ -511,23 +510,23 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Build the `newspack_email_editor_data` payload shared by the editor and any
-	 * surface that previews newsletter blocks (e.g. the admin-shell layouts list).
-	 *
-	 * @return array
+	 * Load up common JS/CSS for newsletter editor.
 	 */
-	public static function get_email_editor_data() {
+	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
 		// Remove the Ads CPT - it does not need MJML handling since ads
 		// will be injected into email content before it's converted to MJML.
 		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters\Ads::CPT ] ) );
 		$provider                 = Newspack_Newsletters::get_service_provider();
 		$conditional_tag_support  = false;
 
-		if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() || self::is_editing_layout() ) ) {
+		if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() ) ) {
 			$conditional_tag_support = $provider::get_conditional_tag_support();
 		}
 
-		return [
+		$email_editor_data = [
 			'email_html_meta'                => Newspack_Newsletters::EMAIL_HTML_META,
 			'mjml_handling_post_types'       => $mjml_handling_post_types,
 			'newsletter_post_type'           => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
@@ -542,22 +541,7 @@ final class Newspack_Newsletters_Editor {
 			],
 			'supported_social_icon_services' => Newspack_Newsletters_Renderer::get_supported_social_icons_services(),
 			'supported_esps'                 => Newspack_Newsletters::get_supported_providers(),
-			'merge_tags'                     => $provider
-				? $provider::get_merge_tags()
-				: Newspack_Newsletters_Service_Provider::get_merge_tags(),
-			'sample_assets_url'              => plugins_url( '../assets/sample-posts/', __FILE__ ),
 		];
-	}
-
-	/**
-	 * Load up common JS/CSS for newsletter editor.
-	 */
-	public static function enqueue_block_assets() {
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		$email_editor_data = self::get_email_editor_data();
 
 		if ( self::is_editing_email() ) {
 			wp_register_style(
@@ -594,7 +578,7 @@ final class Newspack_Newsletters_Editor {
 			);
 		}
 
-		if ( self::is_editing_newsletter() || self::is_editing_layout() ) {
+		if ( self::is_editing_newsletter() ) {
 			wp_localize_script(
 				'newspack-newsletters-editor',
 				'newspack_newsletters_data',
@@ -678,13 +662,6 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Is editing a layout?
-	 */
-	private static function is_editing_layout() {
-		return Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type();
-	}
-
-	/**
 	 * If excerpt length is set in Post Inserter block attributes, override the site's excerpt length using the setting.
 	 *
 	 * @param array           $args Request arguments.
@@ -761,7 +738,7 @@ final class Newspack_Newsletters_Editor {
 						'show_ui'      => true,
 						'show_in_rest' => true,
 					],
-					'names' 
+					'names'
 				),
 				'is_post_type_viewable'
 			)

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -910,13 +910,18 @@ final class Newspack_Newsletters_Editor {
 				];
 			}
 		} else {
+			// Derive the author from the post ID rather than `$post['author']`:
+			// the REST response only carries an `author` key for post types that
+			// support authors, and this field now covers types that may not
+			// (NPPM-2756). `post_author` is always set on the row.
+			$author_id = (int) get_post_field( 'post_author', $post['id'] );
 			$author_data[] = [
 				/* Get the author name */
-				'display_name' => get_the_author_meta( 'display_name', $post['author'] ),
+				'display_name' => get_the_author_meta( 'display_name', $author_id ),
 				/* Get the author ID */
-				'id'           => $post['author'],
+				'id'           => $author_id,
 				/* Get the author Link */
-				'author_link'  => get_author_posts_url( $post['author'] ),
+				'author_link'  => get_author_posts_url( $author_id ),
 			];
 		}
 
@@ -964,7 +969,9 @@ final class Newspack_Newsletters_Editor {
 		if ( $medium_url ) {
 			$featured_media_info['medium_url'] = $medium_url;
 		}
-		return $featured_media_info;
+		// Cast to object so the response always matches the `object` REST schema —
+		// an empty array would otherwise encode as a JSON array `[]`, not `{}`.
+		return (object) $featured_media_info;
 	}
 }
 Newspack_Newsletters_Editor::instance();

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -801,7 +801,7 @@ final class Newspack_Newsletters_Editor {
 					'context' => [
 						'edit',
 					],
-					'type'    => 'array',
+					'type'    => 'object',
 				],
 			]
 		);

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -9,9 +9,9 @@
  * Tests for Newspack_Newsletters_Editor::add_newspack_extra_info().
  *
  * Regression coverage for NPPM-2756: the Posts Inserter block lets the user
- * pick any post type the REST API exposes (viewable + show_ui), but the extra
- * REST fields it relies on — most importantly `featured_media_info` — were only
- * registered for `post`. As a result featured images (and author/byline data)
+ * pick any post type the REST API exposes (REST-exposed + viewable + show_ui),
+ * but the extra REST fields it relies on — most importantly `featured_media_info`
+ * — were only registered for `post`. As a result featured images (and author/byline data)
  * silently disappeared for Pages, Newsletters, Events, etc. This locks the
  * fields to every post type the inserter can actually offer.
  */

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -70,10 +70,10 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 		register_post_type(
 			self::UI_ONLY_CPT,
 			[
-				'public'              => false,
-				'publicly_queryable'  => false,
-				'show_ui'             => true,
-				'show_in_rest'        => true,
+				'public'             => false,
+				'publicly_queryable' => false,
+				'show_ui'            => true,
+				'show_in_rest'       => true,
 			]
 		);
 	}

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -153,8 +153,8 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `featured_media_info` must register for every viewable + show_ui post
-	 * type the inserter can offer — not just `post`.
+	 * `featured_media_info` must register for every REST-exposed + viewable +
+	 * show_ui post type the inserter can offer — not just `post`.
 	 */
 	public function test_featured_media_info_registers_for_inserter_post_types() {
 		Newspack_Newsletters_Editor::add_newspack_extra_info();
@@ -171,7 +171,7 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 		$this->assertContains(
 			self::VIEWABLE_CPT,
 			$types,
-			'public + show_ui CPTs (e.g. events) are offered by the inserter'
+			'REST-exposed + viewable + show_ui CPTs (e.g. events) are offered by the inserter'
 		);
 	}
 

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Class Test_Posts_Inserter_Rest_Fields
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests for Newspack_Newsletters_Editor::add_newspack_extra_info().
+ *
+ * Regression coverage for NPPM-2756: the Posts Inserter block lets the user
+ * pick any post type the REST API exposes (viewable + show_ui), but the extra
+ * REST fields it relies on — most importantly `featured_media_info` — were only
+ * registered for `post`. As a result featured images (and author/byline data)
+ * silently disappeared for Pages, Newsletters, Events, etc. This locks the
+ * fields to every post type the inserter can actually offer.
+ */
+class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
+
+	/**
+	 * A public, UI-visible CPT that stands in for e.g. The Events Calendar's
+	 * `tribe_events` — the inserter offers it, so the fields must cover it.
+	 *
+	 * @var string
+	 */
+	const VIEWABLE_CPT = 'nppm2756_event';
+
+	/**
+	 * A hidden CPT (no show_ui) the inserter never offers — fields must NOT
+	 * be registered for it.
+	 *
+	 * @var string
+	 */
+	const HIDDEN_CPT = 'nppm2756_hidden';
+
+	/**
+	 * A CPT that is UI-visible (show_ui) but NOT viewable (private, not
+	 * publicly queryable). The inserter excludes it, so this isolates the
+	 * `is_post_type_viewable` half of the filter — the gate `show_ui` alone
+	 * would not catch.
+	 *
+	 * @var string
+	 */
+	const UI_ONLY_CPT = 'nppm2756_ui_only';
+
+	/**
+	 * Register the helper post types before the suite runs.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		register_post_type(
+			self::VIEWABLE_CPT,
+			[
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+			]
+		);
+
+		register_post_type(
+			self::HIDDEN_CPT,
+			[
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_rest' => true,
+			]
+		);
+
+		register_post_type(
+			self::UI_ONLY_CPT,
+			[
+				'public'              => false,
+				'publicly_queryable'  => false,
+				'show_ui'             => true,
+				'show_in_rest'        => true,
+			]
+		);
+	}
+
+	/**
+	 * Clean up the helper post types after the suite.
+	 */
+	public static function tear_down_after_class() {
+		unregister_post_type( self::VIEWABLE_CPT );
+		unregister_post_type( self::HIDDEN_CPT );
+		unregister_post_type( self::UI_ONLY_CPT );
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Returns the object types `$field` is registered for in the REST schema.
+	 *
+	 * @param string $field REST field name.
+	 * @return string[] Post types the field is registered for.
+	 */
+	private function registered_post_types_for( $field ) {
+		global $wp_rest_additional_fields;
+		$types = [];
+		foreach ( (array) $wp_rest_additional_fields as $object_type => $fields ) {
+			if ( isset( $fields[ $field ] ) ) {
+				$types[] = $object_type;
+			}
+		}
+		return $types;
+	}
+
+	/**
+	 * `featured_media_info` must register for every viewable + show_ui post
+	 * type the inserter can offer — not just `post`.
+	 */
+	public function test_featured_media_info_registers_for_inserter_post_types() {
+		Newspack_Newsletters_Editor::add_newspack_extra_info();
+
+		$types = $this->registered_post_types_for( 'featured_media_info' );
+
+		$this->assertContains( 'post', $types, 'post must keep the field' );
+		$this->assertContains( 'page', $types, 'pages are offered by the inserter' );
+		$this->assertContains(
+			\Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			$types,
+			'newsletters are offered by the inserter'
+		);
+		$this->assertContains(
+			self::VIEWABLE_CPT,
+			$types,
+			'public + show_ui CPTs (e.g. events) are offered by the inserter'
+		);
+	}
+
+	/**
+	 * The field must NOT register for post types the inserter never offers.
+	 * Two distinct exclusion gates, asserted separately so each stays
+	 * load-bearing: HIDDEN_CPT pins `show_ui`, UI_ONLY_CPT pins
+	 * `is_post_type_viewable` (show_ui true but not viewable).
+	 */
+	public function test_featured_media_info_skips_hidden_post_types() {
+		Newspack_Newsletters_Editor::add_newspack_extra_info();
+
+		$types = $this->registered_post_types_for( 'featured_media_info' );
+
+		$this->assertNotContains( self::HIDDEN_CPT, $types, 'no show_ui → excluded' );
+		$this->assertNotContains( self::UI_ONLY_CPT, $types, 'show_ui but not viewable → excluded' );
+	}
+
+	/**
+	 * The sibling fields that are always registered (author info, custom
+	 * byline) must follow the same post-type scope.
+	 */
+	public function test_sibling_fields_share_the_same_scope() {
+		Newspack_Newsletters_Editor::add_newspack_extra_info();
+
+		foreach ( [ 'newspack_author_info', 'newspack_custom_byline' ] as $field ) {
+			$types = $this->registered_post_types_for( $field );
+			$this->assertContains( 'page', $types, "$field must cover pages" );
+			$this->assertContains( self::VIEWABLE_CPT, $types, "$field must cover viewable CPTs" );
+		}
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -178,4 +178,27 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 			$this->assertContains( self::VIEWABLE_CPT, $types, "$field must cover viewable CPTs" );
 		}
 	}
+
+	/**
+	 * The extra fields must stay scoped to the `edit` context. The safety case
+	 * for registering them across every viewable post type rests on this:
+	 * author/byline/sponsor data is only exposed to authenticated editors, never
+	 * in the public (`view`) REST response. A regression dropping `edit` context
+	 * would silently widen that exposure, so pin it explicitly.
+	 */
+	public function test_extra_fields_are_edit_context_only() {
+		global $wp_rest_additional_fields;
+
+		Newspack_Newsletters_Editor::add_newspack_extra_info();
+
+		foreach ( [ 'newspack_author_info', 'newspack_custom_byline', 'featured_media_info' ] as $field ) {
+			$args = $wp_rest_additional_fields['page'][ $field ] ?? null;
+			$this->assertNotNull( $args, "$field must be registered for page" );
+			$this->assertSame(
+				[ 'edit' ],
+				$args['schema']['context'] ?? null,
+				"$field must be exposed only in the edit context"
+			);
+		}
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -44,6 +44,15 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 	const UI_ONLY_CPT = 'nppm2756_ui_only';
 
 	/**
+	 * A viewable + show_ui CPT that is NOT exposed to REST. The inserter reads
+	 * `/wp/v2/types`, which only lists `show_in_rest` types, so it never offers
+	 * this — isolating the `show_in_rest` half of the filter.
+	 *
+	 * @var string
+	 */
+	const NO_REST_CPT = 'nppm2756_no_rest';
+
+	/**
 	 * Register the helper post types before the suite runs.
 	 */
 	public static function set_up_before_class() {
@@ -76,6 +85,15 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 				'show_in_rest'       => true,
 			]
 		);
+
+		register_post_type(
+			self::NO_REST_CPT,
+			[
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => false,
+			]
+		);
 	}
 
 	/**
@@ -85,6 +103,7 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 		unregister_post_type( self::VIEWABLE_CPT );
 		unregister_post_type( self::HIDDEN_CPT );
 		unregister_post_type( self::UI_ONLY_CPT );
+		unregister_post_type( self::NO_REST_CPT );
 		parent::tear_down_after_class();
 	}
 
@@ -130,9 +149,10 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 
 	/**
 	 * The field must NOT register for post types the inserter never offers.
-	 * Two distinct exclusion gates, asserted separately so each stays
+	 * Three distinct exclusion gates, asserted separately so each stays
 	 * load-bearing: HIDDEN_CPT pins `show_ui`, UI_ONLY_CPT pins
-	 * `is_post_type_viewable` (show_ui true but not viewable).
+	 * `is_post_type_viewable` (show_ui true but not viewable), NO_REST_CPT pins
+	 * `show_in_rest` (viewable + show_ui but not REST-exposed).
 	 */
 	public function test_featured_media_info_skips_hidden_post_types() {
 		Newspack_Newsletters_Editor::add_newspack_extra_info();
@@ -141,6 +161,7 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 
 		$this->assertNotContains( self::HIDDEN_CPT, $types, 'no show_ui → excluded' );
 		$this->assertNotContains( self::UI_ONLY_CPT, $types, 'show_ui but not viewable → excluded' );
+		$this->assertNotContains( self::NO_REST_CPT, $types, 'viewable + show_ui but not REST-exposed → excluded' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -54,6 +54,15 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 	const NO_REST_CPT = 'nppm2756_no_rest';
 
 	/**
+	 * Snapshot of the REST additional-fields registry, captured before each test
+	 * and restored after, so the registrations these tests make don't leak into
+	 * other test classes and cause order-dependent failures.
+	 *
+	 * @var array|null
+	 */
+	private $rest_fields_backup;
+
+	/**
 	 * Register the helper post types before the suite runs.
 	 */
 	public static function set_up_before_class() {
@@ -106,6 +115,24 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 		unregister_post_type( self::UI_ONLY_CPT );
 		unregister_post_type( self::NO_REST_CPT );
 		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Snapshot the REST additional-fields registry before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_rest_additional_fields;
+		$this->rest_fields_backup = $wp_rest_additional_fields;
+	}
+
+	/**
+	 * Restore the REST additional-fields registry after each test.
+	 */
+	public function tear_down() {
+		global $wp_rest_additional_fields;
+		$wp_rest_additional_fields = $this->rest_fields_backup;
+		parent::tear_down();
 	}
 
 	/**
@@ -200,5 +227,20 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 				"$field must be exposed only in the edit context"
 			);
 		}
+	}
+
+	/**
+	 * `featured_media_info` carries keyed URLs (`large_url`/`medium_url`), so its
+	 * schema must be `object`, not `array` — the original NPPM-2756 regression.
+	 * Pin it so a revert to `array` can't slip through.
+	 */
+	public function test_featured_media_info_schema_is_object() {
+		global $wp_rest_additional_fields;
+
+		Newspack_Newsletters_Editor::add_newspack_extra_info();
+
+		$args = $wp_rest_additional_fields['page']['featured_media_info'] ?? null;
+		$this->assertNotNull( $args, 'featured_media_info must be registered for page' );
+		$this->assertSame( 'object', $args['schema']['type'] ?? null );
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
+++ b/plugins/newspack-newsletters/tests/test-posts-inserter-rest-fields.php
@@ -26,8 +26,9 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 	const VIEWABLE_CPT = 'nppm2756_event';
 
 	/**
-	 * A hidden CPT (no show_ui) the inserter never offers — fields must NOT
-	 * be registered for it.
+	 * A viewable + REST-exposed CPT that is NOT UI-visible (no show_ui). The
+	 * inserter never offers it — isolating the `show_ui` half of the filter
+	 * (viewable + show_in_rest both pass, only show_ui fails).
 	 *
 	 * @var string
 	 */
@@ -70,7 +71,7 @@ class Test_Posts_Inserter_Rest_Fields extends WP_UnitTestCase {
 		register_post_type(
 			self::HIDDEN_CPT,
 			[
-				'public'       => false,
+				'public'       => true,
 				'show_ui'      => false,
 				'show_in_rest' => true,
 			]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Posts Inserter block in a newsletter can pull in different content types — posts, pages, newsletters, events, and other types the block offers — and show each item's featured image. Featured images were only appearing for regular **Posts**: pages, newsletters, and events came through as text only, even when they had a featured image set. This restores the image for all of those.

The block builds each image from a piece of REST data the editor attaches to every item. That data was only attached to posts, so the block had nothing to draw from for other content types. This change attaches it to every content type the Posts Inserter lets you choose, including Events Calendar events.

Reference: NPPM-2756

### How to test the changes in this Pull Request:

1. Make sure a **Page** has a featured image set. If The Events Calendar is active, give an **Event** one too.
2. Create or open a newsletter and add a **Posts Inserter** block.
3. Turn on **Featured image** and set **Post type** to **Pages**.
4. Confirm the selected page shows its featured image. Before this change, only the title and text appeared.
5. Repeat with **Post type** set to **Newsletters** and **Events**. Images should appear for each.
6. Set **Post type** back to **Posts** and confirm those still work as before.

### Release risk: Medium

| Signal | Score | Evidence |
|--------|-------|----------|
| Contract surface | Low | Not part of any tracked cross-repo contract; registers the existing edit-context REST fields for more post types, with no signature change. |
| Surface type | Medium | Changes REST response data for editor content types; not a new endpoint, not the newsletter send path. |
| Publisher exposure | Medium | Newspack Newsletters is broadly adopted, but the behavior change only affects Posts Inserter use with non-post content types. |
| Change shape | Medium | About 12 production lines in one file. Risk is a little higher because this registration was introduced by #1969. New tests added. |

Risk is medium because this touches editor REST data in a broadly adopted plugin. The change is additive, limited to edit-context fields, and covered by new regression tests.

### Notes for reviewers

- The missing image data traces to `Newspack_Newsletters_Editor::add_newspack_extra_info()` registering `featured_media_info` (and `newspack_author_info`, `newspack_custom_byline`, `newspack_sponsors_info`) via `register_rest_field( 'post', … )` only. The inserter fetches each type through its own REST route via `getEntityRecords( 'postType', postType )`, so non-`post` routes lacked the field, and with no client-side media fallback the editor showed no image.
- The #1969 change moved image data from a client-side `getMedia()` fetch, which worked across post types, to the server-provided `featured_media_info` field scoped to `post`. This keeps the server-provided field and registers it for the same post types the inserter offers.
- The post-type list mirrors the inserter's own `/wp/v2/types` selector (`viewable === true && show_ui === true`): `array_values( array_filter( get_post_types( [ 'show_ui' => true ], 'names' ), 'is_post_type_viewable' ) )`. That keeps coverage aligned with the inserter, including `tribe_events`.
- All four fields are `context => ['edit']`, so the wider registration is not exposed to anonymous or view-context requests.
- `newspack_author_info` is also registered by newspack-plugin (Co-Authors Plus) at priority 11 for `post` only; that enriched version still wins on `post`, and the newsletters field only adds coverage for other post types.
- Tests cover both filter gates independently: a viewable CPT is in scope, and a `show_ui`-but-not-viewable CPT is out of scope. The exclusion test fails if the `is_post_type_viewable` filter is removed.

### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
