### PR TITLE
feat(insights): Gates Free section empty states (NPPD-1702)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -301,7 +301,8 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	private static function is_window_all_error( array $window ): bool {
 		foreach ( $window as $key => $value ) {
 			// Skip the date metadata and the scalar section-total fields
-			// (e.g. `paywall_attempts_total`, NPPD-1694) — neither is a metric.
+			// (`paywall_*_total`, NPPD-1694; `registration_impressions_total` /
+			// `registrations_total`, NPPD-1702 — int|null) — none is a metric.
 			if ( 'window' === $key || ! is_array( $value ) ) {
 				continue;
 			}
@@ -321,8 +322,10 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	private function build_window( Gates_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
-		// Captured for the Paid-section totals below (NPPD-1694) — derived from
-		// these scalars, not re-queried.
+		// Captured for the section totals below — derived from these scalars, not
+		// re-queried. Paid (NPPD-1694) and Free (NPPD-1702) follow the same shape.
+		$regwall_direct     = $metric->get_regwall_conversion_direct( $start, $end );
+		$regwall_influenced = $metric->get_regwall_conversion_influenced_7d( $start, $end );
 		$paywall_direct     = $metric->get_paywall_conversion_direct( $start, $end );
 		$paywall_influenced = $metric->get_paywall_conversion_influenced_14d( $start, $end );
 
@@ -338,8 +341,8 @@ class Gates_REST_Controller extends WP_REST_Controller {
 				'avg_exposures_per_reader'           => $metric->get_avg_exposures_per_reader( $start, $end ),
 				'sessions_with_gate'                 => $metric->get_sessions_with_gate( $start, $end ),
 				// Section 2.
-				'regwall_conversion_direct'          => $metric->get_regwall_conversion_direct( $start, $end ),
-				'regwall_conversion_influenced_7d'   => $metric->get_regwall_conversion_influenced_7d( $start, $end ),
+				'regwall_conversion_direct'          => $regwall_direct,
+				'regwall_conversion_influenced_7d'   => $regwall_influenced,
 				// Section 3.
 				'paywall_conversion_direct'          => $paywall_direct,
 				'paywall_conversion_influenced_14d'  => $paywall_influenced,
@@ -351,6 +354,9 @@ class Gates_REST_Controller extends WP_REST_Controller {
 				// Section 5.
 				'performance_by_gate'                => $metric->get_performance_by_gate( $start, $end ),
 			],
+			// Section 2 empty-state totals (NPPD-1702) — int|null; null = hub count
+			// fields not yet deployed, so the Free section degrades to percentages.
+			Gates_Metric::regwall_section_totals( $regwall_direct, $regwall_influenced ),
 			// Section 3 empty-state totals (NPPD-1694).
 			Gates_Metric::paywall_section_totals( $paywall_direct, $paywall_influenced )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
@@ -9,6 +9,10 @@
  *     publisher's 25,000 / 2,000 / 400 shape so both drop-off deltas render red.
  *   - 'empty'    — every section reports the empty state (succeeded, no rows).
  *   - 'error'    — every section reports the error state (tab banner shows).
+ *   - 'free_no_conversions' / 'free_fields_absent' — Free-section empty-state
+ *     smoke variants (NPPD-1702); see the Paid variants below for the pattern.
+ *     `free_fields_absent` models the pre-hub-deploy state where the new count
+ *     fields are absent and the section degrades to today's percentage render.
  *
  * Returns a closure so the single required file can build any variant. Never
  * enable fixture mode in production.
@@ -59,9 +63,14 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'error_message'    => 'HTTP 500',
 			];
 		}
-		// Scalar section-total metadata (NPPD-1694) — zero in the all-error window.
-		$current['paywall_attempts_total']    = 0;
-		$current['paywall_conversions_total'] = 0;
+		// Scalar section-total metadata — the regwall totals are null in an
+		// all-error window (the errored scalars carry null counts, so
+		// regwall_section_totals returns null; NPPD-1702), the paywall totals zero
+		// (NPPD-1694).
+		$current['registration_impressions_total'] = null;
+		$current['registrations_total']            = null;
+		$current['paywall_attempts_total']         = 0;
+		$current['paywall_conversions_total']      = 0;
 		$collections = [
 			'conversion_funnel'      => 'stages',
 			'exposures_distribution' => 'buckets',
@@ -95,9 +104,13 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'placeholder_type' => $type,
 			];
 		}
-		// Zero attempts → the Paid section renders its no_opportunity empty state.
-		$current['paywall_attempts_total']    = 0;
-		$current['paywall_conversions_total'] = 0;
+		// Zero impressions / attempts → both Free (NPPD-1702) and Paid (NPPD-1694)
+		// sections render their no_opportunity empty state. Present 0, not null:
+		// these fields exist in the response, they're just empty for this window.
+		$current['registration_impressions_total'] = 0;
+		$current['registrations_total']            = 0;
+		$current['paywall_attempts_total']         = 0;
+		$current['paywall_conversions_total']      = 0;
 		$current['conversion_funnel']      = [
 			'state'  => 'empty',
 			'stages' => [],
@@ -138,8 +151,8 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			'avg_exposures_per_reader'           => $scalar( round( 1.8 * $f, 1 ), null, 'decimal' ),
 			'sessions_with_gate'                 => $scalar( round( 0.34 * $f, 3 ), null, 'rate' ),
 			// Section 2 — Free reader conversion.
-			'regwall_conversion_direct'          => $scalar( round( 0.071 * $f, 3 ), null, 'rate' ),
-			'regwall_conversion_influenced_7d'   => $scalar( round( 0.123 * $f, 3 ), null, 'rate' ),
+			'regwall_conversion_direct'          => $scalar( round( 0.071 * $f, 3 ), (int) round( 14000 * $f ), 'rate', (int) round( 994 * $f ) ),
+			'regwall_conversion_influenced_7d'   => $scalar( round( 0.123 * $f, 3 ), (int) round( 12000 * $f ), 'rate', (int) round( 1476 * $f ) ),
 			// Section 3 — Paid reader conversion. Paywall rate cards carry both
 			// numerator (matched Woo orders) and denominator (attempts) so fixture
 			// mode exercises the NPPD-1694 count fallback.
@@ -147,6 +160,11 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			'paywall_conversion_influenced_14d'  => $scalar( round( 0.038 * $f, 3 ), (int) round( 290 * $f ), 'rate', (int) round( 11 * $f ) ),
 			'total_paywall_revenue_direct'       => $scalar( round( 4180.5 * $f, 2 ), (int) round( 47 * $f ), 'currency' ),
 			'avg_revenue_per_paywall_conversion' => $scalar( round( 88.95 * $f, 2 ), (int) round( 47 * $f ), 'currency' ),
+			// Section 2 empty-state totals (NPPD-1702). int|null in production; the
+			// populated fixture models the post-hub-deploy world where the count
+			// fields are present (`free_fields_absent` models the pre-deploy path).
+			'registration_impressions_total'     => (int) round( 14000 * $f ),
+			'registrations_total'                => (int) round( 1476 * $f ),
 			// Section 3 empty-state totals (NPPD-1694).
 			'paywall_attempts_total'             => (int) round( 320 * $f ),
 			'paywall_conversions_total'          => (int) round( 11 * $f ),
@@ -235,6 +253,37 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			],
 		];
 	};
