### PR TITLE
feat(newsletters): render posts-inserter and share in WC emails

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -52,11 +52,14 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	/**
 	 * Render the inserted child blocks to email-safe HTML.
 	 *
-	 * Concatenates each child's `innerHTML` after running it through
-	 * `do_blocks()`, which renders any nested blocks (so no raw block-comment
-	 * delimiters survive) and, while the package's `render_block` filter is
-	 * active, returns them email-processed. Kept as a static so it stays
-	 * unit-testable without booting the WC engine.
+	 * Wraps each child back into its block delimiter, then runs it through
+	 * `do_blocks()` so the child block itself is rendered — its own
+	 * `render_email_callback` fires via the package's `render_block` filter, and
+	 * any nested blocks render too (no raw block-comment delimiters survive).
+	 * Rendering the bare `innerHTML` instead would render only the inner blocks
+	 * and leave the outer block (e.g. `core/columns`) as raw markup that never
+	 * gets its email wrapper — so its columns overflow the email width. Kept as a
+	 * static so it stays unit-testable without booting the WC engine.
 	 *
 	 * @param array $children The `innerBlocksToInsert` array of child blocks.
 	 * @return string The concatenated rendered HTML, in child order.
@@ -64,10 +67,42 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	public static function render_inserted_blocks( array $children ): string {
 		$html = '';
 		foreach ( $children as $child ) {
-			$inner_html = is_array( $child ) ? ( $child['innerHTML'] ?? '' ) : '';
-			$html      .= do_blocks( (string) $inner_html );
+			if ( ! is_array( $child ) ) {
+				continue;
+			}
+			// Wrap a named child back into its delimiter so the outer block is
+			// email-rendered (its render_email_callback fires). A child without a
+			// block name is unexpected — the editor always stores one — but fall
+			// back to rendering its inner HTML so content is never dropped.
+			$html .= empty( $child['blockName'] )
+				? do_blocks( (string) ( $child['innerHTML'] ?? '' ) )
+				: do_blocks( self::serialize_inserted_block( $child ) );
 		}
 		return $html;
+	}
+
+	/**
+	 * Wrap a parsed child block back into block markup for `do_blocks()`.
+	 *
+	 * Rebuilds the block delimiter around the saved `innerHTML` (which already
+	 * carries the child's own inner-block delimiters), so `do_blocks()` re-parses
+	 * and renders the full block — outer wrapper included. Mirrors core's
+	 * `serialize_block()` but reads from `innerHTML`, since the inserted children
+	 * carry `innerHTML` but not necessarily `innerContent`.
+	 *
+	 * @param array $child A child block shaped `{ blockName, attrs, innerHTML }`.
+	 * @return string Block markup ready for `do_blocks()`.
+	 */
+	private static function serialize_inserted_block( array $child ): string {
+		$name       = (string) $child['blockName'];
+		$short_name = str_starts_with( $name, 'core/' ) ? substr( $name, 5 ) : $name;
+		$attrs      = empty( $child['attrs'] ) ? '' : ' ' . serialize_block_attributes( $child['attrs'] );
+		$inner_html = (string) ( $child['innerHTML'] ?? '' );
+
+		if ( '' === trim( $inner_html ) ) {
+			return "<!-- wp:{$short_name}{$attrs} /-->";
+		}
+		return "<!-- wp:{$short_name}{$attrs} -->{$inner_html}<!-- /wp:{$short_name} -->";
 	}
 }
 

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -46,7 +46,52 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 		if ( ! is_array( $children ) ) {
 			return '';
 		}
