### PR TITLE
chore(content-gate): add Access Control feed restriction tests

### DIFF
--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Tests for restricting gated content in RSS feeds.
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+namespace Newspack\Tests\Content_Gate;
+
+use Newspack\Content_Gate;
+use Newspack\Content_Gate_Advanced_Settings;
+use Newspack\Content_Restriction_Control;
+
+/**
+ * Tests that the "Restrict content in feeds" advanced setting keeps gated
+ * content out of RSS feeds, where Content_Gate::restrict_post() never runs
+ * (it bails on `! is_singular()`), so the feed filters are the only guard.
+ *
+ * @group content-gate
+ */
+class Test_Feed_Restriction extends \WP_UnitTestCase {
+
+	/**
+	 * Gated post content: five distinct paragraphs so we can assert which
+	 * survive truncation (the default visible_paragraphs is 2).
+	 */
+	const POST_CONTENT = '<!-- wp:paragraph --><p>FREE_ONE paragraph one.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>FREE_TWO paragraph two.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>PAID_THREE paragraph three.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>PAID_FOUR paragraph four.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>PAID_FIVE paragraph five.</p><!-- /wp:paragraph -->';
+
+	/**
+	 * Gated post ID.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Gate ID.
+	 *
+	 * @var int
+	 */
+	private $gate_id;
+
+	/**
+	 * Enable the Content Gates feature flag for this class only.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Set up a published registration-mode gate restricting all posts, plus a
+	 * gated post, consumed as an anonymous reader with restrict_feeds enabled.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->gate_id = Content_Gate::create_gate( [ 'title' => 'Feed Gate' ] );
+		Content_Gate::update_gate_settings(
+			$this->gate_id,
+			[
+				'title'         => 'Feed Gate',
+				'status'        => 'publish',
+				'priority'      => 0,
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => [
+					'active'               => true,
+					'metering'             => [
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					],
+					'require_verification' => false,
+					'gate_id'              => 0,
+				],
+			]
+		);
+
+		$this->post_id = $this->factory->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => self::POST_CONTENT,
+			]
+		);
+
+		// Feeds are consumed anonymously.
+		wp_set_current_user( 0 );
+		update_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds', 1, false );
+		Content_Gate_Advanced_Settings::reset_cache();
+	}
+
+	/**
+	 * Teardown after tests.
+	 */
+	public function tear_down() {
+		foreach ( Content_Gate::get_gates() as $gate ) {
+			wp_delete_post( $gate['id'], true );
+		}
+		wp_delete_post( $this->post_id, true );
+		$this->reset_restriction_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the per-request restriction caches between assertions.
+	 */
+	private function reset_restriction_cache() {
+		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map', 'post_gates_map', 'term_descendants_map' ] as $cache_property ) {
+			$cache_property_reflection = new \ReflectionProperty( Content_Restriction_Control::class, $cache_property );
+			$cache_property_reflection->setAccessible( true );
+			$cache_property_reflection->setValue( null, [] );
+		}
+	}
+
+	/**
+	 * Render the gated post through a real feed loop and return the value the
+	 * given callback produces for it. Restores the global query afterwards.
+	 *
+	 * @param callable $render Runs inside the loop with the gated post set up,
+	 *                         and returns the feed string for that post.
+	 *
+	 * @return string
+	 */
+	private function render_in_feed_loop( callable $render ) {
+		$this->go_to( get_feed_link( 'rss2' ) );
+		$this->assertTrue( is_feed(), 'Request should be a feed.' );
+
+		$result = '';
+		ob_start();
+		while ( have_posts() ) {
+			the_post();
+			if ( get_the_ID() === $this->post_id ) {
+				$result = $render();
+			}
+		}
+		ob_end_clean();
+		wp_reset_postdata();
+
+		return $result;
+	}
+
+	/**
+	 * Sanity check: the gate restricts the post for an anonymous reader, so the
+	 * feed filters have something to act on.
+	 */
+	public function test_post_is_restricted_for_anonymous() {
+		$this->assertTrue(
+			(bool) apply_filters( 'newspack_is_post_restricted', false, $this->post_id ),
+			'Gated post should be restricted for an anonymous reader.'
+		);
+	}
+
+	/**
+	 * Full-text feed (rss_use_excerpt=0): <content:encoded> is rendered via
+	 * get_the_content_feed(), and must not leak the paid paragraphs.
+	 */
+	public function test_full_text_feed_content_is_truncated() {
+		update_option( 'rss_use_excerpt', 0 );
+
+		$feed_content = $this->render_in_feed_loop(
+			function () {
+				return get_the_content_feed( 'rss2' );
+			}
+		);
+
+		$this->assertStringContainsString( 'FREE_ONE', $feed_content, 'Free preview should be present in feed content.' );
+		$this->assertStringNotContainsString( 'PAID_THREE', $feed_content, 'Paid paragraph 3 must not leak into full-text feed content.' );
+		$this->assertStringNotContainsString( 'PAID_FIVE', $feed_content, 'Paid paragraph 5 must not leak into full-text feed content.' );
+	}
+
+	/**
+	 * Excerpt feed (rss_use_excerpt=1): <description> is rendered via
+	 * the_excerpt_rss, and must not leak the paid paragraphs.
+	 */
+	public function test_excerpt_feed_is_truncated() {
+		update_option( 'rss_use_excerpt', 1 );
+
+		$feed_excerpt = $this->render_in_feed_loop(
+			function () {
+				return apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+			}
+		);
+
+		$this->assertStringNotContainsString( 'PAID_THREE', $feed_excerpt, 'Paid paragraph 3 must not leak into feed excerpt.' );
+		$this->assertStringNotContainsString( 'PAID_FIVE', $feed_excerpt, 'Paid paragraph 5 must not leak into feed excerpt.' );
+	}
+
+	/**
+	 * When the setting is off, the feed is left untouched: the filters become a
+	 * no-op and the full content flows through.
+	 */
+	public function test_full_content_flows_when_setting_disabled() {
+		update_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds', 0, false );
+		Content_Gate_Advanced_Settings::reset_cache();
+		update_option( 'rss_use_excerpt', 0 );
+
+		$feed_content = $this->render_in_feed_loop(
+			function () {
+				return get_the_content_feed( 'rss2' );
+			}
+		);
+
+		$this->assertStringContainsString( 'PAID_FIVE', $feed_content, 'With restrict_feeds off, full content should flow into the feed.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -105,6 +105,14 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 		}
 		wp_delete_post( $this->post_id, true );
 		$this->reset_restriction_cache();
+
+		// Restore the global state these tests mutate so they can't leak into
+		// other (RSS/feed) suites and cause order-dependent failures.
+		delete_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds' );
+		delete_option( 'rss_use_excerpt' );
+		Content_Gate_Advanced_Settings::reset_cache();
+		wp_set_current_user( 0 );
+
 		parent::tear_down();
 	}
 
@@ -121,7 +129,8 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 
 	/**
 	 * Render the gated post through a real feed loop and return the value the
-	 * given callback produces for it. Restores the global query afterwards.
+	 * given callback produces for it. Resets global post data afterwards via
+	 * wp_reset_postdata().
 	 *
 	 * @param callable $render Runs inside the loop with the gated post set up,
 	 *                         and returns the feed string for that post.
@@ -188,6 +197,10 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 			}
 		);
 
+		// Positive assertion guards against a false negative: if the loop failed
+		// to capture the post and returned an empty string, the "not contains"
+		// checks alone would still pass.
+		$this->assertStringContainsString( 'FREE_ONE', $feed_excerpt, 'Free preview should be present in feed excerpt.' );
 		$this->assertStringNotContainsString( 'PAID_THREE', $feed_excerpt, 'Paid paragraph 3 must not leak into feed excerpt.' );
 		$this->assertStringNotContainsString( 'PAID_FIVE', $feed_excerpt, 'Paid paragraph 5 must not leak into feed excerpt.' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds regression coverage for the Access Control **"Restrict content in feeds"** advanced setting (`newspack_content_gate_restrict_feeds`, on by default). There was no automated test for this feature.

This matters because `Content_Gate::restrict_post()` bails on `! is_singular()`, so it never runs in a feed. The `the_content_feed` / `the_excerpt_rss` filters in `Content_Gate_Advanced_Settings` are the *only* thing keeping gated content out of RSS — and they had no test.

The new `Test_Feed_Restriction` drives a real feed loop as an anonymous reader and asserts:

- **Full-text feed** (`rss_use_excerpt=0`): `<content:encoded>` (via `get_the_content_feed()`) is truncated to the free preview; paid paragraphs do not leak.
- **Excerpt feed** (`rss_use_excerpt=1`): `<description>` (via `the_excerpt_rss`) is truncated; paid paragraphs do not leak.
- The gated post is detected as restricted for an anonymous reader.
- With the setting **off**, full content flows through (filters are a no-op).

**No production code change** — this is a pure regression guard. It was prompted by a support report that feeds weren't being restricted on theassemblync.com; verification (including a live read-only eval) confirmed the feature *is* working, and this test locks that behaviour in.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-plugin`
2. `n test-php --filter Test_Feed_Restriction`
3. Expect `OK (4 tests, 10 assertions)`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TY17kW9cQvYXCBL1zwTs6