### PR TITLE
feat(insights): tier-1 publisher feedback spine (NPPD-1728)

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -176,6 +176,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-subscribers.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-donors.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-advertising.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-feedback.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/gam/class-report-job-status.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/gam/class-report-query.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/gam/class-client.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -95,6 +95,7 @@ class Wizards {
 			Insights_Section_Subscribers::init();
 			Insights_Section_Donors::init();
 			Insights_Section_Advertising::init();
+			Insights_Feedback::init();
 		}
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-feedback-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-feedback-rest-controller.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Newspack Insights — Feedback REST controller (NPPD-1728).
+ *
+ * Single endpoint: `POST /newspack-insights/v1/feedback`. Accepts a per-tab
+ * feedback submission, assembles a server-stamped record, and hands it to the
+ * configured {@see \Newspack\Insights\Feedback\Feedback_Router}.
+ *
+ * Attribution is stamped server-side and never trusted from the client: the
+ * publisher domain comes from `get_site_url()`. (v1 attribution is domain-only;
+ * role is intentionally not stamped — every caller already has
+ * `manage_options`, so role would be noise. See NPPD-1728.)
+ *
+ * Routing is Slack-only in v1 via the router seam; this controller stores
+ * nothing and the routers store nothing. Durable capture is a deliberate v2
+ * decision.
+ *
+ * Permission mirrors the data tabs (`manage_options`); the form is only
+ * reachable by users who can see Insights.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use Newspack\Insights\Feedback\Feedback_Router_Factory;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_REST_Controller;
+
+/**
+ * Feedback REST controller.
+ */
+class Feedback_REST_Controller extends WP_REST_Controller {
+
+
+	/**
+	 * Shared Insights namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'feedback';
+
+	/**
+	 * Allowed `context` values — the Insights tab slugs the affordance can be
+	 * mounted on. Keeps `context` to a known set rather than free text, while
+	 * staying the seam a later product surface can extend.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_CONTEXTS = [
+		'audience',
+		'engagement',
+		'conversion',
+		'gates',
+		'prompts',
+		'subscribers',
+		'donors',
+		'advertising',
+	];
+
+	/**
+	 * Allowed `sentiment` values for the tier-1 thumb.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_SENTIMENTS = [ 'up', 'down' ];
+
+	/**
+	 * Register the feedback route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'submit_feedback' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_endpoint_args(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check. Mirrors the Insights data controllers: any user who can
+	 * see Insights (`manage_options`) can submit feedback.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to submit Insights feedback.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * POST handler. Assembles the record, routes it, and returns a thin success
+	 * envelope the client uses to fire its acknowledgment.
+	 *
+	 * @param  WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function submit_feedback( WP_REST_Request $request ) {
+		$record = $this->build_record( $request );
+
+		$router = Feedback_Router_Factory::get_router();
+		if ( null === $router ) {
+			return new WP_Error(
+				'newspack_insights_feedback_no_router',
+				__( 'Feedback routing is not configured for this site.', 'newspack-plugin' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		$result = $router->send( $record );
+		if ( is_wp_error( $result ) ) {
+			// Surface a generic 502 to the client; the specific failure is
+			// logged server-side by the router. The submitter shouldn't see
+			// relay internals.
+			return new WP_Error(
+				'newspack_insights_feedback_routing_failed',
+				__( 'Your feedback could not be sent. Please try again later.', 'newspack-plugin' ),
+				[ 'status' => 502 ]
+			);
+		}
+
+		return rest_ensure_response( [ 'success' => true ] );
+	}
+
+	/**
+	 * Assemble the sanitized, server-stamped record from the request. The
+	 * domain is always stamped from `get_site_url()`; the client is never
+	 * trusted to assert attribution.
+	 *
+	 * @param  WP_REST_Request $request Request.
+	 * @return array{
+	 *     context: string,
+	 *     sentiment: string,
+	 *     comment: string,
+	 *     domain: string,
+	 *     submitted_at: string
+	 * }
+	 */
+	private function build_record( WP_REST_Request $request ): array {
+		return [
+			'context'      => (string) $request->get_param( 'context' ),
+			'sentiment'    => (string) $request->get_param( 'sentiment' ),
+			'comment'      => (string) ( $request->get_param( 'comment' ) ?? '' ),
+			'domain'       => get_site_url(),
+			'submitted_at' => gmdate( 'Y-m-d\TH:i:s\Z' ),
+		];
+	}
+
+	/**
+	 * Endpoint args spec. `context` and `sentiment` are validated against
+	 * closed allow-lists; the optional tier-2 `comment` is sanitized free text.
+	 *
+	 * @return array
+	 */
+	private function get_endpoint_args(): array {
+		return [
+			'context'   => [
+				'type'              => 'string',
+				'required'          => true,
+				'enum'              => self::ALLOWED_CONTEXTS,
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => 'rest_validate_request_arg',
+				'description'       => __( 'Insights tab the feedback is about.', 'newspack-plugin' ),
+			],
+			'sentiment' => [
+				'type'              => 'string',
+				'required'          => true,
+				'enum'              => self::ALLOWED_SENTIMENTS,
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => 'rest_validate_request_arg',
+				'description'       => __( 'Tier-1 thumb sentiment.', 'newspack-plugin' ),
+			],
+			'comment'   => [
+				'type'              => 'string',
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'description'       => __( 'Tier-2 freeform comment. Empty when the modal is dismissed.', 'newspack-plugin' ),
+			],
+		];
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-feedback.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-feedback.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Newspack Insights — Feedback feature loader (NPPD-1728).
+ *
+ * Wires up the per-tab publisher feedback affordance's server side: the router
+ * seam (interface + Manager relay + email fallback + factory) and the
+ * `POST /newspack-insights/v1/feedback` REST endpoint.
+ *
+ * Unlike the `Insights_Section_*` classes this is not a tab — there's no
+ * metric data layer and no tab visibility. It's a cross-cutting affordance the
+ * React chrome renders into every tab's footer, so it loads once alongside the
+ * sections rather than per tab. Self-gates on the Insights feature flag like
+ * the sections do.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\Insights\Feedback_REST_Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Feedback feature loader.
+ */
+class Insights_Feedback {
+
+	/**
+	 * Initialize. Bails early when the parent Insights feature flag is off.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
+		self::load_dependencies();
+		self::register_hooks();
+	}
+
+	/**
+	 * Include the feedback PHP files.
+	 *
+	 * @return void
+	 */
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'feedback/interface-feedback-router.php';
+		include_once $base . 'feedback/class-manager-relay-router.php';
+		include_once $base . 'feedback/class-channel-email-router.php';
+		include_once $base . 'feedback/class-feedback-router-factory.php';
+		include_once $base . 'api/class-feedback-rest-controller.php';
+	}
+
+	/**
+	 * Register the feedback REST route.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_feedback_route' ] );
+	}
+
+	/**
+	 * Register the feedback REST controller's routes. Hooked to rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register_feedback_route(): void {
+		( new Feedback_REST_Controller() )->register_routes();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/feedback/class-channel-email-router.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/feedback/class-channel-email-router.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Newspack Insights — Channel-email feedback router (fallback).
+ *
+ * Sends the feedback record via `wp_mail` to a Slack channel's email-to-channel
+ * address. This is a real, working path — not a stub — so the feature can ship
+ * at GA even if the Manager relay (the primary router) isn't deployed yet. The
+ * message renders as an email card in the Slack channel; plainer than the
+ * relay's formatted post, but enough for triage (NPPD-1728).
+ *
+ * The destination address is configuration, never hardcoded:
+ *   - `NEWSPACK_INSIGHTS_FEEDBACK_CHANNEL_EMAIL` constant (wp-config), or
+ *   - the `newspack_insights_feedback_channel_email` filter (wins over the constant).
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\Feedback;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+
+/**
+ * Routes feedback to a Slack channel email address via wp_mail.
+ */
+class Channel_Email_Router implements Feedback_Router {
+
+
+	/**
+	 * Resolve the destination channel email address.
+	 *
+	 * @return string Empty string when not configured.
+	 */
+	private function channel_address(): string {
+		$address = defined( 'NEWSPACK_INSIGHTS_FEEDBACK_CHANNEL_EMAIL' )
+		? (string) NEWSPACK_INSIGHTS_FEEDBACK_CHANNEL_EMAIL
+		: '';
+		/**
+		 * Filter the Slack channel email address feedback is routed to when the
+		 * email fallback router is active.
+		 *
+		 * @param string $address Configured channel email address.
+		 */
+		$address = (string) apply_filters( 'newspack_insights_feedback_channel_email', $address );
+		return is_email( $address ) ? $address : '';
+	}
+
+	/**
+	 * Available when a valid channel email address is configured.
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		return '' !== $this->channel_address();
+	}
+
+	/**
+	 * Email the record to the configured channel address.
+	 *
+	 * @param  array $record Assembled feedback record.
+	 * @return true|WP_Error
+	 */
+	public function send( array $record ) {
+		$address = $this->channel_address();
+		if ( '' === $address ) {
+			return new WP_Error(
+				'newspack_insights_feedback_email_unconfigured',
+				__( 'No feedback channel email address is configured.', 'newspack-plugin' )
+			);
+		}
+
+		// One transactional email per feedback submission (a single admin's
+		// thumb click), never bulk — the VIP bulk-mail caution doesn't apply.
+		$sent = wp_mail( $address, $this->build_subject( $record ), $this->build_body( $record ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+		if ( ! $sent ) {
+			return new WP_Error(
+				'newspack_insights_feedback_email_failed',
+				__( 'Feedback email could not be sent.', 'newspack-plugin' )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Build the email subject line.
+	 *
+	 * @param  array $record Assembled feedback record.
+	 * @return string
+	 */
+	private function build_subject( array $record ): string {
+		$sentiment = 'up' === ( $record['sentiment'] ?? '' )
+		? __( '👍 positive', 'newspack-plugin' )
+		: __( '👎 negative', 'newspack-plugin' );
+		return sprintf(
+		/* translators: 1: tab id (e.g. "audience"); 2: sentiment label. */
+			__( 'Insights feedback — %1$s (%2$s)', 'newspack-plugin' ),
+			(string) ( $record['context'] ?? '' ),
+			$sentiment
+		);
+	}
+
+	/**
+	 * Build the plain-text email body. Mirrors the record fields the relay
+	 * would format for Slack; attribution is the server-stamped publisher
+	 * domain.
+	 *
+	 * @param  array $record Assembled feedback record.
+	 * @return string
+	 */
+	private function build_body( array $record ): string {
+		$lines = [
+			sprintf( '%s: %s', __( 'Tab', 'newspack-plugin' ), (string) ( $record['context'] ?? '' ) ),
+			sprintf( '%s: %s', __( 'Sentiment', 'newspack-plugin' ), (string) ( $record['sentiment'] ?? '' ) ),
+			sprintf( '%s: %s', __( 'From', 'newspack-plugin' ), (string) ( $record['domain'] ?? __( 'unknown', 'newspack-plugin' ) ) ),
+			sprintf( '%s: %s', __( 'Submitted', 'newspack-plugin' ), (string) ( $record['submitted_at'] ?? '' ) ),
+		];
+		if ( '' !== (string) ( $record['comment'] ?? '' ) ) {
+			$lines[] = sprintf( "%s:\n%s", __( 'Comment', 'newspack-plugin' ), (string) $record['comment'] );
+		}
+		return implode( "\n", $lines );
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/feedback/class-feedback-router-factory.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/feedback/class-feedback-router-factory.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Newspack Insights — Feedback router factory.
+ *
+ * Picks the active {@see Feedback_Router} so the destination is swappable
+ * without the REST controller knowing which one is in play (NPPD-1728).
+ *
+ * Selection order:
+ *   1. `newspack_insights_feedback_router` filter — a full override. Return a
+ *      `Feedback_Router` instance to force it (tests, bespoke deployments).
+ *   2. `NEWSPACK_INSIGHTS_FEEDBACK_FORCE_EMAIL` constant — pin to the email
+ *      fallback (e.g. while the Manager relay is still pre-deploy), provided
+ *      the email router is actually configured.
+ *   3. The Manager relay when it's available (the default in production).
+ *   4. The email fallback when the relay isn't available but email is.
+ *   5. Null — nothing is configured; the controller surfaces a clear error.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\Feedback;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves the active feedback router.
+ */
+class Feedback_Router_Factory {
+
+
+	/**
+	 * Resolve the router to use for this submission.
+	 *
+	 * @return Feedback_Router|null Null when no router is configured.
+	 */
+	public static function get_router(): ?Feedback_Router {
+		/**
+		 * Filter the active feedback router. Return a Feedback_Router instance
+		 * to override the built-in selection entirely.
+		 *
+		 * @param Feedback_Router|null $router Router override, or null to use the default selection.
+		 */
+		$override = apply_filters( 'newspack_insights_feedback_router', null );
+		if ( $override instanceof Feedback_Router ) {
+			return $override;
+		}
+
+		$relay = new Manager_Relay_Router();
+		$email = new Channel_Email_Router();
+
+		$force_email = defined( 'NEWSPACK_INSIGHTS_FEEDBACK_FORCE_EMAIL' ) && NEWSPACK_INSIGHTS_FEEDBACK_FORCE_EMAIL;
+		if ( $force_email && $email->is_available() ) {
+			return $email;
+		}
+
+		if ( $relay->is_available() ) {
+			return $relay;
+		}
+		if ( $email->is_available() ) {
+			return $email;
+		}
+		return null;
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/feedback/class-manager-relay-router.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/feedback/class-manager-relay-router.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Newspack Insights — Manager relay feedback router (primary).
+ *
+ * Routes a publisher feedback record to Newspack Manager, which holds the
+ * single Slack incoming-webhook secret, formats the Slack message, posts it,
+ * and stores nothing. The webhook secret therefore never lives on a publisher
+ * site — only Manager has it (NPPD-1728).
+ *
+ * Mirrors {@see \Newspack\Insights\BigQuery_Proxy_Client}: same auth resolution
+ * (`Newspack_Manager::authenticate_manager_admin_url()` + api key), same
+ * `wp_remote_post` envelope, same identifying User-Agent, same WP_Error-on-
+ * every-failure-path discipline.
+ *
+ * The Manager-side relay endpoint (`insights-feedback`) is a separate
+ * workstream in the Manager repo; until it's deployed this router reports
+ * `is_available() === false` when Manager isn't connected, and the factory
+ * falls back to {@see Channel_Email_Router} so GA is never hard-blocked on
+ * Manager deploy timing.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\Feedback;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+
+/**
+ * Forwards feedback to the Manager relay endpoint.
+ */
+class Manager_Relay_Router implements Feedback_Router {
+
+
+	/**
+	 * Manager relay route, appended to the authenticated admin URL. Manager
+	 * owns the Slack webhook behind this; the plugin only forwards.
+	 *
+	 * @var string
+	 */
+	const RELAY_ROUTE = '/wp-json/newspack-manager-admin/v1/insights-feedback';
+
+	/**
+	 * Request timeout in seconds. Kept short — the relay is posted inline during
+	 * the publisher's submit, so a slow hub must not stall that request. (v2
+	 * should move this to an async dispatch and drop the wait entirely.)
+	 *
+	 * @var int
+	 */
+	const REQUEST_TIMEOUT = 5;
+
+	/**
+	 * Logger header so all relay failures land in one Logstash bucket.
+	 *
+	 * @var string
+	 */
+	const LOGGER_HEADER = 'NEWSPACK-INSIGHTS-FEEDBACK';
+
+	/**
+	 * The authenticated hub endpoint URL (api_key already appended), or null
+	 * when Manager isn't loaded / connected.
+	 *
+	 * @var string|null
+	 */
+	private ?string $endpoint_url;
+
+	/**
+	 * The hub api key, used as a configuration sentinel (the URL already
+	 * embeds it).
+	 *
+	 * @var string
+	 */
+	private string $api_key;
+
+	/**
+	 * Constructor.
+	 *
+	 * Resolves the hub URL via `Newspack_Manager::authenticate_manager_admin_url()`
+	 * when not explicitly provided. Pass explicit values in tests.
+	 *
+	 * @param string|null $endpoint_url Pre-authenticated hub URL (with api_key). Null to resolve at construction.
+	 * @param string|null $api_key      The hub API key. Null to resolve at construction.
+	 */
+	public function __construct( ?string $endpoint_url = null, ?string $api_key = null ) {
+		if ( null === $endpoint_url || null === $api_key ) {
+			[ $resolved_url, $resolved_key ] = self::resolve_config();
+			$endpoint_url                    = $endpoint_url ?? $resolved_url;
+			$api_key                         = $api_key ?? $resolved_key;
+		}
+		$this->endpoint_url = '' === (string) $endpoint_url ? null : (string) $endpoint_url;
+		$this->api_key      = (string) $api_key;
+	}
+
+	/**
+	 * Resolve the hub URL and api key from the running `Newspack_Manager` plugin.
+	 *
+	 * @return array{0: string|null, 1: string} `[ $url, $api_key ]`. URL is null if Manager isn't loaded or isn't connected.
+	 */
+	private static function resolve_config(): array {
+		if ( ! class_exists( '\Newspack_Manager' ) ) {
+			return [ null, '' ];
+		}
+		$url     = \Newspack_Manager::authenticate_manager_admin_url( self::RELAY_ROUTE );
+		$api_key = \Newspack_Manager::get_manager_admin_api_key();
+		return [ false === $url ? null : (string) $url, (string) $api_key ];
+	}
+
+	/**
+	 * Whether the relay has both a URL and a key (i.e. can attempt a call).
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		return null !== $this->endpoint_url && '' !== $this->api_key;
+	}
+
+	/**
+	 * Forward the record to the Manager relay. Returns true on a 2xx, WP_Error
+	 * on any failure path.
+	 *
+	 * @param  array $record Assembled feedback record.
+	 * @return true|WP_Error
+	 */
+	public function send( array $record ) {
+		if ( ! $this->is_available() ) {
+			$error = new WP_Error(
+				'newspack_insights_feedback_relay_unconfigured',
+				__( 'Newspack Manager is not configured for feedback routing.', 'newspack-plugin' )
+			);
+			$this->log_failure( $error, $record );
+			return $error;
+		}
+
+		$response = wp_remote_post(
+			$this->endpoint_url,
+			[
+				'headers' => [
+					'Content-Type' => 'application/json',
+					'User-Agent'   => 'Newspack-Insights/1.0; ' . home_url(),
+				],
+				'body'    => wp_json_encode( $record ),
+				'timeout' => self::REQUEST_TIMEOUT,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log_failure( $response, $record );
+			return $response;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $code < 200 || $code >= 300 ) {
+			$raw     = wp_remote_retrieve_body( $response );
+			$decoded = json_validate( $raw ) ? json_decode( $raw, true ) : null;
+			$message = is_array( $decoded ) && isset( $decoded['message'] )
+			? (string) $decoded['message']
+			: sprintf( 'HTTP %d', $code );
+			$error   = new WP_Error( 'newspack_insights_feedback_relay_http_error', $message, [ 'status' => $code ] );
+			$this->log_failure( $error, $record );
+			return $error;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Emit a `newspack_log` action about a relay failure. Picked up by Newspack
+	 * Manager and forwarded to Logstash. Safe to call even when Logger isn't
+	 * loaded (no-op).
+	 *
+	 * The record's free-text comment is deliberately omitted from the log to
+	 * avoid duplicating publisher prose into Logstash; only routing context is
+	 * logged.
+	 *
+	 * @param  WP_Error $error  The error being returned to the caller.
+	 * @param  array    $record The record that failed to route.
+	 * @return void
+	 */
+	private function log_failure( WP_Error $error, array $record ): void {
+		if ( ! class_exists( '\Newspack\Logger' ) ) {
+			return;
+		}
+		\Newspack\Logger::newspack_log(
+			'newspack_insights_feedback_relay_failed',
+			sprintf( '%s: %s', $error->get_error_code(), $error->get_error_message() ),
+			[
+				'context'     => $record['context'] ?? null,
+				'sentiment'   => $record['sentiment'] ?? null,
+				'error_code'  => $error->get_error_code(),
+				'http_status' => $error->get_error_data()['status'] ?? null,
+				'header'      => self::LOGGER_HEADER,
+			],
+			'error'
+		);
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/feedback/interface-feedback-router.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/feedback/interface-feedback-router.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Newspack Insights — Feedback router contract.
+ *
+ * A router is the swappable destination for a publisher feedback record.
+ * Implementations forward the record to a triage surface (Slack, today) and
+ * return success or a `WP_Error`. Routers are deliberately stateless: they
+ * forward and forget. Durable storage / aggregation is a separate v2 decision
+ * and must NOT be added here (NPPD-1728).
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\Feedback;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+
+/**
+ * Swappable feedback destination.
+ */
+interface Feedback_Router {
+
+
+	/**
+	 * Whether this router is configured and can attempt a send right now.
+	 *
+	 * Used by the factory to pick a usable router (e.g. fall back to email
+	 * when the Manager relay isn't connected yet).
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool;
+
+	/**
+	 * Forward a single feedback record to the triage surface.
+	 *
+	 * The record is the server-assembled, server-stamped payload (see
+	 * {@see \Newspack\Insights\Feedback_REST_Controller::build_record()}):
+	 * already sanitized, with `domain` stamped server-side — never trust the
+	 * client for attribution. Keys: `context`, `sentiment`, `comment`,
+	 * `domain`, `submitted_at`.
+	 *
+	 * @param array $record Assembled feedback record.
+	 * @return true|WP_Error True on success; WP_Error on any failure path.
+	 */
+	public function send( array $record );
+}

--- a/plugins/newspack-plugin/src/wizards/insights/api/feedback.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/feedback.ts
@@ -1,0 +1,45 @@
+/**
+ * Insights feedback API client (NPPD-1728).
+ *
+ * Thin wrapper around `@wordpress/api-fetch` for the single feedback
+ * endpoint: `POST /newspack-insights/v1/feedback`. The server stamps
+ * attribution (publisher domain) and routes the record to Slack via the
+ * Manager relay (or the email fallback) — the client only submits.
+ *
+ * Slice 1 sends the tier-1 thumb (`context` + `sentiment`). `comment` is part
+ * of the payload contract so Slice 2's tier-2 form can populate it without an
+ * API change; it's optional and omitted by the tier-1 thumb.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+export type FeedbackSentiment = 'up' | 'down';
+
+export interface FeedbackPayload {
+	/** Insights tab id the feedback is about (the affordance's `context`). */
+	context: string;
+	/** Tier-1 thumb sentiment. */
+	sentiment: FeedbackSentiment;
+	/** Tier-2 freeform comment (Slice 2); omitted by the tier-1 thumb. */
+	comment?: string;
+}
+
+export interface FeedbackResponse {
+	success: boolean;
+}
+
+const ENDPOINT = '/newspack-insights/v1/feedback';
+
+/**
+ * Submit a feedback record. Resolves on a 2xx; rejects (apiFetch throws) on a
+ * non-2xx so the caller can surface a retry.
+ */
+export const submitFeedback = async ( payload: FeedbackPayload ): Promise< FeedbackResponse > =>
+	apiFetch< FeedbackResponse >( {
+		path: ENDPOINT,
+		method: 'POST',
+		data: payload,
+	} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -29,6 +29,7 @@ import ComparisonToggle from './ComparisonToggle';
 import DateRangePicker from './DateRangePicker';
 import CooldownNotice from './CooldownNotice';
 import PrintDocumentMeta from './PrintDocumentMeta';
+import TabFeedback from './TabFeedback';
 import TabSpinner from '../tabs/components/TabSpinner';
 import useComparisonMode from '../state/useComparisonMode';
 import useDateRange, { type DateRange } from '../state/useDateRange';
@@ -172,9 +173,12 @@ interface TabSectionRenderProps extends TabSectionProps {
 /**
  * Per-tab wrapper rendered by the Wizard. Carries the print-only document
  * header/footer (NPPD-1661 — used by the "Download PDF" export), the
- * CooldownNotice, the error boundary (keyed by tab so a chunk-load error
- * clears when the user navigates away), and the Suspense boundary for the
- * lazy tab chunk.
+ * CooldownNotice, the error boundary (keyed by tab so a chunk-load error clears
+ * when the user navigates away), the Suspense boundary for the lazy tab chunk,
+ * and the per-tab feedback footer (NPPD-1728). The feedback footer sits outside
+ * the error boundary so it still renders — carrying the same `tabKey` as
+ * `context` — even when a tab chunk fails to load (feedback about a broken tab
+ * is still signal).
  */
 const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange }: TabSectionRenderProps ) => (
 	<>
@@ -183,6 +187,9 @@ const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange }: 
 		<TabErrorBoundary key={ tabKey }>
 			<Suspense fallback={ <Fallback /> }>{ renderTabComponent( tabKey, { range, previousRange } ) }</Suspense>
 		</TabErrorBoundary>
+		<footer className="newspack-insights__tab-footer">
+			<TabFeedback context={ tabKey } />
+		</footer>
 	</>
 );
 
@@ -245,7 +252,13 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 		label: t.label,
 		exact: true,
 		render: TabSection,
-		props: { tabKey: t.key, tabLabel: t.label, range, previousRange, publisherName: config.publisherName },
+		props: {
+			tabKey: t.key,
+			tabLabel: t.label,
+			range,
+			previousRange,
+			publisherName: config.publisherName,
+		},
 	} ) );
 
 	const renderAboveSections = () => (

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for TabFeedback (NPPD-1728, Slice 1) — the tier-1 thumb.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import TabFeedback from './TabFeedback';
+import { submitFeedback } from '../api/feedback';
+
+jest.mock( '../api/feedback' );
+
+const mockedSubmit = submitFeedback as jest.MockedFunction< typeof submitFeedback >;
+
+const thumbUp = () => screen.getByRole( 'button', { name: 'Yes, this tab was useful' } );
+const thumbDown = () => screen.getByRole( 'button', { name: 'No, this tab was not useful' } );
+const ack = () => screen.findByTestId( 'snackbar' );
+
+describe( 'TabFeedback', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the prompt and both thumb controls', () => {
+		render( <TabFeedback context="audience" /> );
+		expect( screen.getByText( 'Was this tab useful?' ) ).toBeInTheDocument();
+		expect( thumbUp() ).toBeInTheDocument();
+		expect( thumbDown() ).toBeInTheDocument();
+	} );
+
+	it( 'submits the sentiment with the tab context and acknowledges on success', async () => {
+		mockedSubmit.mockResolvedValue( { success: true } );
+		render( <TabFeedback context="engagement" /> );
+
+		fireEvent.click( thumbUp() );
+
+		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledWith( { context: 'engagement', sentiment: 'up' } ) );
+		expect( await ack() ).toHaveTextContent( 'Thanks for your feedback!' );
+	} );
+
+	it( 'submits a thumbs-down with the down sentiment', async () => {
+		mockedSubmit.mockResolvedValue( { success: true } );
+		render( <TabFeedback context="donors" /> );
+
+		fireEvent.click( thumbDown() );
+
+		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledWith( { context: 'donors', sentiment: 'down' } ) );
+	} );
+
+	it( 'surfaces an error and allows a retry on failure', async () => {
+		mockedSubmit.mockRejectedValueOnce( new Error( 'nope' ) );
+		render( <TabFeedback context="gates" /> );
+
+		fireEvent.click( thumbUp() );
+
+		expect( await screen.findByRole( 'alert' ) ).toHaveTextContent( 'Could not send. Try again.' );
+
+		// The control re-opens for a retry; a second click goes through.
+		mockedSubmit.mockResolvedValueOnce( { success: true } );
+		fireEvent.click( thumbUp() );
+
+		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledTimes( 2 ) );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.tsx
@@ -1,0 +1,159 @@
+/**
+ * TabFeedback — tier-1 per-tab feedback affordance (NPPD-1728, Slice 1).
+ *
+ * Footer-anchored "Was this tab useful?" prompt with a thumbs up / thumbs
+ * down control, rendered into every Insights tab's footer by `TabSection`.
+ * Carries the tab id as `context` so feedback is attributed per tab. Clicking
+ * a thumb submits the sentiment to `/newspack-insights/v1/feedback` (the
+ * server stamps the publisher domain and routes to Slack) and fires an
+ * immediate Snackbar acknowledgment — never the void.
+ *
+ * Styled to the muted MetricNote scale (small, gray) so it reads as native
+ * chrome. The thumbs use the `@wordpress/components` Button directly (icon +
+ * isPressed accessibility, no router coupling), matching how `CooldownNotice`
+ * uses the WP-core Notice directly.
+ *
+ * Slice 1 is the tier-1 thumb only: clicking a thumb submits sentiment
+ * immediately. The tier-2 freeform comment modal lands in Slice 2.
+ *
+ * User-facing copy is finalized (NPPD-1728), isolated in the COPY block.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Snackbar } from '@wordpress/components';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { thumbsUp, thumbsDown } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { TabKey } from './InsightsWizard';
+import { submitFeedback, type FeedbackSentiment } from '../api/feedback';
+
+/**
+ * User-facing copy (NPPD-1728).
+ */
+const COPY = {
+	prompt: __( 'Was this tab useful?', 'newspack-plugin' ),
+	thumbUp: __( 'Yes, this tab was useful', 'newspack-plugin' ),
+	thumbDown: __( 'No, this tab was not useful', 'newspack-plugin' ),
+	ack: __( 'Thanks for your feedback!', 'newspack-plugin' ),
+	error: __( 'Could not send. Try again.', 'newspack-plugin' ),
+};
+
+/** How long the acknowledgment Snackbar stays up, in ms. */
+const ACK_TIMEOUT_MS = 5000;
+
+type Status = 'idle' | 'submitting' | 'submitted' | 'error';
+
+export interface TabFeedbackProps {
+	/** The tab id, carried through as the feedback `context`. */
+	context: TabKey;
+}
+
+const TabFeedback = ( { context }: TabFeedbackProps ) => {
+	const [ status, setStatus ] = useState< Status >( 'idle' );
+	const [ chosen, setChosen ] = useState< FeedbackSentiment | null >( null );
+	const [ showAck, setShowAck ] = useState( false );
+
+	// A one-shot in-flight guard (set synchronously so a same-tick double-click
+	// can't submit twice) and a mount flag so post-await setters don't run after
+	// unmount.
+	const inFlightRef = useRef( false );
+	const mountedRef = useRef( true );
+
+	useEffect(
+		() => () => {
+			mountedRef.current = false;
+		},
+		[]
+	);
+
+	// Auto-dismiss the acknowledgment after a beat.
+	useEffect( () => {
+		if ( ! showAck ) {
+			return;
+		}
+		const timer = setTimeout( () => setShowAck( false ), ACK_TIMEOUT_MS );
+		return () => clearTimeout( timer );
+	}, [ showAck ] );
+
+	const handleVote = useCallback(
+		async ( sentiment: FeedbackSentiment ): Promise< void > => {
+			if ( inFlightRef.current ) {
+				return;
+			}
+			inFlightRef.current = true;
+			setChosen( sentiment );
+			setStatus( 'submitting' );
+			try {
+				await submitFeedback( { context, sentiment } );
+				if ( ! mountedRef.current ) {
+					return;
+				}
+				setStatus( 'submitted' );
+				setShowAck( true );
+			} catch {
+				// Re-open the control for a retry; the failure is logged
+				// server-side by the router.
+				inFlightRef.current = false;
+				if ( ! mountedRef.current ) {
+					return;
+				}
+				setStatus( 'error' );
+			}
+		},
+		[ context ]
+	);
+
+	// One signal per tab view: lock the thumbs once a vote is in flight or
+	// recorded. An error re-opens them for a retry.
+	const locked = status === 'submitting' || status === 'submitted';
+
+	const promptId = `newspack-insights__tab-feedback-prompt-${ context }`;
+
+	return (
+		<div className="newspack-insights__tab-feedback">
+			<div className="newspack-insights__tab-feedback-row" role="group" aria-labelledby={ promptId }>
+				<span id={ promptId } className="newspack-insights__tab-feedback-prompt">
+					{ COPY.prompt }
+				</span>
+				<div className="newspack-insights__tab-feedback-actions">
+					<Button
+						className="newspack-insights__tab-feedback-thumb"
+						icon={ thumbsUp }
+						label={ COPY.thumbUp }
+						isPressed={ chosen === 'up' }
+						disabled={ locked }
+						accessibleWhenDisabled
+						onClick={ () => handleVote( 'up' ) }
+					/>
+					<Button
+						className="newspack-insights__tab-feedback-thumb"
+						icon={ thumbsDown }
+						label={ COPY.thumbDown }
+						isPressed={ chosen === 'down' }
+						disabled={ locked }
+						accessibleWhenDisabled
+						onClick={ () => handleVote( 'down' ) }
+					/>
+				</div>
+				{ status === 'error' && (
+					<span className="newspack-insights__tab-feedback-error" role="alert">
+						{ COPY.error }
+					</span>
+				) }
+			</div>
+			{ showAck && (
+				<div className="newspack-insights__tab-feedback-snackbar" role="status">
+					<Snackbar onRemove={ () => setShowAck( false ) }>{ COPY.ack }</Snackbar>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default TabFeedback;

--- a/plugins/newspack-plugin/src/wizards/insights/components/_feedback.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_feedback.scss
@@ -1,0 +1,90 @@
+/**
+ * Newspack Insights — per-tab feedback affordance (NPPD-1728, Slice 1).
+ *
+ * Footer-anchored tier-1 "Was this tab useful?" prompt + thumb control,
+ * rendered by `TabSection`. Styled to the muted MetricNote scale (13px,
+ * gray-600) so it reads as native chrome rather than a CTA. Loaded by
+ * `src/wizards/insights/style.scss`.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+.newspack-insights {
+
+	// Footer band that holds the feedback affordance, separated from the tab
+	// body by a hairline rule. Hidden in print (the PDF export owns its own
+	// footer).
+	&__tab-footer {
+		margin-top: 32px;
+		padding-top: 16px;
+		border-top: 1px solid wp-colors.$gray-200;
+
+		@media print {
+			display: none;
+		}
+	}
+
+	&__tab-feedback-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		// Match the MetricNote scale so the prompt reads as muted chrome.
+		font-size: 13px;
+		line-height: 1.4;
+		color: wp-colors.$gray-600;
+	}
+
+	&__tab-feedback-prompt {
+		color: wp-colors.$gray-600;
+	}
+
+	&__tab-feedback-actions {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+	}
+
+	// Small, muted icon buttons. The pressed (chosen) thumb takes the admin
+	// accent so the selection reads at a glance.
+	&__tab-feedback-thumb.components-button.has-icon {
+		min-width: 28px;
+		height: 28px;
+		padding: 4px;
+		color: wp-colors.$gray-600;
+
+		svg {
+			width: 18px;
+			height: 18px;
+		}
+
+		&:hover:not([aria-disabled="true"]) {
+			color: wp-colors.$gray-900;
+		}
+
+		&.is-pressed {
+			color: var( --wp-admin-theme-color );
+		}
+
+		&[aria-disabled="true"] {
+			cursor: default;
+		}
+	}
+
+	&__tab-feedback-error {
+		color: wp-colors.$alert-red;
+	}
+
+	// The acknowledgment Snackbar floats bottom-center over the page, matching
+	// the WP-core SnackbarList placement (which we don't use for a single ack).
+	&__tab-feedback-snackbar {
+		position: fixed;
+		left: 50%;
+		bottom: 24px;
+		transform: translateX( -50% );
+		z-index: 100000;
+
+		@media print {
+			display: none;
+		}
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -17,6 +17,7 @@
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "tabs/components/sections";
+@use "components/feedback";
 @use "print";
 
 .newspack-insights {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-feedback-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-feedback-rest-controller.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * Test Feedback_REST_Controller (NPPD-1728).
+ *
+ * Exercises the feedback endpoint: route registration, the `manage_options`
+ * permission gate, server-side attribution stamping (domain stamped from the
+ * site), the freeform `comment` field, closed-allow-list validation of
+ * `context` / `sentiment`, and the routing outcomes (success envelope, router
+ * failure → 502, no router configured → 503). Routing is exercised through a
+ * capturing test double installed via the `newspack_insights_feedback_router`
+ * filter so no real Slack/Manager call is made.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Feedback\Feedback_Router;
+use Newspack\Insights\Feedback_REST_Controller;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * Feedback_REST_Controller test class.
+ *
+ * @group insights
+ */
+class Test_Feedback_REST_Controller extends WP_UnitTestCase {
+
+	const ROUTE = '/newspack-insights/v1/feedback';
+
+	/**
+	 * Records captured by the test-double router installed via the
+	 * `newspack_insights_feedback_router` filter. Static so the test-double
+	 * router can reach it.
+	 *
+	 * @var array[]
+	 */
+	public static $captured = [];
+
+	/**
+	 * Result the test-double router returns from send() (true or a WP_Error).
+	 *
+	 * @var true|WP_Error
+	 */
+	public static $send_result = true;
+
+	/**
+	 * REST server.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up: an admin user, a registered feedback route, and a capturing
+	 * router installed by default.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_action( 'rest_api_init', [ $this, 'register_feedback_route' ] );
+
+		global $wp_rest_server;
+		$this->server   = new WP_REST_Server();
+		$wp_rest_server = $this->server;
+		do_action( 'rest_api_init' );
+
+		self::$captured    = [];
+		self::$send_result = true;
+		add_filter( 'newspack_insights_feedback_router', [ $this, 'use_capturing_router' ] );
+	}
+
+	/**
+	 * Register the feedback route. Hooked to rest_api_init in set_up().
+	 *
+	 * @return void
+	 */
+	public function register_feedback_route() {
+		( new Feedback_REST_Controller() )->register_routes();
+	}
+
+	/**
+	 * Filter callback: force a capturing test-double router that records the
+	 * assembled record into the test's statics and returns the configured
+	 * result.
+	 *
+	 * @return Feedback_Router
+	 */
+	public function use_capturing_router(): Feedback_Router {
+		return new class() implements Feedback_Router {
+			/**
+			 * Always available.
+			 *
+			 * @return bool
+			 */
+			public function is_available(): bool {
+				return true;
+			}
+
+			/**
+			 * Capture the record and return the configured result.
+			 *
+			 * @param array $record Assembled feedback record.
+			 * @return true|\WP_Error
+			 */
+			public function send( array $record ) {
+				Test_Feedback_REST_Controller::$captured[] = $record;
+				return Test_Feedback_REST_Controller::$send_result;
+			}
+		};
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_insights_feedback_router', [ $this, 'use_capturing_router' ] );
+		remove_action( 'rest_api_init', [ $this, 'register_feedback_route' ] );
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Build + dispatch a POST to the feedback route.
+	 *
+	 * @param array $params Body params.
+	 * @return \WP_REST_Response
+	 */
+	private function post( array $params ) {
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * The route is registered.
+	 */
+	public function test_route_is_registered() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+	}
+
+	/**
+	 * A valid tier-1 thumb returns 200 with a success envelope and hands the
+	 * router a record stamped with the site domain.
+	 */
+	public function test_valid_submission_routes_and_stamps_domain() {
+		$response = $this->post(
+			[
+				'context'   => 'audience',
+				'sentiment' => 'up',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [ 'success' => true ], $response->get_data() );
+
+		$this->assertCount( 1, self::$captured );
+		$record = self::$captured[0];
+		$this->assertSame( 'audience', $record['context'] );
+		$this->assertSame( 'up', $record['sentiment'] );
+		$this->assertSame( '', $record['comment'] );
+		$this->assertSame( get_site_url(), $record['domain'] );
+		$this->assertNotEmpty( $record['submitted_at'] );
+	}
+
+	/**
+	 * The freeform comment is sanitized and carried through to the record.
+	 */
+	public function test_comment_is_recorded() {
+		$this->post(
+			[
+				'context'   => 'engagement',
+				'sentiment' => 'down',
+				'comment'   => 'A subscriber churn breakdown would help.',
+			]
+		);
+
+		$record = self::$captured[0];
+		$this->assertSame( 'A subscriber churn breakdown would help.', $record['comment'] );
+	}
+
+	/**
+	 * The client cannot assert the domain — only the server stamps it. A
+	 * `domain` param in the request body is ignored.
+	 */
+	public function test_client_supplied_domain_is_ignored() {
+		$this->post(
+			[
+				'context'   => 'audience',
+				'sentiment' => 'up',
+				'domain'    => 'https://evil.example',
+			]
+		);
+
+		$record = self::$captured[0];
+		$this->assertSame( get_site_url(), $record['domain'] );
+	}
+
+	/**
+	 * A non-admin cannot submit.
+	 */
+	public function test_requires_manage_options() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$response = $this->post(
+			[
+				'context'   => 'audience',
+				'sentiment' => 'up',
+			]
+		);
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertCount( 0, self::$captured );
+	}
+
+	/**
+	 * An out-of-allow-list context is rejected at validation (400).
+	 */
+	public function test_invalid_context_is_rejected() {
+		$response = $this->post(
+			[
+				'context'   => 'not-a-tab',
+				'sentiment' => 'up',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertCount( 0, self::$captured );
+	}
+
+	/**
+	 * An out-of-allow-list sentiment is rejected at validation (400).
+	 */
+	public function test_invalid_sentiment_is_rejected() {
+		$response = $this->post(
+			[
+				'context'   => 'audience',
+				'sentiment' => 'meh',
+			]
+		);
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * A router failure surfaces a generic 502 (router internals stay
+	 * server-side).
+	 */
+	public function test_router_failure_returns_502() {
+		self::$send_result = new WP_Error( 'boom', 'nope' );
+		$response                          = $this->post(
+			[
+				'context'   => 'audience',
+				'sentiment' => 'up',
+			]
+		);
+		$this->assertSame( 502, $response->get_status() );
+	}
+
+	/**
+	 * With no router configured, the endpoint reports 503 rather than silently
+	 * dropping the submission.
+	 */
+	public function test_no_router_returns_503() {
+		remove_filter( 'newspack_insights_feedback_router', [ $this, 'use_capturing_router' ] );
+		$response = $this->post(
+			[
+				'context'   => 'audience',
+				'sentiment' => 'up',
+			]
+		);
+		$this->assertSame( 503, $response->get_status() );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-feedback-router.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-feedback-router.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Test the feedback router seam (NPPD-1728).
+ *
+ * Covers the factory's selection order, the Manager relay's HTTP envelope
+ * (modeled on BigQuery_Proxy_Client), and the email fallback's wp_mail path.
+ * No real Slack/Manager/SMTP call is made: HTTP is intercepted via
+ * `pre_http_request` and mail via `pre_wp_mail`.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Feedback\Channel_Email_Router;
+use Newspack\Insights\Feedback\Feedback_Router;
+use Newspack\Insights\Feedback\Feedback_Router_Factory;
+use Newspack\Insights\Feedback\Manager_Relay_Router;
+use WP_UnitTestCase;
+
+/**
+ * Feedback router seam test class.
+ *
+ * @group insights
+ */
+class Test_Feedback_Router extends WP_UnitTestCase {
+
+	/**
+	 * Captured HTTP request args from pre_http_request.
+	 *
+	 * @var array|null
+	 */
+	private $captured_http = null;
+
+	/**
+	 * Captured wp_mail atts from pre_wp_mail.
+	 *
+	 * @var array|null
+	 */
+	private $captured_mail = null;
+
+	/**
+	 * A representative assembled record.
+	 *
+	 * @return array
+	 */
+	private function record(): array {
+		return [
+			'context'      => 'audience',
+			'sentiment'    => 'up',
+			'comment'      => '',
+			'domain'       => 'https://example.test',
+			'submitted_at' => '2026-06-18T00:00:00Z',
+		];
+	}
+
+	/* --- Manager relay ------------------------------------------------- */
+
+	/**
+	 * The relay is unavailable with no URL / key, and a send attempt returns a
+	 * WP_Error rather than making a request.
+	 */
+	public function test_relay_unconfigured_is_unavailable() {
+		$router = new Manager_Relay_Router( '', '' );
+		$this->assertFalse( $router->is_available() );
+		$result = $router->send( $this->record() );
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * A configured relay POSTs the JSON record to the authenticated URL and
+	 * returns true on a 2xx.
+	 */
+	public function test_relay_posts_record_and_succeeds() {
+		add_filter( 'pre_http_request', [ $this, 'capture_http_ok' ], 10, 3 );
+
+		$router = new Manager_Relay_Router( 'https://hub.test/relay?api_key=k', 'k' );
+		$this->assertTrue( $router->is_available() );
+		$result = $router->send( $this->record() );
+
+		remove_filter( 'pre_http_request', [ $this, 'capture_http_ok' ], 10 );
+
+		$this->assertTrue( $result );
+		$this->assertNotNull( $this->captured_http );
+		$this->assertSame( 'POST', $this->captured_http['args']['method'] );
+		$this->assertSame( 'https://hub.test/relay?api_key=k', $this->captured_http['url'] );
+		$decoded = json_decode( $this->captured_http['args']['body'], true );
+		$this->assertSame( 'audience', $decoded['context'] );
+		$this->assertSame( 'up', $decoded['sentiment'] );
+	}
+
+	/**
+	 * A non-2xx from the relay returns a WP_Error.
+	 */
+	public function test_relay_http_error_returns_wp_error() {
+		add_filter( 'pre_http_request', [ $this, 'capture_http_500' ], 10, 3 );
+		$router = new Manager_Relay_Router( 'https://hub.test/relay?api_key=k', 'k' );
+		$result = $router->send( $this->record() );
+		remove_filter( 'pre_http_request', [ $this, 'capture_http_500' ], 10 );
+		$this->assertWPError( $result );
+	}
+
+	/* --- Email fallback ------------------------------------------------ */
+
+	/**
+	 * The email router is unavailable until a valid channel address is
+	 * configured.
+	 */
+	public function test_email_unconfigured_is_unavailable() {
+		$this->assertFalse( ( new Channel_Email_Router() )->is_available() );
+	}
+
+	/**
+	 * With a configured channel address, the email router sends a wp_mail to
+	 * that address and returns true.
+	 */
+	public function test_email_sends_to_configured_channel() {
+		add_filter( 'newspack_insights_feedback_channel_email', [ $this, 'channel_address' ] );
+		add_filter( 'pre_wp_mail', [ $this, 'capture_mail' ], 10, 2 );
+
+		$router = new Channel_Email_Router();
+		$this->assertTrue( $router->is_available() );
+		$result = $router->send( $this->record() );
+
+		remove_filter( 'pre_wp_mail', [ $this, 'capture_mail' ], 10 );
+		remove_filter( 'newspack_insights_feedback_channel_email', [ $this, 'channel_address' ] );
+
+		$this->assertTrue( $result );
+		$this->assertNotNull( $this->captured_mail );
+		$this->assertSame( 'channel@example.test', $this->captured_mail['to'] );
+		$this->assertStringContainsString( 'audience', $this->captured_mail['subject'] );
+	}
+
+	/* --- Factory selection --------------------------------------------- */
+
+	/**
+	 * A filter override wins outright.
+	 */
+	public function test_factory_honors_override_filter() {
+		$double = new class() implements Feedback_Router {
+			/**
+			 * Always available.
+			 *
+			 * @return bool
+			 */
+			public function is_available(): bool {
+				return true;
+			}
+
+			/**
+			 * No-op send.
+			 *
+			 * @param array $record Assembled feedback record.
+			 * @return true
+			 */
+			public function send( array $record ) {
+				return true;
+			}
+		};
+		add_filter(
+			'newspack_insights_feedback_router',
+			function () use ( $double ) {
+				return $double;
+			}
+		);
+		$router = Feedback_Router_Factory::get_router();
+		remove_all_filters( 'newspack_insights_feedback_router' );
+		$this->assertSame( $double, $router );
+	}
+
+	/**
+	 * With the relay unavailable but a channel address configured, the factory
+	 * falls back to the email router.
+	 */
+	public function test_factory_falls_back_to_email() {
+		add_filter( 'newspack_insights_feedback_channel_email', [ $this, 'channel_address' ] );
+		$router = Feedback_Router_Factory::get_router();
+		remove_filter( 'newspack_insights_feedback_channel_email', [ $this, 'channel_address' ] );
+		$this->assertInstanceOf( Channel_Email_Router::class, $router );
+	}
+
+	/**
+	 * With nothing configured, the factory returns null.
+	 */
+	public function test_factory_returns_null_when_unconfigured() {
+		$this->assertNull( Feedback_Router_Factory::get_router() );
+	}
+
+	/* --- Filter / capture callbacks ------------------------------------ */
+
+	/**
+	 * Channel address filter callback.
+	 *
+	 * @return string
+	 */
+	public function channel_address(): string {
+		return 'channel@example.test';
+	}
+
+	/**
+	 * Capture an HTTP request and return a 200.
+	 *
+	 * @param mixed  $preempt Pre-emptive response (unused).
+	 * @param array  $args    Request args.
+	 * @param string $url     Request URL.
+	 * @return array
+	 */
+	public function capture_http_ok( $preempt, $args, $url ): array {
+		$this->captured_http = [
+			'args' => $args,
+			'url'  => $url,
+		];
+		return [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"ok":true}',
+		];
+	}
+
+	/**
+	 * Capture an HTTP request and return a 500.
+	 *
+	 * @param mixed  $preempt Pre-emptive response (unused).
+	 * @param array  $args    Request args.
+	 * @param string $url     Request URL.
+	 * @return array
+	 */
+	public function capture_http_500( $preempt, $args, $url ): array {
+		$this->captured_http = [
+			'args' => $args,
+			'url'  => $url,
+		];
+		return [
+			'response' => [ 'code' => 500 ],
+			'body'     => '{"message":"server error"}',
+		];
+	}
+
+	/**
+	 * Short-circuit wp_mail and capture its atts.
+	 *
+	 * @param null  $preempt Short-circuit value (unused).
+	 * @param array $atts    wp_mail atts.
+	 * @return bool
+	 */
+	public function capture_mail( $preempt, $atts ): bool {
+		$this->captured_mail = $atts;
+		return true;
+	}
+}


### PR DESCRIPTION
Slice 1 of the Insights publisher feedback mechanism ([NPPD-1728](https://linear.app/a8c/issue/NPPD-1728)): the server-side spine plus the tier-1 thumb. It stands up a single feedback endpoint, the swappable routing seam that forwards submissions to Slack, and the footer-anchored "Was this tab useful?" affordance rendered into every Insights tab. The tier-2 freeform comment modal and the closing-the-loop plumbing land in the stacked follow-up, #366.

Routing is Slack-only for v1 and the routers are deliberately stateless: durable capture and aggregation are a v2 decision, recorded in the decision record on the ticket. This PR stores nothing.

## Pre-flight decisions

Slack-only, routed through a stateless relay. Rather than putting a Slack webhook secret on every publisher site, the site POSTs to Newspack Manager, which holds the single secret, formats the message, posts it, and stores nothing. This keeps the secret in one place and keeps durable storage out of v1.

The per-tab footer slot is net-new. TabSection had no footer region to anchor to, so this adds one. It sits outside the tab's error boundary on purpose, so the affordance still renders (carrying the same tabKey as context) even when a tab chunk fails to load. Feedback about a broken tab is still signal.

Attribution is domain-only. Every Insights endpoint gates on manage_options, so role would be noise; the server stamps the publisher domain from get_site_url() and never trusts the client. There is no anonymous path.

The routing seam ships with a working email fallback. The Manager relay is the live path, but a wp_mail-to-Slack-channel fallback sits behind the same interface so the feature is never hard-blocked on Manager deploy timing.

## What's in this PR

REST endpoint. includes/wizards/insights/api/class-feedback-rest-controller.php registers POST /newspack-insights/v1/feedback, gated on manage_options like the data controllers. It validates context and sentiment against closed allow-lists (the eight tab slugs; up/down), sanitizes the optional freeform comment, assembles a server-stamped record (domain from get_site_url(), submitted_at), and hands it to the configured router. It returns a thin success envelope, a 502 if routing fails (relay internals stay server-side), and a 503 if no router is configured rather than silently dropping the submission.

Feature loader. includes/wizards/insights/class-insights-feedback.php wires the router files and the controller, self-gating on the Insights feature flag. It is not a tab (no metric layer, no visibility), so it loads once alongside the sections; registered in class-newspack.php and class-wizards.php.

Routing seam. feedback/interface-feedback-router.php defines the Feedback_Router contract (stateless; forward and forget). feedback/class-manager-relay-router.php is the primary, modeled on BigQuery_Proxy_Client (same auth resolution, wp_remote_post envelope, short timeout, and WP_Error-on-every-failure discipline); it reports unavailable when Manager isn't connected. feedback/class-channel-email-router.php is the fallback, sending via wp_mail to an address from the NEWSPACK_INSIGHTS_FEEDBACK_CHANNEL_EMAIL constant or the newspack_insights_feedback_channel_email filter. feedback/class-feedback-router-factory.php picks the active router: override filter, then a force-email constant, then the relay when available, then email, else null.

Tier-1 affordance. src/wizards/insights/components/TabFeedback.tsx renders the "Was this tab useful?" prompt with thumbs up/down (WP-core Button with the thumbsUp/thumbsDown icons, isPressed for the chosen state), submits on click, and fires an immediate @wordpress/components Snackbar acknowledgment. A synchronous in-flight guard prevents a double-submit; a mount flag prevents post-await state updates after unmount; a failure surfaces an inline retry. It mounts in a new <footer className="newspack-insights__tab-footer"> in InsightsWizard.tsx's TabSection. _feedback.scss styles it to the muted MetricNote scale (13px, gray-600) with the pressed thumb taking the admin accent, and hides it in print.

API client. src/wizards/insights/api/feedback.ts is a thin @wordpress/api-fetch wrapper over the endpoint, with the FeedbackPayload type (context, sentiment, optional comment).

Tests. tests/unit-tests/insights/class-test-feedback-rest-controller.php covers route registration, the permission gate, domain stamping, client-supplied-domain rejection, allow-list validation, and the success/502/503 outcomes through a capturing test-double router. tests/unit-tests/insights/class-test-feedback-router.php covers the factory selection order, the relay HTTP envelope (via pre_http_request), and the email path (via pre_wp_mail). TabFeedback.test.tsx covers the thumb render, submit, and retry.

## How to test

- Enable Insights. Configure routing: either connect Manager (relay path) or define NEWSPACK_INSIGHTS_FEEDBACK_CHANNEL_EMAIL to a Slack channel's email-to-channel address (fallback path).
- Open any Insights tab. Confirm the "Was this tab useful?" prompt sits in a hairline-ruled footer and reads as muted chrome.
- Click a thumb. Confirm the Snackbar acknowledgment fires and the chosen thumb shows pressed.
- Confirm the submission arrives in Slack (relay) or as an email card in the channel (fallback), stamped with the site domain.
- Confirm a non-admin gets 403, an unknown context gets 400, and (with no router configured) a submission gets 503.
- Run the PHP suite (--group insights) and the JS suite for TabFeedback.


## Heads-up

- Manager relay endpoint. The Manager-side insights-feedback route is a separate workstream in the Manager repo and is not in this PR. Until it deploys, the relay reports unavailable and the factory falls back to email, so the feature still works.
- No durable storage, by design. The routers forward and forget; aggregation is a v2 decision and must not be added to the interface.
- Stacked. #366 builds tier-2 on this branch; merge this first.