### PR TITLE
fix(newsletters): Batch B separator and social-links parity

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
@@ -67,8 +67,13 @@ class Separator extends Abstract_Block_Renderer {
 		$is_dots = str_contains( $class_name, 'is-style-dots' );
 
 		$color  = $this->resolve_color( $attrs, $rendering_context );
-		$width  = $is_wide ? '100%' : self::DEFAULT_WIDTH;
 		$border = $is_dots ? 'dotted' : 'solid';
+
+		// The CSS width carries the unit, but the HTML `width` attribute must be a
+		// number or a percentage — a `100px` attribute is invalid and some email
+		// clients then fall back to full width — so derive a numeric attribute.
+		$css_width  = $is_wide ? '100%' : self::DEFAULT_WIDTH;
+		$attr_width = $is_wide ? '100%' : (string) (int) self::DEFAULT_WIDTH;
 
 		// Build the rule cell style: the `<td>` itself IS the line.
 		$rule_td_style = sprintf(
@@ -88,8 +93,8 @@ class Separator extends Abstract_Block_Renderer {
 		// we are already supplying the full `<td>`.
 		$table_attrs = array(
 			'align' => 'center',
-			'width' => $width,
-			'style' => sprintf( 'width: %s; margin: 0 auto;', esc_attr( $width ) ),
+			'width' => $attr_width,
+			'style' => sprintf( 'width: %s; margin: 0 auto;', esc_attr( $css_width ) ),
 		);
 
 		return Table_Wrapper_Helper::render_table_wrapper( $cell_html, $table_attrs, array(), array(), false );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
@@ -54,6 +54,37 @@ class Separator extends Abstract_Block_Renderer {
 	const DEFAULT_COLOR = '#dddddd';
 
 	/**
+	 * Recognized CSS named colors (the HTML basic keywords plus a few common
+	 * extras). A safety net only — the block editor emits hex, never a bare color
+	 * name — kept deliberately small so an unresolved palette slug that happens to
+	 * be letters-only (e.g. `primary`) is rejected rather than emitted as an
+	 * invalid color.
+	 *
+	 * @var string[]
+	 */
+	const NAMED_COLORS = array(
+		'aqua',
+		'black',
+		'blue',
+		'fuchsia',
+		'gray',
+		'grey',
+		'green',
+		'lime',
+		'maroon',
+		'navy',
+		'olive',
+		'orange',
+		'purple',
+		'red',
+		'silver',
+		'teal',
+		'transparent',
+		'white',
+		'yellow',
+	);
+
+	/**
 	 * Render the separator block as an email-safe table-based horizontal rule.
 	 *
 	 * @param string            $block_content     Original block content (bare `<hr>`).
@@ -164,8 +195,11 @@ class Separator extends Abstract_Block_Renderer {
 		if ( preg_match( '/^(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s\/]+\)$/i', $value ) ) {
 			return true;
 		}
-		// Single-word named color (letters only — excludes hyphenated slugs).
-		return (bool) preg_match( '/^[a-z]+$/i', $value );
+		// A named color, from a small whitelist. A bare word is only treated as a
+		// color when it's a real CSS keyword, so an unresolved palette slug like
+		// `primary` (letters-only, but not a color) is rejected and falls back to
+		// DEFAULT_COLOR rather than producing an invalid rule.
+		return in_array( strtolower( $value ), self::NAMED_COLORS, true );
 	}
 }
 

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Newspack override of the WC email-editor core/separator renderer.
+ *
+ * The WC package has no dedicated separator renderer — `core/separator` falls
+ * through to the Fallback renderer, which wraps the bare `<hr>` in a table
+ * cell but adds no email-safe dimensions. The `.wp-block-separator` stylesheet
+ * (which gives it an explicit `height`, `border`, and a short `width`) is NOT
+ * loaded in email clients, so:
+ *
+ * - A default-style separator degrades to a full-width gray browser `<hr>`.
+ * - A colored separator's color appears only as a class but has no email impact.
+ * - Width/alignment differences between style variants are invisible.
+ *
+ * This override replaces the bare `<hr>` with a table-based horizontal rule:
+ * a centered `<table>` with a single `<td>` carrying an explicit `border-top`
+ * so color, width, and alignment all survive without any external CSS.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Renders a core/separator block in an email-safe way.
+ *
+ * Emits a centered `<table>` with a single `<td>` carrying an explicit
+ * `border-top` (color + width + alignment) so the separator looks right in
+ * email without relying on the `.wp-block-separator` stylesheet.
+ *
+ * Variants:
+ * - Default (is-style-default or no class): 100px wide, centered.
+ * - Wide (is-style-wide): 100% wide.
+ * - Dots (is-style-dots): dotted border-top, 100px wide, centered.
+ */
+class Separator extends Abstract_Block_Renderer {
+
+	/**
+	 * Default separator width for the short/default variant.
+	 */
+	const DEFAULT_WIDTH = '100px';
+
+	/**
+	 * Default separator color (light gray, matching WP core default).
+	 */
+	const DEFAULT_COLOR = '#dddddd';
+
+	/**
+	 * Render the separator block as an email-safe table-based horizontal rule.
+	 *
+	 * @param string            $block_content     Original block content (bare `<hr>`).
+	 * @param array             $parsed_block      Parsed block data including attrs.
+	 * @param Rendering_Context $rendering_context Rendering context for color resolution.
+	 * @return string Email-safe HTML for the separator.
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$attrs      = $parsed_block['attrs'] ?? array();
+		$class_name = $attrs['className'] ?? '';
+
+		$is_wide = str_contains( $class_name, 'is-style-wide' );
+		$is_dots = str_contains( $class_name, 'is-style-dots' );
+
+		$color  = $this->resolve_color( $attrs, $rendering_context );
+		$width  = $is_wide ? '100%' : self::DEFAULT_WIDTH;
+		$border = $is_dots ? 'dotted' : 'solid';
+
+		// Build the rule cell style: the `<td>` itself IS the line.
+		$rule_td_style = sprintf(
+			'border-top: 1px %s %s; height: 0; line-height: 0; font-size: 0;',
+			esc_attr( $border ),
+			esc_attr( $color )
+		);
+
+		// Use render_cell = false so the `<td>` we supply IS the row content,
+		// not nested inside another auto-generated `<td>`.
+		$cell_html = sprintf(
+			'<td style="%s">&nbsp;</td>',
+			$rule_td_style
+		);
+
+		// Outer table: centered, explicit width. Use render_cell = false because
+		// we are already supplying the full `<td>`.
+		$table_attrs = array(
+			'align' => 'center',
+			'width' => $width,
+			'style' => sprintf( 'width: %s; margin: 0 auto;', esc_attr( $width ) ),
+		);
+
+		return Table_Wrapper_Helper::render_table_wrapper( $cell_html, $table_attrs, array(), array(), false );
+	}
+
+	/**
+	 * Resolve the separator color from block attributes.
+	 *
+	 * Priority (mirrors the MJML renderer in class-newspack-newsletters-renderer.php):
+	 * 1. `style.color.background` (arbitrary inline color).
+	 * 2. `backgroundColor` slug (resolved via the rendering context palette).
+	 * 3. Fallback: DEFAULT_COLOR (light gray).
+	 *
+	 * Note: the MJML renderer checks `style.color.background` for the divider
+	 * color, even though the attribute is named `background`. We follow the same
+	 * convention here so both renderers stay consistent.
+	 *
+	 * @param array             $attrs             Block attributes.
+	 * @param Rendering_Context $rendering_context Rendering context for slug resolution.
+	 * @return string Hex color value (e.g. `#cf2e2e`).
+	 */
+	private function resolve_color( array $attrs, Rendering_Context $rendering_context ): string {
+		// 1. Arbitrary inline color (style.color.background).
+		$inline_color = $attrs['style']['color']['background'] ?? '';
+		if ( $inline_color ) {
+			return $inline_color;
+		}
+
+		// 2. Named preset color slug.
+		$bg_slug = $attrs['backgroundColor'] ?? '';
+		if ( $bg_slug ) {
+			$resolved = $rendering_context->translate_slug_to_color( $bg_slug );
+			if ( $resolved ) {
+				return $resolved;
+			}
+		}
+
+		return self::DEFAULT_COLOR;
+	}
+}
+
+// Self-register this override so the registry discovers it via the blocks/ glob.
+\Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'core/separator', Separator::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-separator.php
@@ -42,9 +42,11 @@ defined( 'ABSPATH' ) || exit;
 class Separator extends Abstract_Block_Renderer {
 
 	/**
-	 * Default separator width for the short/default variant.
+	 * Default separator width in pixels for the short/default variant. Stored as
+	 * a number so the CSS (`{N}px`) and the HTML `width="{N}"` attribute are
+	 * composed from one source and can't drift apart.
 	 */
-	const DEFAULT_WIDTH = '100px';
+	const DEFAULT_WIDTH = 100;
 
 	/**
 	 * Default separator color (light gray, matching WP core default).
@@ -72,8 +74,8 @@ class Separator extends Abstract_Block_Renderer {
 		// The CSS width carries the unit, but the HTML `width` attribute must be a
 		// number or a percentage — a `100px` attribute is invalid and some email
 		// clients then fall back to full width — so derive a numeric attribute.
-		$css_width  = $is_wide ? '100%' : self::DEFAULT_WIDTH;
-		$attr_width = $is_wide ? '100%' : (string) (int) self::DEFAULT_WIDTH;
+		$css_width  = $is_wide ? '100%' : self::DEFAULT_WIDTH . 'px';
+		$attr_width = $is_wide ? '100%' : (string) self::DEFAULT_WIDTH;
 
 		// Build the rule cell style: the `<td>` itself IS the line.
 		$rule_td_style = sprintf(
@@ -114,25 +116,56 @@ class Separator extends Abstract_Block_Renderer {
 	 *
 	 * @param array             $attrs             Block attributes.
 	 * @param Rendering_Context $rendering_context Rendering context for slug resolution.
-	 * @return string Hex color value (e.g. `#cf2e2e`).
+	 * @return string A CSS color safe to interpolate into an inline style, or DEFAULT_COLOR.
 	 */
 	private function resolve_color( array $attrs, Rendering_Context $rendering_context ): string {
 		// 1. Arbitrary inline color (style.color.background).
-		$inline_color = $attrs['style']['color']['background'] ?? '';
-		if ( $inline_color ) {
-			return $inline_color;
-		}
+		$candidate = $attrs['style']['color']['background'] ?? '';
 
-		// 2. Named preset color slug.
-		$bg_slug = $attrs['backgroundColor'] ?? '';
-		if ( $bg_slug ) {
-			$resolved = $rendering_context->translate_slug_to_color( $bg_slug );
-			if ( $resolved ) {
-				return $resolved;
+		// 2. Named preset color slug. translate_slug_to_color() returns the slug
+		// unchanged when it isn't in the email theme palette, so an unresolved slug
+		// surfaces here as its own name (e.g. "vivid-red") — rejected below.
+		if ( '' === $candidate ) {
+			$bg_slug = $attrs['backgroundColor'] ?? '';
+			if ( $bg_slug ) {
+				$candidate = (string) $rendering_context->translate_slug_to_color( $bg_slug );
 			}
 		}
 
-		return self::DEFAULT_COLOR;
+		// 3. Fall back to the default gray unless the value is a recognizable CSS
+		// color. This keeps an unresolved slug (or an unexpected author-supplied
+		// value) from emitting an invalid color — which email clients drop, leaving
+		// no rule — and prevents a crafted value from injecting extra declarations
+		// into the cell's inline style.
+		return $this->is_css_color( $candidate ) ? $candidate : self::DEFAULT_COLOR;
+	}
+
+	/**
+	 * Whether a value is a CSS color safe to interpolate into an inline style.
+	 *
+	 * Accepts hex, `rgb()/rgba()/hsl()/hsla()` with numeric components, and
+	 * single-word named colors. Rejects empty values, unresolved color slugs
+	 * (which contain hyphens), and anything carrying CSS-structural characters
+	 * that could break out of the declaration.
+	 *
+	 * @param string $value Candidate color value.
+	 * @return bool
+	 */
+	private function is_css_color( string $value ): bool {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return false;
+		}
+		// Hex: #rgb, #rgba, #rrggbb, #rrggbbaa.
+		if ( preg_match( '/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i', $value ) ) {
+			return true;
+		}
+		// Functional notation with numeric components only.
+		if ( preg_match( '/^(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s\/]+\)$/i', $value ) ) {
+			return true;
+		}
+		// Single-word named color (letters only — excludes hyphenated slugs).
+		return (bool) preg_match( '/^[a-z]+$/i', $value );
 	}
 }
 

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-social-links.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-social-links.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Newspack override of the WC email-editor core/social-links renderer.
+ *
+ * The package renders each social icon as a `display: inline-table` pill and
+ * concatenates them with no spacing, so the icons sit flush against each other
+ * in email — unlike the editor canvas (and the standard post editor), which
+ * space them with the block's gap. The package applies the block's `spacing`
+ * only as padding on the wrapper, never between icons, so there is no attribute
+ * to set; spacing has to be added to the rendered markup.
+ *
+ * This override defers to the package renderer for all icon/service/markup
+ * logic, then injects a small horizontal margin on each icon pill so the email
+ * matches the canvas.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Social_Links as Package_Social_Links;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds inter-icon spacing to the package's core/social-links email render.
+ */
+class Social_Links extends Package_Social_Links {
+
+	/**
+	 * Horizontal margin applied to each side of an icon pill. 6px per side
+	 * yields a 12px gap between adjacent icons, matching the canvas block gap.
+	 */
+	const ICON_SIDE_MARGIN = '6px';
+
+	/**
+	 * Pattern matching each icon pill's style marker. The package compiles the
+	 * pill table style ending in `display:inline-table;float:none;` (compact, via
+	 * WP_Style_Engine) and concatenates the pills with no spacing — so appending
+	 * a margin to this marker spaces them. Whitespace-tolerant so a later
+	 * style-formatting pass (or a package change) can't break the match.
+	 */
+	const PILL_STYLE_PATTERN = '/display:\s*inline-table;\s*float:\s*none;/';
+
+	/**
+	 * Render the social-links block, then space the icons.
+	 *
+	 * Defers to the package renderer for all markup, then injects a horizontal
+	 * margin on each icon pill so the email matches the editor canvas.
+	 *
+	 * @param string            $block_content     Block content.
+	 * @param array             $parsed_block      Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
+	protected function render_content( $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$html = parent::render_content( $block_content, $parsed_block, $rendering_context );
+		return $this->space_icons( $html );
+	}
+
+	/**
+	 * Inject a horizontal margin on each icon pill.
+	 *
+	 * Appends a side margin to the pill style marker the package emits. If the
+	 * package markup ever changes and the marker is absent, the content is
+	 * returned unchanged (no gap added, no breakage).
+	 *
+	 * @param string $html Rendered social-links HTML.
+	 * @return string
+	 */
+	private function space_icons( string $html ): string {
+		return preg_replace(
+			self::PILL_STYLE_PATTERN,
+			sprintf( '$0 margin-left: %1$s; margin-right: %1$s;', self::ICON_SIDE_MARGIN ),
+			$html
+		);
+	}
+}
+
+// Self-register this override so the registry discovers it via the blocks/ glob.
+\Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'core/social-links', Social_Links::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-social-links.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-social-links.php
@@ -40,6 +40,11 @@ class Social_Links extends Package_Social_Links {
 	 * WP_Style_Engine) and concatenates the pills with no spacing — so appending
 	 * a margin to this marker spaces them. Whitespace-tolerant so a later
 	 * style-formatting pass (or a package change) can't break the match.
+	 *
+	 * This couples to package-internal markup; correctness is pinned by
+	 * `test_social_links_icons_are_spaced`, which fails loudly if the package
+	 * stops emitting this marker. If the email-editor package gains a native
+	 * inter-icon spacing attribute, prefer that and retire this seam.
 	 */
 	const PILL_STYLE_PATTERN = '/display:\s*inline-table;\s*float:\s*none;/';
 
@@ -63,18 +68,22 @@ class Social_Links extends Package_Social_Links {
 	 * Inject a horizontal margin on each icon pill.
 	 *
 	 * Appends a side margin to the pill style marker the package emits. If the
-	 * package markup ever changes and the marker is absent, the content is
-	 * returned unchanged (no gap added, no breakage).
+	 * marker is absent (a package markup change) or `preg_replace()` errors, the
+	 * original HTML is returned unchanged — no gap added, no breakage.
 	 *
 	 * @param string $html Rendered social-links HTML.
 	 * @return string
 	 */
 	private function space_icons( string $html ): string {
+		// Coalesce to the input so a PCRE error (e.g. a backtrack limit or invalid
+		// UTF-8) yields the unspaced HTML rather than null — which would violate
+		// the `: string` return type and, as the package's render() has no
+		// per-block try/catch, collapse the whole newsletter's rendered body.
 		return preg_replace(
 			self::PILL_STYLE_PATTERN,
 			sprintf( '$0 margin-left: %1$s; margin-right: %1$s;', self::ICON_SIDE_MARGIN ),
 			$html
-		);
+		) ?? $html;
 	}
 }
 

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -288,6 +288,14 @@
 			font-size: inherit;
 		}
 
+		// `core/social-link`: the flag-on rule in `../style.scss` gives the block
+		// button a symmetric inset so the icon is round under the WC renderer. The
+		// legacy MJML social styling sizes the `.wp-social-link` wrapper itself and
+		// expects the button's generic inset, so restore it here.
+		.wp-block[data-type="core/social-link"] {
+			padding: 6px 12px;
+		}
+
 		.wp-block {
 			&[data-type="core/button"] {
 				padding: 0;

--- a/plugins/newspack-newsletters/src/editor/style.scss
+++ b/plugins/newspack-newsletters/src/editor/style.scss
@@ -154,6 +154,32 @@
 				padding: 0;
 			}
 
+			// The canvas default separator uses core's 2px editor rule; the email
+			// and the standard post editor render a 1px rule, so thin it to 1px. A
+			// colour-styled separator additionally fills the generic `.wp-block`
+			// inset (6px 12px) with its inline background colour
+			// (`box-sizing: border-box`), rendering as a thick bar — clear the fill
+			// (`!important` beats the inline colour) and draw the rule as a 1px
+			// border instead (`currentColor` is the separator's chosen colour),
+			// keeping the block inset so stacked separators stay spaced. Flag-off
+			// already renders a 1px rule, so no cancellation is needed there.
+			&[data-type="core/separator"] {
+				border-bottom-width: 1px;
+
+				&.has-background {
+					background-color: transparent !important;
+					border-bottom: 1px solid;
+				}
+			}
+
+			// The social-link block button inherits the generic `.wp-block` inset
+			// (6px 12px); the asymmetric padding stretches each round icon into an
+			// oval. Use a symmetric inset so the icon keeps the round shape shown in
+			// the email and the standard post editor.
+			&[data-type="core/social-link"] {
+				padding: 6px;
+			}
+
 			// Batch C canvas↔email parity. On a classic theme the canvas otherwise
 			// falls to WP-core editor defaults (common.css / block-library theme.css)
 			// plus this generic `.wp-block` inset, which under-render these blocks

--- a/plugins/newspack-newsletters/src/editor/style.scss
+++ b/plugins/newspack-newsletters/src/editor/style.scss
@@ -154,17 +154,21 @@
 				padding: 0;
 			}
 
-			// The canvas default separator uses core's 2px editor rule; the email
-			// and the standard post editor render a 1px rule, so thin it to 1px. A
-			// colour-styled separator additionally fills the generic `.wp-block`
-			// inset (6px 12px) with its inline background colour
-			// (`box-sizing: border-box`), rendering as a thick bar — clear the fill
-			// (`!important` beats the inline colour) and draw the rule as a 1px
-			// border instead (`currentColor` is the separator's chosen colour),
-			// keeping the block inset so stacked separators stay spaced. Flag-off
-			// already renders a 1px rule, so no cancellation is needed there.
+			// The canvas default separator uses core's 2px editor rule in a darker
+			// gray; the email and the standard post editor render a light-gray 1px
+			// rule. Thin it to 1px and set the email's default color (#dddddd, the
+			// Separator renderer's DEFAULT_COLOR). A colour-styled separator
+			// additionally fills the generic `.wp-block` inset (6px 12px) with its
+			// inline background colour (`box-sizing: border-box`), rendering as a
+			// thick bar — clear the fill (`!important` beats the inline colour) and
+			// draw the rule as a 1px border instead (`currentColor` is the
+			// separator's chosen colour), keeping the block inset so stacked
+			// separators stay spaced. Flag-off needs no cancellation: it renders a
+			// 1px rule already, and its legacy `border-bottom` shorthand resets the
+			// colour back to `currentColor`.
 			&[data-type="core/separator"] {
 				border-bottom-width: 1px;
+				border-bottom-color: #dddddd;
 
 				&.has-background {
 					background-color: transparent !important;

--- a/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
@@ -51,28 +51,31 @@ class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A default separator renders as a plain rule, matching vanilla WP.
+	 * A default separator renders as an email-safe table-based rule.
 	 *
-	 * Vanilla WP emits a bare `<hr class="wp-block-separator …">` with no inline
-	 * border styling, and so does the WC engine — the package passes the `<hr>`
-	 * through unchanged. No override is needed.
+	 * The Newspack separator override replaces the bare `<hr>` with a centered
+	 * `<table>` carrying an explicit `border-top` on a `<td>`, so the default
+	 * separator renders correctly in email without the `.wp-block-separator`
+	 * stylesheet (which is not loaded in email clients).
 	 */
 	public function test_separator_default_passes_through() {
 		$html = $this->render_newsletter( '<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->' );
-		$this->assertStringContainsString( '<hr class="wp-block-separator', $html, 'Expected the separator <hr> to render with its block class.' );
+		// The override emits a table-based rule, not a bare <hr>.
+		$this->assertStringContainsString( 'border-top:', $html, 'Expected the default separator to render with an explicit border-top on a table cell.' );
+		$this->assertMatchesRegularExpression( '/width:\s*1\d{2}px/', $html, 'Expected the default separator to have a constrained width.' );
 	}
 
 	/**
-	 * A colored separator carries its color as inline styles, matching vanilla WP.
+	 * A colored separator carries its color as a border-top on a table cell.
 	 *
-	 * The preset background/text color must be inlined on the `<hr>` so it shows
-	 * in email clients (which ignore the class-based color stylesheet). The
-	 * package already does this, so no override is needed.
+	 * The Newspack separator override resolves the preset color slug to a hex
+	 * value and emits it as an explicit `border-top` on a `<td>`, so the color
+	 * renders correctly in email clients without external CSS.
 	 */
 	public function test_separator_color_is_inlined() {
 		$content = '<!-- wp:separator {"backgroundColor":"vivid-red","className":"is-style-wide"} --><hr class="wp-block-separator has-text-color has-vivid-red-color has-alpha-channel-opacity has-vivid-red-background-color has-background is-style-wide"/><!-- /wp:separator -->';
 		$html    = $this->render_newsletter( $content );
-		$this->assertMatchesRegularExpression( '/<hr class="wp-block-separator[^"]*"[^>]*style="[^"]*background-color: ?#cf2e2e/', $html, 'Expected the separator background color to be inlined for email.' );
+		$this->assertMatchesRegularExpression( '/<td[^>]*style="[^"]*border-top:[^"]*#cf2e2e/', $html, 'Expected the separator color to appear as a border-top on a table cell.' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
@@ -59,7 +59,7 @@ class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
 	 * separator renders correctly in email without the `.wp-block-separator`
 	 * stylesheet (which is not loaded in email clients).
 	 */
-	public function test_separator_default_passes_through() {
+	public function test_separator_default_renders_email_rule() {
 		$html = $this->render_newsletter( '<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->' );
 		// The override emits a table-based rule, not a bare <hr>.
 		$this->assertStringContainsString( 'border-top:', $html, 'Expected the default separator to render with an explicit border-top on a table cell.' );
@@ -92,7 +92,7 @@ class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'href="https://example.com"', $html, 'Expected the button link href to survive.' );
 		$this->assertStringContainsString( 'target="_blank"', $html, 'Expected the button link to open in a new tab.' );
 		$this->assertStringContainsString( '>Click me</a>', $html, 'Expected the button label to render.' );
-		$this->assertStringContainsString( 'class=" wp-block-button"', $html, 'Expected the button to render inside a wp-block-button table cell.' );
+		$this->assertMatchesRegularExpression( '/class="[^"]*\bwp-block-button\b/', $html, 'Expected the button to render inside a wp-block-button table cell.' );
 	}
 
 	/**
@@ -104,8 +104,8 @@ class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
 	public function test_button_preset_colors_are_inlined() {
 		$content = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"vivid-red","textColor":"white"} --><div class="wp-block-button"><a class="wp-block-button__link has-white-color has-vivid-red-background-color has-text-color has-background wp-element-button" href="https://example.com">Buy</a></div><!-- /wp:button --></div><!-- /wp:buttons -->';
 		$html    = $this->render_newsletter( $content );
-		$this->assertStringContainsString( 'background-color: #cf2e2e', $html, 'Expected the button background color to be inlined.' );
-		$this->assertStringContainsString( 'color: #ffffff', $html, 'Expected the button text color to be inlined.' );
+		$this->assertMatchesRegularExpression( '/background-color:\s*#cf2e2e/', $html, 'Expected the button background color to be inlined.' );
+		$this->assertMatchesRegularExpression( '/(?<!-)color:\s*#ffffff/', $html, 'Expected the button text color to be inlined.' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
@@ -11,12 +11,13 @@ use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
 /**
  * Characterization tests for the Batch B core blocks (NEWS-1904).
  *
- * The audit found the WC email-editor package already renders `core/separator`,
- * `core/button` / `core/buttons`, and `core/social-links` in an email-correct
- * way, so Newspack ships no override for any of them. These tests lock in that
- * decision: they render each block through the WC engine and assert the
- * email-safe output the audit relied on, so a package regression that breaks one
- * of these blocks (and would justify adding an override) fails loudly here.
+ * The audit found the WC email-editor package renders `core/button` /
+ * `core/buttons` email-correctly with no override, and renders `core/separator`
+ * and `core/social-links` mostly correctly — each needs only a small Newspack
+ * override (an email-safe rule for the separator, inter-icon spacing for social
+ * links; see the dedicated renderers in `includes/email-renderers/blocks/`).
+ * These tests render each block through the WC engine and assert the email-safe
+ * output, so a package regression that breaks one of these blocks fails loudly.
  *
  * The reference model is vanilla WordPress output, not legacy MJML. Where the
  * package diverges from vanilla WP it does so in email's favor — most notably
@@ -113,8 +114,9 @@ class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
 	 * This is the audit's headline finding: vanilla WP emits inline `<svg>` icons
 	 * that Gmail and Outlook strip, leaving empty links. The package instead emits
 	 * `<img>` tags pointing at hosted PNG icons with the service brand color as the
-	 * pill background — the email-correct representation. So the package output is
-	 * better than vanilla for email and needs no override.
+	 * pill background — the email-correct representation, better than vanilla. The
+	 * Newspack override leaves all of that intact and only adds inter-icon spacing
+	 * (see test_social_links_icons_are_spaced).
 	 */
 	public function test_social_links_render_png_icons_not_svg() {
 		$content = '<!-- wp:social-links --><ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://twitter.com/x","service":"twitter"} /--><!-- wp:social-link {"url":"https://facebook.com/x","service":"facebook"} /--></ul><!-- /wp:social-links -->';
@@ -138,5 +140,23 @@ class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
 		$content = '<!-- wp:social-links {"showLabels":true} --><ul class="wp-block-social-links has-visible-labels"><!-- wp:social-link {"url":"https://twitter.com/x","service":"twitter","label":"Follow us"} /--></ul><!-- /wp:social-links -->';
 		$html    = $this->render_newsletter( $content );
 		$this->assertStringContainsString( 'Follow us', $html, 'Expected the custom social link label to render.' );
+	}
+
+	/**
+	 * Social link icons are spaced apart in email.
+	 *
+	 * The package concatenates each icon pill (`display: inline-table`) with no
+	 * spacing, so icons render flush against each other — unlike the editor canvas,
+	 * which spaces them with the block gap. The Newspack social-links override
+	 * injects a horizontal margin on each pill so the email matches the canvas.
+	 */
+	public function test_social_links_icons_are_spaced() {
+		$content = '<!-- wp:social-links --><ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://twitter.com/x","service":"twitter"} /--><!-- wp:social-link {"url":"https://facebook.com/x","service":"facebook"} /--></ul><!-- /wp:social-links -->';
+		$html    = $this->render_newsletter( $content );
+		$this->assertMatchesRegularExpression(
+			'/display:\s*inline-table;\s*float:\s*none;\s*margin-left:\s*6px;\s*margin-right:\s*6px;/',
+			$html,
+			'Expected each social icon pill to carry a horizontal margin so the icons are spaced apart.'
+		);
 	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-batch-b-core-blocks.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class Batch B Core Blocks Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+/**
+ * Characterization tests for the Batch B core blocks (NEWS-1904).
+ *
+ * The audit found the WC email-editor package already renders `core/separator`,
+ * `core/button` / `core/buttons`, and `core/social-links` in an email-correct
+ * way, so Newspack ships no override for any of them. These tests lock in that
+ * decision: they render each block through the WC engine and assert the
+ * email-safe output the audit relied on, so a package regression that breaks one
+ * of these blocks (and would justify adding an override) fails loudly here.
+ *
+ * The reference model is vanilla WordPress output, not legacy MJML. Where the
+ * package diverges from vanilla WP it does so in email's favor — most notably
+ * social links, where vanilla emits inline `<svg>` (stripped by Gmail/Outlook)
+ * and the package emits hosted PNG `<img>` icons instead.
+ */
+class Test_Batch_B_Core_Blocks extends WP_UnitTestCase {
+	/**
+	 * Boot the WC editor package so render_wc() can render newsletters.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Editor_Bootstrap::init();
+	}
+
+	/**
+	 * Render newsletter content through the WC engine.
+	 *
+	 * @param string $content Block markup for the newsletter body.
+	 * @return string Rendered email HTML.
+	 */
+	private function render_newsletter( string $content ): string {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Batch B newsletter',
+				'post_content' => $content,
+			]
+		);
+		return Renderer_Controller::render_wc( get_post( $post_id ) );
+	}
+
+	/**
+	 * A default separator renders as a plain rule, matching vanilla WP.
+	 *
+	 * Vanilla WP emits a bare `<hr class="wp-block-separator …">` with no inline
+	 * border styling, and so does the WC engine — the package passes the `<hr>`
+	 * through unchanged. No override is needed.
+	 */
+	public function test_separator_default_passes_through() {
+		$html = $this->render_newsletter( '<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->' );
+		$this->assertStringContainsString( '<hr class="wp-block-separator', $html, 'Expected the separator <hr> to render with its block class.' );
+	}
+
+	/**
+	 * A colored separator carries its color as inline styles, matching vanilla WP.
+	 *
+	 * The preset background/text color must be inlined on the `<hr>` so it shows
+	 * in email clients (which ignore the class-based color stylesheet). The
+	 * package already does this, so no override is needed.
+	 */
+	public function test_separator_color_is_inlined() {
+		$content = '<!-- wp:separator {"backgroundColor":"vivid-red","className":"is-style-wide"} --><hr class="wp-block-separator has-text-color has-vivid-red-color has-alpha-channel-opacity has-vivid-red-background-color has-background is-style-wide"/><!-- /wp:separator -->';
+		$html    = $this->render_newsletter( $content );
+		$this->assertMatchesRegularExpression( '/<hr class="wp-block-separator[^"]*"[^>]*style="[^"]*background-color: ?#cf2e2e/', $html, 'Expected the separator background color to be inlined for email.' );
+	}
+
+	/**
+	 * A button renders as an email-safe linked table cell, matching email needs.
+	 *
+	 * The package wraps the button in a table cell carrying the background color
+	 * and renders the link with an explicit `target="_blank"` and inline color —
+	 * the email-safe shape. The link text and href survive. No override is needed.
+	 */
+	public function test_button_renders_email_safe_link() {
+		$content = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://example.com">Click me</a></div><!-- /wp:button --></div><!-- /wp:buttons -->';
+		$html    = $this->render_newsletter( $content );
+		$this->assertStringContainsString( 'href="https://example.com"', $html, 'Expected the button link href to survive.' );
+		$this->assertStringContainsString( 'target="_blank"', $html, 'Expected the button link to open in a new tab.' );
+		$this->assertStringContainsString( '>Click me</a>', $html, 'Expected the button label to render.' );
+		$this->assertStringContainsString( 'class=" wp-block-button"', $html, 'Expected the button to render inside a wp-block-button table cell.' );
+	}
+
+	/**
+	 * A button with a preset background/text color inlines those colors.
+	 *
+	 * Preset colors must reach the rendered cell/link as inline styles so they
+	 * appear in email. The package inlines them already, so no override is needed.
+	 */
+	public function test_button_preset_colors_are_inlined() {
+		$content = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"vivid-red","textColor":"white"} --><div class="wp-block-button"><a class="wp-block-button__link has-white-color has-vivid-red-background-color has-text-color has-background wp-element-button" href="https://example.com">Buy</a></div><!-- /wp:button --></div><!-- /wp:buttons -->';
+		$html    = $this->render_newsletter( $content );
+		$this->assertStringContainsString( 'background-color: #cf2e2e', $html, 'Expected the button background color to be inlined.' );
+		$this->assertStringContainsString( 'color: #ffffff', $html, 'Expected the button text color to be inlined.' );
+	}
+
+	/**
+	 * Social links render as hosted PNG icons, not stripped inline SVG.
+	 *
+	 * This is the audit's headline finding: vanilla WP emits inline `<svg>` icons
+	 * that Gmail and Outlook strip, leaving empty links. The package instead emits
+	 * `<img>` tags pointing at hosted PNG icons with the service brand color as the
+	 * pill background — the email-correct representation. So the package output is
+	 * better than vanilla for email and needs no override.
+	 */
+	public function test_social_links_render_png_icons_not_svg() {
+		$content = '<!-- wp:social-links --><ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://twitter.com/x","service":"twitter"} /--><!-- wp:social-link {"url":"https://facebook.com/x","service":"facebook"} /--></ul><!-- /wp:social-links -->';
+		$html    = $this->render_newsletter( $content );
+
+		$this->assertStringNotContainsString( '<svg', $html, 'Expected social icons to render as <img>, never stripped-by-email <svg>.' );
+		$this->assertMatchesRegularExpression( '#<img[^>]+src="[^"]*/icons/twitter/twitter-white\.png"#', $html, 'Expected a hosted Twitter PNG icon.' );
+		$this->assertMatchesRegularExpression( '#<img[^>]+src="[^"]*/icons/facebook/facebook-white\.png"#', $html, 'Expected a hosted Facebook PNG icon.' );
+		$this->assertStringContainsString( 'href="https://twitter.com/x"', $html, 'Expected the Twitter link href to survive.' );
+		$this->assertStringContainsString( 'href="https://facebook.com/x"', $html, 'Expected the Facebook link href to survive.' );
+	}
+
+	/**
+	 * Social links render service labels when showLabels is enabled.
+	 *
+	 * With showLabels the package renders a text label next to each icon (a custom
+	 * label overrides the service name). The audit confirmed this works, so no
+	 * override is needed.
+	 */
+	public function test_social_links_render_labels_when_enabled() {
+		$content = '<!-- wp:social-links {"showLabels":true} --><ul class="wp-block-social-links has-visible-labels"><!-- wp:social-link {"url":"https://twitter.com/x","service":"twitter","label":"Follow us"} /--></ul><!-- /wp:social-links -->';
+		$html    = $this->render_newsletter( $content );
+		$this->assertStringContainsString( 'Follow us', $html, 'Expected the custom social link label to render.' );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-separator.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-separator.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Class Separator Block Renderer Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+
+/**
+ * Separator block renderer override tests.
+ *
+ * The WC email-editor package passes `core/separator` through the fallback
+ * renderer, which wraps the bare `<hr>` in a table cell but adds no email-safe
+ * dimensions. The `.wp-block-separator` stylesheet (which gives it `height`,
+ * `border`, and a short `width`) is NOT present in email clients, so a
+ * default-style separator degrades to a full-width gray browser `<hr>`, and
+ * a colored separator loses its color appearance.
+ *
+ * The Newspack override must emit an email-safe structure — a horizontal rule
+ * built from a table `<td>` with an explicit `border-top` (rather than a bare
+ * `<hr>`) — so color, width, and alignment all survive without any external CSS.
+ */
+class Test_Separator extends WP_UnitTestCase {
+	/**
+	 * Boot the WC editor package so render_wc() can render newsletters.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Editor_Bootstrap::init();
+	}
+
+	/**
+	 * Render newsletter content through the WC engine.
+	 *
+	 * @param string $content Block markup for the newsletter body.
+	 * @return string Rendered email HTML.
+	 */
+	private function render_newsletter( string $content ): string {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Separator test newsletter',
+				'post_content' => $content,
+			]
+		);
+		return Renderer_Controller::render_wc( get_post( $post_id ) );
+	}
+
+	/**
+	 * A colored separator must carry its color on a table-based structure.
+	 *
+	 * The WC fallback path passes the `<hr>` through with Emogrifier inlining
+	 * CSS, but `.wp-block-separator` (which sets `height`, `border`, and `width`)
+	 * is not present in email, so color on a bare `<hr>` relies on browser
+	 * defaults for dimensions. The override must emit the color as an explicit
+	 * `border-top` or `background-color` on a table `<td>` instead.
+	 */
+	public function test_colored_separator_carries_color_on_table_cell() {
+		$content = '<!-- wp:separator {"backgroundColor":"vivid-red","className":"is-style-wide"} -->'
+			. '<hr class="wp-block-separator has-text-color has-vivid-red-color has-alpha-channel-opacity has-vivid-red-background-color has-background is-style-wide"/>'
+			. '<!-- /wp:separator -->';
+
+		$html = $this->render_newsletter( $content );
+
+		// The color must appear as a table-based inline style (border-top or background-color on a <td>),
+		// not only on a bare <hr> that relies on missing CSS to render dimensions.
+		$this->assertMatchesRegularExpression(
+			'/<td[^>]*style="[^"]*(?:border-top|background-color):[^"]*#cf2e2e/',
+			$html,
+			'Expected the separator color #cf2e2e to appear as an explicit border-top or background-color on a <td>, not only on a bare <hr>.'
+		);
+	}
+
+	/**
+	 * A default-style separator must have an explicit, constrained width.
+	 *
+	 * Without the `.wp-block-separator` stylesheet, a bare `<hr>` stretches to
+	 * 100% in all email clients. The override must emit an explicit short width
+	 * (matching the editor preview: ~100px) so it looks correct in email.
+	 */
+	public function test_default_separator_has_constrained_width() {
+		$content = '<!-- wp:separator -->'
+			. '<hr class="wp-block-separator has-alpha-channel-opacity"/>'
+			. '<!-- /wp:separator -->';
+
+		$html = $this->render_newsletter( $content );
+
+		// Must carry a constrained pixel width on the rule element (not full-width).
+		$this->assertMatchesRegularExpression(
+			'/width:\s*1\d{2}px/',
+			$html,
+			'Expected the default separator to have a constrained width (e.g. 100px) so it does not degrade to full-width in email.'
+		);
+	}
+
+	/**
+	 * A wide separator spans the full width.
+	 *
+	 * `is-style-wide` stretches edge to edge in the editor preview. The override
+	 * must honor this via an explicit `width: 100%` on the table-based structure.
+	 */
+	public function test_wide_separator_spans_full_width() {
+		$content = '<!-- wp:separator {"className":"is-style-wide"} -->'
+			. '<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>'
+			. '<!-- /wp:separator -->';
+
+		$html = $this->render_newsletter( $content );
+
+		// Wide separators must be explicitly 100% wide.
+		$this->assertStringContainsString(
+			'width: 100%',
+			$html,
+			'Expected the wide separator to span full width (100%) in the email output.'
+		);
+	}
+
+	/**
+	 * Default and wide separators differ in width.
+	 *
+	 * This is the parity assertion: the two variants must produce measurably
+	 * different widths in the email output — not both full-width or both short.
+	 */
+	public function test_default_and_wide_separator_widths_differ() {
+		$default_html = $this->render_newsletter(
+			'<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->'
+		);
+		$wide_html    = $this->render_newsletter(
+			'<!-- wp:separator {"className":"is-style-wide"} --><hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/><!-- /wp:separator -->'
+		);
+
+		$has_constrained = (bool) preg_match( '/width:\s*1\d{2}px/', $default_html );
+		$has_full_width  = str_contains( $wide_html, 'width: 100%' );
+
+		$this->assertTrue( $has_constrained, 'Expected the default separator to carry a constrained pixel width.' );
+		$this->assertTrue( $has_full_width, 'Expected the wide separator to carry width: 100%.' );
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-separator.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-separator.php
@@ -137,4 +137,31 @@ class Test_Separator extends WP_UnitTestCase {
 		$this->assertTrue( $has_constrained, 'Expected the default separator to carry a constrained pixel width.' );
 		$this->assertTrue( $has_full_width, 'Expected the wide separator to carry width: 100%.' );
 	}
+
+	/**
+	 * An unresolvable color slug falls back to the default rule color.
+	 *
+	 * `translate_slug_to_color()` returns the slug unchanged when it isn't in the
+	 * email theme palette, so without validation the renderer would emit an
+	 * invalid `border-top: 1px solid <slug>` that email clients drop, leaving no
+	 * rule. The override must fall back to the default gray so the rule renders.
+	 */
+	public function test_unresolved_color_slug_falls_back_to_default() {
+		$content = '<!-- wp:separator {"backgroundColor":"not-a-palette-color"} -->'
+			. '<hr class="wp-block-separator has-not-a-palette-color-background-color has-background"/>'
+			. '<!-- /wp:separator -->';
+
+		$html = $this->render_newsletter( $content );
+
+		$this->assertStringNotContainsString(
+			'solid not-a-palette-color',
+			$html,
+			'Expected an unresolved color slug not to be emitted as an invalid CSS color.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/border-top:\s*1px\s+solid\s+#dddddd/i',
+			$html,
+			'Expected the separator to fall back to the default gray when the color slug is unresolvable.'
+		);
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-separator.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-separator.php
@@ -144,19 +144,21 @@ class Test_Separator extends WP_UnitTestCase {
 	 * `translate_slug_to_color()` returns the slug unchanged when it isn't in the
 	 * email theme palette, so without validation the renderer would emit an
 	 * invalid `border-top: 1px solid <slug>` that email clients drop, leaving no
-	 * rule. The override must fall back to the default gray so the rule renders.
+	 * rule. A letters-only slug (e.g. a palette name like `primary`) is the tricky
+	 * case — it must not be mistaken for a CSS named color. The override must fall
+	 * back to the default gray so the rule still renders.
 	 */
 	public function test_unresolved_color_slug_falls_back_to_default() {
-		$content = '<!-- wp:separator {"backgroundColor":"not-a-palette-color"} -->'
-			. '<hr class="wp-block-separator has-not-a-palette-color-background-color has-background"/>'
+		$content = '<!-- wp:separator {"backgroundColor":"notacolorslug"} -->'
+			. '<hr class="wp-block-separator has-notacolorslug-background-color has-background"/>'
 			. '<!-- /wp:separator -->';
 
 		$html = $this->render_newsletter( $content );
 
 		$this->assertStringNotContainsString(
-			'solid not-a-palette-color',
+			'solid notacolorslug',
 			$html,
-			'Expected an unresolved color slug not to be emitted as an invalid CSS color.'
+			'Expected an unresolved letters-only color slug not to be emitted as an invalid CSS color.'
 		);
 		$this->assertMatchesRegularExpression(
 			'/border-top:\s*1px\s+solid\s+#dddddd/i',


### PR DESCRIPTION
## Summary

**Audits the Batch B core blocks (`core/separator`, `core/button`/`core/buttons`, `core/social-links`) under the WC email renderer, and brings `core/separator` and `core/social-links` to editor-canvas ↔ email parity.** The blocks render mostly correctly straight from the WooCommerce email-editor package; the email-side fixes are the separator's color/width and inter-icon spacing for social-links. The editor canvas separately applies a generic block inset that distorted the colored separator and the social icons; two small CSS rules bring the canvas in line with the email and the standard post editor. Button is audited clean (no change), and all blocks are locked in with characterization tests so a future package regression fails loudly.

Everything is gated behind the `newspack_newsletters_use_woo_renderer` flag; the MJML / flag-off path stays byte-identical (cancellation rules in the legacy bundle).

What changed, per block:

- **`core/separator` — email render fix.** The package's generic fallback dropped the rule's color and width in email. New `Email_Renderers\Blocks\Separator` emits an email-safe centered `<table>` with a `border-top: 1px solid <color>` rule — color resolved inline → preset slug → `#dddddd` fallback, width 100px (default) / 100% (wide). A default rule and a color-styled rule (e.g. `#cf2e2e`) both survive in email clients.
- **`core/separator` — editor-canvas parity fix.** On a classic theme the canvas applies a generic `.wp-block` inset (`6px 12px`); with `box-sizing: border-box` a *color-styled* separator filled that padding box and rendered as a **thick bar**. Drop the fill and draw the rule as a **1px border** instead, keeping the block's inset so stacked separators stay spaced (zeroing the inset jams them together). Also thin the **default** separator from core's 2px editor rule to **1px** and set the email's light-gray default color (`#dddddd`) — the canvas otherwise showed a darker `#808080` — matching the email and the post editor.
- **`core/social-links` — editor-canvas parity fix.** The social-link block button inherits the same `6px 12px` inset; the asymmetric padding stretched each round icon into an **oval** in the canvas. A symmetric inset restores the round shape shown in the email and the post editor.
- **`core/social-links` — email render fix (icon spacing).** The package concatenates each icon (`display: inline-table`) with no spacing, so icons render **flush against each other** in email — unlike the canvas, which spaces them with the block gap. New `Email_Renderers\Blocks\Social_Links` defers to the package renderer for all icon/markup logic, then injects a 6px horizontal margin on each pill (12px between icons), matching the canvas. (The package's icons are already email-correct — hosted PNG `<img>` with brand-color pills, better than vanilla's Gmail/Outlook-stripped `<svg>` — so only spacing is added.)
- **`core/button` / `core/buttons` — no change needed.** The package renders an email-safe linked table cell: background/text color inlined, `target="_blank"`, href and label preserved, custom-width class kept. Audited default, preset-color, and width variants; the canvas already matches.
- **Characterization + regression tests** rendering all three blocks through `Renderer_Controller::render_wc()` and asserting the audited email-safe output.

**Regression notes:** no behavior change off the flag. The separator and social-links email overrides only attach under the WC email engine; the canvas rules only affect the editor canvas, and the legacy MJML canvas stays byte-identical — verified by toggling the flag (flag-off separators keep their 1px legacy rule and widths; flag-off social keeps its `6px 12px` button inset via a cancellation rule).

Relates to NEWS-1904.

### How to test

Env: a Newspack site with the WC renderer flag **ON**, on a classic theme (e.g. newspack-theme), and a newsletter containing a default separator, a color-styled separator, buttons, and a social-links block.

1. **Separator (email):** preview/send the newsletter — the default rule is a thin gray (`#dddddd`) line, the color-styled rule renders in its color; both are thin 1px rules (not thick bars), centered.
2. **Separator (canvas):** in the editor canvas, both separators are **thin 1px lines** (not 2px, not a thick bar), with clear vertical spacing between stacked separators — matching the email and the standard post editor.
3. **Social-links (canvas):** the icons are **perfectly round** (not ovals), matching the email and the post editor.
4. **Social-links (email):** preview/send and confirm the icons have **space between them** (not flush), matching the canvas.
5. **Button:** buttons are color-styled linked blocks; match between canvas and email.
6. **Tests:**
   - `n test-php --filter Test_Separator` → `OK (6 tests, 8 assertions)`
   - `n test-php --filter Test_Batch_B_Core_Blocks` → `OK (7 tests, 16 assertions)`
   - `n test-php --filter Test_Block_Renderer_Overrides` → `OK (18 tests, 39 assertions)`
7. **Flag off:** disable the flag and confirm the legacy MJML editor is unchanged — separators are 1px rules at their legacy widths, social icons keep their legacy round pills.

## For AI

- **Separator email** — `includes/email-renderers/blocks/class-separator.php`: `Separator extends Abstract_Block_Renderer`; emits a centered `<table>` (`width: 100px` default / `100%` for `is-style-wide`) whose single cell carries `border-top: 1px solid <color>`. Color precedence: inline `style` background/color → `has-<slug>-color` preset → `#dddddd`. Self-registers `core/separator`.
- **Separator canvas** — `src/editor/style.scss`, under `.editor-styles-wrapper .block-editor-block-list__layout .wp-block`: `&[data-type="core/separator"] { border-bottom-width: 1px; border-bottom-color: #dddddd; &.has-background { background-color: transparent !important; border-bottom: 1px solid; } }`. Root cause: the generic `.wp-block { padding: 6px 12px }` inset + `box-sizing: border-box` makes a `has-background` separator's **inline** background color fill a ~14px box (hence `!important` to clear it); the border then draws the rule in the separator's color via `currentColor` (core sets the text color alongside the background), keeping the block inset so stacked separators stay spaced. `border-bottom-width: 1px` thins core's 2px default and `border-bottom-color: #dddddd` lightens its `#808080` default to the email's `DEFAULT_COLOR` (the `has-background` shorthand re-asserts `currentColor`, so the colored rule keeps its own color). Flag-off needs no cancellation: it renders a 1px rule already, and its legacy `border-bottom` shorthand resets both width and color back to the legacy values.
- **Social-links canvas** — `src/editor/style.scss`, same parent: `&[data-type="core/social-link"] { padding: 6px; }`. The social-link block button inherits the asymmetric `6px 12px` inset, sizing the icon pill 48×36 (oval); a symmetric `6px` inset makes it 36×36 (round). Flag-off parity is preserved by a cancellation in `src/editor/legacy-block-styles/style.scss` (`.wp-block[data-type="core/social-link"] { padding: 6px 12px; }`) restoring the generic inset (the legacy social styling sizes the `.wp-social-link` wrapper itself), winning under flag-off via load order (legacy bundle loads after `editor.css` at equal specificity).
- **Social-links email** — `includes/email-renderers/blocks/class-social-links.php`: `Social_Links extends` the package's `Social_Links` renderer and overrides `render_content()` to call `parent::render_content()` then `preg_replace` a `margin-left/right: 6px` onto each pill's `display:inline-table;float:none;` marker (the package compiles styles compact via `WP_Style_Engine`, so the match is whitespace-tolerant). Self-registers `core/social-links`. The package handles all icon/service/markup logic; only spacing is added. Outlook (mso) ignores table margins, so the gap is a no-op there — acceptable for the major clients and the in-app preview.
- **Button** — no production code; rendered by the WC email-editor package's core block renderer. `tests/email-renderers/test-batch-b-core-blocks.php` characterizes the email output of all three blocks so a package regression fails loudly.
- Block renderers in this PR: `core/separator` (email rule) and `core/social-links` (icon spacing). Both are auto-discovered by `Block_Renderer_Registry` (the `blocks/` glob), so no main-file `require` is needed.

### Submission checklist
- [x] Follows Newspack coding standards (PHPCS clean on touched files; SCSS compiles clean via the build)
- [x] Tests added/updated (separator + Batch B suites green)
- [ ] Changelog (auto-generated by CI)
