### PR TITLE
feat(insights): tweak table names and columns; add links if available

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -361,6 +361,7 @@ class Insights_Wizard extends Wizard {
 			'defaultComparison' => false,
 			'timezone'          => wp_timezone_string(),
 			'settingsUrl'       => admin_url( 'admin.php?page=newspack-settings' ),
+			'adminUrl'          => admin_url(),
 		];
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -59,6 +59,7 @@ export interface InsightsBootConfig {
 	defaultComparison: boolean;
 	timezone: string;
 	settingsUrl: string;
+	adminUrl?: string;
 }
 
 export interface InsightsWizardProps {

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -45,6 +45,7 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 	defaultComparison: false,
 	timezone: 'UTC',
 	settingsUrl: '',
+	adminUrl: '',
 	lastUpdated: null,
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
@@ -31,7 +31,7 @@ const ContentPerformanceSection = ( { current }: SectionProps ) => (
 				<h3 className="newspack-insights__chart-card-title">{ __( 'Top Articles', 'newspack-plugin' ) }</h3>
 				<MetricTable
 					payload={ current.top_pages }
-					emptyMessage={ __( 'No page data in this timeframe.', 'newspack-plugin' ) }
+					emptyMessage={ __( 'No article data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
 						{ key: 'page_title', label: __( 'Article', 'newspack-plugin' ) },
 						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
@@ -28,12 +28,12 @@ const ContentPerformanceSection = ( { current }: SectionProps ) => (
 		/>
 		<div className="newspack-insights__table-grid">
 			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Top Pages', 'newspack-plugin' ) }</h3>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top Articles', 'newspack-plugin' ) }</h3>
 				<MetricTable
 					payload={ current.top_pages }
 					emptyMessage={ __( 'No page data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
-						{ key: 'page_title', label: __( 'Page', 'newspack-plugin' ) },
+						{ key: 'page_title', label: __( 'Article', 'newspack-plugin' ) },
 						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
 						{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
 					] }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/adminLinks.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/adminLinks.ts
@@ -2,11 +2,13 @@
  * Admin link helpers for Insights tables.
  *
  * Builds wp-admin URLs from the `adminUrl` boot-config value so links work
- * under any wp-admin subdirectory. Falls back to a relative path if the
- * global isn't present (defensive — matches ConnectBanner's fallback).
+ * under any wp-admin subdirectory. Falls back to a relative URL if the
+ * global isn't present (defensive — matches ConnectBanner's fallback);
+ * a relative `post.php?...` from the wizard's own admin.php URL resolves
+ * to `<wp-admin>/post.php?...` for any install layout.
  */
 
-const adminUrl = (): string => window.newspackInsights?.adminUrl || '/wp-admin/';
+const adminUrl = (): string => window.newspackInsights?.adminUrl || '';
 
 /** Edit URL for a post/CPT (gates, prompts, products all use post.php). */
 export const getPostEditUrl = ( id: number ): string => `${ adminUrl() }post.php?post=${ id }&action=edit`;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/adminLinks.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/adminLinks.ts
@@ -1,0 +1,12 @@
+/**
+ * Admin link helpers for Insights tables.
+ *
+ * Builds wp-admin URLs from the `adminUrl` boot-config value so links work
+ * under any wp-admin subdirectory. Falls back to a relative path if the
+ * global isn't present (defensive — matches ConnectBanner's fallback).
+ */
+
+const adminUrl = (): string => window.newspackInsights?.adminUrl || '/wp-admin/';
+
+/** Edit URL for a post/CPT (gates, prompts, products all use post.php). */
+export const getPostEditUrl = ( id: number ): string => `${ adminUrl() }post.php?post=${ id }&action=edit`;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.test.tsx
@@ -27,7 +27,7 @@ describe( 'OpportunityBucketsSection', () => {
 
 	it( 'renders the top-pages table empty treatment when state is empty', () => {
 		render( <OpportunityBucketsSection current={ makeConversionWindow( { topPagesState: 'empty' } ) } /> );
-		expect( screen.getByText( /No qualifying pages yet/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /No qualifying articles yet/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the top-pages table error treatment when state is error', () => {
@@ -44,6 +44,6 @@ describe( 'OpportunityBucketsSection', () => {
 	it( 'renders the top-pages note regardless of table state', () => {
 		render( <OpportunityBucketsSection current={ makeConversionWindow() } /> );
 		// Note: the rendered string uses a right single quotation mark (U+2019) in "don't".
-		expect( screen.getByText( /These pages get traffic but don/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /These articles get traffic but don/ ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -39,14 +39,18 @@ const TOP_PAGES_COLUMNS: SortableColumn< ConversionTopPageRow >[] = [
 		key: 'page_title',
 		label: __( 'Article', 'newspack-plugin' ),
 		numeric: false,
-		render: row =>
-			row.page_url ? (
+		render: row => {
+			// Reject non-http(s) schemes (e.g. javascript:) before rendering — the row
+			// originates in BigQuery and is trusted, but cheap defense-in-depth.
+			const safe = typeof row.page_url === 'string' && /^https?:\/\//i.test( row.page_url );
+			return safe ? (
 				<a href={ row.page_url } target="_blank" rel="noreferrer">
 					{ row.page_title }
 				</a>
 			) : (
 				row.page_title
-			),
+			);
+		},
 		sortValue: row => row.page_title,
 	},
 	{
@@ -81,7 +85,7 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 			id="newspack-insights-conversion-opportunity-heading"
 			title={ __( 'Opportunity buckets', 'newspack-plugin' ) }
 			description={ __(
-				'Where the funnel has slack. These are diagnostic counts and underperforming pages — readers and content that could move with attention.',
+				'Where the funnel has slack. These are diagnostic counts and underperforming articles — readers and content that could move with attention.',
 				'newspack-plugin'
 			) }
 		/>
@@ -113,9 +117,9 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 			<SectionState
 				state={ current.top_pages_no_conversion.state }
 				emptyMessage={ sprintf(
-					/* translators: %s: minimum pageview count for a page to qualify (formatted). */
+					/* translators: %s: minimum pageview count for an article to qualify (formatted). */
 					__(
-						'No qualifying pages yet. Pages with at least %s pageviews and a measurable conversion rate will appear here.',
+						'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
 						'newspack-plugin'
 					),
 					formatNumber( current.top_pages_no_conversion.threshold_pageviews )
@@ -139,7 +143,7 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 			</SectionState>
 			<p className="newspack-insights__conversion-top-pages-note">
 				{ __(
-					'These pages get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
+					'These articles get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
 					'newspack-plugin'
 				) }
 			</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -37,21 +37,17 @@ const TOP_PAGES_ROW_LIMIT = 25;
 const TOP_PAGES_COLUMNS: SortableColumn< ConversionTopPageRow >[] = [
 	{
 		key: 'page_title',
-		label: __( 'Page title', 'newspack-plugin' ),
+		label: __( 'Article', 'newspack-plugin' ),
 		numeric: false,
-		render: row => row.page_title,
+		render: row =>
+			row.page_url ? (
+				<a href={ row.page_url } target="_blank" rel="noreferrer">
+					{ row.page_title }
+				</a>
+			) : (
+				row.page_title
+			),
 		sortValue: row => row.page_title,
-	},
-	{
-		key: 'page_url',
-		label: __( 'Page URL', 'newspack-plugin' ),
-		numeric: false,
-		render: row => (
-			<a href={ row.page_url } target="_blank" rel="noreferrer">
-				{ row.page_url }
-			</a>
-		),
-		sortValue: row => row.page_url,
 	},
 	{
 		key: 'pageviews',
@@ -113,7 +109,7 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 			/>
 		</div>
 		<div className="newspack-insights__conversion-top-pages">
-			<h3 className="newspack-insights__conversion-subheading">{ __( 'Top pages that don’t convert', 'newspack-plugin' ) }</h3>
+			<h3 className="newspack-insights__conversion-subheading">{ __( 'Top articles that don’t convert', 'newspack-plugin' ) }</h3>
 			<SectionState
 				state={ current.top_pages_no_conversion.state }
 				emptyMessage={ sprintf(

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -132,9 +132,9 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 					defaultSortKey="pageviews"
 					initialRowLimit={ TOP_PAGES_ROW_LIMIT }
 					emptyMessage={ sprintf(
-						/* translators: %s: minimum pageview count for a page to qualify (formatted). */
+						/* translators: %s: minimum pageview count for an article to qualify (formatted). */
 						__(
-							'No qualifying pages yet. Pages with at least %s pageviews and a measurable conversion rate will appear here.',
+							'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
 							'newspack-plugin'
 						),
 						formatNumber( current.top_pages_no_conversion.threshold_pageviews )

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
@@ -31,6 +31,7 @@ import { Fragment } from '@wordpress/element';
 import type { BillingModel, DonorsTierRow, DonorsTierVariationRow } from '../../api/donors';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
+import { getPostEditUrl } from '../components/adminLinks';
 import { formatCurrency, formatNumber } from '../components/format';
 
 export interface PerformanceSectionProps {
@@ -115,7 +116,9 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 						{ rows.map( row => (
 							<Fragment key={ row.product_id }>
 								<tr>
-									<td>{ row.name }</td>
+									<td>
+										<a href={ getPostEditUrl( row.product_id ) }>{ row.name }</a>
+									</td>
 									{ renderRowCells( row ) }
 								</tr>
 								{ row.is_parent &&

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -36,7 +36,7 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-Engaged Articles', 'newspack-plugin' ) }</h3>
 				<MetricTable
 					payload={ current.most_read_articles }
-					emptyMessage={ __( 'No page engagement data in this timeframe.', 'newspack-plugin' ) }
+					emptyMessage={ __( 'No article engagement data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
 						ARTICLE_COL,
 						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -19,7 +19,7 @@ export interface SectionProps {
 	previous: InsightsWindow | null;
 }
 
-const PAGE_COL = { key: 'page_title', label: __( 'Page', 'newspack-plugin' ) };
+const ARTICLE_COL = { key: 'page_title', label: __( 'Article', 'newspack-plugin' ) };
 
 const ContentEngagementSection = ( { current }: SectionProps ) => (
 	<section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-content">
@@ -33,24 +33,24 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 		     have width and the third doesn't stretch full-width. */ }
 		<div className="newspack-insights__table-grid newspack-insights__table-grid--cols-2">
 			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-Engaged Pages', 'newspack-plugin' ) }</h3>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-Engaged Articles', 'newspack-plugin' ) }</h3>
 				<MetricTable
 					payload={ current.most_read_articles }
 					emptyMessage={ __( 'No page engagement data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
-						PAGE_COL,
+						ARTICLE_COL,
 						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
 						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
 					] }
 				/>
 			</div>
 			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Pages by Completion Rate', 'newspack-plugin' ) }</h3>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by Completion Rate', 'newspack-plugin' ) }</h3>
 				<MetricTable
 					payload={ current.articles_by_completion_rate }
 					emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
-						PAGE_COL,
+						ARTICLE_COL,
 						{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
 						{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
 					] }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
@@ -30,6 +30,7 @@ import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
  * Internal dependencies
  */
 import type { GatesPerformanceRow, GatesPerformanceTable } from '../../api/gates';
+import { getPostEditUrl } from '../components/adminLinks';
 import { formatNumber, formatPercent } from '../components/format';
 import SectionHeading from '../components/SectionHeading';
 import { SECTION_ERROR_MESSAGE } from './SectionState';
@@ -69,7 +70,9 @@ const renderPercent = ( v: number | null ) => ( v === null ? <NotApplicable /> :
 
 const renderRow = ( row: GatesPerformanceRow ) => (
 	<tr key={ row.gate_post_id }>
-		<td>{ row.gate_name }</td>
+		<td>
+			<a href={ getPostEditUrl( row.gate_post_id ) }>{ row.gate_name }</a>
+		</td>
 		<td className="newspack-insights__table-num">{ formatNumber( row.impressions ) }</td>
 		<td className="newspack-insights__table-num">{ formatNumber( row.unique_viewers ) }</td>
 		<td className="newspack-insights__table-num">{ formatNumber( row.registrations ) }</td>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as TableData } from '../../../api/prompts';
+import { getPostEditUrl } from '../../components/adminLinks';
 import { formatNumber } from '../../components/format';
 import SortableTable, { renderCount, renderRate, type SortableColumn } from '../../components/SortableTable';
 import { humanizeTerm } from './humanize';
@@ -32,7 +33,13 @@ export interface PerformanceByPromptTableProps {
 }
 
 const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
-	{ key: 'prompt_title', label: __( 'Prompt', 'newspack-plugin' ), numeric: false, render: r => r.prompt_title, sortValue: r => r.prompt_title },
+	{
+		key: 'prompt_title',
+		label: __( 'Prompt', 'newspack-plugin' ),
+		numeric: false,
+		render: r => <a href={ getPostEditUrl( r.popup_id ) }>{ r.prompt_title }</a>,
+		sortValue: r => r.prompt_title,
+	},
 	{ key: 'intent', label: __( 'Intent', 'newspack-plugin' ), numeric: false, render: r => humanizeTerm( r.intent ), sortValue: r => r.intent },
 	{
 		key: 'placement',

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
@@ -24,6 +24,7 @@ import { Fragment } from '@wordpress/element';
 import type { PerformanceRow } from '../../api/subscribers';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
+import { getPostEditUrl } from '../components/adminLinks';
 import { formatCurrency, formatNumber } from '../components/format';
 
 export interface PerformanceSectionProps {
@@ -79,7 +80,9 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 						{ rows.map( row => (
 							<Fragment key={ row.product_id }>
 								<tr>
-									<td>{ row.name }</td>
+									<td>
+										<a href={ getPostEditUrl( row.product_id ) }>{ row.name }</a>
+									</td>
 									<td className="newspack-insights__table-num">{ formatNumber( row.active_subs ) }</td>
 									<td className="newspack-insights__table-num">{ formatNumber( row.churned_subs ) }</td>
 									<td className="newspack-insights__table-num">{ formatCurrency( row.active_value ).display }</td>

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Tests for restricting gated content in RSS feeds.
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+namespace Newspack\Tests\Content_Gate;
+
+use Newspack\Content_Gate;
+use Newspack\Content_Gate_Advanced_Settings;
+use Newspack\Content_Restriction_Control;
+
+/**
+ * Tests that the "Restrict content in feeds" advanced setting keeps gated
+ * content out of RSS feeds, where Content_Gate::restrict_post() never runs
+ * (it bails on `! is_singular()`), so the feed filters are the only guard.
+ *
+ * @group content-gate
+ */
+class Test_Feed_Restriction extends \WP_UnitTestCase {
+
+	/**
+	 * Gated post content: five distinct paragraphs so we can assert which
+	 * survive truncation (the default visible_paragraphs is 2).
+	 */
+	const POST_CONTENT = '<!-- wp:paragraph --><p>FREE_ONE paragraph one.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>FREE_TWO paragraph two.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>PAID_THREE paragraph three.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>PAID_FOUR paragraph four.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>PAID_FIVE paragraph five.</p><!-- /wp:paragraph -->';
+
+	/**
+	 * Gated post ID.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Gate ID.
+	 *
+	 * @var int
+	 */
+	private $gate_id;
+
+	/**
+	 * Enable the Content Gates feature flag for this class only.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Set up a published registration-mode gate restricting all posts, plus a
+	 * gated post, consumed as an anonymous reader with restrict_feeds enabled.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->gate_id = Content_Gate::create_gate( [ 'title' => 'Feed Gate' ] );
+		Content_Gate::update_gate_settings(
+			$this->gate_id,
+			[
+				'title'         => 'Feed Gate',
+				'status'        => 'publish',
+				'priority'      => 0,
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => [
+					'active'               => true,
+					'metering'             => [
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					],
+					'require_verification' => false,
+					'gate_id'              => 0,
+				],
+			]
+		);
+
+		$this->post_id = $this->factory->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => self::POST_CONTENT,
+			]
+		);
+
+		// Feeds are consumed anonymously.
+		wp_set_current_user( 0 );
+		update_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds', 1, false );
+		Content_Gate_Advanced_Settings::reset_cache();
+	}
+
+	/**
+	 * Teardown after tests.
+	 */
+	public function tear_down() {
+		foreach ( Content_Gate::get_gates() as $gate ) {
+			wp_delete_post( $gate['id'], true );
+		}
+		wp_delete_post( $this->post_id, true );
+		$this->reset_restriction_cache();
+
+		// Restore the global state these tests mutate so they can't leak into
+		// other (RSS/feed) suites and cause order-dependent failures.
+		delete_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds' );
+		delete_option( 'rss_use_excerpt' );
+		Content_Gate_Advanced_Settings::reset_cache();
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the per-request restriction caches between assertions.
+	 */
+	private function reset_restriction_cache() {
+		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map', 'post_gates_map', 'term_descendants_map' ] as $cache_property ) {
+			$cache_property_reflection = new \ReflectionProperty( Content_Restriction_Control::class, $cache_property );
+			$cache_property_reflection->setAccessible( true );
+			$cache_property_reflection->setValue( null, [] );
+		}
+	}
+
+	/**
+	 * Render the gated post through a real feed loop and return the value the
+	 * given callback produces for it. Resets global post data afterwards via
+	 * wp_reset_postdata().
+	 *
+	 * @param callable $render Runs inside the loop with the gated post set up,
+	 *                         and returns the feed string for that post.
+	 *
+	 * @return string
+	 */
+	private function render_in_feed_loop( callable $render ) {
+		$this->go_to( get_feed_link( 'rss2' ) );
+		$this->assertTrue( is_feed(), 'Request should be a feed.' );
+
+		$result = '';
+		ob_start();
+		while ( have_posts() ) {
+			the_post();
+			if ( get_the_ID() === $this->post_id ) {
+				$result = $render();
+			}
+		}
+		ob_end_clean();
+		wp_reset_postdata();
+
+		return $result;
+	}
+
+	/**
+	 * Sanity check: the gate restricts the post for an anonymous reader, so the
+	 * feed filters have something to act on.
+	 */
+	public function test_post_is_restricted_for_anonymous() {
+		$this->assertTrue(
+			(bool) apply_filters( 'newspack_is_post_restricted', false, $this->post_id ),
+			'Gated post should be restricted for an anonymous reader.'
+		);
+	}
+
+	/**
+	 * Full-text feed (rss_use_excerpt=0): <content:encoded> is rendered via
+	 * get_the_content_feed(), and must not leak the paid paragraphs.
+	 */
+	public function test_full_text_feed_content_is_truncated() {
+		update_option( 'rss_use_excerpt', 0 );
+
+		$feed_content = $this->render_in_feed_loop(
+			function () {
+				return get_the_content_feed( 'rss2' );
+			}
+		);
+
+		$this->assertStringContainsString( 'FREE_ONE', $feed_content, 'Free preview should be present in feed content.' );
+		$this->assertStringNotContainsString( 'PAID_THREE', $feed_content, 'Paid paragraph 3 must not leak into full-text feed content.' );
+		$this->assertStringNotContainsString( 'PAID_FIVE', $feed_content, 'Paid paragraph 5 must not leak into full-text feed content.' );
+	}
+
+	/**
+	 * Excerpt feed (rss_use_excerpt=1): <description> is rendered via
+	 * the_excerpt_rss, and must not leak the paid paragraphs.
+	 */
+	public function test_excerpt_feed_is_truncated() {
+		update_option( 'rss_use_excerpt', 1 );
+
+		$feed_excerpt = $this->render_in_feed_loop(
+			function () {
+				return apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+			}
+		);
+
+		// Positive assertion guards against a false negative: if the loop failed
+		// to capture the post and returned an empty string, the "not contains"
+		// checks alone would still pass.
+		$this->assertStringContainsString( 'FREE_ONE', $feed_excerpt, 'Free preview should be present in feed excerpt.' );
+		$this->assertStringNotContainsString( 'PAID_THREE', $feed_excerpt, 'Paid paragraph 3 must not leak into feed excerpt.' );
+		$this->assertStringNotContainsString( 'PAID_FIVE', $feed_excerpt, 'Paid paragraph 5 must not leak into feed excerpt.' );
+	}
+
+	/**
+	 * When the setting is off, the feed is left untouched: the filters become a
+	 * no-op and the full content flows through.
+	 */
+	public function test_full_content_flows_when_setting_disabled() {
+		update_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds', 0, false );
+		Content_Gate_Advanced_Settings::reset_cache();
+		update_option( 'rss_use_excerpt', 0 );
+
+		$feed_content = $this->render_in_feed_loop(
+			function () {
+				return get_the_content_feed( 'rss2' );
+			}
+		);
+
+		$this->assertStringContainsString( 'PAID_FIVE', $feed_content, 'With restrict_feeds off, full content should flow into the feed.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Small UX pass over the table chrome across the Insights tabs:

**Renames (no link changes)**

- Audience › "Top Pages" → **"Top Articles"**; first column "Page" → "Article".
- Engagement › "Most-Engaged Pages" → **"Most-Engaged Articles"**; first column "Page" → "Article".
- Engagement › "Pages by Completion Rate" → **"Articles by Completion Rate"**; first column "Page" → "Article".
- Conversion Journey › "Top pages that don't convert" → **"Top articles that don't convert"**; first column "Page title" → "Article".

**New links on the first column** — only on rows that carry a stable identifier the backend already returns:

- Conversion Journey › Top articles that don't convert — title links to the article via the row's existing `page_url`; the standalone "Page URL" column is dropped (redundant).
- Gates › Performance by gate — gate name links to its edit URL (via `gate_post_id`).
- Prompts › Performance by prompt — prompt title links to its edit URL (via `popup_id`). The "by intent" / "by placement" aggregate tables are left unlinked since each row represents many prompts, not one.
- Subscribers › Subscriptions by product — parent product name links to its edit URL (via `product_id`). Variation rows untouched (they sit nested under the parent).
- Donors › Donations by tier — same treatment as Subscribers.

**Audience/Engagement: title and author rows are intentionally NOT linked.** Those tables come from GA4 dimensions (`pageTitle`, `customEvent:author`) which are display strings, not stable IDs — looking up a post by title or a user by display name would silently mis-resolve duplicates and miss retitled posts. Left as plain text rather than ship a fuzzy link.

**Plumbing**

- `class-insights-wizard.php` adds an `adminUrl` value to the boot config (via `admin_url()`), exposed to the React app as `window.newspackInsights.adminUrl`.
- New `src/wizards/insights/tabs/components/adminLinks.ts` — tiny `getPostEditUrl( id )` helper used by Gates, Prompts, Subscribers, and Donors to build the edit URL.

Closes # .

### How to test the changes in this Pull Request:

1. Check out the branch and load the Insights wizard (`?page=newspack-insights`).
2. **Audience tab** — verify "Top Articles" heading + "Article" column heading. Rows are plain text (no link), readers and pageviews unchanged. "Top Authors by Reader Count" is unchanged in label and unlinked.
3. **Engagement tab** — verify "Most-Engaged Articles" and "Articles by Completion Rate" headings + "Article" column heading. Rows are plain text. "Top Authors by Avg Engagement Time" unchanged and unlinked.
4. **Conversion Journey tab** — verify the table heading is "Top articles that don't convert". The standalone "Page URL" column should be gone; the title in the first column should be a clickable link that opens the article in a new tab. Sorting / "See more" should still work.
5. **Gates tab** — Performance by gate: clicking a gate name should open `/wp-admin/post.php?post=<id>&action=edit` for that gate. Sort chrome should still work.
6. **Prompts tab** — Performance by prompt: clicking a prompt title should open the prompt's edit screen. The "Performance by prompt intent" and "Performance by prompt placement" tables should still render with unlinked first cells.
7. **Subscribers tab** — Subscriptions by product: the parent product row's name should link to the product edit screen; nested variation rows below it should remain plain text.
8. **Donors tab** — Donations by tier: same expectation as Subscribers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
