### PR TITLE
feat(insights): empty-state good-zero + voice reference (NPPD-1698)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/README.md
+++ b/plugins/newspack-plugin/includes/wizards/insights/README.md
@@ -190,6 +190,69 @@ Each tab is a lazy-loaded `.tsx` file that calls its data hook, hands the result
 
 The shell and these atoms intentionally lean on `newspack-components` (`Wizard`, `SectionHeader`, `Badge`, `Notice`, `Waiting`, imported from `packages/components/src`) and `@wordpress/components` (`Card`, `Notice`, `Button`) for design-system alignment.
 
+## Empty-state voice & tone (canonical reference)
+
+The standard every Insights tab's empty-state copy conforms to, established by the NPPD-1698 cross-tab audit. New per-tab surfaces follow it; where a tab's data shape genuinely differs, pick the closest pattern below rather than inventing a new one.
+
+### 1. Altitude — which empty primitive to use
+
+| Situation | Primitive |
+| --- | --- |
+| A *scorecard* section whose cards are one coherent story and would all read zero together | whole-section `EmptyMetricSection` (`no_opportunity` / `no_conversions` / `configuration_missing`) |
+| A single zero card inside an otherwise-populated scorecard section | per-card treatment (`zeroFallback`, or a `MetricCard` secondary line) |
+| A *collection* metric (table / funnel / chart) with no rows | `SectionEmpty` (the plain "no data" paragraph) |
+
+Gates' Paid reader conversion uses a whole-section `no_conversions` because its four cards are a single funnel — collapsing them is honest. The mixed-content `WindowedSection`s (Donors, Subscribers) and Advertising's Reach & revenue use *per-card* treatments for the same logical state, because a whole-section collapse there would hide real data in sibling cards. Both altitudes are correct for their data shape; don't force one onto the other.
+
+### 2. Vocabulary
+
+- **"timeframe"** is the term for the selected reporting period. Never "window" in reader-facing copy. ("window" stays fine for internal field/variable names, and for genuinely different concepts — e.g. the fixed *14-day attribution window* / *lookback window*, which is not the selected timeframe.)
+- **"date range"** is reserved for *imperative closers* that tell the publisher to act on the picker control ("Worth expanding the date range…"). It names the actual UI control, so the instruction is concrete. Don't use "date range" mid-sentence to refer to the period — use "timeframe".
+
+### 3. Sentence structure
+
+- **Whole-section bodies** follow a four-beat skeleton: *[what's zero] · [reassurance the feature is configured] · [plausible causes] · [closer]*. Three to four sentences.
+- **Per-card secondary lines** are a single terse, count-led clause: `{N} active donors, but none new this timeframe`. No second-person framing, no trailing period.
+- **Prompts `notCapable`** is two sentences (*[what's missing] · [what to add]*); **`notComputable`** is one. Both end with a period.
+
+### 4. `{N}` interpolation
+
+Lead with the count where it's a standing population (active donors / subscribers) or an in-window volume (impressions). Gates' mid-sentence "reached {N} readers" is the funnel-altitude exception. Always format the count through the shared `formatNumber`.
+
+### 5. Good-zero handling
+
+A "good zero" is a metric whose zero is the desired outcome. Rule, split by format:
+
+- **Rate-format good-zeros** get explicit positive/neutral copy via the em-dash treatment — e.g. Subscribers' *"No refund requests in this timeframe."* (orders but no refunds) and *"No failed payments in this timeframe."* (no retries to recover).
+- **Count-format good-zeros** rely on the native `lowerIsBetter` visual (the green down-delta) and render the real `0` with no editorial copy — e.g. Churned subscribers, Lapsed donors.
+
+A computable zero that is *not* good (e.g. a 0% recovery rate when retries did happen) renders as the real value, not a reframe.
+
+### 6. Action closers
+
+- **Diagnostic closers** use the "Worth [verb-ing] …" form ("Worth expanding the date range…").
+- **Navigational closers** ("See the per-gate breakdown below…") are used only when there's a real on-page destination, and may stand instead of a diagnostic closer.
+
+### 7. Em-dash vs value rendering
+
+- Render the **em-dash (`—`)** hero when the value carries no signal: no opportunity count (`zeroFallback` denominator 0), not capable, not computable, or a good-zero reframe.
+- Render the **real value** when the zero itself is the observation — the per-card `no_conversions` states (New donors `0`, Total Revenue `$0.00`) keep their real hero plus a secondary line.
+- Render a **text fallback** (`0 of 17`, `0 conversions`) when a zero needs companion context to read honestly.
+
+This is the existing convention — codified, not changed.
+
+### 8. Period-delta suppression
+
+Suppress the period-over-period delta on every empty/fallback hero (per-card `no_conversions`, all `zeroFallback`, `notCapable`/`notComputable`) — a "↓ 100%" against a real prior reads as a regression rather than "nothing here yet." Preserve the delta on real computed values, including `lowerIsBetter` good-zero count cards (the green delta *is* the signal).
+
+### 9. Punctuation & fallbacks
+
+Sentence-form empty-state copy ends with a period. Generic safety-net fallbacks share the per-intent voice ("Not measurable for your active prompts.", "Data temporarily unavailable.").
+
+### 10. Per-tab character is preserved, not flattened
+
+This reference standardizes *structure*, not personality. Subscribers' good-zero copy is intentionally warmer ("No failed payments in this timeframe.") than Advertising's terse data notes ("No ad revenue in this timeframe.") — both are right for their context. When a tab's voice and its data shape pull toward a warmer or terser register, follow the register; conform to the patterns above, not to a single flattened tone.
+
 ## Testing
 
 Jest, colocated `*.test.ts(x)` next to the source. Key spots:

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -67,7 +67,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 				caption={ CAPTION }
 				state="no_opportunity"
 				body={ __(
-					'No ad impressions in this timeframe. Your ad server is configured, but the report shows no impressions for this timeframe. Could be a placement question, an off-season period, or a configuration issue. Try expanding the date range or checking your ad unit setup.',
+					'No ad impressions in this timeframe. Your ad server is configured, but the report shows no impressions for this timeframe. Could be a placement question, an off-season period, or a configuration issue. Worth expanding the date range or checking your ad unit setup.',
 					'newspack-plugin'
 				) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -106,7 +106,9 @@ export interface MetricCardProps {
 	 * were viewed. Renders the same em-dash hero + secondary line as
 	 * `notCapableMessage`, but sits one slot lower in precedence: `notCapable`
 	 * wins (its "add the block" nudge is more actionable than "wait for data"),
-	 * and this in turn beats `zeroFallback`. Absent for every non-Prompts caller.
+	 * and this in turn beats `zeroFallback`. Originally a Prompts concept; also
+	 * used by Subscribers (NPPD-1698) to render its rate-card good-zeros (no orders
+	 * / no refunds / no failed payments) with the same em-dash + line treatment.
 	 */
 	notComputableMessage?: string;
 }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -106,6 +106,40 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		expect( screen.queryByText( 'No payment retries in this timeframe.' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'GOOD ZERO: orders but zero refunds renders em-dash + "No refund requests" (NPPD-1698 D4)', () => {
+		// Orders exist (gross > 0) but no refunds → refund rate is a computable 0%,
+		// a good zero. Renders the em-dash + positive line, not a literal "0%".
+		const current = makeWindow( { refund_rate: { value: 0, computable: true, denominator: 120 } } );
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'No refund requests in this timeframe.' ) ).toBeInTheDocument();
+		// Distinct from the no-orders message, and the hero is the em-dash, not "0%".
+		expect( screen.queryByText( 'No subscription orders in this timeframe.' ) ).not.toBeInTheDocument();
+		expect( cardValueByLabel( container, 'Refund rate' ) ).toBe( '—' );
+	} );
+
+	it( 'D5: Refund rate and Failed payment recovery good-zeros share the em-dash treatment', () => {
+		// Churn-only window (no orders → refund not computable; no retries → failed-
+		// payment good zero): both rate cards render the shared em-dash + line, not the
+		// old bespoke empty-note markup.
+		const current = makeWindow( {
+			new_subscribers: 0,
+			churned_subscribers: 4,
+			revenue_gross: 0,
+			revenue_net: 0,
+			refund_rate: { value: 0, computable: false, denominator: 0 },
+			failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 },
+		} );
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
+
+		expect( cardValueByLabel( container, 'Refund rate' ) ).toBe( '—' );
+		expect( cardValueByLabel( container, 'Failed payment recovery' ) ).toBe( '—' );
+		expect( screen.getByText( 'No failed payments in this timeframe.' ) ).toBeInTheDocument();
+		// The old bespoke empty-note element no longer renders for these cards.
+		expect( container.querySelectorAll( '.newspack-insights__metric-card--empty' ).length ).toBe( 0 );
+	} );
+
 	it( 'shows the currency count fallback when there were no subscription orders', () => {
 		// Churn-only window: activity is true (churn), but no completed orders →
 		// Gross and Net show "No subscription orders…" instead of $0.00.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -142,6 +142,25 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 	const noOrders = current.revenue_gross === 0;
 	const subscriptionOrdersLabel = __( 'subscription orders', 'newspack-plugin' );
 
+	// Rate-format good-zeros (NPPD-1698 D4 / D5): render the em-dash + a
+	// positive/neutral secondary line via MetricCard's shared em-dash treatment,
+	// not a bespoke note — so Refund rate and Failed payment recovery render
+	// identically to the other em-dashed cards.
+	//   · Refund rate: no orders → "No subscription orders…"; orders but zero
+	//     refunds (a good zero) → "No refund requests…"; otherwise the real rate.
+	//   · Failed payment recovery: no retries means no failed payments (a good
+	//     zero) → "No failed payments…". A computable 0% (retries ran, none
+	//     recovered) is a real bad zero and renders as 0%.
+	let refundEmptyMessage: string | undefined;
+	if ( ! refund.computable ) {
+		refundEmptyMessage = __( 'No subscription orders in this timeframe.', 'newspack-plugin' );
+	} else if ( refund.value === 0 ) {
+		refundEmptyMessage = __( 'No refund requests in this timeframe.', 'newspack-plugin' );
+	}
+	const retryEmptyMessage = ! retry.computable ? __( 'No failed payments in this timeframe.', 'newspack-plugin' ) : undefined;
+	const refundPrevious = previous?.refund_rate?.computable ? previous.refund_rate.value : null;
+	const retryPrevious = previous?.failed_payment_retry_rate?.computable ? previous.failed_payment_retry_rate.value : null;
+
 	return (
 		<section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
 			<SectionHeading id="newspack-insights-windowed-heading" title={ getHeading( range ) } />
@@ -188,43 +207,25 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					zeroFallback={ noOrders ? { denominator: 0, currencyRole: 'total', attemptsLabel: subscriptionOrdersLabel } : undefined }
 					description={ __( 'Gross minus refunds processed', 'newspack-plugin' ) }
 				/>
-				{ refund.computable ? (
-					<MetricCard
-						label={ __( 'Refund rate', 'newspack-plugin' ) }
-						value={ refund.value }
-						format="percent"
-						previousValue={ previous?.refund_rate?.computable ? previous.refund_rate.value : null }
-						lowerIsBetter
-						secondary={ ordersCohortSubtitle( refund.denominator ) }
-						description={ __( 'Refunds ÷ subscription orders', 'newspack-plugin' ) }
-					/>
-				) : (
-					<div className="newspack-insights__metric-card newspack-insights__metric-card--empty">
-						<div className="newspack-insights__metric-card-label">{ __( 'Refund rate', 'newspack-plugin' ) }</div>
-						<p className="newspack-insights__metric-card-empty-note">
-							{ __( 'No subscription orders in this timeframe.', 'newspack-plugin' ) }
-						</p>
-					</div>
-				) }
-				{ retry.computable ? (
-					<MetricCard
-						label={ __( 'Failed payment recovery', 'newspack-plugin' ) }
-						value={ retry.value }
-						format="percent"
-						previousValue={ previous?.failed_payment_retry_rate?.computable ? previous.failed_payment_retry_rate.value : null }
-						secondary={ retriesCohortSubtitle( retry.denominator ) }
-						description={ __( 'Recovered retries ÷ retry attempts', 'newspack-plugin' ) }
-					/>
-				) : (
-					<div className="newspack-insights__metric-card newspack-insights__metric-card--empty">
-						<div className="newspack-insights__metric-card-label">{ __( 'Failed payment recovery', 'newspack-plugin' ) }</div>
-						<p className="newspack-insights__metric-card-empty-note">
-							{ /* Good zero (NPPD-1726): no retries means no failed payments — frame it
-							     as the positive outcome, not a missing-data note. */ }
-							{ __( 'No failed payments in this timeframe.', 'newspack-plugin' ) }
-						</p>
-					</div>
-				) }
+				<MetricCard
+					label={ __( 'Refund rate', 'newspack-plugin' ) }
+					value={ refund.computable ? refund.value : 0 }
+					format="percent"
+					previousValue={ refundEmptyMessage ? undefined : refundPrevious }
+					lowerIsBetter
+					secondary={ refundEmptyMessage ? undefined : ordersCohortSubtitle( refund.denominator ) }
+					notComputableMessage={ refundEmptyMessage }
+					description={ __( 'Refunds ÷ subscription orders', 'newspack-plugin' ) }
+				/>
+				<MetricCard
+					label={ __( 'Failed payment recovery', 'newspack-plugin' ) }
+					value={ retry.computable ? retry.value : 0 }
+					format="percent"
+					previousValue={ retryEmptyMessage ? undefined : retryPrevious }
+					secondary={ retryEmptyMessage ? undefined : retriesCohortSubtitle( retry.denominator ) }
+					notComputableMessage={ retryEmptyMessage }
+					description={ __( 'Recovered retries ÷ retry attempts', 'newspack-plugin' ) }
+				/>
 			</div>
 		</section>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**PR 2 of 2 for [NPPD-1698](https://linear.app/a8c/issue/NPPD-1698)** (empty-state voice & tone) — the editorial/structural pass + the canonical reference doc.

Decisions implemented (from the signed-off audit / decision report):

- **D4(C) — good-zero strategy, split by format.** Rate-format good-zeros get explicit copy; count-format good-zeros keep the native `lowerIsBetter` visual. The one new state: Subscribers' **Refund rate** now renders a good-zero when orders exist but there were zero refunds — em-dash + *"No refund requests in this timeframe."* — distinct from the existing no-orders case (*"No subscription orders in this timeframe."*). Churned subscribers / Lapsed donors (count good-zeros) are unchanged.
- **D5 — Subscribers Windowed bespoke cards aligned.** Refund rate and Failed payment recovery previously used a bespoke `metric-card--empty` note; they now render through `MetricCard`'s shared em-dash + secondary-line treatment, so they match every other em-dashed card. This is the only structural change in the PR. No other bespoke section is migrated (Donors Retention/Performance, Subscribers Tenure/Performance, Advertising Top performers / Revenue mix / Inventory all stay as-is per the audit).
- **D6 — action closers.** Advertising's `no_opportunity` closer changes "Try expanding…" → "Worth expanding…", standardizing the diagnostic closers on the "Worth …" form. Gates' navigational closer ("See the per-gate breakdown…") is intentionally left.
- **Canonical reference** added to the Insights README (`includes/wizards/insights/README.md`) — a 10-point "Empty-state voice & tone" section codifying altitude, vocabulary, structure, `{N}`, good-zero, closers, em-dash-vs-value (D8), delta suppression, punctuation, and an explicit note that per-tab character is preserved, not flattened.

Deliberate no-ops (documented for the record, no code change):

- **D2 — `no_conversions` copy stays terse.** The per-card secondaries shipped terse; the parallel form referenced in the NPPD-1695/1696 PR descriptions never matched the code. The canonical reference codifies the terse form.
- **D3 — Gates `no_conversions` stays whole-section.** Its four cards are one funnel; the mixed-content WindowedSections legitimately use per-card. Different altitudes for different data shapes, codified in the reference.

No behavior change beyond the new Refund-rate good-zero state and the Subscribers rate-card rendering alignment.

Closes # .

### How to test the changes in this Pull Request:

1. Build the plugin and open Insights → **Subscribers**.
2. **Refund rate good-zero (new):** a window with completed orders but zero refunds → the Refund rate card shows the em-dash (`—`) + *"No refund requests in this timeframe."*, not "0%".
3. **Refund rate, no orders:** a window with no subscription orders → em-dash + *"No subscription orders in this timeframe."* (unchanged copy, now rendered via the shared em-dash treatment, not the old bespoke note).
4. **Failed payment recovery good-zero:** a window with no payment retries → em-dash + *"No failed payments in this timeframe."* Confirm it renders the same em-dash treatment as Refund rate (D5 alignment).
5. **Failed payment recovery, real bad zero:** retries happened but none recovered (computable 0%) → renders the real **0%**, not a positive reframe.
6. **Advertising → Reach & revenue**, no impressions: the closer now reads *"Worth expanding the date range…"* (was "Try expanding…").
7. **Count good-zeros unchanged:** Churned subscribers / Lapsed donors still render their real `0` with the green `lowerIsBetter` delta — no copy reframe.
8. Read the new **"Empty-state voice & tone (canonical reference)"** section in the Insights README and confirm it matches shipped behavior.
9. CI: `tsc`, ESLint, and the Jest suite green, including the new Subscribers `WindowedSection` cases (refund good-zero; Refund rate + Failed payment recovery share the em-dash treatment).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (Two new Subscribers `WindowedSection` cases for D4(C)/D5.)
* [x] Have you successfully run tests with your changes locally? (tsc clean on changed files, ESLint clean; `.tsx` component tests run in CI — local load is blocked by the known component-barrel resolution issue.)
