### PR TITLE
feat: expand theme.json builder to full newsletter theme

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
@@ -81,21 +81,28 @@ class Theme_Json_Builder {
 		$header_font = self::resolve_font( (string) \get_post_meta( $post->ID, 'font_header', true ), self::DEFAULT_HEADER_FONT );
 		$body_font   = self::resolve_font( (string) \get_post_meta( $post->ID, 'font_body', true ), self::DEFAULT_BODY_FONT );
 
+		$settings = [
+			'spacing'    => [
+				'spacingSizes' => self::build_presets( self::SPACING_SIZES ),
+			],
+			'typography' => [
+				// Disable fluid typography so font sizes resolve to fixed pixels in email.
+				'fluid'     => false,
+				'fontSizes' => self::build_presets( self::FONT_SIZES ),
+			],
+		];
+
+		// Only emit the palette when the newsletter configures one. WP_Theme_JSON::merge()
+		// replaces preset arrays per origin, so an empty palette would wipe the editor's
+		// default color presets rather than leave them intact.
+		$palette = self::build_palette();
+		if ( ! empty( $palette ) ) {
+			$settings['color'] = [ 'palette' => $palette ];
+		}
+
 		return [
 			'version'  => 3,
-			'settings' => [
-				'color'      => [
-					'palette' => self::build_palette(),
-				],
-				'spacing'    => [
-					'spacingSizes' => self::build_presets( self::SPACING_SIZES ),
-				],
-				'typography' => [
-					// Disable fluid typography so font sizes resolve to fixed pixels in email.
-					'fluid'     => false,
-					'fontSizes' => self::build_presets( self::FONT_SIZES ),
-				],
-			],
+			'settings' => $settings,
 			'styles'   => [
 				'color'      => [
 					'background' => $background ? $background : '#ffffff',
@@ -141,14 +148,16 @@ class Theme_Json_Builder {
 			return $palette;
 		}
 		foreach ( $option as $slug => $hex ) {
+			// Slugs become CSS custom-property/classname fragments, so sanitize them.
+			$slug  = \sanitize_key( (string) $slug );
 			$color = \sanitize_hex_color( (string) $hex );
-			if ( ! $color ) {
+			if ( '' === $slug || ! $color ) {
 				continue;
 			}
 			$palette[] = [
-				'slug'  => (string) $slug,
+				'slug'  => $slug,
 				'color' => $color,
-				'name'  => (string) $slug,
+				'name'  => $slug,
 			];
 		}
 		return $palette;

--- a/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
@@ -15,6 +15,60 @@ defined( 'ABSPATH' ) || exit;
  */
 class Theme_Json_Builder {
 	/**
+	 * Newspack newsletter font-size scale (slug => CSS size). Mirrors
+	 * Newspack_Newsletters_Renderer::get_font_size() so presets resolve to the
+	 * same pixel values the newsletter editor has always used.
+	 *
+	 * @var array
+	 */
+	const FONT_SIZES = [
+		'xx-small'     => '8px',
+		'x-small'      => '10px',
+		'small'        => '12px',
+		'normal'       => '16px',
+		'medium'       => '16px',
+		'large'        => '24px',
+		'huge'         => '36px',
+		'x-large'      => '36px',
+		'xx-large'     => '40px',
+		'xxx-large'    => '48px',
+		'xxxx-large'   => '56px',
+		'xxxxx-large'  => '64px',
+		'xxxxxx-large' => '72px',
+	];
+
+	/**
+	 * Newspack newsletter spacing scale (slug => CSS size). Mirrors the presets
+	 * in Newspack_Newsletters_Renderer::get_spacing_value() so
+	 * `var:preset|spacing|*` references resolve.
+	 *
+	 * @var array
+	 */
+	const SPACING_SIZES = [
+		'20' => '8px',
+		'30' => '16px',
+		'40' => '24px',
+		'50' => '32px',
+		'60' => '32px',
+		'70' => '48px',
+		'80' => '64px',
+	];
+
+	/**
+	 * Default heading font stack when meta is absent/unsupported.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_HEADER_FONT = 'Arial, Helvetica, sans-serif';
+
+	/**
+	 * Default body font stack when meta is absent/unsupported.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_BODY_FONT = 'Georgia, serif';
+
+	/**
 	 * Build a theme.json-shaped array for a newsletter.
 	 *
 	 * @param \WP_Post $post Newsletter post.
@@ -24,14 +78,97 @@ class Theme_Json_Builder {
 		$background = \sanitize_hex_color( (string) \get_post_meta( $post->ID, 'background_color', true ) );
 		$text       = \sanitize_hex_color( (string) \get_post_meta( $post->ID, 'text_color', true ) );
 
+		$header_font = self::resolve_font( (string) \get_post_meta( $post->ID, 'font_header', true ), self::DEFAULT_HEADER_FONT );
+		$body_font   = self::resolve_font( (string) \get_post_meta( $post->ID, 'font_body', true ), self::DEFAULT_BODY_FONT );
+
 		return [
-			'version' => 3,
-			'styles'  => [
-				'color' => [
+			'version'  => 3,
+			'settings' => [
+				'color'      => [
+					'palette' => self::build_palette(),
+				],
+				'spacing'    => [
+					'spacingSizes' => self::build_presets( self::SPACING_SIZES ),
+				],
+				'typography' => [
+					// Disable fluid typography so font sizes resolve to fixed pixels in email.
+					'fluid'     => false,
+					'fontSizes' => self::build_presets( self::FONT_SIZES ),
+				],
+			],
+			'styles'   => [
+				'color'      => [
 					'background' => $background ? $background : '#ffffff',
 					'text'       => $text ? $text : '#000000',
 				],
+				'typography' => [
+					'fontFamily' => $body_font,
+				],
+				'elements'   => [
+					'heading' => [
+						'typography' => [
+							'fontFamily' => $header_font,
+						],
+					],
+				],
 			],
 		];
+	}
+
+	/**
+	 * Resolve a font meta value to a supported font stack, or a default.
+	 *
+	 * @param string $font    Stored font meta value.
+	 * @param string $fallback Default stack when the value is empty/unsupported.
+	 * @return string
+	 */
+	private static function resolve_font( string $font, string $fallback ): string {
+		if ( $font && \in_array( $font, \Newspack_Newsletters::$supported_fonts, true ) ) {
+			return $font;
+		}
+		return $fallback;
+	}
+
+	/**
+	 * Build the theme color palette from the newsletter color-palette option.
+	 *
+	 * @return array Theme.json color palette entries.
+	 */
+	private static function build_palette(): array {
+		$option  = \json_decode( (string) \get_option( \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE_META, '{}' ), true );
+		$palette = [];
+		if ( ! \is_array( $option ) ) {
+			return $palette;
+		}
+		foreach ( $option as $slug => $hex ) {
+			$color = \sanitize_hex_color( (string) $hex );
+			if ( ! $color ) {
+				continue;
+			}
+			$palette[] = [
+				'slug'  => (string) $slug,
+				'color' => $color,
+				'name'  => (string) $slug,
+			];
+		}
+		return $palette;
+	}
+
+	/**
+	 * Convert a slug => size map into theme.json preset entries.
+	 *
+	 * @param array $map Slug => CSS size.
+	 * @return array Theme.json preset entries ({ slug, size, name }).
+	 */
+	private static function build_presets( array $map ): array {
+		$presets = [];
+		foreach ( $map as $slug => $size ) {
+			$presets[] = [
+				'slug' => (string) $slug,
+				'size' => $size,
+				'name' => (string) $slug,
+			];
+		}
+		return $presets;
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
@@ -52,6 +52,47 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Remove options mutated by tests so they never leak between cases.
+	 */
+	public function tear_down() {
+		delete_option( 'newspack_newsletters_color_palette' );
+		parent::tear_down();
+	}
+
+	/**
+	 * With no palette configured, the palette key is omitted so the merge does
+	 * not wipe the editor's default color presets.
+	 */
+	public function test_omits_palette_when_option_unconfigured() {
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertArrayNotHasKey( 'color', $theme['settings'] );
+	}
+
+	/**
+	 * Palette entries with invalid hex values are skipped.
+	 */
+	public function test_palette_skips_invalid_hex_entries() {
+		update_option(
+			'newspack_newsletters_color_palette',
+			wp_json_encode(
+				[
+					'good' => '#112233',
+					'bad'  => 'not-a-hex',
+				]
+			)
+		);
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertNotNull( $this->find_preset( $theme['settings']['color']['palette'], 'good' ) );
+		$this->assertNull( $this->find_preset( $theme['settings']['color']['palette'], 'bad' ) );
+	}
+
+	/**
 	 * Find a preset entry by its slug.
 	 *
 	 * @param array  $presets Theme.json preset array (palette/fontSizes/spacingSizes).
@@ -85,8 +126,8 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
 
 		$primary = $this->find_preset( $theme['settings']['color']['palette'], 'primary' );
+		$this->assertNotNull( $primary );
 		$this->assertSame( '#003da5', $primary['color'] );
-		delete_option( 'newspack_newsletters_color_palette' );
 	}
 
 	/**
@@ -98,6 +139,7 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
 
 		$small = $this->find_preset( $theme['settings']['typography']['fontSizes'], 'small' );
+		$this->assertNotNull( $small );
 		$this->assertSame( '12px', $small['size'] );
 	}
 
@@ -110,6 +152,7 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
 
 		$fifty = $this->find_preset( $theme['settings']['spacing']['spacingSizes'], '50' );
+		$this->assertNotNull( $fifty );
 		$this->assertSame( '32px', $fifty['size'] );
 	}
 

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
@@ -50,4 +50,105 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 		$this->assertSame( '#ffffff', $theme['styles']['color']['background'] );
 		$this->assertSame( '#000000', $theme['styles']['color']['text'] );
 	}
+
+	/**
+	 * Find a preset entry by its slug.
+	 *
+	 * @param array  $presets Theme.json preset array (palette/fontSizes/spacingSizes).
+	 * @param string $slug    Slug to find.
+	 * @return array|null
+	 */
+	private function find_preset( $presets, $slug ) {
+		foreach ( (array) $presets as $preset ) {
+			if ( isset( $preset['slug'] ) && $slug === $preset['slug'] ) {
+				return $preset;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The newsletter color palette option is injected as the theme color palette.
+	 */
+	public function test_injects_color_palette_from_option() {
+		update_option(
+			'newspack_newsletters_color_palette',
+			wp_json_encode(
+				[
+					'primary'   => '#003da5',
+					'secondary' => '#112233',
+				]
+			)
+		);
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$primary = $this->find_preset( $theme['settings']['color']['palette'], 'primary' );
+		$this->assertSame( '#003da5', $primary['color'] );
+		delete_option( 'newspack_newsletters_color_palette' );
+	}
+
+	/**
+	 * The Newspack font-size scale is injected (e.g. small resolves to 12px).
+	 */
+	public function test_injects_newspack_font_size_scale() {
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$small = $this->find_preset( $theme['settings']['typography']['fontSizes'], 'small' );
+		$this->assertSame( '12px', $small['size'] );
+	}
+
+	/**
+	 * The Newspack spacing scale is injected (e.g. preset 50 resolves to 32px).
+	 */
+	public function test_injects_newspack_spacing_scale() {
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$fifty = $this->find_preset( $theme['settings']['spacing']['spacingSizes'], '50' );
+		$this->assertSame( '32px', $fifty['size'] );
+	}
+
+	/**
+	 * Fluid typography is disabled so font sizes resolve to fixed pixel values.
+	 */
+	public function test_disables_fluid_typography() {
+		$post_id = self::factory()->post->create();
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertFalse( $theme['settings']['typography']['fluid'] );
+	}
+
+	/**
+	 * Supported font_header/font_body meta map to heading and body font families.
+	 */
+	public function test_maps_fonts_from_meta() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'font_header', 'Georgia, serif' );
+		update_post_meta( $post_id, 'font_body', 'Verdana, sans-serif' );
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertSame( 'Verdana, sans-serif', $theme['styles']['typography']['fontFamily'] );
+		$this->assertSame( 'Georgia, serif', $theme['styles']['elements']['heading']['typography']['fontFamily'] );
+	}
+
+	/**
+	 * Unsupported or empty font meta falls back to the default font stacks.
+	 */
+	public function test_font_meta_falls_back_to_defaults_when_unsupported() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'font_header', 'Comic Sans' );
+		update_post_meta( $post_id, 'font_body', '' );
+
+		$theme = Theme_Json_Builder::build( get_post( $post_id ) );
+
+		$this->assertSame( 'Arial, Helvetica, sans-serif', $theme['styles']['elements']['heading']['typography']['fontFamily'] );
+		$this->assertSame( 'Georgia, serif', $theme['styles']['typography']['fontFamily'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Expands `Theme_Json_Builder::build()` into a full translation of the newsletter theme**, so the WooCommerce email-editor renderer resolves color, fonts, font sizes, and spacing the way each newsletter is configured — instead of falling back to the email-editor package / WP-core defaults (Inter font, WP-core palette + type scale).

This is the highest-leverage item in the block-fidelity work (NEWS-1904): one change resolves the theme-rooted impedance findings across many blocks at once, so a chunk of the per-block sub-issues collapse to "verify."

What changed (`includes/email-renderers/class-theme-json-builder.php`):

- **`settings.color.palette`** ← the `newspack_newsletters_color_palette` option (slug→hex), sanitized. Newspack palette slugs (`primary`, etc.) now resolve. *(NEWS-1901 finding C1)*
- **`settings.typography.fontSizes`** ← the Newspack font-size scale (xx-small 8px … small 12px … huge 36px), mirroring `Newspack_Newsletters_Renderer::get_font_size()`. *(T3)*
- **`settings.spacing.spacingSizes`** ← the Newspack spacing scale (20→8px … 80→64px), so `var:preset|spacing|*` references resolve. *(S1)*
- **`styles.typography.fontFamily`** (body) + **`styles.elements.heading.typography.fontFamily`** ← `font_body`/`font_header` meta, validated against `Newspack_Newsletters::$supported_fonts`, defaulting to `Georgia, serif` / `Arial, Helvetica, sans-serif`. *(T1)*
- **`settings.typography.fluid = false`** — disable fluid typography so sizes resolve to fixed pixels in email.

Notes:

- The bg/text color mapping (the original minimal builder) is unchanged.
- `settings.typography.fontFamilies` is intentionally **not** injected — newsletters apply fonts globally via `styles`, not per-block font-family slugs, so registering selectable families isn't needed for rendering.
- Reference model: these values mirror the **newsletter's own theme** (publisher palette/fonts + Newspack's type/spacing scale), which is the correct target — distinct from per-block *rendering*, where the target is vanilla WP (NEWS-1901).

Part of NEWS-2539.

### How to test the changes in this Pull Request:

1. With the WC renderer flag on, open a newsletter whose `font_header`/`font_body` are set (e.g. Georgia / Verdana) and that uses font-size presets, spacing presets, and palette colors.
2. Render it through the WC pipeline (editor preview or `Renderer_Controller::render_wc()`):
   - Body text uses the configured **body font**, headings the **heading font** (no longer Inter).
   - `small` font-size resolves to **12px** (Newspack scale), not 13px.
   - A Newspack palette slug (e.g. `primary`) resolves to its configured hex.
   - `var:preset|spacing|50` resolves to 32px padding.
3. **PHPUnit:** `n test-php --filter Test_Theme_Json_Builder` (9 tests). Full suite stays green (456 tests).

### Other information:

* [x] Have you written new tests for your changes, as applicable? — 6 new builder tests (palette, font-size scale, spacing scale, fluid-off, font mapping, font fallback).
* [x] Have you successfully run tests with your changes locally? — builder suite + full plugin suite green; verified end-to-end in an env (fonts, sizes, palette all flow through the `WP_Theme_JSON` merge).

---

## For AI / reviewers (detail)

- **Merge path:** the Task 6 theme filter does `$theme->merge( new WP_Theme_JSON( Theme_Json_Builder::build( $post ), 'default' ) )` via `woocommerce_email_editor_theme_json`. Verified in an env that the injected `settings` (palette/fontSizes) and `styles` (fontFamily) actually flow through to the rendered HTML — not just present in the `build()` array.
- **Scales are duplicated, not referenced:** `FONT_SIZES`/`SPACING_SIZES` constants mirror the legacy renderer's private `get_font_size()`/`get_spacing_value()` rather than coupling the `Email_Renderers` namespace to the legacy renderer. Documented in the constants' docblocks; a future refactor could hoist a shared source.
- **Out of scope:** a stray `Inter` remaining in some renders comes from a specific block's inline default (likely the WC button renderer), not the theme — tracked in the per-block issues.
