### PR TITLE
feat(insights): per-tab PDF export (NPPD-1661)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -365,8 +365,11 @@ class Insights_Wizard extends Wizard {
 			'siteKitUrl'        => self::get_site_kit_url(),
 			// Publisher (site) name, shown in the PDF export document header
 			// (NPPD-1661). Resolved at render time from the site's own title —
-			// never a hardcoded name.
-			'publisherName'     => get_bloginfo( 'name' ),
+			// never a hardcoded name. Decode entities: `blogname` is stored
+			// HTML-escaped (e.g. "Ben &amp; Jerry's"), and React escapes again
+			// on render, so a raw get_bloginfo() would print the literal entity.
+			// Hand React the decoded string and let it do the single escaping.
+			'publisherName'     => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -363,6 +363,10 @@ class Insights_Wizard extends Wizard {
 			'adminUrl'          => admin_url(),
 			'settingsUrl'       => admin_url( 'admin.php?page=newspack-settings' ),
 			'siteKitUrl'        => self::get_site_kit_url(),
+			// Publisher (site) name, shown in the PDF export document header
+			// (NPPD-1661). Resolved at render time from the site's own title —
+			// never a hardcoded name.
+			'publisherName'     => get_bloginfo( 'name' ),
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/_print.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/_print.scss
@@ -1,0 +1,210 @@
+/**
+ * Print stylesheet for per-tab PDF export (NPPD-1661).
+ *
+ * The "Download PDF" item in the Insights options kebab calls
+ * `window.print()`; this stylesheet is what turns the live admin view into
+ * a clean document. We chose print-CSS over html2canvas/jsPDF precisely
+ * because the charts are hand-rolled inline SVG (LineChart, PieChart,
+ * Funnel) and plain DOM (BarChart, tables, scorecards) — the browser's own
+ * print engine renders them at full vector fidelity and paginates long
+ * tables natively, with no rasterization and no added bundle weight.
+ *
+ * This file is bundled into the Insights chunk (imported by `style.scss`),
+ * which only loads on the Insights page, so the global `@media print`
+ * selectors below can safely reach WordPress admin chrome without leaking
+ * to other admin screens.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+// The document header/footer are invisible on screen and only painted when
+// printing. Kept out of the `@media print` block so the default is "hidden"
+// everywhere else.
+.newspack-insights__print-only {
+	display: none;
+}
+
+@media print {
+	// --- Strip the WordPress admin frame -------------------------------------
+	#adminmenumain,
+	#adminmenuwrap,
+	#adminmenuback,
+	#wpadminbar,
+	#wpfooter,
+	#screen-meta,
+	#screen-meta-links,
+	.update-nag,
+	.notice,
+	.wp-header-end,
+	.newspack-wizard__header,
+	.newspack-tabbed-navigation,
+	.newspack-footer {
+		display: none !important;
+	}
+
+	// Reclaim the full page width once the admin menu is gone.
+	html.wp-toolbar {
+		padding-top: 0 !important;
+	}
+
+	#wpcontent,
+	#wpbody-content,
+	#wpbody {
+		margin: 0 !important;
+		padding: 0 !important;
+	}
+
+	body {
+		background: #fff !important;
+	}
+
+	// --- Hide Insights screen-only controls ----------------------------------
+	// The date-range picker / comparison toggle, the kebab itself, the
+	// cooldown notice, and the refetch overlay are all interactive chrome that
+	// has no place in a static export. The "Last updated" timestamp stays — it
+	// is useful provenance in a printed report.
+	.newspack-insights__header-controls,
+	.newspack-insights__refresh-menu,
+	.newspack-insights__cooldown-notice,
+	.newspack-insights__tab-refreshing,
+	.newspack-insights__sortable-table-more {
+		display: none !important;
+	}
+
+	// A dimmed tab body (mid-refresh) must print at full opacity.
+	.newspack-insights__tab-body.is-refreshing > * {
+		opacity: 1 !important;
+	}
+
+	// --- Reveal the print document chrome ------------------------------------
+	.newspack-insights__print-only {
+		display: block;
+	}
+
+	.newspack-insights__print-header {
+		margin: 0 0 24px;
+		padding-bottom: 12px;
+		border-bottom: 2px solid wp-colors.$gray-900;
+	}
+
+	.newspack-insights__print-publisher {
+		margin: 0 0 4px;
+		font-size: 13px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: wp-colors.$gray-700;
+	}
+
+	.newspack-insights__print-title {
+		margin: 0;
+		font-size: 26px;
+		font-weight: 700;
+		line-height: 1.2;
+		color: wp-colors.$gray-900;
+	}
+
+	.newspack-insights__print-range {
+		margin: 6px 0 0;
+		font-size: 14px;
+		color: wp-colors.$gray-700;
+	}
+
+	.newspack-insights__print-compare {
+		margin: 2px 0 0;
+		font-size: 13px;
+		color: wp-colors.$gray-600;
+	}
+
+	// Footer pinned to the bottom margin of every printed page.
+	.newspack-insights__print-footer {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		padding-top: 6px;
+		border-top: 1px solid wp-colors.$gray-300;
+		background: #fff;
+		font-size: 11px;
+		color: wp-colors.$gray-600;
+		text-align: right;
+	}
+
+	// --- Colour fidelity -----------------------------------------------------
+	// Browsers drop background colours when printing by default. The BarChart
+	// fills, takeaway accent border, info callouts, legend swatches, etc. are
+	// painted via `background`, so force exact colour reproduction across the
+	// whole wizard. (SVG `fill`/`stroke` — pie + funnel — print regardless.)
+	.newspack-insights,
+	.newspack-insights * {
+		-webkit-print-color-adjust: exact !important;
+		print-color-adjust: exact !important;
+	}
+
+	// --- Page setup ----------------------------------------------------------
+	@page {
+		margin: 1.5cm;
+		// Leave room for the fixed footer so body content never collides with it.
+		margin-bottom: 2cm;
+	}
+
+	// --- Pagination: keep coherent units together ---------------------------
+	// Cards, charts, and funnels should not split across a page break.
+	.newspack-insights__metric-card,
+	.newspack-insights__chart-card,
+	.newspack-insights__takeaway-card,
+	.newspack-insights__funnel,
+	.newspack-insights__line,
+	.newspack-insights__bars,
+	.newspack-insights__pie {
+		break-inside: avoid;
+	}
+
+	// Section headings should not be orphaned at the bottom of a page.
+	.newspack-insights__section-heading,
+	.newspack-wizard__section-header {
+		break-after: avoid;
+	}
+
+	// Long tables (e.g. the Gates tab) paginate natively: repeat the header on
+	// every page and never split a row. NOTE: a row-capped table prints only
+	// its expanded rows — what's on screen — since the collapsed rows aren't in
+	// the DOM. Expand "See more" before exporting to capture the full table.
+	.newspack-insights__table thead {
+		display: table-header-group;
+	}
+
+	.newspack-insights__table tr {
+		break-inside: avoid;
+	}
+
+	// --- Watch item: Funnel (JS-driven layout) -------------------------------
+	// Funnel's side/compact layout is chosen in JS from the on-screen container
+	// width (ResizeObserver), so whatever the screen showed is what prints. Pin
+	// a deterministic max width and let the viewBox'd SVG scale within it, so
+	// the chosen layout lays out predictably on the narrower print page rather
+	// than overflowing.
+	.newspack-insights__funnel {
+		max-width: 17cm;
+	}
+
+	.newspack-insights__funnel-svg {
+		max-height: 11cm;
+	}
+
+	// --- Watch item: BarChart (percentage-height flexbox) --------------------
+	// The bars are a fixed-height flex container whose fills are sized in % of
+	// the track. Re-assert the explicit heights so the flex chain can't collapse
+	// to zero under print layout (which would blank the bars).
+	.newspack-insights__bars {
+		height: 160px !important;
+	}
+
+	.newspack-insights__takeaway-chart .newspack-insights__bars {
+		height: 60px !important;
+	}
+
+	.newspack-insights__bar-col {
+		height: 100% !important;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -28,6 +28,7 @@ import { Wizard } from '../../../../packages/components/src';
 import ComparisonToggle from './ComparisonToggle';
 import DateRangePicker from './DateRangePicker';
 import CooldownNotice from './CooldownNotice';
+import PrintDocumentMeta from './PrintDocumentMeta';
 import TabSpinner from '../tabs/components/TabSpinner';
 import useComparisonMode from '../state/useComparisonMode';
 import useDateRange, { type DateRange } from '../state/useDateRange';
@@ -62,6 +63,8 @@ export interface InsightsBootConfig {
 	settingsUrl: string;
 	siteKitUrl: string;
 	lastUpdated: null | string;
+	/** Site title, rendered in the PDF export document header (NPPD-1661). */
+	publisherName: string;
 }
 
 export interface InsightsWizardProps {
@@ -162,16 +165,20 @@ const renderTabComponent = ( tabKey: TabKey, sectionProps: TabSectionProps ): Re
 
 interface TabSectionRenderProps extends TabSectionProps {
 	tabKey: TabKey;
+	tabLabel: string;
+	publisherName: string;
 }
 
 /**
- * Per-tab wrapper rendered by the Wizard. Carries the CooldownNotice,
- * the error boundary (keyed by tab so a chunk-load error clears when
- * the user navigates away), and the Suspense boundary for the lazy
- * tab chunk.
+ * Per-tab wrapper rendered by the Wizard. Carries the print-only document
+ * header/footer (NPPD-1661 — used by the "Download PDF" export), the
+ * CooldownNotice, the error boundary (keyed by tab so a chunk-load error
+ * clears when the user navigates away), and the Suspense boundary for the
+ * lazy tab chunk.
  */
-const TabSection = ( { tabKey, range, previousRange }: TabSectionRenderProps ) => (
+const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange }: TabSectionRenderProps ) => (
 	<>
+		<PrintDocumentMeta tabLabel={ tabLabel } publisherName={ publisherName } range={ range } previousRange={ previousRange } />
 		<CooldownNotice tab={ tabKey } range={ range } previousRange={ previousRange } />
 		<TabErrorBoundary key={ tabKey }>
 			<Suspense fallback={ <Fallback /> }>{ renderTabComponent( tabKey, { range, previousRange } ) }</Suspense>
@@ -238,7 +245,7 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 		label: t.label,
 		exact: true,
 		render: TabSection,
-		props: { tabKey: t.key, range, previousRange },
+		props: { tabKey: t.key, tabLabel: t.label, range, previousRange, publisherName: config.publisherName },
 	} ) );
 
 	const renderAboveSections = () => (

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
@@ -69,4 +69,31 @@ describe( 'LastUpdated', () => {
 		const item = screen.getByRole( 'menuitem', { name: /refresh now/i } );
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
+
+	it( 'prints with a tab+range filename on Download PDF', () => {
+		const printSpy = jest.spyOn( window, 'print' ).mockImplementation( () => undefined );
+		seedSlot( 'engagement', { status: 'success', computedAt: '2026-06-10T18:42:13Z' } );
+
+		let titleAtPrint = '';
+		printSpy.mockImplementation( () => {
+			titleAtPrint = document.title;
+		} );
+
+		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /download pdf/i } ) );
+
+		expect( printSpy ).toHaveBeenCalledTimes( 1 );
+		expect( titleAtPrint ).toBe( 'engagement-2026-01-01_to_2026-01-31' );
+		printSpy.mockRestore();
+	} );
+
+	it( 'disables Download PDF while the slot is loading', () => {
+		seedSlot( 'engagement', { status: 'loading', computedAt: '2026-06-10T18:42:13Z' } );
+
+		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
+		const item = screen.getByRole( 'menuitem', { name: /download pdf/i } );
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -22,6 +22,7 @@ import type { DateRange } from '../state/useDateRange';
 import { insightsCache, makeSlotKey, type CacheSlot } from '../state/insightsCache';
 import { useInvokeRefresh } from '../state/refreshRegistry';
 import useCountdown from '../hooks/useCountdown';
+import { buildPdfFilename, printCurrentTab } from '../lib/pdfExport';
 
 export interface LastUpdatedProps {
 	tab: string | null;
@@ -67,7 +68,12 @@ const LastUpdated = ( { tab, range, previousRange }: LastUpdatedProps ) => {
 					dateI18n( 'M j, Y H:i:s', slot.computedAt )
 				) }
 			</span>
-			<RefreshMenu onRefresh={ () => invoke( tab ) } disabled={ slot.status === 'loading' || cooldownActive } />
+			<RefreshMenu
+				onRefresh={ () => invoke( tab ) }
+				disabled={ slot.status === 'loading' || cooldownActive }
+				onDownloadPdf={ () => printCurrentTab( buildPdfFilename( tab, range ) ) }
+				downloadDisabled={ slot.status === 'loading' }
+			/>
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/components/PrintDocumentMeta.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/PrintDocumentMeta.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tests for PrintDocumentMeta (NPPD-1661).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PrintDocumentMeta from './PrintDocumentMeta';
+import type { DateRange } from '../state/useDateRange';
+
+const range = { preset: 'last-30', start: '2026-05-20', end: '2026-06-18' } as DateRange;
+const previousRange = { preset: 'custom', start: '2026-04-20', end: '2026-05-19' } as DateRange;
+
+describe( 'PrintDocumentMeta', () => {
+	it( 'renders the publisher, tab title, and date range in the header', () => {
+		const { container } = render(
+			<PrintDocumentMeta tabLabel="Audience" publisherName="The Daily Example" range={ range } previousRange={ null } />
+		);
+
+		expect( screen.getByRole( 'heading', { name: 'Audience' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'The Daily Example' ) ).toBeInTheDocument();
+		// Scope to the range line: the footer's generation date can coincide with
+		// the range end date, so a bare getByText would match twice.
+		expect( container.querySelector( '.newspack-insights__print-range' ) ).toHaveTextContent( 'May 20, 2026 – Jun 18, 2026' );
+	} );
+
+	it( 'omits the publisher line when the name is empty', () => {
+		const { container } = render( <PrintDocumentMeta tabLabel="Audience" publisherName="" range={ range } previousRange={ null } /> );
+		expect( container.querySelector( '.newspack-insights__print-publisher' ) ).toBeNull();
+	} );
+
+	it( 'shows the comparison period only when previousRange is set', () => {
+		const { rerender } = render(
+			<PrintDocumentMeta tabLabel="Audience" publisherName="The Daily Example" range={ range } previousRange={ null } />
+		);
+		expect( screen.queryByText( /Compared to/ ) ).toBeNull();
+
+		rerender( <PrintDocumentMeta tabLabel="Audience" publisherName="The Daily Example" range={ range } previousRange={ previousRange } /> );
+		expect( screen.getByText( /Compared to/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a generation-date footer', () => {
+		render( <PrintDocumentMeta tabLabel="Audience" publisherName="The Daily Example" range={ range } previousRange={ null } /> );
+		expect( screen.getByText( /Generated/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/PrintDocumentMeta.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/PrintDocumentMeta.tsx
@@ -1,0 +1,75 @@
+/**
+ * PrintDocumentMeta (NPPD-1661).
+ *
+ * Print-only document chrome for the per-tab PDF export. Hidden on screen
+ * (`.newspack-insights__print-only { display: none }`) and revealed under
+ * `@media print`, so it costs nothing in the normal admin view and only
+ * surfaces when the user runs "Download PDF" from the Insights options
+ * kebab.
+ *
+ * Renders:
+ *   - a document header (publisher name + tab title + the active date
+ *     range, plus the comparison period when compare mode is on), printed
+ *     once at the top of the first page; and
+ *   - a footer with the generation date, fixed to the bottom of every
+ *     printed page via the print stylesheet.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+
+export interface PrintDocumentMetaProps {
+	/** Human tab title, e.g. "Audience" (the printed document's heading). */
+	tabLabel: string;
+	/** Site title from the boot config; omitted from the header when empty. */
+	publisherName: string;
+	/** Active date range. */
+	range: DateRange;
+	/** Previous-period range when compare mode is on, else null. */
+	previousRange: DateRange | null;
+}
+
+/** Format a range as "May 20 – Jun 18, 2026" for the document header. */
+const formatRangeLabel = ( range: DateRange ): string =>
+	sprintf(
+		/* translators: 1: range start date, 2: range end date. */
+		__( '%1$s – %2$s', 'newspack-plugin' ),
+		dateI18n( 'M j, Y', range.start ),
+		dateI18n( 'M j, Y', range.end )
+	);
+
+const PrintDocumentMeta = ( { tabLabel, publisherName, range, previousRange }: PrintDocumentMetaProps ) => (
+	<>
+		<header className="newspack-insights__print-only newspack-insights__print-header">
+			{ publisherName && <p className="newspack-insights__print-publisher">{ publisherName }</p> }
+			<h1 className="newspack-insights__print-title">{ tabLabel }</h1>
+			<p className="newspack-insights__print-range">{ formatRangeLabel( range ) }</p>
+			{ previousRange && (
+				<p className="newspack-insights__print-compare">
+					{ sprintf(
+						/* translators: %s is the previous comparison period date range. */
+						__( 'Compared to %s', 'newspack-plugin' ),
+						formatRangeLabel( previousRange )
+					) }
+				</p>
+			) }
+		</header>
+		<footer className="newspack-insights__print-only newspack-insights__print-footer">
+			{ sprintf(
+				/* translators: %s is the date the PDF was generated. */
+				__( 'Generated %s', 'newspack-plugin' ),
+				dateI18n( 'M j, Y', new Date() )
+			) }
+		</footer>
+	</>
+);
+
+export default PrintDocumentMeta;

--- a/plugins/newspack-plugin/src/wizards/insights/components/RefreshMenu.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/RefreshMenu.tsx
@@ -1,5 +1,6 @@
 /**
- * RefreshMenu — header kebab dropdown with a single "Refresh now" item.
+ * RefreshMenu — the "Insights options" header kebab dropdown. Holds
+ * "Refresh now" and "Download PDF" (NPPD-1661).
  */
 
 /**
@@ -12,9 +13,13 @@ import { moreVertical } from '@wordpress/icons';
 export interface RefreshMenuProps {
 	onRefresh: () => void;
 	disabled: boolean;
+	/** Trigger the per-tab PDF export (browser print). */
+	onDownloadPdf: () => void;
+	/** Disable the export while the tab is still loading its data. */
+	downloadDisabled: boolean;
 }
 
-const RefreshMenu = ( { onRefresh, disabled }: RefreshMenuProps ) => (
+const RefreshMenu = ( { onRefresh, disabled, onDownloadPdf, downloadDisabled }: RefreshMenuProps ) => (
 	<DropdownMenu
 		icon={ moreVertical }
 		label={ __( 'Insights options', 'newspack-plugin' ) }
@@ -24,6 +29,11 @@ const RefreshMenu = ( { onRefresh, disabled }: RefreshMenuProps ) => (
 				title: __( 'Refresh now', 'newspack-plugin' ),
 				onClick: onRefresh,
 				isDisabled: disabled,
+			},
+			{
+				title: __( 'Download PDF', 'newspack-plugin' ),
+				onClick: onDownloadPdf,
+				isDisabled: downloadDisabled,
 			},
 		] }
 	/>

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -48,6 +48,7 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 	adminUrl: '',
 	siteKitUrl: '',
 	lastUpdated: null,
+	publisherName: '',
 };
 
 const Index = () => {

--- a/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the PDF export helpers (NPPD-1661).
+ */
+
+/**
+ * Internal dependencies
+ */
+import { buildPdfFilename, printCurrentTab } from './pdfExport';
+import type { DateRange } from '../state/useDateRange';
+
+const range = { preset: 'custom', start: '2026-05-20', end: '2026-06-18' } as DateRange;
+
+describe( 'buildPdfFilename', () => {
+	it( 'joins tab slug and the range bounds as <tab>-<start>_to_<end>', () => {
+		expect( buildPdfFilename( 'audience', range ) ).toBe( 'audience-2026-05-20_to_2026-06-18' );
+	} );
+} );
+
+describe( 'printCurrentTab', () => {
+	const originalTitle = 'Insights ‹ My Site — WordPress';
+	let printSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		document.title = originalTitle;
+		printSpy = jest.spyOn( window, 'print' ).mockImplementation( () => undefined );
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		printSpy.mockRestore();
+		jest.useRealTimers();
+	} );
+
+	it( 'sets the document title to the filename before printing', () => {
+		let titleAtPrint = '';
+		printSpy.mockImplementation( () => {
+			titleAtPrint = document.title;
+		} );
+
+		printCurrentTab( 'audience-2026-05-20_to_2026-06-18' );
+
+		expect( printSpy ).toHaveBeenCalledTimes( 1 );
+		expect( titleAtPrint ).toBe( 'audience-2026-05-20_to_2026-06-18' );
+	} );
+
+	it( 'restores the original title on afterprint', () => {
+		printCurrentTab( 'audience-2026-05-20_to_2026-06-18' );
+		window.dispatchEvent( new Event( 'afterprint' ) );
+		expect( document.title ).toBe( originalTitle );
+	} );
+
+	it( 'restores the original title via the timeout fallback', () => {
+		printCurrentTab( 'audience-2026-05-20_to_2026-06-18' );
+		expect( document.title ).toBe( 'audience-2026-05-20_to_2026-06-18' );
+		jest.runAllTimers();
+		expect( document.title ).toBe( originalTitle );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.test.ts
@@ -27,6 +27,9 @@ describe( 'printCurrentTab', () => {
 	} );
 
 	afterEach( () => {
+		// Fire afterprint to clear the module-level in-flight guard so each
+		// test starts fresh (a no-op if the test already restored).
+		window.dispatchEvent( new Event( 'afterprint' ) );
 		printSpy.mockRestore();
 		jest.useRealTimers();
 	} );
@@ -54,5 +57,12 @@ describe( 'printCurrentTab', () => {
 		expect( document.title ).toBe( 'audience-2026-05-20_to_2026-06-18' );
 		jest.runAllTimers();
 		expect( document.title ).toBe( originalTitle );
+	} );
+
+	it( 'ignores a re-entrant call while a print is pending', () => {
+		printCurrentTab( 'audience-first' );
+		printCurrentTab( 'audience-second' ); // should be ignored — print still pending
+		expect( printSpy ).toHaveBeenCalledTimes( 1 );
+		expect( document.title ).toBe( 'audience-first' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.ts
@@ -25,15 +25,25 @@ import type { DateRange } from '../state/useDateRange';
 export const buildPdfFilename = ( tab: string, range: DateRange ): string => `${ tab }-${ range.start }_to_${ range.end }`;
 
 /**
+ * In-flight guard. `window.print()` blocks the main thread in most
+ * browsers, so a second invocation can't normally land mid-print — but
+ * embedded webviews don't always block, and a re-entrant call would
+ * capture the already-swapped filename as `originalTitle` and strand it.
+ * Ignore invocations until the in-flight print has restored the title.
+ */
+let printPending = false;
+
+/**
  * Trigger the browser print dialog with a temporary document title so the
  * suggested "Save as PDF" filename matches `name`. The title is restored
  * on the `afterprint` event, with a timeout fallback for browsers that
  * don't fire it reliably.
  */
 export const printCurrentTab = ( name: string ): void => {
-	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
+	if ( typeof window === 'undefined' || typeof document === 'undefined' || printPending ) {
 		return;
 	}
+	printPending = true;
 
 	const originalTitle = document.title;
 	let restored = false;
@@ -42,6 +52,7 @@ export const printCurrentTab = ( name: string ): void => {
 			return;
 		}
 		restored = true;
+		printPending = false;
 		document.title = originalTitle;
 		window.removeEventListener( 'afterprint', restore );
 	};

--- a/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.ts
@@ -1,0 +1,55 @@
+/**
+ * PDF export helpers (NPPD-1661).
+ *
+ * The Insights "Download PDF" export is print-based: a `@media print`
+ * stylesheet hides the WordPress/wizard chrome and reveals a document
+ * header + footer, then we hand off to the browser's own print engine
+ * via `window.print()`. The browser renders the live SVG/DOM charts at
+ * full vector fidelity — no rasterization, no charting-library round-trip
+ * — and paginates long tables natively. See the PR pre-flight notes for
+ * why this beats html2canvas/jsPDF for our hand-rolled SVG charts.
+ *
+ * Because the export is `window.print()`, the suggested filename is taken
+ * from `document.title` (there's no API to pass a filename to the print
+ * dialog). We set the title to the desired name for the duration of the
+ * print, then restore it.
+ */
+
+import type { DateRange } from '../state/useDateRange';
+
+/**
+ * Build the suggested PDF filename for a tab + date range, e.g.
+ * `audience-2026-05-20_to_2026-06-18`. The browser appends `.pdf` when
+ * the user picks "Save as PDF", matching the `<tab>-<date_range>` shape.
+ */
+export const buildPdfFilename = ( tab: string, range: DateRange ): string => `${ tab }-${ range.start }_to_${ range.end }`;
+
+/**
+ * Trigger the browser print dialog with a temporary document title so the
+ * suggested "Save as PDF" filename matches `name`. The title is restored
+ * on the `afterprint` event, with a timeout fallback for browsers that
+ * don't fire it reliably.
+ */
+export const printCurrentTab = ( name: string ): void => {
+	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
+		return;
+	}
+
+	const originalTitle = document.title;
+	let restored = false;
+	const restore = () => {
+		if ( restored ) {
+			return;
+		}
+		restored = true;
+		document.title = originalTitle;
+		window.removeEventListener( 'afterprint', restore );
+	};
+
+	window.addEventListener( 'afterprint', restore );
+	document.title = name;
+	window.print();
+	// Safety net: Safari (and some embedded webviews) don't always emit
+	// `afterprint`, which would otherwise strand the temporary title.
+	window.setTimeout( restore, 1000 );
+};

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -17,6 +17,7 @@
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "tabs/components/sections";
+@use "print";
 
 .newspack-insights {
 	color: wp-colors.$gray-900;


### PR DESCRIPTION
## Summary

Per-tab PDF export for Newspack Insights, landing on `feat/insights-rsm`. Closes [NPPD-1661](https://linear.app/a8c/issue/NPPD-1661). Adds a **Download PDF** item to the existing "Insights options" kebab on every tab; choosing it produces a PDF of the current tab *as visible* — tab title + publisher + date-range header, section-by-section layout (scorecards, charts, tables), charts as crisp vector graphics, footer with generation date, compare-mode deltas included. PDF-only — the per-table CSV half of the ticket is struck through and out of scope here.

### Pre-flight decisions

Surfaced before writing code, where the codebase disagreed with the ticket's assumption.

- **Rendering: print-stylesheet + `window.print()`, not html2pdf/html2canvas.** Recon found all Insights charts are hand-rolled inline SVG (`LineChart`, `PieChart`, `Funnel`) or plain DOM (`BarChart`, tables, scorecards) — no charting library, no `<canvas>`. html2canvas has documented gaps rasterizing inline SVG, so the ticket's recommended approach A would have forced an `XMLSerializer` SVG→image workaround on three charts and still shipped a flat raster (non-selectable text, manual page-slicing for long tables) plus ~200 KB of bundle. The browser's own print engine renders the live SVG/DOM at full vector fidelity, paginates long tables natively, and adds zero dependencies. This **inverts the ticket's A-over-print recommendation** now that the chart internals are known. Accepted tradeoffs: browser print dialog rather than a silent download, filename via `document.title` rather than a controlled string, and browser-injected page header/footer. If one-click silent download + exact filename + controlled chrome later become hard requirements, html2pdf (with the SVG-serialization workaround) or server-side headless Chromium is the v1.2 upgrade — the same fallback the ticket already named, just re-ordered.
- **Menu placement & label.** "Download PDF" as a second item in the existing `RefreshMenu` kebab, below "Refresh now" — secondary by virtue of living in the overflow menu, per the ticket comment. No standalone button.
- **`publisherName` added to the boot config.** `get_boot_config()` now localizes `'publisherName' => get_bloginfo( 'name' )` (runtime call, never a hardcoded name) so the document header can show the publisher.
- **Loading indicator: N/A for the print path.** `window.print()` opens the dialog synchronously — there's no async generation gap to indicate. The export item is disabled while a tab's data is still loading.
- **Compare mode: free.** `previousRange` deltas are already in the snapshotted DOM; the header adds a "Compared to <prev range>" line when compare is on.
- **Long-tab pagination (Gates): native.** `@page` margins + repeating `<thead>` + `break-inside: avoid` on rows/cards/charts. Note: a row-capped table prints only its *expanded* rows (collapsed rows aren't in the DOM) and the "See more" button is hidden in print — expand before exporting for the full table.

### What's in it

- `components/RefreshMenu.tsx` — adds the "Download PDF" control.
- `components/LastUpdated.tsx` — builds the `<tab>-<start>_to_<end>` filename and triggers the print.
- `lib/pdfExport.ts` — `buildPdfFilename` + `printCurrentTab` (swap `document.title`, print, restore on `afterprint` with a timeout fallback).
- `components/PrintDocumentMeta.tsx` — print-only document header (publisher / title / range / compare) + fixed footer (generation date), wired into `TabSection` for all eight tabs.
- `_print.scss` — strips WP + wizard chrome, reveals the document header/footer, forces `print-color-adjust: exact`, pins the `Funnel` width and `BarChart` heights (the two width-dependent watch items), and sets native table pagination.
- `class-insights-wizard.php` — `publisherName` in the boot config.

### Testing

- 14 unit tests green (`pdfExport`, `PrintDocumentMeta`, `LastUpdated`); `n build newspack-plugin` + JS/SCSS/PHP lint all clean.
- **Live print-preview QA** in Chrome against fixture data (Audience + Gates): admin/wizard chrome stripped, document header/footer correct, color fidelity holds, and `LineChart`/`BarChart`/`PieChart`/`Funnel`/tables all render at vector fidelity. Both width-dependent watch items confirmed — Funnel's JS-driven layout renders constrained, and BarChart's percentage-height flex chain does not collapse.
- Not yet confirmed: physical multi-page pagination (`thead`-repeat across pages) via a real Save-as-PDF. The CSS setup is standard; a quick manual check is recommended.