### PR TITLE
fix(insights): point Audience/Engagement empty state to Site Kit

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -360,7 +360,31 @@ class Insights_Wizard extends Wizard {
 			],
 			'defaultComparison' => false,
 			'timezone'          => wp_timezone_string(),
-			'settingsUrl'       => admin_url( 'admin.php?page=newspack-settings' ),
+			'siteKitUrl'        => self::get_site_kit_url(),
 		];
+	}
+
+	/**
+	 * Admin URL for connecting Google Analytics through Site Kit, used by the
+	 * Audience and Engagement connect banner when GA4 isn't connected
+	 * (NPPD-1731). GA4 is owned upstream by Site Kit, so the banner points
+	 * there rather than at Newspack → Connections.
+	 *
+	 * Precedence mirrors Newspack Settings and the Dashboard:
+	 *  - Site Kit set up with the Analytics module → deep link to the GA4 service.
+	 *  - Site Kit active but Analytics not yet connected → Site Kit's setup splash.
+	 *  - Site Kit not installed at all → Newspack → Connections, where it gets
+	 *    installed (the splash URL would 404 without the plugin present).
+	 *
+	 * @return string
+	 */
+	private static function get_site_kit_url(): string {
+		if ( google_site_kit_available() ) {
+			return admin_url( 'admin.php?page=googlesitekit-settings#/connected-services/analytics-4' );
+		}
+		if ( GoogleSiteKit::is_active() ) {
+			return admin_url( 'admin.php?page=googlesitekit-splash' );
+		}
+		return admin_url( 'admin.php?page=newspack-settings' );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -93,7 +93,7 @@ final class Audience_Metric {
 		}
 		return [
 			'tab_error'   => 'oauth_not_connected',
-			'banner_text' => __( 'Connect Google Analytics in Newspack → Connections to see this tab.', 'newspack-plugin' ),
+			'banner_text' => __( 'Audience metrics come from a GA4 property connected through Site Kit. Set up Site Kit to start seeing data here.', 'newspack-plugin' ),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -96,7 +96,7 @@ final class Engagement_Metric {
 		}
 		return [
 			'tab_error'   => 'oauth_not_connected',
-			'banner_text' => __( 'Connect Google Analytics in Newspack → Connections to see this tab.', 'newspack-plugin' ),
+			'banner_text' => __( 'Engagement metrics come from a GA4 property connected through Site Kit. Set up Site Kit to start seeing data here.', 'newspack-plugin' ),
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -58,7 +58,7 @@ export interface InsightsBootConfig {
 	defaultDateRange: DateRange;
 	defaultComparison: boolean;
 	timezone: string;
-	settingsUrl: string;
+	siteKitUrl: string;
 }
 
 export interface InsightsWizardProps {

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -44,7 +44,7 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 	} )(),
 	defaultComparison: false,
 	timezone: 'UTC',
-	settingsUrl: '',
+	siteKitUrl: '',
 	lastUpdated: null,
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.test.tsx
@@ -33,14 +33,9 @@ describe( 'ConnectBanner', () => {
 			<ConnectBanner text="Audience metrics come from a GA4 property connected through Site Kit. Set up Site Kit to start seeing data here." />
 		);
 
-		expect(
-			screen.getByText( /Audience metrics come from a GA4 property connected through Site Kit/ )
-		).toBeInTheDocument();
+		expect( screen.getByText( /Audience metrics come from a GA4 property connected through Site Kit/ ) ).toBeInTheDocument();
 		const cta = screen.getByRole( 'link', { name: 'Set up Site Kit →' } );
-		expect( cta ).toHaveAttribute(
-			'href',
-			'https://example.test/wp-admin/admin.php?page=googlesitekit-splash'
-		);
+		expect( cta ).toHaveAttribute( 'href', 'https://example.test/wp-admin/admin.php?page=googlesitekit-splash' );
 	} );
 
 	it( 'falls back to default Site Kit copy and a relative admin path when the global is absent', () => {
@@ -49,12 +44,7 @@ describe( 'ConnectBanner', () => {
 
 		render( <ConnectBanner /> );
 
-		expect(
-			screen.getByText( 'Connect Google Analytics through Site Kit to see this tab.' )
-		).toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: 'Set up Site Kit →' } ) ).toHaveAttribute(
-			'href',
-			'admin.php?page=newspack-settings'
-		);
+		expect( screen.getByText( 'Connect Google Analytics through Site Kit to see this tab.' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Set up Site Kit →' } ) ).toHaveAttribute( 'href', 'admin.php?page=newspack-settings' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for ConnectBanner (NPPD-1649, NPPD-1731): the full-tab "connect
+ * Google Analytics" state shown on Audience and Engagement when GA4 isn't
+ * connected. Verifies the Site Kit copy and that the CTA links to the Site
+ * Kit URL from the boot config, falling back to a relative admin path when
+ * the global is absent.
+ *
+ * SITE_KIT_URL is read at module-eval time, so each case resets modules and
+ * sets window.newspackInsights before requiring the component.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+const importBanner = () => require( './ConnectBanner' ).default;
+
+describe( 'ConnectBanner', () => {
+	afterEach( () => {
+		delete ( window as { newspackInsights?: unknown } ).newspackInsights;
+		jest.resetModules();
+	} );
+
+	it( 'renders the provided banner text and links the CTA to the Site Kit URL', () => {
+		jest.resetModules();
+		( window as { newspackInsights?: unknown } ).newspackInsights = {
+			siteKitUrl: 'https://example.test/wp-admin/admin.php?page=googlesitekit-splash',
+		};
+		const ConnectBanner = importBanner();
+
+		render(
+			<ConnectBanner text="Audience metrics come from a GA4 property connected through Site Kit. Set up Site Kit to start seeing data here." />
+		);
+
+		expect(
+			screen.getByText( /Audience metrics come from a GA4 property connected through Site Kit/ )
+		).toBeInTheDocument();
+		const cta = screen.getByRole( 'link', { name: 'Set up Site Kit →' } );
+		expect( cta ).toHaveAttribute(
+			'href',
+			'https://example.test/wp-admin/admin.php?page=googlesitekit-splash'
+		);
+	} );
+
+	it( 'falls back to default Site Kit copy and a relative admin path when the global is absent', () => {
+		jest.resetModules();
+		const ConnectBanner = importBanner();
+
+		render( <ConnectBanner /> );
+
+		expect(
+			screen.getByText( 'Connect Google Analytics through Site Kit to see this tab.' )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Set up Site Kit →' } ) ).toHaveAttribute(
+			'href',
+			'admin.php?page=newspack-settings'
+		);
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.test.tsx
@@ -5,8 +5,8 @@
  * Kit URL from the boot config, falling back to a relative admin path when
  * the global is absent.
  *
- * SITE_KIT_URL is read at module-eval time, so each case resets modules and
- * sets window.newspackInsights before requiring the component.
+ * siteKitUrl is read at render time, so each case sets window.newspackInsights
+ * before rendering — no module reload needed.
  */
 
 /**
@@ -14,34 +14,33 @@
  */
 import { render, screen } from '@testing-library/react';
 
-const importBanner = () => require( './ConnectBanner' ).default;
+/**
+ * Internal dependencies
+ */
+import ConnectBanner from './ConnectBanner';
 
 describe( 'ConnectBanner', () => {
 	afterEach( () => {
 		delete ( window as { newspackInsights?: unknown } ).newspackInsights;
-		jest.resetModules();
 	} );
 
 	it( 'renders the provided banner text and links the CTA to the Site Kit URL', () => {
-		jest.resetModules();
 		( window as { newspackInsights?: unknown } ).newspackInsights = {
 			siteKitUrl: 'https://example.test/wp-admin/admin.php?page=googlesitekit-splash',
 		};
-		const ConnectBanner = importBanner();
 
 		render(
 			<ConnectBanner text="Audience metrics come from a GA4 property connected through Site Kit. Set up Site Kit to start seeing data here." />
 		);
 
 		expect( screen.getByText( /Audience metrics come from a GA4 property connected through Site Kit/ ) ).toBeInTheDocument();
-		const cta = screen.getByRole( 'link', { name: 'Set up Site Kit →' } );
-		expect( cta ).toHaveAttribute( 'href', 'https://example.test/wp-admin/admin.php?page=googlesitekit-splash' );
+		expect( screen.getByRole( 'link', { name: 'Set up Site Kit →' } ) ).toHaveAttribute(
+			'href',
+			'https://example.test/wp-admin/admin.php?page=googlesitekit-splash'
+		);
 	} );
 
 	it( 'falls back to default Site Kit copy and a relative admin path when the global is absent', () => {
-		jest.resetModules();
-		const ConnectBanner = importBanner();
-
 		render( <ConnectBanner /> );
 
 		expect( screen.getByText( 'Connect Google Analytics through Site Kit to see this tab.' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.tsx
@@ -1,10 +1,11 @@
 /**
- * ConnectBanner (NPPD-1649).
+ * ConnectBanner (NPPD-1649, NPPD-1731).
  *
  * Full-tab state shown when the orchestrator returns
  * `{ tab_error: 'oauth_not_connected', banner_text }` — i.e. the publisher
  * has no Google Analytics connection. Replaces all section content with a
- * single connect CTA. Used by both AudienceTab and EngagementTab.
+ * single CTA directing them to Site Kit, where GA4 is connected. Used by
+ * both AudienceTab and EngagementTab.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.tsx
@@ -17,29 +17,31 @@ import { __ } from '@wordpress/i18n';
  */
 import { Notice, Button } from '../../../../../packages/components/src';
 
-// Localized, subdirectory-safe URL to Site Kit's GA4 connection — or, when
-// Site Kit isn't installed, the Newspack → Connections page where it gets
-// installed (NPPD-1731). Built with admin_url() in the PHP boot config; falls
-// back to a relative admin path if the global isn't present.
-const SITE_KIT_URL = window.newspackInsights?.siteKitUrl || 'admin.php?page=newspack-settings';
-
 export interface ConnectBannerProps {
 	text?: string;
 }
 
-const ConnectBanner = ( { text }: ConnectBannerProps ) => (
-	<Notice
-		isWarning
-		className="newspack-insights__connect-banner"
-		noticeText={
-			<>
-				{ text || __( 'Connect Google Analytics through Site Kit to see this tab.', 'newspack-plugin' ) }{ ' ' }
-				<Button variant="link" href={ SITE_KIT_URL }>
-					{ __( 'Set up Site Kit →', 'newspack-plugin' ) }
-				</Button>
-			</>
-		}
-	/>
-);
+const ConnectBanner = ( { text }: ConnectBannerProps ) => {
+	// Localized, subdirectory-safe URL to Site Kit's GA4 connection — or, when
+	// Site Kit isn't installed, the Newspack → Connections page where it gets
+	// installed (NPPD-1731). Built with admin_url() in the PHP boot config; read
+	// at render time, with a relative-path fallback if the global isn't present.
+	const siteKitUrl = window.newspackInsights?.siteKitUrl || 'admin.php?page=newspack-settings';
+
+	return (
+		<Notice
+			isWarning
+			className="newspack-insights__connect-banner"
+			noticeText={
+				<>
+					{ text || __( 'Connect Google Analytics through Site Kit to see this tab.', 'newspack-plugin' ) }{ ' ' }
+					<Button variant="link" href={ siteKitUrl }>
+						{ __( 'Set up Site Kit →', 'newspack-plugin' ) }
+					</Button>
+				</>
+			}
+		/>
+	);
+};
 
 export default ConnectBanner;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ConnectBanner.tsx
@@ -17,10 +17,11 @@ import { __ } from '@wordpress/i18n';
  */
 import { Notice, Button } from '../../../../../packages/components/src';
 
-// Localized, subdirectory-safe URL to the Newspack settings page (where the
-// Google connection lives), built with admin_url() in the PHP boot config.
-// Falls back to a relative admin path if the global isn't present.
-const SETTINGS_URL = window.newspackInsights?.settingsUrl || 'admin.php?page=newspack-settings';
+// Localized, subdirectory-safe URL to Site Kit's GA4 connection — or, when
+// Site Kit isn't installed, the Newspack → Connections page where it gets
+// installed (NPPD-1731). Built with admin_url() in the PHP boot config; falls
+// back to a relative admin path if the global isn't present.
+const SITE_KIT_URL = window.newspackInsights?.siteKitUrl || 'admin.php?page=newspack-settings';
 
 export interface ConnectBannerProps {
 	text?: string;
@@ -32,9 +33,9 @@ const ConnectBanner = ( { text }: ConnectBannerProps ) => (
 		className="newspack-insights__connect-banner"
 		noticeText={
 			<>
-				{ text || __( 'Connect Google Analytics in Newspack → Settings → Connections to see this tab.', 'newspack-plugin' ) }{ ' ' }
-				<Button variant="link" href={ SETTINGS_URL }>
-					{ __( 'Connect Google Analytics →', 'newspack-plugin' ) }
+				{ text || __( 'Connect Google Analytics through Site Kit to see this tab.', 'newspack-plugin' ) }{ ' ' }
+				<Button variant="link" href={ SITE_KIT_URL }>
+					{ __( 'Set up Site Kit →', 'newspack-plugin' ) }
 				</Button>
 			</>
 		}


### PR DESCRIPTION
Implements [NPPD-1731](https://linear.app/a8c/issue/NPPD-1731). Base branch is `feat/insights-rsm` (the v1 integration branch).

When a publisher hasn't connected Google Analytics, the Audience and Engagement tabs collapse to a single connect banner. That banner pointed at **Newspack → Connections** — the wrong destination. GA4 is owned upstream by **Site Kit** (for both publisher-owned and Newspack-owned GA4 properties), so the banner now directs there. This also re-voices the copy to the NPPD-1698 empty-state standard.

First per-tab application landing after the [NPPD-1698](https://linear.app/a8c/issue/NPPD-1698) canonical reference shipped. Conforms to the README §Empty-state voice & tone standard.

### Pre-flight decisions

- **D1 — Copy:** Option B (one diagnostic sentence naming the Site Kit source + a closer), per-tab noun preserved (§10).
- **D2 — Link target:** reuse the house `google_site_kit_available()` ternary already used by Newspack Settings and the Dashboard — most stable, no new constant.
- **D3 — Scope:** Audience + Engagement only. Conversion Journey was re-checked and has **no** GA connection gate (its data comes from BigQuery-via-proxy + Woo joins, not GA4/Site Kit), so it's correctly untouched.
- **D4 — No-Site-Kit case:** when Site Kit isn't installed at all, fall back to Newspack → Connections (where it gets installed), since the Site Kit splash URL would 404 without the plugin present.

## What's in this PR

### Copy (Site Kit, conformed to NPPD-1698)
- `Audience_Metric::connection_error()` / `Engagement_Metric::connection_error()` `banner_text` now reads *"{Audience|Engagement} metrics come from a GA4 property connected through Site Kit. Set up Site Kit to start seeing data here."*
- `ConnectBanner` CTA label is now **"Set up Site Kit →"**; its fallback default copy is *"Connect Google Analytics through Site Kit to see this tab."*

### Link target
- New `Insights_Wizard::get_site_kit_url()` resolves the destination with the established precedence:
  - Site Kit set up with the Analytics module → deep link `…googlesitekit-settings#/connected-services/analytics-4`
  - Site Kit active but Analytics not yet connected → `…googlesitekit-splash`
  - Site Kit not installed → `…newspack-settings` (Connections, where Site Kit is installed)
- Boot-config key `settingsUrl` renamed to `siteKitUrl` (its only consumer is the connect banner); `InsightsBootConfig` type, the frontend fallback config, and `ConnectBanner` updated to match.

### Tests
- New `ConnectBanner.test.tsx`: asserts the Site Kit copy renders and the CTA links to `window.newspackInsights.siteKitUrl`, with the relative-path fallback when the global is absent (the link wiring was previously untested).

## How to test

1. On a site **without** a connected GA4 property, open Insights → **Audience** (and **Engagement**).
2. Confirm the tab shows the connect banner with the new Site Kit copy and a **"Set up Site Kit →"** link.
3. Click it and confirm the destination matches the publisher's Site Kit state:
   - GA4 module connected → Site Kit's GA4 service settings.
   - Site Kit active, GA4 not connected → Site Kit setup splash.
   - Site Kit not installed → Newspack → Connections.
4. Connect GA4 and confirm both tabs populate normally (banner gone).
5. Confirm **Conversion Journey** is unaffected (no GA connection banner there).

`NEWSPACK_INSIGHTS_FIXTURE_MODE` plus toggling the GA/Site Kit connection is the quickest way to exercise the banner without live data.

## Heads-up

- **Verification:** CI is green — JS (lint + tests, including the new `ConnectBanner` test), PHPCS, and PHPUnit all pass. Backend behavior was also confirmed live on an isolated env via WP-CLI: both tabs serve the new Site Kit copy, and `get_site_kit_url()` resolves to the deep GA4 link when Site Kit + GA4 are connected and to the Newspack → Connections fallback when Site Kit isn't installed.
- **Reference gap (NPPD-1698 first real-world test):** the canonical README §1/§3 codifies `EmptyMetricSection` *section* states and a 3–4-sentence body skeleton — it does **not** cover the tab-level `ConnectBanner` primitive. This PR keeps `ConnectBanner` (the right primitive for a whole-tab no-connection state) and applies the *applicable* beats in 1–2 sentences rather than padding to four. Worth a small README addendum (a "tab-level connect banner" row) as a follow-up.
- **Follow-up candidate (not bundled):** the `banner_text` string is duplicated verbatim across `class-audience-metric.php` and `class-engagement-metric.php`. Left in place per no-bundled-refactors; could consolidate into a shared helper later.