+
+	// --- Free-section empty-state smoke variants (NPPD-1702). ---
+	if ( 'free_no_conversions' === $variant ) {
+		// 14,000 registration gate impressions, zero registrations → the Free
+		// section's `no_conversions` empty state with {N} = 14,000.
+		$current                                    = $build( 1.0 );
+		$current['registrations_total']             = 0;
+		$current['regwall_conversion_direct']       = $scalar( 0.0, 14000, 'rate', 0 );
+		$current['regwall_conversion_influenced_7d'] = $scalar( 0.0, 12000, 'rate', 0 );
+		return [
+			'tab_error' => false,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
+	if ( 'free_fields_absent' === $variant ) {
+		// The production-safety crux (NPPD-1702): the hub count fields are NOT yet
+		// deployed. The regwall scalars carry null counts and the section totals are
+		// null — so the Free section must degrade to today's percentage scorecards,
+		// no empty state. This is the default until Derrick's hub change ships.
+		$current                                     = $build( 1.0 );
+		$current['regwall_conversion_direct']        = $scalar( 0.071, null, 'rate' );
+		$current['regwall_conversion_influenced_7d'] = $scalar( 0.123, null, 'rate' );
+		$current['registration_impressions_total']   = null;
+		$current['registrations_total']              = null;
+		return [
+			'tab_error' => false,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
 
 	// --- Paid-section empty-state smoke variants (NPPD-1694). ---
 	if ( 'paid_no_conversions' === $variant ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -234,6 +234,96 @@ final class Gates_Metric {
 	}
 
 	/**
+	 * Compute a regwall conversion rate from a precomputed hub rate, optionally
+	 * surfacing the new count fields the empty-state pattern needs (NPPD-1702).
+	 *
+	 * Unlike the paywall rate (computed locally from a Woo join), the regwall rate
+	 * is precomputed server-side by the hub. This method reads that rate exactly as
+	 * `compute_metric_from_proxy` would, then *additionally* reads two integer
+	 * columns the hub query will start returning once Derrick's Newspack Manager
+	 * change ships: `registration_impressions_total` (the denominator / {N}) and
+	 * `registrations_total` (the numerator).
+	 *
+	 * The production-safety crux: those columns do not exist in the hub response
+	 * yet. When they are absent, this returns numerator + denominator as `null` —
+	 * byte-for-byte today's regwall envelope — so the React layer renders the
+	 * percentage scorecards and no empty state (graceful degradation). An absent
+	 * field is NOT a zero: a present `0` is a real "no impressions" signal, a
+	 * missing field is "the hub hasn't deployed yet." The two are kept distinct all
+	 * the way to the component. The fields are read as a pair: a half-populated
+	 * response (one present, one absent/non-numeric) is treated as absent so a
+	 * malformed envelope degrades rather than half-renders a count fallback.
+	 *
+	 * @param string            $query_name Catalog name (`gates_regwall_conversion_*`).
+	 * @param string            $rate_key   Column holding the precomputed rate.
+	 * @param DateTimeInterface $start      Window start.
+	 * @param DateTimeInterface $end        Window end.
+	 * @return array
+	 */
+	private function compute_regwall_rate_from_proxy(
+		string $query_name,
+		string $rate_key,
+		DateTimeInterface $start,
+		DateTimeInterface $end
+	): array {
+		$rows = $this->proxy->query( $query_name, $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $this->error_scalar( 'rate', $rows );
+		}
+		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $rate_key, $rows[0] ) ) {
+			// Query succeeded with no usable value → non-computable zero. Mirrors
+			// compute_metric_from_proxy exactly, including the int 0 it uses for a
+			// non-decimal placeholder (a rate). Counts stay null: nothing to surface.
+			return $this->populated_scalar( 0, false, null, 'rate' );
+		}
+		$row   = $rows[0];
+		$value = $row[ $rate_key ];
+		// SAFE_DIVIDE NULL: legitimate "no eligible events", non-computable zero.
+		if ( null === $value ) {
+			return $this->populated_scalar( 0, false, null, 'rate' );
+		}
+		// Non-numeric rate signals catalog/schema drift — surface as an error so a
+		// real data-quality regression isn't masked as a benign zero.
+		if ( ! is_numeric( $value ) ) {
+			return $this->error_scalar(
+				'rate',
+				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric value.', 'newspack-plugin' ) )
+			);
+		}
+		// Read the new count columns iff BOTH are present and integer-valued.
+		// Absent (pre-hub-deploy) → null counts → today's envelope, today's render.
+		$impressions = $this->read_optional_count( $row, 'registration_impressions_total' );
+		$registrations = $this->read_optional_count( $row, 'registrations_total' );
+		if ( null === $impressions || null === $registrations ) {
+			return $this->populated_scalar( (float) $value, true, null, 'rate' );
+		}
+		return $this->populated_scalar( (float) $value, true, $impressions, 'rate', $registrations );
+	}
+
+	/**
+	 * Read an optional non-negative integer column from a proxy row (NPPD-1702).
+	 *
+	 * Returns the int when the key is present and integer-valued (a float like 3.7
+	 * is rejected as catalog drift), or `null` when the key is absent or not a
+	 * clean integer. Distinguishing "absent" from "0" is the whole point: callers
+	 * use `null` to mean "the hub hasn't deployed this field yet."
+	 *
+	 * @param array  $row Proxy row.
+	 * @param string $key Column name.
+	 * @return int|null
+	 */
+	private function read_optional_count( array $row, string $key ): ?int {
+		if ( ! array_key_exists( $key, $row ) || null === $row[ $key ] ) {
+			return null;
+		}
+		$raw = $row[ $key ];
+		if ( ! is_numeric( $raw ) || (float) $raw !== (float) (int) $raw ) {
+			return null;
+		}
+		return (int) $raw;
+	}
+
+	/**
 	 * Compute a paywall conversion rate from BQ rows + Woo completion join.
 	 *
 	 * @param string            $query_name Catalog name (`gates_paywall_conversion_*`).
@@ -363,7 +453,7 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_regwall_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_metric_from_proxy( 'gates_regwall_conversion_direct', 'regwall_conversion_rate_direct', 'rate', $start, $end );
+		return $this->compute_regwall_rate_from_proxy( 'gates_regwall_conversion_direct', 'regwall_conversion_rate_direct', $start, $end );
 	}
 
 	/**
@@ -374,7 +464,7 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_regwall_conversion_influenced_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_metric_from_proxy( 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced', 'rate', $start, $end );
+		return $this->compute_regwall_rate_from_proxy( 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced', $start, $end );
 	}
 
 	// --- Section 3: Paid reader conversion ------------------------------
@@ -462,6 +552,49 @@ final class Gates_Metric {
 				(int) ( $direct['numerator'] ?? 0 ),
 				(int) ( $influenced['numerator'] ?? 0 )
 			),
+		];
+	}
+
+	/**
+	 * Free-section totals for the empty-state gate (NPPD-1702).
+	 *
+	 * The Free counterpart to `paywall_section_totals`, with one deliberate and
+	 * load-bearing difference: it returns `int|null`, never coercing a missing
+	 * count to `0`. `null` means "the hub hasn't deployed the count fields yet"
+	 * (the `compute_regwall_rate_from_proxy` numerator/denominator are null in that
+	 * case); the React layer reads it to *degrade to today's percentage render*
+	 * rather than show a false `no_opportunity`. Coercing to 0 here — as the
+	 * paywall helper does, where the denominator always exists because it's
+	 * computed locally — would silently break a working production section the
+	 * moment this ships, with no hub change involved. An absent field is not a zero.
+	 *
+	 *   - `registration_impressions_total` = the Direct rate denominator (sessions
+	 *     with a registration gate impression; the {N} in the "no registrations"
+	 *     copy). Mirrors paywall keying attempts off the Direct denominator.
+	 *   - `registrations_total` = the most inclusive registration count across
+	 *     attributions (max of Direct and Influenced numerators), so a section with
+	 *     Influenced-only registrations still renders its scorecards. `null` only
+	 *     when neither attribution carries a count (fields absent).
+	 *
+	 * @param array $direct     The `regwall_conversion_direct` scalar payload.
+	 * @param array $influenced The `regwall_conversion_influenced_7d` scalar payload.
+	 * @return array{registration_impressions_total:int|null, registrations_total:int|null}
+	 */
+	public static function regwall_section_totals( array $direct, array $influenced ): array {
+		// `isset` is intentional: it treats a present-but-null denominator the same
+		// as a missing key — both mean "no count from the hub" → null. A present 0
+		// passes through as 0 (a real "no impressions" signal, NOT degradation).
+		$impressions = isset( $direct['denominator'] ) ? (int) $direct['denominator'] : null;
+
+		$direct_regs     = $direct['numerator'] ?? null;
+		$influenced_regs = $influenced['numerator'] ?? null;
+		$registrations   = ( null === $direct_regs && null === $influenced_regs )
+			? null
+			: max( (int) $direct_regs, (int) $influenced_regs );
+
+		return [
+			'registration_impressions_total' => $impressions,
+			'registrations_total'            => $registrations,
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
@@ -107,6 +107,14 @@ export interface GatesWindow {
 	// Section 2 — Free reader conversion.
 	regwall_conversion_direct: GatesScalarMetric;
 	regwall_conversion_influenced_7d: GatesScalarMetric;
+	// Section 2 empty-state totals (NPPD-1702): drive the Free section's
+	// no_opportunity / no_conversions / normal decision. Derived server-side from
+	// the regwall scalars — no extra query. `null` (not 0) when the hub count
+	// fields aren't deployed yet, so the section degrades to today's percentage
+	// render. An absent field is not a zero: a present 0 is a real "no impressions"
+	// signal; null is "the hub hasn't shipped the count fields." See NPPD-1702.
+	registration_impressions_total: number | null;
+	registrations_total: number | null;
 	// Section 3 — Paid reader conversion.
 	paywall_conversion_direct: GatesScalarMetric;
 	paywall_conversion_influenced_14d: GatesScalarMetric;
@@ -152,7 +160,8 @@ const queryString = ( query: GatesQuery ): string => {
 		params.set( 'compare_end', query.compare_end );
 	}
 	// Forward the `_fixture_state` URL param so fixture mode's render variants
-	// (empty / error / paid_no_conversions / paid_zero_cards) are reachable from
+	// (empty / error / free_no_conversions / free_fields_absent /
+	// paid_no_conversions / paid_zero_cards) are reachable from
 	// the UI for smoke testing. A no-op in production: the server ignores it
 	// unless NEWSPACK_INSIGHTS_FIXTURE_MODE is enabled.
 	if ( typeof window !== 'undefined' ) {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for FreeReaderConversionSection empty states (NPPD-1702): the THREE-way
+ * field-presence detection that is the point of this ticket —
+ *   - fields absent (hub not deployed) → percentages, NO empty state (degrade)
+ *   - fields present, impressions 0     → no_opportunity
+ *   - fields present, registrations 0   → no_conversions (with {N})
+ *   - fields present, normal data       → scorecards + per-card "0 of N" fallback
+ * plus the errored-scalar fall-through (a zero total behind an error must not
+ * masquerade as a genuine empty state).
+ *
+ * `.test.tsx` harness gap from NPPD-1683 still applies, so this may not run in CI
+ * yet; written to the sibling PaidReaderConversionSection.test.tsx convention.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import FreeReaderConversionSection from './FreeReaderConversionSection';
+import type { GatesScalarMetric, GatesWindow } from '../../api/gates';
+
+const scalar = ( over: Partial< GatesScalarMetric > = {} ): GatesScalarMetric => ( {
+	state: 'populated',
+	value: 0,
+	computable: true,
+	denominator: null,
+	numerator: null,
+	placeholder_type: 'rate',
+	...over,
+} );
+
+const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
+	window: { start: '2026-03-01', end: '2026-03-31' },
+	total_gate_impressions: scalar( { placeholder_type: 'count', value: 100 } ),
+	unique_readers_reached: scalar( { placeholder_type: 'count' } ),
+	avg_exposures_per_reader: scalar( { placeholder_type: 'decimal' } ),
+	sessions_with_gate: scalar(),
+	regwall_conversion_direct: scalar(),
+	regwall_conversion_influenced_7d: scalar(),
+	paywall_conversion_direct: scalar(),
+	paywall_conversion_influenced_14d: scalar(),
+	total_paywall_revenue_direct: scalar( { placeholder_type: 'currency' } ),
+	avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency' } ),
+	paywall_attempts_total: 0,
+	paywall_conversions_total: 0,
+	// Default: hub count fields ABSENT (null) — the pre-deploy production state.
+	registration_impressions_total: null,
+	registrations_total: null,
+	conversion_funnel: { state: 'empty', stages: [] },
+	exposures_distribution: { state: 'empty', buckets: [] },
+	performance_by_gate: { state: 'empty', rows: [] },
+	...over,
+} );
+
+describe( 'FreeReaderConversionSection empty states (NPPD-1702)', () => {
+	it( 'degrades to the percentage scorecards (NO empty state) when the hub count fields are absent', () => {
+		// The crux: fields null even though the regwall rates are a non-computable
+		// zero. Absent is NOT zero — today's render must be preserved exactly.
+		const current = makeWindow( {
+			registration_impressions_total: null,
+			registrations_total: null,
+			regwall_conversion_direct: scalar( { value: 0, computable: false } ),
+			regwall_conversion_influenced_7d: scalar( { value: 0, computable: false } ),
+		} );
+		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Regwall Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Regwall Conversion (Influenced, 7d)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders no_opportunity when the fields are present and impressions === 0', () => {
+		const current = makeWindow( { registration_impressions_total: 0, registrations_total: 0 } );
+		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		// Body asserted on the container — the Notice's speak() duplicates it into a
+		// global live-region, so a screen-level text query would match twice.
+		expect( container ).toHaveTextContent( 'No registration gate impressions in this timeframe' );
+		expect( screen.queryByText( 'Regwall Conversion (Direct)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders no_conversions with the impressions count interpolated when impressions > 0 and registrations === 0', () => {
+		const current = makeWindow( { registration_impressions_total: 14000, registrations_total: 0 } );
+		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_conversions"]' ) ).toBeInTheDocument();
+		// 14000 → "14,000" via the shared formatNumber.
+		expect( container ).toHaveTextContent( 'Your registration gates reached 14,000 readers' );
+		// 7-day attribution window in the Free copy (NOT 14 — that's the Paid side).
+		expect( container ).toHaveTextContent( 'within the 7-day attribution window' );
+		expect( screen.queryByText( 'Regwall Conversion (Direct)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the two scorecards (no empty state) when the section has data', () => {
+		const current = makeWindow( {
+			registration_impressions_total: 14000,
+			registrations_total: 994,
+			regwall_conversion_direct: scalar( { value: 0.071, numerator: 994, denominator: 14000 } ),
+			regwall_conversion_influenced_7d: scalar( { value: 0.123, numerator: 1476, denominator: 12000 } ),
+		} );
+		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Regwall Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Regwall Conversion (Influenced, 7d)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'applies the per-card count fallback inside a normal section render', () => {
+		// Section has data (Influenced registered some) so the grid renders, but the
+		// Direct card is 0 of 14,000 → exercises the "0 of N" rate fallback.
+		const current = makeWindow( {
+			registration_impressions_total: 14000,
+			registrations_total: 1476,
+			regwall_conversion_direct: scalar( { value: 0, computable: true, numerator: 0, denominator: 14000 } ),
+			regwall_conversion_influenced_7d: scalar( { value: 0.123, numerator: 1476, denominator: 12000 } ),
+		} );
+		render( <FreeReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( screen.getByText( '0 of 14,000' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does NOT show an empty state when a regwall scalar errored — renders the scorecards instead', () => {
+		// Even with impressions present at 0 (which would otherwise be no_opportunity),
+		// an errored Direct query must fall through to the scorecards so the errored
+		// card surfaces its own error treatment rather than a misleading empty state.
+		const current = makeWindow( {
+			registration_impressions_total: 0,
+			registrations_total: 0,
+			regwall_conversion_direct: scalar( { state: 'error', computable: false, error_message: 'BQ down' } ),
+		} );
+		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( container ).not.toHaveTextContent( 'No registration gate impressions in this timeframe' );
+		expect( screen.getByText( 'Regwall Conversion (Direct)' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
@@ -1,8 +1,25 @@
 /**
- * FreeReaderConversionSection (NPPD-1604, Section 2).
+ * FreeReaderConversionSection (NPPD-1604, Section 2; empty states NPPD-1702).
  *
  * Two scorecards side-by-side covering registration-gate conversion
  * (Direct attribution and Influenced 7-day lookback).
+ *
+ * Mirrors the Paid section's empty-state treatment (NPPD-1694), with one
+ * production-safety distinction that is the whole point of NPPD-1702: the count
+ * fields this section reads (`registration_impressions_total` /
+ * `registrations_total`) come from a hub BigQuery change that may ship AFTER
+ * this code. So detection is THREE-way, not two:
+ *   - fields ABSENT (hub not deployed) → render exactly today's behavior: the
+ *     regwall percentage scorecards, no empty state. Graceful degradation.
+ *   - fields present, impressions === 0 → `no_opportunity`
+ *   - fields present, impressions > 0 but registrations === 0 → `no_conversions`
+ *     (with the impressions count as {N})
+ *   - fields present, normal data → the scorecards, each carrying its count
+ *     fallback so an individual zero card reads as "0 of N" rather than 0%.
+ *
+ * An absent field is NOT a zero: a present 0 is a real signal, a missing field
+ * is "the hub hasn't shipped." Collapsing the two would silently degrade a
+ * working production section — the exact failure this ticket exists to prevent.
  */
 
 /**
@@ -16,6 +33,7 @@ import { __ } from '@wordpress/i18n';
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
 import SectionHeading from '../components/SectionHeading';
+import EmptyMetricSection from '../components/EmptyMetricSection';
 import { scalarToMetricCardProps } from './scalarToCard';
 
 export interface FreeReaderConversionSectionProps {
@@ -23,41 +41,107 @@ export interface FreeReaderConversionSectionProps {
 	previous: GatesWindow | null;
 }
 
-const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversionSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby="newspack-insights-gates-free-heading">
-		<SectionHeading
-			id="newspack-insights-gates-free-heading"
-			title={ __( 'Free reader conversion', 'newspack-plugin' ) }
-			description={ __(
-				'How effectively registration gates convert visitors into registered readers. Direct counts registrations that happened in the same session as a registration gate impression. Influenced counts registrations that happened in a later session within 7 days of a registration gate impression.',
-				'newspack-plugin'
-			) }
-		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--pair">
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Regwall Conversion (Direct)', 'newspack-plugin' ),
-					description: __(
-						'Sessions with a registration after a registration gate impression ÷ sessions with a registration gate impression',
-						'newspack-plugin'
-					),
-					current: current.regwall_conversion_direct,
-					previous: previous?.regwall_conversion_direct,
-				} ) }
+const HEADING_ID = 'newspack-insights-gates-free-heading';
+
+const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversionSectionProps ) => {
+	const title = __( 'Free reader conversion', 'newspack-plugin' );
+	const caption = __(
+		'How effectively registration gates convert visitors into registered readers. Direct counts registrations that happened in the same session as a registration gate impression. Influenced counts registrations that happened in a later session within 7 days of a registration gate impression.',
+		'newspack-plugin'
+	);
+	const impressionsLabel = __( 'registration gate impressions', 'newspack-plugin' );
+
+	const impressions = current.registration_impressions_total;
+	const registrations = current.registrations_total;
+
+	// Field PRESENCE, not value. The hub count fields land in a separate Newspack
+	// Manager deploy that may follow this PR; until then they are absent (null) and
+	// the section must render exactly as it does today — percentages, no empty
+	// state. `typeof === 'number'` distinguishes a present 0 (a real "no
+	// impressions" signal) from an absent field (null). Keyed on impressions (the
+	// denominator / {N}), mirroring the Paid section keying off the Direct denominator.
+	const fieldsPresent = typeof impressions === 'number';
+
+	// As on the Paid side: a zero total is only a *genuine* empty state when both
+	// source scalars actually computed. If either regwall query errored we fall
+	// through to the scorecards so each card surfaces its own error treatment
+	// rather than a misleading empty state. (Direct and Influenced are separate
+	// queries and can fail independently.)
+	const dataKnown = current.regwall_conversion_direct.state !== 'error' && current.regwall_conversion_influenced_7d.state !== 'error';
+
+	// Empty states (NPPD-1702). Gated on field presence first — absent fields never
+	// reach here. Order matters: no opportunity before no conversions.
+	if ( fieldsPresent && dataKnown && impressions === 0 ) {
+		return (
+			<EmptyMetricSection
+				title={ title }
+				caption={ caption }
+				state="no_opportunity"
+				body={ __(
+					'No registration gate impressions in this timeframe. Your registration gates may not be reaching readers in this date range. See the per-gate breakdown below.',
+					'newspack-plugin'
+				) }
 			/>
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Regwall Conversion (Influenced, 7d)', 'newspack-plugin' ),
-					description: __(
-						'Readers who registered in a later session within 7 days of seeing a registration gate ÷ readers who saw a registration gate',
-						'newspack-plugin'
-					),
-					current: current.regwall_conversion_influenced_7d,
-					previous: previous?.regwall_conversion_influenced_7d,
-				} ) }
+		);
+	}
+	if ( fieldsPresent && dataKnown && registrations === 0 ) {
+		return (
+			<EmptyMetricSection
+				title={ title }
+				caption={ caption }
+				state="no_conversions"
+				signalCount={ impressions }
+				body={ __(
+					'No registrations from gates in this timeframe. Your registration gates reached {N} readers, but none completed registration within the 7-day attribution window. Worth a look at your registration prompt or value proposition. See the per-gate breakdown below.',
+					'newspack-plugin'
+				) }
 			/>
-		</div>
-	</section>
-);
+		);
+	}
+
+	return (
+		<section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby={ HEADING_ID }>
+			<SectionHeading id={ HEADING_ID } title={ title } description={ caption } />
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--pair">
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Regwall Conversion (Direct)', 'newspack-plugin' ),
+						description: __(
+							'Sessions with a registration after a registration gate impression ÷ sessions with a registration gate impression',
+							'newspack-plugin'
+						),
+						current: current.regwall_conversion_direct,
+						previous: previous?.regwall_conversion_direct,
+						// Count fallback (NPPD-1702). When the hub fields are absent the
+						// scalar's numerator/denominator are null → undefined here, and
+						// MetricCard falls through to the normal percentage render — today's
+						// behavior. When present, a zero card reads "0 of N" instead of "0%".
+						zeroFallback: {
+							numerator: current.regwall_conversion_direct.numerator ?? undefined,
+							denominator: current.regwall_conversion_direct.denominator ?? undefined,
+							attemptsLabel: impressionsLabel,
+						},
+					} ) }
+				/>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Regwall Conversion (Influenced, 7d)', 'newspack-plugin' ),
+						description: __(
+							'Readers who registered in a later session within 7 days of seeing a registration gate ÷ readers who saw a registration gate',
+							'newspack-plugin'
+						),
+						current: current.regwall_conversion_influenced_7d,
+						previous: previous?.regwall_conversion_influenced_7d,
+						zeroFallback: {
+							numerator: current.regwall_conversion_influenced_7d.numerator ?? undefined,
+							denominator: current.regwall_conversion_influenced_7d.denominator ?? undefined,
+							attemptsLabel: impressionsLabel,
+						},
+					} ) }
+				/>
+			</div>
+		</section>
+	);
+};
 
 export default FreeReaderConversionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -39,6 +39,10 @@ const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
 	avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency' } ),
 	paywall_attempts_total: 0,
 	paywall_conversions_total: 0,
+	// NPPD-1702 Free-section totals — required by the type; null (absent) here
+	// since these tests exercise the Paid section, which never reads them.
+	registration_impressions_total: null,
+	registrations_total: null,
 	conversion_funnel: { state: 'empty', stages: [] },
 	exposures_distribution: { state: 'empty', buckets: [] },
 	performance_by_gate: { state: 'empty', rows: [] },

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -1033,19 +1033,33 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	 * a `?? 0` and silently breaks a working production section.
 	 */
 	public function test_regwall_envelope_unchanged_when_hub_fields_absent() {
+		// A pre-hub-deploy response: each query returns its precomputed rate but
+		// neither count column. Both regwall scalars are produced by their real
+		// public methods (not hand-built) so the guard exercises the full path the
+		// REST controller consumes — including the Influenced method's own rate_key.
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [ [ 'regwall_conversion_rate_direct' => 0.071 ] ] );
+		$proxy->method( 'query' )->willReturnCallback(
+			static function ( string $query_name ) {
+				if ( 'gates_regwall_conversion_influenced_7d' === $query_name ) {
+					return [ [ 'regwall_conversion_influenced' => 0.123 ] ];
+				}
+				return [ [ 'regwall_conversion_rate_direct' => 0.071 ] ];
+			}
+		);
 
 		$metric     = new Gates_Metric( $proxy );
 		$direct     = $metric->get_regwall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-		$influenced = [
-			'denominator' => null,
-			'numerator'   => null,
-		];
+		$influenced = $metric->get_regwall_conversion_influenced_7d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 		$totals     = Gates_Metric::regwall_section_totals( $direct, $influenced );
 
+		// Rates compute; counts stay null on both scalars (columns absent).
+		$this->assertTrue( $direct['computable'] );
 		$this->assertNull( $direct['denominator'] );
 		$this->assertNull( $direct['numerator'] );
+		$this->assertTrue( $influenced['computable'] );
+		$this->assertNull( $influenced['denominator'] );
+		$this->assertNull( $influenced['numerator'] );
+		// Section totals degrade to null (never `?? 0`), the production-safety crux.
 		$this->assertNull( $totals['registration_impressions_total'] );
 		$this->assertNull( $totals['registrations_total'] );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -786,4 +786,267 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0, $missing['paywall_attempts_total'] );
 		$this->assertSame( 0, $missing['paywall_conversions_total'] );
 	}
+
+	// --- NPPD-1702: Free-section count fields + empty-state envelope ---------
+
+	/**
+	 * When the hub returns the new count columns, the regwall rate scalar surfaces
+	 * them as numerator (registrations) + denominator (impressions), same shape as
+	 * the Paid rate scalars — so the card can render "0 of N".
+	 *
+	 * @dataProvider provide_regwall_methods
+	 * @param string $method     Method on Gates_Metric to call.
+	 * @param string $query_name Catalog query name.
+	 * @param string $rate_key   Precomputed-rate column.
+	 */
+	public function test_regwall_surfaces_counts_when_fields_present( string $method, string $query_name, string $rate_key ) {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn(
+				[
+					[
+						$rate_key                        => 0.05,
+						'registration_impressions_total' => 200,
+						'registrations_total'            => 10,
+					],
+				]
+			);
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->$method( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 0.05, $result['value'] );
+		$this->assertSame( 200, $result['denominator'] );
+		$this->assertSame( 10, $result['numerator'] );
+	}
+
+	/**
+	 * Production-safety crux: when the hub has NOT deployed the count columns, the
+	 * regwall scalar's numerator/denominator stay null — byte-for-byte today's
+	 * envelope — so the React layer renders percentages, not an empty state. An
+	 * absent field is not a zero.
+	 *
+	 * @dataProvider provide_regwall_methods
+	 * @param string $method     Method on Gates_Metric to call.
+	 * @param string $query_name Catalog query name (unused; dispatch asserted elsewhere).
+	 * @param string $rate_key   Precomputed-rate column.
+	 */
+	public function test_regwall_counts_null_when_fields_absent( string $method, string $query_name, string $rate_key ) {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		// Only the precomputed rate column — no count columns (pre-hub-deploy).
+		$proxy->method( 'query' )->willReturn( [ [ $rate_key => 0.08 ] ] );
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->$method( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 0.08, $result['value'] );
+		$this->assertNull( $result['denominator'] );
+		$this->assertNull( $result['numerator'] );
+	}
+
+	/**
+	 * A half-populated response (one count column present, the other absent) is
+	 * treated as absent — both counts null — so a malformed envelope degrades to
+	 * percentages rather than half-rendering a count fallback.
+	 */
+	public function test_regwall_counts_null_when_only_one_field_present() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'regwall_conversion_rate_direct' => 0.05,
+					'registration_impressions_total' => 200,
+					// registrations_total absent.
+				],
+			]
+		);
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->get_regwall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertNull( $result['denominator'] );
+		$this->assertNull( $result['numerator'] );
+	}
+
+	/**
+	 * A present-but-zero impressions column is a real "no impressions" signal, NOT
+	 * absence: it surfaces as denominator 0 (the section's no_opportunity trigger),
+	 * distinct from the null-denominator degradation path.
+	 */
+	public function test_regwall_counts_present_zero_is_not_absent() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'regwall_conversion_rate_direct' => 0.0,
+					'registration_impressions_total' => 0,
+					'registrations_total'            => 0,
+				],
+			]
+		);
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->get_regwall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 0, $result['denominator'] );
+		$this->assertSame( 0, $result['numerator'] );
+	}
+
+	/**
+	 * A non-integer count column signals catalog drift and is treated as absent
+	 * (null), not truncated — the section degrades rather than trusting bad data.
+	 */
+	public function test_regwall_counts_null_on_non_integer_field() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'regwall_conversion_rate_direct' => 0.05,
+					'registration_impressions_total' => 12.5,
+					'registrations_total'            => 3,
+				],
+			]
+		);
+
+		$metric = new Gates_Metric( $proxy );
+		$result = $metric->get_regwall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertNull( $result['denominator'] );
+		$this->assertNull( $result['numerator'] );
+	}
+
+	/**
+	 * Data provider: the two regwall rate methods + their catalog dispatch.
+	 *
+	 * @return array
+	 */
+	public function provide_regwall_methods(): array {
+		return [
+			'direct'     => [ 'get_regwall_conversion_direct', 'gates_regwall_conversion_direct', 'regwall_conversion_rate_direct' ],
+			'influenced' => [ 'get_regwall_conversion_influenced_7d', 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced' ],
+		];
+	}
+
+	/**
+	 * Free section totals: impressions from the Direct denominator; registrations
+	 * the inclusive max across Direct and Influenced numerators.
+	 */
+	public function test_regwall_section_totals_normal_data() {
+		$totals = Gates_Metric::regwall_section_totals(
+			[
+				'denominator' => 14000,
+				'numerator'   => 994,
+			],
+			[
+				'denominator' => 12000,
+				'numerator'   => 1476,
+			]
+		);
+
+		$this->assertSame( 14000, $totals['registration_impressions_total'] );
+		// max( direct 994, influenced 1476 ) — don't hide Influenced-only registrations.
+		$this->assertSame( 1476, $totals['registrations_total'] );
+	}
+
+	/**
+	 * Free section totals: impressions > 0 but zero registrations in either
+	 * attribution → the section's no_conversions trigger (a present 0, not null).
+	 */
+	public function test_regwall_section_totals_zero_registrations() {
+		$totals = Gates_Metric::regwall_section_totals(
+			[
+				'denominator' => 14000,
+				'numerator'   => 0,
+			],
+			[
+				'denominator' => 12000,
+				'numerator'   => 0,
+			]
+		);
+
+		$this->assertSame( 14000, $totals['registration_impressions_total'] );
+		$this->assertSame( 0, $totals['registrations_total'] );
+	}
+
+	/**
+	 * Free section totals: a present-zero impressions count → no_opportunity. This
+	 * is a real 0, distinct from the null degradation path below.
+	 */
+	public function test_regwall_section_totals_zero_impressions() {
+		$totals = Gates_Metric::regwall_section_totals(
+			[
+				'denominator' => 0,
+				'numerator'   => 0,
+			],
+			[
+				'denominator' => 0,
+				'numerator'   => 0,
+			]
+		);
+
+		$this->assertSame( 0, $totals['registration_impressions_total'] );
+		$this->assertSame( 0, $totals['registrations_total'] );
+	}
+
+	/**
+	 * The production-safety crux at the helper level: when the regwall scalars
+	 * carry null counts (hub fields absent), the totals are null — NOT 0 — so the
+	 * React layer degrades to percentages instead of a false no_opportunity. This
+	 * is the deliberate divergence from `paywall_section_totals`, which coerces to
+	 * 0 because its denominator is always computed locally.
+	 */
+	public function test_regwall_section_totals_null_when_fields_absent() {
+		$absent = Gates_Metric::regwall_section_totals(
+			[
+				'denominator' => null,
+				'numerator'   => null,
+			],
+			[
+				'denominator' => null,
+				'numerator'   => null,
+			]
+		);
+		$this->assertNull( $absent['registration_impressions_total'] );
+		$this->assertNull( $absent['registrations_total'] );
+
+		// Missing keys entirely (e.g. a payload shape that predates the field) also
+		// degrade to null, not 0.
+		$missing = Gates_Metric::regwall_section_totals( [], [] );
+		$this->assertNull( $missing['registration_impressions_total'] );
+		$this->assertNull( $missing['registrations_total'] );
+	}
+
+	/**
+	 * End-to-end envelope guard: a fields-absent proxy response produces a regwall
+	 * scalar with null counts AND null section totals — the whole graceful-
+	 * degradation path, asserted through the public method that the REST controller
+	 * consumes. This is the test that fails loudly if a future refactor reintroduces
+	 * a `?? 0` and silently breaks a working production section.
+	 */
+	public function test_regwall_envelope_unchanged_when_hub_fields_absent() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [ [ 'regwall_conversion_rate_direct' => 0.071 ] ] );
+
+		$metric     = new Gates_Metric( $proxy );
+		$direct     = $metric->get_regwall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+		$influenced = [
+			'denominator' => null,
+			'numerator'   => null,
+		];
+		$totals     = Gates_Metric::regwall_section_totals( $direct, $influenced );
+
+		$this->assertNull( $direct['denominator'] );
+		$this->assertNull( $direct['numerator'] );
+		$this->assertNull( $totals['registration_impressions_total'] );
+		$this->assertNull( $totals['registrations_total'] );
+	}
 }


### PR DESCRIPTION
## What & why

Sibling application of the empty-state pattern that shipped for the **Paid** Gates section in [NPPD-1694](https://github.com/Automattic/newspack-workspace/pull/291), now applied to the **Free (regwall)** section. The Free side was scoped out of 1694 because the registration-impression / registration counts it needs are not returned by the hub-side BigQuery query today — that hub change is tracked in [NPPD-1744](https://linear.app/a8c/issue/NPPD-1744) (lands via hub PR [newspack-manager-admin#462](https://github.com/Automattic/newspack-manager-admin/pull/462)) and is **out of scope here**. This PR is the client-side half, written and tested against a fixture.

## ⚠️ Hub-dependent — do not deploy ahead of the hub field

**Deploy gate:** this must not ship ahead of [NPPD-1744](https://linear.app/a8c/issue/NPPD-1744), the additive hub-side change that surfaces `registration_impressions_total` / `registrations_total`. Merging #370 first is fine; *deploying* it before the columns exist is also fine (it degrades — see below), but the empty states stay dormant until the hub columns land under those exact names.

The new hub columns (`registration_impressions_total`, `registrations_total`) **do not exist in production yet**. The detection logic is deliberately **three-way, not two**:

- **Fields absent** (hub not deployed) → render exactly today's behavior: the regwall percentage scorecards, no empty state. Graceful degradation — the default until the hub ships.
- **Fields present, impressions == 0** → `no_opportunity`.
- **Fields present, impressions > 0 but registrations == 0** → `no_conversions`, `{N}` = impressions.
- **Fields present, normal data** → scorecards with per-card `zeroFallback` (`0 of N`).

An absent field is **not** a zero. Collapsing the two would silently degrade a working production section with no hub PR involved — the exact failure this ticket exists to prevent. This PR is safe to land before the hub change (stale/old envelopes simply lack the fields → degradation path).

## Changes

**PHP — envelope (`class-gates-metric.php`)**
- `compute_regwall_rate_from_proxy()` — reads the hub's precomputed rate, then reads the two new integer columns **as a pair, only when both are present and integer-valued**; absent → `numerator`/`denominator` stay `null` (byte-for-byte today's envelope). `read_optional_count()` helper distinguishes absent/null/non-integer from a real `0`.
- `regwall_section_totals()` — Free counterpart to `paywall_section_totals`, returning **`int|null`, never `?? 0`** (`null` = hub fields not deployed).

**PHP — assembly (`class-gates-rest-controller.php`)**
- `build_window()` merges `regwall_section_totals()` into the window, mirroring the paywall capture.

**TS / React**
- `gates.ts`: `registration_impressions_total` / `registrations_total: number | null` on `GatesWindow`.
- `FreeReaderConversionSection.tsx`: three-way detection in the component layer (not the orchestrator), keyed on `typeof impressions === 'number'` plus the Paid `dataKnown` error guard.

**Fixture**: new fields in populated/empty/error variants + `free_no_conversions` and `free_fields_absent` smoke variants (`?_fixture_state=…`).

## Testing

- **PHP**: 51/51 pass (11 new — fields present/absent/half-populated/present-zero/non-integer, section-totals incl. null-when-absent, and an end-to-end "envelope unchanged when hub fields absent" guard).
- **JS**: full suite 76 suites / 580 pass, including the new four-state `FreeReaderConversionSection.test.tsx`.
- PHPCS clean, ESLint clean, `tsc` clean for production code.
- The `.test.tsx` harness gap from NPPD-1683 is fixed, so the React tests run in CI.