### PR TITLE
feat(insights): tier-2 feedback modal (NPPD-1728)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -421,7 +421,7 @@ class Insights_Wizard extends Wizard {
 			// trailing DONATION_ACTIVITY_WINDOW_DAYS window (cached for a day). Gates is
 			// gated to the preview constant NEWSPACK_INSIGHTS_GATES_PREVIEW
 			// while Phase 1 (placeholder data) is being validated.
-			'tabs'              => [
+			'tabs'                => [
 				'audience'    => true,
 				'engagement'  => true,
 				'conversion'  => true,
@@ -431,23 +431,31 @@ class Insights_Wizard extends Wizard {
 				'donors'      => self::has_donation_activity(),
 				'advertising' => self::is_advertising_tab_visible(),
 			],
-			'defaultDateRange'  => [
+			'defaultDateRange'    => [
 				'preset' => 'last-30',
 				'start'  => $thirty_ago->format( 'Y-m-d' ),
 				'end'    => $today->format( 'Y-m-d' ),
 			],
-			'defaultComparison' => false,
-			'timezone'          => wp_timezone_string(),
-			'adminUrl'          => admin_url(),
-			'settingsUrl'       => admin_url( 'admin.php?page=newspack-settings' ),
-			'siteKitUrl'        => self::get_site_kit_url(),
+			'defaultComparison'   => false,
+			'timezone'            => wp_timezone_string(),
+			'adminUrl'            => admin_url(),
+			'settingsUrl'         => admin_url( 'admin.php?page=newspack-settings' ),
+			'siteKitUrl'          => self::get_site_kit_url(),
 			// Publisher (site) name, shown in the PDF export document header
 			// (NPPD-1661). Resolved at render time from the site's own title —
 			// never a hardcoded name. Decode entities: `blogname` is stored
 			// HTML-escaped (e.g. "Ben &amp; Jerry's"), and React escapes again
 			// on render, so a raw get_bloginfo() would print the literal entity.
 			// Hand React the decoded string and let it do the single escaping.
-			'publisherName'     => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			'publisherName'       => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			// Feedback abandon-beacon (NPPD-1728). navigator.sendBeacon can't set
+			// request headers, so the client needs the absolute REST URL plus a
+			// `wp_rest` nonce as a query param. apiFetch carries its own nonce for
+			// the normal submit/dismiss path, but the beacon can't reuse it and
+			// `window.wpApiSettings` isn't enqueued on this page — so hand both to
+			// the client explicitly here.
+			'feedbackBeaconUrl'   => rest_url( 'newspack-insights/v1/feedback' ),
+			'feedbackBeaconNonce' => wp_create_nonce( 'wp_rest' ),
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/api/feedback.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/feedback.ts
@@ -6,9 +6,9 @@
  * attribution (publisher domain) and routes the record to Slack via the
  * Manager relay (or the email fallback) — the client only submits.
  *
- * Slice 1 sends the tier-1 thumb (`context` + `sentiment`). `comment` is part
- * of the payload contract so Slice 2's tier-2 form can populate it without an
- * API change; it's optional and omitted by the tier-1 thumb.
+ * One record per event: the thumb stages `context` + `sentiment`; `comment`
+ * carries the tier-2 text on submit, and is empty/omitted when the modal is
+ * skipped or the tab is closed mid-modal.
  */
 
 /**
@@ -23,7 +23,7 @@ export interface FeedbackPayload {
 	context: string;
 	/** Tier-1 thumb sentiment. */
 	sentiment: FeedbackSentiment;
-	/** Tier-2 freeform comment (Slice 2); omitted by the tier-1 thumb. */
+	/** Tier-2 freeform comment; empty/omitted when the modal is skipped. */
 	comment?: string;
 }
 
@@ -43,3 +43,22 @@ export const submitFeedback = async ( payload: FeedbackPayload ): Promise< Feedb
 		method: 'POST',
 		data: payload,
 	} );
+
+/**
+ * Send a sentiment-only record via `navigator.sendBeacon` for the abandoner
+ * case — the publisher who opens the tier-2 modal and closes the tab without
+ * resolving it. A normal fetch wouldn't survive unload; the beacon does.
+ *
+ * The absolute REST URL and a `wp_rest` nonce come from the boot config (the
+ * page doesn't enqueue `window.wpApiSettings`, and a beacon can't set the
+ * `X-WP-Nonce` header), so the nonce rides as a `_wpnonce` query param, which
+ * WordPress cookie auth reads. Returns true if the beacon was queued.
+ */
+export const beaconSentiment = ( payload: FeedbackPayload, beaconUrl: string, nonce: string ): boolean => {
+	if ( ! beaconUrl || ! nonce || typeof navigator === 'undefined' || ! navigator.sendBeacon ) {
+		return false;
+	}
+	const url = `${ beaconUrl }?_wpnonce=${ encodeURIComponent( nonce ) }`;
+	const blob = new Blob( [ JSON.stringify( payload ) ], { type: 'application/json' } );
+	return navigator.sendBeacon( url, blob );
+};

--- a/plugins/newspack-plugin/src/wizards/insights/components/FeedbackModal.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/FeedbackModal.tsx
@@ -1,0 +1,110 @@
+/**
+ * FeedbackModal — tier-2 freeform feedback (NPPD-1728).
+ *
+ * The light modal that expands from a tier-1 thumb: a single optional freeform
+ * textarea with a sentiment-aware prompt — 👍 asks what's useful, 👎 asks what's
+ * missing or frustrating. Keeps the publisher on the page.
+ *
+ * Freeform, not multiple-choice: routing is Slack-only, so a human reads every
+ * message and fixed categories buy no aggregation; freeform captures the
+ * surprise insight a fixed list can't; and the taxonomy is better designed in
+ * v2 from real answers than guessed now.
+ *
+ * The modal owns its own field state, plus the `submitting` / `errored` props
+ * the parent (`TabFeedback`) drives: on a submit failure the parent keeps the
+ * modal open so the publisher's typed comment survives a retry. Resolution
+ * follows the one-record model — submitting sends the comment, dismissing
+ * (X / Esc / overlay / Skip) sends a sentiment-only record.
+ *
+ * Assembled from `@wordpress/components` (the upstream of the newspack
+ * design-system wrappers) — consistent with how `CooldownNotice` and
+ * `InfoCallout` use WP-core Notice directly, and avoiding the router coupling
+ * the newspack Button wrapper carries.
+ *
+ * User-facing copy is finalized (NPPD-1728), isolated in the COPY block.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal, TextareaControl, Button, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { FeedbackSentiment } from '../api/feedback';
+
+/**
+ * User-facing copy (NPPD-1728). The two prompt strings are sentiment-aware; the
+ * rest is shared.
+ */
+const COPY = {
+	title: __( 'Tell us more', 'newspack-plugin' ),
+	// The thumb rating is the feedback; this comment is optional. Because
+	// skipping or closing the tab still sends the rating (and the close-tab path
+	// has no UI of its own), say so up front so "Skip" / closing never reads as
+	// "discard".
+	intro: __( 'Your rating has been recorded. While optional, we’d love to hear more.', 'newspack-plugin' ),
+	promptPositive: __( 'What do you find most useful here?', 'newspack-plugin' ),
+	promptNegative: __( 'What’s missing or frustrating about this tab?', 'newspack-plugin' ),
+	submit: __( 'Send comment', 'newspack-plugin' ),
+	skip: __( 'Skip', 'newspack-plugin' ),
+	error: __( 'Could not send. Try again.', 'newspack-plugin' ),
+};
+
+export interface FeedbackDetail {
+	comment: string;
+}
+
+export interface FeedbackModalProps {
+	/** Thumb sentiment — selects the prompt wording. */
+	sentiment: FeedbackSentiment;
+	/** A submit is in flight — disable the submit control. */
+	submitting?: boolean;
+	/** The last submit failed — show a retry error (the comment is preserved). */
+	errored?: boolean;
+	/** Submit with the freeform comment. */
+	onSubmit: ( detail: FeedbackDetail ) => void;
+	/** Dismiss (X / Esc / overlay / Skip) — resolves sentiment-only. */
+	onDismiss: () => void;
+}
+
+const FeedbackModal = ( { sentiment, submitting = false, errored = false, onSubmit, onDismiss }: FeedbackModalProps ) => {
+	const [ comment, setComment ] = useState( '' );
+	const prompt = 'up' === sentiment ? COPY.promptPositive : COPY.promptNegative;
+	// The intro carries the load-bearing "Skip isn't discard" reassurance, so
+	// wire it to the dialog's accessible description (WP Modal forwards
+	// `aria.describedby` onto the dialog) — otherwise a screen reader hears only
+	// the title and can skip past it.
+	const introId = `newspack-insights__feedback-modal-intro-${ sentiment }`;
+
+	return (
+		<Modal title={ COPY.title } onRequestClose={ onDismiss } className="newspack-insights__feedback-modal" aria={ { describedby: introId } }>
+			<p id={ introId } className="newspack-insights__feedback-modal-intro">
+				{ COPY.intro }
+			</p>
+			<TextareaControl className="newspack-insights__feedback-modal-comment" label={ prompt } value={ comment } onChange={ setComment } />
+			{ errored && (
+				// role="alert" so the failure is announced (WP Notice is not a live
+				// region on its own) and the publisher knows to retry.
+				<div className="newspack-insights__feedback-modal-error" role="alert">
+					<Notice status="error" isDismissible={ false }>
+						{ COPY.error }
+					</Notice>
+				</div>
+			) }
+			<div className="newspack-insights__feedback-modal-actions">
+				<Button variant="tertiary" onClick={ onDismiss }>
+					{ COPY.skip }
+				</Button>
+				<Button variant="primary" isBusy={ submitting } disabled={ submitting } onClick={ () => onSubmit( { comment } ) }>
+					{ COPY.submit }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default FeedbackModal;

--- a/plugins/newspack-plugin/src/wizards/insights/components/FeedbackShipCallback.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/FeedbackShipCallback.tsx
@@ -1,0 +1,44 @@
+/**
+ * FeedbackShipCallback — closing the loop (NPPD-1728).
+ *
+ * Renders the dismissible top-of-tab "you asked for X, we shipped it" callout
+ * for a tab when one is configured, reusing the existing `InfoCallout`. The
+ * registry (`lib/feedbackCallbacks`) is empty at launch, so this renders
+ * nothing today — it's the plumbing, ready for the first feedback-driven ship.
+ *
+ * Dismissal persists per-publisher (InfoCallout's `storageKey` localStorage),
+ * namespaced by tab + callback id so a later callback on the same tab
+ * re-announces instead of inheriting an old dismissal.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type { TabKey } from './InsightsWizard';
+import InfoCallout from '../tabs/components/InfoCallout';
+import { getShipCallback } from '../lib/feedbackCallbacks';
+
+export interface FeedbackShipCallbackProps {
+	/** The tab id to look up a ship callback for. */
+	context: TabKey;
+}
+
+const FeedbackShipCallback = ( { context }: FeedbackShipCallbackProps ) => {
+	const callback = getShipCallback( context );
+	if ( ! callback ) {
+		return null;
+	}
+	return (
+		<InfoCallout
+			heading={ callback.heading }
+			dismissible
+			persist
+			storageKey={ `feedback-callback-${ context }-${ callback.id }` }
+			className="newspack-insights__feedback-callback"
+		>
+			<p>{ callback.body }</p>
+		</InfoCallout>
+	);
+};
+
+export default FeedbackShipCallback;

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -30,6 +30,7 @@ import DateRangePicker from './DateRangePicker';
 import CooldownNotice from './CooldownNotice';
 import PrintDocumentMeta from './PrintDocumentMeta';
 import TabFeedback from './TabFeedback';
+import FeedbackShipCallback from './FeedbackShipCallback';
 import TabSpinner from '../tabs/components/TabSpinner';
 import useComparisonMode from '../state/useComparisonMode';
 import useDateRange, { type DateRange } from '../state/useDateRange';
@@ -66,6 +67,10 @@ export interface InsightsBootConfig {
 	lastUpdated: null | string;
 	/** Site title, rendered in the PDF export document header (NPPD-1661). */
 	publisherName: string;
+	/** Absolute REST URL for the feedback endpoint (NPPD-1728 abandon beacon). */
+	feedbackBeaconUrl: string;
+	/** `wp_rest` nonce for the abandon beacon (rides as a `_wpnonce` query param). */
+	feedbackBeaconNonce: string;
 }
 
 export interface InsightsWizardProps {
@@ -168,27 +173,31 @@ interface TabSectionRenderProps extends TabSectionProps {
 	tabKey: TabKey;
 	tabLabel: string;
 	publisherName: string;
+	feedbackBeaconUrl: string;
+	feedbackBeaconNonce: string;
 }
 
 /**
  * Per-tab wrapper rendered by the Wizard. Carries the print-only document
  * header/footer (NPPD-1661 — used by the "Download PDF" export), the
- * CooldownNotice, the error boundary (keyed by tab so a chunk-load error clears
- * when the user navigates away), the Suspense boundary for the lazy tab chunk,
- * and the per-tab feedback footer (NPPD-1728). The feedback footer sits outside
- * the error boundary so it still renders — carrying the same `tabKey` as
+ * CooldownNotice, the feedback ship-callback (NPPD-1728, top of tab), the
+ * error boundary (keyed by tab so a chunk-load error clears when the user
+ * navigates away), the Suspense boundary for the lazy tab chunk, and the
+ * per-tab feedback footer (NPPD-1728). The feedback footer sits outside the
+ * error boundary so it still renders — carrying the same `tabKey` as
  * `context` — even when a tab chunk fails to load (feedback about a broken tab
  * is still signal).
  */
-const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange }: TabSectionRenderProps ) => (
+const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange, feedbackBeaconUrl, feedbackBeaconNonce }: TabSectionRenderProps ) => (
 	<>
 		<PrintDocumentMeta tabLabel={ tabLabel } publisherName={ publisherName } range={ range } previousRange={ previousRange } />
 		<CooldownNotice tab={ tabKey } range={ range } previousRange={ previousRange } />
+		<FeedbackShipCallback context={ tabKey } />
 		<TabErrorBoundary key={ tabKey }>
 			<Suspense fallback={ <Fallback /> }>{ renderTabComponent( tabKey, { range, previousRange } ) }</Suspense>
 		</TabErrorBoundary>
 		<footer className="newspack-insights__tab-footer">
-			<TabFeedback context={ tabKey } />
+			<TabFeedback context={ tabKey } beaconUrl={ feedbackBeaconUrl } beaconNonce={ feedbackBeaconNonce } />
 		</footer>
 	</>
 );
