### PR TITLE
feat: stamp producing engine when a newsletter is sent

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -459,6 +459,10 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 
 		if ( true === $result ) {
 			Newspack_Newsletters::set_newsletter_sent( $post_id );
+			\Newspack\Newsletters\Email_Renderers\Renderer_Controller::stamp_renderer(
+				$post_id,
+				\Newspack\Newsletters\Email_Renderers\Renderer_Controller::active_engine()
+			);
 		}
 
 		if ( \is_wp_error( $result ) ) {

--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -459,6 +459,12 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 
 		if ( true === $result ) {
 			Newspack_Newsletters::set_newsletter_sent( $post_id );
+			// Stamp the engine active at send time as the producing engine. Send time is
+			// the source of truth: the dispatched HTML reflects the engine resolved here,
+			// and for a scheduled send the flag is read on dispatch (not at authoring), so
+			// a flag flip between authoring and send is recorded as the send-time engine.
+			// The write is intentionally lossy toward MJML: if it fails, the resolver's
+			// default (Renderer_Controller::get_post_renderer) reports mjml.
 			\Newspack\Newsletters\Email_Renderers\Renderer_Controller::stamp_renderer(
 				$post_id,
 				\Newspack\Newsletters\Email_Renderers\Renderer_Controller::active_engine()

--- a/plugins/newspack-newsletters/tests/email-renderers/test-stamp-on-send.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-stamp-on-send.php
@@ -348,6 +348,8 @@ class Test_Stamp_On_Send extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+		delete_option( 'newspack_newsletters_use_woo_renderer' );
 		parent::tear_down();
 	}
 
@@ -382,6 +384,10 @@ class Test_Stamp_On_Send extends WP_UnitTestCase {
 	 * Flag OFF plus a successful send stamps the MJML engine.
 	 */
 	public function test_successful_send_stamps_mjml_when_flag_off() {
+		// Force the flag off so the assertion is independent of option/filter state
+		// leaked by other tests in the full suite — the filter wins last in Feature_Flag.
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+
 		$post_id = $this->create_draft_newsletter();
 		$result  = $this->provider->send_newsletter( get_post( $post_id ) );
 

--- a/plugins/newspack-newsletters/tests/email-renderers/test-stamp-on-send.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-stamp-on-send.php
@@ -29,8 +29,11 @@ class Stamp_On_Send_Test_Provider extends Newspack_Newsletters_Service_Provider 
 	 * Construct the test-double, registering its service slug.
 	 */
 	public function __construct() {
+		// Intentionally skip parent::__construct(): it registers global send/transition
+		// hooks bound to $this, and set_up() builds a fresh provider per test, so those
+		// callbacks would accumulate across the suite. These tests call send_newsletter()
+		// directly and need only the service slug, not the registered hooks.
 		$this->service = 'stamp_on_send_test';
-		parent::__construct();
 	}
 
 	/**
@@ -405,9 +408,15 @@ class Test_Stamp_On_Send extends WP_UnitTestCase {
 		$this->provider->set_send_result( new WP_Error( 'send_failed', 'Send failed.' ) );
 
 		$post_id = $this->create_draft_newsletter();
-		$result  = $this->provider->send_newsletter( get_post( $post_id ) );
+		// Mark as a scheduled send so the base class suppresses the admin failure email
+		// (an unrelated global side effect) on this non-final attempt.
+		update_post_meta( $post_id, 'sending_scheduled', true );
+		$result = $this->provider->send_newsletter( get_post( $post_id ) );
 
 		$this->assertWPError( $result, 'Harness must drive the failure branch.' );
+		// The send was attempted and failed — not skipped — so the post is not marked sent.
+		$this->assertFalse( Newspack_Newsletters::is_newsletter_sent( $post_id ), 'A failed send must not mark the newsletter sent.' );
+		// And with no stamp written, the resolver returns its intentional MJML default.
 		$this->assertSame( '', get_post_meta( $post_id, Renderer_Controller::RENDERER_META, true ) );
 		$this->assertSame( Renderer_Controller::ENGINE_MJML, Renderer_Controller::get_post_renderer( $post_id ) );
 	}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-stamp-on-send.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-stamp-on-send.php
@@ -1,0 +1,408 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests that a successful send stamps the producing engine on the newsletter.
+ *
+ * @package Newspack_Newsletters
+ */
+
+// The test-double provider and the test case share this file by design.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+/**
+ * Minimal test-double provider whose send() outcome is configurable.
+ *
+ * Implements every ESP API and hookable method as a no-op stub so the test can
+ * drive send_newsletter()'s success branch without any real ESP coupling. Only
+ * send() carries behaviour: it returns whatever was injected via set_send_result().
+ */
+class Stamp_On_Send_Test_Provider extends Newspack_Newsletters_Service_Provider {
+	/**
+	 * Value send() returns. Defaults to true (successful send).
+	 *
+	 * @var true|WP_Error
+	 */
+	private $send_result = true;
+
+	/**
+	 * Construct the test-double, registering its service slug.
+	 */
+	public function __construct() {
+		$this->service = 'stamp_on_send_test';
+		parent::__construct();
+	}
+
+	/**
+	 * Inject the result that send() should return.
+	 *
+	 * @param true|WP_Error $result Desired send() outcome.
+	 * @return void
+	 */
+	public function set_send_result( $result ) {
+		$this->send_result = $result;
+	}
+
+	/**
+	 * Return the injected send result, driving the success or failure branch.
+	 *
+	 * @param WP_Post $post Newsletter post being sent.
+	 * @return true|WP_Error
+	 */
+	public function send( $post ) {
+		unset( $post );
+		return $this->send_result;
+	}
+
+	/**
+	 * No-op save hook stub.
+	 *
+	 * @param int    $meta_id  Meta ID.
+	 * @param int    $post_id  Post ID.
+	 * @param string $meta_key Meta key.
+	 * @return void
+	 */
+	public function save( $meta_id, $post_id, $meta_key ) {}
+
+	/**
+	 * No-op trash hook stub.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	public function trash( $post_id ) {}
+
+	/**
+	 * No-op credentials accessor stub.
+	 *
+	 * @return array
+	 */
+	public function api_credentials() {
+		return [];
+	}
+
+	/**
+	 * No-op credentials setter stub.
+	 *
+	 * @param object $credentials API credentials.
+	 * @return void
+	 */
+	public function set_api_credentials( $credentials ) {}
+
+	/**
+	 * No-op credentials check stub.
+	 *
+	 * @return bool
+	 */
+	public function has_api_credentials() {
+		return true;
+	}
+
+	/**
+	 * No-op labels stub.
+	 *
+	 * @param mixed $context Label context.
+	 * @return array
+	 */
+	public static function get_labels( $context = '' ) {
+		return [];
+	}
+
+	/**
+	 * No-op conditional tag support stub.
+	 *
+	 * @return array
+	 */
+	public static function get_conditional_tag_support() {
+		return [];
+	}
+
+	/**
+	 * No-op list assignment stub.
+	 *
+	 * @param string $post_id Post ID.
+	 * @param string $list_id List ID.
+	 * @return array
+	 */
+	public function list( $post_id, $list_id ) {
+		return [];
+	}
+
+	/**
+	 * No-op retrieve stub.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array
+	 */
+	public function retrieve( $post_id ) {
+		return [];
+	}
+
+	/**
+	 * No-op test-email stub.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $emails  Recipient emails.
+	 * @return array
+	 */
+	public function test( $post_id, $emails ) {
+		return [];
+	}
+
+	/**
+	 * No-op sync stub.
+	 *
+	 * @param WP_Post $post Post to sync.
+	 * @return array
+	 */
+	public function sync( $post ) {
+		return [];
+	}
+
+	/**
+	 * No-op lists accessor stub.
+	 *
+	 * @return array
+	 */
+	public function get_lists() {
+		return [];
+	}
+
+	/**
+	 * No-op send-lists accessor stub.
+	 *
+	 * @param array $args     Search args.
+	 * @param bool  $to_array Whether to return arrays.
+	 * @return array
+	 */
+	public function get_send_lists( $args, $to_array = false ) {
+		return [];
+	}
+
+	/**
+	 * No-op add-contact stub.
+	 *
+	 * @param array  $contact Contact data.
+	 * @param string $list_id List ID.
+	 * @return array
+	 */
+	public function add_contact( $contact, $list_id = false ) {
+		return [];
+	}
+
+	/**
+	 * No-op contact-data accessor stub.
+	 *
+	 * @param string $email          Contact email.
+	 * @param bool   $return_details Whether to return full details.
+	 * @return array
+	 */
+	public function get_contact_data( $email, $return_details = false ) {
+		return [];
+	}
+
+	/**
+	 * No-op contact-lists accessor stub.
+	 *
+	 * @param string $email Contact email.
+	 * @return array
+	 */
+	public function get_contact_lists( $email ) {
+		return [];
+	}
+
+	/**
+	 * No-op contact-lists update stub.
+	 *
+	 * @param string   $email           Contact email.
+	 * @param string[] $lists_to_add    Lists to add.
+	 * @param string[] $lists_to_remove Lists to remove.
+	 * @return bool
+	 */
+	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
+		return true;
+	}
+
+	/**
+	 * No-op tag-id accessor stub.
+	 *
+	 * @param string $tag_name            Tag name.
+	 * @param bool   $create_if_not_found Whether to create.
+	 * @param string $list_id             List ID.
+	 * @return int
+	 */
+	public function get_tag_id( $tag_name, $create_if_not_found = true, $list_id = null ) {
+		return 0;
+	}
+
+	/**
+	 * No-op tag-by-id accessor stub.
+	 *
+	 * @param int    $tag_id  Tag ID.
+	 * @param string $list_id List ID.
+	 * @return string
+	 */
+	public function get_tag_by_id( $tag_id, $list_id = null ) {
+		return '';
+	}
+
+	/**
+	 * No-op create-tag stub.
+	 *
+	 * @param string $tag     Tag name.
+	 * @param string $list_id List ID.
+	 * @return array
+	 */
+	public function create_tag( $tag, $list_id = null ) {
+		return [];
+	}
+
+	/**
+	 * No-op update-tag stub.
+	 *
+	 * @param string|int $tag_id  Tag ID.
+	 * @param string     $tag     Tag name.
+	 * @param string     $list_id List ID.
+	 * @return array
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null ) {
+		return [];
+	}
+
+	/**
+	 * No-op add-tag-to-contact stub.
+	 *
+	 * @param string     $email   Contact email.
+	 * @param string|int $tag     Tag ID.
+	 * @param string     $list_id List ID.
+	 * @return bool
+	 */
+	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+		return true;
+	}
+
+	/**
+	 * No-op remove-tag-from-contact stub.
+	 *
+	 * @param string     $email   Contact email.
+	 * @param string|int $tag     Tag ID.
+	 * @param string     $list_id List ID.
+	 * @return bool
+	 */
+	public function remove_tag_from_contact( $email, $tag, $list_id = null ) {
+		return true;
+	}
+
+	/**
+	 * No-op contact-tags accessor stub.
+	 *
+	 * @param string $email Contact email.
+	 * @return array
+	 */
+	public function get_contact_tags_ids( $email ) {
+		return [];
+	}
+
+	/**
+	 * No-op reader-error-message stub.
+	 *
+	 * @param array $params    Request params.
+	 * @param mixed $raw_error Raw error.
+	 * @return string
+	 */
+	public function get_reader_error_message( $params = [], $raw_error = null ) {
+		return '';
+	}
+
+	/**
+	 * No-op usage-report stub.
+	 *
+	 * @return array
+	 */
+	public function get_usage_report() {
+		return [];
+	}
+}
+
+/**
+ * Asserts send_newsletter() stamps the active engine on a genuinely successful send.
+ */
+class Test_Stamp_On_Send extends WP_UnitTestCase {
+	/**
+	 * Shared test-double provider instance.
+	 *
+	 * @var Stamp_On_Send_Test_Provider
+	 */
+	private $provider;
+
+	/**
+	 * Test set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->provider = new Stamp_On_Send_Test_Provider();
+	}
+
+	/**
+	 * Test tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a draft newsletter and return its ID.
+	 *
+	 * @return int
+	 */
+	private function create_draft_newsletter() {
+		return self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+	}
+
+	/**
+	 * Flag ON plus a successful send stamps the WC engine.
+	 */
+	public function test_successful_send_stamps_wc_when_flag_on() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+
+		$post_id = $this->create_draft_newsletter();
+		$result  = $this->provider->send_newsletter( get_post( $post_id ) );
+
+		$this->assertTrue( $result, 'Harness must drive the success branch.' );
+		$this->assertSame( Renderer_Controller::ENGINE_WC, Renderer_Controller::get_post_renderer( $post_id ) );
+	}
+
+	/**
+	 * Flag OFF plus a successful send stamps the MJML engine.
+	 */
+	public function test_successful_send_stamps_mjml_when_flag_off() {
+		$post_id = $this->create_draft_newsletter();
+		$result  = $this->provider->send_newsletter( get_post( $post_id ) );
+
+		$this->assertTrue( $result, 'Harness must drive the success branch.' );
+		$this->assertSame( Renderer_Controller::ENGINE_MJML, Renderer_Controller::get_post_renderer( $post_id ) );
+		$this->assertSame( Renderer_Controller::ENGINE_MJML, get_post_meta( $post_id, Renderer_Controller::RENDERER_META, true ) );
+	}
+
+	/**
+	 * A failed send writes no stamp and leaves the resolver at its MJML default.
+	 */
+	public function test_failed_send_does_not_stamp() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+
+		$this->provider->set_send_result( new WP_Error( 'send_failed', 'Send failed.' ) );
+
+		$post_id = $this->create_draft_newsletter();
+		$result  = $this->provider->send_newsletter( get_post( $post_id ) );
+
+		$this->assertWPError( $result, 'Harness must drive the failure branch.' );
+		$this->assertSame( '', get_post_meta( $post_id, Renderer_Controller::RENDERER_META, true ) );
+		$this->assertSame( Renderer_Controller::ENGINE_MJML, Renderer_Controller::get_post_renderer( $post_id ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Stamps the producing engine (`mjml` or `wc`) on a newsletter the moment it is successfully sent**, so a frozen/sent newsletter records which renderer produced its HTML.

Part of the renderer-foundation work (Task 9). The resolver + stamp helpers already exist on `Renderer_Controller` (merged); this wires the write into the send lifecycle. Reading it back later (`get_post_renderer()`) lets downstream code interpret a sent newsletter under the engine that actually produced it (absence ⇒ `mjml`, so historical newsletters are unaffected).

What changed:

- In the service-provider base class, inside `send_newsletter()`'s success branch (right after `set_newsletter_sent()`), add a single `Renderer_Controller::stamp_renderer( $post_id, Renderer_Controller::active_engine() )` call.

Behavior & safety notes:

- `send_newsletter()` is the **single convergence point** for both the immediate-publish (`pre_post_update`) and scheduled (`transition_post_status`) send paths, and the only method that calls `$this->send()`. Stamping there means exactly one write per successful send, for every ESP.
- The stamp fires **only when the send genuinely succeeds** (`true === $result`). A failed send writes nothing — correct, since the newsletter can still be re-edited and re-sent under whatever engine is active then.
- Layout posts and already-sent newsletters short-circuit with `return null;` *before* this branch, so they never stamp.
- Purely additive — no change to send semantics, dispatch, error handling, retries/scheduling, or status transitions.

Part of NEWS-1908 (producing-engine stamp).

### How to test the changes in this Pull Request:

1. **Flag on, successful send → `wc`:** with `newspack_newsletters_use_woo_renderer` enabled, send a newsletter through a working ESP; afterwards `Renderer_Controller::get_post_renderer( $post_id )` returns `'wc'`.
2. **Flag off, successful send → `mjml`:** same, flag disabled → resolves to `'mjml'`.
3. **Failed send → no stamp:** a send that errors leaves no `newspack_newsletter_renderer` meta; the resolver returns the `'mjml'` default.
4. **PHPUnit:** `n test-php --filter Test_Stamp_On_Send` (3 cases). Regression: `Test_Layouts_Send_Suppression`, `Test_Controlled_Statuses`, `Test_Service_Provider` all stay green.

### Other information:

* [x] Have you written new tests for your changes, as applicable? — `tests/email-renderers/test-stamp-on-send.php` (test-double provider drives a real successful send; 3 cases incl. the failed-send no-stamp case).
* [x] Have you successfully run tests with your changes locally? — new suite green; the three neighbouring send/transition suites green.

---

## For AI / reviewers (detail)

- **Files:** `includes/service-providers/class-newspack-newsletters-service-provider.php` (+4 lines), `tests/email-renderers/test-stamp-on-send.php` (new).
- **Why `send_newsletter()` success branch and not the transition hooks:** both transition handlers (`pre_post_update`, `transition_post_status`) funnel into `send_newsletter()`, which is the lone caller of `$this->send()`. Stamping inside `if ( true === $result )` guarantees exactly-once, success-only, provider-agnostic behavior, and inherits the existing layout/already-sent short-circuits above it.
- **Test harness choice:** a minimal `Newspack_Newsletters_Service_Provider` subclass whose `send()` returns an injectable result (default `true`), called via `send_newsletter()` directly — avoids ESP coupling entirely and reliably exercises the success branch. The base class implements two interfaces (~28 methods, none `abstract`-keyworded but all required); they're stubbed as documented no-ops. Two classes in one test file follow the repo's existing `phpcs:disable OneObjectStructurePerFile` pattern.
