### PR TITLE
feat(insights): not-computable rendering branch for Prompts tab (NPPD-1704)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/prompts-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/prompts-fixture.php
@@ -15,8 +15,10 @@
  *   - 'not_computable' — populated data, but all 13 conversion-tied scalars are
  *     capable (has_capability:true) yet non-computable (state 'populated',
  *     computable:false) so their cards render the "no inputs this window"
- *     treatment (NPPD-1704); exposure / engagement scalars keep real values,
- *     proving the gate is per-metric, not tab-wide.
+ *     treatment (NPPD-1704). The other exposure/engagement scalars (impressions,
+ *     CTR, dismissal) keep real values, proving the gate is per-metric, not
+ *     tab-wide. Note form_submission_rate is an engagement-area metric that IS
+ *     gated — it's one of the 13 conversion-tied scalars.
  *
  * Returns a closure so the single required file can build any variant. Never
  * enable fixture mode in production.
@@ -423,12 +425,14 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 
 	// --- Not-computable variant (NPPD-1704): capable, but no inputs this window. ---
 	// All 13 conversion-tied scalars stay capable (has_capability:true) yet report a
-	// non-computable zero (state 'populated', computable:false) — the exact envelope
-	// the metric class emits when SAFE_DIVIDE returns NULL on a zero denominator
-	// (compute_metric_from_proxy). Exposure / engagement scalars are left untouched
-	// with their real values, so a reviewer hitting _fixture_state=not_computable
-	// sees ONLY the conversion cards em-dashed — proof the gate is per-metric, not
-	// tab-wide. Contrast not_capable (pre-query block scan); this is post-query math.
+	// non-computable zero (state 'populated', computable:false) — the envelope the
+	// metric class emits for an empty window (the 5 proxy rate metrics via SAFE_DIVIDE
+	// NULL; the 8 Woo-joined paid-conversion + revenue metrics via count(rows) === 0).
+	// The other exposure/engagement scalars (impressions, CTR, dismissal) keep their
+	// real values, so a reviewer hitting _fixture_state=not_computable sees ONLY the
+	// conversion cards em-dashed — proof the gate is per-metric, not tab-wide.
+	// (form_submission_rate is the one engagement-area metric among the 13.) Contrast
+	// not_capable (pre-query block scan); this is post-query math.
 	$conversion_metrics   = [
 		'form_submission_rate',
 		'registration_conversion_direct',

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/prompts-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/prompts-fixture.php
@@ -12,6 +12,11 @@
  *   - 'not_capable' — populated data, but registration / donation / subscription
  *     metrics are marked has_capability:false (NPPD-1720) so their cards render
  *     the structural "not capable" treatment; newsletter stays capable.
+ *   - 'not_computable' — populated data, but all 13 conversion-tied scalars are
+ *     capable (has_capability:true) yet non-computable (state 'populated',
+ *     computable:false) so their cards render the "no inputs this window"
+ *     treatment (NPPD-1704); exposure / engagement scalars keep real values,
+ *     proving the gate is per-metric, not tab-wide.
  *
  * Returns a closure so the single required file can build any variant. Never
  * enable fixture mode in production.
@@ -416,9 +421,56 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		return $win;
 	};
 
