### PR TITLE
feat(insights): add Subscribers tab empty states (NPPD-1695)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -286,19 +286,29 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	private function build_window( Subscribers_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		$new_subscribers     = $metric->get_new_subscribers_in_window( $start, $end );
+		$churned_subscribers = $metric->get_churned_subscribers_in_window( $start, $end );
+		$revenue_gross       = $metric->get_subscription_revenue_gross( $start, $end );
+		$revenue_net         = $metric->get_subscription_revenue_net( $start, $end );
+
 		return [
 			'window'                    => [
 				'start' => $start->format( 'Y-m-d' ),
 				'end'   => $end->format( 'Y-m-d' ),
 			],
-			'new_subscribers'           => $metric->get_new_subscribers_in_window( $start, $end ),
-			'churned_subscribers'       => $metric->get_churned_subscribers_in_window( $start, $end ),
-			'revenue_gross'             => $metric->get_subscription_revenue_gross( $start, $end ),
-			'revenue_net'               => $metric->get_subscription_revenue_net( $start, $end ),
+			'new_subscribers'           => $new_subscribers,
+			'churned_subscribers'       => $churned_subscribers,
+			'revenue_gross'             => $revenue_gross,
+			'revenue_net'               => $revenue_net,
 			'refund_rate'               => $metric->get_subscription_refund_rate( $start, $end ),
 			'failed_payment_retry_rate' => $metric->get_failed_payment_retry_rate( $start, $end ),
 			'subscriptions_by_product'  => $metric->get_subscriptions_by_product( $start, $end ),
 			'cancellation_reasons'      => $metric->get_cancellation_reasons( $start, $end ),
+			// Derived empty-state signal (NPPD-1695): true when the window saw any
+			// subscription activity. Pure derivation from values already fetched
+			// above — no extra query — kept in the metric class alongside the other
+			// derived signals, mirroring Donors_Metric::window_activity_signal().
+			'has_window_activity'       => Subscribers_Metric::window_activity_signal( $new_subscribers, $churned_subscribers, $revenue_gross, $revenue_net ),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -114,6 +114,32 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Derived empty-state signal (NPPD-1695): whether a window saw any
+	 * subscription activity at all. A pure function of values the controller
+	 * already fetches — no query — mirroring {@see Donors_Metric::window_activity_signal()}.
+	 * The REST controller folds the result into the window payload; the React
+	 * layer uses it to choose the windowed section's `no_opportunity` empty
+	 * state. The `no_opportunity` / `no_conversions` decision itself stays in
+	 * the component, not here.
+	 *
+	 * Churn EVENTS count as activity (a window where subscribers left is not
+	 * empty), so `churned_subscribers > 0` contributes. Zero churn does not —
+	 * but a window with zero revenue, zero new, and zero churn genuinely has no
+	 * movement and collapses to the empty state. Net revenue is included
+	 * alongside gross so a refund-only window (gross 0, net negative) still
+	 * reads as activity.
+	 *
+	 * @param int   $new_subscribers     First-time subscribers in the window.
+	 * @param int   $churned_subscribers Subscribers who churned in the window.
+	 * @param float $revenue_gross       Gross subscription revenue in the window.
+	 * @param float $revenue_net         Net subscription revenue in the window.
+	 * @return bool
+	 */
+	public static function window_activity_signal( int $new_subscribers, int $churned_subscribers, float $revenue_gross, float $revenue_net ): bool {
+		return 0.0 !== $revenue_gross || 0.0 !== $revenue_net || $new_subscribers > 0 || $churned_subscribers > 0;
+	}
+
+	/**
 	 * Distinct active non-donation subscribers right now.
 	 *
 	 * @return int

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -106,6 +106,14 @@ export interface SubscribersWindow {
 	failed_payment_retry_rate: SubscribersRateValue;
 	subscriptions_by_product: PerformanceRow[];
 	cancellation_reasons: CancellationReasonRow[];
+	/**
+	 * Derived empty-state signal (NPPD-1695): true when the window saw
+	 * any subscription activity (revenue, a new subscriber, or churn).
+	 * Drives the WindowedSection's whole-section `no_opportunity` empty
+	 * state. Derived server-side from values already computed — no extra
+	 * query.
+	 */
+	has_window_activity: boolean;
 }
 
 export interface SubscribersResponse {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -56,7 +56,12 @@ const SubscribersTab = ( { range, previousRange }: SubscribersTabProps ) => {
 						snapshot={ data.snapshot }
 						lastUpdated={ <LastUpdated tab="subscribers" range={ range } previousRange={ previousRange } /> }
 					/>
-					<WindowedSection range={ range } current={ data.current } previous={ data.previous } />
+					<WindowedSection
+						range={ range }
+						current={ data.current }
+						previous={ data.previous }
+						activeSubscribers={ data.snapshot.active_subscribers }
+					/>
 					<TenureSection rows={ data.snapshot.tenure_distribution } />
 					<PerformanceSection rows={ data.current.subscriptions_by_product } />
 				</>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -67,6 +67,12 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( '128 active subscribers, but none new this timeframe' ) ).toBeInTheDocument();
+		// The misleading period delta is suppressed even though `previous` has a real
+		// prior count — a "↓ 100%" would misread an honest zero.
+		const newCard = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
+			.find( el => el.textContent === 'New subscribers' )
+			?.closest( '.newspack-insights__metric-card' );
+		expect( newCard?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
 		// Real cards still render.
 		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Gross revenue' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -66,7 +66,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 128 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Your 128 existing subscribers are active, but no new readers converted in this timeframe.' ) ).toBeInTheDocument();
+		expect( screen.getByText( '128 active subscribers, but none new this timeframe' ) ).toBeInTheDocument();
 		// Real cards still render.
 		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Gross revenue' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for the Subscribers WindowedSection empty states (NPPD-1695): the
+ * whole-section no_opportunity collapse, the per-card no-acquisition treatment
+ * on New subscribers, the currency zeroFallback, and — the new wrinkle in 1695
+ * vs 1696 — the GOOD-ZERO cases: zero churn renders normally (NOT an empty
+ * state) and zero failed payments reframes positively (NPPD-1726).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import WindowedSection from './WindowedSection';
+import type { SubscribersWindow } from '../../api/subscribers';
+import type { DateRange } from '../../state/useDateRange';
+
+const RANGE: DateRange = { preset: 'last-30', start: '2026-05-19', end: '2026-06-17' };
+
+const makeWindow = ( over: Partial< SubscribersWindow > = {} ): SubscribersWindow => ( {
+	window: { start: '2026-05-19', end: '2026-06-17' },
+	new_subscribers: 14,
+	churned_subscribers: 3,
+	revenue_gross: 5000,
+	revenue_net: 4800,
+	refund_rate: { value: 0.02, computable: true, denominator: 120 },
+	failed_payment_retry_rate: { value: 0.8, computable: true, denominator: 10 },
+	subscriptions_by_product: [],
+	cancellation_reasons: [],
+	has_window_activity: true,
+	...over,
+} );
+
+/** Read a MetricCard's hero value text by its label (skips empty-note cards). */
+const cardValueByLabel = ( container: HTMLElement, label: string ): string => {
+	const labelEl = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) ).find( el => el.textContent === label );
+	const card = labelEl?.closest( '.newspack-insights__metric-card' );
+	return card?.querySelector( '.newspack-insights__metric-card-value' )?.textContent ?? '';
+};
+
+describe( 'Subscribers WindowedSection empty states', () => {
+	it( 'collapses to a no_opportunity EmptyMetricSection when the window saw no activity', () => {
+		const current = makeWindow( {
+			has_window_activity: false,
+			new_subscribers: 0,
+			churned_subscribers: 0,
+			revenue_gross: 0,
+			revenue_net: 0,
+			refund_rate: { value: 0, computable: false, denominator: 0 },
+			failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 },
+		} );
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		// Assert on the container — the Notice's speak() duplicates copy into a live-region.
+		expect( container ).toHaveTextContent( 'No subscription activity in this timeframe' );
+		expect( screen.queryByText( 'Churned subscribers' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Gross revenue' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the per-card no-acquisition state on New subscribers without collapsing the section', () => {
+		const current = makeWindow( { new_subscribers: 0, churned_subscribers: 2 } );
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 128 } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Your 128 existing subscribers are active, but no new readers converted in this timeframe.' ) ).toBeInTheDocument();
+		// Real cards still render.
+		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Gross revenue' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does NOT show the no-acquisition line when there are no active subscribers either', () => {
+		const current = makeWindow( { new_subscribers: 0, churned_subscribers: 1 } );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } /> );
+
+		expect( screen.queryByText( /existing subscribers are active/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'GOOD ZERO: zero churn renders the card normally, NOT an empty state', () => {
+		// Activity present (new subscribers + revenue), but zero churn this window.
+		const current = makeWindow( { new_subscribers: 9, churned_subscribers: 0 } );
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 200 } /> );
+
+		// Section is NOT collapsed and the churn card is a real card showing 0.
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
+		expect( cardValueByLabel( container, 'Churned subscribers' ) ).toBe( '0' );
+	} );
+
+	it( 'GOOD ZERO: zero failed payments reframes positively (NPPD-1726), section intact', () => {
+		const current = makeWindow( { failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 } } );
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'No failed payments this timeframe.' ) ).toBeInTheDocument();
+		// Not the old missing-data phrasing.
+		expect( screen.queryByText( 'No payment retries in this timeframe.' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the currency count fallback when there were no subscription orders', () => {
+		// Churn-only window: activity is true (churn), but no completed orders →
+		// Gross and Net show "No subscription orders…" instead of $0.00.
+		const current = makeWindow( {
+			new_subscribers: 0,
+			churned_subscribers: 4,
+			revenue_gross: 0,
+			revenue_net: 0,
+			refund_rate: { value: 0, computable: false, denominator: 0 },
+		} );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 50 } /> );
+
+		// Gross + Net both fall back (shared MetricCard helper renders "…in this window").
+		expect( screen.getAllByText( 'No subscription orders in this window' ).length ).toBeGreaterThanOrEqual( 2 );
+	} );
+
+	it( 'renders all six cards when fully populated', () => {
+		const { container } = render( <WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'New subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Refund rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Failed payment recovery' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -1,5 +1,5 @@
 /**
- * WindowedSection (NPPD-1616).
+ * WindowedSection (NPPD-1616, empty states NPPD-1695).
  *
  * All Tab 6 metrics that ARE scoped to the date range picker:
  * new/churned subscriber counts, gross/net subscription revenue,
@@ -7,12 +7,27 @@
  * with a dynamic section heading that mirrors the active preset
  * ("In the last 30 days", "This month", "From Sep 5 to Oct 5", etc.).
  *
+ * Empty states (NPPD-1695), mirroring Tab 7 (Donors):
+ *   - Whole-section `EmptyMetricSection` (`no_opportunity`) when the
+ *     window saw NO subscription activity at all (`has_window_activity`
+ *     false) — the whole grid would be zeros.
+ *   - Per-card no-acquisition treatment on "New subscribers" when there
+ *     are active subscribers but none new this window (period delta
+ *     suppressed). A whole-section empty would hide the real churn /
+ *     revenue cards, so this stays a single-card treatment.
+ *   - `zeroFallback` count context on the currency cards when there were
+ *     no subscription orders.
+ *
+ * Good zeros render normally, NOT as empty states: "Churned subscribers"
+ * is a count (its 0 + green `lowerIsBetter` delta IS the good-zero
+ * signal), and "Failed payment recovery" reframes its no-retries case as
+ * the positive "No failed payments this timeframe" (NPPD-1726) rather
+ * than a missing-data note.
+ *
  * The two rate metrics (refund rate, retry recovery) carry the
- * `{value, computable, denominator}` shape so the UI can:
- *   - render a small-cohort 0% as "0% of N orders" with inline context
- *   - swap to a per-card empty state when the denominator is 0
- *     ("No subscription orders in this timeframe." for refund rate)
- * Same pattern as Tab 7's RetentionSection.
+ * `{value, computable, denominator}` shape so the UI can render a
+ * small-cohort 0% as "0% of N orders" with inline context, or swap to a
+ * per-card note when the denominator is 0.
  */
 
 /**
@@ -25,6 +40,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import type { SubscribersRateValue, SubscribersWindow } from '../../api/subscribers';
 import type { DateRange } from '../../state/useDateRange';
+import EmptyMetricSection from '../components/EmptyMetricSection';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
 import { formatNumber } from '../components/format';
@@ -33,6 +49,13 @@ export interface WindowedSectionProps {
 	range: DateRange;
 	current: SubscribersWindow;
 	previous: SubscribersWindow | null;
+	/**
+	 * Window-independent count of active subscribers (from
+	 * `snapshot.active_subscribers`). Supplies the `{N}` context for the
+	 * "New subscribers" no-acquisition state — the publisher has existing
+	 * subscribers, just none new in this window.
+	 */
+	activeSubscribers: number;
 }
 
 const parseISO = ( s: string ): Date => {
@@ -87,9 +110,37 @@ const retriesCohortSubtitle = ( denominator: number ): string =>
 		)
 	);
 
-const WindowedSection = ( { range, current, previous }: WindowedSectionProps ) => {
+const WindowedSection = ( { range, current, previous, activeSubscribers }: WindowedSectionProps ) => {
+	// Whole-section empty: nothing happened this window. Collapse the grid to a
+	// single callout (NPPD-1694 `EmptyMetricSection`). Checked first so the
+	// per-card states below only fire inside a section that has real data.
+	if ( ! current.has_window_activity ) {
+		return (
+			<EmptyMetricSection
+				title={ getHeading( range ) }
+				state="no_opportunity"
+				body={ __(
+					'No subscription activity in this timeframe. Your subscription product is configured, but no new subscribers, churn, or revenue changes happened during the date range. Worth expanding the timeframe or checking the conversion funnel.',
+					'newspack-plugin'
+				) }
+			/>
+		);
+	}
+
 	const refund: SubscribersRateValue = current.refund_rate;
 	const retry: SubscribersRateValue = current.failed_payment_retry_rate;
+
+	// Per-card no-acquisition state: the section has activity (revenue and/or
+	// churn), but no first-time subscribers landed. A whole-section empty here
+	// would hide the real churn / revenue cards, so this stays single-card.
+	const noNewSubscribers = current.new_subscribers === 0 && activeSubscribers > 0;
+
+	// No completed subscription orders this window → the currency cards show a
+	// count note instead of "$0.00". Gated on GROSS (not net): a window with
+	// orders that fully refunded has gross > 0 and a real net of 0, which should
+	// render as $0.00, not "no orders".
+	const noOrders = current.revenue_gross === 0;
+	const subscriptionOrdersLabel = __( 'subscription orders', 'newspack-plugin' );
 
 	return (
 		<section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
@@ -99,7 +150,21 @@ const WindowedSection = ( { range, current, previous }: WindowedSectionProps ) =
 					label={ __( 'New subscribers', 'newspack-plugin' ) }
 					value={ current.new_subscribers }
 					format="number"
-					previousValue={ previous?.new_subscribers }
+					// Drop the period delta when there are no new subscribers: a "↓ 100%"
+					// against a real prior count would misread an honest zero.
+					previousValue={ noNewSubscribers ? undefined : previous?.new_subscribers }
+					secondary={
+						noNewSubscribers
+							? sprintf(
+									/* translators: %s: count of active subscribers (current state) */
+									__(
+										'Your %s existing subscribers are active, but no new readers converted in this timeframe.',
+										'newspack-plugin'
+									),
+									formatNumber( activeSubscribers )
+							  )
+							: undefined
+					}
 					description={ __( 'First-time subscribers', 'newspack-plugin' ) }
 				/>
 				<MetricCard
@@ -115,6 +180,7 @@ const WindowedSection = ( { range, current, previous }: WindowedSectionProps ) =
 					value={ current.revenue_gross }
 					format="currency"
 					previousValue={ previous?.revenue_gross }
+					zeroFallback={ noOrders ? { denominator: 0, currencyRole: 'total', attemptsLabel: subscriptionOrdersLabel } : undefined }
 					description={ __( 'Subscription orders before refunds', 'newspack-plugin' ) }
 				/>
 				<MetricCard
@@ -122,6 +188,7 @@ const WindowedSection = ( { range, current, previous }: WindowedSectionProps ) =
 					value={ current.revenue_net }
 					format="currency"
 					previousValue={ previous?.revenue_net }
+					zeroFallback={ noOrders ? { denominator: 0, currencyRole: 'total', attemptsLabel: subscriptionOrdersLabel } : undefined }
 					description={ __( 'Gross minus refunds processed', 'newspack-plugin' ) }
 				/>
 				{ refund.computable ? (
@@ -155,7 +222,9 @@ const WindowedSection = ( { range, current, previous }: WindowedSectionProps ) =
 					<div className="newspack-insights__metric-card newspack-insights__metric-card--empty">
 						<div className="newspack-insights__metric-card-label">{ __( 'Failed payment recovery', 'newspack-plugin' ) }</div>
 						<p className="newspack-insights__metric-card-empty-note">
-							{ __( 'No payment retries in this timeframe.', 'newspack-plugin' ) }
+							{ /* Good zero (NPPD-1726): no retries means no failed payments — frame it
+							     as the positive outcome, not a missing-data note. */ }
+							{ __( 'No failed payments this timeframe.', 'newspack-plugin' ) }
 						</p>
 					</div>
 				) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -157,10 +157,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 						noNewSubscribers
 							? sprintf(
 									/* translators: %s: count of active subscribers (current state) */
-									__(
-										'Your %s existing subscribers are active, but no new readers converted in this timeframe.',
-										'newspack-plugin'
-									),
+									__( '%s active subscribers, but none new this timeframe', 'newspack-plugin' ),
 									formatNumber( activeSubscribers )
 							  )
 							: undefined

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscribers-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscribers-metric.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Test Subscribers_Metric (NPPD-1695).
+ *
+ * Covers the derived `has_window_activity` empty-state signal —
+ * `Subscribers_Metric::window_activity_signal()`, a pure function of values the
+ * controller already fetches. Tested directly (no reflection, no mock),
+ * mirroring the Donors metric test.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Subscribers_Metric;
+use WP_UnitTestCase;
+
+/**
+ * Subscribers_Metric test class.
+ *
+ * @group insights
+ */
+class Test_Subscribers_Metric extends WP_UnitTestCase {
+
+	/**
+	 * An empty window — no revenue, no new subscribers, no churn — is the
+	 * no_opportunity state: the signal is false.
+	 */
+	public function test_no_activity_is_false() {
+		$this->assertFalse( Subscribers_Metric::window_activity_signal( 0, 0, 0.0, 0.0 ) );
+	}
+
+	/**
+	 * Any one of the signals flips the activity flag true.
+	 *
+	 * @dataProvider activity_signal_provider
+	 *
+	 * @param int    $new_subscribers     First-time subscriber count.
+	 * @param int    $churned_subscribers Churned subscriber count.
+	 * @param float  $revenue_gross       Gross subscription revenue.
+	 * @param float  $revenue_net         Net subscription revenue.
+	 * @param bool   $expected            Expected has_window_activity.
+	 * @param string $message             Assertion message.
+	 */
+	public function test_activity_signals( int $new_subscribers, int $churned_subscribers, float $revenue_gross, float $revenue_net, bool $expected, string $message ) {
+		$this->assertSame(
+			$expected,
+			Subscribers_Metric::window_activity_signal( $new_subscribers, $churned_subscribers, $revenue_gross, $revenue_net ),
+			$message
+		);
+	}
+
+	/**
+	 * Each signal in isolation, the all-zero baseline, the refund-only edge
+	 * (negative net), and the two churn cases that matter for the good-zero
+	 * treatment: churn EVENTS are activity, but zero churn alone is not.
+	 *
+	 * @return array<string, array{0:int,1:int,2:float,3:float,4:bool,5:string}>
+	 */
+	public function activity_signal_provider(): array {
+		return [
+			'all zero'                     => [ 0, 0, 0.0, 0.0, false, 'No revenue, no new subscribers, no churn → no activity.' ],
+			'gross revenue only'           => [ 0, 0, 250.0, 250.0, true, 'Subscription revenue alone is activity.' ],
+			'refund-only (negative net)'   => [ 0, 0, 0.0, -50.0, true, 'A refund (negative net revenue) is still activity, not an empty window.' ],
+			'new subscribers only'         => [ 5, 0, 0.0, 0.0, true, 'A first-time subscriber is activity even at $0.' ],
+			'churn only'                   => [ 0, 3, 0.0, 0.0, true, 'Churn EVENTS are activity — a window where subscribers left is not empty.' ],
+			'zero churn does not suppress' => [ 0, 0, 500.0, 500.0, true, 'Zero churn alongside non-zero revenue still renders (the churn card shows its good zero).' ],
+			'all signals present'          => [ 8, 2, 900.0, 850.0, true, 'A fully populated window is active.' ],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

The empty-state pattern from [[NPPD-1694](https://linear.app/a8c/issue/NPPD-1694)](https://linear.app/a8c/issue/NPPD-1694) applied to the Subscribers tab's `WindowedSection`, landing on `feat/insights-rsm`. Closes [[NPPD-1695](https://linear.app/a8c/issue/NPPD-1695)](https://linear.app/a8c/issue/NPPD-1695) and [[NPPD-1726](https://linear.app/a8c/issue/NPPD-1726)](https://linear.app/a8c/issue/NPPD-1726). Mirrors the Donors application in PR #343 — same `WindowedSection`-style mixed-content layout, same `has_window_activity` derivation strategy, same per-card / whole-section primitive split. The new wrinkle is the **good-zero** treatment for metrics where zero is the publisher's desired outcome (churn, failed payment recovery): those cards render normally rather than as empty states.

The Subscribers `WindowedSection` mixes acquisition (New subscribers), revenue (Gross / Net), churn (Churned subscribers — a good-zero count), and rates (Refund rate, Failed payment recovery — both good-zero rates). Collapsing the whole section only fires when revenue, new, and churn are all flat — genuinely "nothing happened in this timeframe." In-section variants (zero new while subscribers exist; zero failed-payment retries; revenue zero alongside churn) get per-card treatments that don't destroy real data.

### Pre-flight decisions

Surfaced before writing code, where the codebase or the ticket's framing didn't match the shipped tab.

- The good-zero pattern is the structural addition over Donors. Two cards on this tab represent zero-as-positive-outcome: Churned subscribers (a `number`-format count with `lowerIsBetter`) and Failed payment recovery (a rate). Both render normally rather than being swept into a problem-framed empty state. Churn at zero is already its own good-zero signal via the green `lowerIsBetter` delta — `zeroFallback` doesn't apply to number-format cards anyway, so it's untouched. Failed payment recovery gets a copy reframe on the no-retries case (was a neutral "No payment retries…" reading as missing data, now positive "No failed payments this timeframe" reading as the good outcome).

- `has_window_activity` composes from four signals: gross revenue, net revenue, new subscribers, churned subscribers. Both revenue figures are included so a refund-only window (gross 0, net negative) doesn't collapse — same edge that Donors handled. Churned subscribers > 0 counts as activity, but zero churn does NOT force collapse when revenue or new are non-zero; that's how the good-zero treatment plays with the section-level decision.

- The retry-only-window edge is accepted as a collapse. A window with zero revenue, zero new, zero churn, but failed payment retries that all failed would collapse and hide the retry card's data. Rare and arguably "no real subscription activity"; if it ever matters, OR-ing `failed_payment_retry_rate.denominator > 0` into `window_activity_signal()` is a trivial follow-up. Not paid for upfront.

- No wizard-level `has_subscription_activity()` gate exists. Unlike Donors, the wizard hardcodes `'subscribers' => true` with an explicit comment that subscription-presence detection is a deferred follow-up. Building the gate here is scope creep on a polish ticket — the `no_opportunity` collapse + existing Tenure / Performance empties handle the visible degradation, and the `configuration_missing` `EmptyMetricSection` state simply goes unused on this tab. Defensive-only, not built.

- [[NPPD-1726](https://linear.app/a8c/issue/NPPD-1726)](https://linear.app/a8c/issue/NPPD-1726) (Failed Payment Recovery card) folds in cleanly via the copy reframe. The v1.1 tracker called it "likely closes as duplicate when NPPD-1695 ships," and that's exactly what's happening — it's structurally a windowed-section card, not a Retention concern, so it belongs in this PR.

- Mode suppression doesn't apply. Donors had a one-time / recurring secondary line on its Total revenue card; Subscribers has no analogous breakdown on any windowed card (gross / net carry no monthly/annual or variable/simple split — that lives in the per-product table and server-side MRR normalization, neither of which is a windowed secondary). Flagging explicitly since the ticket asked.

- `snapshot.active_subscribers` (already on the payload) satisfies the `{N}` count for the per-card `no_conversions` treatment. No storage-interface change. Same shape as Donors used `snapshot.active_donors` in PR #343.

- Tests drive against component payloads, not a `_fixture_state` harness. Subscribers, like Donors, has no `get_fixture()` / `FIXTURE_MODE` path — README convention covers empty / error states via component tests. Adding a Subscribers fixture harness is real separate scope.

- TenureSection (the Retention analogue) and PerformanceSection stay as-is. Both already own their own empty patterns (`!stats → SectionEmpty` and `rows.length === 0 → SectionEmpty` respectively). Migrating them is scope creep on a polish ticket; the [[NPPD-1698](https://linear.app/a8c/issue/NPPD-1698)](https://linear.app/a8c/issue/NPPD-1698) voice and tone sweep is the right venue to unify the variants across tabs.

## What's in this PR

### Server-side `window_activity_signal` derivation

`includes/wizards/insights/metrics/class-subscribers-metric.php` adds a static pure method:

```php
public static function window_activity_signal(
    int $new_subscribers,
    int $churned_subscribers,
    float $revenue_gross,
    float $revenue_net
): bool {
    return 0.0 !== $revenue_gross
        || 0.0 !== $revenue_net
        || $new_subscribers > 0
        || $churned_subscribers > 0;
}
```

Folded into `class-subscribers-rest-controller.php::build_window()` — no extra query, no storage-interface or classifier change. Mirrors how `Donors_Rest_Controller::build_window()` derived its `has_window_activity` bool from values it already fetched.

### `WindowedSection` rendering states

`src/wizards/insights/tabs/subscribers/WindowedSection.tsx` reads four states from the payload. `!has_window_activity` collapses the whole section to an `EmptyMetricSection` `no_opportunity` treatment with the copy *"No subscription activity in this timeframe…"*. `new_subscribers === 0 && active_subscribers > 0` triggers a per-card `no_conversions` on the New subscribers card with `signalCount = snapshot.active_subscribers` and the period delta suppressed (same "-100% reads as regression" concern from PR #343). The two currency cards (Gross / Net revenue) carry `zeroFallback`, gated on gross so a refund-only net-negative window still renders its real Net value. Good-zero rendering on the remaining cards: Churned subscribers is untouched (its `0` + green `lowerIsBetter` delta is the good-zero signal); Failed payment recovery reframes its no-retries fallback to *"No failed payments this timeframe."* — the change that closes NPPD-1726.

### Types

`has_window_activity` added to `SubscribersWindow` in `src/wizards/insights/api/subscribers.ts`. `SubscribersTab` threads `activeSubscribers` into `WindowedSection` so the per-card `no_conversions` treatment has access to its `{N}` count without re-deriving it.

## How to test

1. Check out `feat/insights-subscribers-empty-states` and run `./n build newspack-plugin`.
2. **Dormant publisher (subscriptions configured, zero activity in window):** with a publisher that has subscription products but no new subscribers, no churn, and no revenue in the selected window, confirm `WindowedSection` collapses to *"No subscription activity in this timeframe."* Scorecards ("Subscribers at a glance"), Tenure, and Performance sections are unchanged.
3. **Active publisher, zero new subscribers in window:** New subscribers card renders em-dash + *"Your {N} existing subscribers are active, but no new readers converted in this timeframe."* Gross / Net revenue and churn cards render real values. No `-100%` delta on New subscribers.
4. **Active publisher, zero churn in window (good zero):** Churned subscribers card renders `0` with its green `lowerIsBetter` delta. The whole section does NOT collapse (revenue or new are non-zero). Reads as "healthy zero churn," not "missing data."
5. **Active publisher, zero failed payment retries in window (good zero):** Failed payment recovery card renders em-dash + *"No failed payments this timeframe."* Other cards render normally.
6. **Active publisher, refund-only month:** Gross revenue card renders em-dash + zero-currency fallback; Net revenue card renders the real negative value. Section does NOT collapse (net activity counts).
7. **Active publisher, healthy month:** every card renders normally; no empty branches fire.
8. `./n test-php --filter Subscribers_Metric`: `window_activity_signal` directly — all-zero → `false`; each individual signal (gross, net, new, churned) → `true`; churn-only → `true`; zero-churn-with-non-zero-elsewhere doesn't suppress activity. PHPCS clean.
9. `pnpm --filter newspack-plugin test subscribers/WindowedSection`: component-test cases covering `no_opportunity` collapse, per-card no-acquisition, the no-subscriber-base guard (`active_subscribers === 0` → falls through to value), populated, good-zero churn (section does NOT collapse, card renders `0` natively), good-zero failed payments (positive copy), currency `zeroFallback` on the gross card. `tsc --noEmit` + ESLint + production build clean.

## Heads-up

- The good-zero pattern lands here for the first time. Two cards demonstrate the principle — Churned subscribers natively via `lowerIsBetter`, Failed payment recovery via copy reframe. [[NPPD-1698](https://linear.app/a8c/issue/NPPD-1698)](https://linear.app/a8c/issue/NPPD-1698) is the venue to audit and decide whether other tabs need explicit positive copy on their good-zero cards, or whether the visual `lowerIsBetter` signal is enough.

- [[NPPD-1726](https://linear.app/a8c/issue/NPPD-1726)](https://linear.app/a8c/issue/NPPD-1726) closes via this PR — the Failed Payment Recovery card's copy reframe was the entire fix. No separate work needed.

- Subscription product detection at the wizard level (the `has_subscription_activity()` analogue to `has_donation_activity()`) remains deferred per the wizard's own comment. The Subscribers tab is visible for publishers with no subscription product configured; the `no_opportunity` collapse handles the visible degradation but isn't a substitute for the boot-level gate. Worth filing a follow-up ticket if the deferral has gone stale.

- Advertising ([[NPPD-1697](https://linear.app/a8c/issue/NPPD-1697)](https://linear.app/a8c/issue/NPPD-1697)) is the remaining per-tab application. Special wrinkle there is coordination with the existing `is_loading` async state from [[NPPD-1684](https://linear.app/a8c/issue/NPPD-1684)](https://linear.app/a8c/issue/NPPD-1684) — the empty-state copy must never render while a GAM report is still running.

- The cross-tab `in this window` → `in this timeframe` normalization remains [[NPPD-1698](https://linear.app/a8c/issue/NPPD-1698)](https://linear.app/a8c/issue/NPPD-1698) territory. The shared `MetricCard` zero-fallback helper still emits "in this window" and touches Gates too.