### PR TITLE
fix(insights): normalize empty-state copy vocabulary (NPPD-1698)

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -67,7 +67,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 				caption={ CAPTION }
 				state="no_opportunity"
 				body={ __(
-					'No ad impressions in this timeframe. Your ad server is configured, but the report shows no impressions for the date range. Could be a placement question, an off-season window, or a configuration issue. Try expanding the date range or checking your ad unit setup.',
+					'No ad impressions in this timeframe. Your ad server is configured, but the report shows no impressions for this timeframe. Could be a placement question, an off-season period, or a configuration issue. Try expanding the date range or checking your ad unit setup.',
 					'newspack-plugin'
 				) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
@@ -21,6 +21,9 @@ import EmptyMetricSection from './EmptyMetricSection';
 
 describe( 'EmptyMetricSection', () => {
 	it( 'renders the title and caption as the section identity', () => {
+		// Sample props exercising the component's rendering — NOT corpus copy, so
+		// they are intentionally not part of the "window" → "timeframe"
+		// normalization (NPPD-1698). Don't "sync" them.
 		const { container } = render(
 			<EmptyMetricSection
 				title="Paid reader conversion"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.test.tsx
@@ -48,6 +48,9 @@ describe( 'LineChart render', () => {
 	} );
 
 	it( 'renders a custom emptyMessage when every series is empty', () => {
+		// Sample prop exercising the generic emptyMessage passthrough — NOT corpus
+		// copy, so it is intentionally not part of the "window" → "timeframe"
+		// normalization (NPPD-1698). Don't "sync" it.
 		render(
 			<LineChart
 				series={ [

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -65,10 +65,10 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 			expect( screen.getByText( '0 of 1,234,567' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the em-dash + "No paywall attempts in this window" when denominator is 0', () => {
+		it( 'renders the em-dash + "No paywall attempts in this timeframe" when denominator is 0', () => {
 			render( <MetricCard label="Rate" value={ 0 } format="percent" zeroFallback={ { numerator: 0, denominator: 0, ...PAYWALL } } /> );
 			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
-			expect( screen.getByText( 'No paywall attempts in this window' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No paywall attempts in this timeframe' ) ).toBeInTheDocument();
 		} );
 
 		it( 'falls through to the normal percentage when numerator and denominator are both positive', () => {
@@ -92,7 +92,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 			expect( screen.queryByText( '$0.00' ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'renders the em-dash + "No paywall attempts in this window" when attempts are 0', () => {
+		it( 'renders the em-dash + "No paywall attempts in this timeframe" when attempts are 0', () => {
 			render(
 				<MetricCard
 					label="Total"
@@ -102,12 +102,12 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 				/>
 			);
 			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
-			expect( screen.getByText( 'No paywall attempts in this window' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No paywall attempts in this timeframe' ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'currency average card (currencyRole="average")', () => {
-		it( 'renders the em-dash + "No conversions in this window" when conversions are 0 but attempts > 0', () => {
+		it( 'renders the em-dash + "No conversions in this timeframe" when conversions are 0 but attempts > 0', () => {
 			render(
 				<MetricCard
 					label="Avg revenue per paywall conversion"
@@ -117,10 +117,10 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 				/>
 			);
 			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
-			expect( screen.getByText( 'No conversions in this window' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No conversions in this timeframe' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders "No paywall attempts in this window" when attempts are 0', () => {
+		it( 'renders "No paywall attempts in this timeframe" when attempts are 0', () => {
 			render(
 				<MetricCard
 					label="Avg"
@@ -129,7 +129,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 					zeroFallback={ { numerator: 0, denominator: 0, currencyRole: 'average', ...PAYWALL } }
 				/>
 			);
-			expect( screen.getByText( 'No paywall attempts in this window' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No paywall attempts in this timeframe' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -142,7 +142,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 				zeroFallback={ { numerator: 0, denominator: 0, attemptsLabel: 'registration gate impressions' } }
 			/>
 		);
-		expect( screen.getByText( 'No registration gate impressions in this window' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No registration gate impressions in this timeframe' ) ).toBeInTheDocument();
 	} );
 
 	it( 'suppresses the comparison delta when a fallback hero is shown', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -58,7 +58,7 @@ export interface MetricCardZeroFallback {
 	numerator?: number;
 	denominator?: number;
 	currencyRole?: 'total' | 'average';
-	/** Plural noun for the "No … in this window" line, e.g. "paywall attempts". */
+	/** Plural noun for the "No … in this timeframe" line, e.g. "paywall attempts". */
 	attemptsLabel: string;
 	/** Plural noun for the conversions line, e.g. "conversions". */
 	conversionsLabel?: string;
@@ -182,7 +182,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 	} else if ( notComputableMessage ) {
 		// "Not computable this window" (NPPD-1704): the metric is capable (its block
 		// exists) but the math couldn't complete — typically a zero denominator, so
-		// there were no in-intent inputs in this window. Same em-dash + secondary
+		// there were no in-intent inputs in this timeframe. Same em-dash + secondary
 		// treatment as not-capable, one slot lower: not-capable already short-
 		// circuited above (its nudge is the more actionable of the two), and this
 		// beats `zeroFallback`. A longer window or more traffic can fill this gap.
@@ -194,11 +194,11 @@ const MetricCard = ( props: MetricCardProps ) => {
 		const noneInWindow = ( pluralNoun: string ) =>
 			sprintf(
 				/* translators: %s is a plural noun, e.g. "paywall attempts". */
-				__( 'No %s in this window', 'newspack-plugin' ),
+				__( 'No %s in this timeframe', 'newspack-plugin' ),
 				pluralNoun
 			);
 		if ( denominator === 0 ) {
-			// Nothing happened at all → em-dash + "No <attempts> in this window".
+			// Nothing happened at all → em-dash + "No <attempts> in this timeframe".
 			fallbackHero = EM_DASH;
 			fallbackSecondary = noneInWindow( attemptsLabel );
 		} else if ( numerator === 0 && typeof denominator === 'number' && denominator > 0 ) {
@@ -219,7 +219,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 					conversionsNoun
 				);
 			} else {
-				// Currency average → em-dash + "No conversions in this window".
+				// Currency average → em-dash + "No conversions in this timeframe".
 				fallbackHero = EM_DASH;
 				fallbackSecondary = noneInWindow( conversionsNoun );
 			}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.test.tsx
@@ -23,7 +23,7 @@ describe( 'ConversionRateTrendsSection', () => {
 
 	it( 'renders the empty treatment when state is empty', () => {
 		render( <ConversionRateTrendsSection current={ makeConversionWindow( { weeklyTrendsState: 'empty' } ) } /> );
-		expect( screen.getByText( 'Weekly trends will appear once the window contains at least 4 weeks of data.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the error treatment when state is error', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -62,17 +62,17 @@ const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionPr
 			id="newspack-insights-conversion-rate-trends-heading"
 			title={ __( 'Conversion rate trends', 'newspack-plugin' ) }
 			description={ __(
-				'Weekly conversion rates across the selected window. Useful for spotting acceleration, plateaus, or seasonality.',
+				'Weekly conversion rates across the selected timeframe. Useful for spotting acceleration, plateaus, or seasonality.',
 				'newspack-plugin'
 			) }
 		/>
 		<SectionState
 			state={ current.weekly_conversion_rates.state }
-			emptyMessage={ __( 'Weekly trends will appear once the window contains at least 4 weeks of data.', 'newspack-plugin' ) }
+			emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
 		>
 			<LineChart
 				series={ toTrendSeries( current.weekly_conversion_rates ) }
-				emptyMessage={ __( 'Weekly trends will appear once the window contains at least 4 weeks of data.', 'newspack-plugin' ) }
+				emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
 			/>
 		</SectionState>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
@@ -32,7 +32,7 @@ describe( 'HowLongConversionsTakeSection', () => {
 
 	it( 'renders 4.1 empty treatment when time-to-register state is empty', () => {
 		render( <HowLongConversionsTakeSection current={ makeConversionWindow( { timeToRegisterState: 'empty' } ) } /> );
-		expect( screen.getByText( 'Time-to-register data will appear once registrations occur in this window.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Time-to-register data will appear once registrations occur in this timeframe.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders 4.1 error treatment when time-to-register state is error', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -70,12 +70,12 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 				<CurveCell title={ __( 'Time to register', 'newspack-plugin' ) }>
 					<SectionState
 						state={ current.time_to_register_distribution.state }
-						emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this window.', 'newspack-plugin' ) }
+						emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this timeframe.', 'newspack-plugin' ) }
 					>
 						<LineChart
 							points={ toLinePoints( current.time_to_register_distribution.points ) }
 							yMax={ 1 }
-							emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this window.', 'newspack-plugin' ) }
+							emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this timeframe.', 'newspack-plugin' ) }
 						/>
 					</SectionState>
 				</CurveCell>
@@ -83,12 +83,12 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 				<CurveCell title={ __( 'Time to subscribe', 'newspack-plugin' ) }>
 					<SectionState
 						state={ current.time_to_subscribe_distribution.state }
-						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 					>
 						<LineChart
 							series={ toLineSeries( current.time_to_subscribe_distribution ) }
 							yMax={ 1 }
-							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 						/>
 					</SectionState>
 				</CurveCell>
@@ -96,12 +96,12 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 				<CurveCell title={ __( 'Time to donate', 'newspack-plugin' ) }>
 					<SectionState
 						state={ current.time_to_donate_distribution.state }
-						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 					>
 						<LineChart
 							series={ toLineSeries( current.time_to_donate_distribution ) }
 							yMax={ 1 }
-							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 						/>
 					</SectionState>
 				</CurveCell>
@@ -114,12 +114,12 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					) : (
 						<SectionState
 							state={ lag.state }
-							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 						>
 							<LineChart
 								points={ toLinePoints( lag.points ) }
 								yMax={ 1 }
-								emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this window.', 'newspack-plugin' ) }
+								emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 							/>
 						</SectionState>
 					) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -101,7 +101,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 				<StandardFunnelCell
 					data={ current.anonymous_to_registered_funnel }
 					emptyMessage={ __(
-						'No registration funnel data yet. This will populate once registrations occur in this window.',
+						'No registration funnel data yet. This will populate once registrations occur in this timeframe.',
 						'newspack-plugin'
 					) }
 				/>
@@ -116,7 +116,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 				<StandardFunnelCell
 					data={ current.registered_to_subscriber_funnel }
 					emptyMessage={ __(
-						'No subscription funnel data yet. This will populate once subscriptions occur in this window.',
+						'No subscription funnel data yet. This will populate once subscriptions occur in this timeframe.',
 						'newspack-plugin'
 					) }
 				/>
@@ -127,7 +127,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 			>
 				<StandardFunnelCell
 					data={ current.registered_to_donor_funnel }
-					emptyMessage={ __( 'No donor funnel data yet. This will populate once donations occur in this window.', 'newspack-plugin' ) }
+					emptyMessage={ __( 'No donor funnel data yet. This will populate once donations occur in this timeframe.', 'newspack-plugin' ) }
 				/>
 			</JourneyFunnel>
 			<JourneyFunnel

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.test.tsx
@@ -26,8 +26,8 @@ describe( 'WhereConversionsComeFromSection', () => {
 
 	it( 'renders the empty treatment when state is empty', () => {
 		render( <WhereConversionsComeFromSection current={ makeConversionWindow( { sourceMixState: 'empty' } ) } /> );
-		expect( screen.getByText( 'Source data will appear once registrations occur in this window.' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Source data will appear once donations occur in this window.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Source data will appear once registrations occur in this timeframe.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Source data will appear once donations occur in this timeframe.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the error treatment when state is error', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -60,7 +60,7 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 			id="newspack-insights-conversion-source-mix-heading"
 			title={ __( 'Where conversions come from', 'newspack-plugin' ) }
 			description={ __(
-				'Source attribution for new conversions in the window. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?',
+				'Source attribution for new conversions in this timeframe. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?',
 				'newspack-plugin'
 			) }
 		/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -68,17 +68,17 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 			<SourcePie
 				title={ __( 'New registrations', 'newspack-plugin' ) }
 				data={ current.source_mix_registrations }
-				emptyMessage={ __( 'Source data will appear once registrations occur in this window.', 'newspack-plugin' ) }
+				emptyMessage={ __( 'Source data will appear once registrations occur in this timeframe.', 'newspack-plugin' ) }
 			/>
 			<SourcePie
 				title={ __( 'New subscribers', 'newspack-plugin' ) }
 				data={ current.source_mix_subscribers }
-				emptyMessage={ __( 'Source data will appear once subscriptions occur in this window.', 'newspack-plugin' ) }
+				emptyMessage={ __( 'Source data will appear once subscriptions occur in this timeframe.', 'newspack-plugin' ) }
 			/>
 			<SourcePie
 				title={ __( 'New donors', 'newspack-plugin' ) }
 				data={ current.source_mix_donors }
-				emptyMessage={ __( 'Source data will appear once donations occur in this window.', 'newspack-plugin' ) }
+				emptyMessage={ __( 'Source data will appear once donations occur in this timeframe.', 'newspack-plugin' ) }
 			/>
 		</div>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
@@ -38,7 +38,7 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	// misleading zero. The raw message stays server-side; the card shows generic
 	// copy keyed off the `error` prop.
 	if ( current.state === 'error' ) {
-		return { label, description, error: current.error_message ?? __( 'Data unavailable', 'newspack-plugin' ) };
+		return { label, description, error: current.error_message ?? __( 'Data temporarily unavailable.', 'newspack-plugin' ) };
 	}
 	return {
 		label,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
@@ -120,7 +120,7 @@ describe( 'WindowedSection empty states', () => {
 		expect( breakdown ).not.toMatch( /one-time/ );
 		expect( breakdown ).not.toContain( '+' );
 		// Average one-time gift falls back to a count message rather than $0.00.
-		expect( screen.getByText( 'No one-time gifts in this window' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No one-time gifts in this timeframe' ) ).toBeInTheDocument();
 	} );
 
 	it( 'suppresses the empty mode in the revenue breakdown — one-time-only window', () => {
@@ -135,7 +135,7 @@ describe( 'WindowedSection empty states', () => {
 
 	it( 'shows the Total donation revenue count fallback when revenue is a real zero', () => {
 		// A window where only lapses happened: section renders (has_window_activity true),
-		// but total revenue is genuinely $0 → "No donations in this window", not "$0.00".
+		// but total revenue is genuinely $0 → "No donations in this timeframe", not "$0.00".
 		const current = makeWindow( {
 			new_donors: 0,
 			lapsed_donors: 4,
@@ -146,6 +146,6 @@ describe( 'WindowedSection empty states', () => {
 		} );
 		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 30 } /> );
 
-		expect( screen.getByText( 'No donations in this window' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No donations in this timeframe' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -47,7 +47,7 @@ export interface WindowedSectionProps {
 	 * Window-independent count of active donors (trailing 12 months,
 	 * from `snapshot.active_donors`). Supplies the `{N}` context for the
 	 * "New donors" no-acquisition state — the publisher has existing
-	 * donors, just none new in this window.
+	 * donors, just none new in this timeframe.
 	 */
 	activeDonors: number;
 }
@@ -127,7 +127,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 				title={ getHeading( range ) }
 				state="no_opportunity"
 				body={ __(
-					'No donations in this timeframe. Your donation flow is configured, but no readers contributed during the date range. Worth expanding the timeframe or checking the donation flow placement on the site.',
+					'No donations in this timeframe. Your donation flow is configured, but no readers contributed in this timeframe. Worth expanding the date range or checking the donation flow placement on the site.',
 					'newspack-plugin'
 				) }
 			/>
@@ -183,7 +183,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					previousValue={ previous?.total_revenue }
 					secondary={ revenueBreakdown( current ) }
 					// Real zero (e.g. a window where only lapses occurred): show "No
-					// donations in this window" rather than a bare $0.00.
+					// donations in this timeframe" rather than a bare $0.00.
 					zeroFallback={
 						current.total_revenue === 0 ? { denominator: 0, currencyRole: 'total', attemptsLabel: donationsLabel } : undefined
 					}
@@ -195,7 +195,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					format="currency"
 					previousValue={ previous?.average_gift }
 					// Recurring-only window: no one-time gifts to average. Show "No one-time
-					// gifts in this window" instead of $0.00 (NPPD-1696 mode suppression).
+					// gifts in this timeframe" instead of $0.00 (NPPD-1696 mode suppression).
 					zeroFallback={
 						current.one_time_revenue === 0 ? { denominator: 0, currencyRole: 'average', attemptsLabel: oneTimeGiftsLabel } : undefined
 					}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -53,7 +53,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Body is asserted on the container — the Notice's speak() duplicates it into a
 		// global live-region, so a screen-level text query would match twice.
-		expect( container ).toHaveTextContent( 'No paywall attempts in this window' );
+		expect( container ).toHaveTextContent( 'No paywall attempts in this timeframe' );
 		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 
@@ -94,7 +94,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( container ).not.toHaveTextContent( 'No paywall attempts in this window' );
+		expect( container ).not.toHaveTextContent( 'No paywall attempts in this timeframe' );
 		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
 	} );
 
@@ -113,7 +113,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		// Assert on the container, not `screen`: the Notice's speak() leaves the
 		// no_conversions copy in a global live-region from an earlier test.
-		expect( container ).not.toHaveTextContent( 'No paywall conversions in this window' );
+		expect( container ).not.toHaveTextContent( 'No paywall conversions in this timeframe' );
 		// Scorecards render; the errored Influenced card shows the shared error note.
 		expect( screen.getByText( 'Paywall Conversion (Influenced, 14d)' ) ).toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -63,7 +63,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				caption={ caption }
 				state="no_opportunity"
 				body={ __(
-					'No paywall attempts in this window. Your paywall gates may not be reaching readers — could be a placement question, a frequency question, or simply that the date range doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
+					'No paywall attempts in this timeframe. Your paywall gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
 					'newspack-plugin'
 				) }
 			/>
@@ -77,7 +77,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				state="no_conversions"
 				signalCount={ attempts }
 				body={ __(
-					'No paywall conversions in this window. Your paywall reached {N} readers, but none completed a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
+					'No paywall conversions in this timeframe. Your paywall reached {N} readers, but none completed a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
 					'newspack-plugin'
 				) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
@@ -44,7 +44,7 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	// misleading zero. The raw message stays server-side; the card shows generic
 	// copy keyed off the `error` prop.
 	if ( current.state === 'error' ) {
-		return { label, description, error: current.error_message ?? __( 'Data unavailable', 'newspack-plugin' ) };
+		return { label, description, error: current.error_message ?? __( 'Data temporarily unavailable.', 'newspack-plugin' ) };
 	}
 	return {
 		label,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.test.ts
@@ -38,7 +38,7 @@ describe( 'prompts scalarToMetricCardProps — capability routing (NPPD-1720)', 
 			description: 'd',
 			current: scalar( { has_capability: false } ),
 		} );
-		expect( props.notCapableMessage ).toBe( 'Not measurable for your active prompts' );
+		expect( props.notCapableMessage ).toBe( 'Not measurable for your active prompts.' );
 	} );
 
 	it( 'lets the error treatment win over not-capable', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/scalarToCard.ts
@@ -54,7 +54,7 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	// misleading zero. The raw message stays server-side; the card shows generic
 	// copy keyed off the `error` prop.
 	if ( current.state === 'error' ) {
-		return { label, description, error: current.error_message ?? __( 'Data unavailable', 'newspack-plugin' ) };
+		return { label, description, error: current.error_message ?? __( 'Data temporarily unavailable.', 'newspack-plugin' ) };
 	}
 	// Structural "not capable" (NPPD-1720): no active prompt carries the block
 	// this metric measures, so there's nothing to compute regardless of window.
@@ -64,7 +64,7 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 		return {
 			label,
 			description,
-			notCapableMessage: notCapableMessage ?? __( 'Not measurable for your active prompts', 'newspack-plugin' ),
+			notCapableMessage: notCapableMessage ?? __( 'Not measurable for your active prompts.', 'newspack-plugin' ),
 		};
 	}
 	// "Not computable this window" (NPPD-1704): the metric is capable (its block

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -101,7 +101,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'No failed payments this timeframe.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No failed payments in this timeframe.' ) ).toBeInTheDocument();
 		// Not the old missing-data phrasing.
 		expect( screen.queryByText( 'No payment retries in this timeframe.' ) ).not.toBeInTheDocument();
 	} );
@@ -118,8 +118,8 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		} );
 		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 50 } /> );
 
-		// Gross + Net both fall back (shared MetricCard helper renders "…in this window").
-		expect( screen.getAllByText( 'No subscription orders in this window' ).length ).toBeGreaterThanOrEqual( 2 );
+		// Gross + Net both fall back (shared MetricCard helper renders "…in this timeframe").
+		expect( screen.getAllByText( 'No subscription orders in this timeframe' ).length ).toBeGreaterThanOrEqual( 2 );
 	} );
 
 	it( 'renders all six cards when fully populated', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -21,7 +21,7 @@
  * Good zeros render normally, NOT as empty states: "Churned subscribers"
  * is a count (its 0 + green `lowerIsBetter` delta IS the good-zero
  * signal), and "Failed payment recovery" reframes its no-retries case as
- * the positive "No failed payments this timeframe" (NPPD-1726) rather
+ * the positive "No failed payments in this timeframe" (NPPD-1726) rather
  * than a missing-data note.
  *
  * The two rate metrics (refund rate, retry recovery) carry the
@@ -53,7 +53,7 @@ export interface WindowedSectionProps {
 	 * Window-independent count of active subscribers (from
 	 * `snapshot.active_subscribers`). Supplies the `{N}` context for the
 	 * "New subscribers" no-acquisition state — the publisher has existing
-	 * subscribers, just none new in this window.
+	 * subscribers, just none new in this timeframe.
 	 */
 	activeSubscribers: number;
 }
@@ -120,7 +120,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 				title={ getHeading( range ) }
 				state="no_opportunity"
 				body={ __(
-					'No subscription activity in this timeframe. Your subscription product is configured, but no new subscribers, churn, or revenue changes happened during the date range. Worth expanding the timeframe or checking the conversion funnel.',
+					'No subscription activity in this timeframe. Your subscription product is configured, but no new subscribers, churn, or revenue changes happened in this timeframe. Worth expanding the date range or checking the conversion funnel.',
 					'newspack-plugin'
 				) }
 			/>
@@ -221,7 +221,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 						<p className="newspack-insights__metric-card-empty-note">
 							{ /* Good zero (NPPD-1726): no retries means no failed payments — frame it
 							     as the positive outcome, not a missing-data note. */ }
-							{ __( 'No failed payments this timeframe.', 'newspack-plugin' ) }
+							{ __( 'No failed payments in this timeframe.', 'newspack-plugin' ) }
 						</p>
 					</div>
 				) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**PR 1 of 2 for [NPPD-1698](https://linear.app/a8c/issue/NPPD-1698)** (empty-state voice & tone). This is the mechanical vocabulary-normalization pass; the editorial/structural changes and the canonical reference doc follow in PR 2. Both ship against `feat/insights-rsm`. No behavior changes — copy strings and their test assertions only.

Reader-facing empty-state copy across the Insights tabs had drifted between "window" and "timeframe" for the same concept. This normalizes on **"timeframe"**, reserves **"date range"** for imperative closers (it names the actual picker control), and tidies a few fallback strings.

Decisions implemented (from the signed-off audit, `nppd-1698-audit.md`):

- **D1** — "in this window" → "in this timeframe". The shared `MetricCard` zero-fallback helper (`No %s in this timeframe`) is the single lever that updates the Gates, Donors, and Subscribers currency cards at once; the two Gates section bodies are flipped directly.
- **D9** — mid-sentence "date range" (referring to the concept) → "timeframe"; "date range" kept only in imperative closers ("expanding the date range"). Advertising "off-season window" → "off-season period".
- **D7** — `No failed payments this timeframe.` → `No failed payments in this timeframe.`
- **D11** — generic fallbacks normalized: `Not measurable for your active prompts` gains a trailing period; the `Data unavailable` error fallback (all three `scalarToCard.ts`) → `Data temporarily unavailable.`
- **D12** — Conversion Journey (Tab 3): all 14 "in this window" → "in this timeframe". No other Tab 3 changes (its empty states wait for its real implementation).
- **D10** — the `#e6f1fb` light-blue hex tracker item is a confirmed no-op: it was already removed when Tab 3 migrated to Phase 2 (the `ConversionPreviewBanner` no longer renders), and there was never a Gates instance. No code change for that item.

Judgment calls worth a reviewer's eye:

1. **"14-day attribution window" is intentionally preserved** in the Gates no-conversions body. That "window" is the attribution *lookback* period, not the selected timeframe — the sibling `DirectVsInfluencedCallout`, `PromptsTab`, and Conversion tab all use "lookback window/period" for the same concept. Only the selected-timeframe "in this window" was flipped.
2. **`conversion/scalarToCard.ts`'s `Data unavailable`** was normalized along with the Gates/Prompts copies (D11 names `scalarToCard.ts`; it's an error fallback, not reader-visible, and not an empty-state string — so outside D12's "leave Tab 3's empty states" carve-out).
3. **One "in the window" left in `WhereConversionsComeFromSection.tsx`** — it's a section *description*, not an empty-state string and not in the audit inventory, so outside this PR's scope. Flagging as the last remaining "window" in Tab 3.
4. **Two generic-atom tests** (`LineChart.test`, `EmptyMetricSection.test`) keep "window" in their sample props — they pass an arbitrary message in and assert it renders, so they're decoupled from corpus copy.

Closes # .

### How to test the changes in this Pull Request:

1. Build the plugin (`n build newspack-plugin`) and open Insights.
2. **Gates → Paid reader conversion**, no attempts in range: empty state reads "No paywall attempts **in this timeframe**… or simply that the **timeframe** doesn't include enough traffic."
3. **Gates**, attempts but no conversions: reads "No paywall conversions **in this timeframe**… within the **14-day attribution window**" (the attribution-window term is unchanged).
4. **Donors / Subscribers** windowed section with a zero-revenue/zero-order window: currency cards' fallback reads "No … **in this timeframe**" (driven by the shared `MetricCard` helper); the whole-section empty closes with "Worth expanding the **date range**…".
5. **Subscribers**, zero failed-payment retries (good zero): reads "No failed payments **in this timeframe**."
6. **Advertising → Reach & revenue**, no impressions: reads "…no impressions for **this timeframe**… an **off-season period**… Try expanding the **date range**…".
7. **Prompts**, a not-capable metric with no per-card copy: generic fallback reads "Not measurable for your active prompts**.**"
8. **Conversion Journey (Tab 3)** empty funnels/curves/source pies: all read "…occur **in this timeframe**."
9. CI: `tsc`, ESLint, and the Jest suite (incl. the updated `MetricCard`, `PaidReaderConversionSection`, Donors/Subscribers `WindowedSection`, `prompts/scalarToCard`, and Conversion section tests) are green.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (Updated existing assertions to the new copy; no new behavior to test — see PR 2 for the new good-zero state.)
* [x] Have you successfully run tests with your changes locally? (tsc clean on changed files, ESLint clean, pure-logic `scalarToCard.test.ts` 11/11; `.tsx` component tests run in CI — local load is blocked by the known component-barrel resolution issue.)