-		return self::render_inserted_blocks( $children );
+		return self::apply_email_styles( self::render_inserted_blocks( $children ) );
+	}
+
+	/**
+	 * Vertical gap between the meta blocks within a post item (title, subtitle,
+	 * date, excerpt, continue-reading), replacing the package's uniform 16px.
+	 *
+	 * The posts-inserter has no post-editor equivalent, so it matches the tighter
+	 * MJML newsletter look rather than the package default.
+	 */
+	const META_GAP = '8px';
+
+	/**
+	 * Vertical gap between consecutive post items. The package concatenates the
+	 * inserted children with no gap, so each item after the first gets this top
+	 * margin to separate the posts.
+	 */
+	const POST_GAP = '24px';
+
+	/**
+	 * Restyle the rendered post items to match the MJML newsletter look.
+	 *
+	 * Two adjustments, since the posts-inserter has no post-editor equivalent and
+	 * matches MJML:
+	 * 1. Post title / "continue reading" links: the package renders them with no
+	 *    colour (→ the client's default blue) and `text-decoration: none`. Set
+	 *    them black + underlined. Anchors are bare at this stage; the CSS inliner
+	 *    adds its styles downstream but preserves existing inline styles, so this
+	 *    wins. Image-wrapping anchors are skipped via the lookahead.
+	 * 2. Block spacing: collapse the package's uniform 16px gap to META_GAP.
+	 * 3. Root padding: each child renders as a top-level block and so gets the
+	 *    email's 24px root padding again — on top of the posts-inserter block's
+	 *    own root padding — double-indenting the posts. Zero the inner root
+	 *    padding so the posts line up flush with the other blocks.
+	 *
+	 * @param string $html Rendered posts-inserter HTML.
+	 * @return string
+	 */
+	private static function apply_email_styles( string $html ): string {
+		$html = (string) preg_replace(
+			'/<a\b([^>]*)>(?!\s*<img)/i',
+			'<a$1 style="text-decoration: underline; color: #000000;">',
+			$html
+		);
+		$html = (string) preg_replace( '/margin-top:\s*16px/i', 'margin-top: ' . self::META_GAP, $html );
+		return (string) preg_replace( '/padding-left:\s*24px;\s*padding-right:\s*24px/i', 'padding-left: 0; padding-right: 0', $html );
 	}
 
 	/**
@@ -65,18 +110,29 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	 * @return string The concatenated rendered HTML, in child order.
 	 */
 	public static function render_inserted_blocks( array $children ): string {
-		$html = '';
+		$html  = '';
+		$index = 0;
 		foreach ( $children as $child ) {
 			if ( ! is_array( $child ) ) {
 				continue;
 			}
-			// Wrap a named child back into its delimiter so the outer block is
-			// email-rendered (its render_email_callback fires). A child without a
-			// block name is unexpected — the editor always stores one — but fall
-			// back to rendering its inner HTML so content is never dropped.
-			$html .= empty( $child['blockName'] )
-				? do_blocks( (string) ( $child['innerHTML'] ?? '' ) )
-				: do_blocks( self::serialize_inserted_block( $child ) );
+			// A child without a block name is unexpected — the editor always stores
+			// one — but fall back to rendering its inner HTML so content is never
+			// dropped.
+			if ( empty( $child['blockName'] ) ) {
+				$html .= do_blocks( (string) ( $child['innerHTML'] ?? '' ) );
+				++$index;
+				continue;
+			}
+			// Separate consecutive post items: give every item after the first a top
+			// margin (the package renders the concatenated children with no gap).
+			if ( $index > 0 ) {
+				$child['attrs']['style']['spacing']['margin']['top'] = self::POST_GAP;
+			}
+			// Wrap the child back into its delimiter so the outer block is
+			// email-rendered (its render_email_callback fires).
+			$html .= do_blocks( self::serialize_inserted_block( $child ) );
+			++$index;
 		}
 		return $html;
 	}

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -66,15 +66,27 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	const POST_GAP = '24px';
 
 	/**
+	 * Top/bottom padding wrapped around each block of the flat ("image on top", or
+	 * no featured image) layout. There the inserted children are the individual
+	 * heading/paragraph/image blocks, which the package stacks flush; the editor
+	 * canvas gives every such block a 6px top/bottom padding, so match it here so
+	 * the email and the editor read the same.
+	 */
+	const FLAT_BLOCK_PAD = '6px';
+
+	/**
 	 * Restyle the rendered post items to match the MJML newsletter look.
 	 *
 	 * Two adjustments, since the posts-inserter has no post-editor equivalent and
 	 * matches MJML:
 	 * 1. Post title / "continue reading" links: the package renders them with no
 	 *    colour (→ the client's default blue) and `text-decoration: none`. Set
-	 *    them black + underlined. Anchors are bare at this stage; the CSS inliner
-	 *    adds its styles downstream but preserves existing inline styles, so this
-	 *    wins. Image-wrapping anchors are skipped via the lookahead.
+	 *    them underlined and inheriting their element's colour, so they read black
+	 *    by default but follow the block's own heading/text colour when one is set
+	 *    (forcing `#000000` clobbered the title's colour). Anchors are bare at this
+	 *    stage; the CSS inliner adds its styles downstream but preserves existing
+	 *    inline styles, so this wins. Image-wrapping anchors are skipped via the
+	 *    lookahead.
 	 * 2. Block spacing: collapse the package's uniform 16px gap to META_GAP.
 	 * 3. Root padding: each child renders as a top-level block and so gets the
 	 *    email's 24px root padding again — on top of the posts-inserter block's
@@ -87,7 +99,7 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	private static function apply_email_styles( string $html ): string {
 		$html = (string) preg_replace(
 			'/<a\b([^>]*)>(?!\s*<img)/i',
-			'<a$1 style="text-decoration: underline; color: #000000;">',
+			'<a$1 style="text-decoration: underline; color: inherit;">',
 			$html
 		);
 		$html = (string) preg_replace( '/margin-top:\s*16px/i', 'margin-top: ' . self::META_GAP, $html );
@@ -124,17 +136,47 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 				++$index;
 				continue;
 			}
-			// Separate consecutive post items: give every item after the first a top
-			// margin (the package renders the concatenated children with no gap).
-			if ( $index > 0 ) {
-				$child['attrs']['style']['spacing']['margin']['top'] = self::POST_GAP;
+			if ( 'core/columns' === $child['blockName'] ) {
+				// Side-by-side layout (image left/right): each child is a whole post
+				// wrapped in a columns block. Separate consecutive posts with a top
+				// margin (the package concatenates them with no gap).
+				if ( $index > 0 ) {
+					$child['attrs']['style']['spacing']['margin']['top'] = self::POST_GAP;
+				}
+				// Wrap the child back into its delimiter so the outer block is
+				// email-rendered (its render_email_callback fires).
+				$html .= do_blocks( self::serialize_inserted_block( $child ) );
+			} else {
+				// Flat layout (image on top, or no featured image): each child is an
+				// individual heading/paragraph/image block. The package stacks these
+				// flush and ignores their margin/padding attrs, so wrap each rendered
+				// block in a padded cell — matching the editor canvas's per-block
+				// 6px top/bottom padding so the email and the editor read the same.
+				$html .= self::wrap_flat_block( do_blocks( self::serialize_inserted_block( $child ) ) );
 			}
-			// Wrap the child back into its delimiter so the outer block is
-			// email-rendered (its render_email_callback fires).
-			$html .= do_blocks( self::serialize_inserted_block( $child ) );
 			++$index;
 		}
 		return $html;
+	}
+
+	/**
+	 * Wrap a rendered flat-layout block in a table cell with top/bottom padding.
+	 *
+	 * The flat ("image on top" / no featured image) layout renders each post block
+	 * as a standalone top-level block; the package stacks them flush and ignores
+	 * their spacing attrs, so an email-safe padded `<td>` re-creates the editor
+	 * canvas's per-block 6px top/bottom padding (kept symmetric on every block so
+	 * the gap between any two is 12px, matching the canvas).
+	 *
+	 * @param string $block_html Rendered email HTML for a single block.
+	 * @return string The block wrapped in a padded cell.
+	 */
+	private static function wrap_flat_block( string $block_html ): string {
+		return sprintf(
+			'<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="border-collapse: collapse;"><tbody><tr><td style="padding-top: %1$s; padding-bottom: %1$s;">%2$s</td></tr></tbody></table>',
+			self::FLAT_BLOCK_PAD,
+			$block_html
+		);
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Newspack WC email-editor renderer for the posts-inserter block.
+ *
+ * Renders each inserted child block through `do_blocks()` so nested blocks are
+ * fully rendered and email-processed, instead of leaking raw block-comment
+ * delimiters into the email body.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Renders a newspack-newsletters/posts-inserter block under the WC engine.
+ *
+ * The block stores its content in the `innerBlocksToInsert` attribute, an array
+ * of child blocks shaped `{ blockName, attrs, innerHTML, innerBlocks }`. The
+ * block's own server render callback concatenates each child's raw `innerHTML`,
+ * so any child carrying nested blocks leaks literal `<!-- wp:... -->` delimiters
+ * into the output. This override instead pushes each child's `innerHTML` through
+ * `do_blocks()`. Because the package's `render_block` filter is still active mid
+ * render, the rendered children come back email-processed for free.
+ */
+class Posts_Inserter extends Abstract_Block_Renderer {
+	/**
+	 * Render the posts-inserter content.
+	 *
+	 * Rebuilds the output from the `innerBlocksToInsert` attribute rather than the
+	 * supplied `$block_content` (the block's own callback produces the leaky raw
+	 * concatenation). The base `render()` adds the spacer and the package adds the
+	 * root horizontal padding around the result.
+	 *
+	 * @param string            $block_content     Block content (ignored; rebuilt from attrs).
+	 * @param array             $parsed_block      Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$children = $parsed_block['attrs']['innerBlocksToInsert'] ?? [];
+		if ( ! is_array( $children ) ) {
+			return '';
+		}
+		return self::render_inserted_blocks( $children );
+	}
+
+	/**
+	 * Render the inserted child blocks to email-safe HTML.
+	 *
+	 * Concatenates each child's `innerHTML` after running it through
+	 * `do_blocks()`, which renders any nested blocks (so no raw block-comment
+	 * delimiters survive) and, while the package's `render_block` filter is
+	 * active, returns them email-processed. Kept as a static so it stays
+	 * unit-testable without booting the WC engine.
+	 *
+	 * @param array $children The `innerBlocksToInsert` array of child blocks.
+	 * @return string The concatenated rendered HTML, in child order.
+	 */
+	public static function render_inserted_blocks( array $children ): string {
+		$html = '';
+		foreach ( $children as $child ) {
+			$inner_html = is_array( $child ) ? ( $child['innerHTML'] ?? '' ) : '';
+			$html      .= do_blocks( (string) $inner_html );
+		}
+		return $html;
+	}
+}
+
+// Self-register this override so the registry discovers it via the blocks/ glob.
+\Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'newspack-newsletters/posts-inserter', Posts_Inserter::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -86,7 +86,8 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	 *    (forcing `#000000` clobbered the title's colour). Anchors are bare at this
 	 *    stage; the CSS inliner adds its styles downstream but preserves existing
 	 *    inline styles, so this wins. Image-wrapping anchors are skipped via the
-	 *    lookahead.
+	 *    `<img` lookahead, and any anchor that already carries a `style` attribute
+	 *    is skipped too (the `style=` lookahead) so we never emit a duplicate one.
 	 * 2. Block spacing: collapse the package's uniform 16px gap to META_GAP.
 	 * 3. Root padding: each child renders as a top-level block and so gets the
 	 *    email's 24px root padding again — on top of the posts-inserter block's
@@ -98,7 +99,7 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	 */
 	private static function apply_email_styles( string $html ): string {
 		$html = (string) preg_replace(
-			'/<a\b([^>]*)>(?!\s*<img)/i',
+			'/<a\b(?![^>]*\bstyle=)([^>]*)>(?!\s*<img)/i',
 			'<a$1 style="text-decoration: underline; color: inherit;">',
 			$html
 		);

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
@@ -86,8 +86,12 @@ class Share extends Abstract_Block_Renderer {
 		if ( '' === $href ) {
 			return '';
 		}
+		// Match the editor's default link rendering: underlined and inheriting the
+		// text colour. The package's CSS inliner otherwise gives the anchor the
+		// client-default blue with no underline; it preserves existing inline
+		// styles, so styling the anchor here wins.
 		return sprintf(
-			'<p class="newspack-newsletters-share-block"><a href="%1$s">%2$s</a></p>',
+			'<p class="newspack-newsletters-share-block"><a href="%1$s" style="text-decoration: underline; color: inherit;">%2$s</a></p>',
 			esc_url( $href, [ 'http', 'https', 'mailto' ] ),
 			wp_kses_post( $content )
 		);

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
@@ -67,7 +67,90 @@ class Share extends Abstract_Block_Renderer {
 			$content = $matches[1];
 		}
 
-		return self::build_share_html( $href, $content );
+		// Resolve the block's chosen background/text colours. Named presets
+		// (`backgroundColor`/`textColor`) resolve through the palette; a custom
+		// value lives under `style.color`.
+		$background = self::resolve_color( (string) ( $attrs['backgroundColor'] ?? '' ) );
+		if ( '' === $background ) {
+			$background = (string) ( $attrs['style']['color']['background'] ?? '' );
+		}
+		$text = self::resolve_color( (string) ( $attrs['textColor'] ?? '' ) );
+		if ( '' === $text ) {
+			$text = (string) ( $attrs['style']['color']['text'] ?? '' );
+		}
+
+		// Resolve the chosen font size. A named preset (`fontSize`) resolves through
+		// the font-size scale; a custom value lives under `style.typography`.
+		$font_size = self::resolve_font_size( (string) ( $attrs['fontSize'] ?? '' ) );
+		if ( '' === $font_size ) {
+			$font_size = (string) ( $attrs['style']['typography']['fontSize'] ?? '' );
+		}
+
+		return self::build_share_html( $href, $content, $background, $text, $font_size );
+	}
+
+	/**
+	 * Resolve a colour preset slug (or `var:preset|color|slug`) to its hex value.
+	 *
+	 * The override builds the share markup itself, so it bypasses the package's
+	 * colour handling — and class-based preset colours would inline as unresolved
+	 * `var(--wp--preset--color--*)` (dead in email clients). Resolve the slug
+	 * against the active (email) theme.json palette so an inline hex can be set.
+	 * A value that is already a literal colour (hex / rgb) is returned as-is.
+	 *
+	 * @param string $value Preset slug, `var:preset|color|slug`, or literal colour.
+	 * @return string The hex/literal colour, or an empty string when unresolved.
+	 */
+	private static function resolve_color( string $value ): string {
+		if ( '' === $value ) {
+			return '';
+		}
+		if ( '#' === $value[0] || 0 === strpos( $value, 'rgb' ) ) {
+			return $value;
+		}
+		if ( 0 === strpos( $value, 'var:preset|color|' ) ) {
+			$value = substr( $value, strlen( 'var:preset|color|' ) );
+		}
+		$palette = wp_get_global_settings( [ 'color', 'palette' ] );
+		$colors  = isset( $palette['theme'] ) || isset( $palette['default'] ) || isset( $palette['custom'] )
+			? array_merge( $palette['theme'] ?? [], $palette['custom'] ?? [], $palette['default'] ?? [] )
+			: (array) $palette;
+		foreach ( $colors as $color ) {
+			if ( is_array( $color ) && ( $color['slug'] ?? '' ) === $value ) {
+				return (string) ( $color['color'] ?? '' );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Resolve a font-size preset slug (e.g. `huge`) to its value.
+	 *
+	 * Like the colour resolution, the override builds the markup itself, so the
+	 * block's chosen size must be set inline. A named preset resolves against the
+	 * active (email) theme.json font-size scale; a literal size (carrying a digit
+	 * or `clamp(`) is returned as-is.
+	 *
+	 * @param string $value Preset slug or literal size (e.g. `huge`, `44px`).
+	 * @return string The resolved size, or an empty string when unresolved.
+	 */
+	private static function resolve_font_size( string $value ): string {
+		if ( '' === $value ) {
+			return '';
+		}
+		if ( preg_match( '/[\d(]/', $value ) ) {
+			return $value;
+		}
+		$sizes = wp_get_global_settings( [ 'typography', 'fontSizes' ] );
+		$list  = isset( $sizes['theme'] ) || isset( $sizes['default'] ) || isset( $sizes['custom'] )
+			? array_merge( $sizes['theme'] ?? [], $sizes['custom'] ?? [], $sizes['default'] ?? [] )
+			: (array) $sizes;
+		foreach ( $list as $size ) {
+			if ( is_array( $size ) && ( $size['slug'] ?? '' ) === $value ) {
+				return (string) ( $size['size'] ?? '' );
+			}
+		}
+		return '';
 	}
 
 	/**
@@ -78,22 +161,42 @@ class Share extends Abstract_Block_Renderer {
 	 * markup: a paragraph wrapping a single anchor. Returns an empty string when
 	 * there is no link to point at.
 	 *
-	 * @param string $href    The share link URL.
-	 * @param string $content The link text.
+	 * @param string $href       The share link URL.
+	 * @param string $content    The link text.
+	 * @param string $background Resolved background colour (hex/literal), or ''.
+	 * @param string $text       Resolved text colour (hex/literal), or ''.
+	 * @param string $font_size  Resolved font size (e.g. `44px`), or ''.
 	 * @return string The share anchor HTML, or an empty string when href is empty.
 	 */
-	public static function build_share_html( string $href, string $content ): string {
+	public static function build_share_html( string $href, string $content, string $background = '', string $text = '', string $font_size = '' ): string {
 		if ( '' === $href ) {
 			return '';
 		}
+		// Apply the block's background/text colours and font size inline on the
+		// paragraph so they survive into the email. A background-carrying block also
+		// gets the editor canvas's 6px/12px padding so the colour block reads the
+		// same.
+		$p_styles = [];
+		if ( '' !== $background ) {
+			$p_styles[] = 'background-color: ' . $background;
+			$p_styles[] = 'padding: 6px 12px';
+		}
+		if ( '' !== $text ) {
+			$p_styles[] = 'color: ' . $text;
+		}
+		if ( '' !== $font_size ) {
+			$p_styles[] = 'font-size: ' . $font_size;
+		}
+		$p_style = empty( $p_styles ) ? '' : ' style="' . esc_attr( implode( '; ', $p_styles ) . ';' ) . '"';
 		// Match the editor's default link rendering: underlined and inheriting the
-		// text colour. The package's CSS inliner otherwise gives the anchor the
-		// client-default blue with no underline; it preserves existing inline
-		// styles, so styling the anchor here wins.
+		// text colour (so it follows the block's text colour). The package's CSS
+		// inliner otherwise gives the anchor the client-default blue with no
+		// underline; it preserves existing inline styles, so styling here wins.
 		return sprintf(
-			'<p class="newspack-newsletters-share-block"><a href="%1$s" style="text-decoration: underline; color: inherit;">%2$s</a></p>',
+			'<p class="newspack-newsletters-share-block"%3$s><a href="%1$s" style="text-decoration: underline; color: inherit;">%2$s</a></p>',
 			esc_url( $href, [ 'http', 'https', 'mailto' ] ),
-			wp_kses_post( $content )
+			wp_kses_post( $content ),
+			$p_style
 		);
 	}
 }

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Newspack WC email-editor renderer for the share block.
+ *
+ * Emits the saved share anchor when the newsletter is public, mirroring the
+ * legacy MJML renderer's intent. The block's own server render callback returns
+ * an empty string unconditionally, so under the WC engine a public newsletter's
+ * valid share link renders empty.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Renders a newspack-newsletters/share block under the WC engine.
+ *
+ * The share link only makes sense when the newsletter has a public permalink,
+ * so the override renders the saved anchor only when the newsletter's
+ * `is_public` meta is truthy, and nothing otherwise. The anchor is rebuilt from
+ * the saved `href` and `content` attributes (v1 reuses the saved values,
+ * matching the legacy MJML path).
+ */
+class Share extends Abstract_Block_Renderer {
+	/**
+	 * Render the share block content.
+	 *
+	 * Resolves the newsletter post, gates on its `is_public` meta, and emits the
+	 * saved share anchor. Returns an empty string when the post cannot be resolved
+	 * or the newsletter is not public.
+	 *
+	 * @param string            $block_content     Block content (ignored; rebuilt from attrs).
+	 * @param array             $parsed_block      Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$post = Renderer_Controller::get_rendering_post();
+		if ( ! $post instanceof \WP_Post ) {
+			$post = $GLOBALS['post'] ?? null;
+		}
+		if ( ! $post instanceof \WP_Post ) {
+			return '';
+		}
+
+		// Only public newsletters have a permalink the share link can point to.
+		if ( ! get_post_meta( $post->ID, 'is_public', true ) ) {
+			return '';
+		}
+
+		$attrs   = $parsed_block['attrs'] ?? [];
+		$href    = (string) ( $attrs['href'] ?? '' );
+		$content = (string) ( $attrs['content'] ?? '' );
+
+		return self::build_share_html( $href, $content );
+	}
+
+	/**
+	 * Build the share anchor markup.
+	 *
+	 * Pure string builder kept separate from the post resolution so it stays
+	 * unit-testable without booting the WC engine. Mirrors the block's saved
+	 * markup: a paragraph wrapping a single anchor. Returns an empty string when
+	 * there is no link to point at.
+	 *
+	 * @param string $href    The share link URL.
+	 * @param string $content The link text.
+	 * @return string The share anchor HTML, or an empty string when href is empty.
+	 */
+	public static function build_share_html( string $href, string $content ): string {
+		if ( '' === $href ) {
+			return '';
+		}
+		return sprintf(
+			'<p class="newspack-newsletters-share-block"><a href="%1$s">%2$s</a></p>',
+			esc_url( $href, [ 'http', 'https', 'mailto' ] ),
+			wp_kses_post( $content )
+		);
+	}
+}
+
+// Self-register this override so the registry discovers it via the blocks/ glob.
+\Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'newspack-newsletters/share', Share::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
@@ -58,6 +58,15 @@ class Share extends Abstract_Block_Renderer {
 		$href    = (string) ( $attrs['href'] ?? '' );
 		$content = (string) ( $attrs['content'] ?? '' );
 
+		// `content` is an HTML-sourced RichText attribute, so it is not serialized
+		// into the block delimiter that email rendering parses — the link text
+		// lives in the saved markup. Fall back to the saved anchor's inner HTML
+		// (mirroring the legacy renderer, which renders the share block from its
+		// inner HTML) so the email link isn't empty.
+		if ( '' === $content && preg_match( '/<a\b[^>]*>(.*?)<\/a>/is', (string) ( $parsed_block['innerHTML'] ?? '' ), $matches ) ) {
+			$content = $matches[1];
+		}
+
 		return self::build_share_html( $href, $content );
 	}
 

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-share.php
@@ -112,8 +112,11 @@ class Share extends Abstract_Block_Renderer {
 			$value = substr( $value, strlen( 'var:preset|color|' ) );
 		}
 		$palette = wp_get_global_settings( [ 'color', 'palette' ] );
-		$colors  = isset( $palette['theme'] ) || isset( $palette['default'] ) || isset( $palette['custom'] )
-			? array_merge( $palette['theme'] ?? [], $palette['custom'] ?? [], $palette['default'] ?? [] )
+		// Search custom → theme → default and return the first slug match, mirroring
+		// WordPress' own origin precedence (user/custom overrides theme overrides
+		// default) so a customised preset wins over a colliding theme slug.
+		$colors = isset( $palette['theme'] ) || isset( $palette['default'] ) || isset( $palette['custom'] )
+			? array_merge( $palette['custom'] ?? [], $palette['theme'] ?? [], $palette['default'] ?? [] )
 			: (array) $palette;
 		foreach ( $colors as $color ) {
 			if ( is_array( $color ) && ( $color['slug'] ?? '' ) === $value ) {
@@ -138,17 +141,22 @@ class Share extends Abstract_Block_Renderer {
 		if ( '' === $value ) {
 			return '';
 		}
-		if ( preg_match( '/[\d(]/', $value ) ) {
-			return $value;
-		}
+		// Try a named preset first — searching custom → theme → default to mirror
+		// WordPress' origin precedence — so a preset slug that happens to carry a
+		// digit (e.g. `h1`, `step-2`) isn't misread as a literal size below.
 		$sizes = wp_get_global_settings( [ 'typography', 'fontSizes' ] );
 		$list  = isset( $sizes['theme'] ) || isset( $sizes['default'] ) || isset( $sizes['custom'] )
-			? array_merge( $sizes['theme'] ?? [], $sizes['custom'] ?? [], $sizes['default'] ?? [] )
+			? array_merge( $sizes['custom'] ?? [], $sizes['theme'] ?? [], $sizes['default'] ?? [] )
 			: (array) $sizes;
 		foreach ( $list as $size ) {
 			if ( is_array( $size ) && ( $size['slug'] ?? '' ) === $value ) {
 				return (string) ( $size['size'] ?? '' );
 			}
+		}
+		// No preset matched: a value carrying a digit or `clamp(` is a literal size;
+		// anything else is an unknown slug we can't resolve.
+		if ( preg_match( '/[\d(]/', $value ) ) {
+			return $value;
 		}
 		return '';
 	}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-block-renderer-registry.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-block-renderer-registry.php
@@ -12,6 +12,14 @@
  * every file in that directory so the overrides register themselves. Adding an
  * override is therefore a drop-in new file with no edits to this class.
  *
+ * The `block_type_metadata_settings` filter only fires for blocks registered via
+ * `register_block_type_from_metadata()`. Blocks registered with a plain
+ * `register_block_type()` call (e.g. `newspack-newsletters/posts-inserter`) never
+ * run that filter, so their override would never be wired up. To cover those, a
+ * second pass (`apply_to_registered_blocks()`) runs at render start and sets
+ * `render_email_callback` directly on any already-registered block type that has
+ * an override but no callback yet — the same dynamic property the package reads.
+ *
  * @package Newspack
  */
 
@@ -84,6 +92,48 @@ class Block_Renderer_Registry {
 		self::discover( __DIR__ . '/blocks' );
 
 		add_filter( 'block_type_metadata_settings', [ __CLASS__, 'update_block_settings' ], 11, 1 );
+
+		// The metadata filter above misses blocks registered without metadata (plain
+		// register_block_type()), so it never sets their render_email_callback. Apply
+		// the overrides to already-registered block types at render start instead.
+		// The package fires this action inside its content renderer right before it
+		// renders the blocks, so it runs after all blocks are registered, only when a
+		// WC email render actually happens, in every render context (REST preview,
+		// sending, cron) — and never for the MJML renderer, which doesn't boot the
+		// package and so never fires it.
+		add_action( 'woocommerce_email_editor_render_start', [ __CLASS__, 'apply_to_registered_blocks' ] );
+	}
+
+	/**
+	 * Set render_email_callback on already-registered block types that have an
+	 * override but no callback yet.
+	 *
+	 * Covers blocks registered without metadata, for which
+	 * `block_type_metadata_settings` never fires. Idempotent: only fills in a
+	 * callback that is missing, so the metadata path stays authoritative for the
+	 * blocks it already handled and re-running this is a no-op. Setting the dynamic
+	 * `render_email_callback` property directly is what the package itself relies on.
+	 *
+	 * @return void
+	 */
+	public static function apply_to_registered_blocks(): void {
+		if ( empty( self::$renderers ) ) {
+			return;
+		}
+		$block_registry = \WP_Block_Type_Registry::get_instance();
+		foreach ( array_keys( self::$renderers ) as $name ) {
+			$block_type = $block_registry->get_registered( $name );
+			// Skip unregistered blocks and any block that already has a callback
+			// (e.g. set by the metadata filter) so that path stays authoritative.
+			if ( ! $block_type instanceof \WP_Block_Type || isset( $block_type->render_email_callback ) ) {
+				continue;
+			}
+			$instance = self::get_renderer_instance( $name );
+			if ( null === $instance ) {
+				continue;
+			}
+			$block_type->render_email_callback = [ $instance, 'render' ];
+		}
 	}
 
 	/**
@@ -116,30 +166,51 @@ class Block_Renderer_Registry {
 	 * @return array The (possibly modified) settings.
 	 */
 	public static function update_block_settings( array $settings ): array {
-		$name = $settings['name'] ?? '';
-		if ( ! isset( self::$renderers[ $name ] ) ) {
+		$name     = $settings['name'] ?? '';
+		$instance = self::get_renderer_instance( $name );
+		if ( null === $instance ) {
 			return $settings;
 		}
-		if ( ! isset( self::$instances[ $name ] ) ) {
-			$renderer_class = self::$renderers[ $name ];
-			// Fail closed: a class that isn't a package block renderer (missing,
-			// wrong type, the abstract base itself) leaves the package callback in
-			// place rather than fataling during block registration. is_subclass_of
-			// autoloads and returns false for a non-existent class.
-			if ( ! is_subclass_of( $renderer_class, Abstract_Block_Renderer::class ) ) {
-				\Newspack_Newsletters_Logger::log( 'Email editor: skipping invalid block override for ' . $name . ' (' . $renderer_class . ' is not a block renderer).' );
-				return $settings;
-			}
-			try {
-				// Guards above don't catch an abstract subclass or a throwing /
-				// required-arg constructor, so instantiation stays in a try/catch.
-				self::$instances[ $name ] = new $renderer_class();
-			} catch ( \Throwable $e ) {
-				\Newspack_Newsletters_Logger::log( 'Email editor: could not instantiate block override for ' . $name . ' (' . $renderer_class . '): ' . $e->getMessage() );
-				return $settings;
-			}
-		}
-		$settings['render_email_callback'] = [ self::$instances[ $name ], 'render' ];
+		$settings['render_email_callback'] = [ $instance, 'render' ];
 		return $settings;
+	}
+
+	/**
+	 * Resolve (and lazily instantiate) the override renderer for a block name.
+	 *
+	 * Shared by both override paths — the metadata filter
+	 * (update_block_settings()) and the render-start pass
+	 * (apply_to_registered_blocks()) — so they share one fail-closed guard.
+	 *
+	 * Fails closed (returns null) when the block has no override, the override
+	 * class isn't a package block renderer (missing, wrong type, the abstract base
+	 * itself), or its constructor throws — so a bad override leaves the package
+	 * callback in place rather than fataling during block registration or render.
+	 * is_subclass_of() autoloads and returns false for a non-existent class.
+	 *
+	 * @param string $name Block name, e.g. `core/column`.
+	 * @return object|null The renderer instance, or null when unavailable.
+	 */
+	private static function get_renderer_instance( string $name ): ?object {
+		if ( ! isset( self::$renderers[ $name ] ) ) {
+			return null;
+		}
+		if ( isset( self::$instances[ $name ] ) ) {
+			return self::$instances[ $name ];
+		}
+		$renderer_class = self::$renderers[ $name ];
+		if ( ! is_subclass_of( $renderer_class, Abstract_Block_Renderer::class ) ) {
+			\Newspack_Newsletters_Logger::log( 'Email editor: skipping invalid block override for ' . $name . ' (' . $renderer_class . ' is not a block renderer).' );
+			return null;
+		}
+		try {
+			// The type guard above doesn't catch an abstract subclass or a throwing /
+			// required-arg constructor, so instantiation stays in a try/catch.
+			self::$instances[ $name ] = new $renderer_class();
+		} catch ( \Throwable $e ) {
+			\Newspack_Newsletters_Logger::log( 'Email editor: could not instantiate block override for ' . $name . ' (' . $renderer_class . '): ' . $e->getMessage() );
+			return null;
+		}
+		return self::$instances[ $name ];
 	}
 }

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
@@ -15,36 +15,51 @@ import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 import classnames from 'classnames';
 
 /**
- * Post-item typography and spacing for the preview, matching the values the WC
- * email renderer produces: title 24px / subtitle 16px / body 16px, an 8px gap
- * between the title, subtitle, date, excerpt and continue-reading link. The
- * preview is an iframed `BlockPreview`, so this can't live in the block's editor
- * stylesheet (the outer document) — it's injected straight into the iframe. The
- * inserted blocks carry authored inline font sizes (e.g. the date's 20px) that
- * the email normalises away, so `!important` is needed to beat them.
+ * Post-item line-height/weight and spacing for the preview, matching the WC
+ * email renderer: headings 1.2 / body 1.5, an 8px gap between the title,
+ * subtitle, date, excerpt and continue-reading link, and a 16px gap between the
+ * featured-image and content columns (the email applies a 16px padding-left on
+ * the content column).
+ *
+ * Font SIZES and COLOURS are deliberately NOT forced here: the block's own
+ * heading/text font-size and colour controls write inline styles that the email
+ * renderer honours, so the preview must honour them too (forcing sizes with
+ * `!important` made the preview ignore those controls). Only line-height, weight
+ * and spacing — which the block doesn't expose and which the email normalises —
+ * are pinned.
+ *
+ * The editor otherwise gives each column its own `12px 6px` padding, which
+ * double-pads the gap, so the column padding is zeroed and the 16px is supplied
+ * solely by the columns gap. The preview is an iframed `BlockPreview`, so this
+ * can't live in the block's editor stylesheet (the outer document) — it's
+ * injected straight into the iframe.
+ *
+ * The column-scoped rules (8px inter-block gap, column padding / columns gap)
+ * only affect the side-by-side layouts (image left / right), which build a
+ * `core/columns`. The "image on top" layout (`utils.js`) renders flat blocks
+ * with no columns, so those rules don't match it and its spacing is left alone.
  */
 const POST_ITEM_PREVIEW_STYLES = `
-	h3.wp-block-heading {
-		font-size: 24px !important;
-		line-height: 1.2 !important;
-		font-weight: 700 !important;
-	}
+	h3.wp-block-heading,
 	h4.wp-block-heading {
-		font-size: 16px !important;
 		line-height: 1.2 !important;
 		font-weight: 700 !important;
 	}
-	.wp-block-column p {
-		font-size: 16px !important;
+	p.wp-block-paragraph {
 		line-height: 1.5 !important;
 		font-weight: 400 !important;
 	}
 	.wp-block-column > * {
-		margin-top: 0 !important;
-		margin-bottom: 0 !important;
+		margin-block: 0 !important;
 	}
 	.wp-block-column > * + * {
-		margin-top: 8px !important;
+		margin-block-start: 8px !important;
+	}
+	.wp-block-column {
+		padding: 0 !important;
+	}
+	.wp-block-columns {
+		gap: 16px !important;
 	}
 `;
 
@@ -103,30 +118,61 @@ const PostsPreview = ( { isReady, blocks, className, viewportWidth }, ref ) => {
 	}, [] );
 
 	// Inject the email-matching post-item typography into the preview iframe.
+	//
+	// The preview is an iframed `BlockPreview` whose document is populated — and
+	// re-populated on every render — asynchronously, after the iframe element
+	// mounts. So mirror the editor canvas-styling walker's reach: (re)inject the
+	// <style> on the iframe `load` event AND whenever its document mutates, with
+	// an id guard so it's never duplicated. A single non-subtree observer (the
+	// previous approach) missed those later document swaps, so the style never
+	// landed — which is why the spacing reset to the flow-layout default.
 	const usePostItemStyles = useRefEffect( node => {
-		const applyStyle = () => {
-			const iframe = node.querySelector( 'iframe[title="Editor canvas"]' );
-			if ( ! iframe ) {
+		const cleanups = [];
+		const inject = iframe => {
+			const doc = iframe.contentDocument;
+			if ( ! doc?.head || doc.getElementById( 'newspack-posts-inserter-preview-typography' ) ) {
 				return;
 			}
-			const injectStyle = () => {
-				const doc = iframe.contentDocument;
-				if ( ! doc || doc.getElementById( 'newspack-posts-inserter-preview-typography' ) ) {
-					return;
-				}
-				const styleEl = doc.createElement( 'style' );
-				styleEl.id = 'newspack-posts-inserter-preview-typography';
-				styleEl.textContent = POST_ITEM_PREVIEW_STYLES;
-				doc.head.appendChild( styleEl );
-			};
-			injectStyle();
-			iframe.addEventListener( 'load', injectStyle );
+			const styleEl = doc.createElement( 'style' );
+			styleEl.id = 'newspack-posts-inserter-preview-typography';
+			styleEl.textContent = POST_ITEM_PREVIEW_STYLES;
+			doc.head.appendChild( styleEl );
 		};
-		const observer = new MutationObserver( applyStyle );
-		observer.observe( node, { childList: true } );
-		applyStyle();
+		const seen = new WeakSet();
+		const watchIframe = iframe => {
+			if ( seen.has( iframe ) ) {
+				return;
+			}
+			seen.add( iframe );
+			let innerObserver;
+			const onReady = () => {
+				inject( iframe );
+				const doc = iframe.contentDocument;
+				if ( doc?.body ) {
+					innerObserver?.disconnect();
+					innerObserver = new MutationObserver( () => inject( iframe ) );
+					innerObserver.observe( doc.body, { childList: true, subtree: true } );
+				}
+			};
+			onReady();
+			iframe.addEventListener( 'load', onReady );
+			cleanups.push( () => {
+				iframe.removeEventListener( 'load', onReady );
+				innerObserver?.disconnect();
+			} );
+		};
+		const scan = () => {
+			const iframe = node.querySelector( 'iframe[title="Editor canvas"]' );
+			if ( iframe ) {
+				watchIframe( iframe );
+			}
+		};
+		scan();
+		const observer = new MutationObserver( scan );
+		observer.observe( node, { childList: true, subtree: true } );
 		return () => {
 			observer.disconnect();
+			cleanups.forEach( fn => fn() );
 		};
 	}, [] );
 

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/posts-preview.js
@@ -15,6 +15,40 @@ import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 import classnames from 'classnames';
 
 /**
+ * Post-item typography and spacing for the preview, matching the values the WC
+ * email renderer produces: title 24px / subtitle 16px / body 16px, an 8px gap
+ * between the title, subtitle, date, excerpt and continue-reading link. The
+ * preview is an iframed `BlockPreview`, so this can't live in the block's editor
+ * stylesheet (the outer document) — it's injected straight into the iframe. The
+ * inserted blocks carry authored inline font sizes (e.g. the date's 20px) that
+ * the email normalises away, so `!important` is needed to beat them.
+ */
+const POST_ITEM_PREVIEW_STYLES = `
+	h3.wp-block-heading {
+		font-size: 24px !important;
+		line-height: 1.2 !important;
+		font-weight: 700 !important;
+	}
+	h4.wp-block-heading {
+		font-size: 16px !important;
+		line-height: 1.2 !important;
+		font-weight: 700 !important;
+	}
+	.wp-block-column p {
+		font-size: 16px !important;
+		line-height: 1.5 !important;
+		font-weight: 400 !important;
+	}
+	.wp-block-column > * {
+		margin-top: 0 !important;
+		margin-bottom: 0 !important;
+	}
+	.wp-block-column > * + * {
+		margin-top: 8px !important;
+	}
+`;
+
+/**
  * Posts Preview component.
  */
 const PostsPreview = ( { isReady, blocks, className, viewportWidth }, ref ) => {
@@ -68,10 +102,38 @@ const PostsPreview = ( { isReady, blocks, className, viewportWidth }, ref ) => {
 		};
 	}, [] );
 
+	// Inject the email-matching post-item typography into the preview iframe.
+	const usePostItemStyles = useRefEffect( node => {
+		const applyStyle = () => {
+			const iframe = node.querySelector( 'iframe[title="Editor canvas"]' );
+			if ( ! iframe ) {
+				return;
+			}
+			const injectStyle = () => {
+				const doc = iframe.contentDocument;
+				if ( ! doc || doc.getElementById( 'newspack-posts-inserter-preview-typography' ) ) {
+					return;
+				}
+				const styleEl = doc.createElement( 'style' );
+				styleEl.id = 'newspack-posts-inserter-preview-typography';
+				styleEl.textContent = POST_ITEM_PREVIEW_STYLES;
+				doc.head.appendChild( styleEl );
+			};
+			injectStyle();
+			iframe.addEventListener( 'load', injectStyle );
+		};
+		const observer = new MutationObserver( applyStyle );
+		observer.observe( node, { childList: true } );
+		applyStyle();
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
 	return (
 		<div
 			className={ classnames( 'newspack-posts-inserter__preview', className ) }
-			ref={ useMergeRefs( [ ref, useIframeBorderFix, useLayoutStyle, useCustomFontsInIframe() ] ) }
+			ref={ useMergeRefs( [ ref, useIframeBorderFix, useLayoutStyle, usePostItemStyles, useCustomFontsInIframe() ] ) }
 		>
 			{ ! isReady && <Spinner /> }
 			{ isReady && blocks?.length > 0 && <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> }

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/style.scss
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/style.scss
@@ -75,28 +75,6 @@
 	}
 }
 
-// The post-inserter editor preview is a scaled BlockPreview that renders the
-// inserted blocks with the editor's (fluid) type scale, so it drifts from the
-// de-fluid WC email. Pin the post-item type scale and spacing to the email's
-// values so the editor preview reads the same: 24px headings, 16px body, and an
-// 8px gap between the title, subtitle, date, excerpt, and continue-reading. The
-// gap between posts is left to the preview's own layout.
-.newspack-posts-inserter__preview .block-editor-block-preview__content {
-	.wp-block-heading {
-		font-size: 24px;
-		line-height: 1.2;
-	}
-
-	.wp-block-column p {
-		font-size: 16px;
-		line-height: 1.5;
-	}
-
-	.wp-block-column > * + * {
-		margin-top: 8px;
-	}
-}
-
 // FormTokenField
 
 .newspack-newsletters-query-controls {

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/style.scss
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/style.scss
@@ -75,6 +75,28 @@
 	}
 }
 
+// The post-inserter editor preview is a scaled BlockPreview that renders the
+// inserted blocks with the editor's (fluid) type scale, so it drifts from the
+// de-fluid WC email. Pin the post-item type scale and spacing to the email's
+// values so the editor preview reads the same: 24px headings, 16px body, and an
+// 8px gap between the title, subtitle, date, excerpt, and continue-reading. The
+// gap between posts is left to the preview's own layout.
+.newspack-posts-inserter__preview .block-editor-block-preview__content {
+	.wp-block-heading {
+		font-size: 24px;
+		line-height: 1.2;
+	}
+
+	.wp-block-column p {
+		font-size: 16px;
+		line-height: 1.5;
+	}
+
+	.wp-block-column > * + * {
+		margin-top: 8px;
+	}
+}
+
 // FormTokenField
 
 .newspack-newsletters-query-controls {

--- a/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
@@ -435,4 +435,56 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 			'With no post in context the override must not add the Newspack border.'
 		);
 	}
+
+	/**
+	 * The render-start pass sets render_email_callback on a non-metadata block.
+	 *
+	 * `newspack-newsletters/posts-inserter` is registered with a plain
+	 * register_block_type() (no metadata), so the `block_type_metadata_settings`
+	 * filter never fires for it and its callback is never set by the metadata path.
+	 * apply_to_registered_blocks() must fill it in directly, bound to the Newspack
+	 * Posts_Inserter renderer — the fix for the production delimiter leak.
+	 */
+	public function test_render_start_pass_sets_callback_on_non_metadata_block() {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( ! $registry->is_registered( 'newspack-newsletters/posts-inserter' ) ) {
+			\Newspack_Newsletters::register_blocks();
+		}
+		$block_type = $registry->get_registered( 'newspack-newsletters/posts-inserter' );
+		unset( $block_type->render_email_callback );
+
+		Block_Renderer_Registry::apply_to_registered_blocks();
+
+		$this->assertTrue( isset( $block_type->render_email_callback ), 'Expected the render-start pass to set render_email_callback on the non-metadata block.' );
+		$this->assertIsCallable( $block_type->render_email_callback, 'The render_email_callback must be callable.' );
+		$this->assertInstanceOf(
+			\Newspack\Newsletters\Email_Renderers\Blocks\Posts_Inserter::class,
+			$block_type->render_email_callback[0],
+			'The callback must be bound to the Newspack Posts_Inserter renderer.'
+		);
+	}
+
+	/**
+	 * The render-start pass never clobbers a callback the metadata path already set.
+	 *
+	 * For a metadata-registered block whose callback is already in place, the pass
+	 * must be a no-op (idempotent), leaving the existing instance untouched so the
+	 * metadata filter stays authoritative.
+	 */
+	public function test_render_start_pass_does_not_clobber_existing_callback() {
+		$registry   = \WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( 'core/column' );
+		$this->assertInstanceOf( \WP_Block_Type::class, $block_type, 'core/column must be registered for this test.' );
+
+		$sentinel                          = static function () {
+			return '';
+		};
+		$block_type->render_email_callback = $sentinel;
+
+		Block_Renderer_Registry::apply_to_registered_blocks();
+
+		$this->assertSame( $sentinel, $block_type->render_email_callback, 'Expected the existing callback to be left untouched.' );
+
+		unset( $block_type->render_email_callback );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -81,6 +81,49 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The flat layout ("image on top" / no featured image) pads each block.
+	 *
+	 * There the inserted children are individual heading/paragraph/image blocks
+	 * the package stacks flush, so each must be wrapped in a 6px top/bottom padded
+	 * cell to match the editor canvas — while a side-by-side `core/columns` child
+	 * (a whole post) must NOT be wrapped (it uses the post-gap margin instead).
+	 */
+	public function test_posts_inserter_pads_flat_layout_blocks() {
+		$flat = [
+			[
+				'blockName' => 'core/heading',
+				'attrs'     => [ 'level' => 3 ],
+				'innerHTML' => '<h3 class="wp-block-heading">Title</h3>',
+			],
+			[
+				'blockName' => 'core/paragraph',
+				'attrs'     => [],
+				'innerHTML' => '<p>June 18, 2026</p>',
+			],
+		];
+		$flat_result = Posts_Inserter::render_inserted_blocks( $flat );
+		$this->assertSame(
+			2,
+			substr_count( $flat_result, 'padding-top: 6px; padding-bottom: 6px' ),
+			'Expected each flat-layout block to be wrapped in a 6px top/bottom padded cell.'
+		);
+
+		$columns = [
+			[
+				'blockName' => 'core/columns',
+				'attrs'     => [],
+				'innerHTML' => '<div class="wp-block-columns"></div>',
+			],
+		];
+		$columns_result = Posts_Inserter::render_inserted_blocks( $columns );
+		$this->assertStringNotContainsString(
+			'padding-top: 6px; padding-bottom: 6px',
+			$columns_result,
+			'Expected a side-by-side columns child not to get the flat-block padding.'
+		);
+	}
+
+	/**
 	 * Serialize a posts-inserter block whose innerBlocksToInsert holds the given
 	 * children, the way the block editor stores it.
 	 *
@@ -195,13 +238,16 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Post-item text links render black and underlined (matching MJML); image
-	 * links are left alone.
+	 * Post-item text links render underlined and inherit their element's colour
+	 * (black by default, or the block's heading/text colour); image links are left
+	 * alone.
 	 *
 	 * The package renders post title / "continue reading" links with no colour
 	 * (so they fall to the client's default blue) and no underline. Since the
 	 * posts-inserter has no post-editor equivalent, the override restyles its text
-	 * links to the MJML newsletter look. Image-wrapping anchors must be untouched.
+	 * links to the MJML newsletter look — but via `color: inherit` so a custom
+	 * heading/text colour is not clobbered. Image-wrapping anchors must be
+	 * untouched.
 	 */
 	public function test_posts_inserter_styles_text_links_for_email() {
 		Editor_Bootstrap::init();
@@ -223,11 +269,12 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 		);
 		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter_with_content( $content ) ) );
 
-		// The post title link is black + underlined (style order-independent).
+		// The post title link is underlined and inherits its colour (so a custom
+		// heading colour is respected; black by default). Style order-independent.
 		$this->assertMatchesRegularExpression(
-			'/<a\b[^>]*style="(?=[^"]*text-decoration:\s*underline)(?=[^"]*color:\s*#000000)[^"]*"[^>]*>\s*My Post Title/i',
+			'/<a\b[^>]*style="(?=[^"]*text-decoration:\s*underline)(?=[^"]*color:\s*inherit)[^"]*"[^>]*>\s*My Post Title/i',
 			$html,
-			'Expected the post title link to render black and underlined for email.'
+			'Expected the post title link to render underlined and inherit its colour for email.'
 		);
 		// Image-wrapping anchors are not given the text-link underline.
 		$this->assertDoesNotMatchRegularExpression(
@@ -255,6 +302,27 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	 */
 	public function test_share_builder_empty_href_renders_nothing() {
 		$this->assertSame( '', Share::build_share_html( '', 'Share this' ), 'Expected an empty href to render nothing.' );
+	}
+
+	/**
+	 * The share builder applies the block's background/text colours inline.
+	 *
+	 * The override builds the markup itself, so the block's chosen colours must be
+	 * set as inline styles (resolved hex) to survive into the email — with the
+	 * editor's 6px/12px padding when a background is present. With no colours the
+	 * paragraph carries no background/padding.
+	 */
+	public function test_share_builder_applies_colors() {
+		$styled = Share::build_share_html( 'mailto:?body=x', 'Share this', '#003da5', '#ffffff', '44px' );
+		$this->assertStringContainsString( 'background-color: #003da5', $styled, 'Expected the resolved background colour inline.' );
+		$this->assertStringContainsString( 'color: #ffffff', $styled, 'Expected the resolved text colour inline.' );
+		$this->assertStringContainsString( 'padding: 6px 12px', $styled, 'Expected the background block to get the editor padding.' );
+		$this->assertStringContainsString( 'font-size: 44px', $styled, 'Expected the resolved font size inline.' );
+
+		$plain = Share::build_share_html( 'mailto:?body=x', 'Share this' );
+		$this->assertStringNotContainsString( 'background-color', $plain, 'Expected no background style when no colour is set.' );
+		$this->assertStringNotContainsString( 'padding:', $plain, 'Expected no padding when no background is set.' );
+		$this->assertStringNotContainsString( 'font-size', $plain, 'Expected no font-size style when no size is set.' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -195,6 +195,49 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Post-item text links render black and underlined (matching MJML); image
+	 * links are left alone.
+	 *
+	 * The package renders post title / "continue reading" links with no colour
+	 * (so they fall to the client's default blue) and no underline. Since the
+	 * posts-inserter has no post-editor equivalent, the override restyles its text
+	 * links to the MJML newsletter look. Image-wrapping anchors must be untouched.
+	 */
+	public function test_posts_inserter_styles_text_links_for_email() {
+		Editor_Bootstrap::init();
+
+		$inner = '<div class="wp-block-columns"><!-- wp:column --><div class="wp-block-column">'
+			. '<!-- wp:image --><figure class="wp-block-image"><a href="https://example.com/p"><img src="https://example.com/i.jpg" alt=""/></a></figure><!-- /wp:image -->'
+			. '<!-- wp:heading --><h3 class="wp-block-heading"><a href="https://example.com/p">My Post Title</a></h3><!-- /wp:heading -->'
+			. '</div><!-- /wp:column --></div>';
+		$content = $this->serialize_posts_inserter(
+			[
+				[
+					'blockName'    => 'core/columns',
+					'attrs'        => [],
+					'innerHTML'    => $inner,
+					'innerContent' => [ $inner ],
+					'innerBlocks'  => [],
+				],
+			]
+		);
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter_with_content( $content ) ) );
+
+		// The post title link is black + underlined (style order-independent).
+		$this->assertMatchesRegularExpression(
+			'/<a\b[^>]*style="(?=[^"]*text-decoration:\s*underline)(?=[^"]*color:\s*#000000)[^"]*"[^>]*>\s*My Post Title/i',
+			$html,
+			'Expected the post title link to render black and underlined for email.'
+		);
+		// Image-wrapping anchors are not given the text-link underline.
+		$this->assertDoesNotMatchRegularExpression(
+			'/<a\b[^>]*text-decoration:\s*underline[^>]*><img/i',
+			$html,
+			'Expected image-wrapping links to be left alone.'
+		);
+	}
+
+	/**
 	 * The share builder wraps the content in a single anchor with the href.
 	 */
 	public function test_share_builder_wraps_anchor() {

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -243,7 +243,8 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	public function test_share_builder_wraps_anchor() {
 		$result = Share::build_share_html( 'mailto:?body=x', 'Share this' );
 
-		$this->assertStringContainsString( '<a href="mailto:?body=x">', $result, 'Expected the anchor to carry the share href.' );
+		$this->assertStringContainsString( '<a href="mailto:?body=x"', $result, 'Expected the anchor to carry the share href.' );
+		$this->assertMatchesRegularExpression( '/<a\b[^>]*style="(?=[^"]*text-decoration:\s*underline)(?=[^"]*color:\s*inherit)[^"]*"/i', $result, 'Expected the anchor to be underlined and inherit the text colour, matching the editor default.' );
 		$this->assertStringContainsString( 'Share this', $result, 'Expected the link text to be preserved.' );
 		$this->assertStringContainsString( 'newspack-newsletters-share-block', $result, 'Expected the share-block paragraph class.' );
 		$this->assertSame( 1, substr_count( $result, '<a ' ), 'Expected exactly one anchor in the share markup.' );

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Class Newspack Block Renderers Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry;
+use Newspack\Newsletters\Email_Renderers\Blocks\Posts_Inserter;
+use Newspack\Newsletters\Email_Renderers\Blocks\Share;
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+/**
+ * Tests the Newspack dynamic-block overrides for the WC email engine:
+ * posts-inserter (renders inserted children through do_blocks) and share
+ * (emits the saved anchor only when the newsletter is public).
+ */
+class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
+	/**
+	 * Run override discovery so the self-registering renderers are mapped.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Block_Renderer_Registry::init();
+	}
+
+	/**
+	 * The posts-inserter helper renders nested blocks, leaking no delimiters.
+	 *
+	 * A child whose innerHTML carries a nested core/columns block must come back
+	 * fully rendered (the wp-block-columns markup) with no raw `<!-- wp:`
+	 * block-comment delimiters surviving into the output.
+	 */
+	public function test_posts_inserter_renders_nested_blocks_without_delimiters() {
+		$children = [
+			[
+				'blockName' => 'core/columns',
+				'innerHTML' => '<!-- wp:columns --><div class="wp-block-columns">'
+					. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+					. '</div><!-- /wp:columns -->',
+			],
+		];
+
+		$result = Posts_Inserter::render_inserted_blocks( $children );
+
+		$this->assertStringContainsString( 'wp-block-columns', $result, 'Expected the nested columns block to be rendered.' );
+		$this->assertStringContainsString( 'Hello', $result, 'Expected the inner paragraph content to survive.' );
+		$this->assertStringNotContainsString( '<!-- wp:', $result, 'Expected no raw block-comment delimiters to leak into the output.' );
+	}
+
+	/**
+	 * The posts-inserter helper returns an empty string for no children.
+	 */
+	public function test_posts_inserter_empty_array_renders_nothing() {
+		$this->assertSame( '', Posts_Inserter::render_inserted_blocks( [] ), 'Expected an empty children array to render nothing.' );
+	}
+
+	/**
+	 * The posts-inserter helper concatenates children in document order.
+	 *
+	 * Two paragraph children must render in the same order they appear in the
+	 * innerBlocksToInsert array.
+	 */
+	public function test_posts_inserter_preserves_child_order() {
+		$children = [
+			[ 'innerHTML' => '<!-- wp:paragraph --><p>First</p><!-- /wp:paragraph -->' ],
+			[ 'innerHTML' => '<!-- wp:paragraph --><p>Second</p><!-- /wp:paragraph -->' ],
+		];
+
+		$result = Posts_Inserter::render_inserted_blocks( $children );
+
+		$this->assertLessThan(
+			strpos( $result, 'Second' ),
+			strpos( $result, 'First' ),
+			'Expected children to render in document order.'
+		);
+		$this->assertStringNotContainsString( '<!-- wp:', $result, 'Expected no raw block-comment delimiters to leak.' );
+	}
+
+	/**
+	 * A real posts-inserter render emits the child columns and no raw comments.
+	 *
+	 * Renders a newsletter CPT containing a posts-inserter block whose
+	 * innerBlocksToInsert holds a columns child through the full WC pipeline and
+	 * asserts the column markup appears with no leaked block-comment delimiters.
+	 */
+	public function test_posts_inserter_integration_renders_columns() {
+		Editor_Bootstrap::init();
+
+		$inner = '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column {"width":"50%"} --><div class="wp-block-column"><!-- wp:paragraph --><p>Inserted col</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+
+		$attrs = [
+			'innerBlocksToInsert' => [
+				[
+					'blockName' => 'core/columns',
+					'attrs'     => [],
+					'innerHTML' => $inner,
+				],
+			],
+		];
+
+		$content = '<!-- wp:newspack-newsletters/posts-inserter ' . wp_json_encode( $attrs ) . ' /-->';
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Posts inserter newsletter',
+				'post_content' => $content,
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		$this->assertStringContainsString( 'wp-block-column', $html, 'Expected the inserted column markup to appear in the email.' );
+		$this->assertStringContainsString( 'Inserted col', $html, 'Expected the inserted paragraph content to appear.' );
+		$this->assertStringNotContainsString( '<!-- wp:', $html, 'Expected no raw block-comment delimiters in the rendered email.' );
+	}
+
+	/**
+	 * The share builder wraps the content in a single anchor with the href.
+	 */
+	public function test_share_builder_wraps_anchor() {
+		$result = Share::build_share_html( 'mailto:?body=x', 'Share this' );
+
+		$this->assertStringContainsString( '<a href="mailto:?body=x">', $result, 'Expected the anchor to carry the share href.' );
+		$this->assertStringContainsString( 'Share this', $result, 'Expected the link text to be preserved.' );
+		$this->assertStringContainsString( 'newspack-newsletters-share-block', $result, 'Expected the share-block paragraph class.' );
+		$this->assertSame( 1, substr_count( $result, '<a ' ), 'Expected exactly one anchor in the share markup.' );
+	}
+
+	/**
+	 * The share builder renders nothing when there is no href to link to.
+	 */
+	public function test_share_builder_empty_href_renders_nothing() {
+		$this->assertSame( '', Share::build_share_html( '', 'Share this' ), 'Expected an empty href to render nothing.' );
+	}
+
+	/**
+	 * A public newsletter renders the share anchor.
+	 *
+	 * With `is_public` meta truthy the override must emit the saved share anchor
+	 * (the mailto link) into the rendered email.
+	 */
+	public function test_share_integration_public_renders_anchor() {
+		Editor_Bootstrap::init();
+
+		$content = '<!-- wp:newspack-newsletters/share {"href":"mailto:?body=read-this","content":"Share this"} -->'
+			. '<p class="newspack-newsletters-share-block"><a href="mailto:?body=read-this">Share this</a></p>'
+			. '<!-- /wp:newspack-newsletters/share -->';
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Public share newsletter',
+				'post_content' => $content,
+			]
+		);
+		update_post_meta( $post_id, 'is_public', 1 );
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		$this->assertStringContainsString( 'mailto:?body=read-this', $html, 'Expected the share anchor href in a public newsletter email.' );
+		$this->assertStringContainsString( 'Share this', $html, 'Expected the share link text in a public newsletter email.' );
+	}
+
+	/**
+	 * A non-public newsletter renders no share anchor.
+	 *
+	 * Without `is_public` meta the share link points nowhere, so the override must
+	 * emit nothing for the share block.
+	 */
+	public function test_share_integration_non_public_renders_no_anchor() {
+		Editor_Bootstrap::init();
+
+		$content = '<!-- wp:newspack-newsletters/share {"href":"mailto:?body=read-this","content":"Share this"} -->'
+			. '<p class="newspack-newsletters-share-block"><a href="mailto:?body=read-this">Share this</a></p>'
+			. '<!-- /wp:newspack-newsletters/share -->';
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Non-public share newsletter',
+				'post_content' => $content,
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		$this->assertStringNotContainsString( 'mailto:?body=read-this', $html, 'Expected no share anchor href in a non-public newsletter email.' );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -79,44 +79,109 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A real posts-inserter render emits the child columns and no raw comments.
+	 * Serialize a posts-inserter block whose innerBlocksToInsert holds the given
+	 * children, the way the block editor stores it.
 	 *
-	 * Renders a newsletter CPT containing a posts-inserter block whose
-	 * innerBlocksToInsert holds a columns child through the full WC pipeline and
-	 * asserts the column markup appears with no leaked block-comment delimiters.
+	 * Uses serialize_block() so the children's HTML is JSON-escaped exactly as the
+	 * editor writes it (e.g. `<!-- wp:columns -->`).
+	 * Critically, the saved comment carries no raw `<` for kses to strip, so when
+	 * stored via wp_slash()+wp_insert_post the markup survives byte-for-byte and
+	 * parse_blocks() decodes each child's innerHTML back to real block delimiters.
+	 *
+	 * A naive `'<!-- wp:... ' . wp_json_encode( $attrs ) . ' /-->'` does NOT survive
+	 * kses on save (the unescaped child HTML is stripped), which is why this fixture
+	 * had to mirror the editor's escaping to reproduce the production leak.
+	 *
+	 * @param array $children innerBlocksToInsert child blocks (blockName/innerHTML).
+	 * @return string Serialized posts-inserter block markup.
 	 */
-	public function test_posts_inserter_integration_renders_columns() {
-		Editor_Bootstrap::init();
+	private function serialize_posts_inserter( array $children ): string {
+		return serialize_block(
+			[
+				'blockName'    => 'newspack-newsletters/posts-inserter',
+				'attrs'        => [ 'innerBlocksToInsert' => $children ],
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			]
+		);
+	}
 
-		$inner = '<!-- wp:columns --><div class="wp-block-columns">'
-			. '<!-- wp:column {"width":"50%"} --><div class="wp-block-column"><!-- wp:paragraph --><p>Inserted col</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
-			. '</div><!-- /wp:columns -->';
-
-		$attrs = [
-			'innerBlocksToInsert' => [
-				[
-					'blockName' => 'core/columns',
-					'attrs'     => [],
-					'innerHTML' => $inner,
-				],
-			],
-		];
-
-		$content = '<!-- wp:newspack-newsletters/posts-inserter ' . wp_json_encode( $attrs ) . ' /-->';
-
-		$post_id = self::factory()->post->create(
+	/**
+	 * Create a newsletter CPT carrying the given block markup, kses-safe.
+	 *
+	 * Slashing preserves the editor's backslash escapes through wp_insert_post so
+	 * the stored content is byte-identical to the serialized markup.
+	 *
+	 * @param string $content Serialized block markup.
+	 * @return int Created post ID.
+	 */
+	private function create_newsletter_with_content( string $content ): int {
+		return self::factory()->post->create(
 			[
 				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'post_status'  => 'draft',
 				'post_title'   => 'Posts inserter newsletter',
-				'post_content' => $content,
+				'post_content' => wp_slash( $content ),
+			]
+		);
+	}
+
+	/**
+	 * A real posts-inserter render emits the child columns as email tables and
+	 * leaks no raw block-comment delimiters.
+	 *
+	 * This is the end-to-end regression for the override never wiring up in the real
+	 * WC pipeline. The posts-inserter block is registered via register_block_type()
+	 * (no metadata), so the package's `block_type_metadata_settings` filter — the
+	 * only path the registry used to set `render_email_callback` — never fired for
+	 * it. The engine then fell back to the block's own server callback, which
+	 * concatenates each child's raw innerHTML, leaking `<!-- wp:columns -->` and
+	 * never turning the columns into email tables.
+	 *
+	 * The fixture mirrors post 76: a heading child plus a nested columns child,
+	 * serialized exactly as the editor stores it (see serialize_posts_inserter).
+	 */
+	public function test_posts_inserter_integration_renders_columns() {
+		Editor_Bootstrap::init();
+
+		$columns_inner = '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Left column body</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Right column body</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+
+		$content = $this->serialize_posts_inserter(
+			[
+				[
+					'blockName'    => 'core/heading',
+					'attrs'        => [],
+					'innerHTML'    => '<h2>Latest posts</h2>',
+					'innerContent' => [ '<h2>Latest posts</h2>' ],
+					'innerBlocks'  => [],
+				],
+				[
+					'blockName'    => 'core/columns',
+					'attrs'        => [],
+					'innerHTML'    => $columns_inner,
+					'innerContent' => [ $columns_inner ],
+					'innerBlocks'  => [],
+				],
 			]
 		);
 
+		$post_id = $this->create_newsletter_with_content( $content );
+
 		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
 
-		$this->assertStringContainsString( 'wp-block-column', $html, 'Expected the inserted column markup to appear in the email.' );
-		$this->assertStringContainsString( 'Inserted col', $html, 'Expected the inserted paragraph content to appear.' );
+		// The heading and both column bodies must survive into the email.
+		$this->assertStringContainsString( 'Latest posts', $html, 'Expected the inserted heading content to appear.' );
+		$this->assertStringContainsString( 'Left column body', $html, 'Expected the left column body to appear.' );
+		$this->assertStringContainsString( 'Right column body', $html, 'Expected the right column body to appear.' );
+
+		// The columns must be rendered as the email-block column markup, not leaked raw.
+		$this->assertStringContainsString( 'wp-block-column', $html, 'Expected the inserted columns to render as column markup.' );
+
+		// No raw block-comment delimiters may leak into the email body — this is the bug.
 		$this->assertStringNotContainsString( '<!-- wp:', $html, 'Expected no raw block-comment delimiters in the rendered email.' );
 	}
 

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -35,10 +35,12 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	public function test_posts_inserter_renders_nested_blocks_without_delimiters() {
 		$children = [
 			[
+				// A real inserted child carries the block's INNER html (no outer
+				// `<!-- wp:columns -->` delimiter — that is implied by blockName).
 				'blockName' => 'core/columns',
-				'innerHTML' => '<!-- wp:columns --><div class="wp-block-columns">'
+				'innerHTML' => '<div class="wp-block-columns">'
 					. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
-					. '</div><!-- /wp:columns -->',
+					. '</div>',
 			],
 		];
 
@@ -145,10 +147,12 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	public function test_posts_inserter_integration_renders_columns() {
 		Editor_Bootstrap::init();
 
-		$columns_inner = '<!-- wp:columns --><div class="wp-block-columns">'
+		// A real inserted child carries the block's INNER html — no outer
+		// `<!-- wp:columns -->` delimiter (that is implied by blockName).
+		$columns_inner = '<div class="wp-block-columns">'
 			. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Left column body</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
 			. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Right column body</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
-			. '</div><!-- /wp:columns -->';
+			. '</div>';
 
 		$content = $this->serialize_posts_inserter(
 			[
@@ -180,6 +184,11 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 
 		// The columns must be rendered as the email-block column markup, not leaked raw.
 		$this->assertStringContainsString( 'wp-block-column', $html, 'Expected the inserted columns to render as column markup.' );
+
+		// The outer columns block must be email-rendered with its width wrapper, not
+		// left as a raw div that overflows the email body — the override must render
+		// the whole child block, not only its inner blocks.
+		$this->assertStringContainsString( 'email-block-columns', $html, 'Expected the inserted columns to get the email-block-columns width wrapper.' );
 
 		// No raw block-comment delimiters may leak into the email body — this is the bug.
 		$this->assertStringNotContainsString( '<!-- wp:', $html, 'Expected no raw block-comment delimiters in the rendered email.' );
@@ -213,7 +222,10 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	public function test_share_integration_public_renders_anchor() {
 		Editor_Bootstrap::init();
 
-		$content = '<!-- wp:newspack-newsletters/share {"href":"mailto:?body=read-this","content":"Share this"} -->'
+		// Mirror production: `content` is an HTML-sourced RichText attribute, so it
+		// is NOT serialized into the block comment — the link text lives only in the
+		// saved anchor. The override must recover it from the inner HTML.
+		$content = '<!-- wp:newspack-newsletters/share {"href":"mailto:?body=read-this"} -->'
 			. '<p class="newspack-newsletters-share-block"><a href="mailto:?body=read-this">Share this</a></p>'
 			. '<!-- /wp:newspack-newsletters/share -->';
 
@@ -242,7 +254,10 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	public function test_share_integration_non_public_renders_no_anchor() {
 		Editor_Bootstrap::init();
 
-		$content = '<!-- wp:newspack-newsletters/share {"href":"mailto:?body=read-this","content":"Share this"} -->'
+		// Mirror production: `content` is an HTML-sourced RichText attribute, so it
+		// is NOT serialized into the block comment — the link text lives only in the
+		// saved anchor. The override must recover it from the inner HTML.
+		$content = '<!-- wp:newspack-newsletters/share {"href":"mailto:?body=read-this"} -->'
 			. '<p class="newspack-newsletters-share-block"><a href="mailto:?body=read-this">Share this</a></p>'
 			. '<!-- /wp:newspack-newsletters/share -->';
 

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -326,6 +326,65 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The share resolvers turn named theme.json presets into inline values.
+	 *
+	 * This locks in the trickiest part of the override: resolving a `backgroundColor`
+	 * /`textColor`/`fontSize` slug against the active theme.json. It also guards the
+	 * font-size edge where a preset slug carries a digit (e.g. `h1`) — which must
+	 * resolve to the preset's size, not be misread as a literal — and that an
+	 * unknown slug resolves to an empty string.
+	 */
+	public function test_share_resolves_named_presets() {
+		$inject = function ( $data ) {
+			return $data->update_with(
+				[
+					'version'  => 2,
+					'settings' => [
+						'color'      => [
+							'palette' => [
+								[
+									'slug'  => 'brand',
+									'color' => '#abcdef',
+									'name'  => 'Brand',
+								],
+							],
+						],
+						'typography' => [
+							'fontSizes' => [
+								[
+									'slug' => 'h1',
+									'size' => '77px',
+									'name' => 'H1',
+								],
+							],
+						],
+					],
+				]
+			);
+		};
+		add_filter( 'wp_theme_json_data_theme', $inject );
+		\WP_Theme_JSON_Resolver::clean_cached_data();
+
+		$resolve = function ( $method, $arg ) {
+			$reflection = new \ReflectionMethod( Share::class, $method );
+			$reflection->setAccessible( true );
+			return $reflection->invoke( null, $arg );
+		};
+
+		try {
+			$this->assertSame( '#abcdef', $resolve( 'resolve_color', 'brand' ), 'Expected a named colour preset to resolve to its hex.' );
+			$this->assertSame( '#abcdef', $resolve( 'resolve_color', 'var:preset|color|brand' ), 'Expected the var:preset colour form to resolve too.' );
+			$this->assertSame( '', $resolve( 'resolve_color', 'nope' ), 'Expected an unknown colour slug to resolve to an empty string.' );
+			$this->assertSame( '77px', $resolve( 'resolve_font_size', 'h1' ), 'Expected a digit-bearing preset slug to resolve to its size, not be read as a literal.' );
+			$this->assertSame( '44px', $resolve( 'resolve_font_size', '44px' ), 'Expected a literal size to be returned as-is.' );
+			$this->assertSame( '', $resolve( 'resolve_font_size', 'nope' ), 'Expected an unknown font-size slug to resolve to an empty string.' );
+		} finally {
+			remove_filter( 'wp_theme_json_data_theme', $inject );
+			\WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+	}
+
+	/**
 	 * A public newsletter renders the share anchor.
 	 *
 	 * With `is_public` meta truthy the override must emit the saved share anchor

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -72,6 +72,11 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 
 		$result = Posts_Inserter::render_inserted_blocks( $children );
 
+		// Assert both children rendered before comparing positions — otherwise a
+		// missing child makes strpos() return false (== 0) and the order check
+		// could pass for the wrong reason.
+		$this->assertStringContainsString( 'First', $result, 'Expected the first child to render.' );
+		$this->assertStringContainsString( 'Second', $result, 'Expected the second child to render.' );
 		$this->assertLessThan(
 			strpos( $result, 'Second' ),
 			strpos( $result, 'First' ),


### PR DESCRIPTION
## Summary

**Adds per-block WC email-editor overrides for the two Newspack dynamic blocks `posts-inserter` and `share` so they render correctly under the WooCommerce email engine — and brings their styling into parity between the newsletter editor and the WC renderer.**

Both blocks store their content outside the normal block parse tree, so the package's per-block email pipeline never processes them and their existing server callbacks produce the wrong output. Each override extends `Abstract_Block_Renderer`, implements `render_content()`, and self-registers via `Block_Renderer_Registry::add()`.

### Rendering — the blocks produce valid email

- **posts-inserter** (`blocks/class-posts-inserter.php`): the block's content lives in the `innerBlocksToInsert` attribute; the original callback concatenates each child's raw `innerHTML` and leaks literal `<!-- wp:... -->` delimiters whenever a child carries nested blocks. The override **wraps each child back into its block delimiter** and runs it through `do_blocks()`, so the *child block itself* is email-rendered (its `render_email_callback` fires) — not only its inner blocks. (Rendering a child's bare `innerHTML` instead leaves the outer `core/columns` as a raw `<div>` with no email width wrapper, so **its columns overflow the email body**.)
- **share** (`blocks/class-share.php`): the block's callback returns `''` unconditionally, so a public newsletter's valid share link renders empty under WC. The override resolves the newsletter post (guarded for null) and, only when its `is_public` meta is truthy, emits the saved share anchor. The link text is an **HTML-sourced RichText attribute** (`content`) not serialized into the block comment, so the override recovers it from the saved anchor's inner HTML.

### Styling parity — editor preview ↔ WC renderer

Once the blocks rendered, their styling drifted between what the editor canvas shows and what the email produces. This reconciles the two (verified element-by-element against the live editor and the rendered email):

- **posts-inserter typography & spacing:** headings/body line-height and weight, an **8px gap** between the title, subtitle, date, excerpt and continue-reading link, and a **16px image↔content column gap** matching the email (which applies a 16px `padding-left` on the content column). The editor double-padded the columns, so the column padding is zeroed and the 16px is supplied once.
- **"Image on top" layout:** that layout renders flat blocks with no `core/columns`, which the package stacks flush. The renderer now wraps each flat block in a **6px top/bottom padded cell**, matching the editor canvas's per-block padding.
- **Editor preview honours the block's own controls:** the posts-inserter preview is an **iframed `BlockPreview`**, so the matching styles are injected straight into the iframe (the block's outer editor stylesheet can't reach it). It pins **only** line-height/weight/spacing — **font sizes and colours flow from the block's heading/text controls** so they're respected in the preview (forcing them with `!important` made the preview ignore those controls).
- **Share block respects its attributes:** the override resolves the block's **background/text colour** (named presets through the theme.json palette, or custom hex) and **font size** (named preset or custom) to inline styles — class-based colours would otherwise inline as unresolved CSS vars. A background-carrying block gets the editor's 6px/12px padding; the link is underlined and inherits the text colour.
- **Title / "continue reading" links inherit their colour** (`color: inherit` rather than forced black) so a custom heading/text colour is respected, while still reading black by default.

**Regression note:** the overrides only attach under the WC email engine (via the `block_type_metadata_settings` → `render_email_callback` swap, behind the renderer flag). Legacy MJML rendering and public web rendering are unchanged. The `ad` block is intentionally untouched (separate effort, #422).

Relates to NEWS-1904 (sub-issues NEWS-2535 posts-inserter, NEWS-2537 share).

### How to test

1. **Unit + integration:** from the plugin dir, `n test-php --filter Test_Newspack_Block_Renderers` → 11 passing (pure-helper + `render_wc` integration, covering the column-width/empty-share regressions, flat-layout padding, share colour/size resolution, and the inherit-colour links). The broader override suite stays green.
2. **posts-inserter rendering:** with the WC renderer flag on, add a Posts Inserter holding a **columns** child; preview. Expected: real HTML with **no literal `<!-- wp:... -->`**, columns stay within the email width.
3. **posts-inserter styling:** compare the editor preview to the renderer for **image left/right** and **image on top** — title/subtitle/date/excerpt/continue spacing and the image↔content gap should match. Then **set a heading/text colour and font size** on the block: both the editor preview and the email should reflect them.
4. **share — public:** mark a newsletter public, add a Share block, set a **background, text colour and font size**; preview. Expected: the `mailto:` anchor with its link text, rendered as a coloured bar with the chosen colours/size (matching the editor).
5. **share — non-public:** leave a newsletter non-public with a Share block. Expected: no share anchor renders.

## For AI

- **posts-inserter** — `render_inserted_blocks()` branches per child: a `core/columns` child (a whole post in the side-by-side layouts) gets the inter-post top margin; any other child (the flat "image on top" / no-image layout) is wrapped by `wrap_flat_block()` in a 6px top/bottom padded `<td>` (the package ignores margin/padding attrs on standalone text blocks). `apply_email_styles()` post-processes the rendered HTML: text links → underlined + `color: inherit` (image-wrapping anchors skipped via lookahead), the package's 16px block gap → 8px, and the duplicated 24px root padding zeroed.
- **share** — `render_content()` reads `href`/`content` (with an innerHTML fallback for the HTML-sourced text), resolves `backgroundColor`/`textColor`/`fontSize` via `resolve_color()` / `resolve_font_size()` (preset slugs against the active theme.json palette + font-size scale; literals passed through), and `build_share_html()` applies them inline.
- **Editor preview** — `posts-preview.js` injects `POST_ITEM_PREVIEW_STYLES` into the nested `BlockPreview` iframe via a `useRefEffect` that re-injects on the iframe `load` event and an inner `MutationObserver` (a single non-subtree observer missed BlockPreview's later document swaps). It pins line-height/weight/spacing only; font sizes/colours are left to the block.
- **Tests** — `tests/email-renderers/test-newspack-block-renderers.php`: fixtures are the production block shape; new cases cover flat-layout padding, share colour/font-size, and inherit-colour links.

### Submission checklist
- [x] Follows Newspack coding standards (PHPCS clean on touched files)
- [x] Tests added/updated (Newspack_Block_Renderers green — 11 tests, 32 assertions)
- [ ] Changelog (auto-generated by CI)