+	// --- Not-computable variant (NPPD-1704): capable, but no inputs this window. ---
+	// All 13 conversion-tied scalars stay capable (has_capability:true) yet report a
+	// non-computable zero (state 'populated', computable:false) — the exact envelope
+	// the metric class emits when SAFE_DIVIDE returns NULL on a zero denominator
+	// (compute_metric_from_proxy). Exposure / engagement scalars are left untouched
+	// with their real values, so a reviewer hitting _fixture_state=not_computable
+	// sees ONLY the conversion cards em-dashed — proof the gate is per-metric, not
+	// tab-wide. Contrast not_capable (pre-query block scan); this is post-query math.
+	$conversion_metrics   = [
+		'form_submission_rate',
+		'registration_conversion_direct',
+		'registration_conversion_influenced_7d',
+		'newsletter_signup_conversion_direct',
+		'newsletter_signup_conversion_influenced_7d',
+		'donation_conversion_direct',
+		'donation_conversion_influenced_14d',
+		'subscription_conversion_direct',
+		'subscription_conversion_influenced_14d',
+		'donation_revenue_direct',
+		'donation_revenue_influenced_14d',
+		'subscription_revenue_direct',
+		'subscription_revenue_influenced_14d',
+	];
+	$apply_not_computable = static function ( array $win ) use ( $conversion_metrics, $scalar_types, $zero_value ) {
+		foreach ( $conversion_metrics as $key ) {
+			$type          = $scalar_types[ $key ];
+			$win[ $key ] = [
+				'state'            => 'populated',
+				'value'            => $zero_value( $type ),
+				'computable'       => false,
+				'denominator'      => null,
+				'placeholder_type' => $type,
+				'has_capability'   => true,
+			];
+		}
+		return $win;
+	};
+
+	// not_capable stamps capability flags; not_computable overrides the 13 conversion
+	// scalars; populated leaves the window as built.
+	$transform = static function ( array $win ) use ( $variant, $apply_capabilities, $apply_not_computable ) {
+		if ( 'not_computable' === $variant ) {
+			return $apply_not_computable( $win );
+		}
+		return $apply_capabilities( $win );
+	};
+
 	return [
 		'tab_error' => false,
-		'current'   => $apply_capabilities( $build( 1.0, $window ) ),
-		'previous'  => $compare ? $apply_capabilities( $build( 0.9, $prev_window ) ) : null,
+		'current'   => $transform( $build( 1.0, $window ) ),
+		'previous'  => $compare ? $transform( $build( 0.9, $prev_window ) ) : null,
 	];
 };

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -200,9 +200,11 @@ final class Prompts_Metric {
 	 * Return the canned fixture payload for the Prompts tab.
 	 *
 	 * Returned by the REST controller when NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
-	 * The variant selects a render path: 'populated' (default), 'empty', 'error'.
+	 * The variant selects a render path: 'populated' (default), 'empty', 'error',
+	 * 'not_capable' (NPPD-1720), 'not_computable' (NPPD-1704).
 	 *
-	 * @param string $variant One of 'populated', 'empty', 'error'.
+	 * @param string $variant One of 'populated', 'empty', 'error', 'not_capable',
+	 *                        'not_computable'.
 	 * @param bool   $compare Whether comparison was requested; when false the
 	 *                        `previous` window is null (no period-over-period deltas).
 	 * @return array Full { tab_error, current, previous } response shape.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -500,8 +500,12 @@ final class Prompts_Metric {
 			return $rows;
 		}
 
-		// A successful but empty response is real "no conversions", not an error:
-		// zero conversions / zero revenue, which the callers render as $0.00.
+		// A successful but empty response is real "no attempts", not an error:
+		// zero rows / zero conversions / zero revenue. Callers treat an empty window
+		// (no in-intent prompts viewed) as non-computable — both the rate and revenue
+		// methods gate `computable` on `count( rows ) > 0` — so it renders the
+		// not-computable em-dash. A window WITH attempts but no conversions is a real
+		// 0 / $0.00 (computable).
 		$rows   = is_array( $rows ) ? $rows : [];
 		$result = [
 			'rows'        => $rows,
@@ -807,7 +811,11 @@ final class Prompts_Metric {
 		if ( is_wp_error( $joined ) ) {
 			return $this->error_scalar( 'currency', $joined );
 		}
-		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
+		// Computable only when at least one paid-intent prompt was viewed (mirrors
+		// the matching conversion-rate method's `count( rows ) > 0` gate). An empty
+		// window is "no in-intent prompts viewed", not a real $0 — so it renders the
+		// not-computable em-dash, consistent with its sibling rate card (NPPD-1704).
+		return $this->populated_scalar( $joined['revenue'], count( $joined['rows'] ) > 0, $joined['conversions'], 'currency' );
 	}
 
 	/**
@@ -822,7 +830,11 @@ final class Prompts_Metric {
 		if ( is_wp_error( $joined ) ) {
 			return $this->error_scalar( 'currency', $joined );
 		}
-		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
+		// Computable only when at least one paid-intent prompt was viewed (mirrors
+		// the matching conversion-rate method's `count( rows ) > 0` gate). An empty
+		// window is "no in-intent prompts viewed", not a real $0 — so it renders the
+		// not-computable em-dash, consistent with its sibling rate card (NPPD-1704).
+		return $this->populated_scalar( $joined['revenue'], count( $joined['rows'] ) > 0, $joined['conversions'], 'currency' );
 	}
 
 	/**
@@ -837,7 +849,11 @@ final class Prompts_Metric {
 		if ( is_wp_error( $joined ) ) {
 			return $this->error_scalar( 'currency', $joined );
 		}
-		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
+		// Computable only when at least one paid-intent prompt was viewed (mirrors
+		// the matching conversion-rate method's `count( rows ) > 0` gate). An empty
+		// window is "no in-intent prompts viewed", not a real $0 — so it renders the
+		// not-computable em-dash, consistent with its sibling rate card (NPPD-1704).
+		return $this->populated_scalar( $joined['revenue'], count( $joined['rows'] ) > 0, $joined['conversions'], 'currency' );
 	}
 
 	/**
@@ -852,7 +868,11 @@ final class Prompts_Metric {
 		if ( is_wp_error( $joined ) ) {
 			return $this->error_scalar( 'currency', $joined );
 		}
-		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
+		// Computable only when at least one paid-intent prompt was viewed (mirrors
+		// the matching conversion-rate method's `count( rows ) > 0` gate). An empty
+		// window is "no in-intent prompts viewed", not a real $0 — so it renders the
+		// not-computable em-dash, consistent with its sibling rate card (NPPD-1704).
+		return $this->populated_scalar( $joined['revenue'], count( $joined['rows'] ) > 0, $joined['conversions'], 'currency' );
 	}
 
 	// --- Section 6: How readers convert ---------------------------------

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -209,3 +209,75 @@ describe( 'MetricCard notCapableMessage (NPPD-1720)', () => {
 		expect( screen.queryByText( description ) ).not.toBeInTheDocument();
 	} );
 } );
+
+describe( 'MetricCard notComputableMessage (NPPD-1704)', () => {
+	const MESSAGE = 'No donation-intent prompts viewed in this timeframe.';
+	const NUDGE = 'No donation block detected in your active prompts.';
+
+	it( 'renders the em-dash hero + the message as the secondary line', () => {
+		render( <MetricCard label="Donation Conversion (Direct)" value={ 0 } format="percent" notComputableMessage={ MESSAGE } /> );
+		expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
+		expect( screen.getByText( MESSAGE ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the metric value', () => {
+		render( <MetricCard label="Donation Conversion (Direct)" value={ 0.42 } format="percent" notComputableMessage={ MESSAGE } /> );
+		expect( screen.queryByText( /%/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'yields to not-capable (add-the-block beats wait-for-data)', () => {
+		render(
+			<MetricCard
+				label="Donation Conversion (Direct)"
+				value={ 0 }
+				format="percent"
+				notCapableMessage={ NUDGE }
+				notComputableMessage={ MESSAGE }
+			/>
+		);
+		expect( screen.getByText( NUDGE ) ).toBeInTheDocument();
+		expect( screen.queryByText( MESSAGE ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'wins over zeroFallback (capable-but-no-inputs beats a bare zero count)', () => {
+		render(
+			<MetricCard
+				label="Donation Conversion (Direct)"
+				value={ 0 }
+				format="percent"
+				notComputableMessage={ MESSAGE }
+				zeroFallback={ { numerator: 0, denominator: 17, attemptsLabel: 'donation prompts' } }
+			/>
+		);
+		expect( screen.getByText( MESSAGE ) ).toBeInTheDocument();
+		expect( screen.queryByText( '0 of 17' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'yields to the error treatment (error wins over not-computable)', () => {
+		render( <MetricCard label="Donation Conversion (Direct)" error="boom" notComputableMessage={ MESSAGE } /> );
+		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( MESSAGE ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'suppresses the comparison delta', () => {
+		const { container } = render(
+			<MetricCard label="Donation Conversion (Direct)" value={ 0 } previousValue={ 0.4 } format="percent" notComputableMessage={ MESSAGE } />
+		);
+		expect( container.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+	} );
+
+	it( 'hides the formula description (the message replaces it)', () => {
+		const description = 'Completed donations ÷ donation-intent prompt impressions';
+		render(
+			<MetricCard
+				label="Donation Conversion (Direct)"
+				value={ 0 }
+				format="percent"
+				description={ description }
+				notComputableMessage={ MESSAGE }
+			/>
+		);
+		expect( screen.getByText( MESSAGE ) ).toBeInTheDocument();
+		expect( screen.queryByText( description ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -99,6 +99,16 @@ export interface MetricCardProps {
 	 * window-bound). Absent for capable metrics and every non-Prompts caller.
 	 */
 	notCapableMessage?: string;
+	/**
+	 * "Not computable this window" copy (NPPD-1704). When set, the metric IS
+	 * capable (the block exists) but the math couldn't complete for this window —
+	 * typically a zero denominator (SAFE_DIVIDE NULL) because no in-intent prompts
+	 * were viewed. Renders the same em-dash hero + secondary line as
+	 * `notCapableMessage`, but sits one slot lower in precedence: `notCapable`
+	 * wins (its "add the block" nudge is more actionable than "wait for data"),
+	 * and this in turn beats `zeroFallback`. Absent for every non-Prompts caller.
+	 */
+	notComputableMessage?: string;
 }
 
 // Currency is handled by the caller (it needs both display + title from one
@@ -139,6 +149,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 		valueTitle,
 		zeroFallback,
 		notCapableMessage,
+		notComputableMessage,
 	} = props;
 
 	// Shared graceful-failure state (missing dimension / not configured / error).