@@ -258,6 +267,8 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 			range,
 			previousRange,
 			publisherName: config.publisherName,
+			feedbackBeaconUrl: config.feedbackBeaconUrl,
+			feedbackBeaconNonce: config.feedbackBeaconNonce,
 		},
 	} ) );
 

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.test.tsx
@@ -1,69 +1,145 @@
 /**
- * Tests for TabFeedback (NPPD-1728, Slice 1) — the tier-1 thumb.
+ * Tests for TabFeedback (NPPD-1728) — the one-record tier-1/tier-2 flow.
  */
 
 /**
  * External dependencies
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import TabFeedback from './TabFeedback';
-import { submitFeedback } from '../api/feedback';
+import { submitFeedback, beaconSentiment } from '../api/feedback';
 
 jest.mock( '../api/feedback' );
 
 const mockedSubmit = submitFeedback as jest.MockedFunction< typeof submitFeedback >;
+const mockedBeacon = beaconSentiment as jest.MockedFunction< typeof beaconSentiment >;
+
+const BEACON_URL = 'https://example.test/wp-json/newspack-insights/v1/feedback';
+const BEACON_NONCE = 'nonce-xyz';
+
+const renderTab = ( context: 'audience' | 'donors' = 'audience' ) =>
+	render( <TabFeedback context={ context } beaconUrl={ BEACON_URL } beaconNonce={ BEACON_NONCE } /> );
 
 const thumbUp = () => screen.getByRole( 'button', { name: 'Yes, this tab was useful' } );
 const thumbDown = () => screen.getByRole( 'button', { name: 'No, this tab was not useful' } );
+const modalTitle = () => screen.queryByText( 'Tell us more' );
 const ack = () => screen.findByTestId( 'snackbar' );
+const modalError = () => document.querySelector( '.newspack-insights__feedback-modal-error' );
 
 describe( 'TabFeedback', () => {
+	beforeEach( () => {
+		mockedSubmit.mockResolvedValue( { success: true } );
+	} );
+
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
 
 	it( 'renders the prompt and both thumb controls', () => {
-		render( <TabFeedback context="audience" /> );
+		renderTab();
 		expect( screen.getByText( 'Was this tab useful?' ) ).toBeInTheDocument();
 		expect( thumbUp() ).toBeInTheDocument();
 		expect( thumbDown() ).toBeInTheDocument();
 	} );
 
-	it( 'submits the sentiment with the tab context and acknowledges on success', async () => {
-		mockedSubmit.mockResolvedValue( { success: true } );
-		render( <TabFeedback context="engagement" /> );
-
+	it( 'opens the tier-2 modal on a thumb click without posting yet', () => {
+		renderTab();
 		fireEvent.click( thumbUp() );
 
-		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledWith( { context: 'engagement', sentiment: 'up' } ) );
+		expect( modalTitle() ).toBeInTheDocument();
+		expect( mockedSubmit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows a positive prompt for thumbs-up and a "missing" prompt for thumbs-down', () => {
+		const { unmount } = renderTab();
+		fireEvent.click( thumbUp() );
+		expect( screen.getByText( 'What do you find most useful here?' ) ).toBeInTheDocument();
+		unmount();
+
+		renderTab();
+		fireEvent.click( thumbDown() );
+		expect( screen.getByText( 'What’s missing or frustrating about this tab?' ) ).toBeInTheDocument();
+	} );
+
+	it( 'posts one record with the freeform comment on submit', async () => {
+		renderTab();
+		fireEvent.click( thumbDown() );
+
+		fireEvent.change( screen.getByRole( 'textbox' ), { target: { value: 'needs a CSV export' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send comment' } ) );
+
+		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledTimes( 1 ) );
+		expect( mockedSubmit ).toHaveBeenCalledWith( {
+			context: 'audience',
+			sentiment: 'down',
+			comment: 'needs a CSV export',
+		} );
+		expect( await ack() ).toHaveTextContent( 'Thanks for your feedback!' );
+		expect( modalTitle() ).not.toBeInTheDocument();
+	} );
+
+	it( 'posts one sentiment-only record and stays silent when skipped', async () => {
+		renderTab( 'donors' );
+		fireEvent.click( thumbUp() );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Skip' } ) );
+
+		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledTimes( 1 ) );
+		expect( mockedSubmit ).toHaveBeenCalledWith( {
+			context: 'donors',
+			sentiment: 'up',
+			comment: '',
+		} );
+		// Skip is silent — the rating lands, but no acknowledgment toast.
+		expect( screen.queryByTestId( 'snackbar' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the modal open and preserves the comment on a submit failure, then retries', async () => {
+		mockedSubmit.mockRejectedValueOnce( new Error( 'boom' ) );
+		renderTab();
+		fireEvent.click( thumbDown() );
+
+		const textarea = screen.getByRole( 'textbox' );
+		fireEvent.change( textarea, { target: { value: 'do not lose me' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send comment' } ) );
+
+		// Modal stays open, error shown, comment preserved.
+		await waitFor( () => expect( modalError() ).toBeInTheDocument() );
+		expect( modalTitle() ).toBeInTheDocument();
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'do not lose me' );
+
+		// Retry succeeds.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send comment' } ) );
+		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledTimes( 2 ) );
 		expect( await ack() ).toHaveTextContent( 'Thanks for your feedback!' );
 	} );
 
-	it( 'submits a thumbs-down with the down sentiment', async () => {
-		mockedSubmit.mockResolvedValue( { success: true } );
-		render( <TabFeedback context="donors" /> );
+	it( 'beacons a sentiment-only record (with url + nonce) when the tab is closed mid-modal', () => {
+		renderTab();
+		fireEvent.click( thumbUp() );
+		expect( modalTitle() ).toBeInTheDocument();
 
-		fireEvent.click( thumbDown() );
+		act( () => {
+			window.dispatchEvent( new Event( 'pagehide' ) );
+		} );
 
-		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledWith( { context: 'donors', sentiment: 'down' } ) );
+		expect( mockedBeacon ).toHaveBeenCalledWith( { context: 'audience', sentiment: 'up' }, BEACON_URL, BEACON_NONCE );
+		expect( mockedSubmit ).not.toHaveBeenCalled();
 	} );
 
-	it( 'surfaces an error and allows a retry on failure', async () => {
-		mockedSubmit.mockRejectedValueOnce( new Error( 'nope' ) );
-		render( <TabFeedback context="gates" /> );
-
+	it( 'does not beacon on a bfcache pagehide (persisted)', () => {
+		renderTab();
 		fireEvent.click( thumbUp() );
 
-		expect( await screen.findByRole( 'alert' ) ).toHaveTextContent( 'Could not send. Try again.' );
+		act( () => {
+			const event = new Event( 'pagehide' ) as PageTransitionEvent;
+			Object.defineProperty( event, 'persisted', { value: true } );
+			window.dispatchEvent( event );
+		} );
 
-		// The control re-opens for a retry; a second click goes through.
-		mockedSubmit.mockResolvedValueOnce( { success: true } );
-		fireEvent.click( thumbUp() );
-
-		await waitFor( () => expect( mockedSubmit ).toHaveBeenCalledTimes( 2 ) );
+		expect( mockedBeacon ).not.toHaveBeenCalled();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/TabFeedback.tsx
@@ -1,20 +1,26 @@
 /**
- * TabFeedback — tier-1 per-tab feedback affordance (NPPD-1728, Slice 1).
+ * TabFeedback — per-tab feedback affordance (NPPD-1728).
  *
- * Footer-anchored "Was this tab useful?" prompt with a thumbs up / thumbs
- * down control, rendered into every Insights tab's footer by `TabSection`.
- * Carries the tab id as `context` so feedback is attributed per tab. Clicking
- * a thumb submits the sentiment to `/newspack-insights/v1/feedback` (the
- * server stamps the publisher domain and routes to Slack) and fires an
- * immediate Snackbar acknowledgment — never the void.
+ * Footer-anchored "Was this tab useful?" thumb that, on click, stages the
+ * sentiment and expands the tier-2 freeform modal. It carries the tab id as
+ * `context` so feedback is attributed per tab, and fires an immediate Snackbar
+ * acknowledgment on resolve. Styled to the muted MetricNote scale so it reads
+ * as native chrome.
  *
- * Styled to the muted MetricNote scale (small, gray) so it reads as native
- * chrome. The thumbs use the `@wordpress/components` Button directly (icon +
- * isPressed accessibility, no router coupling), matching how `CooldownNotice`
- * uses the WP-core Notice directly.
+ * One record per event (the deliberate data model — keeps sentiment and the
+ * comment on the same row, posts to Slack once):
+ *   - Thumb click stages the sentiment and opens the modal; nothing is posted
+ *     yet.
+ *   - Submitting the modal posts the record (sentiment + comment); dismissing
+ *     it (Cancel / Esc / overlay) posts a sentiment-only record; closing the
+ *     tab mid-modal posts sentiment-only via `navigator.sendBeacon`.
+ *   - On a submit failure the modal stays open so the typed comment survives a
+ *     retry; only a successful submit (or a dismiss) closes it.
  *
- * Slice 1 is the tier-1 thumb only: clicking a thumb submits sentiment
- * immediately. The tier-2 freeform comment modal lands in Slice 2.
+ * The thumb always opens the modal — there's no rate-limit. A publisher who
+ * only wants to react dismisses in one click and their sentiment still lands,
+ * and anyone with detailed feedback is never locked out (NPPD-1728 decision:
+ * no cooldown).
  *
  * User-facing copy is finalized (NPPD-1728), isolated in the COPY block.
  */
