### PR TITLE
feat(insights): first-conversion-date storage helpers for Tab 3

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -406,6 +406,18 @@ class Donors_Metric {
 	}
 
 	/**
+	 * Earliest completed/processing donation order date per customer for the
+	 * given set. List-param — NOT cached (result varies per call). Keyed by
+	 * customer_id.
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_first_donation_order_dates( array $customer_ids ): array {
+		return $this->storage->get_first_donation_order_dates( $customer_ids );
+	}
+
+	/**
 	 * Flush all Tab 7 metric caches. Hook point for NPPD-1605.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -466,6 +466,17 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Earliest non-donation subscription start per customer for the given set.
+	 * List-param — NOT cached (result varies per call). Keyed by customer_id.
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_first_subscription_order_dates( array $customer_ids ): array {
+		return $this->storage->get_first_subscription_order_dates( $customer_ids );
+	}
+
+	/**
 	 * Flush ALL Tab 6 metric caches. Use after a manual data correction
 	 * or from the future NPPD-1605 invalidation system; not wired to any
 	 * automatic trigger today because the WP transient API has no key

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -317,4 +317,19 @@ interface Donors_Storage_Interface {
 	 * @return array<int, array<string, mixed>>
 	 */
 	public function get_donations_by_tier( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
+	 * Earliest completed/processing donation order date per customer, restricted
+	 * to the given customer set. Same first-donation-per-customer definition as
+	 * {@see get_new_donors_in_window()}, but returns the dates rather than
+	 * counting a window. Used by Tab 3 (Conversion Journey) to compute
+	 * registration→donation lag and to anchor the BQ source-match window.
+	 *
+	 * Customers in the input list with no completed donation are absent from the
+	 * result. Empty input returns `[]` with no DB round-trip.
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable> customer_id => first donation date (UTC).
+	 */
+	public function get_first_donation_order_dates( array $customer_ids ): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -944,6 +944,45 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_first_donation_order_dates( array $customer_ids ): array {
+		if ( empty( $customer_ids ) ) {
+			return [];
+		}
+
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+		$ids       = $this->id_list( $customer_ids );
+
+		// Earliest completed/processing donation order date per customer, scoped
+		// to the given customer set. Mirrors the inner aggregate of
+		// get_new_donors_in_window() (same first-donation definition).
+		$sql = "SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
+			FROM {$prefix}wc_orders o
+			JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
+			WHERE o.type = 'shop_order'
+			  AND o.status IN ('wc-completed', 'wc-processing')
+			  AND opl.product_id IN ($donations)
+			  AND o.customer_id IN ($ids)
+			GROUP BY o.customer_id";
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$map  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['first_donation_date'] ) ) {
+				continue;
+			}
+			$map[ (int) $row['customer_id'] ] = new \DateTimeImmutable( $row['first_donation_date'], new \DateTimeZone( 'UTC' ) );
+		}
+		return $map;
+	}
+
+	/**
 	 * Aggregate flat per-variation rows into parent + nested
 	 * variations shape. Mirrors the Tab 6 pattern but with Tab 7's
 	 * five-metric column set.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1145,6 +1145,11 @@ class HPOS_Storage implements Storage_Interface {
 		// (om.meta_value != '') so a blank value can't yield a bogus epoch
 		// date. The window-count method drops blanks implicitly via its
 		// BETWEEN bounds, so results reconcile on healthy data.
+		// MIN(om.meta_value) is a lexical comparison: wc_orders_meta.meta_value
+		// is a string column, and _schedule_start is stored zero-padded
+		// `Y-m-d H:i:s`, so lexical order equals chronological order. The
+		// donation helper aggregates a real datetime column, so it carries no
+		// such assumption.
 		$sql = "SELECT o.customer_id, MIN(om.meta_value) AS first_start
 			FROM {$prefix}wc_orders o
 			JOIN {$prefix}wc_orders_meta om

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1140,7 +1140,11 @@ class HPOS_Storage implements Storage_Interface {
 
 		// Earliest non-donation subscription _schedule_start per customer,
 		// scoped to the given customer set. Mirrors the inner aggregate of
-		// get_new_subscribers_in_window() (same first-start definition).
+		// get_new_subscribers_in_window() (same first-start definition), with
+		// one added guard: this query also excludes empty _schedule_start
+		// (om.meta_value != '') so a blank value can't yield a bogus epoch
+		// date. The window-count method drops blanks implicitly via its
+		// BETWEEN bounds, so results reconcile on healthy data.
 		$sql = "SELECT o.customer_id, MIN(om.meta_value) AS first_start
 			FROM {$prefix}wc_orders o
 			JOIN {$prefix}wc_orders_meta om

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1121,4 +1121,48 @@ class HPOS_Storage implements Storage_Interface {
 			$rows
 		);
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_first_subscription_order_dates( array $customer_ids ): array {
+		if ( empty( $customer_ids ) ) {
+			return [];
+		}
+
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+		$ids       = $this->id_list( $customer_ids );
+
+		// Earliest non-donation subscription _schedule_start per customer,
+		// scoped to the given customer set. Mirrors the inner aggregate of
+		// get_new_subscribers_in_window() (same first-start definition).
+		$sql = "SELECT o.customer_id, MIN(om.meta_value) AS first_start
+			FROM {$prefix}wc_orders o
+			JOIN {$prefix}wc_orders_meta om
+				ON om.order_id = o.id AND om.meta_key = '_schedule_start'
+			JOIN {$prefix}woocommerce_order_items oi
+				ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+			JOIN {$prefix}woocommerce_order_itemmeta oim
+				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+			WHERE o.type = 'shop_subscription'
+			  AND oim.meta_value NOT IN ($donations)
+			  AND om.meta_value != ''
+			  AND o.customer_id IN ($ids)
+			GROUP BY o.customer_id";
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$map  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['first_start'] ) ) {
+				continue;
+			}
+			$map[ (int) $row['customer_id'] ] = new \DateTimeImmutable( $row['first_start'], new \DateTimeZone( 'UTC' ) );
+		}
+		return $map;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -923,7 +923,9 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		// Legacy CPT equivalent of HPOS_Donors_Storage::get_first_donation_order_dates():
 		// earliest completed/processing donation order post_date_gmt per
 		// _customer_user, scoped to the given set. Mirrors get_new_donors_in_window().
-		$sql = "SELECT cust.meta_value AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
+		// _customer_user is cast to UNSIGNED (it is stored as a string) to match the
+		// other list-scoped legacy donor queries and align grouping with the int keys returned.
+		$sql = "SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
 			FROM {$prefix}posts p
 			JOIN {$prefix}postmeta cust
 				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
@@ -931,8 +933,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 			WHERE p.post_type = 'shop_order'
 			  AND p.post_status IN ('wc-completed', 'wc-processing')
 			  AND opl.product_id IN ($donations)
-			  AND cust.meta_value IN ($ids)
-			GROUP BY cust.meta_value";
+			  AND CAST(cust.meta_value AS UNSIGNED) IN ($ids)
+			GROUP BY CAST(cust.meta_value AS UNSIGNED)";
 
 		$rows = $wpdb->get_results( $sql, ARRAY_A );
 		$map  = [];

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -905,6 +905,47 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_first_donation_order_dates( array $customer_ids ): array {
+		if ( empty( $customer_ids ) ) {
+			return [];
+		}
+
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+		$ids       = $this->id_list( $customer_ids );
+
+		// Legacy CPT equivalent of HPOS_Donors_Storage::get_first_donation_order_dates():
+		// earliest completed/processing donation order post_date_gmt per
+		// _customer_user, scoped to the given set. Mirrors get_new_donors_in_window().
+		$sql = "SELECT cust.meta_value AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
+			FROM {$prefix}posts p
+			JOIN {$prefix}postmeta cust
+				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+			JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
+			WHERE p.post_type = 'shop_order'
+			  AND p.post_status IN ('wc-completed', 'wc-processing')
+			  AND opl.product_id IN ($donations)
+			  AND cust.meta_value IN ($ids)
+			GROUP BY cust.meta_value";
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$map  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['first_donation_date'] ) ) {
+				continue;
+			}
+			$map[ (int) $row['customer_id'] ] = new \DateTimeImmutable( $row['first_donation_date'], new \DateTimeZone( 'UTC' ) );
+		}
+		return $map;
+	}
+
+	/**
 	 * Aggregate flat per-variation rows into parent + nested variations.
 	 * Duplicated from {@see HPOS_Donors_Storage} — pure PHP transform
 	 * keeping each storage class self-contained.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1078,6 +1078,10 @@ class Legacy_Storage implements Storage_Interface {
 		// — the window-count method drops blanks implicitly via its BETWEEN bounds.
 		// _customer_user is cast to UNSIGNED (it is stored as a string) to match the
 		// other list-scoped legacy queries and align grouping with the int keys returned.
+		// MIN(start.meta_value) is a lexical comparison: postmeta.meta_value is a string
+		// column, and _schedule_start is stored zero-padded `Y-m-d H:i:s`, so lexical
+		// order equals chronological order. The donation helper aggregates the real
+		// post_date_gmt datetime column, so it carries no such assumption.
 		$sql = "SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
 			FROM {$prefix}posts p
 			JOIN {$prefix}postmeta cust

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1053,4 +1053,50 @@ class Legacy_Storage implements Storage_Interface {
 			$rows
 		);
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_first_subscription_order_dates( array $customer_ids ): array {
+		if ( empty( $customer_ids ) ) {
+			return [];
+		}
+
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+		$ids       = $this->id_list( $customer_ids );
+
+		// Legacy CPT equivalent of HPOS_Storage::get_first_subscription_order_dates():
+		// earliest non-donation subscription _schedule_start per _customer_user,
+		// scoped to the given customer set. Mirrors get_new_subscribers_in_window().
+		$sql = "SELECT cust.meta_value AS customer_id, MIN(start.meta_value) AS first_start
+			FROM {$prefix}posts p
+			JOIN {$prefix}postmeta cust
+				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+			JOIN {$prefix}postmeta start
+				ON start.post_id = p.ID AND start.meta_key = '_schedule_start'
+			JOIN {$prefix}woocommerce_order_items oi
+				ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+			JOIN {$prefix}woocommerce_order_itemmeta oim
+				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+			WHERE p.post_type = 'shop_subscription'
+			  AND oim.meta_value NOT IN ($donations)
+			  AND start.meta_value != ''
+			  AND cust.meta_value IN ($ids)
+			GROUP BY cust.meta_value";
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$map  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['first_start'] ) ) {
+				continue;
+			}
+			$map[ (int) $row['customer_id'] ] = new \DateTimeImmutable( $row['first_start'], new \DateTimeZone( 'UTC' ) );
+		}
+		return $map;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1072,8 +1072,13 @@ class Legacy_Storage implements Storage_Interface {
 
 		// Legacy CPT equivalent of HPOS_Storage::get_first_subscription_order_dates():
 		// earliest non-donation subscription _schedule_start per _customer_user,
-		// scoped to the given customer set. Mirrors get_new_subscribers_in_window().
-		$sql = "SELECT cust.meta_value AS customer_id, MIN(start.meta_value) AS first_start
+		// scoped to the given customer set. Mirrors get_new_subscribers_in_window(),
+		// with one added guard: this query also excludes empty _schedule_start
+		// (start.meta_value != '') so a blank value can't yield a bogus epoch date
+		// — the window-count method drops blanks implicitly via its BETWEEN bounds.
+		// _customer_user is cast to UNSIGNED (it is stored as a string) to match the
+		// other list-scoped legacy queries and align grouping with the int keys returned.
+		$sql = "SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
 			FROM {$prefix}posts p
 			JOIN {$prefix}postmeta cust
 				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
@@ -1086,8 +1091,8 @@ class Legacy_Storage implements Storage_Interface {
 			WHERE p.post_type = 'shop_subscription'
 			  AND oim.meta_value NOT IN ($donations)
 			  AND start.meta_value != ''
-			  AND cust.meta_value IN ($ids)
-			GROUP BY cust.meta_value";
+			  AND CAST(cust.meta_value AS UNSIGNED) IN ($ids)
+			GROUP BY CAST(cust.meta_value AS UNSIGNED)";
 
 		$rows = $wpdb->get_results( $sql, ARRAY_A );
 		$map  = [];

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -315,6 +315,12 @@ interface Storage_Interface {
 	 * Customers in the input list with no non-donation subscription are absent
 	 * from the result. Empty input returns `[]` with no DB round-trip.
 	 *
+	 * Not perfect parity with {@see get_new_subscribers_in_window()} in
+	 * data-corruption edge cases: implementations additionally exclude rows
+	 * with an empty `_schedule_start` so a blank value can't yield a bogus
+	 * epoch date. The window-count metric leans on its `BETWEEN` bounds to
+	 * drop blanks implicitly, so the two reconcile on healthy data.
+	 *
 	 * @param int[] $customer_ids Customer IDs to look up.
 	 * @return array<int, \DateTimeImmutable> customer_id => first subscription start (UTC).
 	 */

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -303,4 +303,20 @@ interface Storage_Interface {
 	 * @return int
 	 */
 	public function get_stale_registered_users(): int;
+
+	/**
+	 * Earliest non-donation subscription start (`_schedule_start`) per customer,
+	 * restricted to the given customer set. Same first-start-per-customer
+	 * definition as {@see get_new_subscribers_in_window()}, but returns the
+	 * dates rather than counting a window. Used by Tab 3 (Conversion Journey)
+	 * to compute registration→subscription lag and to anchor the BQ
+	 * source-match window.
+	 *
+	 * Customers in the input list with no non-donation subscription are absent
+	 * from the result. Empty input returns `[]` with no DB round-trip.
+	 *
+	 * @param int[] $customer_ids Customer IDs to look up.
+	 * @return array<int, \DateTimeImmutable> customer_id => first subscription start (UTC).
+	 */
+	public function get_first_subscription_order_dates( array $customer_ids ): array;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -348,6 +348,58 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$this->assertSame( 0, $metric->count_completed_donation_order_customers_by_customer_ids( [] ) );
 	}
 