@@ -168,6 +179,15 @@ const MetricCard = ( props: MetricCardProps ) => {
 		// no date range can fill) wins over a window-bound zero count.
 		fallbackHero = EM_DASH;
 		fallbackSecondary = notCapableMessage;
+	} else if ( notComputableMessage ) {
+		// "Not computable this window" (NPPD-1704): the metric is capable (its block
+		// exists) but the math couldn't complete — typically a zero denominator, so
+		// there were no in-intent inputs in this window. Same em-dash + secondary
+		// treatment as not-capable, one slot lower: not-capable already short-
+		// circuited above (its nudge is the more actionable of the two), and this
+		// beats `zeroFallback`. A longer window or more traffic can fill this gap.
+		fallbackHero = EM_DASH;
+		fallbackSecondary = notComputableMessage;
 	} else if ( zeroFallback && ( format === 'percent' || format === 'currency' ) ) {
 		const { numerator, denominator, currencyRole, attemptsLabel, conversionsLabel } = zeroFallback;
 		const conversionsNoun = conversionsLabel ?? __( 'conversions', 'newspack-plugin' );
@@ -296,10 +316,13 @@ const MetricCard = ( props: MetricCardProps ) => {
 					</div>
 				) }
 			</div>
-			{ /* The not-capable nudge replaces the formula description (NPPD-1720): the
-			     description explains how the metric is computed, which is moot when there's
-			     structurally nothing to compute, and would just double the text block. */ }
-			{ description && ! notCapableMessage && <div className="newspack-insights__metric-card-description">{ description }</div> }
+			{ /* The not-capable / not-computable secondary line replaces the formula
+			     description (NPPD-1720, NPPD-1704): the description explains how the
+			     metric is computed, which is moot when there's nothing to compute, and
+			     would just double the text block. */ }
+			{ description && ! notCapableMessage && ! notComputableMessage && (
+				<div className="newspack-insights__metric-card-description">{ description }</div>
+			) }
 		</Card>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -18,6 +18,7 @@ import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
