### PR TITLE
feat(insights): registered readers on the Audience tab (NPPD-1733)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -249,14 +249,31 @@ class Audience_REST_Controller extends WP_REST_Controller {
 		?DateTimeImmutable $compare_start,
 		?DateTimeImmutable $compare_end
 	): array {
+		// Registered readers come from the local wp_users table, not GA4/BQ, so
+		// they are computed here — outside Audience_Metric::get_all()'s GA4
+		// connection gate (NPPD-1733). Attached at a stable top-level key in both
+		// response shapes so the cards render even when the rest of the tab is a
+		// connect banner.
+		$registered_readers = [
+			'total' => Audience_Metric::registered_readers_total(),
+			'new'   => [
+				'current'  => Audience_Metric::registered_readers_new( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) ),
+				'previous' => ( $compare_start && $compare_end )
+					? Audience_Metric::registered_readers_new( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ) )
+					: null,
+			],
+		];
+
 		$current = Audience_Metric::get_all( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), false );
 		if ( isset( $current['tab_error'] ) ) {
+			$current['registered_readers'] = $registered_readers;
 			return $current;
 		}
 
 		$response = [
-			'current'  => $current,
-			'previous' => null,
+			'current'            => $current,
+			'previous'           => null,
+			'registered_readers' => $registered_readers,
 		];
 		if ( $compare_start && $compare_end ) {
 			$previous             = Audience_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/audience-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/audience-fixture.php
@@ -471,6 +471,29 @@ $build = function ( float $f ) use ( $scalar, $breakdown, $table, $series, $star
 };
 
 return [
-	'current'  => $build( 1.0 ),
-	'previous' => $build( 0.88 ),
+	'current'            => $build( 1.0 ),
+	'previous'           => $build( 0.88 ),
+	// Registered readers (local wp_users, NPPD-1733): a window-independent total
+	// snapshot plus a windowed "new" count with its prior-window companion for the
+	// period delta. Lives at top level — not inside the windows — because it is
+	// GA4-independent and present even when the tab is a connect banner.
+	'registered_readers' => [
+		'total' => [
+			'value'      => 24680,
+			'computable' => true,
+			'type'       => 'count',
+		],
+		'new'   => [
+			'current'  => [
+				'value'      => 412,
+				'computable' => true,
+				'type'       => 'count',
+			],
+			'previous' => [
+				'value'      => 357,
+				'computable' => true,
+				'type'       => 'count',
+			],
+		],
+	],
 ];

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -133,6 +133,133 @@ final class Audience_Metric {
 		return require NEWSPACK_ABSPATH . 'includes/wizards/insights/fixtures/audience-fixture.php';
 	}
 
+	/*
+	===================================================================
+	 * Registered readers (local wp_users — GA4-independent, NPPD-1733)
+	 * ===================================================================
+	 */
+
+	/**
+	 * Total registered readers — an all-time snapshot count of reader accounts in
+	 * the local wp_users table. Alone among Audience metrics this reads from
+	 * wp_users, not GA4/BigQuery, so it is computed by the REST controller outside
+	 * the GA4 connection gate and renders even when the rest of the tab cannot.
+	 *
+	 * "Reader" approximates {@see \Newspack\Reader_Activation::is_user_reader()} via
+	 * its reader-role branch rather than a raw `subscriber`-role filter: the
+	 * population is the configured reader roles (subscriber + customer by default)
+	 * minus the restricted staff roles (administrator + editor). It does not also
+	 * union readers carrying only the `np_reader` meta without a reader role — that
+	 * cohort is empty in practice, and the role branch is what stays faithful on
+	 * legacy sites where the meta was never backfilled. Close to the GA4 "known
+	 * reader" segment; avoids folding in legacy staff and missing customer-role
+	 * (WooCommerce) readers.
+	 *
+	 * @return array Scalar payload { value, computable, type } | not-computable.
+	 */
+	public static function registered_readers_total(): array {
+		return self::count_registered_readers( null, null );
+	}
+
+	/**
+	 * New registered readers whose account was created within the window, by
+	 * `user_registered`. Same scalar shape as the snapshot; the REST controller
+	 * pairs the current and prior windows so the card can render a period delta.
+	 *
+	 * @param string $start_date Inclusive window start, YYYY-MM-DD (site timezone).
+	 * @param string $end_date   Inclusive window end, YYYY-MM-DD (site timezone).
+	 * @return array Scalar payload { value, computable, type } | not-computable.
+	 */
+	public static function registered_readers_new( string $start_date, string $end_date ): array {
+		return self::count_registered_readers( $start_date, $end_date );
+	}
+
+	/**
+	 * Count reader accounts via WP_User_Query, optionally bounded to a
+	 * registration window. Parameterized end to end — WP_User_Query builds the SQL,
+	 * nothing is interpolated. Returns a not-computable payload (the NPPD-1698
+	 * em-dash treatment) when Reader Activation is unavailable or no reader roles
+	 * are configured — never a misleading 0.
+	 *
+	 * @param string|null $start_date Window start YYYY-MM-DD, or null for all-time.
+	 * @param string|null $end_date   Window end YYYY-MM-DD, or null for all-time.
+	 * @return array
+	 */
+	private static function count_registered_readers( ?string $start_date, ?string $end_date ): array {
+		if ( ! class_exists( '\Newspack\Reader_Activation' ) ) {
+			return self::registered_readers_not_computable();
+		}
+
+		$reader_roles = \Newspack\Reader_Activation::get_reader_roles();
+		if ( ! is_array( $reader_roles ) || empty( $reader_roles ) ) {
+			return self::registered_readers_not_computable();
+		}
+
+		$args = [
+			'role__in'    => $reader_roles,
+			'number'      => 1,     // Count only; never hydrate the matched users.
+			'fields'      => 'ID',
+			'count_total' => true,
+		];
+
+		// Mirror is_user_reader(): staff roles never count as readers. Same filter,
+		// so a publisher that has customized the restriction stays consistent.
+		$restricted_roles = \apply_filters( 'newspack_reader_restricted_roles', [ 'administrator', 'editor' ] );
+		if ( is_array( $restricted_roles ) && ! empty( $restricted_roles ) ) {
+			$args['role__not_in'] = $restricted_roles;
+		}
+
+		if ( null !== $start_date && null !== $end_date ) {
+			$args['date_query'] = [
+				[
+					'column'    => 'user_registered',
+					'after'     => self::window_bound_to_utc( $start_date, false ),
+					'before'    => self::window_bound_to_utc( $end_date, true ),
+					'inclusive' => true,
+				],
+			];
+		}
+
+		$query = new \WP_User_Query( $args );
+
+		return [
+			'value'      => (int) $query->get_total(),
+			'computable' => true,
+			'type'       => 'count',
+		];
+	}
+
+	/**
+	 * Convert a site-timezone calendar bound (YYYY-MM-DD) into the UTC datetime
+	 * string WP_User_Query needs to match against `user_registered`, which WP
+	 * stores in UTC. Without this a registration near local midnight would land in
+	 * the wrong window by the site's UTC offset.
+	 *
+	 * @param string $date       YYYY-MM-DD in the site timezone.
+	 * @param bool   $end_of_day Anchor at 23:59:59 (true) or 00:00:00 (false).
+	 * @return string `Y-m-d H:i:s` in UTC.
+	 */
+	private static function window_bound_to_utc( string $date, bool $end_of_day ): string {
+		$time  = $end_of_day ? ' 23:59:59' : ' 00:00:00';
+		$local = new \DateTimeImmutable( $date . $time, wp_timezone() );
+		return $local->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Not-computable payload for the registered-reader counts — a genuine wp_users
+	 * failure (or missing Reader Activation), surfaced via the NPPD-1698 em-dash +
+	 * line treatment in the UI rather than a misleading 0.
+	 *
+	 * @return array
+	 */
+	private static function registered_readers_not_computable(): array {
+		return [
+			'value'      => null,
+			'computable' => false,
+			'type'       => 'count',
+		];
+	}
+
 	/**
 	 * Immediately-preceding window of equal length.
 	 *

--- a/plugins/newspack-plugin/src/wizards/insights/api/audience.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/audience.ts
@@ -22,11 +22,29 @@ import type { MetricPayload } from '../tabs/components/metrics';
 /** A window of metrics keyed by metric name, plus a `window` meta entry. */
 export type InsightsWindow = Record< string, MetricPayload >;
 
+/**
+ * Registered readers (NPPD-1733). Sourced from the local `wp_users` table, not
+ * GA4/BQ, so it sits at the top level of the response — present even when the
+ * rest of the tab is a connect banner (`tab_error`). `total` is a window-
+ * independent snapshot; `new` pairs the current window with its prior window so
+ * the card can render a period delta.
+ */
+export interface RegisteredReadersNew {
+	current: MetricPayload;
+	previous: MetricPayload | null;
+}
+
+export interface RegisteredReaders {
+	total: MetricPayload;
+	new: RegisteredReadersNew;
+}
+
 export interface AudienceResponse {
 	tab_error?: string;
 	banner_text?: string;
 	current?: InsightsWindow;
 	previous?: InsightsWindow | null;
+	registered_readers?: RegisteredReaders;
 }
 
 export interface InsightsQuery {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -22,6 +22,7 @@ import ConnectBanner from './components/ConnectBanner';
 import TabStateView from './components/TabStateView';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ReachSection from './audience/sections/ReachSection';
+import RegisteredReadersSection from './audience/sections/RegisteredReadersSection';
 import CompositionSection from './audience/sections/CompositionSection';
 import TimeTrendsSection from './audience/sections/TimeTrendsSection';
 import TrafficSourcesSection from './audience/sections/TrafficSourcesSection';
@@ -42,6 +43,10 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 	// Fixture mode returns a `previous` window unconditionally, so gate on the
 	// toggle here rather than on the response — matches Gates/Subscribers/Donors.
 	const previous = previousRange ? data?.previous ?? null : null;
+	// Registered readers (NPPD-1733) come from local wp_users, so they render even
+	// when GA4 isn't connected — present in both the banner and the normal branch.
+	const registeredReaders = data?.registered_readers ?? null;
+	const showComparison = !! previousRange;
 
 	return (
 		<TabStateView
@@ -54,7 +59,12 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 		>
 			{ data &&
 				( data.tab_error || ! current ? (
-					<ConnectBanner text={ data.banner_text } />
+					<>
+						<ConnectBanner text={ data.banner_text } />
+						{ registeredReaders && (
+							<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
+						) }
+					</>
 				) : (
 					<>
 						<ReachSection
@@ -62,6 +72,9 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 							previous={ previous }
 							lastUpdated={ <LastUpdated tab="audience" range={ range } previousRange={ previousRange } /> }
 						/>
+						{ registeredReaders && (
+							<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
+						) }
 						<CompositionSection current={ current } previous={ previous } />
 						<TrafficSourcesSection current={ current } previous={ previous } />
 						<GeographicSection current={ current } previous={ previous } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for RegisteredReadersSection (NPPD-1733).
+ *
+ * Covers the two cards across populated / honest-zero / not-computable states
+ * and the new-readers delta suppression on an honest zero.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import RegisteredReadersSection from './RegisteredReadersSection';
+import type { MetricPayload, RegisteredReaders } from '../../../api/audience';
+
+const count = ( value: number | null, computable = true ): MetricPayload => ( { value, computable, type: 'count' } );
+
+const make = ( total: MetricPayload, current: MetricPayload, previous: MetricPayload | null = null ): RegisteredReaders => ( {
+	total,
+	new: { current, previous },
+} );
+
+describe( 'RegisteredReadersSection', () => {
+	it( 'renders the heading and both cards with formatted counts', () => {
+		render( <RegisteredReadersSection registeredReaders={ make( count( 24680 ), count( 412 ), count( 357 ) ) } showComparison /> );
+		expect( screen.getByRole( 'heading', { name: 'Registered readers' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total registered readers' ) ).toBeInTheDocument();
+		expect( screen.getByText( '24,680' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New registered readers' ) ).toBeInTheDocument();
+		expect( screen.getByText( '412' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a new-publisher zero as an honest 0 with no period delta', () => {
+		render( <RegisteredReadersSection registeredReaders={ make( count( 0 ), count( 0 ), count( 0 ) ) } showComparison /> );
+		expect( screen.getAllByText( '0' ).length ).toBeGreaterThanOrEqual( 2 );
+		expect( screen.queryByText( '↑' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( '↓' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the not-computable em-dash + line when a count fails server-side', () => {
+		render( <RegisteredReadersSection registeredReaders={ make( count( null, false ), count( null, false ), null ) } showComparison /> );
+		expect( screen.getAllByLabelText( 'Not applicable' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( 'Registered reader count is unavailable right now.' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'suppresses the new-readers delta when none were created this timeframe', () => {
+		render( <RegisteredReadersSection registeredReaders={ make( count( 100 ), count( 0 ), count( 40 ) ) } showComparison /> );
+		// A real prior value exists, but an honest zero must not render "↓100%".
+		expect( screen.queryByText( '↓' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'omits the new-readers delta when the comparison toggle is off', () => {
+		render( <RegisteredReadersSection registeredReaders={ make( count( 100 ), count( 60 ), count( 40 ) ) } showComparison={ false } /> );
+		expect( screen.queryByText( '↑' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( '↓' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx
@@ -1,0 +1,87 @@
+/**
+ * Audience › Registered readers (NPPD-1733).
+ *
+ * The one Audience section sourced from the local wp_users table rather than
+ * GA4. It is the foundational audience population in the funnel
+ * (visitors → registered readers → subscribers → donors) and the canonical count
+ * behind the GA4 "known reader" segment shown in Composition below — the section
+ * description names that relationship so the two numbers don't read as competing.
+ *
+ * Two cards, both via MetricCard directly (not Scorecard) so the wp_users
+ * query-error edge state can use the NPPD-1698 notComputable em-dash + line:
+ *   - Total registered readers — all-time snapshot, no period delta. A real 0
+ *     (new publisher) renders as an honest 0, not an empty state.
+ *   - New registered readers — accounts created in the timeframe, with a period
+ *     delta vs the previous equal-length timeframe. The delta is suppressed when
+ *     none were created (a "↓100%" against a real prior would misread an honest
+ *     zero), mirroring Subscribers' "New subscribers" card.
+ *
+ * Rendered in both AudienceTab branches: alongside the GA4 sections normally, and
+ * directly under the connect banner when GA4 isn't connected (this count doesn't
+ * need GA4).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { MetricPayload, RegisteredReaders } from '../../../api/audience';
+import MetricCard from '../../components/MetricCard';
+import SectionHeading from '../../components/SectionHeading';
+
+export interface RegisteredReadersSectionProps {
+	registeredReaders: RegisteredReaders;
+	/** Whether the comparison toggle is on — gates the "new" card's period delta. */
+	showComparison: boolean;
+}
+
+/** A count payload is usable when it didn't fail server-side and carries a number. */
+const readCount = ( payload: MetricPayload | null | undefined ): number | null =>
+	payload && payload.computable !== false && typeof payload.value === 'number' ? payload.value : null;
+
+const UNAVAILABLE_MESSAGE = __( 'Registered reader count is unavailable right now.', 'newspack-plugin' );
+
+const RegisteredReadersSection = ( { registeredReaders, showComparison }: RegisteredReadersSectionProps ) => {
+	const { total, new: newReaders } = registeredReaders;
+
+	const totalCount = readCount( total );
+	const newCount = readCount( newReaders.current );
+
+	// Suppress the period delta when no accounts were created this timeframe: a
+	// "↓100%" against a real prior count would misread an honest zero.
+	const previousNew = showComparison && newCount !== 0 ? readCount( newReaders.previous ) : null;
+
+	return (
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-registered-readers">
+			<SectionHeading
+				id="newspack-insights-audience-registered-readers"
+				title={ __( 'Registered readers', 'newspack-plugin' ) }
+				description={ __( 'People who registered on your site — the known-reader population behind the segments below.', 'newspack-plugin' ) }
+			/>
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-2">
+				<MetricCard
+					label={ __( 'Total registered readers', 'newspack-plugin' ) }
+					value={ totalCount ?? 0 }
+					format="number"
+					// Window-independent snapshot: never a period delta.
+					notComputableMessage={ totalCount === null ? UNAVAILABLE_MESSAGE : undefined }
+					description={ __( 'All-time registrations on your site', 'newspack-plugin' ) }
+				/>
+				<MetricCard
+					label={ __( 'New registered readers', 'newspack-plugin' ) }
+					value={ newCount ?? 0 }
+					format="number"
+					previousValue={ previousNew }
+					notComputableMessage={ newCount === null ? UNAVAILABLE_MESSAGE : undefined }
+					description={ __( 'Registrations created in this timeframe', 'newspack-plugin' ) }
+				/>
+			</div>
+		</section>
+	);
+};
+
+export default RegisteredReadersSection;

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-metric.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Test Audience_Metric registered-readers counts (NPPD-1733).
+ *
+ * The one Audience metric sourced from local wp_users rather than GA4. Covers
+ * the is_user_reader()-equivalent role filter (reader roles minus staff), the
+ * inclusive registration window, the honest-zero baseline, and the
+ * not-computable guard.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Audience_Metric;
+use WP_UnitTestCase;
+
+/**
+ * Audience_Metric registered-readers test class.
+ *
+ * @group insights
+ */
+class Test_Audience_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Create a user with a role and an explicit registration datetime (UTC, as
+	 * WordPress stores `user_registered`).
+	 *
+	 * @param string $role       Role slug.
+	 * @param string $registered `Y-m-d H:i:s` in UTC.
+	 * @return int User ID.
+	 */
+	private function make_user( string $role, string $registered ): int {
+		return self::factory()->user->create(
+			[
+				'role'            => $role,
+				'user_registered' => $registered,
+			]
+		);
+	}
+
+	/**
+	 * Total counts the configured reader roles (subscriber + customer) and
+	 * excludes staff (administrator + editor) and non-reader roles (author).
+	 */
+	public function test_total_counts_reader_roles_excluding_staff() {
+		$this->make_user( 'subscriber', '2026-01-10 12:00:00' );
+		$this->make_user( 'subscriber', '2026-02-10 12:00:00' );
+		$this->make_user( 'customer', '2026-03-10 12:00:00' );
+		$this->make_user( 'administrator', '2026-01-05 12:00:00' );
+		$this->make_user( 'editor', '2026-01-06 12:00:00' );
+		$this->make_user( 'author', '2026-01-07 12:00:00' );
+
+		$payload = Audience_Metric::registered_readers_total();
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 'count', $payload['type'] );
+		$this->assertSame( 3, $payload['value'], 'Counts subscriber + customer; excludes admin, editor, author.' );
+	}
+
+	/**
+	 * New counts only accounts registered within the window.
+	 */
+	public function test_new_counts_only_within_window() {
+		$this->make_user( 'subscriber', '2026-01-15 12:00:00' );
+		$this->make_user( 'customer', '2026-01-20 12:00:00' );
+		$this->make_user( 'subscriber', '2025-12-31 12:00:00' );
+		$this->make_user( 'subscriber', '2026-02-01 12:00:00' );
+
+		$payload = Audience_Metric::registered_readers_new( '2026-01-01', '2026-01-31' );
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 2, $payload['value'] );
+	}
+
+	/**
+	 * The window is inclusive of both calendar boundaries (00:00:00 → 23:59:59).
+	 */
+	public function test_window_bounds_are_inclusive() {
+		$this->make_user( 'subscriber', '2026-01-01 00:00:00' );
+		$this->make_user( 'subscriber', '2026-01-31 23:59:59' );
+
+		$payload = Audience_Metric::registered_readers_new( '2026-01-01', '2026-01-31' );
+
+		$this->assertSame( 2, $payload['value'] );
+	}
+
+	/**
+	 * No reader accounts → an honest, computable 0 (NOT a not-computable state):
+	 * a new publisher's real zero, per NPPD-1733's empty-state contract.
+	 */
+	public function test_new_publisher_zero_is_computable() {
+		$payload = Audience_Metric::registered_readers_total();
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 0, $payload['value'] );
+	}
+
+	/**
+	 * When no reader roles are configured the count is genuinely unknowable, so
+	 * the metric reports not-computable (the UI's em-dash treatment) rather than a
+	 * misleading 0.
+	 */
+	public function test_not_computable_when_no_reader_roles() {
+		add_filter( 'newspack_reader_user_roles', '__return_empty_array' );
+		$payload = Audience_Metric::registered_readers_total();
+		remove_filter( 'newspack_reader_user_roles', '__return_empty_array' );
+
+		$this->assertFalse( $payload['computable'] );
+		$this->assertNull( $payload['value'] );
+	}
+}


### PR DESCRIPTION
## Registered readers on the Audience tab

Adds the foundational audience-population count to the Insights Audience tab — the one Audience metric sourced from the local `wp_users` table rather than GA4/BigQuery. It fills the missing rung in the cross-tab funnel story (`total visitors → registered readers → newsletter subscribers → donors/subscribers`): publishers could see who *visits* but not how many readers they'd actually *captured*. It's also the canonical population behind the GA4 "known reader" segment shown in Composition, so the two are framed as related, not competing.

Linear: [NPPD-1733](https://linear.app/a8c/issue/NPPD-1733/insights-report-total-registered-users-on-the-audience-tab)

Scope is two cards: **Total registered readers** (all-time snapshot, honest `0` for a new publisher, no period delta) and **New registered readers** (registrations in the selected timeframe, carrying a period delta vs the previous equal-length timeframe). The "active registered readers" third card is **deferred** — Reader Activation tracks no per-reader last-activity timestamp to build it on honestly.

<img width="1059" height="298" alt="Screenshot 2026-06-18 at 3 09 19 PM" src="https://github.com/user-attachments/assets/fffa3e6b-4a72-449a-9dc0-3389faf9d173" />

## Pre-flight decisions

These were settled during recon, before any code:

- **Reader filter — `is_user_reader()`-equivalent, not raw `subscriber` role.** Verified against three live publishers. The ticket's `wp_capabilities LIKE '%subscriber%'` is wrong both ways: it overcounts staff who happen to carry the `subscriber` cap and misses `customer`-role (WooCommerce) readers, while a strict `np_reader`-meta filter returns **0** on a large legacy publisher where the meta was never backfilled (≈75k accounts). The only definition correct on all three sites — and the one that matches both the product-wide "reader" concept and the GA4 known-reader segment — is `Reader_Activation::get_reader_roles()` (subscriber + customer, filterable) minus the restricted staff roles (administrator + editor). Implemented as a `WP_User_Query` (`role__in` / `role__not_in` / `count_total`), which honors the role filters and is fully parameterized.
- **No new REST endpoint.** The Audience tab serves every metric through the single `GET /newspack-insights/v1/audience` route; the ticket's proposed `/audience/registered-readers` would have been a new pattern. The counts ride the existing response at a stable top-level `registered_readers` key instead.
- **Computed outside the GA4 connection gate.** Because this is the one Audience metric that doesn't need GA4, it must render even when GA4 isn't connected and the rest of the tab is a connect banner. It's computed in the REST controller, never inside `Audience_Metric::get_all()`'s `connection_error()` short-circuit, and is attached in both the `tab_error` and normal response shapes.
- **Error edge state uses the canonical not-computable treatment.** A genuine `wp_users` failure renders the NPPD-1698 em-dash + line, consistent with sibling "no number" cards.

## What's in this PR

### Server — the count (`includes/wizards/insights/metrics/class-audience-metric.php`)
New public statics `registered_readers_total()` and `registered_readers_new( $start, $end )`, both backed by a private `count_registered_readers()`. It uses `WP_User_Query` with `role__in => Reader_Activation::get_reader_roles()`, `role__not_in` from the same `newspack_reader_restricted_roles` filter `is_user_reader()` uses, `count_total => true`, and (for the windowed card) a `date_query` on `user_registered`. Window bounds are converted **site-timezone → UTC** because WordPress stores `user_registered` in UTC — without it a registration near local midnight would fall in the wrong window. Guards (Reader Activation unavailable, no reader roles, or a `$wpdb->last_error`) return a not-computable payload rather than a misleading `0`.

### Server — wiring (`includes/wizards/insights/api/class-audience-rest-controller.php`)
`build_response()` computes `registered_readers` (the snapshot `total` plus `new.{current,previous}` for the delta) independently of `get_all()` and attaches it at the top level of both the connect-banner and the normal response.

### Frontend — the cards (`src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx`)
Renders both cards with `MetricCard` directly (not the `Scorecard` wrapper) so the query-error case can pass `notComputableMessage` for the em-dash treatment. Honest `0` on the snapshot, period delta on "new" — suppressed when none were created this timeframe (a `↓100%` against a real prior would misread an honest zero), mirroring Subscribers' "New subscribers" card.

### Frontend — placement (`src/wizards/insights/tabs/AudienceTab.tsx`)
The section renders in **both** branches: directly under the `ConnectBanner` when GA4 isn't connected, and after `ReachSection` (just before Composition, where known/anonymous lives) in the normal flow. Types live in `src/wizards/insights/api/audience.ts`; fixture-mode values in `includes/wizards/insights/fixtures/audience-fixture.php`.

### Tests
- `tests/unit-tests/insights/class-test-audience-metric.php` — reader roles counted, staff (admin/editor) and non-reader roles excluded, inclusive registration window, honest-`0`-is-computable, and the not-computable guard. **Passes** (`n test-php --group insights` → 300/300).
- `RegisteredReadersSection.test.tsx` — populated, honest-zero, not-computable em-dash, and delta-suppression cases.

## How to test

1. With `NEWSPACK_INSIGHTS_FIXTURE_MODE` on, open Insights → **Audience**. Confirm a **Registered readers** section appears after Reach with two cards (Total 24,680; New 412 with an upward delta).
2. Turn fixture mode off on a site with reader accounts but no GA4 connection. Confirm the tab shows the GA4 connect banner **and** the Registered readers cards below it (proving the GA4-independent path) — the Total should equal your subscriber + customer count minus admins/editors.
3. On a brand-new site with zero readers, confirm Total renders an honest **0** (no period delta), not an empty state.
4. Toggle the comparison timeframe and confirm "New registered readers" gains a period delta; with zero new in the timeframe, confirm no misleading `↓100%`.
5. Run `n test-php --group insights` and the JS suite.