+	/**
+	 * HPOS_Storage exposes get_first_subscription_order_dates().
+	 */
+	public function test_hpos_storage_implements_first_subscription_order_dates(): void {
+		$storage = new HPOS_Storage( [] );
+		$this->assertTrue( method_exists( $storage, 'get_first_subscription_order_dates' ) );
+	}
+
+	/**
+	 * Legacy_Storage exposes get_first_subscription_order_dates().
+	 */
+	public function test_legacy_storage_implements_first_subscription_order_dates(): void {
+		$storage = new Legacy_Storage( [] );
+		$this->assertTrue( method_exists( $storage, 'get_first_subscription_order_dates' ) );
+	}
+
+	/**
+	 * HPOS: get_first_subscription_order_dates([]) → [] (no DB round-trip).
+	 */
+	public function test_hpos_get_first_subscription_order_dates_empty_list_returns_empty_array(): void {
+		$storage = new HPOS_Storage( [] );
+		$this->assertSame( [], $storage->get_first_subscription_order_dates( [] ) );
+	}
+
+	/**
+	 * Legacy: get_first_subscription_order_dates([]) → [].
+	 */
+	public function test_legacy_get_first_subscription_order_dates_empty_list_returns_empty_array(): void {
+		$storage = new Legacy_Storage( [] );
+		$this->assertSame( [], $storage->get_first_subscription_order_dates( [] ) );
+	}
+
+	/**
+	 * Subscribers_Metric::get_first_subscription_order_dates() delegates directly
+	 * (list-param — NOT cached, so two distinct lists hit storage twice).
+	 */
+	public function test_subscribers_metric_get_first_subscription_order_dates_delegates(): void {
+		$dates = [
+			1 => $this->make_date( '2026-01-15' ),
+			2 => $this->make_date( '2026-02-20' ),
+		];
+		$mock = $this->createMock( Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'get_first_subscription_order_dates' )
+			->willReturnOnConsecutiveCalls( $dates, [] );
+
+		$metric = $this->make_subscribers_metric( $mock );
+
+		$this->assertSame( $dates, $metric->get_first_subscription_order_dates( [ 1, 2 ] ) );
+		$this->assertSame( [], $metric->get_first_subscription_order_dates( [ 99 ] ) );
+	}
+
 	// =========================================================================
 	// Stale-registered: Subscribers_Metric wrapper delegates correctly.
 	// The actual SQL in the storage classes queries WC HPOS/legacy tables

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -400,6 +400,58 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$this->assertSame( [], $metric->get_first_subscription_order_dates( [ 99 ] ) );
 	}
 