+import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
 import { scalarToMetricCardProps } from './scalarToCard';
 
 export interface FreeReaderConversionSectionProps {
@@ -46,6 +47,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					current: current.registration_conversion_direct,
 					previous: previous?.registration_conversion_direct,
 					notCapableMessage: NOT_CAPABLE_COPY.registration,
+					notComputableMessage: NOT_COMPUTABLE_COPY.registration,
 				} ) }
 			/>
 			<MetricCard
@@ -58,6 +60,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					current: current.registration_conversion_influenced_7d,
 					previous: previous?.registration_conversion_influenced_7d,
 					notCapableMessage: NOT_CAPABLE_COPY.registration,
+					notComputableMessage: NOT_COMPUTABLE_COPY.registration,
 				} ) }
 			/>
 			<MetricCard
@@ -70,6 +73,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					current: current.newsletter_signup_conversion_direct,
 					previous: previous?.newsletter_signup_conversion_direct,
 					notCapableMessage: NOT_CAPABLE_COPY.newsletter,
+					notComputableMessage: NOT_COMPUTABLE_COPY.newsletter,
 				} ) }
 			/>
 			<MetricCard
@@ -82,6 +86,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					current: current.newsletter_signup_conversion_influenced_7d,
 					previous: previous?.newsletter_signup_conversion_influenced_7d,
 					notCapableMessage: NOT_CAPABLE_COPY.newsletter,
+					notComputableMessage: NOT_COMPUTABLE_COPY.newsletter,
 				} ) }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -64,6 +64,9 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
 				} ) }
 			/>