@@ -31,7 +37,8 @@ import { thumbsUp, thumbsDown } from '@wordpress/icons';
  * Internal dependencies
  */
 import type { TabKey } from './InsightsWizard';
-import { submitFeedback, type FeedbackSentiment } from '../api/feedback';
+import FeedbackModal, { type FeedbackDetail } from './FeedbackModal';
+import { submitFeedback, beaconSentiment, type FeedbackSentiment } from '../api/feedback';
 
 /**
  * User-facing copy (NPPD-1728).
@@ -52,17 +59,23 @@ type Status = 'idle' | 'submitting' | 'submitted' | 'error';
 export interface TabFeedbackProps {
 	/** The tab id, carried through as the feedback `context`. */
 	context: TabKey;
+	/** Absolute REST URL for the abandon beacon. */
+	beaconUrl: string;
+	/** `wp_rest` nonce for the abandon beacon. */
+	beaconNonce: string;
 }
 
-const TabFeedback = ( { context }: TabFeedbackProps ) => {
+const TabFeedback = ( { context, beaconUrl, beaconNonce }: TabFeedbackProps ) => {
 	const [ status, setStatus ] = useState< Status >( 'idle' );
 	const [ chosen, setChosen ] = useState< FeedbackSentiment | null >( null );
+	const [ modalOpen, setModalOpen ] = useState( false );
 	const [ showAck, setShowAck ] = useState( false );
 
-	// A one-shot in-flight guard (set synchronously so a same-tick double-click
-	// can't submit twice) and a mount flag so post-await setters don't run after
-	// unmount.
-	const inFlightRef = useRef( false );
+	// Refs that async resolution / the unload beacon read without re-binding:
+	// the staged sentiment, a one-shot guard so a record posts exactly once per
+	// event, and a mount flag so post-await setters don't run after unmount.
+	const chosenRef = useRef< FeedbackSentiment | null >( null );
+	const resolvedRef = useRef( false );
 	const mountedRef = useRef( true );
 
 	useEffect(
@@ -81,37 +94,88 @@ const TabFeedback = ( { context }: TabFeedbackProps ) => {
 		return () => clearTimeout( timer );
 	}, [ showAck ] );
 
-	const handleVote = useCallback(
-		async ( sentiment: FeedbackSentiment ): Promise< void > => {
-			if ( inFlightRef.current ) {
+	// Abandoner: the publisher who opens the modal and closes the tab without
+	// resolving. A normal fetch wouldn't survive unload, so post sentiment-only
+	// via sendBeacon. Skip bfcache (`event.persisted`) — the page may be
+	// restored with the modal still open, and sending then would lock out the
+	// real submit. Guarded so it never double-posts with a real resolve.
+	//
+	// `pagehide` (not `visibilitychange`) on purpose: visibilitychange→hidden
+	// also fires on an ordinary tab switch, which would beacon prematurely and
+	// lock out a publisher who tabs away and comes back to finish. That trade
+	// favors this desktop-admin surface; the cost is missing the rare mobile
+	// background-then-discard abandon, which is acceptable here.
+	useEffect( () => {
+		if ( ! modalOpen ) {
+			return;
+		}
+		const onHide = ( event: PageTransitionEvent ) => {
+			if ( event.persisted || resolvedRef.current || ! chosenRef.current ) {
 				return;
 			}
-			inFlightRef.current = true;
-			setChosen( sentiment );
+			resolvedRef.current = true;
+			beaconSentiment( { context, sentiment: chosenRef.current }, beaconUrl, beaconNonce );
+		};
+		window.addEventListener( 'pagehide', onHide );
+		return () => window.removeEventListener( 'pagehide', onHide );
+	}, [ modalOpen, context, beaconUrl, beaconNonce ] );
+
+	// Post the single record for this event. `detail` is empty for a
+	// sentiment-only resolve (modal skipped). `isSubmit` distinguishes an
+	// explicit "Send comment" from a skip/dismiss: a submit shows the ack on
+	// success and keeps the modal open on failure (so the typed comment survives
+	// a retry); a skip is silent (no ack — the rating still lands) and just
+	// closes on failure since there's nothing to preserve.
+	const resolve = useCallback(
+		async ( detail: FeedbackDetail, isSubmit: boolean ): Promise< void > => {
+			if ( resolvedRef.current || ! chosenRef.current ) {
+				return;
+			}
+			resolvedRef.current = true;
 			setStatus( 'submitting' );
 			try {
-				await submitFeedback( { context, sentiment } );
+				await submitFeedback( { context, sentiment: chosenRef.current, comment: detail.comment } );
 				if ( ! mountedRef.current ) {
 					return;
 				}
+				setModalOpen( false );
 				setStatus( 'submitted' );
-				setShowAck( true );
+				if ( isSubmit ) {
+					setShowAck( true );
+				}
 			} catch {
+				if ( ! mountedRef.current ) {
+					return;
+				}
 				// Re-open the control for a retry; the failure is logged
 				// server-side by the router.
-				inFlightRef.current = false;
-				if ( ! mountedRef.current ) {
-					return;
-				}
 				setStatus( 'error' );
+				resolvedRef.current = false;
+				if ( ! isSubmit ) {
+					setModalOpen( false );
+					chosenRef.current = null;
+					setChosen( null );
+				}
 			}
 		},
 		[ context ]
 	);
 
-	// One signal per tab view: lock the thumbs once a vote is in flight or
-	// recorded. An error re-opens them for a retry.
-	const locked = status === 'submitting' || status === 'submitted';
+	// A vote is in motion or recorded — lock the thumbs. An error on dismiss
+	// re-opens them.
+	const locked = chosen !== null;
+
+	const handleVote = ( sentiment: FeedbackSentiment ): void => {
+		// Gate on the ref (set synchronously) so a same-tick double-click can't
+		// open two modals before `chosen` state settles.
+		if ( chosenRef.current ) {
+			return;
+		}
+		chosenRef.current = sentiment;
+		resolvedRef.current = false;
+		setChosen( sentiment );
+		setModalOpen( true );
+	};
 
 	const promptId = `newspack-insights__tab-feedback-prompt-${ context }`;
 
@@ -141,12 +205,21 @@ const TabFeedback = ( { context }: TabFeedbackProps ) => {
 						onClick={ () => handleVote( 'down' ) }
 					/>
 				</div>
-				{ status === 'error' && (
+				{ status === 'error' && ! modalOpen && (
 					<span className="newspack-insights__tab-feedback-error" role="alert">
 						{ COPY.error }
 					</span>
 				) }
 			</div>
+			{ modalOpen && chosen && (
+				<FeedbackModal
+					sentiment={ chosen }
+					submitting={ status === 'submitting' }
+					errored={ status === 'error' }
+					onSubmit={ detail => resolve( detail, true ) }
+					onDismiss={ () => resolve( { comment: '' }, false ) }
+				/>
+			) }
 			{ showAck && (
 				<div className="newspack-insights__tab-feedback-snackbar" role="status">
 					<Snackbar onRemove={ () => setShowAck( false ) }>{ COPY.ack }</Snackbar>

--- a/plugins/newspack-plugin/src/wizards/insights/components/_feedback.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_feedback.scss
@@ -87,4 +87,23 @@
 			display: none;
 		}
 	}
+
+	// Tier-2 modal. The WP-core Modal owns its chrome (overlay, header, close);
+	// these classes are flat (the modal renders in a portal outside the
+	// `.newspack-insights` root), so `&__x` here is concatenation, not nesting.
+	&__feedback-modal-intro {
+		margin: 0 0 16px;
+		color: wp-colors.$gray-700;
+	}
+
+	&__feedback-modal-comment {
+		margin-bottom: 16px;
+	}
+
+	&__feedback-modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 24px;
+	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -49,6 +49,8 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 	siteKitUrl: '',
 	lastUpdated: null,
 	publisherName: '',
+	feedbackBeaconUrl: '',
+	feedbackBeaconNonce: '',
 };
 
 const Index = () => {

--- a/plugins/newspack-plugin/src/wizards/insights/lib/feedbackCallbacks.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/feedbackCallbacks.ts
@@ -1,0 +1,43 @@
+/**
+ * Tab-scoped "ship callback" config (NPPD-1728).
+ *
+ * Closes the feedback loop: when we ship a change a publisher asked for on a
+ * given tab, we surface a dismissible top-of-tab callout — "You asked for X on
+ * this tab; we just shipped it." Research says this is the single thing that
+ * sustains response rate, so the plumbing is built now and sits ready.
+ *
+ * The registry is intentionally EMPTY at launch — nothing has shipped from
+ * feedback yet, so no callout fires. When the first requested change ships,
+ * add an entry: `tab -> { id, heading, body }`. The `id` namespaces the
+ * per-tab dismissal so a later callback re-announces rather than inheriting an
+ * old dismissal. Each entry's heading/body is authored when the change ships.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type { TabKey } from '../components/InsightsWizard';
+
+export interface ShipCallback {
+	/** Stable id; namespaces the per-tab dismissal so a new callback re-shows. */
+	id: string;
+	/** Bold heading for the callout. */
+	heading: string;
+	/** Body copy. */
+	body: string;
+}
+
+/**
+ * Per-tab ship-callback registry. Empty until the first feedback-driven change
+ * ships.
+ */
+const CALLBACKS: Partial< Record< TabKey, ShipCallback > > = {};
+
+/**
+ * The ship callback to surface on a tab, or null when there's nothing to
+ * announce.
+ *
+ * @param tab Tab id.
+ * @return The callback, or null.
+ */
+export const getShipCallback = ( tab: TabKey ): ShipCallback | null => CALLBACKS[ tab ] ?? null;


### PR DESCRIPTION
Slice 2 of the Insights publisher feedback mechanism ([NPPD-1728](https://linear.app/a8c/issue/NPPD-1728)), stacked on the spine (#365). It adds the tier-2 freeform comment modal, the one-record submission model that ties the thumb and the comment into a single Slack message, and the closing-the-loop plumbing. Targets nppd-1728-insights-feedback-spine; rebase onto feat/insights-rsm once the spine merges.

## Pre-flight decisions

Freeform, not multiple-choice. Tier-2 is a single optional textarea with a sentiment-aware prompt, no option lists. With Slack-only routing a human reads every message, so fixed categories buy no aggregation; freeform captures the surprise insight a fixed list can't; and the taxonomy is better designed in v2 from real answers than guessed now.

One record per event. The thumb stages the sentiment and opens the modal without posting; the single POST fires when the modal resolves. Submitting sends sentiment plus comment; dismissing (Skip, Esc, overlay) sends sentiment-only; closing the tab mid-modal sends sentiment-only via navigator.sendBeacon. This keeps sentiment and comment on one row and posts to Slack exactly once, and is the cleaner foundation for v2 durable storage (one row, not a correlation across two).

No cooldown. The thumb always opens the modal; there is no rate-limit. A publisher who only wants to react dismisses in one click and their sentiment still lands, and anyone with detailed feedback is never locked out.

## What's in this PR

Tier-2 modal. src/wizards/insights/components/FeedbackModal.tsx is a light WP-core Modal with one TextareaControl, a sentiment-aware prompt label (👍 asks what's most useful, 👎 asks what's missing or frustrating), and Skip/Send actions. It owns its field state and takes submitting/errored from the parent so a submit failure keeps the modal open and the typed comment survives a retry. The intro line is wired to the dialog's accessible description so a screen reader hears it.

One-record flow. TabFeedback.tsx is reworked from the spine's submit-on-click into the staged model above, using refs for the staged sentiment, a one-shot resolve guard (so a record posts exactly once), and the mount flag. The abandon beacon listens on pagehide (not visibilitychange, which also fires on an ordinary tab switch and would beacon prematurely) and skips bfcache restores (event.persisted).

Abandon beacon. feedback.ts gains beaconSentiment, which posts via navigator.sendBeacon. Because a beacon can't set the X-WP-Nonce header and this page doesn't enqueue window.wpApiSettings, class-insights-wizard.php adds feedbackBeaconUrl (absolute rest_url) and feedbackBeaconNonce (a wp_rest nonce) to the boot config, and the nonce rides as a _wpnonce query param. Threaded through InsightsWizard.tsx and index.tsx's fallback config.

Closing the loop. src/wizards/insights/components/FeedbackShipCallback.tsx renders a dismissible top-of-tab callout via the existing InfoCallout, reading from src/wizards/insights/lib/feedbackCallbacks.ts. The registry is intentionally empty at launch, so nothing renders today; it is the plumbing, ready for the first feedback-driven ship. Dismissal persists per publisher, namespaced by tab plus callback id so a later callback re-announces.

Tests. TabFeedback.test.tsx is rewritten for the one-record flow: modal-opens-without-posting, sentiment-aware prompts, one-record-on-submit, silent sentiment-only-on-skip, open-and-comment-preserved-on-failure, the pagehide beacon, and the bfcache no-beacon case.

## How to test

- Rebase onto feat/insights-rsm if the spine has merged. Enable Insights with routing configured (see #365).
- Click a thumb. Confirm the modal opens and nothing has posted yet.
- Confirm 👍 and 👎 show different prompts.
- Type a comment and Send. Confirm one Slack message with sentiment plus comment, and the acknowledgment fires.
- Click a thumb, then Skip. Confirm one sentiment-only message and no acknowledgment toast.
- Open the modal and close the tab. Confirm one sentiment-only beacon arrives.
- Force a submit failure. Confirm the modal stays open, shows the error, preserves the comment, and a retry succeeds.
- Run the TabFeedback JS suite.

## Heads-up

- Ship-callback registry is empty at launch. feedbackCallbacks.ts ships with no entries by design, so no callout renders until the first requested change ships and an entry plus its copy are added.
- pagehide over visibilitychange. This favors the desktop-admin surface (no premature beacon on tab switch) at the cost of missing the rare mobile background-then-discard abandon. Called out in the code comment.
