### PR TITLE
feat(insights): add Advertising tab empty states (NPPD-1697)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -12,7 +12,12 @@
  * Variants (via the `_fixture_state` query param — see dev-notes.md):
  *   populated       — full scorecards + tables + direct/programmatic split.
  *   not_ready       — is_report_ready false; both readiness issues present.
- *   zero            — zero-impression window: scorecards 0, tables empty.
+ *   zero            — zero-activity window: scorecards 0, tables empty
+ *                     (has_window_activity false → ReachRevenue no_opportunity).
+ *   no_revenue      — impressions running, zero revenue (ReachRevenue per-card
+ *                     no-revenue treatment on Total Revenue).
+ *   loading         — is_loading true, empty metrics (tab shows progressive
+ *                     messages; the empty-state branches must NOT render).
  *   no_viewability  — viewability scorecard as a data_unavailable overlay.
  *
  * All dates are computed at runtime so the fixture never goes stale.
@@ -69,6 +74,58 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 					'type'        => 'rate',
 					'numerator'   => 0,
 					'denominator' => 0,
+				],
+				'direct_vs_programmatic' => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'breakdown',
+				],
+				'top_ad_units'           => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+				'top_advertisers'        => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+			];
+		}
+
+		if ( 'no_revenue' === $window_variant ) {
+			// Impressions running, zero revenue — exercises the ReachRevenue per-card
+			// no-revenue treatment on the Total Revenue card.
+			$no_rev_impressions = (int) round( 2400000 * $scale );
+			return [
+				'total_impressions'      => [
+					'value'      => $no_rev_impressions,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'total_revenue'          => [
+					'value'      => 0.0,
+					'computable' => true,
+					'type'       => 'currency',
+				],
+				'avg_ecpm'               => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'currency',
+					'numerator'   => 0.0,
+					'denominator' => 0,
+				],
+				'fill_rate'              => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'rate',
+					'numerator'   => 0,
+					'denominator' => 0,
+				],
+				'viewability_rate'       => [
+					'value'      => null,
+					'computable' => false,
+					'overlay'    => [ 'type' => 'data_unavailable' ],
 				],
 				'direct_vs_programmatic' => [
 					'rows'       => [],
@@ -231,7 +288,28 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		];
 	}
 
