### PR TITLE
test(insights): rename format.test.js back to .ts (NPPD-1683)

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.test.ts
@@ -1,11 +1,7 @@
 /**
  * Tests for the tiered currency formatter (NPPD-1684).
  *
- * Named `.test.js` (not `.ts`) so the suite is actually collected: the current
- * testMatch only matches `test.js` / `test.jsx`, excluding `.ts`/`.tsx`
- * (NPPD-1683). The `./format` import still resolves to format.ts via Jest's
- * default moduleFileExtensions + the TS-aware babel transform. Expected strings
- * assume the en-US default locale used by the test environment.
+ * Expected strings assume the en-US default locale used by the test environment.
  */
 
 /**


### PR DESCRIPTION
Closes the final acceptance criterion of [NPPD-1683](https://linear.app/a8c/issue/NPPD-1683/insights-tab-tsx-and-ts-test-files-not-collected-by-npm-test-harness): renaming the `format.test.js` workaround back to `format.test.ts` now that the harness actually collects TypeScript tests.

The bulk of NPPD-1683 already landed on `feat/insights-rsm` ahead of this PR — this is the small, deliberately-separate tail end so the ticket closes with a clean provenance trail rather than looking abandoned. 

## Pre-flight decisions

- **Most of NPPD-1683 was already done.** AC 1–3 (testMatch widening, TS transform coverage, and the React/jsx-runtime resolution that lets the colocated component tests pass) landed in two earlier commits on `feat/insights-rsm`:
  - `4a4a572130` — *build(insights): include .tsx test files in Jest testMatch* — widened the glob in `packages/scripts/scripts/test.js` from `**/*test.js?(x)` to `**/*test.[jt]s?(x)` and fixed the assertions in the newly-running tests.
  - `ec12afacfc` — *ci: re-enable JS unit tests as a blocking gate* — added the `transformIgnorePatterns` allowlist (pnpm-nested `@wordpress/*` ESM) that lets the colocated component tests transform and run.
- **No React-19 resolution work was needed.** The ticket flagged a "multiple copies of React" / dataviews `Cannot unlock` chain. That reproduces only against a drifted **local** `node_modules`; CI's fresh install resolves a single copy of react/react-dom/dataviews and all seven named tests pass there. Verified green on `feat/insights-rsm` (`JS / newspack`: 74 suites / 566 tests passing). So this PR is a pure rename — no shared jest config is touched.
- **Scope held to the rename.** No migration of existing `.js`/`.jsx` tests, no new tests — both explicitly out of scope per the ticket.

## What's in this PR

### `format.test.js` → `format.test.ts`
`src/wizards/insights/tabs/components/format.test.js` is renamed to `format.test.ts`. The file imports the `.ts` module under test (`./format`) and uses only standard Jest — nothing changes about how it runs; it is simply collected under the widened `.ts` glob now instead of relying on the `.js` extension to be picked up.

### Trim the obsolete workaround note
The file's header comment previously documented *why* it had to be named `.js` (the NPPD-1683 collection gap). That gap is closed, so the explanatory paragraph is removed, leaving only the locale note that still matters.

## How to test

1. From `plugins/newspack-plugin`, run the full JS suite: `npm test`.
2. Confirm `src/wizards/insights/tabs/components/format.test.ts` is **collected and passes** (7 tests in the `formatCurrency` describe block). Before this PR the same assertions ran only because the file carried a `.js` extension; they now run as a first-class `.ts` test.
3. Sanity-check that the colocated TypeScript tests are genuinely running, not silently skipped: the run reports the Insights `.ts`/`.tsx` suites (e.g. `metrics.test.ts`, `MetricCard.test.tsx`, `AudienceTab.test.tsx`) in its output. CI's `JS / newspack` job is the source of truth here — a clean local `node_modules` is required for the component `.tsx` suites to pass locally (see Heads-up).
4. `git log --oneline` / `git show --stat` confirms a single-file rename with only the header comment trimmed — no logic change.

## Heads-up

- **Provenance, not new behavior.** AC 1–3 already shipped in `4a4a572130` and `ec12afacfc`; this PR only satisfies AC 4 (the rename). The ticket's "harness fix + React-19 resolution may need to land together" framing was overtaken by events — they already landed and are green in CI.
- **Local-only test reds are expected.** On a drifted local `node_modules`, the Insights component `.tsx` suites fail with `@wordpress/dataviews` "Cannot unlock" / "older version of React". That is duplicate-react peer drift in the local pnpm store, not a regression — CI passes them. A clean reinstall clears it; it is out of scope here and won't be addressed by editing committed config.