### PR TITLE
feat(newsletters): theme-native fonts and list/quote/site-title parity

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-quote.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-quote.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Newspack override of the WC email-editor core/quote renderer.
+ *
+ * Exists solely to restore editor↔email cite parity: the package's
+ * Integrations/Core/theme.json declares `fontStyle: italic` for the cite
+ * element inside core/quote, which the CSS inliner injects as
+ * `font-style: italic` on the rendered `<cite class="email-block-quote-citation">`.
+ * The editor canvas renders the cite upright (font-style: normal), so the
+ * email must match.
+ *
+ * The fix is applied via a `woocommerce_email_editor_theme_json` filter at
+ * priority 11 (after the Core Initializer's priority-10 which sets italic) to
+ * override `core/quote.elements.cite.typography.fontStyle` to `"normal"`. This
+ * runs before the CSS inliner, so the inliner writes `font-style: normal`
+ * instead of `font-style: italic`.
+ *
+ * The block-renderer class itself is a required structural shim — the registry
+ * only wires up overrides that extend a package renderer class. All layout,
+ * border, padding, and wrapper logic are inherited from the package's Quote
+ * renderer without modification.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Quote as Package_Quote;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Renders a core/quote block, inheriting the package renderer unchanged.
+ *
+ * The only behavioral change is delivered via the theme.json filter registered
+ * below, not via render_content() — the filter runs before CSS inlining, which
+ * is where the forced italic is injected. Extending Package_Quote satisfies the
+ * registry type-guard and inherits all quote layout logic.
+ */
+class Quote extends Package_Quote {
+	/**
+	 * Override the package theme.json's forced cite italic for core/quote.
+	 *
+	 * The Core Initializer merges `core/quote.elements.cite.typography.fontStyle =
+	 * "italic"` via `woocommerce_email_editor_theme_json` at priority 10. This
+	 * callback runs at priority 11 and merges `"normal"` so the CSS inliner sees
+	 * `font-style: normal` — matching what the editor canvas shows the author.
+	 *
+	 * Registered from the blocks/ file (not Editor_Bootstrap) so the fix is
+	 * co-located with the block it concerns and loaded only through the same
+	 * auto-discovery gate as all other overrides.
+	 *
+	 * @param \WP_Theme_JSON $theme The assembled email editor theme.
+	 * @return \WP_Theme_JSON
+	 */
+	public static function un_italic_cite( \WP_Theme_JSON $theme ): \WP_Theme_JSON {
+		$theme->merge(
+			new \WP_Theme_JSON(
+				[
+					'version' => 3,
+					'styles'  => [
+						'blocks' => [
+							'core/quote' => [
+								'elements' => [
+									'cite' => [
+										'typography' => [
+											'fontStyle' => 'normal',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+				'default'
+			)
+		);
+		return $theme;
+	}
+}
+
+add_filter( 'woocommerce_email_editor_theme_json', [ Quote::class, 'un_italic_cite' ], 11 );
+
+// Self-register this override so the registry discovers it via the blocks/ glob.
+\Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'core/quote', Quote::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-quote.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-quote.php
@@ -2,23 +2,28 @@
 /**
  * Newspack override of the WC email-editor core/quote renderer.
  *
- * Exists solely to restore editor↔email cite parity: the package's
- * Integrations/Core/theme.json declares `fontStyle: italic` for the cite
- * element inside core/quote, which the CSS inliner injects as
- * `font-style: italic` on the rendered `<cite class="email-block-quote-citation">`.
- * The editor canvas renders the cite upright (font-style: normal), so the
- * email must match.
+ * Adjusts two reader-facing quote styles, both via theme.json so the editor
+ * canvas and the rendered email stay in agreement:
  *
- * The fix is applied via a `woocommerce_email_editor_theme_json` filter at
- * priority 11 (after the Core Initializer's priority-10 which sets italic) to
- * override `core/quote.elements.cite.typography.fontStyle` to `"normal"`. This
- * runs before the CSS inliner, so the inliner writes `font-style: normal`
- * instead of `font-style: italic`.
+ * 1. Cite parity: the package's Integrations/Core/theme.json declares
+ *    `fontStyle: italic` for the cite element inside core/quote, which the CSS
+ *    inliner injects as `font-style: italic` on the rendered
+ *    `<cite class="email-block-quote-citation">`. The editor canvas renders the
+ *    cite upright (font-style: normal), so the email must match.
+ *
+ * 2. Border weight: the package declares a `0 0 0 1px` left border for the
+ *    quote. Newspack uses a 2px left bar to match the standard post editor, so
+ *    we override the border width here (the editor canvas applies the matching
+ *    2px in src/editor/style.scss).
+ *
+ * Both are applied via a `woocommerce_email_editor_theme_json` filter at
+ * priority 11 (after the Core Initializer's priority-10 defaults), which runs
+ * before the CSS inliner so the inliner writes the overridden values.
  *
  * The block-renderer class itself is a required structural shim — the registry
  * only wires up overrides that extend a package renderer class. All layout,
- * border, padding, and wrapper logic are inherited from the package's Quote
- * renderer without modification.
+ * padding, and wrapper logic are inherited from the package's Quote renderer
+ * without modification.
  *
  * @package Newspack
  */
@@ -32,19 +37,28 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Renders a core/quote block, inheriting the package renderer unchanged.
  *
- * The only behavioral change is delivered via the theme.json filter registered
- * below, not via render_content() — the filter runs before CSS inlining, which
- * is where the forced italic is injected. Extending Package_Quote satisfies the
- * registry type-guard and inherits all quote layout logic.
+ * The only behavioral changes are delivered via the theme.json filter
+ * registered below, not via render_content() — the filter runs before CSS
+ * inlining, which is where the package's cite italic and 1px border are applied.
+ * Extending Package_Quote satisfies the registry type-guard and inherits all
+ * quote layout logic.
  */
 class Quote extends Package_Quote {
 	/**
-	 * Override the package theme.json's forced cite italic for core/quote.
+	 * Newspack left-bar weight for the email quote, matching the post editor.
 	 *
-	 * The Core Initializer merges `core/quote.elements.cite.typography.fontStyle =
-	 * "italic"` via `woocommerce_email_editor_theme_json` at priority 10. This
-	 * callback runs at priority 11 and merges `"normal"` so the CSS inliner sees
-	 * `font-style: normal` — matching what the editor canvas shows the author.
+	 * @var string
+	 */
+	public const BORDER_WIDTH = '0 0 0 2px';
+
+	/**
+	 * Override the package theme.json for core/quote (cite italic + border width).
+	 *
+	 * The Core Initializer merges the package quote defaults via
+	 * `woocommerce_email_editor_theme_json` at priority 10 (cite `fontStyle:
+	 * italic`, border `0 0 0 1px`). This callback runs at priority 11 and merges
+	 * the Newspack values so the CSS inliner sees `font-style: normal` and a 2px
+	 * left border — matching what the editor canvas shows the author.
 	 *
 	 * Registered from the blocks/ file (not Editor_Bootstrap) so the fix is
 	 * co-located with the block it concerns and loaded only through the same
@@ -53,7 +67,7 @@ class Quote extends Package_Quote {
 	 * @param \WP_Theme_JSON $theme The assembled email editor theme.
 	 * @return \WP_Theme_JSON
 	 */
-	public static function un_italic_cite( \WP_Theme_JSON $theme ): \WP_Theme_JSON {
+	public static function override_quote_email_styles( \WP_Theme_JSON $theme ): \WP_Theme_JSON {
 		$theme->merge(
 			new \WP_Theme_JSON(
 				[
@@ -61,6 +75,11 @@ class Quote extends Package_Quote {
 					'styles'  => [
 						'blocks' => [
 							'core/quote' => [
+								'border'   => [
+									'width' => self::BORDER_WIDTH,
+									'style' => 'solid',
+									'color' => 'currentColor',
+								],
 								'elements' => [
 									'cite' => [
 										'typography' => [
@@ -79,7 +98,7 @@ class Quote extends Package_Quote {
 	}
 }
 
-add_filter( 'woocommerce_email_editor_theme_json', [ Quote::class, 'un_italic_cite' ], 11 );
+add_filter( 'woocommerce_email_editor_theme_json', [ Quote::class, 'override_quote_email_styles' ], 11 );
 
 // Self-register this override so the registry discovers it via the blocks/ glob.
 \Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'core/quote', Quote::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-quote.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-quote.php
@@ -64,10 +64,24 @@ class Quote extends Package_Quote {
 	 * co-located with the block it concerns and loaded only through the same
 	 * auto-discovery gate as all other overrides.
 	 *
+	 * `woocommerce_email_editor_theme_json` is a GLOBAL hook shared with the
+	 * WooCommerce block-email editor package. On a site running WooCommerce's own
+	 * transactional-email editor (same package, same hook), an unguarded override
+	 * would restyle core/quote in WC emails too. Guard it to the newsletter CPT,
+	 * mirroring Editor_Bootstrap::merge_theme_json() (the sibling on this hook).
+	 *
 	 * @param \WP_Theme_JSON $theme The assembled email editor theme.
 	 * @return \WP_Theme_JSON
 	 */
 	public static function override_quote_email_styles( \WP_Theme_JSON $theme ): \WP_Theme_JSON {
+		$post = \Newspack\Newsletters\Email_Renderers\Renderer_Controller::get_rendering_post();
+		if ( ! $post ) {
+			$post = \get_post();
+		}
+		if ( ! $post || \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
+			return $theme;
+		}
+
 		$theme->merge(
 			new \WP_Theme_JSON(
 				[

--- a/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
@@ -110,8 +110,11 @@ class Email_Defaults {
 	 * global fonts are set" requirement.
 	 *
 	 * Guarded identically to inject_button_border_radius(): WC renderer flag on
-	 * AND an email-editor request. When there is no resolvable post being edited
-	 * (e.g. post-new.php before a draft exists) it skips gracefully.
+	 * AND an email-editor request. is_email_editor_request() is also true on
+	 * post-new.php (create), where there is no post yet — in that case fonts are
+	 * resolved with empty meta (global → theme → default), so a brand-new
+	 * newsletter's canvas still shows the resolved theme fonts instead of the
+	 * hardcoded builder defaults.
 	 *
 	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data.
 	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
@@ -125,12 +128,9 @@ class Email_Defaults {
 			return $theme_json;
 		}
 
-		$post = self::get_editing_post();
-		if ( ! $post instanceof \WP_Post ) {
-			return $theme_json;
-		}
-
-		$fonts = Fonts::resolve( $post );
+		// On post-new.php there is no editing post yet; resolve() accepts null and
+		// skips the per-post meta step, running the global → theme → default chain.
+		$fonts = Fonts::resolve( self::get_editing_post() );
 
 		return $theme_json->update_with(
 			[

--- a/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
@@ -53,6 +53,7 @@ class Email_Defaults {
 			return;
 		}
 		add_filter( 'wp_theme_json_data_default', [ __CLASS__, 'inject_button_border_radius' ] );
+		add_filter( 'wp_theme_json_data_default', [ __CLASS__, 'inject_fonts' ] );
 	}
 
 	/**
@@ -96,5 +97,75 @@ class Email_Defaults {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Inject the resolved newsletter body/header fonts at the default origin.
+	 *
+	 * This makes the editor canvas show the same fonts the rendered email uses
+	 * for an un-customized newsletter — by default the active theme's fonts,
+	 * matching the standard post editor. Injecting at the `default` origin (this
+	 * filter fires before `_theme`/`_user`) means any global-styles or
+	 * theme-origin font family still overrides it: that is exactly the "unless
+	 * global fonts are set" requirement.
+	 *
+	 * Guarded identically to inject_button_border_radius(): WC renderer flag on
+	 * AND an email-editor request. When there is no resolvable post being edited
+	 * (e.g. post-new.php before a draft exists) it skips gracefully.
+	 *
+	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data.
+	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
+	 */
+	public static function inject_fonts( \WP_Theme_JSON_Data $theme_json ): \WP_Theme_JSON_Data {
+		if ( ! Feature_Flag::is_enabled() ) {
+			return $theme_json;
+		}
+
+		if ( ! \Newspack_Newsletters_Editor::is_email_editor_request() ) {
+			return $theme_json;
+		}
+
+		$post = self::get_editing_post();
+		if ( ! $post instanceof \WP_Post ) {
+			return $theme_json;
+		}
+
+		$fonts = Fonts::resolve( $post );
+
+		return $theme_json->update_with(
+			[
+				'version' => 3,
+				'styles'  => [
+					'typography' => [
+						'fontFamily' => $fonts['body'],
+					],
+					'elements'   => [
+						'heading' => [
+							'typography' => [
+								'fontFamily' => $fonts['header'],
+							],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Resolve the newsletter post currently being edited, if any.
+	 *
+	 * Reads the `post` URL param (the same signal is_email_editor_request()
+	 * validates for post.php). Returns null on post-new.php / when absent so the
+	 * caller can skip injection gracefully.
+	 *
+	 * @return \WP_Post|null The post being edited, or null.
+	 */
+	private static function get_editing_post(): ?\WP_Post {
+		$post_id = isset( $_GET['post'] ) ? \absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! $post_id ) {
+			return null;
+		}
+		$post = \get_post( $post_id );
+		return $post instanceof \WP_Post ? $post : null;
 	}
 }

--- a/plugins/newspack-newsletters/includes/email-renderers/class-fonts.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-fonts.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Shared font resolver for newsletter email rendering and the editor canvas.
+ *
+ * Resolves the body/header font stacks a newsletter should use, with a clear
+ * precedence so the email render and the editor canvas agree, and so an
+ * un-customized newsletter inherits the active theme's fonts (matching the
+ * standard post editor) instead of a hardcoded default.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves newsletter body/header font stacks.
+ *
+ * Precedence (highest first):
+ *   1. Explicit newsletter font meta (font_header/font_body), validated against
+ *      the supported-fonts whitelist — preserves the legacy authoring behaviour.
+ *   2. Global styles typography.fontFamily (the "unless global fonts are set"
+ *      branch) — site-wide/global-styles typography wins over the theme default.
+ *   3. Active theme fonts via the theme's newspack_font_stack() — the new default
+ *      that matches what the standard post editor shows.
+ *   4. Hardcoded fallback (Theme_Json_Builder defaults) — standalone / no-theme.
+ *
+ * Every theme function and theme-mod call is guarded so the plugin works
+ * standalone with no Newspack theme installed.
+ */
+class Fonts {
+
+	/**
+	 * Newspack-theme default body font stack.
+	 *
+	 * Mirrors `--newspack-theme-font-body` in newspack-theme's
+	 * sass/variables-site/_fonts.scss. This is what the standard post editor
+	 * shows when no `font_body` customizer mod is set — newspack_font_stack()
+	 * returns a degenerate `"","Georgia","serif"` for an unset mod, so we use the
+	 * theme's actual CSS default here to match the post editor exactly.
+	 *
+	 * @var string
+	 */
+	const THEME_DEFAULT_BODY_FONT = 'georgia, garamond, "Times New Roman", serif';
+
+	/**
+	 * Newspack-theme default heading font stack.
+	 *
+	 * Mirrors `--newspack-theme-font-heading` in newspack-theme's
+	 * sass/variables-site/_fonts.scss — the stack the standard post editor shows
+	 * when no `font_header` customizer mod is set.
+	 *
+	 * @var string
+	 */
+	const THEME_DEFAULT_HEADER_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
+
+	/**
+	 * Resolve the body and header font stacks for a newsletter.
+	 *
+	 * @param \WP_Post $post Newsletter post.
+	 * @return array{body:string,header:string} Resolved font stacks.
+	 */
+	public static function resolve( \WP_Post $post ): array {
+		return [
+			'body'   => self::resolve_side(
+				(string) \get_post_meta( $post->ID, 'font_body', true ),
+				'body',
+				Theme_Json_Builder::DEFAULT_BODY_FONT
+			),
+			'header' => self::resolve_side(
+				(string) \get_post_meta( $post->ID, 'font_header', true ),
+				'header',
+				Theme_Json_Builder::DEFAULT_HEADER_FONT
+			),
+		];
+	}
+
+	/**
+	 * Resolve a single side (body or header) through the precedence chain.
+	 *
+	 * @param string $meta_value Stored font meta value for this side.
+	 * @param string $side       'body' or 'header'.
+	 * @param string $fallback   Hardcoded fallback stack.
+	 * @return string Resolved font stack.
+	 */
+	private static function resolve_side( string $meta_value, string $side, string $fallback ): string {
+		// 1. Explicit, supported newsletter font meta wins.
+		$explicit = self::validate_meta_font( $meta_value );
+		if ( null !== $explicit ) {
+			return $explicit;
+		}
+
+		// 2. Global styles typography.fontFamily.
+		$global = self::resolve_global_font( $side );
+		if ( null !== $global ) {
+			return $global;
+		}
+
+		// 3. Active theme fonts (matches the standard post editor).
+		$theme = self::resolve_theme_font( $side );
+		if ( null !== $theme ) {
+			return $theme;
+		}
+
+		// 4. Hardcoded fallback (standalone / no theme).
+		return $fallback;
+	}
+
+	/**
+	 * Validate an explicit font meta value against the supported-fonts whitelist.
+	 *
+	 * Mirrors the builder's former resolve_font() validation so the explicit
+	 * authoring path is unchanged.
+	 *
+	 * @param string $font Stored font meta value.
+	 * @return string|null The font when supported, or null to fall through.
+	 */
+	private static function validate_meta_font( string $font ): ?string {
+		if ( $font && \in_array( $font, \Newspack_Newsletters::$supported_fonts, true ) ) {
+			return $font;
+		}
+		return null;
+	}
+
+	/**
+	 * Resolve the global-styles font family for a side, if set.
+	 *
+	 * Reads `typography.fontFamily` (body) or
+	 * `elements.heading.typography.fontFamily` (header) from the site's global
+	 * styles. A test seam filter (`newspack_newsletters_test_global_styles`)
+	 * allows unit tests to inject a global-styles array without a live theme.
+	 *
+	 * @param string $side 'body' or 'header'.
+	 * @return string|null The global font family, or null when unset/unavailable.
+	 */
+	private static function resolve_global_font( string $side ): ?string {
+		$styles = self::get_global_styles();
+		if ( ! \is_array( $styles ) ) {
+			return null;
+		}
+
+		if ( 'header' === $side ) {
+			$value = $styles['elements']['heading']['typography']['fontFamily'] ?? null;
+		} else {
+			$value = $styles['typography']['fontFamily'] ?? null;
+		}
+
+		if ( \is_string( $value ) && '' !== \trim( $value ) ) {
+			return $value;
+		}
+		return null;
+	}
+
+	/**
+	 * Fetch the site's global styles array defensively.
+	 *
+	 * @return array|null Global styles array, or null when unavailable.
+	 */
+	private static function get_global_styles(): ?array {
+		/**
+		 * Test seam: lets unit tests inject a global-styles array.
+		 *
+		 * @param array|null $styles Global styles array, or null to read live.
+		 */
+		$injected = \apply_filters( 'newspack_newsletters_test_global_styles', null );
+		if ( \is_array( $injected ) ) {
+			return $injected;
+		}
+
+		if ( ! \function_exists( 'wp_get_global_styles' ) ) {
+			return null;
+		}
+
+		$styles = \wp_get_global_styles();
+		return \is_array( $styles ) ? $styles : null;
+	}
+
+	/**
+	 * Resolve the active theme's font stack for a side.
+	 *
+	 * Mirrors the newspack-theme contract (sass/variables-site/_fonts.scss +
+	 * inc/typography.php), which is what the standard post editor renders:
+	 *
+	 *  - When the customizer `font_body`/`font_header` mod IS set, the theme
+	 *    builds the stack with newspack_font_stack( <mod>, <stack> ) — replicated
+	 *    here so a customized site matches the post editor.
+	 *  - When the mod is UNSET, the theme falls back to its CSS-var defaults
+	 *    (`--newspack-theme-font-body` / `--newspack-theme-font-heading`).
+	 *    newspack_font_stack( '', 'serif' ) would instead yield a degenerate
+	 *    `"","Georgia","serif"`, so we use the theme's actual default stacks here
+	 *    to match the post editor exactly.
+	 *
+	 * Returns null only when no Newspack theme is detected (standalone install),
+	 * so the caller falls through to the hardcoded email-safe default.
+	 *
+	 * @param string $side 'body' or 'header'.
+	 * @return string|null The theme font stack, or null when no Newspack theme.
+	 */
+	private static function resolve_theme_font( string $side ): ?string {
+		// Detect the Newspack theme via its font helper. Absent → standalone.
+		if ( ! \function_exists( 'newspack_font_stack' ) || ! \function_exists( 'get_theme_mod' ) ) {
+			return null;
+		}
+
+		if ( 'header' === $side ) {
+			$primary      = (string) \get_theme_mod( 'font_header', '' );
+			$fallback     = (string) \get_theme_mod( 'font_header_stack', 'serif' );
+			$theme_default = self::THEME_DEFAULT_HEADER_FONT;
+		} else {
+			$primary      = (string) \get_theme_mod( 'font_body', '' );
+			$fallback     = (string) \get_theme_mod( 'font_body_stack', 'serif' );
+			$theme_default = self::THEME_DEFAULT_BODY_FONT;
+		}
+
+		// Mod unset → use the theme's CSS-var default (matches the post editor).
+		if ( '' === \trim( $primary ) ) {
+			return $theme_default;
+		}
+
+		$stack = \newspack_font_stack( $primary, $fallback );
+		if ( \is_string( $stack ) && '' !== \trim( $stack ) ) {
+			return $stack;
+		}
+		return $theme_default;
+	}
+}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-fonts.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-fonts.php
@@ -56,24 +56,73 @@ class Fonts {
 	const THEME_DEFAULT_HEADER_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif';
 
 	/**
+	 * Per-request memo of resolved font stacks, keyed by post ID.
+	 *
+	 * The resolve() chain (post meta + global styles + up to four
+	 * get_theme_mod calls) is invoked from Theme_Json_Builder::build() and the
+	 * wp_theme_json_data_default filter, which fires several times per request.
+	 * The memo is request-scoped (static) and a newsletter's font meta is stable
+	 * within one request. The no-post case (post-new.php) shares a stable sentinel
+	 * key so it is memoized too.
+	 *
+	 * @var array<int|string,array{body:string,header:string}>
+	 */
+	private static $memo = [];
+
+	/**
+	 * Sentinel memo key for the no-post (create) resolution path.
+	 *
+	 * @var string
+	 */
+	const NO_POST_MEMO_KEY = '__no_post__';
+
+	/**
 	 * Resolve the body and header font stacks for a newsletter.
 	 *
-	 * @param \WP_Post $post Newsletter post.
+	 * When $post is null (e.g. post-new.php before a draft exists), the per-post
+	 * meta step is skipped and resolution runs the global → theme → fallback chain,
+	 * so a brand-new newsletter's canvas still shows the resolved theme fonts.
+	 *
+	 * @param \WP_Post|null $post Newsletter post, or null to resolve without meta.
 	 * @return array{body:string,header:string} Resolved font stacks.
 	 */
-	public static function resolve( \WP_Post $post ): array {
-		return [
+	public static function resolve( ?\WP_Post $post ): array {
+		$memo_key = $post instanceof \WP_Post ? $post->ID : self::NO_POST_MEMO_KEY;
+		if ( isset( self::$memo[ $memo_key ] ) ) {
+			return self::$memo[ $memo_key ];
+		}
+
+		$body_meta   = $post instanceof \WP_Post ? (string) \get_post_meta( $post->ID, 'font_body', true ) : '';
+		$header_meta = $post instanceof \WP_Post ? (string) \get_post_meta( $post->ID, 'font_header', true ) : '';
+
+		$resolved = [
 			'body'   => self::resolve_side(
-				(string) \get_post_meta( $post->ID, 'font_body', true ),
+				$body_meta,
 				'body',
 				Theme_Json_Builder::DEFAULT_BODY_FONT
 			),
 			'header' => self::resolve_side(
-				(string) \get_post_meta( $post->ID, 'font_header', true ),
+				$header_meta,
 				'header',
 				Theme_Json_Builder::DEFAULT_HEADER_FONT
 			),
 		];
+
+		self::$memo[ $memo_key ] = $resolved;
+		return $resolved;
+	}
+
+	/**
+	 * Clear the per-request resolution memo.
+	 *
+	 * Primarily a test seam: the memo is keyed by post ID (with a stable sentinel
+	 * for the no-post case), so tests that mutate global styles or theme mods for a
+	 * reused key must reset it between cases. Harmless to call at runtime.
+	 *
+	 * @return void
+	 */
+	public static function reset_memo(): void {
+		self::$memo = [];
 	}
 
 	/**
@@ -146,10 +195,20 @@ class Fonts {
 			$value = $styles['typography']['fontFamily'] ?? null;
 		}
 
-		if ( \is_string( $value ) && '' !== \trim( $value ) ) {
-			return $value;
+		if ( ! \is_string( $value ) || '' === \trim( $value ) ) {
+			return null;
 		}
-		return null;
+
+		// Block themes often return a CSS custom property reference such as
+		// `var(--wp--preset--font-family--inter)`. The email CSS inliner and email
+		// clients can't resolve custom properties, so treat it as UNSET and fall
+		// through to the theme/fallback branch rather than emitting an unresolvable
+		// var() into the email theme.json.
+		if ( false !== \stripos( $value, 'var(' ) ) {
+			return null;
+		}
+
+		return $value;
 	}
 
 	/**
@@ -193,6 +252,11 @@ class Fonts {
 	 *
 	 * Returns null only when no Newspack theme is detected (standalone install),
 	 * so the caller falls through to the hardcoded email-safe default.
+	 *
+	 * Caveat: detection keys off function_exists( 'newspack_font_stack' ). A
+	 * non-Newspack theme (or a plugin) that defines a function by that name would
+	 * receive Newspack's font stacks rather than its own — the "matches the post
+	 * editor" guarantee holds for genuine Newspack themes.
 	 *
 	 * @param string $side 'body' or 'header'.
 	 * @return string|null The theme font stack, or null when no Newspack theme.

--- a/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-theme-json-builder.php
@@ -78,8 +78,13 @@ class Theme_Json_Builder {
 		$background = \sanitize_hex_color( (string) \get_post_meta( $post->ID, 'background_color', true ) );
 		$text       = \sanitize_hex_color( (string) \get_post_meta( $post->ID, 'text_color', true ) );
 
-		$header_font = self::resolve_font( (string) \get_post_meta( $post->ID, 'font_header', true ), self::DEFAULT_HEADER_FONT );
-		$body_font   = self::resolve_font( (string) \get_post_meta( $post->ID, 'font_body', true ), self::DEFAULT_BODY_FONT );
+		// Resolve fonts through the shared precedence chain: explicit newsletter
+		// meta → global styles → active theme fonts → hardcoded default. An
+		// un-customized newsletter therefore inherits the theme's fonts (matching
+		// the standard post editor) instead of the hardcoded Arial/Georgia.
+		$fonts       = Fonts::resolve( $post );
+		$header_font = $fonts['header'];
+		$body_font   = $fonts['body'];
 
 		$settings = [
 			'spacing'    => [
@@ -327,20 +332,6 @@ class Theme_Json_Builder {
 
 		// Anything else (percentages, vw, unresolvable, etc.) is not email-safe.
 		return null;
-	}
-
-	/**
-	 * Resolve a font meta value to a supported font stack, or a default.
-	 *
-	 * @param string $font    Stored font meta value.
-	 * @param string $fallback Default stack when the value is empty/unsupported.
-	 * @return string
-	 */
-	private static function resolve_font( string $font, string $fallback ): string {
-		if ( $font && \in_array( $font, \Newspack_Newsletters::$supported_fonts, true ) ) {
-			return $font;
-		}
-		return $fallback;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -55,6 +55,7 @@ if ( file_exists( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.
 // Include main plugin resources.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-logger.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-feature-flag.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-fonts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-email-defaults.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-renderer-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-editor-bootstrap.php';

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -111,6 +111,12 @@
 
 		a {
 			font-family: inherit;
+			// Underline links — moved from `../style.scss`. This is an opinionated
+			// appearance rule, not structural: under flag-on the canvas lets link
+			// decoration flow from theme.json/core (so e.g. the site-title link is
+			// not underlined, matching the WC email and the standard post editor),
+			// while flag-off restores the legacy MJML underline here.
+			text-decoration: underline;
 		}
 
 		code {

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -263,6 +263,31 @@
 			}
 		}
 
+		// Cancel the flag-on batch-C canvas↔email parity rules from `../style.scss`
+		// so the flag-off (MJML) canvas stays byte-identical to its pre-batch-C
+		// appearance. Those rules live in the always-enqueued `editor.css`; this
+		// bundle loads after it (flag-off only) at equal specificity, so restoring
+		// the prior values here wins. (`core/list` is already restored below via its
+		// own `padding: 6px 12px 6px 30px`, which overrides the flag-on
+		// `padding-left: 40px`.) The quote wrapper and site-title sizing have no
+		// pre-existing legacy rule, so reset them to their pre-batch-C values:
+		// the quote wrapper falls back to the generic `.wp-block` inset with no
+		// added border/size, and the site title inherits core's heading sizing.
+		.wp-block[data-type="core/quote"] {
+			padding: 6px 12px;
+			border-left-width: 0;
+			font-size: inherit;
+
+			.wp-block {
+				padding: 6px 12px;
+			}
+		}
+
+		h1.wp-block-site-title,
+		h2.wp-block-site-title {
+			font-size: inherit;
+		}
+
 		.wp-block {
 			&[data-type="core/button"] {
 				padding: 0;

--- a/plugins/newspack-newsletters/src/editor/style.scss
+++ b/plugins/newspack-newsletters/src/editor/style.scss
@@ -168,7 +168,7 @@
 
 			&[data-type="core/quote"] {
 				padding: 20px;
-				border-left-width: 1px;
+				border-left-width: 2px;
 				font-size: 20px;
 
 				// The quote's own 20px padding already insets its contents to match

--- a/plugins/newspack-newsletters/src/editor/style.scss
+++ b/plugins/newspack-newsletters/src/editor/style.scss
@@ -170,6 +170,13 @@
 				padding: 20px;
 				border-left-width: 1px;
 				font-size: 20px;
+
+				// The quote's own 20px padding already insets its contents to match
+				// the email; zero the generic `.wp-block` inset on the inner blocks so
+				// the text isn't double-padded (email inner paragraph has no padding).
+				.wp-block {
+					padding: 0;
+				}
 			}
 
 			&[data-align="full"] {

--- a/plugins/newspack-newsletters/src/editor/style.scss
+++ b/plugins/newspack-newsletters/src/editor/style.scss
@@ -79,10 +79,6 @@
 			}
 		}
 
-		a {
-			text-decoration: underline;
-		}
-
 		a:not(:is(.wp-block-paragraph.has-link-color a, .wp-block-paragraph.has-link-color * a)) {
 			color: inherit;
 		}

--- a/plugins/newspack-newsletters/src/editor/style.scss
+++ b/plugins/newspack-newsletters/src/editor/style.scss
@@ -154,6 +154,24 @@
 				padding: 0;
 			}
 
+			// Batch C canvas↔email parity. On a classic theme the canvas otherwise
+			// falls to WP-core editor defaults (common.css / block-library theme.css)
+			// plus this generic `.wp-block` inset, which under-render these blocks
+			// relative to the WC email output (e.g. the list loses its bullet indent,
+			// the quote shows core's 4px rule, the site title renders smaller). Align
+			// the canvas to the rendered email so the preview is accurate. This is a
+			// targeted patch for the batch-C blocks; theme-agnostic canvas/theme.json
+			// parity is tracked separately.
+			&[data-type="core/list"] {
+				padding-left: 40px;
+			}
+
+			&[data-type="core/quote"] {
+				padding: 20px;
+				border-left-width: 1px;
+				font-size: 20px;
+			}
+
 			&[data-align="full"] {
 				margin: 0;
 				padding: 0;
@@ -164,6 +182,17 @@
 				}
 			}
 		}
+		// Batch C canvas↔email parity for the site title: its block data-type sits on
+		// the heading element itself, so size it by tag + class (not a descendant) to
+		// match the email render (h1 40px / h2 32px).
+		h1.wp-block-site-title {
+			font-size: 40px;
+		}
+
+		h2.wp-block-site-title {
+			font-size: 32px;
+		}
+
 		.has-xx-small-font-size {
 			font-size: var(--wp--preset--font-size--xx-small);
 		}

--- a/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Stand-in newspack-theme typography functions for tests.
+ *
+ * Mirrors themes/newspack-theme/newspack-theme/inc/typography.php so the Fonts
+ * resolver's theme branch can be exercised when the real theme is not loaded in
+ * the PHPUnit environment. Guarded by function_exists so requiring this file is
+ * idempotent and so it never clobbers the real theme's functions.
+ *
+ * @package Newspack_Newsletters
+ */
+
+if ( ! function_exists( 'newspack_get_font_stacks' ) ) {
+	/**
+	 * Fallback font stacks (subset of the real theme's).
+	 *
+	 * @return array
+	 */
+	function newspack_get_font_stacks() {
+		return [
+			'serif'      => [ 'fonts' => [ 'Georgia', 'serif' ] ],
+			'sans_serif' => [ 'fonts' => [ 'Helvetica', 'sans-serif' ] ],
+		];
+	}
+}
+
+if ( ! function_exists( 'newspack_font_stack' ) ) {
+	/**
+	 * Build a font-family stack from a primary font and a fallback id.
+	 *
+	 * @param string $primary     Primary font name.
+	 * @param string $fallback_id Fallback stack id.
+	 * @return string
+	 */
+	function newspack_font_stack( $primary, $fallback_id ) {
+		$stacks = newspack_get_font_stacks();
+		$fonts  = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : [];
+		array_unshift( $fonts, $primary );
+		foreach ( $fonts as &$font ) {
+			$font = '"' . $font . '"';
+		}
+		return implode( ',', $fonts );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
@@ -7,9 +7,11 @@
 
 use Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry;
 use Newspack\Newsletters\Email_Renderers\Blocks\Column;
+use Newspack\Newsletters\Email_Renderers\Blocks\Quote;
 use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
 use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column as Package_Column;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Quote as Package_Quote;
 
 /**
  * Block Renderer Overrides Test.
@@ -254,5 +256,104 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 		// No per-column double-wrapper: a div.email-block-layout must never wrap a column td.
 		$double_wrappers = preg_match_all( '/<div class="email-block-layout"[^>]*>\s*<td class="block wp-block-column/', $html );
 		$this->assertSame( 0, $double_wrappers, 'Expected no column <td> to be wrapped in an extra div.email-block-layout (the f1 double-wrapper).' );
+	}
+
+	/**
+	 * The Newspack Quote renderer extends the package Quote renderer.
+	 *
+	 * The override must extend the package class (not just the abstract base) so
+	 * all the package's quote layout, border, and wrapper logic is inherited
+	 * unchanged. The cite parity fix is applied via theme.json filter, not
+	 * via render_content(), so the class is a structural shim that satisfies
+	 * the registry type-guard.
+	 */
+	public function test_quote_renderer_extends_package_quote() {
+		$this->assertTrue(
+			is_subclass_of( Quote::class, Package_Quote::class ),
+			'The Newspack Quote renderer must extend the package Quote so all layout logic is inherited.'
+		);
+	}
+
+	/**
+	 * A rendered quote cite does NOT carry font-style: italic.
+	 *
+	 * The package vendor theme.json declares `fontStyle: italic` for the cite
+	 * element inside core/quote. The editor canvas renders the cite upright
+	 * (font-style: normal), so the email must match. This test renders a
+	 * quote-with-cite through the real WC pipeline and confirms the cite's
+	 * inline style no longer contains font-style: italic while still carrying the
+	 * other citation styles (font-size, font-weight) that the package provides.
+	 */
+	public function test_quote_cite_is_not_italic() {
+		Editor_Bootstrap::init();
+
+		$content = '<!-- wp:quote --><blockquote class="wp-block-quote">'
+			. '<!-- wp:paragraph --><p>Quoted text here.</p><!-- /wp:paragraph -->'
+			. '<cite>A. Reporter</cite></blockquote><!-- /wp:quote -->';
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Quote cite parity test',
+				'post_content' => $content,
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		// The cite must be present with the citation class.
+		$this->assertStringContainsString( 'email-block-quote-citation', $html, 'Expected the citation wrapper class to be present.' );
+		$this->assertStringContainsString( 'A. Reporter', $html, 'Expected the citation text to survive.' );
+
+		// Extract the cite element's style and assert it does NOT contain italic.
+		preg_match( '/<cite class="email-block-quote-citation"[^>]*style="([^"]*)"/', $html, $matches );
+		$cite_style = $matches[1] ?? '';
+		$this->assertNotEmpty( $cite_style, 'Expected the cite to have an inline style attribute.' );
+		$this->assertStringNotContainsString( 'font-style: italic', $cite_style, 'Expected the cite NOT to carry font-style: italic (editor renders it upright).' );
+		$this->assertStringContainsString( 'font-style: normal', $cite_style, 'Expected the cite to carry font-style: normal to match the editor canvas.' );
+
+		// Other package-provided cite styles must still be present.
+		$this->assertStringContainsString( 'font-size: 13px', $cite_style, 'Expected the package font-size to be preserved.' );
+	}
+
+	/**
+	 * The quote un-italic filter overrides the vendor cite italic in theme.json.
+	 *
+	 * The Core Initializer merges `core/quote.elements.cite.typography.fontStyle =
+	 * "italic"` at priority 10. The quote file registers a filter at priority 11
+	 * that merges `"normal"` so the CSS inliner sees `font-style: normal`. This
+	 * test simulates both filter calls in order and verifies the final merged
+	 * theme.json reports `normal` for the cite element.
+	 */
+	public function test_quote_theme_json_filter_overrides_vendor_italic() {
+		// Start with a base theme that mimics the Core Initializer's italic injection.
+		$theme = new \WP_Theme_JSON(
+			[
+				'version' => 3,
+				'styles'  => [
+					'blocks' => [
+						'core/quote' => [
+							'elements' => [
+								'cite' => [
+									'typography' => [
+										'fontStyle' => 'italic',
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			'default'
+		);
+
+		// The un-italic filter runs at priority 11 (after the italic is set).
+		$theme = Quote::un_italic_cite( $theme );
+
+		// The merged theme must report normal for the cite font-style.
+		$raw        = $theme->get_raw_data();
+		$font_style = $raw['styles']['blocks']['core/quote']['elements']['cite']['typography']['fontStyle'] ?? '';
+		$this->assertSame( 'normal', $font_style, 'Expected the quote un-italic filter to override the cite fontStyle to "normal".' );
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
@@ -331,6 +331,13 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 	 * theme.json reports `normal` for the cite element.
 	 */
 	public function test_quote_theme_json_filter_overrides_vendor_italic() {
+		// The override is guarded to the newsletter CPT — set a newsletter as the
+		// global post so the filter's context check passes.
+		$newsletter_id   = self::factory()->post->create(
+			[ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ]
+		);
+		$GLOBALS['post'] = get_post( $newsletter_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
 		// Start with a base theme that mimics the Core Initializer's italic injection.
 		$theme = new \WP_Theme_JSON(
 			[
@@ -355,6 +362,8 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 		// The override filter runs at priority 11 (after the package defaults).
 		$theme = Quote::override_quote_email_styles( $theme );
 
+		unset( $GLOBALS['post'] );
+
 		// The merged theme must report normal for the cite font-style.
 		$raw        = $theme->get_raw_data();
 		$font_style = $raw['styles']['blocks']['core/quote']['elements']['cite']['typography']['fontStyle'] ?? '';
@@ -363,5 +372,67 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 		// The merged theme must also report the Newspack 2px left border width.
 		$border_width = $raw['styles']['blocks']['core/quote']['border']['width'] ?? '';
 		$this->assertSame( Quote::BORDER_WIDTH, $border_width, 'Expected the quote override filter to set the 2px left border width.' );
+	}
+
+	/**
+	 * The quote override is a NO-OP outside the newsletter CPT context.
+	 *
+	 * `woocommerce_email_editor_theme_json` is a global hook shared with the
+	 * WooCommerce block-email editor. When the rendering post is not a newsletter
+	 * (here: a regular post, or no post at all), the override must return the theme
+	 * untouched so it never bleeds the Newspack quote styles into WC transactional
+	 * emails on a site running both editors.
+	 */
+	public function test_quote_override_is_no_op_for_non_newsletter_context() {
+		$base_styles = [
+			'version' => 3,
+			'styles'  => [
+				'blocks' => [
+					'core/quote' => [
+						'elements' => [
+							'cite' => [
+								'typography' => [
+									'fontStyle' => 'italic',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		// Case 1: a non-newsletter post is the global post → no-op.
+		$regular_id      = self::factory()->post->create( [ 'post_type' => 'post' ] );
+		$GLOBALS['post'] = get_post( $regular_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$theme_regular = Quote::override_quote_email_styles( new \WP_Theme_JSON( $base_styles, 'default' ) );
+		$raw_regular   = $theme_regular->get_raw_data();
+
+		$this->assertSame(
+			'italic',
+			$raw_regular['styles']['blocks']['core/quote']['elements']['cite']['typography']['fontStyle'] ?? '',
+			'On a non-newsletter post the override must not touch the cite fontStyle.'
+		);
+		$this->assertArrayNotHasKey(
+			'border',
+			$raw_regular['styles']['blocks']['core/quote'] ?? [],
+			'On a non-newsletter post the override must not add the Newspack border.'
+		);
+
+		// Case 2: no post in context at all → also a no-op.
+		unset( $GLOBALS['post'] );
+		$theme_none = Quote::override_quote_email_styles( new \WP_Theme_JSON( $base_styles, 'default' ) );
+		$raw_none   = $theme_none->get_raw_data();
+
+		$this->assertSame(
+			'italic',
+			$raw_none['styles']['blocks']['core/quote']['elements']['cite']['typography']['fontStyle'] ?? '',
+			'With no post in context the override must not touch the cite fontStyle.'
+		);
+		$this->assertArrayNotHasKey(
+			'border',
+			$raw_none['styles']['blocks']['core/quote'] ?? [],
+			'With no post in context the override must not add the Newspack border.'
+		);
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-block-renderer-overrides.php
@@ -315,6 +315,10 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 
 		// Other package-provided cite styles must still be present.
 		$this->assertStringContainsString( 'font-size: 13px', $cite_style, 'Expected the package font-size to be preserved.' );
+
+		// The quote table must carry the Newspack 2px left bar (not the package 1px).
+		$this->assertStringContainsString( 'border-width: 0 0 0 2px', $html, 'Expected the quote to carry a 2px left border to match the post editor.' );
+		$this->assertStringNotContainsString( 'border-width: 0 0 0 1px', $html, 'Expected the package 1px quote border to be overridden.' );
 	}
 
 	/**
@@ -348,12 +352,16 @@ class Test_Block_Renderer_Overrides extends WP_UnitTestCase {
 			'default'
 		);
 
-		// The un-italic filter runs at priority 11 (after the italic is set).
-		$theme = Quote::un_italic_cite( $theme );
+		// The override filter runs at priority 11 (after the package defaults).
+		$theme = Quote::override_quote_email_styles( $theme );
 
 		// The merged theme must report normal for the cite font-style.
 		$raw        = $theme->get_raw_data();
 		$font_style = $raw['styles']['blocks']['core/quote']['elements']['cite']['typography']['fontStyle'] ?? '';
-		$this->assertSame( 'normal', $font_style, 'Expected the quote un-italic filter to override the cite fontStyle to "normal".' );
+		$this->assertSame( 'normal', $font_style, 'Expected the quote override filter to set the cite fontStyle to "normal".' );
+
+		// The merged theme must also report the Newspack 2px left border width.
+		$border_width = $raw['styles']['blocks']['core/quote']['border']['width'] ?? '';
+		$this->assertSame( Quote::BORDER_WIDTH, $border_width, 'Expected the quote override filter to set the 2px left border width.' );
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-core-block-fidelity.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-core-block-fidelity.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Class Core Block Fidelity Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+/**
+ * Core Block Fidelity Test.
+ *
+ * Locks in the Batch C audit finding (NEWS-1904): the core blocks `core/list`
+ * (with its `core/list-item` children), `core/quote`, and `core/site-title`
+ * render correctly through the WC email engine WITHOUT a Newspack override. The
+ * package's own renderers already match vanilla WordPress block semantics in a
+ * way that is email-safe, so no `blocks/class-*.php` override is registered for
+ * any of them.
+ *
+ * These tests render each block through `Renderer_Controller::render_wc()` and
+ * assert the structural traits that would break if the package regressed
+ * (list markers, the quote wrapper, the dynamic site-title resolving). If a
+ * future package version diverges, one of these fails and the finding gets a
+ * fresh look — the cheap guard that justifies shipping zero overrides.
+ */
+class Test_Core_Block_Fidelity extends WP_UnitTestCase {
+	/**
+	 * Boot the editor package and override registry once per test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Editor_Bootstrap::init();
+	}
+
+	/**
+	 * Render a block-markup string through the WC engine on a newsletter CPT.
+	 *
+	 * @param string $content Block markup (serialized comments + HTML).
+	 * @return string The rendered email HTML.
+	 */
+	private function render( string $content ): string {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Core block fidelity',
+				'post_content' => $content,
+			]
+		);
+		return Renderer_Controller::render_wc( get_post( $post_id ) );
+	}
+
+	/**
+	 * An unordered list keeps its `<ul>`, items, and left padding for markers.
+	 *
+	 * The package List_Block renderer emits the `<ul class="wp-block-list">` with
+	 * `padding: 0 0 0 40px` so the bullets render in email clients, and keeps both
+	 * `<li>` children. That matches vanilla WP, so no override is needed — this
+	 * asserts the marker padding and item survival that would break otherwise.
+	 */
+	public function test_unordered_list_preserves_markers_and_items() {
+		$content = '<!-- wp:list --><ul class="wp-block-list">'
+			. '<!-- wp:list-item --><li>First item</li><!-- /wp:list-item -->'
+			. '<!-- wp:list-item --><li>Second item</li><!-- /wp:list-item -->'
+			. '</ul><!-- /wp:list -->';
+
+		$html = $this->render( $content );
+
+		$this->assertStringContainsString( '<ul class="wp-block-list"', $html, 'Expected the unordered list tag to survive.' );
+		$this->assertStringContainsString( 'padding: 0 0 0 40px', $html, 'Expected the left padding that renders list markers in email clients.' );
+		$this->assertStringContainsString( 'First item', $html, 'Expected the first list item text.' );
+		$this->assertStringContainsString( 'Second item', $html, 'Expected the second list item text.' );
+	}
+
+	/**
+	 * An ordered list renders an `<ol>` (not a `<ul>`) with its items.
+	 *
+	 * The package keys the tag off `attrs.ordered`, so an ordered list must emit
+	 * `<ol>`. This guards the ordered/unordered distinction surviving the WC render.
+	 */
+	public function test_ordered_list_renders_ol() {
+		$content = '<!-- wp:list {"ordered":true} --><ol class="wp-block-list">'
+			. '<!-- wp:list-item --><li>Step one</li><!-- /wp:list-item -->'
+			. '<!-- wp:list-item --><li>Step two</li><!-- /wp:list-item -->'
+			. '</ol><!-- /wp:list -->';
+
+		$html = $this->render( $content );
+
+		$this->assertStringContainsString( '<ol class="wp-block-list"', $html, 'Expected the ordered list to render as <ol>.' );
+		$this->assertStringContainsString( 'Step one', $html, 'Expected the first ordered item text.' );
+		$this->assertStringContainsString( 'Step two', $html, 'Expected the second ordered item text.' );
+	}
+
+	/**
+	 * A nested list keeps both levels, each with its own marker padding.
+	 *
+	 * Nested `core/list` blocks are the likeliest place a list renderer drops
+	 * structure. Two `<ul class="wp-block-list">` with marker padding must appear
+	 * (parent + child), and both items' text must survive.
+	 */
+	public function test_nested_list_preserves_both_levels() {
+		$content = '<!-- wp:list --><ul class="wp-block-list">'
+			. '<!-- wp:list-item --><li>Parent'
+			. '<!-- wp:list --><ul class="wp-block-list">'
+			. '<!-- wp:list-item --><li>Child</li><!-- /wp:list-item -->'
+			. '</ul><!-- /wp:list --></li><!-- /wp:list-item -->'
+			. '</ul><!-- /wp:list -->';
+
+		$html = $this->render( $content );
+
+		$this->assertSame( 2, substr_count( $html, '<ul class="wp-block-list"' ), 'Expected both the parent and child <ul> to render.' );
+		$this->assertSame( 2, substr_count( $html, 'padding: 0 0 0 40px' ), 'Expected marker padding on both list levels.' );
+		$this->assertStringContainsString( 'Parent', $html, 'Expected the parent item text.' );
+		$this->assertStringContainsString( 'Child', $html, 'Expected the nested child item text.' );
+	}
+
+	/**
+	 * A quote renders the email-block-quote wrapper with its content and citation.
+	 *
+	 * The package wraps the quote in an `email-block-quote` table (the visual
+	 * indent that survives in email) and keeps both the quoted paragraph and the
+	 * `<cite>` citation. That is the correct email rendering, not an MJML
+	 * workaround, so no override is needed.
+	 */
+	public function test_quote_renders_wrapper_content_and_citation() {
+		$content = '<!-- wp:quote --><blockquote class="wp-block-quote">'
+			. '<!-- wp:paragraph --><p>Quoted text here.</p><!-- /wp:paragraph -->'
+			. '<cite>A citation</cite></blockquote><!-- /wp:quote -->';
+
+		$html = $this->render( $content );
+
+		$this->assertStringContainsString( 'email-block-quote', $html, 'Expected the email-safe quote table wrapper.' );
+		$this->assertStringContainsString( 'Quoted text here.', $html, 'Expected the quoted paragraph text.' );
+		$this->assertStringContainsString( 'email-block-quote-citation', $html, 'Expected the citation wrapper.' );
+		$this->assertStringContainsString( 'A citation', $html, 'Expected the citation text.' );
+	}
+
+	/**
+	 * The dynamic site-title block resolves to the site name and home link.
+	 *
+	 * `core/site-title` is a dynamic block; the audit confirmed it resolves under
+	 * the WC engine (the package routes it through the Text renderer). It must emit
+	 * the real blog name inside an `<h1 class="wp-block-site-title">` linked home.
+	 */
+	public function test_site_title_resolves_name_and_link() {
+		$html = $this->render( '<!-- wp:site-title /-->' );
+
+		$this->assertStringContainsString( 'wp-block-site-title', $html, 'Expected the site-title class to survive.' );
+		$this->assertStringContainsString( get_bloginfo( 'name' ), $html, 'Expected the dynamic block to resolve to the site name.' );
+		$this->assertStringContainsString( 'rel="home"', $html, 'Expected the home link the site-title renders by default.' );
+	}
+
+	/**
+	 * The site-title block honors a non-default heading level.
+	 *
+	 * With `level:2` the block must render `<h2>` (not `<h1>`), proving the WC
+	 * engine respects the authored heading level rather than flattening it.
+	 */
+	public function test_site_title_honors_heading_level() {
+		$html = $this->render( '<!-- wp:site-title {"level":2} /-->' );
+
+		$this->assertStringContainsString( '<h2 class="wp-block-site-title"', $html, 'Expected level:2 to render an <h2>.' );
+		$this->assertStringNotContainsString( '<h1 class="wp-block-site-title"', $html, 'Expected no <h1> when level:2 is authored.' );
+	}
+
+	/**
+	 * The site-title block honors `isLink:false` by dropping the anchor.
+	 *
+	 * With linking disabled the rendered title must be plain text with no `<a>`
+	 * wrapping the site name — matching vanilla WP for that attribute.
+	 */
+	public function test_site_title_honors_is_link_false() {
+		$html = $this->render( '<!-- wp:site-title {"isLink":false} /-->' );
+
+		$this->assertStringContainsString( 'wp-block-site-title', $html, 'Expected the site-title to still render.' );
+		$this->assertStringContainsString( get_bloginfo( 'name' ), $html, 'Expected the site name to still resolve.' );
+		$this->assertStringNotContainsString( 'rel="home"', $html, 'Expected no home link when isLink is false.' );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-core-block-fidelity.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-core-block-fidelity.php
@@ -134,7 +134,15 @@ class Test_Core_Block_Fidelity extends WP_UnitTestCase {
 
 		$html = $this->render( $content );
 
-		$this->assertStringContainsString( 'email-block-quote', $html, 'Expected the email-safe quote table wrapper.' );
+		// Assert the main quote wrapper class specifically — `email-block-quote`
+		// followed by a class boundary (space or quote). A bare substring check
+		// would be satisfied by `email-block-quote-citation` alone, masking a
+		// regression of the actual wrapper.
+		$this->assertSame(
+			1,
+			preg_match( '/class="[^"]*\bemail-block-quote(\s|")/', $html ),
+			'Expected the main email-block-quote wrapper class (not just the citation class).'
+		);
 		$this->assertStringContainsString( 'Quoted text here.', $html, 'Expected the quoted paragraph text.' );
 		$this->assertStringContainsString( 'email-block-quote-citation', $html, 'Expected the citation wrapper.' );
 		$this->assertStringContainsString( 'A citation', $html, 'Expected the citation text.' );
@@ -179,6 +187,15 @@ class Test_Core_Block_Fidelity extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wp-block-site-title', $html, 'Expected the site-title to still render.' );
 		$this->assertStringContainsString( get_bloginfo( 'name' ), $html, 'Expected the site name to still resolve.' );
-		$this->assertStringNotContainsString( 'rel="home"', $html, 'Expected no home link when isLink is false.' );
+
+		// Prove the title is genuinely unlinked: the site-title heading must contain
+		// no anchor at all. Asserting only the absence of rel="home" would pass for
+		// an <a> without that attribute. Isolate the heading and assert no <a> in it.
+		$this->assertSame(
+			1,
+			preg_match( '/<h1[^>]*\bwp-block-site-title\b[^>]*>(.*?)<\/h1>/s', $html, $heading ),
+			'Expected the site-title heading to be present.'
+		);
+		$this->assertStringNotContainsString( '<a', $heading[1], 'Expected no anchor tag inside the site-title heading when isLink is false.' );
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-core-block-fidelity.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-core-block-fidelity.php
@@ -12,17 +12,20 @@ use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
  * Core Block Fidelity Test.
  *
  * Locks in the Batch C audit finding (NEWS-1904): the core blocks `core/list`
- * (with its `core/list-item` children), `core/quote`, and `core/site-title`
- * render correctly through the WC email engine WITHOUT a Newspack override. The
- * package's own renderers already match vanilla WordPress block semantics in a
- * way that is email-safe, so no `blocks/class-*.php` override is registered for
- * any of them.
+ * (with its `core/list-item` children) and `core/site-title` render correctly
+ * through the WC email engine without a Newspack override. The package's own
+ * renderers already match vanilla WordPress block semantics in a way that is
+ * email-safe.
+ *
+ * `core/quote` does have a Newspack override (blocks/class-quote.php) solely to
+ * un-italic the cite element — the package theme.json forces `fontStyle: italic`
+ * on the cite, but the editor canvas renders it upright. The override is a theme.json
+ * filter, not a render_content override, so all structural quote traits (wrapper,
+ * content, citation) remain the package's responsibility and are tested here.
  *
  * These tests render each block through `Renderer_Controller::render_wc()` and
  * assert the structural traits that would break if the package regressed
- * (list markers, the quote wrapper, the dynamic site-title resolving). If a
- * future package version diverges, one of these fails and the finding gets a
- * fresh look — the cheap guard that justifies shipping zero overrides.
+ * (list markers, the quote wrapper, the dynamic site-title resolving).
  */
 class Test_Core_Block_Fidelity extends WP_UnitTestCase {
 	/**
@@ -120,8 +123,9 @@ class Test_Core_Block_Fidelity extends WP_UnitTestCase {
 	 *
 	 * The package wraps the quote in an `email-block-quote` table (the visual
 	 * indent that survives in email) and keeps both the quoted paragraph and the
-	 * `<cite>` citation. That is the correct email rendering, not an MJML
-	 * workaround, so no override is needed.
+	 * `<cite>` citation. The Newspack Quote override exists only to fix cite
+	 * italic parity via theme.json — the structural layout here (wrapper, content,
+	 * citation presence) is still fully the package's responsibility.
 	 */
 	public function test_quote_renders_wrapper_content_and_citation() {
 		$content = '<!-- wp:quote --><blockquote class="wp-block-quote">'

--- a/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
@@ -73,6 +73,7 @@ class Test_Email_Defaults extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		delete_option( Feature_Flag::OPTION );
+		\Newspack\Newsletters\Email_Renderers\Fonts::reset_memo();
 
 		if ( null === $this->saved_pagenow ) {
 			unset( $GLOBALS['pagenow'] );

--- a/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
@@ -227,6 +227,102 @@ class Test_Email_Defaults extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * Pull a font-family out of a WP_Theme_JSON_Data.
+	 *
+	 * @param \WP_Theme_JSON_Data $data Theme.json data.
+	 * @param string              $side 'body' or 'header'.
+	 * @return string|null Font family value or null if absent.
+	 */
+	private function get_font( \WP_Theme_JSON_Data $data, string $side ) {
+		$raw = $data->get_data();
+		if ( 'header' === $side ) {
+			return $raw['styles']['elements']['heading']['typography']['fontFamily'] ?? null;
+		}
+		return $raw['styles']['typography']['fontFamily'] ?? null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Font injection guards + behaviour.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Flag OFF → font injection is a no-op (MJML path unchanged).
+	 */
+	public function test_fonts_no_op_when_flag_is_off() {
+		$this->simulate_email_editor_request();
+
+		$data   = $this->make_empty_default_data();
+		$result = Email_Defaults::inject_fonts( $data );
+
+		$this->assertNull( $this->get_font( $result, 'body' ), 'Body font must not inject when flag is off.' );
+		$this->assertNull( $this->get_font( $result, 'header' ), 'Header font must not inject when flag is off.' );
+	}
+
+	/**
+	 * Flag ON but not an email-editor request → font injection is a no-op.
+	 */
+	public function test_fonts_no_op_when_not_email_editor_request() {
+		update_option( Feature_Flag::OPTION, '1' );
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		$data   = $this->make_empty_default_data();
+		$result = Email_Defaults::inject_fonts( $data );
+
+		$this->assertNull( $this->get_font( $result, 'body' ) );
+		$this->assertNull( $this->get_font( $result, 'header' ) );
+	}
+
+	/**
+	 * Flag ON + email-editor request → resolved body/header fonts are injected
+	 * at the default origin so global/theme fonts can still override them.
+	 */
+	public function test_fonts_injected_when_flag_on_and_email_editor() {
+		update_option( Feature_Flag::OPTION, '1' );
+		$this->simulate_email_editor_request();
+
+		$data   = $this->make_empty_default_data();
+		$result = Email_Defaults::inject_fonts( $data );
+
+		$expected = \Newspack\Newsletters\Email_Renderers\Fonts::resolve( get_post( self::$newsletter_post_id ) );
+
+		$this->assertSame( $expected['body'], $this->get_font( $result, 'body' ) );
+		$this->assertSame( $expected['header'], $this->get_font( $result, 'header' ) );
+	}
+
+	/**
+	 * A theme-origin font must win over the Newspack default-origin font, proving
+	 * the "unless global/theme fonts are set" semantics of the default origin.
+	 */
+	public function test_theme_origin_font_wins_over_default() {
+		update_option( Feature_Flag::OPTION, '1' );
+		$this->simulate_email_editor_request();
+
+		$default_data  = $this->make_empty_default_data();
+		$injected_data = Email_Defaults::inject_fonts( $default_data );
+		$default_theme = new \WP_Theme_JSON( $injected_data->get_data(), 'default' );
+
+		$theme_json = new \WP_Theme_JSON(
+			[
+				'version' => 3,
+				'styles'  => [ 'typography' => [ 'fontFamily' => 'ThemeBody, sans-serif' ] ],
+			],
+			'theme'
+		);
+
+		$default_theme->merge( $theme_json );
+
+		$raw    = $default_theme->get_raw_data();
+		$result = $raw['styles']['typography']['fontFamily'] ?? null;
+
+		$this->assertSame(
+			'ThemeBody, sans-serif',
+			$result,
+			'A theme-origin body font must override the Newspack default-origin font after merge.'
+		);
+	}
+
+	/**
 	 * A theme-origin button radius must win over the Newspack default-origin value.
 	 *
 	 * WP_Theme_JSON merges origins in ascending order (default < theme < user).

--- a/plugins/newspack-newsletters/tests/email-renderers/test-fonts.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-fonts.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Class Test_Fonts
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Fonts;
+use Newspack\Newsletters\Email_Renderers\Theme_Json_Builder;
+
+/**
+ * Tests for the shared font resolver.
+ *
+ * Precedence (highest first):
+ *  1. Explicit newsletter font meta (font_header/font_body), validated against
+ *     Newspack_Newsletters::$supported_fonts.
+ *  2. Global styles typography.fontFamily (the "unless global fonts are set" branch).
+ *  3. Active theme fonts via newspack_font_stack() when available.
+ *  4. Hardcoded DEFAULT_BODY_FONT / DEFAULT_HEADER_FONT fallback.
+ */
+class Test_Fonts extends WP_UnitTestCase {
+
+	/**
+	 * Clean up filters/options mutated by tests.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'newspack_newsletters_test_global_styles' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Explicit, supported font meta wins over everything else.
+	 */
+	public function test_explicit_meta_wins() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'font_header', 'Georgia, serif' );
+		update_post_meta( $post_id, 'font_body', 'Verdana, sans-serif' );
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		$this->assertSame( 'Verdana, sans-serif', $fonts['body'] );
+		$this->assertSame( 'Georgia, serif', $fonts['header'] );
+	}
+
+	/**
+	 * Unsupported explicit meta is rejected and falls through to the next branch.
+	 *
+	 * With no theme function available and no global styles, that next branch is
+	 * the hardcoded fallback.
+	 */
+	public function test_unsupported_meta_falls_through() {
+		if ( function_exists( 'newspack_font_stack' ) ) {
+			$this->markTestSkipped( 'Theme font fn present; this case asserts the hardcoded-fallback branch.' );
+		}
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'font_header', 'Comic Sans' );
+		update_post_meta( $post_id, 'font_body', 'Wingdings' );
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		// No theme fn / no global styles in the default test theme → hardcoded fallback.
+		$this->assertSame( Theme_Json_Builder::DEFAULT_BODY_FONT, $fonts['body'] );
+		$this->assertSame( Theme_Json_Builder::DEFAULT_HEADER_FONT, $fonts['header'] );
+	}
+
+	/**
+	 * Global styles typography.fontFamily wins over theme fonts and fallback when
+	 * no explicit meta is set. Simulated via the resolver's test seam filter.
+	 */
+	public function test_global_styles_win_over_theme_and_fallback() {
+		$post_id = self::factory()->post->create();
+
+		add_filter(
+			'newspack_newsletters_test_global_styles',
+			function () {
+				return [
+					'typography' => [ 'fontFamily' => 'GlobalBody, sans-serif' ],
+					'elements'   => [
+						'heading' => [
+							'typography' => [ 'fontFamily' => 'GlobalHeading, serif' ],
+						],
+					],
+				];
+			}
+		);
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		$this->assertSame( 'GlobalBody, sans-serif', $fonts['body'] );
+		$this->assertSame( 'GlobalHeading, serif', $fonts['header'] );
+	}
+
+	/**
+	 * A global body font with no heading override applies to body; the header
+	 * falls through to the next branch (theme/fallback) independently.
+	 */
+	public function test_global_body_only_leaves_header_to_fall_through() {
+		if ( function_exists( 'newspack_font_stack' ) ) {
+			$this->markTestSkipped( 'Theme font fn present; header would resolve to the theme stack, not the hardcoded fallback.' );
+		}
+		$post_id = self::factory()->post->create();
+
+		add_filter(
+			'newspack_newsletters_test_global_styles',
+			function () {
+				return [
+					'typography' => [ 'fontFamily' => 'GlobalBody, sans-serif' ],
+				];
+			}
+		);
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		$this->assertSame( 'GlobalBody, sans-serif', $fonts['body'] );
+		// No global heading, no theme fn → hardcoded header fallback.
+		$this->assertSame( Theme_Json_Builder::DEFAULT_HEADER_FONT, $fonts['header'] );
+	}
+
+	/**
+	 * When the theme exposes newspack_font_stack(), its resolved stacks are used
+	 * as the default (no explicit meta, no global styles). Simulated by defining
+	 * stand-in theme functions only if the real theme isn't loaded.
+	 *
+	 * The default test theme has no newspack_font_stack(), so this asserts the
+	 * resolver's wiring: when the function is absent, it must NOT fatal and must
+	 * fall back to the hardcoded defaults.
+	 */
+	public function test_falls_back_to_hardcoded_when_theme_fn_absent() {
+		if ( function_exists( 'newspack_font_stack' ) ) {
+			$this->markTestSkipped( 'newspack_font_stack() is defined in this process; cannot exercise the absent-fn branch.' );
+		}
+
+		$post_id = self::factory()->post->create();
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		$this->assertSame( Theme_Json_Builder::DEFAULT_BODY_FONT, $fonts['body'] );
+		$this->assertSame( Theme_Json_Builder::DEFAULT_HEADER_FONT, $fonts['header'] );
+	}
+
+	/**
+	 * When the theme's newspack_font_stack() exists, the resolver uses the
+	 * theme's resolved stacks (no explicit meta, no global styles).
+	 *
+	 * The default test theme defines no such function, so we define stand-ins
+	 * that mirror the real theme contract. Function definitions persist for the
+	 * PHP process; that is acceptable because they reproduce the real theme's API
+	 * exactly (and other tests guard on function_exists()).
+	 */
+	public function test_theme_fonts_used_as_default_when_theme_fn_present() {
+		require_once __DIR__ . '/fixtures/theme-font-functions.php';
+
+		$post_id = self::factory()->post->create();
+
+		// Simulate the theme mods the real theme reads.
+		add_filter(
+			'theme_mod_font_body',
+			function () {
+				return 'Source Serif Pro';
+			}
+		);
+		add_filter(
+			'theme_mod_font_body_stack',
+			function () {
+				return 'serif';
+			}
+		);
+		add_filter(
+			'theme_mod_font_header',
+			function () {
+				return 'Source Sans Pro';
+			}
+		);
+		add_filter(
+			'theme_mod_font_header_stack',
+			function () {
+				return 'sans_serif';
+			}
+		);
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		$this->assertSame( newspack_font_stack( 'Source Serif Pro', 'serif' ), $fonts['body'] );
+		$this->assertSame( newspack_font_stack( 'Source Sans Pro', 'sans_serif' ), $fonts['header'] );
+		$this->assertStringContainsString( 'Source Serif Pro', $fonts['body'] );
+		$this->assertStringContainsString( 'Source Sans Pro', $fonts['header'] );
+
+		remove_all_filters( 'theme_mod_font_body' );
+		remove_all_filters( 'theme_mod_font_body_stack' );
+		remove_all_filters( 'theme_mod_font_header' );
+		remove_all_filters( 'theme_mod_font_header_stack' );
+	}
+
+	/**
+	 * When the Newspack theme is present but the customizer font mods are UNSET,
+	 * the resolver uses the theme's CSS-var default stacks (what the standard
+	 * post editor shows) — NOT the degenerate newspack_font_stack( '', 'serif' ).
+	 */
+	public function test_unset_theme_mods_use_theme_css_default_stacks() {
+		require_once __DIR__ . '/fixtures/theme-font-functions.php';
+
+		$post_id = self::factory()->post->create();
+
+		// Force the mods to be empty (unset).
+		add_filter( 'theme_mod_font_body', '__return_empty_string' );
+		add_filter( 'theme_mod_font_header', '__return_empty_string' );
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		remove_filter( 'theme_mod_font_body', '__return_empty_string' );
+		remove_filter( 'theme_mod_font_header', '__return_empty_string' );
+
+		$this->assertSame( Fonts::THEME_DEFAULT_BODY_FONT, $fonts['body'] );
+		$this->assertSame( Fonts::THEME_DEFAULT_HEADER_FONT, $fonts['header'] );
+		$this->assertStringContainsString( 'garamond', $fonts['body'] );
+		$this->assertStringContainsString( 'apple-system', $fonts['header'] );
+	}
+
+	/**
+	 * The resolver always returns both keys as non-empty strings.
+	 */
+	public function test_returns_body_and_header_keys() {
+		$post_id = self::factory()->post->create();
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		$this->assertArrayHasKey( 'body', $fonts );
+		$this->assertArrayHasKey( 'header', $fonts );
+		$this->assertNotEmpty( $fonts['body'] );
+		$this->assertNotEmpty( $fonts['header'] );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-fonts.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-fonts.php
@@ -25,6 +25,7 @@ class Test_Fonts extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters( 'newspack_newsletters_test_global_styles' );
+		Fonts::reset_memo();
 		parent::tear_down();
 	}
 
@@ -214,6 +215,92 @@ class Test_Fonts extends WP_UnitTestCase {
 		$this->assertSame( Fonts::THEME_DEFAULT_HEADER_FONT, $fonts['header'] );
 		$this->assertStringContainsString( 'garamond', $fonts['body'] );
 		$this->assertStringContainsString( 'apple-system', $fonts['header'] );
+	}
+
+	/**
+	 * A global font expressed as a CSS custom property (var(...)) is treated as
+	 * UNSET and falls through to the theme/fallback branch, because the email CSS
+	 * inliner and email clients can't resolve custom properties.
+	 */
+	public function test_global_var_font_falls_through_to_theme() {
+		require_once __DIR__ . '/fixtures/theme-font-functions.php';
+
+		$post_id = self::factory()->post->create();
+
+		// Global styles return an unresolvable CSS var for both sides.
+		add_filter(
+			'newspack_newsletters_test_global_styles',
+			function () {
+				return [
+					'typography' => [ 'fontFamily' => 'var(--wp--preset--font-family--inter)' ],
+					'elements'   => [
+						'heading' => [
+							'typography' => [ 'fontFamily' => 'var(--wp--preset--font-family--montserrat)' ],
+						],
+					],
+				];
+			}
+		);
+
+		// Theme mods unset → theme branch yields the CSS-var default stacks.
+		add_filter( 'theme_mod_font_body', '__return_empty_string' );
+		add_filter( 'theme_mod_font_header', '__return_empty_string' );
+
+		$fonts = Fonts::resolve( get_post( $post_id ) );
+
+		remove_filter( 'theme_mod_font_body', '__return_empty_string' );
+		remove_filter( 'theme_mod_font_header', '__return_empty_string' );
+
+		// The var() globals are skipped; resolution lands on the theme defaults,
+		// never returning the unresolvable var() into the email theme.json.
+		$this->assertStringNotContainsString( 'var(', $fonts['body'], 'Body must not contain an unresolvable CSS var.' );
+		$this->assertStringNotContainsString( 'var(', $fonts['header'], 'Header must not contain an unresolvable CSS var.' );
+		$this->assertSame( Fonts::THEME_DEFAULT_BODY_FONT, $fonts['body'] );
+		$this->assertSame( Fonts::THEME_DEFAULT_HEADER_FONT, $fonts['header'] );
+	}
+
+	/**
+	 * Resolving with null (the post-new.php create path) skips the per-post meta
+	 * step and runs the global → theme → fallback chain, returning both keys.
+	 *
+	 * With no theme fn and no global styles, that chain lands on the hardcoded
+	 * fallback — proving null is accepted and the meta lookups are skipped.
+	 */
+	public function test_resolves_without_post_falls_through_to_fallback() {
+		if ( function_exists( 'newspack_font_stack' ) ) {
+			$this->markTestSkipped( 'Theme font fn present; this case asserts the no-post hardcoded-fallback branch.' );
+		}
+
+		$fonts = Fonts::resolve( null );
+
+		$this->assertSame( Theme_Json_Builder::DEFAULT_BODY_FONT, $fonts['body'] );
+		$this->assertSame( Theme_Json_Builder::DEFAULT_HEADER_FONT, $fonts['header'] );
+	}
+
+	/**
+	 * Resolving with null honors global styles (the create path still picks up
+	 * site-wide global typography), proving the meta step is skipped but the
+	 * global/theme chain still runs.
+	 */
+	public function test_resolves_without_post_honors_global_styles() {
+		add_filter(
+			'newspack_newsletters_test_global_styles',
+			function () {
+				return [
+					'typography' => [ 'fontFamily' => 'GlobalBody, sans-serif' ],
+					'elements'   => [
+						'heading' => [
+							'typography' => [ 'fontFamily' => 'GlobalHeading, serif' ],
+						],
+					],
+				];
+			}
+		);
+
+		$fonts = Fonts::resolve( null );
+
+		$this->assertSame( 'GlobalBody, sans-serif', $fonts['body'] );
+		$this->assertSame( 'GlobalHeading, serif', $fonts['header'] );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-json-builder.php
@@ -185,6 +185,9 @@ class Test_Theme_Json_Builder extends WP_UnitTestCase {
 	 * Unsupported or empty font meta falls back to the default font stacks.
 	 */
 	public function test_font_meta_falls_back_to_defaults_when_unsupported() {
+		if ( function_exists( 'newspack_font_stack' ) ) {
+			$this->markTestSkipped( 'Theme font fn present; unsupported meta resolves to the theme stack, not the hardcoded fallback.' );
+		}
 		$post_id = self::factory()->post->create();
 		update_post_meta( $post_id, 'font_header', 'Comic Sans' );
 		update_post_meta( $post_id, 'font_body', '' );


### PR DESCRIPTION
## Summary

**Brings the batch-C blocks (`core/list`, `core/quote`, `core/site-title`) to full editor-canvas ↔ email parity under the theme-native editor, and makes newsletters default to the active theme's fonts.** This started as a fidelity audit — the package renderers are already email-correct, so **no per-block render-callback overrides were needed** — but manual review on a classic theme surfaced several canvas/email divergences, which this PR now fixes via theme.json + editor CSS only.

Everything is gated behind the `newspack_newsletters_use_woo_renderer` flag; the MJML renderer / flag-off path is byte-identical to before.

What changed:

- **Fonts default to the active theme (canvas + email).** New `Email_Renderers\Fonts` resolver picks fonts with precedence: explicit newsletter `font_body`/`font_header` meta → global-styles typography → the active theme's fonts → hardcoded fallback. The email builder and the editor canvas both use it, so an un-customized newsletter shows the **theme's** fonts (Georgia body / system-sans headings) instead of bare `serif` in the canvas and `Arial` in the email — matching the standard post editor, **unless global fonts are set**.
- **Theme-native editor no longer forces link underlines.** Moved the opinionated `a { text-decoration: underline }` to the flag-off legacy bundle, so under the flag canvas links fall to theme.json/core (the linked site-title is no longer underlined — matching the email + post editor).
- **`core/quote` cite is upright in email.** Overrides the package theme.json's cite `font-style: italic` → `normal` so the email matches the canvas.
- **`core/quote` uses a 2px left bar (canvas + email).** Overrides the package's `0 0 0 1px` border → `0 0 0 2px` to match the post editor.
- **Batch-C canvas spacing/size aligned to the email.** Editor-canvas rules bring the list indent (40px), quote padding/border/font-size, and site-title sizes (h1 40 / h2 32) up to what the email renders — the canvas otherwise fell to WP-core editor defaults.
- **Quote inner text no longer double-padded.** Zeroes the generic `.wp-block` inset on blocks inside the quote so the text sits at the email's 20px, not 32px.
- **Fidelity/regression tests** locking list/quote/site-title WC rendering, plus tests for every fix above.

**Regression notes:** when the flag is off, nothing changes for any engine. The font default and canvas overrides only apply on a WC-renderer email-editor request.

Relates to NEWS-1904.

### How to test

Env: a Newspack site with the WC renderer flag **ON**, on a classic theme (e.g. newspack-theme).

1. **Fonts:** open a newsletter with no `font_body`/`font_header` set — canvas body should be the theme body stack (Georgia), headings the theme heading stack (matching the standard post editor, not `serif`); preview/send and confirm the email uses the same stacks (not Arial). Set the newsletter's font (or a global-styles font) and confirm it overrides.
2. **Quote:** cite is upright (not italic), left bar is 2px, and the text sits ~20px from the bar (not double-indented) — in both the canvas and the email preview.
3. **List / site-title:** list bullets indent 40px; site-title h1/h2 render at 40/32px — canvas matches the email.
4. **Links:** the linked site-title is not underlined in the canvas (matches email + post editor).
5. **Tests:** `cd plugins/newspack-newsletters && n test-php` (email-renderers group) — all green (Fonts, Email_Defaults, Theme_Json_Builder, Block_Renderer_Overrides, Core_Block_Fidelity, …).
6. **Flag off:** disable the flag and confirm the MJML editor/email are unchanged.

## For AI

- **Fonts** — `includes/email-renderers/class-fonts.php`: `Fonts::resolve( \WP_Post ): array{body,header}`. Precedence: validated `font_body`/`font_header` meta → `wp_get_global_styles()` typography → `newspack_font_stack( get_theme_mod(...) )` when `function_exists` (with `THEME_DEFAULT_BODY_FONT`/`THEME_DEFAULT_HEADER_FONT` for the unset-mod case, since the theme's CSS-var defaults — not `newspack_font_stack('', …)` — are what the post editor actually shows) → `Theme_Json_Builder::DEFAULT_*`. `Theme_Json_Builder::build()` calls it for the email; `Email_Defaults::inject_fonts()` (hooked `wp_theme_json_data_default`, gated on flag + `Newspack_Newsletters_Editor::is_email_editor_request()`) injects it into the editor canvas at the **default origin** so global/theme fonts still win.
- **Canvas overrides** — `src/editor/style.scss` under `.editor-styles-wrapper .block-editor-block-list__layout`: list/quote/site-title sizing, quote 2px border + inner-block `padding:0` reset. The link-underline rule moved to `src/editor/legacy-block-styles/style.scss` (flag-off bundle).
- **Email overrides** — theme.json merges in `includes/email-renderers/blocks/class-quote.php` (`override_quote_email_styles`: cite `fontStyle:normal`, border `0 0 0 2px`) via `woocommerce_email_editor_theme_json` priority 11.
- No render-callback overrides were added; all changes are theme.json + editor CSS.

### Submission checklist
- [x] Follows Newspack coding standards (PHPCS clean on touched files)
- [x] Tests added/updated (email-renderer suite green)
- [ ] Changelog (auto-generated by CI)