+			{ /* Block-name vs intent-name asymmetry: NOT_CAPABLE keys off the block that
+			     grants capability (checkout); NOT_COMPUTABLE keys off the metric's intent
+			     (subscription). Same pattern in RevenueFromPromptsSection. */ }
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Subscription Conversion (Direct)', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -19,6 +19,7 @@ import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
+import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
 import { scalarToMetricCardProps } from './scalarToCard';
 
 export interface PaidReaderConversionSectionProps {
@@ -47,6 +48,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					current: current.donation_conversion_direct,
 					previous: previous?.donation_conversion_direct,
 					notCapableMessage: NOT_CAPABLE_COPY.donation,
+					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
 				} ) }
 			/>
 			<MetricCard
@@ -59,6 +61,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					current: current.donation_conversion_influenced_14d,
 					previous: previous?.donation_conversion_influenced_14d,
 					notCapableMessage: NOT_CAPABLE_COPY.donation,
+					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
 				} ) }
 			/>
 			<MetricCard
@@ -71,6 +74,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					current: current.subscription_conversion_direct,
 					previous: previous?.subscription_conversion_direct,
 					notCapableMessage: NOT_CAPABLE_COPY.checkout,
+					notComputableMessage: NOT_COMPUTABLE_COPY.subscription,
 				} ) }
 			/>
 			<MetricCard
@@ -83,6 +87,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					current: current.subscription_conversion_influenced_14d,
 					previous: previous?.subscription_conversion_influenced_14d,
 					notCapableMessage: NOT_CAPABLE_COPY.checkout,
+					notComputableMessage: NOT_COMPUTABLE_COPY.subscription,
 				} ) }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
@@ -17,6 +17,7 @@ import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
+import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
 import { scalarToMetricCardProps } from './scalarToCard';
 
 export interface PromptEngagementSectionProps {
@@ -53,6 +54,7 @@ const PromptEngagementSection = ( { current, previous }: PromptEngagementSection
 					current: current.form_submission_rate,
 					previous: previous?.form_submission_rate,
 					notCapableMessage: NOT_CAPABLE_COPY.formBearing,
+					notComputableMessage: NOT_COMPUTABLE_COPY.formBearing,
 				} ) }
 			/>
 			<MetricCard

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
@@ -19,6 +19,7 @@ import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
+import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
 import { scalarToMetricCardProps } from './scalarToCard';
 
 export interface RevenueFromPromptsSectionProps {
@@ -47,6 +48,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 					current: current.donation_revenue_direct,
 					previous: previous?.donation_revenue_direct,
 					notCapableMessage: NOT_CAPABLE_COPY.donation,
+					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
 				} ) }
 			/>
 			<MetricCard
@@ -59,6 +61,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 					current: current.donation_revenue_influenced_14d,
 					previous: previous?.donation_revenue_influenced_14d,
 					notCapableMessage: NOT_CAPABLE_COPY.donation,
+					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
 				} ) }
 			/>
 			<MetricCard
@@ -71,6 +74,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 					current: current.subscription_revenue_direct,
 					previous: previous?.subscription_revenue_direct,
 					notCapableMessage: NOT_CAPABLE_COPY.checkout,
+					notComputableMessage: NOT_COMPUTABLE_COPY.subscription,
 				} ) }
 			/>
 			<MetricCard
@@ -83,6 +87,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 					current: current.subscription_revenue_influenced_14d,
 					previous: previous?.subscription_revenue_influenced_14d,
 					notCapableMessage: NOT_CAPABLE_COPY.checkout,
+					notComputableMessage: NOT_COMPUTABLE_COPY.subscription,
 				} ) }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
@@ -64,6 +64,9 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
 				} ) }
 			/>