-	$envelope = [
+	// Loading render path: report not yet cached, background refresh scheduled.
+	// The tab shows progressive GAM messages (NPPD-1684) and the empty-state
+	// branches must NOT render — has_window_activity is deliberately absent.
+	if ( 'loading' === $variant ) {
+		return [
+			'current'  => [
+				'window'           => [
+					'start' => $start_date,
+					'end'   => $end_date,
+				],
+				'is_tab_visible'   => true,
+				'is_report_ready'  => true,
+				'readiness_issues' => [],
+				'metrics'          => [],
+				'is_loading'       => true,
+			],
+			'previous' => null,
+		];
+	}
+
+	$current_metrics = $metrics( 1.0, $variant );
+	$envelope        = [
 		'window'                      => [
 			'start' => $start_date,
 			'end'   => $end_date,
@@ -239,10 +317,14 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		'is_tab_visible'              => true,
 		'is_report_ready'             => true,
 		'readiness_issues'            => [],
-		'metrics'                     => $metrics( 1.0, $variant ),
+		'metrics'                     => $current_metrics,
 		'data_as_of'                  => $data_as_of,
 		'has_estimated_data'          => true,
 		'estimated_window_start_date' => $est_start,
+		// Derived empty-state signal (NPPD-1697): mirrors the live read_window()
+		// derivation. `zero` → false (drives no_opportunity); populated / no_revenue
+		// → true.
+		'has_window_activity'         => ( ( $current_metrics['total_impressions']['value'] ?? 0 ) > 0 ) || ( ( $current_metrics['total_revenue']['value'] ?? 0 ) > 0 ),
 	];
 
 	$previous = null;
@@ -260,8 +342,10 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		}
 
 		// 0.85 scale → current is higher on volume (positive deltas) while a few
-		// per-row figures land lower, exercising both delta directions.
-		$previous = [
+		// per-row figures land lower, exercising both delta directions. The prior
+		// window always uses a non-empty variant so comparison deltas render.
+		$prev_metrics = $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant );
+		$previous     = [
 			'window'                      => [
 				'start' => $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start,
 				'end'   => $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end,
@@ -269,10 +353,11 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 			'is_tab_visible'              => true,
 			'is_report_ready'             => true,
 			'readiness_issues'            => [],
-			'metrics'                     => $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant ),
+			'metrics'                     => $prev_metrics,
 			'data_as_of'                  => $data_as_of,
 			'has_estimated_data'          => true,
 			'estimated_window_start_date' => $est_start,
+			'has_window_activity'         => ( ( $prev_metrics['total_impressions']['value'] ?? 0 ) > 0 ) || ( ( $prev_metrics['total_revenue']['value'] ?? 0 ) > 0 ),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -321,11 +321,16 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		'data_as_of'                  => $data_as_of,
 		'has_estimated_data'          => true,
 		'estimated_window_start_date' => $est_start,
-		// Derived empty-state signal (NPPD-1697): mirrors the live read_window()
-		// derivation. `zero` → false (drives no_opportunity); populated / no_revenue
-		// → true.
-		'has_window_activity'         => ( ( $current_metrics['total_impressions']['value'] ?? 0 ) > 0 ) || ( ( $current_metrics['total_revenue']['value'] ?? 0 ) > 0 ),
 	];
+	// Derived empty-state signal (NPPD-1697): mirror the live read_window()
+	// derivation EXACTLY — same signal function, and set ONLY when both volume
+	// metrics are computable. Left absent otherwise, so an errored-volume-metric
+	// variant would render per-card errors rather than collapse to no_opportunity.
+	$imp = $current_metrics['total_impressions'] ?? [];
+	$rev = $current_metrics['total_revenue'] ?? [];
+	if ( ! empty( $imp['computable'] ) && ! empty( $rev['computable'] ) ) {
+		$envelope['has_window_activity'] = \Newspack\Insights\Advertising_Metric::window_activity_signal( (int) ( $imp['value'] ?? 0 ), (float) ( $rev['value'] ?? 0 ) );
+	}
 
 	$previous = null;
 	if ( $compare ) {
@@ -357,8 +362,12 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 			'data_as_of'                  => $data_as_of,
 			'has_estimated_data'          => true,
 			'estimated_window_start_date' => $est_start,
-			'has_window_activity'         => ( ( $prev_metrics['total_impressions']['value'] ?? 0 ) > 0 ) || ( ( $prev_metrics['total_revenue']['value'] ?? 0 ) > 0 ),
 		];
+		$prev_imp = $prev_metrics['total_impressions'] ?? [];
+		$prev_rev = $prev_metrics['total_revenue'] ?? [];
+		if ( ! empty( $prev_imp['computable'] ) && ! empty( $prev_rev['computable'] ) ) {
+			$previous['has_window_activity'] = \Newspack\Insights\Advertising_Metric::window_activity_signal( (int) ( $prev_imp['value'] ?? 0 ), (float) ( $prev_rev['value'] ?? 0 ) );
+		}
 	}
 
 	return [

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -278,9 +278,10 @@ class Advertising_Metric {
 	/**
 	 * Derived empty-state signal (NPPD-1697): whether a resolved window saw any
 	 * ad activity. A pure function of the two volume metrics the report already
-	 * produces — no SOAP query — mirroring {@see Donors_Metric::window_activity_signal()}
-	 * and the Subscribers equivalent. GAM has no refunds (no negative revenue) and
-	 * no transaction count, so impressions and revenue are the only signals.
+	 * produces — no SOAP query — mirroring the Donors / Subscribers empty-state
+	 * derivation (their respective `window_activity_signal()` helpers). GAM has no
+	 * refunds (no negative revenue) and no transaction count, so impressions and
+	 * revenue are the only signals.
 	 *
 	 * Set on the window only once the report has resolved AND both metrics are
 	 * computable (see {@see self::read_window()}); during loading, or when either

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -275,6 +275,26 @@ class Advertising_Metric {
 		return $fixture( $start_date, $end_date, $compare, $variant );
 	}
 
+	/**
+	 * Derived empty-state signal (NPPD-1697): whether a resolved window saw any
+	 * ad activity. A pure function of the two volume metrics the report already
+	 * produces — no SOAP query — mirroring {@see Donors_Metric::window_activity_signal()}
+	 * and the Subscribers equivalent. GAM has no refunds (no negative revenue) and
+	 * no transaction count, so impressions and revenue are the only signals.
+	 *
+	 * Set on the window only once the report has resolved AND both metrics are
+	 * computable (see {@see self::read_window()}); during loading, or when either
+	 * metric errored, it is left absent so the React layer's strict `=== false`
+	 * check can't fire mid-load or mask a per-card error.
+	 *
+	 * @param int   $impressions Total impressions in the window.
+	 * @param float $revenue     Total revenue in the window.
+	 * @return bool
+	 */
+	public static function window_activity_signal( int $impressions, float $revenue ): bool {
+		return $impressions > 0 || $revenue > 0.0;
+	}
+
 	/*
 	 * Cache (transient SWR) + Action Scheduler refresh
 	 */
@@ -302,6 +322,19 @@ class Advertising_Metric {
 			self::schedule_refresh( $start_date, $end_date );
 			$window['is_stale'] = true;
 		}
+
+		// Derived empty-state signal (NPPD-1697). Set only on a resolved window
+		// (this branch — the loading branch above returns first) and only when both
+		// volume metrics are computable. Left ABSENT when either errored, so the
+		// errored card surfaces its own error treatment rather than the section
+		// collapsing to a no_opportunity empty state (mirrors Gates' dataKnown gate).
+		$metrics = $window['metrics'] ?? [];
+		$imp     = $metrics['total_impressions'] ?? [];
+		$rev     = $metrics['total_revenue'] ?? [];
+		if ( ! empty( $imp['computable'] ) && ! empty( $rev['computable'] ) ) {
+			$window['has_window_activity'] = self::window_activity_signal( (int) ( $imp['value'] ?? 0 ), (float) ( $rev['value'] ?? 0 ) );
+		}
+
 		return $window;
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
@@ -46,6 +46,16 @@ export interface AdvertisingWindow {
 	is_loading?: boolean;
 	/** Serving a stale payload while a background refresh runs. */
 	is_stale?: boolean;
+	/**
+	 * Derived empty-state signal (NPPD-1697): true when the resolved report saw
+	 * any ad activity (impressions or revenue). Present (boolean) only once the
+	 * report resolves and both volume metrics are computable — ABSENT while
+	 * `is_loading`, or when a metric errored. The ReachRevenueSection reads
+	 * `=== false` to fire its `no_opportunity` collapse, so `undefined` (loading /
+	 * error) falls through and never collapses mid-load. Matches the optional
+	 * `is_loading?` / `is_stale?` convention.
+	 */
+	has_window_activity?: boolean;
 }
 
 export interface AdvertisingResponse {

--- a/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
@@ -80,6 +80,17 @@ const queryString = ( query: InsightsQuery ): string => {
 		params.set( 'compare_start', query.compare_start );
 		params.set( 'compare_end', query.compare_end );
 	}
+	// Forward the `_fixture_state` URL param so fixture mode's render variants
+	// (populated / not_ready / zero / no_revenue / loading / no_viewability) are
+	// reachable from the UI for smoke testing — matching the gates / prompts tabs.
+	// A no-op in production: the server ignores it unless
+	// NEWSPACK_INSIGHTS_FIXTURE_MODE is enabled.
+	if ( typeof window !== 'undefined' ) {
+		const fixtureState = new URLSearchParams( window.location.search ).get( '_fixture_state' );
+		if ( fixtureState ) {
+			params.set( '_fixture_state', fixtureState );
+		}
+	}
 	return params.toString();
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
@@ -89,6 +89,37 @@ describe( 'AdvertisingTab', () => {
 		expect( screen.getByText( 'Loading ad performance…' ) ).toBeInTheDocument();
 	} );
 
+	it( 'does NOT render the empty state while loading, even when has_window_activity is false (NPPD-1697 regression)', () => {
+		// The make-or-break: a still-running report must short-circuit to the
+		// progressive loading messages BEFORE the no_opportunity branch can evaluate,
+		// even though the payload would otherwise trigger it.
+		mockData( baseWindow( { is_loading: true, has_window_activity: false, metrics: {} } ) );
+		render( <AdvertisingTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'Loading ad performance…' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /No ad impressions in this timeframe/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Reach & revenue' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'collapses the Reach & revenue section to no_opportunity on a resolved zero window', () => {
+		mockData(
+			baseWindow( {
+				has_window_activity: false,
+				metrics: {
+					total_impressions: { value: 0, computable: true, type: 'count' },
+					total_revenue: { value: 0, computable: true, type: 'currency' },
+					direct_vs_programmatic: { type: 'breakdown', computable: false, rows: [] },
+				},
+			} )
+		);
+		const { container } = render( <AdvertisingTab range={ range } previousRange={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'No ad impressions in this timeframe' );
+		// The headline scorecards are gone; the other sections still render.
+		expect( screen.queryByText( 'Total Impressions' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders all sections with values when ready', () => {
 		mockData(
 			baseWindow( {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -83,6 +83,7 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 					<ReachRevenueSection
 						current={ current.metrics }
 						previous={ previous }
+						hasWindowActivity={ current.has_window_activity }
 						lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
 					/>
 					<InventoryPerformanceSection current={ current.metrics } previous={ previous } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
@@ -58,17 +58,24 @@ describe( 'ReachRevenueSection empty states', () => {
 			total_revenue: { value: 0, computable: true, type: 'currency' },
 		} );
 		// hasWindowActivity is true here (impressions > 0) — only the revenue card changes.
-		const { container } = render( <ReachRevenueSection current={ current } previous={ metrics() } hasWindowActivity /> );
+		// Prior window has lower impressions so the impressions card has a real delta to render.
+		const previous = metrics( { total_impressions: { value: 2000000, computable: true, type: 'count' } } );
+		const { container } = render( <ReachRevenueSection current={ current } previous={ previous } hasWindowActivity /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		// Real impressions count still shown — section not collapsed.
 		expect( screen.getByText( '2,400,000' ) ).toBeInTheDocument();
 		expect( screen.getByText( '2,400,000 impressions, but no revenue this timeframe' ) ).toBeInTheDocument();
+
+		const cardByLabel = ( label: string ) =>
+			Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
+				.find( el => el.textContent === label )
+				?.closest( '.newspack-insights__metric-card' );
 		// The Total Revenue card shows $0 with the period delta suppressed.
-		const revenueCard = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
-			.find( el => el.textContent === 'Total Revenue' )
-			?.closest( '.newspack-insights__metric-card' );
-		expect( revenueCard?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+		expect( cardByLabel( 'Total Revenue' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+		// Special-casing the revenue card must NOT suppress the sibling impressions
+		// card's normal period comparison.
+		expect( cardByLabel( 'Total Impressions' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).not.toBeNull();
 	} );
 
 	it( 'does NOT collapse or show no-revenue when a metric errored — the card surfaces its own error', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for ReachRevenueSection empty states (NPPD-1697): the whole-section
+ * no_opportunity collapse, the per-card no-revenue treatment on Total Revenue,
+ * and the error-guard (an errored metric must NOT collapse / mask its error).
+ *
+ * The is_loading short-circuit is verified at the tab level in
+ * AdvertisingTab.test.tsx (sections never see is_loading).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ReachRevenueSection from './ReachRevenueSection';
+import type { InsightsWindow } from '../../../api/advertising';
+
+const metrics = ( over: InsightsWindow = {} ): InsightsWindow => ( {
+	total_impressions: { value: 2400000, computable: true, type: 'count' },
+	total_revenue: { value: 4200, computable: true, type: 'currency' },
+	direct_vs_programmatic: {
+		type: 'breakdown',
+		computable: true,
+		rows: [
+			{ label: 'direct', revenue: 2520, impressions: 1320000 },
+			{ label: 'programmatic', revenue: 1680, impressions: 1080000 },
+		],
+	},
+	...over,
+} );
+
+/** Read a MetricCard's hero value by label (skips non-card nodes). */
+const cardValueByLabel = ( container: HTMLElement, label: string ): string => {
+	const labelEl = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) ).find( el => el.textContent === label );
+	return labelEl?.closest( '.newspack-insights__metric-card' )?.querySelector( '.newspack-insights__metric-card-value' )?.textContent ?? '';
+};
+
+describe( 'ReachRevenueSection empty states', () => {
+	it( 'collapses to a no_opportunity EmptyMetricSection when hasWindowActivity is false', () => {
+		const current = metrics( {
+			total_impressions: { value: 0, computable: true, type: 'count' },
+			total_revenue: { value: 0, computable: true, type: 'currency' },
+			direct_vs_programmatic: { type: 'breakdown', computable: false, rows: [] },
+		} );
+		const { container } = render( <ReachRevenueSection current={ current } previous={ null } hasWindowActivity={ false } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		// Assert on the container — the Notice's speak() duplicates copy into a live-region.
+		expect( container ).toHaveTextContent( 'No ad impressions in this timeframe' );
+		expect( screen.queryByText( 'Total Impressions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the per-card no-revenue treatment on Total Revenue when impressions run but revenue is zero', () => {
+		const current = metrics( {
+			total_revenue: { value: 0, computable: true, type: 'currency' },
+		} );
+		// hasWindowActivity is true here (impressions > 0) — only the revenue card changes.
+		const { container } = render( <ReachRevenueSection current={ current } previous={ metrics() } hasWindowActivity /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		// Real impressions count still shown — section not collapsed.
+		expect( screen.getByText( '2,400,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2,400,000 impressions, but no revenue this timeframe' ) ).toBeInTheDocument();
+		// The Total Revenue card shows $0 with the period delta suppressed.
+		const revenueCard = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
+			.find( el => el.textContent === 'Total Revenue' )
+			?.closest( '.newspack-insights__metric-card' );
+		expect( revenueCard?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+	} );
+
+	it( 'does NOT collapse or show no-revenue when a metric errored — the card surfaces its own error', () => {
+		const current = metrics( {
+			total_revenue: { value: null, computable: false, error: 'GAM report failed' },
+		} );
+		const { container } = render( <ReachRevenueSection current={ current } previous={ null } hasWindowActivity={ undefined } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /but no revenue this timeframe/ ) ).not.toBeInTheDocument();
+		// The errored revenue card shows the shared graceful-failure note.
+		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the normal scorecards when populated', () => {
+		const { container } = render( <ReachRevenueSection current={ metrics() } previous={ null } hasWindowActivity /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( cardValueByLabel( container, 'Total Impressions' ) ).toBe( '2,400,000' );
+		expect( screen.getByText( 'Total Revenue' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -1,9 +1,24 @@
 /**
- * Advertising › Reach & revenue (NPPD-1618, Section 1).
+ * Advertising › Reach & revenue (NPPD-1618, Section 1; empty states NPPD-1697).
  *
  * Headline scorecards for the period: impressions served, revenue earned, and
  * the revenue mix (direct share). Three equal-width cards, matching the
  * Inventory performance row's sizing.
+ *
+ * Empty states (NPPD-1697), mirroring Donors (NPPD-1696) / Subscribers
+ * (NPPD-1695):
+ *   - Whole-section `EmptyMetricSection` (`no_opportunity`) when the resolved
+ *     report saw no ad activity (`hasWindowActivity === false`). This is the
+ *     off-season / no-impressions case.
+ *   - Per-card no-revenue treatment on the Total Revenue card when impressions
+ *     are running but revenue is zero — a whole-section empty would hide the
+ *     real impressions count, so only that card gets the context line (delta
+ *     suppressed).
+ *
+ * `is_loading` is gated at the AdvertisingTab level (NPPD-1684) — this section
+ * only mounts on a resolved report, so neither branch can fire mid-load.
+ * `hasWindowActivity` is additionally absent (not `false`) while loading or on
+ * an errored metric, so the strict `=== false` check is belt-and-suspenders.
  */
 
 /**
@@ -14,46 +29,94 @@ import type { ReactNode } from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { InsightsWindow } from '../../../api/advertising';
+import EmptyMetricSection from '../../components/EmptyMetricSection';
+import MetricCard from '../../components/MetricCard';
 import Scorecard from '../../components/Scorecard';
 import SectionHeading from '../../components/SectionHeading';
+import { formatNumber } from '../../components/format';
 import RevenueMixCard from '../RevenueMixCard';
 
 export interface SectionProps {
 	current: InsightsWindow;
 	previous: InsightsWindow | null;
+	/**
+	 * Derived server signal: `false` only on a resolved window with zero ad
+	 * activity. Absent while loading or on an errored metric (see api/advertising).
+	 */
+	hasWindowActivity?: boolean;
 	lastUpdated?: ReactNode;
 }
 
-const ReachRevenueSection = ( { current, previous, lastUpdated }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
-		<SectionHeading
-			id="newspack-insights-advertising-reach-revenue"
-			title={ __( 'Reach & revenue', 'newspack-plugin' ) }
-			description={ __( 'Volume and revenue mix for the period.', 'newspack-plugin' ) }
-			actions={ lastUpdated }
-		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
-			<Scorecard
-				label={ __( 'Total Impressions', 'newspack-plugin' ) }
-				description={ __( 'Total ad impressions served on your site in this timeframe.', 'newspack-plugin' ) }
-				current={ current.total_impressions }
-				previous={ previous?.total_impressions }
+const TITLE = __( 'Reach & revenue', 'newspack-plugin' );
+const CAPTION = __( 'Volume and revenue mix for the period.', 'newspack-plugin' );
+
+const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdated }: SectionProps ) => {
+	// Whole-section empty: the report resolved with no ad activity. Collapse the
+	// grid to a single callout. Strict `=== false` so the absent-while-loading /
+	// absent-on-error cases fall through to the normal render.
+	if ( hasWindowActivity === false ) {
+		return (
+			<EmptyMetricSection
+				title={ TITLE }
+				caption={ CAPTION }
+				state="no_opportunity"
+				body={ __(
+					'No ad impressions in this timeframe. Your ad server is configured, but the report shows no impressions for the date range. Could be a placement question, an off-season window, or a configuration issue. Try expanding the date range or checking your ad unit setup.',
+					'newspack-plugin'
+				) }
 			/>
-			<Scorecard
-				label={ __( 'Total Revenue', 'newspack-plugin' ) }
-				description={ __( 'Total ad revenue earned in this timeframe, before fees.', 'newspack-plugin' ) }
-				current={ current.total_revenue }
-				previous={ previous?.total_revenue }
-			/>
-			<RevenueMixCard payload={ current.direct_vs_programmatic } />
-		</div>
-	</section>
-);
+		);
+	}
+
+	const impressions = current.total_impressions;
+	const revenue = current.total_revenue;
+	// Per-card no-revenue state: impressions are running but the report shows zero
+	// revenue. Gated on both metrics being computable so an errored metric keeps
+	// its own error treatment rather than reading as an honest zero.
+	const noRevenue = !! impressions?.computable && !! revenue?.computable && ( impressions?.value ?? 0 ) > 0 && ( revenue?.value ?? 0 ) === 0;
+
+	return (
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
+			<SectionHeading id="newspack-insights-advertising-reach-revenue" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+				<Scorecard
+					label={ __( 'Total Impressions', 'newspack-plugin' ) }
+					description={ __( 'Total ad impressions served on your site in this timeframe.', 'newspack-plugin' ) }
+					current={ current.total_impressions }
+					previous={ previous?.total_impressions }
+				/>
+				{ noRevenue ? (
+					<MetricCard
+						label={ __( 'Total Revenue', 'newspack-plugin' ) }
+						value={ 0 }
+						format="currency"
+						// No previousValue → the period delta is suppressed; a "↓ 100%" would
+						// misread the honest zero against a prior window that had revenue.
+						secondary={ sprintf(
+							/* translators: %s: count of ad impressions in this timeframe */
+							__( '%s impressions, but no revenue this timeframe', 'newspack-plugin' ),
+							formatNumber( impressions?.value ?? 0 )
+						) }
+						description={ __( 'Total ad revenue earned in this timeframe, before fees.', 'newspack-plugin' ) }
+					/>
+				) : (
+					<Scorecard
+						label={ __( 'Total Revenue', 'newspack-plugin' ) }
+						description={ __( 'Total ad revenue earned in this timeframe, before fees.', 'newspack-plugin' ) }
+						current={ current.total_revenue }
+						previous={ previous?.total_revenue }
+					/>
+				) }
+				<RevenueMixCard payload={ current.direct_vs_programmatic } />
+			</div>
+		</section>
+	);
+};
 
 export default ReachRevenueSection;

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-advertising-metric.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Test Advertising_Metric (NPPD-1697).
+ *
+ * Covers the derived `has_window_activity` empty-state signal —
+ * `Advertising_Metric::window_activity_signal()`, a pure function of the two
+ * GAM volume metrics. Tested directly (no reflection, no mock), mirroring the
+ * Donors / Subscribers metric tests.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Advertising_Metric;
+use WP_UnitTestCase;
+
+/**
+ * Advertising_Metric test class.
+ *
+ * @group insights
+ */
+class Test_Advertising_Metric extends WP_UnitTestCase {
+
+	/**
+	 * A resolved window with no impressions and no revenue is the
+	 * no_opportunity state: the signal is false.
+	 */
+	public function test_no_activity_is_false() {
+		$this->assertFalse( Advertising_Metric::window_activity_signal( 0, 0.0 ) );
+	}
+
+	/**
+	 * Either volume signal flips the activity flag true.
+	 *
+	 * @dataProvider activity_signal_provider
+	 *
+	 * @param int    $impressions Total impressions.
+	 * @param float  $revenue     Total revenue.
+	 * @param bool   $expected    Expected has_window_activity.
+	 * @param string $message     Assertion message.
+	 */
+	public function test_activity_signals( int $impressions, float $revenue, bool $expected, string $message ) {
+		$this->assertSame( $expected, Advertising_Metric::window_activity_signal( $impressions, $revenue ), $message );
+	}
+
+	/**
+	 * Impressions alone, revenue alone, the all-zero baseline, and both.
+	 * GAM has no refunds (no negative revenue) and no transaction count, so
+	 * these two are the only signals.
+	 *
+	 * @return array<string, array{0:int,1:float,2:bool,3:string}>
+	 */
+	public function activity_signal_provider(): array {
+		return [
+			'all zero'                => [ 0, 0.0, false, 'No impressions and no revenue → no activity.' ],
+			'impressions only'        => [ 2400000, 0.0, true, 'Impressions running is activity (drives the per-card no-revenue treatment).' ],
+			'revenue only'            => [ 0, 50.0, true, 'Revenue alone is activity.' ],
+			'impressions and revenue' => [ 2400000, 4200.0, true, 'A fully populated window is active.' ],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

The empty-state pattern from [[NPPD-1694](https://linear.app/a8c/issue/NPPD-1694)](https://linear.app/a8c/issue/NPPD-1694) applied to the Advertising tab's `ReachRevenueSection`, landing on `feat/insights-rsm`. Closes [[NPPD-1697](https://linear.app/a8c/issue/NPPD-1697)](https://linear.app/a8c/issue/NPPD-1697). Final per-tab application of the pattern — completes the sweep started by Gates Paid (PR #291) and continued through Donors (PR #343) and Subscribers (PR #344). The defining constraint is coordination with the existing `is_loading` async state from [[NPPD-1684](https://linear.app/a8c/issue/NPPD-1684)](https://linear.app/a8c/issue/NPPD-1684): empty-state copy must never render while a GAM report is still running, because a publisher waiting on their SOAP report would otherwise see "no ad impressions" copy mid-load.

Recon on the `is_loading` rig before any code landed: the boundary is already airtight. `is_loading` is gated at the tab level in `AdvertisingTab.tsx`, checked before any section component mounts. Sections never receive `is_loading` in their props — it lives on `AdvertisingWindow`, not on the metrics map that sections consume. Server-side, `is_loading` is atomic: set only in `read_window()` on a full cache miss, and in that branch `metrics` is `[]`. Never partial. The new empty-state branches live inside `ReachRevenueSection`, which structurally cannot render during loading because the tab returns ahead of it. The NPPD-1684 rig is preserved exactly as-is.

### Pre-flight decisions

Surfaced before writing code, where the codebase or the ticket's framing didn't match the shipped tab.

- The `has_window_activity` envelope addition uses the optional / present-when-resolved convention (`has_window_activity?: boolean`) rather than `null | boolean`. This matches the existing `is_loading?` / `is_stale?` convention on `AdvertisingWindow` — consistency with the established envelope shape beats introducing a new nullability discipline, and the tab-level `is_loading` gate is the real safety guarantee. The field is absent while loading or when an upstream metric isn't computable; React reads `has_window_activity === false` (strict) to fire the empty-state branch, so `undefined` falls through naturally. Belt-and-suspenders with the tab gate.

- The `has_window_activity` derivation is error-guarded. The field is left ABSENT when either of the two volume metrics (`total_impressions`, `total_revenue`) isn't computable. Mirrors the `dataKnown` guard from Gates: an errored window must render the errored cards (so their error treatment surfaces) rather than collapsing to `no_opportunity` on an upstream failure. Composition is just impressions + revenue — GAM has no refunds or transactions, so the four-signal expression used on Donors / Subscribers reduces to two here.

- The Advertising tab uses a different card API than Donors / Subscribers. Sections render `<Scorecard current={payload} />`, which routes through `payloadToCard` to derive format from `payload.type` — not raw `<MetricCard>` with explicit props. The per-card `no_conversions` treatment on Total Revenue therefore special-cases that one card as a raw `<MetricCard>` in `ReachRevenueSection` rather than extending the `Scorecard` wrapper to support secondary / zeroFallback / suppressed-delta props. Localized, more code than the Donors / Subscribers prop-tweak approach, but the wrapper extension only earns its keep if more cards across other tabs need the treatment — [[NPPD-1698](https://linear.app/a8c/issue/NPPD-1698)](https://linear.app/a8c/issue/NPPD-1698) can lift it later if the audit surfaces the need.

- The per-card `no_conversions` copy is terse — *"{N} impressions, but no revenue this timeframe."* — rather than the longer parallel form Donors / Subscribers landed on (*"Your {N} existing X are active, but no new readers converted in this timeframe."*). The parallel form references a subject population (existing donors / subscribers); impressions are transient events, not subjects, so the longer construction reads awkwardly. Sibling-tab consistency loses to readability here; NPPD-1698 normalizes either way.

- No good-zero cases on this tab. Unlike Subscribers (where Churned subscribers + Failed payment recovery are good zeros), zero impressions and zero revenue on Advertising are just "nothing happening" — neither desired nor undesired on their own. The good-zero composition concern from PR #344 doesn't apply, and the `no_opportunity` collapse can be unconditional once `has_window_activity === false`.

- The fill-rate "impossible zero" case (zero fill rate alongside non-zero impressions and revenue) needs no handling. Fill rate is a derived rate (`impressions ÷ requests`) living in `InventoryPerformanceSection`. A true zero-fill-with-non-zero-impressions can't occur mathematically; a zero-requests window is already `computable: false` and handled by the existing `payloadToCard` error path. If it ever fires it's a calculation bug, not a publisher-facing empty state — so no `zeroFallback` propagation, matching the ticket.

- Tab-level hiding is already covered by `Insights_Wizard::is_advertising_tab_visible()` plus the `current.is_tab_visible` short-circuit in `AdvertisingTab`. Both gates run ahead of any section render, so the section-level empties don't interfere. No `has_advertising_activity()` analogue needed — the existing GAM-active check already serves the role that `has_donation_activity()` plays on Donors.

- Three sections on the tab stay as-is. `InventoryPerformanceSection` (Avg eCPM, Fill Rate, Viewability) is downstream of impressions; if impressions are zero the section already overlay-degrades, and none of its cards have a good / bad zero distinction worth migrating. `TopPerformersSection` is two collection tables (Top Ad Units, Top Advertisers) that already self-empty via their `emptyMessage` props. `RevenueMixCard` (direct vs programmatic share, inside `ReachRevenueSection`) already self-handles `total <= 0` → *"No ad revenue in this timeframe."* — leaving it as-is keeps the section's two empty signals consistent (whole-section `no_opportunity` outside, per-card "no ad revenue" inside).

- Advertising has a `get_fixture()` / `_fixture_state` harness, unlike Donors and Subscribers. So tests run in both fixture mode and against component payloads. The existing `zero` variant gets `has_window_activity: false` added (becomes the `no_opportunity` fixture), a new `no_revenue` variant covers per-card `no_conversions`, and a new `loading` variant lets the tab-level short-circuit be manually demoable.

## What's in this PR

### Server-side `window_activity_signal` derivation

`includes/wizards/insights/metrics/class-advertising-metric.php` adds a static pure method:

```php
public static function window_activity_signal( int $impressions, float $revenue ): bool {
    return $impressions > 0 || $revenue > 0.0;
}
```

Called in `read_window()` on the resolved branch only, gated on both `total_impressions.computable === true` and `total_revenue.computable === true`. When either upstream metric isn't computable, `has_window_activity` is left absent from the envelope — the errored cards surface their own error treatment instead of triggering a misleading whole-section collapse. Same `dataKnown` discipline as Gates. No SOAP query, no GAM client change.

### `ReachRevenueSection` rendering states

`src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx` reads two states from the payload. `hasWindowActivity === false` collapses the whole section to an `EmptyMetricSection` `no_opportunity` treatment — the off-season / no-impressions case for publishers running seasonal inventory or fresh GAM setups. The per-card no-revenue treatment fires when `total_impressions.value > 0 && total_revenue.value === 0` (both computable): the Total Revenue card renders as a raw `<MetricCard>` (rather than via the tab's `Scorecard` / `payloadToCard` wrapper) with value `$0`, a secondary line of *"{N} impressions, but no revenue this timeframe."*, and the period delta suppressed. The whole-section collapse is structurally wrong here because Total Impressions has real data; the per-card treatment preserves it. `RevenueMixCard` already shows its own "No ad revenue" line in this case, so the two render consistently.

### Types and prop threading

Optional `has_window_activity?: boolean` added to `AdvertisingWindow` in `src/wizards/insights/api/advertising.ts` (matches the existing `is_loading?` / `is_stale?` convention). `AdvertisingTab` threads `hasWindowActivity={ current.has_window_activity }` into `ReachRevenueSection` — sections otherwise only receive `current.metrics`, so this is the one envelope field that flows past the metrics map.

### Fixture variants

The existing `zero` variant on `Advertising_Metric::get_fixture()` gets `has_window_activity: false` added — it now exercises the `no_opportunity` collapse. New `no_revenue` variant (impressions > 0, revenue === 0, `has_window_activity` absent) covers the per-card `no_conversions` treatment. New `loading` variant (`is_loading: true`, empty metrics) lets the tab-level short-circuit be manually demoable via `_fixture_state=loading` — useful for visual confirmation that the empty-state branches stay dormant during loads.

## How to test

1. Check out `feat/insights-advertising-empty-states` and run `./n build newspack-plugin`.
2. **The critical regression — fixture mode**: visit `?page=newspack-insights#/advertising&_fixture_state=loading`. Confirm the tab renders `<TabLoading>` with progressive messages — NOT the `no_opportunity` empty state, despite `has_window_activity` being absent (and therefore `=== false` at React level). This is the case we most need to prevent regressing.
3. **Off-season publisher (fixture mode)**: `?page=newspack-insights#/advertising&_fixture_state=zero`. Confirm `ReachRevenueSection` collapses to *"No ad impressions in this timeframe…"* `InventoryPerformanceSection`, `TopPerformersSection`, and the rest of the tab unchanged.
4. **Off-season publisher (real data)**: with a publisher whose GAM is connected but ran no inventory in the selected window, confirm the same collapse — `no_opportunity` fires, other sections unchanged.
5. **Impressions but no revenue (fixture mode)**: `?page=newspack-insights#/advertising&_fixture_state=no_revenue`. Confirm the Total Revenue card renders `$0` + *"{N} impressions, but no revenue this timeframe."* with no `-100%` delta. Total Impressions and `RevenueMixCard` ("No ad revenue in this timeframe") render their real / native treatments. No whole-section collapse.
6. **Impressions but no revenue (real data)**: with a publisher whose ad units are filling impressions but not monetizing (under-priced floors, fill-rate issues, or ad-blocking heavy audience), confirm the same per-card treatment.
7. **Errored upstream metric (real or fixture)**: simulate `total_impressions.computable: false`. Confirm the Total Impressions card surfaces its error treatment and the section does NOT collapse to `no_opportunity` — the `dataKnown` guard prevents the misleading collapse on upstream errors.
8. **Healthy publisher**: every section and card renders normally; no empty branches fire.
9. `./n test-php --filter Advertising_Metric`: `window_activity_signal` directly — zero impressions + zero revenue → `false`; non-zero impressions → `true`; non-zero revenue → `true`. PHPCS clean.
10. `pnpm --filter newspack-plugin test advertising`: 26 React test cases across the advertising suites including the unchanged existing zero-window assertion, the tab-level `is_loading` regression (`AdvertisingTab.test.tsx`), `ReachRevenueSection.test.tsx` (`no_opportunity` collapse, per-card no-revenue with delta suppression, errored-metric guard, populated). `tsc --noEmit` + ESLint + production build clean.