### PR TITLE
feat(insights): add timestamp-window Source_Matcher

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-source-matcher.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-source-matcher.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Newspack Insights — Source Matcher.
+ *
+ * Attaches a BigQuery-derived conversion source (gate / prompt / direct) to a
+ * local record (a Woo order or a WP user) by TIMESTAMP PROXIMITY — never by a BQ
+ * identifier. BQ's `user_id`/`user_pseudo_id` is a GA client cookie, not a WP/Woo
+ * customer ID, so the old `(int)$uid → customer_id` join silently dropped ~all
+ * rows. Instead we anchor on the local record's own timestamp (`date_created` for
+ * orders, `user_registered` for users) and find the BQ source event that falls in
+ * the record's window. Pure: no DB access, fully unit-testable with arrays.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Matches local records to BigQuery source events by timestamp window.
+ */
+class Source_Matcher {
+
+	/** Symmetric ±window (seconds) for the user_registered anchor (registration ≈ reg event). */
+	const WINDOW_REGISTRATION_SECONDS = 120;
+
+	/** Window (seconds) for the order anchor; event must precede the order (attempt → completion). */
+	const WINDOW_ORDER_SECONDS = 1800;
+
+	/** Source bucket for records with no matching event. */
+	const SOURCE_DIRECT = 'direct';
+
+	/** All source buckets, in display order. */
+	const SOURCES = [ 'gate', 'prompt', self::SOURCE_DIRECT ];
+
+	/**
+	 * Attach a source to each record by finding a BQ event in [ts − before, ts + after].
+	 *
+	 * Each event is consumed at most once (assigned to the nearest eligible record)
+	 * to limit over-attribution on dense windows. Records with no eligible event get
+	 * SOURCE_DIRECT.
+	 *
+	 * @param array $records        [ [ 'key' => int|string, 'ts' => int ], … ] (ts = epoch seconds).
+	 * @param array $events         [ [ 'ts' => int, 'source' => string ], … ] (ts = epoch seconds).
+	 * @param int   $before_seconds Seconds before the record's ts an event may fall.
+	 * @param int   $after_seconds  Seconds after the record's ts an event may fall.
+	 * @return array<int|string,string> Map of record key => source.
+	 */
+	public static function attach_sources( array $records, array $events, int $before_seconds, int $after_seconds ): array {
+		$result = [];
+		foreach ( $records as $record ) {
+			$result[ $record['key'] ] = self::SOURCE_DIRECT;
+		}
+
+		// Greedy nearest-match: for each event, claim the nearest unclaimed record in range.
+		$claimed = [];
+		foreach ( $events as $event ) {
+			$best_key  = null;
+			$best_dist = null;
+			foreach ( $records as $record ) {
+				$key = $record['key'];
+				if ( isset( $claimed[ $key ] ) ) {
+					continue;
+				}
+				$lo = $record['ts'] - $before_seconds;
+				$hi = $record['ts'] + $after_seconds;
+				if ( $event['ts'] < $lo || $event['ts'] > $hi ) {
+					continue;
+				}
+				$dist = abs( $event['ts'] - $record['ts'] );
+				if ( null === $best_dist || $dist < $best_dist ) {
+					$best_dist = $dist;
+					$best_key  = $key;
+				}
+			}
+			if ( null !== $best_key ) {
+				$result[ $best_key ] = $event['source'];
+				$claimed[ $best_key ] = true;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Tally a key=>source map into per-source counts (all buckets zero-filled).
+	 *
+	 * @param array<int|string,string> $key_to_source Output of attach_sources().
+	 * @return array<string,int>
+	 */
+	public static function count_by_source( array $key_to_source ): array {
+		$counts = array_fill_keys( self::SOURCES, 0 );
+		foreach ( $key_to_source as $source ) {
+			if ( isset( $counts[ $source ] ) ) {
+				++$counts[ $source ];
+			}
+		}
+		return $counts;
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-source-matcher.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-source-matcher.php
@@ -53,6 +53,14 @@ class Source_Matcher {
 			$result[ $record['key'] ] = self::SOURCE_DIRECT;
 		}
 
+		// Sort both inputs by timestamp so attribution is deterministic regardless of
+		// caller / BigQuery row order; ties resolve by earliest timestamp.
+		$ts_sort = static function ( $a, $b ) {
+			return $a['ts'] <=> $b['ts'];
+		};
+		usort( $records, $ts_sort );
+		usort( $events, $ts_sort );
+
 		// Greedy nearest-match: for each event, claim the nearest unclaimed record in range.
 		$claimed = [];
 		foreach ( $events as $event ) {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-source-matcher.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-source-matcher.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests for Newspack\Insights\Source_Matcher.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Insights\Source_Matcher;
+
+/**
+ * Tests for Source_Matcher.
+ *
+ * @group insights
+ */
+class Newspack_Test_Source_Matcher extends WP_UnitTestCase {
+
+	/** A record at ts matches an event within the symmetric window and takes its source. */
+	public function test_attaches_source_within_symmetric_window() {
+		$records = [
+			[
+				'key' => 11,
+				'ts'  => 1000,
+			],
+		];
+		$events  = [
+			[
+				'ts'     => 1050,
+				'source' => 'gate',
+			],
+		]; // +50s, inside ±120s.
+		$result  = Source_Matcher::attach_sources( $records, $events, 120, 120 );
+		$this->assertSame( [ 11 => 'gate' ], $result );
+	}
+
+	/** An event outside the window leaves the record 'direct'. */
+	public function test_unmatched_record_is_direct() {
+		$records = [
+			[
+				'key' => 11,
+				'ts'  => 1000,
+			],
+		];
+		$events  = [
+			[
+				'ts'     => 5000,
+				'source' => 'prompt',
+			],
+		]; // far outside.
+		$result  = Source_Matcher::attach_sources( $records, $events, 120, 120 );
+		$this->assertSame( [ 11 => Source_Matcher::SOURCE_DIRECT ], $result );
+	}
+
+	/** Asymmetric (order) window: event must precede the record (attempt before order). */
+	public function test_order_window_requires_event_before_record() {
+		$records = [
+			[
+				'key' => 7,
+				'ts'  => 2000,
+			],
+		];
+		$before  = [
+			[
+				'ts'     => 1500,
+				'source' => 'gate',
+			],
+		];   // 500s before, inside [ts-1800, ts].
+		$after   = [
+			[
+				'ts'     => 2500,
+				'source' => 'gate',
+			],
+		];   // 500s after, OUTSIDE (after=0).
+		$this->assertSame( [ 7 => 'gate' ], Source_Matcher::attach_sources( $records, $before, 1800, 0 ) );
+		$this->assertSame( [ 7 => Source_Matcher::SOURCE_DIRECT ], Source_Matcher::attach_sources( $records, $after, 1800, 0 ) );
+	}
+
+	/** Each event is consumed once: two records, one event → only the nearest matches. */
+	public function test_event_consumed_once_nearest_wins() {
+		$records = [
+			[
+				'key' => 'a',
+				'ts'  => 1000,
+			],
+			[
+				'key' => 'b',
+				'ts'  => 1010,
+			],
+		];
+		$events  = [
+			[
+				'ts'     => 1012,
+				'source' => 'prompt',
+			],
+		]; // nearest to 'b'.
+		$result  = Source_Matcher::attach_sources( $records, $events, 120, 120 );
+		$this->assertSame( 'prompt', $result['b'] );
+		$this->assertSame( Source_Matcher::SOURCE_DIRECT, $result['a'] );
+	}
+
+	/** Counts by source, zero-filling all three buckets. */
+	public function test_count_by_source_zero_fills() {
+		$map = [
+			1 => 'gate',
+			2 => 'gate',
+			3 => 'direct',
+		];
+		$this->assertSame(
+			[
+				'gate'   => 2,
+				'prompt' => 0,
+				'direct' => 1,
+			],
+			Source_Matcher::count_by_source( $map )
+		);
+	}
+
+	/** Empty inputs are safe. */
+	public function test_empty_inputs() {
+		$this->assertSame( [], Source_Matcher::attach_sources( [], [], 120, 120 ) );
+		$this->assertSame(
+			[
+				'gate'   => 0,
+				'prompt' => 0,
+				'direct' => 0,
+			],
+			Source_Matcher::count_by_source( [] )
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-source-matcher.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-source-matcher.php
@@ -5,14 +5,57 @@
  * @package Newspack
  */
 
+namespace Newspack\Tests\Insights;
+
 use Newspack\Insights\Source_Matcher;
+use WP_UnitTestCase;
 
 /**
  * Tests for Source_Matcher.
  *
  * @group insights
  */
-class Newspack_Test_Source_Matcher extends WP_UnitTestCase {
+class Test_Source_Matcher extends WP_UnitTestCase {
+
+	/** Attribution is deterministic regardless of caller / BigQuery row order. */
+	public function test_matching_is_order_independent() {
+		$records  = [
+			[
+				'key' => 'a',
+				'ts'  => 1000,
+			],
+			[
+				'key' => 'b',
+				'ts'  => 2000,
+			],
+		];
+		$sorted   = [
+			[
+				'ts'     => 1005,
+				'source' => 'gate',
+			],
+			[
+				'ts'     => 2005,
+				'source' => 'prompt',
+			],
+		];
+		$shuffled = [
+			[
+				'ts'     => 2005,
+				'source' => 'prompt',
+			],
+			[
+				'ts'     => 1005,
+				'source' => 'gate',
+			],
+		];
+		$expected = [
+			'a' => 'gate',
+			'b' => 'prompt',
+		];
+		$this->assertSame( $expected, Source_Matcher::attach_sources( $records, $sorted, 120, 120 ) );
+		$this->assertSame( $expected, Source_Matcher::attach_sources( $records, $shuffled, 120, 120 ) );
+	}
 
 	/** A record at ts matches an event within the symmetric window and takes its source. */
 	public function test_attaches_source_within_symmetric_window() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a pure `Newspack\Insights\Source_Matcher` utility — the shared foundation for an upcoming remediation of the Insights Conversion / Gates / Prompts revenue metrics.

Those metrics currently attribute conversions by casting a BigQuery `uid` to a WooCommerce `customer_id`, but that `uid` is a GA client cookie, not a WP user ID, so the join resolves to nothing on real data. The fix (landing in follow-up PRs) inverts to a WP/Woo identity spine and uses BigQuery only for the conversion **source** split (gate / prompt / direct), attaching it to each local record by **timestamp proximity**. `Source_Matcher` is that timestamp-window matcher.

This PR is **foundation only — tested but not yet wired** to any metric, so there is no behavior change. It is the first in a staged, sequentially-reviewed series; the metric rewiring and the new Tab 3 Phase B metrics build on it in subsequent PRs.

> Stacked on `feat/insights-rsm`.

### How to test the changes in this Pull Request:

1. Check out the branch and run the Insights unit tests: `n test-php --filter Source_Matcher` — expect `OK (6 tests, ...)`.
2. Review `includes/wizards/insights/class-source-matcher.php` and confirm purity: no database, WordPress, or WooCommerce calls (it operates only on plain arrays).
3. Confirm scope: the diff adds only the new class and its test — no existing metric or resolver code is modified, so live Insights behavior is unchanged.
4. (Optional) Cross-check the matching semantics against the tests: symmetric ±120s window vs. the asymmetric order window (event must precede the record), nearest-record-wins single-consume, unmatched records fall back to `direct`, and `count_by_source` zero-fills all buckets.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
