### PR TITLE
docs(insights): subscriber churn canonical reference (NPPD-1724)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/README.md
+++ b/plugins/newspack-plugin/includes/wizards/insights/README.md
@@ -253,6 +253,38 @@ Sentence-form empty-state copy ends with a period. Generic safety-net fallbacks 
 
 This reference standardizes *structure*, not personality. Subscribers' good-zero copy is intentionally warmer ("No failed payments in this timeframe.") than Advertising's terse data notes ("No ad revenue in this timeframe.") — both are right for their context. When a tab's voice and its data shape pull toward a warmer or terser register, follow the register; conform to the patterns above, not to a single flattened tone.
 
+## Subscriber churn metric (canonical reference)
+
+Verified semantics of the Subscribers tab "Churned subscribers" count (NPPD-1724 audit + site-data verification). The query looks wrong — it inner-joins on `_schedule_cancelled` while counting expirations — but is correct; the notes below document why, so it isn't "fixed" into a regression.
+
+### What it counts
+
+Distinct customers whose last non-donation subscription reached `wc-cancelled` or `wc-expired`, attributed to the timeframe by `_schedule_cancelled`, with no remaining `wc-active` non-donation subscription. Query: `get_churned_subscribers_in_window()` in [`storage/class-hpos-storage.php`](storage/class-hpos-storage.php) (line 173), mirrored against legacy CPT storage in [`storage/class-legacy-storage.php`](storage/class-legacy-storage.php) (line 195). Non-donation only; the Donors-tab equivalent and its product-classification gap are NPPD-1736, out of scope here.
+
+### Both statuses, one bucket
+
+`wc-cancelled` and `wc-expired` count together. The dominant flow on Newspack publishers is `active → pending-cancel → expired`, not `active → cancelled`: readers cancel, ride out the paid period, then expire. Splitting the statuses separates "cancelled immediately" from "cancelled and lapsed," not voluntary from involuntary — not a distinction the metric draws. Together they mean subscribers lost in the timeframe. Transition-pattern follow-up: NPPD-1735.
+
+### `_schedule_cancelled` as the date key
+
+The schema reference implies `_schedule_cancelled` is set only on cancellation, so the inner join should drop natural expirations. It doesn't — because expirations arrive via the cancel-then-expire flow, the cancel timestamp is already set. Verified populated on 100% of expired subscriptions, none empty:
+
+| Site | Expired subs | `_schedule_cancelled` populated |
+| --- | --- | --- |
+| Richland Source | 392 | 100% |
+| Block Club Chicago | 2,542 | 100% |
+
+The field anchors the loss to when cancel was clicked, regardless of terminal status. The `!= ''` guard covers the empty edge case (removed nothing on either site). The audit's hypothesized COALESCE-onto-`_schedule_end` fix (F1) would be a no-op, so the SQL is unchanged.
+
+### Excluded
+
+| Status | Why |
+| --- | --- |
+| `wc-pending-cancel` | Cancellation scheduled but still entitled through the paid period — not yet lost. Counted when it transitions to `cancelled`/`expired`. |
+| `wc-on-hold` | Failed renewal inside the retry window — may recover. Counted only if it later reaches a terminal status. |
+
+D1 decision, confirmed against the data; counting either early overstates churn.
+
 ## Testing
 
 Jest, colocated `*.test.ts(x)` next to the source. Key spots:


### PR DESCRIPTION
Closes the documentation tail of [NPPD-1724](https://linear.app/a8c/issue/NPPD-1724). The audit hypothesized a bug in the subscriber-churn metric; data verification on two publishers refuted it. This PR records the *verified* semantics so the seemingly-buggy query isn't "fixed" by a future reader, and leaves a publisher-facing disclosure draft for the help site.

Doc-only. No metric SQL, storage adapter, classifier, metric class, test, or fixture changes.

## Pre-flight decisions

- **No code change to the churn metric.** Verification on Richland Source (392 expired subs) and Block Club Chicago (2,542 expired subs) found `_schedule_cancelled` populated on 100% of expired subscriptions, none empty — so the audit's F1 hypothesis (that the `_schedule_cancelled` inner join silently drops expirations) does not hold, and the proposed COALESCE fix would be a no-op. The current query is correct; it stays as-is.
- **`pending-cancel` / `on-hold` excluded — status quo confirmed (D1).** Documented as intentional rather than changed.
- **Donor side split out.** The donor-lapse problem turned out to be a `Donation_Product_Classifier` data-source gap, not a definition mismatch — spun out to [NPPD-1736](https://linear.app/a8c/issue/NPPD-1736) and explicitly scoped *out* of this reference.
- **State-transition pattern noted, not solved.** The `active → pending-cancel → expired` dominance has its own discovery ticket, [NPPD-1735](https://linear.app/a8c/issue/NPPD-1735), cross-referenced from the doc.
- **Register match.** Written to the lean, table-forward register Derrick established in the code-adjacent README (#318), not the more discursive NPPD-1698 voice-reference style.

## What's in this PR

- **Subscriber churn canonical reference** — a new section in `plugins/newspack-plugin/includes/wizards/insights/README.md`, parallel to the NPPD-1698 "Empty-state voice & tone" reference. Four labelled subsections: *what it counts* (with `get_churned_subscribers_in_window()` anchors for both storage backends), *both statuses, one bucket* (the cancel-then-expire flow → NPPD-1735), *`_schedule_cancelled` as the date key* (the verification figures, why the query isn't buggy), and *excluded* (pending-cancel / on-hold → D1).

## Not in this PR

- **Help-site disclosure draft** lives at `/tmp/nppd-1724-subscriber-churn-disclosure-draft.md` (publisher-empathetic framing, no WC internals, no CTA). A starting point for Katie's editorial pass and help-site IA decisions — deliberately not committed.

## How to test

1. Open `plugins/newspack-plugin/includes/wizards/insights/README.md` at the new "Subscriber churn metric (canonical reference)" section and read it.
2. Sanity-check the cross-references resolve: the `class-hpos-storage.php` / `class-legacy-storage.php` links and the `get_churned_subscribers_in_window()` line anchors (173 / 195), and the NPPD-1735 / NPPD-1736 ticket references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)