### PR TITLE
fix(insights): gate Donors tab on donation activity in last 365 days

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -181,15 +181,34 @@ class Insights_Wizard extends Wizard {
 	const DONATION_ACTIVITY_TRANSIENT = 'newspack_insights_has_donation_activity';
 
 	/**
-	 * Donors tab visibility. True when the publisher has at least one
-	 * donation-related order or subscription in their history.
+	 * Trailing window, in days, over which a completed donation order keeps the
+	 * Donors tab visible. Matches the active-donor recency leg the donor
+	 * storage adapters use ({@see \Newspack\Insights\HPOS_Donors_Storage}),
+	 * so the visibility gate and the tab's own metrics agree on what counts
+	 * as "has donations". (Active subscriptions keep the tab visible
+	 * regardless of this window — see {@see self::build_donation_activity_sql()}.)
+	 *
+	 * @var int
+	 */
+	const DONATION_ACTIVITY_WINDOW_DAYS = 365;
+
+	/**
+	 * Donors tab visibility. True when the publisher has active donation
+	 * activity — an active donation subscription, or a completed donation
+	 * order in the trailing {@see self::DONATION_ACTIVITY_WINDOW_DAYS} days
+	 * (the same two-leg definition the Donors metrics use for an active
+	 * donor). A publisher who collects donations through a third-party
+	 * platform — or who has no active donation subscription and no
+	 * Newspack-native WooCommerce donation order in over a year — does not
+	 * get the tab, because its metrics would have nothing to report.
 	 *
 	 * Product existence is NOT a useful signal: every Newspack publisher
 	 * receives the canonical donation product family on install regardless
 	 * of whether they ever collect donations, so a product-existence
 	 * check showed Tab 7 on every site, including the many publishers
-	 * who have never taken a donation. Activity is the right heuristic —
-	 * a single qualifying order or subscription gates the tab visible.
+	 * who have never taken a donation. Recent activity is the right
+	 * heuristic — an active donation subscription, or a single qualifying
+	 * donation order in the trailing window, gates the tab visible.
 	 *
 	 * Result is cached for 24h via {@see self::DONATION_ACTIVITY_TRANSIENT}.
 	 * State transitions ("publisher started taking donations") are rare
@@ -227,6 +246,16 @@ class Insights_Wizard extends Wizard {
 	 */
 	public static function force_refresh_donation_activity(): bool {
 		delete_transient( self::DONATION_ACTIVITY_TRANSIENT );
+		// Recompute from live state: also clear the donation-product set and
+		// backend caches the activity query depends on, so a just-configured
+		// donation (or a test) isn't evaluated against a stale product set or
+		// backend.
+		if ( class_exists( '\Newspack\Insights\Donation_Product_Classifier' ) ) {
+			\Newspack\Insights\Donation_Product_Classifier::flush_cache();
+		}
+		if ( class_exists( '\Newspack\Insights\Storage_Detector' ) ) {
+			\Newspack\Insights\Storage_Detector::force_refresh();
+		}
 		$has_activity = self::compute_donation_activity();
 		set_transient( self::DONATION_ACTIVITY_TRANSIENT, $has_activity ? 'yes' : 'no', DAY_IN_SECONDS );
 		return $has_activity;
@@ -247,9 +276,6 @@ class Insights_Wizard extends Wizard {
 			return false;
 		}
 
-		global $wpdb;
-		$donations_list = implode( ',', array_map( 'intval', $donation_ids ) );
-
 		// Dispatch by backend so we read from the authoritative orders
 		// source rather than scanning a potentially stale legacy CPT
 		// table on HPOS sites (or vice versa).
@@ -257,44 +283,96 @@ class Insights_Wizard extends Wizard {
 			? \Newspack\Insights\Storage_Detector::detect()
 			: 'legacy';
 
-		// Constrain to statuses that represent actual donation activity:
-		// completed/processing/refunded one-time orders, and subscriptions that
-		// have genuinely existed (active through expired). This keeps failed,
-		// pending, trash, auto-draft, and checkout-draft objects from surfacing
-		// the tab on a site that never actually took a donation.
+		$donations_list = implode( ',', array_map( 'intval', $donation_ids ) );
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return (bool) (int) $wpdb->get_var( self::build_donation_activity_sql( $backend, $donations_list ) );
+		// phpcs:enable
+	}
+
+	/**
+	 * Build the query that tests for active donation activity.
+	 *
+	 * Mirrors the two-leg "active donor" definition the Donors metrics use
+	 * ({@see \Newspack\Insights\HPOS_Donors_Storage::get_active_donors()}) so
+	 * the gate and the tab's own scorecards agree on whether there's anything
+	 * to show. A publisher is active if EITHER:
+	 *
+	 *  - they have an **active donation subscription** (`shop_subscription` in
+	 *    `wc-active`), regardless of date — this keeps recurring donors
+	 *    (annual subscribers, and subscribers whose latest renewal order is
+	 *    pending/on-hold after a retry) visible, which a shop_order-only
+	 *    recency check would wrongly hide; OR
+	 *  - they have a **completed donation order** (`shop_order` in
+	 *    `wc-completed` / `wc-processing`) in the trailing
+	 *    {@see self::DONATION_ACTIVITY_WINDOW_DAYS}-day window — this also
+	 *    covers one-time gifts and subscription renewals, which post their own
+	 *    dated `shop_order` rows.
+	 *
+	 * The order leg resolves products via `wc_order_product_lookup`, the same
+	 * table the metrics use, so the two can't disagree at the margins: if that
+	 * analytics table is unpopulated the tab's metrics are empty too, so
+	 * hiding stays consistent. Lapsed subscription statuses (`wc-cancelled`,
+	 * `wc-expired`, …) and refunded/failed/pending orders are intentionally
+	 * excluded — they aren't active activity. `UTC_TIMESTAMP()` matches the
+	 * UTC `*_gmt` columns.
+	 *
+	 * Returned as a string (rather than executed in place) so the query shape
+	 * is unit-testable without WooCommerce order tables installed.
+	 *
+	 * @param string $backend        Storage backend: 'hpos' or 'legacy'.
+	 * @param string $donations_list Comma-separated, integer-sanitized product IDs.
+	 * @return string SQL string.
+	 */
+	private static function build_donation_activity_sql( string $backend, string $donations_list ): string {
+		global $wpdb;
+		$prefix = $wpdb->prefix;
+		$days   = (int) self::DONATION_ACTIVITY_WINDOW_DAYS;
+
 		if ( 'hpos' === $backend ) {
-			$sql = "SELECT EXISTS (
-				SELECT 1 FROM {$wpdb->prefix}wc_orders o
-				JOIN {$wpdb->prefix}woocommerce_order_items items ON items.order_id = o.id
-				JOIN {$wpdb->prefix}woocommerce_order_itemmeta meta
-					ON meta.order_item_id = items.order_item_id
-					AND meta.meta_key = '_product_id'
-				WHERE (
-					( o.type = 'shop_order' AND o.status IN ('wc-completed', 'wc-processing', 'wc-refunded') )
-					OR ( o.type = 'shop_subscription' AND o.status IN ('wc-active', 'wc-on-hold', 'wc-pending-cancel', 'wc-cancelled', 'wc-expired') )
+			return "SELECT (
+				EXISTS (
+					SELECT 1 FROM {$prefix}wc_orders o
+					JOIN {$prefix}woocommerce_order_items oi
+						ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim
+						ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+					WHERE o.type = 'shop_subscription'
+					  AND o.status = 'wc-active'
+					  AND oim.meta_value IN ($donations_list)
 				)
-				  AND meta.meta_value IN ($donations_list)
-				LIMIT 1
-			) AS has_activity";
-		} else {
-			$sql = "SELECT EXISTS (
-				SELECT 1 FROM {$wpdb->prefix}posts p
-				JOIN {$wpdb->prefix}woocommerce_order_items items ON items.order_id = p.ID
-				JOIN {$wpdb->prefix}woocommerce_order_itemmeta meta
-					ON meta.order_item_id = items.order_item_id
-					AND meta.meta_key = '_product_id'
-				WHERE (
-					( p.post_type = 'shop_order' AND p.post_status IN ('wc-completed', 'wc-processing', 'wc-refunded') )
-					OR ( p.post_type = 'shop_subscription' AND p.post_status IN ('wc-active', 'wc-on-hold', 'wc-pending-cancel', 'wc-cancelled', 'wc-expired') )
+				OR EXISTS (
+					SELECT 1 FROM {$prefix}wc_orders o
+					JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
+					WHERE o.type = 'shop_order'
+					  AND o.status IN ('wc-completed', 'wc-processing')
+					  AND o.date_created_gmt >= DATE_SUB( UTC_TIMESTAMP(), INTERVAL {$days} DAY )
+					  AND opl.product_id IN ($donations_list)
 				)
-				  AND meta.meta_value IN ($donations_list)
-				LIMIT 1
 			) AS has_activity";
 		}
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return (bool) (int) $wpdb->get_var( $sql );
-		// phpcs:enable
+		return "SELECT (
+			EXISTS (
+				SELECT 1 FROM {$prefix}posts p
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND p.post_status = 'wc-active'
+				  AND oim.meta_value IN ($donations_list)
+			)
+			OR EXISTS (
+				SELECT 1 FROM {$prefix}posts p
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
+				WHERE p.post_type = 'shop_order'
+				  AND p.post_status IN ('wc-completed', 'wc-processing')
+				  AND p.post_date_gmt >= DATE_SUB( UTC_TIMESTAMP(), INTERVAL {$days} DAY )
+				  AND opl.product_id IN ($donations_list)
+			)
+		) AS has_activity";
 	}
 
 	/**
@@ -337,10 +415,10 @@ class Insights_Wizard extends Wizard {
 			// See is_advertising_tab_visible(). Subscribers stays all-on for now;
 			// Tab 6 visibility detection (non-donation subscription
 			// product presence) is a separate follow-up. Donors hides
-			// when there's no donation activity — has_donation_activity()
+			// when there's no recent donation activity — has_donation_activity()
 			// uses the Donation_Product_Classifier to find donation
-			// products, then checks for actual orders/subscriptions in
-			// qualifying statuses (result cached for a day). Gates is
+			// products, then checks for an active donation subscription or a qualifying donation order in the
+			// trailing DONATION_ACTIVITY_WINDOW_DAYS window (cached for a day). Gates is
 			// gated to the preview constant NEWSPACK_INSIGHTS_GATES_PREVIEW
 			// while Phase 1 (placeholder data) is being validated.
 			'tabs'              => [

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-gate.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-gate.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Test the Donors tab donation-activity visibility gate (NPPD-1737).
+ *
+ * The gate (Insights_Wizard::has_donation_activity / compute_donation_activity)
+ * hides Tab 7 unless the publisher has active donation activity, defined the
+ * same two-leg way the Donors metrics define an active donor: an active
+ * donation subscription, OR a completed donation order in the trailing
+ * DONATION_ACTIVITY_WINDOW_DAYS window. Its SQL bodies query WooCommerce order
+ * tables, which the unit-test bootstrap does not install — consistent with the
+ * rest of the insights storage tests, whose SQL bodies are verified via the
+ * live-environment smoke test rather than here. What IS unit-testable:
+ *
+ *   - the empty-classifier short-circuit (no donation products → gate false,
+ *     no SQL issued); and
+ *   - the shape of the query built by build_donation_activity_sql(): both
+ *     legs present (active subscription + recent completed order), the 365-day
+ *     bound on the order leg, the analytics-lookup join, and the absence of
+ *     refunded/lapsed statuses.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights_Wizard;
+use Newspack\Insights\Donation_Product_Classifier;
+use WP_UnitTestCase;
+
+/**
+ * Donation-activity gate test class.
+ *
+ * @group insights
+ */
+class Test_Donation_Activity_Gate extends WP_UnitTestCase {
+
+	/**
+	 * Invoke the private static SQL builder via reflection.
+	 *
+	 * @param string $backend        'hpos' or 'legacy'.
+	 * @param string $donations_list Comma-separated product IDs.
+	 * @return string
+	 */
+	private function build_sql( string $backend, string $donations_list ): string {
+		$method = new \ReflectionMethod( Insights_Wizard::class, 'build_donation_activity_sql' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $backend, $donations_list );
+	}
+
+	/**
+	 * With no donation products configured the classifier set is empty, so the
+	 * gate returns false without issuing the (WC-table) activity query — the
+	 * no-product publisher correctly does not get the Donors tab.
+	 */
+	public function test_gate_is_false_without_donation_products() {
+		if ( ! class_exists( Donation_Product_Classifier::class ) ) {
+			$this->markTestSkipped( 'Donation_Product_Classifier not loaded in this bootstrap.' );
+		}
+		delete_option( 'newspack_donation_product_id' );
+		// Reset every cache the classifier reads through: its own transient AND
+		// Donations' in-memory flagged-product static. A prior test in the same
+		// process can populate that static, and flush_cache() alone doesn't
+		// clear it — which would otherwise leak a non-empty set into this test
+		// (the cause of the original CI-only failure).
+		if ( method_exists( '\Newspack\Donations', 'reset_flagged_donation_product_ids_cache' ) ) {
+			\Newspack\Donations::reset_flagged_donation_product_ids_cache();
+		}
+		Donation_Product_Classifier::flush_cache();
+
+		// Precondition: the classifier really resolves to an empty set, so the
+		// short-circuit (not an incidental empty order result) is what's tested.
+		$this->assertSame( [], Donation_Product_Classifier::get_donation_product_ids() );
+
+		$this->assertFalse( Insights_Wizard::force_refresh_donation_activity() );
+	}
+
+	/**
+	 * The HPOS query has both legs of the active-donor definition: an active
+	 * donation subscription (any date) OR a completed/processing donation
+	 * shop_order in the trailing 365 days, resolved via the analytics lookup.
+	 * Refunded/lapsed statuses are excluded.
+	 */
+	public function test_hpos_sql_has_both_active_donor_legs() {
+		$sql = $this->build_sql( 'hpos', '11,22,33' );
+
+		// Leg A — active subscription, no date bound.
+		$this->assertStringContainsString( "o.type = 'shop_subscription'", $sql, 'Includes the active-subscription leg.' );
+		$this->assertStringContainsString( "o.status = 'wc-active'", $sql, 'Subscription leg keys on wc-active.' );
+		// Leg B — recent completed order via the analytics lookup.
+		$this->assertStringContainsString( "o.type = 'shop_order'", $sql, 'Includes the recent-order leg.' );
+		$this->assertStringContainsString( 'wc_order_product_lookup', $sql, 'Order leg resolves products via the analytics lookup (matches the metrics).' );
+		$this->assertStringContainsString( "o.status IN ('wc-completed', 'wc-processing')", $sql, 'Order leg keys on completed/processing only.' );
+		$this->assertStringContainsString( 'date_created_gmt >= DATE_SUB( UTC_TIMESTAMP(), INTERVAL 365 DAY )', $sql, '365-day UTC recency bound on the order leg.' );
+		$this->assertStringContainsString( 'IN (11,22,33)', $sql, 'Constrains both legs to the resolved donation product IDs.' );
+		// Excluded.
+		$this->assertStringNotContainsString( 'wc-refunded', $sql, 'Refunded orders are not active activity.' );
+		$this->assertStringNotContainsString( 'wc-cancelled', $sql, 'Lapsed subscriptions are not active activity.' );
+	}
+
+	/**
+	 * The legacy (CPT) query mirrors the HPOS one against wp_posts.
+	 */
+	public function test_legacy_sql_has_both_active_donor_legs() {
+		$sql = $this->build_sql( 'legacy', '44,55' );
+
+		$this->assertStringContainsString( "p.post_type = 'shop_subscription'", $sql, 'Includes the active-subscription leg.' );
+		$this->assertStringContainsString( "p.post_status = 'wc-active'", $sql, 'Subscription leg keys on wc-active.' );
+		$this->assertStringContainsString( "p.post_type = 'shop_order'", $sql, 'Includes the recent-order leg.' );
+		$this->assertStringContainsString( 'wc_order_product_lookup', $sql, 'Order leg resolves products via the analytics lookup.' );
+		$this->assertStringContainsString( "p.post_status IN ('wc-completed', 'wc-processing')", $sql, 'Order leg keys on completed/processing only.' );
+		$this->assertStringContainsString( 'post_date_gmt >= DATE_SUB( UTC_TIMESTAMP(), INTERVAL 365 DAY )', $sql, '365-day UTC recency bound on the order leg.' );
+		$this->assertStringContainsString( 'IN (44,55)', $sql, 'Constrains both legs to the resolved donation product IDs.' );
+		$this->assertStringNotContainsString( 'wc-refunded', $sql, 'Refunded orders are not active activity.' );
+	}
+
+	/**
+	 * The window constant is the 365-day active-donor recency precedent.
+	 */
+	public function test_window_constant_is_365() {
+		$this->assertSame( 365, Insights_Wizard::DONATION_ACTIVITY_WINDOW_DAYS );
+	}
+}


### PR DESCRIPTION
## Summary

Tightens the Donors (Tab 7) visibility gate so it keys on **active** donation activity instead of lifetime activity, landing on `feat/insights-rsm`. Closes [NPPD-1737](https://linear.app/a8c/issue/NPPD-1737).

Recon found the capability gate the ticket describes already largely exists: `Insights_Wizard::has_donation_activity()` resolves the donation set via `Donation_Product_Classifier` and runs an `EXISTS` over real donation orders through the same HPOS/legacy backend the metrics use, hiding the tab when false. The only gap versus Option A was that it keyed on activity *ever* — so a publisher who last took a WooCommerce donation years ago, or who has no donation orders at all, still saw the tab. This PR narrows it to the **same two-leg "active donor" definition the Donors metrics already use**, keeping the existing hide behavior (no visible empty state, per decision).

### Pre-flight decisions

- **Harden the existing gate rather than build a parallel 1720-style gate.** `Insights_Wizard::has_donation_activity()` already gates `tabs.donors` in `get_boot_config()` on the classifier's resolved set via the correct storage backend — a second mechanism would be two sources of truth for one boolean.
- **Hide, not an explained empty state.** Option A's empty state was considered and declined; the tab continues to hide when there's no active activity. No client/envelope changes.
- **Mirror `get_active_donors()`'s two-leg definition** rather than inventing a gate-specific rule, so the gate and the tab's scorecards can't disagree about whether there's data: a publisher is active if they have an **active donation subscription** (`shop_subscription`/`wc-active`, any date) **OR** a **completed/processing donation order** (`shop_order`) in the trailing 365 days.
- **Window = 365 days** for the order leg — the only existing recency precedent in the donor path (the active-donor leg of `HPOS_Donors_Storage`); the lapsed-donor metric has no fixed window of its own (it uses the selected timeframe), so it couldn't supply N.
- **SQL extracted to a builder** (`build_donation_activity_sql()`) so the query shape is unit-testable without WooCommerce tables installed (the bootstrap doesn't install them — consistent with the other insights storage tests).

*(This started as a `shop_order`-only recency check that dropped the subscription branch entirely; a code-review pass caught that it would hide active annual/payment-retry recurring donors the metrics still count — so the active-subscription leg was restored to match `get_active_donors()`.)*

## What's in this PR

### Two-leg activity gate — `includes/wizards/insights/class-insights-wizard.php`

`compute_donation_activity()` now delegates to `build_donation_activity_sql( $backend, $donations_list )`, which builds `( EXISTS(<active donation subscription>) OR EXISTS(<recent completed donation order>) )` for the detected backend. The subscription leg matches `shop_subscription`/`wc-active` via order-item meta (no date bound); the order leg matches `shop_order` in `wc-completed`/`wc-processing` within the trailing window, resolved through `wc_order_product_lookup` (the same table the metrics use), with `date_created_gmt`/`post_date_gmt >= DATE_SUB( UTC_TIMESTAMP(), INTERVAL 365 DAY )`. New `DONATION_ACTIVITY_WINDOW_DAYS` constant; docblocks and the boot-config comment updated. `force_refresh_donation_activity()` now also flushes the classifier and storage-detector caches so it's a true recompute-from-live-state. The 24h transient cache is otherwise unchanged.

### Test — `tests/unit-tests/insights/class-test-donation-activity-gate.php`

Asserts the no-products short-circuit returns false (with a classifier-resolves-to-`[]` precondition), and that both backend query shapes contain both active-donor legs, the 365-day UTC bound, the analytics-lookup join, the resolved IDs, and exclude refunded/lapsed statuses.

## How to test

1. `n build newspack-plugin`
2. **Unit:** `n test-php --filter Test_Donation_Activity_Gate` — green (4 tests, 20 assertions, PHP 8.3).
3. **Live — active WC-native donor keeps the tab:** on a publisher with donation orders in the last year (e.g. Evanston RoundTable) or an active donation subscription, confirm the Donors tab still renders with real numbers.
4. **Live — dormant/third-party site loses it:** on a publisher with a donation product but no active donation subscription and no donation order in the last 365 days (e.g. a Stripe-direct/third-party site, or one whose last donation order is >1 year old), confirm the Donors tab nav entry no longer renders. (Bust the cache with `Insights_Wizard::force_refresh_donation_activity()` or wait out the 24h transient.)
5. `npm run lint:php` — clean.

## Heads-up

- **Composition with the NPPD-1696 window collapse is untouched.** `has_window_activity` remains the per-timeframe section collapse ("No donations in this timeframe") inside `WindowedSection`; this gate sits above it at the tab/boot layer. They answer different questions and don't overlap.
- **BROKEN_RESOLUTION sites stay hidden until the NPPD-1738 backfill.** A handful of publishers take WooCommerce donations only on orphaned product families outside the classifier's resolved set; they are hidden today and remain so until `_newspack_is_donation` is backfilled. Out of scope here.
- **Guest (customer-id 0) donations.** The gate intentionally does not apply `get_active_donors()`'s `customer_id > 0` filter — a recent guest one-time donation still populates the tab's revenue metrics, so it should keep the tab visible.
- **Cache latency is 24h.** A site crossing the active/inactive boundary updates within a day, or immediately via `force_refresh_donation_activity()`.