+			{ /* Block-name vs intent-name asymmetry: NOT_CAPABLE keys off the block that
+			     grants capability (checkout); NOT_COMPUTABLE keys off the metric's intent
+			     (subscription). Same pattern in PaidReaderConversionSection. */ }
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Subscription Revenue (Direct)', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-intent "not computable this window" copy for the Prompts tab (NPPD-1704).
+ *
+ * Shown when a conversion metric IS capable (its block exists in an active
+ * prompt) but the math couldn't complete for the selected window — typically a
+ * zero denominator (SAFE_DIVIDE NULL) because no in-intent prompts were viewed.
+ * Distinct from `notCapableCopy` (NPPD-1720), which fires before the BigQuery
+ * query when the block is structurally absent: that nudge says "add the block",
+ * these say "no inputs this timeframe — try a longer range or wait for traffic".
+ * Reader-facing copy says "timeframe" (not "window") to match the rest of the
+ * Insights UI, e.g. the Prompt exposure section on this same tab.
+ *
+ * Intent-grouped: the four conversion intents (newsletter, registration,
+ * donation, subscription) each share one string across their Direct, Influenced,
+ * and Revenue cards, plus the cross-intent form-submission case. Centralized here
+ * (rather than inline on each card) so the cross-tab voice-and-tone audit
+ * (NPPD-1698) has a single place to review them. Strings end with a period to
+ * match 1720's nudges.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const NOT_COMPUTABLE_COPY = {
+	/** Form submission rate — denominator is impressions on any form-bearing prompt. */
+	formBearing: __( 'No form-bearing prompts viewed in this timeframe.', 'newspack-plugin' ),
+	newsletter: __( 'No newsletter-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+	registration: __( 'No registration-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+	donation: __( 'No donation-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+	subscription: __( 'No subscription-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+};

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.test.ts
@@ -73,3 +73,80 @@ describe( 'prompts scalarToMetricCardProps — capability routing (NPPD-1720)', 
 		expect( props ).not.toHaveProperty( 'notCapableMessage' );
 	} );
 } );
