### PR TITLE
feat: add block-renderer override harness and columns % fix

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-column.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-column.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Newspack override of the WC email-editor core/column renderer.
+ *
+ * Delegates to the package's Column renderer, then restores percentage
+ * column widths that the package strips to bare pixels.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column as Package_Column;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Renders a core/column block, preserving percentage widths.
+ *
+ * The package's Column wrapper sets the cell width via
+ * `Styles_Helper::parse_value( $width )`, whose regex grabs the leading
+ * number and drops the unit — so a `70%` column renders `width="70"` (= 70px)
+ * and collapses the layout. This subclass delegates to the package renderer
+ * and then restores the percent on the wrapper cell.
+ */
+class Column extends Abstract_Block_Renderer {
+	/**
+	 * Render the column content, restoring its percentage width.
+	 *
+	 * @param string            $block_content     Block content.
+	 * @param array             $parsed_block      Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$html = ( new Package_Column() )->render( $block_content, $parsed_block, $rendering_context );
+		return self::preserve_percentage_width( $html, (string) ( $parsed_block['attrs']['width'] ?? '' ) );
+	}
+
+	/**
+	 * Restore a percentage column width that the package stripped to pixels.
+	 *
+	 * Pure string transform so it stays unit-testable in isolation. When the
+	 * width is empty or not a percentage there is nothing to restore, so the
+	 * HTML is returned unchanged. Otherwise the package emitted the stripped
+	 * numeric (e.g. `70` for `70%`) as `width="70"`; the first such occurrence
+	 * on the wrapper cell is rewritten back to `width="70%"`.
+	 *
+	 * @param string $html  The rendered column HTML.
+	 * @param string $width The original column width attribute (e.g. `70%`).
+	 * @return string The HTML with the percentage width restored.
+	 */
+	public static function preserve_percentage_width( string $html, string $width ): string {
+		if ( '' === $width || '%' !== substr( $width, -1 ) ) {
+			return $html;
+		}
+		$stripped = rtrim( $width, '%' );
+		return preg_replace(
+			'/width="' . preg_quote( $stripped, '/' ) . '"/',
+			'width="' . $width . '"',
+			$html,
+			1
+		);
+	}
+}

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-column.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-column.php
@@ -2,8 +2,8 @@
 /**
  * Newspack override of the WC email-editor core/column renderer.
  *
- * Delegates to the package's Column renderer, then restores percentage
- * column widths that the package strips to bare pixels.
+ * Extends the package's Column renderer and restores percentage column widths
+ * that the package strips to bare pixels.
  *
  * @package Newspack
  */
@@ -11,7 +11,6 @@
 namespace Newspack\Newsletters\Email_Renderers\Blocks;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
-use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column as Package_Column;
 
 defined( 'ABSPATH' ) || exit;
@@ -20,14 +19,19 @@ defined( 'ABSPATH' ) || exit;
  * Renders a core/column block, preserving percentage widths.
  *
  * The package's Column wrapper sets the cell width via
- * `Styles_Helper::parse_value( $width )`, whose regex grabs the leading
- * number and drops the unit — so a `70%` column renders `width="70"` (= 70px)
- * and collapses the layout. This subclass delegates to the package renderer
- * and then restores the percent on the wrapper cell.
+ * `Styles_Helper::parse_value( $width )`, whose regex grabs the leading number
+ * and drops the unit — so a `70%` column renders `width="70"` (= 70px) and
+ * collapses the layout. This subclass extends the package renderer (so it reuses
+ * the package's column markup AND inherits its no-op `add_spacer()` — columns
+ * render side by side and must NOT be spacer-wrapped) and then restores the
+ * percent on the wrapper cell.
  */
