### PR TITLE
fix(insights): prompt cards full width, landscape PDF, relabel export

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/_print.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/_print.scss
@@ -1,7 +1,7 @@
 /**
  * Print stylesheet for per-tab PDF export (NPPD-1661).
  *
- * The "Download PDF" item in the Insights options kebab calls
+ * The "Print / Save as PDF" item in the Insights options kebab calls
  * `window.print()`; this stylesheet is what turns the live admin view into
  * a clean document. We chose print-CSS over html2canvas/jsPDF precisely
  * because the charts are hand-rolled inline SVG (LineChart, PieChart,
@@ -143,6 +143,9 @@
 
 	// --- Page setup ----------------------------------------------------------
 	@page {
+		// Landscape gives the three-up scorecard rows and wide charts/tables room
+		// to breathe; the browser's "Save as PDF" honours this orientation.
+		size: landscape;
 		margin: 1.5cm;
 		// Leave room for the fixed footer so body content never collides with it.
 		margin-bottom: 2cm;

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -179,7 +179,7 @@ interface TabSectionRenderProps extends TabSectionProps {
 
 /**
  * Per-tab wrapper rendered by the Wizard. Carries the print-only document
- * header/footer (NPPD-1661 — used by the "Download PDF" export), the
+ * header/footer (NPPD-1661 — used by the "Print / Save as PDF" export), the
  * CooldownNotice, the feedback ship-callback (NPPD-1728, top of tab), the
  * error boundary (keyed by tab so a chunk-load error clears when the user
  * navigates away), the Suspense boundary for the lazy tab chunk, and the

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
@@ -70,7 +70,7 @@ describe( 'LastUpdated', () => {
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
-	it( 'prints with a tab+range filename on Download PDF', () => {
+	it( 'prints with a tab+range filename on Print / Save as PDF', () => {
 		const printSpy = jest.spyOn( window, 'print' ).mockImplementation( () => undefined );
 		seedSlot( 'engagement', { status: 'success', computedAt: '2026-06-10T18:42:13Z' } );
 
@@ -81,19 +81,19 @@ describe( 'LastUpdated', () => {
 
 		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
 		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
-		fireEvent.click( screen.getByRole( 'menuitem', { name: /download pdf/i } ) );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /save as pdf/i } ) );
 
 		expect( printSpy ).toHaveBeenCalledTimes( 1 );
 		expect( titleAtPrint ).toBe( 'engagement-2026-01-01_to_2026-01-31' );
 		printSpy.mockRestore();
 	} );
 
-	it( 'disables Download PDF while the slot is loading', () => {
+	it( 'disables Print / Save as PDF while the slot is loading', () => {
 		seedSlot( 'engagement', { status: 'loading', computedAt: '2026-06-10T18:42:13Z' } );
 
 		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
 		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
-		const item = screen.getByRole( 'menuitem', { name: /download pdf/i } );
+		const item = screen.getByRole( 'menuitem', { name: /save as pdf/i } );
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/components/PrintDocumentMeta.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/PrintDocumentMeta.tsx
@@ -4,7 +4,7 @@
  * Print-only document chrome for the per-tab PDF export. Hidden on screen
  * (`.newspack-insights__print-only { display: none }`) and revealed under
  * `@media print`, so it costs nothing in the normal admin view and only
- * surfaces when the user runs "Download PDF" from the Insights options
+ * surfaces when the user runs "Print / Save as PDF" from the Insights options
  * kebab.
  *
  * Renders:

--- a/plugins/newspack-plugin/src/wizards/insights/components/RefreshMenu.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/RefreshMenu.tsx
@@ -1,6 +1,6 @@
 /**
  * RefreshMenu — the "Insights options" header kebab dropdown. Holds
- * "Refresh now" and "Download PDF" (NPPD-1661).
+ * "Refresh now" and "Print / Save as PDF…" (NPPD-1661).
  */
 
 /**
@@ -31,7 +31,7 @@ const RefreshMenu = ( { onRefresh, disabled, onDownloadPdf, downloadDisabled }: 
 				isDisabled: disabled,
 			},
 			{
-				title: __( 'Download PDF', 'newspack-plugin' ),
+				title: __( 'Print / Save as PDF…', 'newspack-plugin' ),
 				onClick: onDownloadPdf,
 				isDisabled: downloadDisabled,
 			},

--- a/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/pdfExport.ts
@@ -1,7 +1,7 @@
 /**
  * PDF export helpers (NPPD-1661).
  *
- * The Insights "Download PDF" export is print-based: a `@media print`
+ * The Insights "Print / Save as PDF" export is print-based: a `@media print`
  * stylesheet hides the WordPress/wizard chrome and reveals a document
  * header + footer, then we hand off to the browser's own print engine
  * via `window.print()`. The browser renders the live SVG/DOM charts at

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
         </div>
       </div>
       <div
-        class="newspack-insights__metric-grid"
+        class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
       >
         <div
           class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -249,7 +249,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
         </div>
       </div>
       <div
-        class="newspack-insights__metric-grid"
+        class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
       >
         <div
           class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
@@ -38,7 +38,7 @@ const PromptEngagementSection = ( { current, previous }: PromptEngagementSection
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Click-Through Rate', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
@@ -39,7 +39,7 @@ const PromptExposureSection = ( { current, previous, lastUpdated }: PromptExposu
 			description={ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Total Prompt Impressions', 'newspack-plugin' ),


### PR DESCRIPTION
## Summary

Three small, unrelated Insights UI tweaks bundled into one PR.

### 1. Prompt scorecards go full-width 3-up
The **Prompt exposure** and **Prompt engagement** sections used the default auto-fill grid, so their three cards didn't stretch the way the Advertising tab's do. Added the existing `newspack-insights__metric-grid--cols-3` modifier (same rule the Advertising tab already uses) so they render as three even, full-width columns, collapsing to a single column below 782px.

### 2. PDF export prints landscape
Added `size: landscape;` to the `@page` rule in the print stylesheet. The browser's "Save as PDF" honours it, giving the three-up rows and wide charts/tables more room.

### 3. Relabel "Download PDF" → "Print / Save as PDF…"
The export is intentionally print-based (`window.print()`) so the live SVG charts render at full vector fidelity — browsers offer no API to silently download a styled PDF without the print dialog. The old "Download PDF" label over-promised an automatic download. Renamed the menu item (and synced the doc comments) so the label matches the behaviour. No functional change to the export itself.

## Test plan
- Insights → Prompts tab: confirm the two scorecard rows are full-width 3-up, matching Advertising; collapse to 1 column on narrow viewports.
- Insights options kebab now reads "Print / Save as PDF…"; clicking it opens the print dialog with a landscape page.
- Updated the two `LastUpdated` tests that queried the menu item by its old label.