+
+describe( 'prompts scalarToMetricCardProps — not-computable routing (NPPD-1704)', () => {
+	// Capable (block exists) but the window produced no inputs: SAFE_DIVIDE NULL on
+	// a zero denominator surfaces as a populated, non-computable scalar.
+	const notComputable = ( overrides: Partial< PromptsScalarMetric > = {} ): PromptsScalarMetric =>
+		scalar( { value: 0, computable: false, has_capability: true, ...overrides } );
+
+	it( 'routes capable + non-computable to the supplied not-computable message', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'Donation Conversion (Direct)',
+			description: 'd',
+			current: notComputable(),
+			notComputableMessage: 'No donation-intent prompts viewed in this timeframe.',
+		} );
+		expect( props.notComputableMessage ).toBe( 'No donation-intent prompts viewed in this timeframe.' );
+		// The value path is skipped entirely.
+		expect( props ).not.toHaveProperty( 'value' );
+	} );
+
+	it( 'falls back to a generic message when the section omits copy', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: notComputable(),
+		} );
+		expect( props.notComputableMessage ).toBe( 'Not enough data to calculate.' );
+	} );
+
+	it( 'lets not-capable win over not-computable (add-the-block beats wait-for-data)', () => {
+		// A scalar that is BOTH not-capable and (vacuously) non-computable: the more
+		// actionable not-capable nudge must take the slot.
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: scalar( { value: 0, computable: false, has_capability: false } ),
+			notCapableMessage: 'Add a Donate block.',
+			notComputableMessage: 'No donation-intent prompts viewed in this timeframe.',
+		} );
+		expect( props.notCapableMessage ).toBe( 'Add a Donate block.' );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+	} );
+
+	it( 'lets the error treatment win over not-computable', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: notComputable( { state: 'error', error_message: 'boom' } ),
+			notComputableMessage: 'No donation-intent prompts viewed in this timeframe.',
+		} );
+		expect( props.error ).toBe( 'boom' );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+	} );
+
+	it( 'renders the normal value when capable and computable, ignoring any message', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: scalar( { has_capability: true, computable: true } ),
+			notComputableMessage: 'unused',
+		} );
+		expect( props.value ).toBe( 0.42 );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+	} );
+
+	it( 'does NOT route non-conversion scalars (no has_capability) to not-computable', () => {
+		// Exposure / engagement scalars carry no capability flag; a non-computable
+		// zero there must fall through to the normal value path, never the em-dash —
+		// the gate is scoped to conversion-tied metrics only.
+		const props = scalarToMetricCardProps( {
+			label: 'Click-Through Rate',
+			description: 'd',
+			current: scalar( { value: 0, computable: false } ),
+		} );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+		expect( props.value ).toBe( 0 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
@@ -38,10 +38,18 @@ export interface ScalarCardProps {
 	 * `has_capability === false`; ignored otherwise.
 	 */
 	notCapableMessage?: string;
+	/**
+	 * Intent-grouped "no inputs this window" copy (NPPD-1704). Routed to
+	 * MetricCard's em-dash treatment when the envelope reports a capable metric
+	 * (`has_capability === true`) whose math couldn't complete this window
+	 * (`state === 'populated' && computable === false`, e.g. a zero denominator).
+	 * Ignored otherwise. Sits one slot below `notCapableMessage` in precedence.
+	 */
+	notComputableMessage?: string;
 }
 
 export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
-	const { label, description, current, previous, notCapableMessage } = props;
+	const { label, description, current, previous, notCapableMessage, notComputableMessage } = props;
 	// A failed query renders MetricCard's shared error treatment rather than a
 	// misleading zero. The raw message stays server-side; the card shows generic
 	// copy keyed off the `error` prop.
@@ -57,6 +65,22 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 			label,
 			description,
 			notCapableMessage: notCapableMessage ?? __( 'Not measurable for your active prompts', 'newspack-plugin' ),
+		};
+	}
+	// "Not computable this window" (NPPD-1704): the metric is capable (its block
+	// exists) but the math couldn't complete — typically SAFE_DIVIDE NULL from a
+	// zero denominator, i.e. no in-intent prompts viewed this window. Gated on
+	// `has_capability === true` so only the 13 conversion-tied scalars participate;
+	// exposure/engagement scalars carry no capability flag and a non-computable
+	// zero there falls through to the normal/zeroFallback path untouched. Sits
+	// below not-capable (which already returned above): "add the block" beats
+	// "wait for data". A generic fallback guarantees the em-dash even if a call
+	// site forgot its per-metric copy.
+	if ( current.has_capability === true && current.state === 'populated' && current.computable === false ) {
+		return {
+			label,
+			description,
+			notComputableMessage: notComputableMessage ?? __( 'Not enough data to calculate.', 'newspack-plugin' ),
 		};
 	}
 	return {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -427,14 +427,16 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Wired revenue methods: empty BQ rows → $0.00 populated, computable=true
-	 * (the sum is a real 0), denominator 0 (zero conversions matched).
+	 * Wired revenue methods: empty BQ rows → state 'populated' but NON-computable
+	 * (NPPD-1704). An empty window means no in-intent prompts were viewed, so
+	 * revenue gates `computable` on `count( rows ) > 0` exactly like its sibling
+	 * rate method — it renders the not-computable em-dash, not a misleading $0.00.
 	 *
 	 * @dataProvider provide_paid_revenue_methods
 	 * @param string $method     Method on Prompts_Metric to call.
 	 * @param string $query_name Underlying conversion query name dispatched.
 	 */
-	public function test_paid_revenue_returns_zero_on_empty( string $method, string $query_name ) {
+	public function test_paid_revenue_returns_noncomputable_on_empty( string $method, string $query_name ) {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->expects( $this->once() )
 			->method( 'query' )
@@ -450,7 +452,7 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertSame( 0.0, $result['value'] );
-		$this->assertSame( 0, $result['denominator'] );
+		$this->assertFalse( $result['computable'] );
 		$this->assertSame( 'currency', $result['placeholder_type'] );
 	}
 


### PR DESCRIPTION
## The problem

On a real publisher's 90-day Prompts tab, 5 cards (Form submission rate + 4 Free reader conversion cards) rendered the **error** treatment — _"Data temporarily unavailable."_ — even though **no error occurred**. The BigQuery query succeeded; the denominators were just zero (no in-intent prompts viewed in the window), so `SAFE_DIVIDE` returned NULL and the server stamped `state: 'populated', computable: false`. Readers saw a broken-looking dashboard when the real state was "computable, but no inputs this timeframe — try a longer range or wait for traffic."

This fills the next slot in the MetricCard precedence chain established by NPPD-1720:

```
error → notCapable → notComputable → zeroFallback → normal value
        (1720)       (THIS PR)
```

`notCapable` ("no block — add one") still wins over `notComputable` ("capable, but no data this timeframe") because the add-the-block nudge is the more actionable of the two.

## What's in the PR

- **`MetricCard` `notComputableMessage` branch** — new render branch between `notCapable` and `zeroFallback`. Reuses the existing em-dash hero + secondary-line primitive; hides the formula description and suppresses the delta, same as `notCapable`.
- **`scalarToCard.ts` routing** — new branch detecting `has_capability === true && state === 'populated' && computable === false`. Gating on `has_capability === true` scopes the treatment to the 13 conversion-tied scalars only; exposure/engagement scalars carry no capability flag, so a non-computable zero there falls through to the normal path untouched.
- **`notComputableCopy.ts`** — intent-grouped copy (form-bearing / newsletter / registration / donation / subscription), applied per metric across all 13 conversion cards (Form submission + Free reader + Paid reader + Revenue).
- **Revenue metrics gated on attempts** — the 4 donation/subscription *revenue* methods (`class-prompts-metric.php`) now derive `computable` from `count( rows ) > 0`, mirroring their sibling conversion-rate methods, instead of hard-coding `true`. So a window with no in-intent prompt views em-dashes (consistent with the rate card and the intent copy) instead of showing a misleading `$0.00`; a window *with* views but no conversions still shows a real `$0.00`. This makes the `notComputable` treatment apply uniformly across all 13 conversion-tied cards.
- **`not_computable` fixture variant** — all 13 conversion scalars `computable: false, has_capability: true`; exposure/engagement keep real values. Reachable via `_fixture_state=not_computable`.
- **Tests** — 6 new pure-logic adapter cases in `scalarToCard.test.ts` (incl. precedence ordering and the non-conversion-scalar exclusion); 7 new `MetricCard.test.tsx` component cases; plus an updated PHPUnit case (`test_paid_revenue_returns_noncomputable_on_empty`) pinning revenue's `computable: false` on an empty window.

## Test plan — fixture mode (no BigQuery required)

1. `wp config set NEWSPACK_INSIGHTS_FIXTURE_MODE true --raw`, then build the plugin.
2. Visit `wp-admin/admin.php?page=newspack-insights&_fixture_state=not_computable#/prompts`.
3. Confirm Form Submission Rate + all 12 conversion scorecards render the em-dash + intent-grouped copy ("form-bearing", "newsletter-intent", "registration-intent", "donation-intent", "subscription-intent").
4. Confirm exposure + engagement (CTR, dismissal) scorecards render real values — proves the gate is per-metric, not tab-wide.
5. Confirm visual distinction from `_fixture_state=error` (info-icon "Data temporarily unavailable.", applies tab-wide) and visual consistency with `_fixture_state=not_capable` (same em-dash treatment, different copy + different gated set).
6. Swap `_fixture_state` to `populated`, `empty`, `error`, `not_capable` — confirm those are unchanged.

**✅ All fixture-mode steps verified locally** (screenshots of `not_computable`, `not_capable`, and `error` captured).

## Test plan — real publisher (needs a configured environment)

- **Motivating publisher, 90-day**: the 5 cards that showed "Data temporarily unavailable" now render the `notComputable` treatment; Newsletter cards with real data still render values.
- **Same publisher, 7-day** (smaller window): more cards fall through to `notComputable`; all paths still render.
- **Healthy publisher**: every card renders normally; the branch never fires.
- **Forced real error**: the error treatment still wins over `notComputable`.

## Heads-up

- **Revenue behavior change.** Revenue cards previously always reported `computable: true` (rendering `$0.00` even when no prompts were viewed). This PR aligns them with the conversion-rate cards so they em-dash on an empty window — applying the not-computable treatment uniformly across all 13 conversion-tied cards (matches the ticket's copy table). Behavior with actual prompt views is unchanged: a real `$0.00` when viewed-but-no-conversion. The empty-window case is now pinned by `test_paid_revenue_returns_noncomputable_on_empty`.
- **Copy: "in this timeframe" (not "in this window").** The ticket spec'd "in this window," but "timeframe" is the dominant reader-facing term across Insights — including the Prompt exposure section on this same tab ("Every prompt view in this timeframe") and MetricCard's own delta a11y ("vs previous timeframe"). Switched for consistency. (Aside for NPPD-1698: the Gates tab and zeroFallback copy still say "window" — a pre-existing inconsistency worth normalizing in the voice-and-tone pass.)
- **Copy: trailing periods.** Added to match 1720's nudges, which end with periods.
- **Fixture `value`.** The ticket said `value: null`; the fixture uses the type's zero (`0.0`) instead, to mirror production exactly (`populated_scalar( $zero, false, … )` is what the metric class emits on an empty window) and keep the `value: number` TS type honest. Rendering is identical — the adapter routes away before reading `value`.
- **Component-test local failure (same as 1720).** `MetricCard.test.tsx` fails to _load_ locally on the `@wordpress/dataviews` "Cannot unlock" issue (module-load through the components barrel, not a logic failure). It executes in CI. The pure-logic `scalarToCard.test.ts` runs clean locally (11/11).