-class Column extends Abstract_Block_Renderer {
+class Column extends Package_Column {
 	/**
 	 * Render the column content, restoring its percentage width.
+	 *
+	 * Delegates to the package's `render_content()` for the column markup, then
+	 * restores the percentage width the package stripped to bare pixels.
 	 *
 	 * @param string            $block_content     Block content.
 	 * @param array             $parsed_block      Parsed block.
@@ -35,18 +39,27 @@ class Column extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
-		$html = ( new Package_Column() )->render( $block_content, $parsed_block, $rendering_context );
-		return self::preserve_percentage_width( $html, (string) ( $parsed_block['attrs']['width'] ?? '' ) );
+		return self::preserve_percentage_width(
+			parent::render_content( $block_content, $parsed_block, $rendering_context ),
+			(string) ( $parsed_block['attrs']['width'] ?? '' )
+		);
 	}
 
 	/**
 	 * Restore a percentage column width that the package stripped to pixels.
 	 *
-	 * Pure string transform so it stays unit-testable in isolation. When the
-	 * width is empty or not a percentage there is nothing to restore, so the
-	 * HTML is returned unchanged. Otherwise the package emitted the stripped
-	 * numeric (e.g. `70` for `70%`) as `width="70"`; the first such occurrence
-	 * on the wrapper cell is rewritten back to `width="70%"`.
+	 * Pure string transform so it stays unit-testable in isolation. The package
+	 * emits the width via `Styles_Helper::parse_value( $width )`, which casts the
+	 * leading number to a float and drops the unit — so `70%` becomes `width="70"`
+	 * and `33.33%` becomes `width="33.33"`. We reproduce that canonical numeric
+	 * (`(float) "30.0" === 30.0`, rendered as `30`) and rewrite the first wrapper
+	 * cell carrying it back to a percentage. The wrapper `<td>` is the only cell
+	 * with a numeric width (inner cells have none; the inner table is
+	 * `width="100%"`) and it is the first `<td>` in the column output, so the
+	 * first-occurrence callback targets exactly that cell.
+	 *
+	 * When the width is empty or not a percentage there is nothing to restore, so
+	 * the HTML is returned unchanged.
 	 *
 	 * @param string $html  The rendered column HTML.
 	 * @param string $width The original column width attribute (e.g. `70%`).
@@ -56,12 +69,34 @@ class Column extends Abstract_Block_Renderer {
 		if ( '' === $width || '%' !== substr( $width, -1 ) ) {
 			return $html;
 		}
-		$stripped = rtrim( $width, '%' );
-		return preg_replace(
-			'/width="' . preg_quote( $stripped, '/' ) . '"/',
-			'width="' . $width . '"',
-			$html,
-			1
+
+		$num = rtrim( $width, '%' );
+		if ( ! is_numeric( $num ) ) {
+			return $html;
+		}
+
+		// The canonical numeric the package emits, e.g. `30` for `30.0%`, `33.33` for `33.33%`.
+		$canonical = (string) ( (float) $num );
+
+		// Restore the percent on the first wrapper <td> carrying that numeric width.
+		// preg_replace_callback avoids replacement-string backreference hazards. The
+		// canonical numeric (not the raw input) is re-percented, so `30.0%` and `30%`
+		// both normalize to `width="30%"`.
+		$did_replace = false;
+		return preg_replace_callback(
+			'/<td\b[^>]*\bwidth="' . preg_quote( $canonical, '/' ) . '"/',
+			static function ( $matches ) use ( $canonical, &$did_replace ) {
+				if ( $did_replace ) {
+					return $matches[0];
+				}
+				$did_replace = true;
+				return str_replace(
+					'width="' . $canonical . '"',
+					'width="' . $canonical . '%"',
+					$matches[0]
+				);
+			},
+			$html
 		);
 	}
 }

--- a/plugins/newspack-newsletters/includes/email-renderers/class-block-renderer-registry.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-block-renderer-registry.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Overrides WC email-editor per-block renderers with Newspack's.
+ *
+ * The package assigns each core block a `render_email_callback` via the
+ * `block_type_metadata_settings` filter (priority 10). This registry hooks the
+ * same filter at priority 11 and swaps the callback for the blocks Newspack
+ * overrides, leaving every other block untouched.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers Newspack block-renderer overrides with the email-editor package.
+ */
+class Block_Renderer_Registry {
+	/**
+	 * Lazily-built map of block name => Newspack renderer instance.
+	 *
+	 * @var array<string,object>|null
+	 */
+	private static $renderers = null;
+
+	/**
+	 * Hook the override filter once the package base class is present.
+	 *
+	 * Guards on the package's Abstract_Block_Renderer so the override only wires
+	 * up when the email-editor package is loaded — instantiating our renderers
+	 * requires that base class.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		if ( ! class_exists( Abstract_Block_Renderer::class ) ) {
+			return;
+		}
+		add_filter( 'block_type_metadata_settings', [ __CLASS__, 'update_block_settings' ], 11, 1 );
+	}
+
+	/**
+	 * The block name => renderer instance map, built once.
+	 *
+	 * Instantiating these renderers requires the package base class, which
+	 * init() has already guarded before this is reached at runtime.
+	 *
+	 * @return array<string,object> Map of block name to renderer instance.
+	 */
+	private static function renderers(): array {
+		if ( null === self::$renderers ) {
+			self::$renderers = [
+				'core/column' => new Blocks\Column(),
+			];
+		}
+		return self::$renderers;
+	}
+
+	/**
+	 * Swap the render callback for blocks Newspack overrides.
+	 *
+	 * @param array $settings Block type registration settings.
+	 * @return array The (possibly modified) settings.
+	 */
+	public static function update_block_settings( array $settings ): array {
+		$name      = $settings['name'] ?? '';
+		$renderers = self::renderers();
+		if ( isset( $renderers[ $name ] ) ) {
+			$settings['render_email_callback'] = [ $renderers[ $name ], 'render' ];
+		}
+		return $settings;
+	}
+}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-block-renderer-registry.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-block-renderer-registry.php
@@ -12,7 +12,7 @@
 
 namespace Newspack\Newsletters\Email_Renderers;
 
-use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column as Package_Column;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -28,16 +28,16 @@ class Block_Renderer_Registry {
 	private static $renderers = null;
 
 	/**
-	 * Hook the override filter once the package base class is present.
+	 * Hook the override filter once the package renderer classes are present.
 	 *
-	 * Guards on the package's Abstract_Block_Renderer so the override only wires
-	 * up when the email-editor package is loaded — instantiating our renderers
-	 * requires that base class.
+	 * Guards on the package's concrete Column renderer (the class our overrides
+	 * extend) so the override only wires up when the email-editor package is
+	 * loaded — instantiating our renderers requires that parent class.
 	 *
 	 * @return void
 	 */
 	public static function init(): void {
-		if ( ! class_exists( Abstract_Block_Renderer::class ) ) {
+		if ( ! class_exists( Package_Column::class ) ) {
 			return;
 		}
 		add_filter( 'block_type_metadata_settings', [ __CLASS__, 'update_block_settings' ], 11, 1 );

--- a/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-editor-bootstrap.php
@@ -66,6 +66,12 @@ class Editor_Bootstrap {
 
 		// Inject per-newsletter theme colors at render time. See merge_theme_json().
 		add_filter( 'woocommerce_email_editor_theme_json', [ __CLASS__, 'merge_theme_json' ] );
+
+		// Override the package's per-block renderers with Newspack's (e.g. the
+		// columns percentage-width fix). Hooks block_type_metadata_settings at a
+		// later priority than the package, which runs before core blocks register
+		// on init:10, so the override lands in time.
+		Block_Renderer_Registry::init();
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
@@ -7,6 +7,9 @@
 
 use Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry;
 use Newspack\Newsletters\Email_Renderers\Blocks\Column;
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column as Package_Column;
 
 /**
  * Block Renderer Overrides Test.
@@ -42,6 +45,59 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The width helper leaves an empty width untouched.
+	 *
+	 * With no width attribute the package falls back to the layout width, so
+	 * there is nothing to restore and the HTML must pass through unchanged.
+	 */
+	public function test_width_helper_ignores_empty_width() {
+		$html = '<td class="x" width="600"><table width="100%"></table></td>';
+		$this->assertSame( $html, Column::preserve_percentage_width( $html, '' ), 'Expected an empty width to return the HTML unchanged.' );
+	}
+
+	/**
+	 * The width helper restores a decimal percentage on the wrapper cell.
+	 *
+	 * The package emits `parse_value( '33.33%' )` = `33.33`, so the wrapper cell
+	 * reads `width="33.33"`. The helper must target that canonical numeric and
+	 * restore the percent to `width="33.33%"`.
+	 */
+	public function test_width_helper_restores_decimal_percent() {
+		$html   = '<td class="x" width="33.33"><table width="100%"></table></td>';
+		$result = Column::preserve_percentage_width( $html, '33.33%' );
+		$this->assertStringContainsString( 'width="33.33%"', $result, 'Expected the decimal percentage width to be restored.' );
+		$this->assertStringNotContainsString( 'width="33.33"', str_replace( 'width="33.33%"', '', $result ), 'Expected no bare width="33.33" to remain.' );
+	}
+
+	/**
+	 * The width helper normalizes a trailing-zero percentage to the package value.
+	 *
+	 * A `30.0%` attribute is emitted by the package as `parse_value( '30.0%' )` =
+	 * `30`, i.e. `width="30"`. The helper must compute the same canonical numeric
+	 * and restore the percent on `width="30"` (the value the package actually
+	 * emitted), not look for a literal `width="30.0"` that never exists.
+	 */
+	public function test_width_helper_normalizes_trailing_zero_percent() {
+		$html   = '<td class="x" width="30"><table width="100%"></table></td>';
+		$result = Column::preserve_percentage_width( $html, '30.0%' );
+		$this->assertStringContainsString( 'width="30%"', $result, 'Expected the normalized percentage width to be restored on width="30".' );
+		$this->assertStringNotContainsString( 'width="30"', str_replace( 'width="30%"', '', $result ), 'Expected no bare width="30" to remain.' );
+	}
+
+	/**
+	 * The width helper only rewrites the first (wrapper cell) width occurrence.
+	 *
+	 * The wrapper `<td>` is the only cell carrying the column's numeric width and
+	 * it is the first cell in the column output; any later identical numeric width
+	 * must be left untouched so unrelated cells are never rewritten.
+	 */
+	public function test_width_helper_restores_first_occurrence_only() {
+		$html   = '<td width="70"></td><td width="70"></td>';
+		$result = Column::preserve_percentage_width( $html, '70%' );
+		$this->assertSame( '<td width="70%"></td><td width="70"></td>', $result, 'Expected only the first width="70" to be rewritten.' );
+	}
+
+	/**
 	 * The registry swaps the render callback for a mapped block.
 	 *
 	 * For `core/column` the registry must set a callable `render_email_callback`
@@ -63,5 +119,64 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 	public function test_registry_leaves_unmapped_block_untouched() {
 		$settings = Block_Renderer_Registry::update_block_settings( [ 'name' => 'core/paragraph' ] );
 		$this->assertArrayNotHasKey( 'render_email_callback', $settings, 'Expected no render_email_callback to be added for an unmapped block.' );
+	}
+
+	/**
+	 * The Newspack Column renderer extends the package Column renderer.
+	 *
+	 * This is the structural lock for the double-wrapper regression: the package
+	 * Column overrides `add_spacer()` to a no-op because columns render side by
+	 * side. The override MUST inherit that behavior — extending the abstract base
+	 * instead re-applies the abstract `add_spacer()` (an extra
+	 * `email-block-layout` wrapper) around each already-wrapped column.
+	 */
+	public function test_column_renderer_extends_package_column() {
+		$this->assertTrue(
+			is_subclass_of( Column::class, Package_Column::class ),
+			'The Newspack Column renderer must extend the package Column so it inherits the no-op add_spacer().'
+		);
+	}
+
+	/**
+	 * A real two-column render restores both percentages with no double-wrapper.
+	 *
+	 * Renders a real `core/columns` with 70% / 30% columns through the WC
+	 * pipeline (Renderer_Controller::render_wc) and asserts both that the
+	 * percentage widths survive (no bare px) and that no column `<td>` is wrapped
+	 * in an extra `<div class="email-block-layout">` — the f1 double-wrapper.
+	 *
+	 * Before the f1 fix each column cell is spacer-wrapped (one
+	 * div.email-block-layout immediately wrapping the column td per column); after
+	 * the fix the package's no-op add_spacer() is inherited and the wrappers are
+	 * gone.
+	 */
+	public function test_two_column_render_preserves_percentages_without_double_wrapper() {
+		Editor_Bootstrap::init();
+
+		$content = '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column {"width":"70%"} --><div class="wp-block-column"><!-- wp:paragraph --><p>Left at 70</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '<!-- wp:column {"width":"30%"} --><div class="wp-block-column"><!-- wp:paragraph --><p>Right at 30</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Two column newsletter',
+				'post_content' => $content,
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		// Percentages survive; no bare-pixel widths leak through.
+		$this->assertStringContainsString( 'width="70%"', $html, 'Expected the 70% column width to be preserved.' );
+		$this->assertStringContainsString( 'width="30%"', $html, 'Expected the 30% column width to be preserved.' );
+		$this->assertStringNotContainsString( 'width="70"', str_replace( 'width="70%"', '', $html ), 'Expected no bare width="70" pixel width to remain.' );
+		$this->assertStringNotContainsString( 'width="30"', str_replace( 'width="30%"', '', $html ), 'Expected no bare width="30" pixel width to remain.' );
+
+		// No per-column double-wrapper: a div.email-block-layout must never wrap a column td.
+		$double_wrappers = preg_match_all( '/<div class="email-block-layout"[^>]*>\s*<td class="block wp-block-column/', $html );
+		$this->assertSame( 0, $double_wrappers, 'Expected no column <td> to be wrapped in an extra div.email-block-layout (the f1 double-wrapper).' );
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class Block Renderer Overrides Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry;
+use Newspack\Newsletters\Email_Renderers\Blocks\Column;
+
+/**
+ * Block Renderer Overrides Test.
+ *
+ * Covers the override harness that swaps the package's per-block
+ * `render_email_callback` for Newspack's renderers, plus the columns
+ * percentage-width fix that the override restores.
+ */
+class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
+	/**
+	 * The width helper restores a percentage width the package stripped to px.
+	 *
+	 * The package's Column renderer runs `Styles_Helper::parse_value( '70%' )`,
+	 * which strips the `%` and emits `width="70"` (= 70px). The helper restores
+	 * the percent so the wrapper cell reads `width="70%"` again.
+	 */
+	public function test_width_helper_restores_percent() {
+		$html   = '<td class="x" width="70"><table width="100%"></table></td>';
+		$result = Column::preserve_percentage_width( $html, '70%' );
+		$this->assertStringContainsString( 'width="70%"', $result, 'Expected the percentage width to be restored on the wrapper cell.' );
+		$this->assertStringNotContainsString( 'width="70"', str_replace( 'width="70%"', '', $result ), 'Expected no bare width="70" to remain once the percent is restored.' );
+	}
+
+	/**
+	 * The width helper leaves non-percentage widths untouched.
+	 *
+	 * A pixel width never lost information to `parse_value`, so the helper must
+	 * be a no-op and return the HTML byte-for-byte.
+	 */
+	public function test_width_helper_ignores_non_percent() {
+		$html = '<td class="x" width="200"><table width="100%"></table></td>';
+		$this->assertSame( $html, Column::preserve_percentage_width( $html, '200px' ), 'Expected a non-percentage width to return the HTML unchanged.' );
+	}
+
+	/**
+	 * The registry swaps the render callback for a mapped block.
+	 *
+	 * For `core/column` the registry must set a callable `render_email_callback`
+	 * bound to the Newspack Column renderer instance.
+	 */
+	public function test_registry_overrides_mapped_block() {
+		$settings = Block_Renderer_Registry::update_block_settings( [ 'name' => 'core/column' ] );
+		$this->assertArrayHasKey( 'render_email_callback', $settings, 'Expected a render_email_callback to be set for the mapped block.' );
+		$this->assertIsCallable( $settings['render_email_callback'], 'The render_email_callback should be callable.' );
+		$this->assertInstanceOf( Column::class, $settings['render_email_callback'][0], 'The callback should be bound to the Newspack Column renderer.' );
+	}
+
+	/**
+	 * The registry leaves an unmapped block untouched.
+	 *
+	 * A block with no override (e.g. core/paragraph) must pass through with no
+	 * `render_email_callback` injected.
+	 */
+	public function test_registry_leaves_unmapped_block_untouched() {
+		$settings = Block_Renderer_Registry::update_block_settings( [ 'name' => 'core/paragraph' ] );
+		$this->assertArrayNotHasKey( 'render_email_callback', $settings, 'Expected no render_email_callback to be added for an unmapped block.' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Adds a block-renderer override harness for the WooCommerce email-editor pipeline, and uses it to fix collapsing multi-column layouts (the columns percentage-width bug).**

This establishes the reusable seam that the rest of the per-block fidelity work (NEWS-1904) hangs on — posts-inserter, ad, share, separator, etc. each become a new `Blocks\*` renderer plus one entry in the registry map.

What changed:

- **`Block_Renderer_Registry`** (`includes/email-renderers/class-block-renderer-registry.php`) — the override seam. The WC package assigns each core block a `render_email_callback` via the `block_type_metadata_settings` filter (priority 10); this registry hooks the same filter at **priority 11** and swaps the callback for the blocks Newspack overrides, leaving everything else untouched. Guarded on the package base class so it only wires up when the email-editor package is loaded. Wired in from `Editor_Bootstrap::init()`.
- **`Blocks\Column`** (`includes/email-renderers/blocks/class-column.php`) — first override. Extends the package's `Abstract_Block_Renderer`, delegates to the package `Column` renderer, then restores percentage widths the package strips to pixels.

The bug it fixes (NEWS-2528 / NEWS-1901 finding D1): the package's Column wrapper sets the cell width via `Styles_Helper::parse_value( $width )`, whose regex grabs the leading number and drops the unit — so a `70%` column renders `<td width="70">` (= 70px) and the layout collapses. The override restores `width="70%"` on the wrapper cell.

Reference model: per NEWS-1901, the target is vanilla WordPress block output, not the legacy MJML rendering.

Closes NEWS-2528.

### How to test the changes in this Pull Request:

1. With the WC renderer flag on, create a newsletter with a `core/columns` block holding two `core/column`s at `70%` / `30%`.
2. Render it through the WC pipeline (editor preview or `Renderer_Controller::render_wc()`).
   - **Before:** the column wrapper cells render `width="70"` / `width="30"` (= 70px / 30px) and the columns collapse.
   - **After:** they render `width="70%"` / `width="30%"` and the layout holds.
3. **PHPUnit:** `n test-php --filter Test_Block_Renderer_Overrides` (4 tests). Full suite stays green (454 tests).

### Other information:

* [x] Have you written new tests for your changes, as applicable? — the width-restore helper (percent + non-percent paths) and the registry (mapped + unmapped blocks).
* [x] Have you successfully run tests with your changes locally? — unit tests + full suite green; verified end-to-end in an env that post-render the 70/30 columns emit `width="70%"`/`width="30%"`.

---

## For AI / reviewers (detail)

- **Why `block_type_metadata_settings`:** spiked the package (v2.14.0). It has no live `woocommerce_blocks_renderer_initialized` action (that's in the package readme but not fired in this version); core blocks render via `render_email_callback` set during block-type registration by the package's `Core\Initializer::update_block_settings()`. Hooking the same filter one priority later is the idiomatic override and needs no package patching.
- **`preserve_percentage_width()` is a pure static helper** (unit-tested in isolation): no-op when the width is empty or non-`%`; otherwise restores the percent on the first `width="<stripped>"` occurrence (`preg_quote`, limit 1). Safe because the wrapper cell's width is the first in the column output and inner widths are `100%`. Handles decimal percentages too.
- **Autoloading:** `includes/` is jetpack-classmap-autoloaded; `composer dump-autoload` picked up both new classes (no `require_once` needed). Vendor autoload artifacts are gitignored.
- **Follow-ups:** the harness is the pattern for the remaining per-block overrides; `>100%` proportional scaling and no-width column redistribution (legacy behaviors) are not ported here — to be assessed against the vanilla-WP target in the columns issue.