+	/**
+	 * HPOS_Donors_Storage exposes get_first_donation_order_dates().
+	 */
+	public function test_hpos_donors_storage_implements_first_donation_order_dates(): void {
+		$storage = new HPOS_Donors_Storage( [] );
+		$this->assertTrue( method_exists( $storage, 'get_first_donation_order_dates' ) );
+	}
+
+	/**
+	 * Legacy_Donors_Storage exposes get_first_donation_order_dates().
+	 */
+	public function test_legacy_donors_storage_implements_first_donation_order_dates(): void {
+		$storage = new Legacy_Donors_Storage( [] );
+		$this->assertTrue( method_exists( $storage, 'get_first_donation_order_dates' ) );
+	}
+
+	/**
+	 * HPOS: get_first_donation_order_dates([]) → [] (no DB round-trip).
+	 */
+	public function test_hpos_get_first_donation_order_dates_empty_list_returns_empty_array(): void {
+		$storage = new HPOS_Donors_Storage( [] );
+		$this->assertSame( [], $storage->get_first_donation_order_dates( [] ) );
+	}
+
+	/**
+	 * Legacy: get_first_donation_order_dates([]) → [].
+	 */
+	public function test_legacy_get_first_donation_order_dates_empty_list_returns_empty_array(): void {
+		$storage = new Legacy_Donors_Storage( [] );
+		$this->assertSame( [], $storage->get_first_donation_order_dates( [] ) );
+	}
+
+	/**
+	 * Donors_Metric::get_first_donation_order_dates() delegates directly
+	 * (list-param — NOT cached, so two distinct lists hit storage twice).
+	 */
+	public function test_donors_metric_get_first_donation_order_dates_delegates(): void {
+		$dates = [
+			3 => $this->make_date( '2026-03-10' ),
+			4 => $this->make_date( '2026-04-05' ),
+		];
+		$mock = $this->createMock( Donors_Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'get_first_donation_order_dates' )
+			->willReturnOnConsecutiveCalls( $dates, [] );
+
+		$metric = $this->make_donors_metric( $mock );
+
+		$this->assertSame( $dates, $metric->get_first_donation_order_dates( [ 3, 4 ] ) );
+		$this->assertSame( [], $metric->get_first_donation_order_dates( [ 99 ] ) );
+	}
+
 	// =========================================================================
 	// Stale-registered: Subscribers_Metric wrapper delegates correctly.
 	// The actual SQL in the storage classes queries WC HPOS/legacy tables


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds two per-customer-set storage helpers to the Insights data layer that return each customer's **first conversion timestamp**:

- `get_first_subscription_order_dates( int[] $customer_ids )` — earliest non-donation subscription start per customer.
- `get_first_donation_order_dates( int[] $customer_ids )` — earliest completed/processing donation order date per customer.

Both return `array<int, \DateTimeImmutable>` keyed by `customer_id` (UTC), are added to the relevant storage interface with HPOS and legacy implementations, and are exposed through uncached pass-throughs on the `Subscribers_Metric` / `Donors_Metric` wrappers.

This is the storage foundation for the Conversion Journey (Tab 3) "Phase B" remediation. A follow-up PR consumes these helpers to compute registration→conversion lag and to anchor BigQuery source-matching to each local record — keeping WP/Woo as the identity spine. The first-conversion definitions deliberately mirror the existing `get_new_subscribers_in_window()` / `get_new_donors_in_window()` aggregates (`MIN(date) … GROUP BY customer_id`), so "first subscription/donation" stays consistent across metrics. **Backend-only; no user-facing behavior changes in this PR.**

Closes NPPD-1616.

### How to test the changes in this Pull Request:

1. Check out this branch in the consumer plugin and confirm PHPUnit passes for the new contract tests: from `plugins/newspack-plugin`, run `n test-php --filter 'first_subscription_order_dates'` and `n test-php --filter 'first_donation_order_dates'` — expect 5 passing tests each (interface presence, empty-list guard for both backends, and metric-wrapper delegation).
2. Confirm no regressions in the wider group: `n test-php --group insights` (note: any pre-existing `Source_Matcher not found` errors are an unrelated stale-classmap artifact in local checkouts and clear with `composer dump-autoload`; CI installs a fresh classmap).
3. Confirm the empty-input guard does no DB work: both `get_first_subscription_order_dates([])` and `get_first_donation_order_dates([])` return `[]` immediately (covered by the new tests).
4. Lint on the host (the workspace ruleset resolves from the repo root): from `plugins/newspack-plugin`, run `./vendor/bin/phpcs includes/wizards/insights/storage includes/wizards/insights/metrics` — expect no errors on the changed files.
5. Optional live check (requires WooCommerce data): in an environment with subscription and donation orders, call the two `Subscribers_Metric` / `Donors_Metric` helpers with a known customer-ID set and confirm the returned dates match each customer's earliest subscription start / earliest completed donation order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<sub>Note for reviewers: the ten new tests are grouped together as one block in the test file rather than distributed across the existing section-header comments — they cover one feature (two symmetric helpers) and read more clearly together.</sub>
