### PR TITLE
feat(insights): Conversion Journeys config matrix + leg empty states (NPPD-1742)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -104,8 +104,23 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'reader_lifecycle_funnel'          => array_merge( $error, [ 'stages' => [] ] ),
 				// Section 2.
 				'anonymous_to_registered_funnel'   => array_merge( $error, [ 'stages' => [] ] ),
-				'registered_to_subscriber_funnel'  => array_merge( $error, [ 'stages' => [] ] ),
-				'registered_to_donor_funnel'       => array_merge( $error, [ 'stages' => [] ] ),
+				// Config-matrix legs (NPPD-1742): configured (visible); the query errored.
+				'registered_to_subscriber_funnel'  => array_merge(
+					$error,
+					[
+						'stages'            => [],
+						'visibility'        => 'visible',
+						'visibility_reason' => null,
+					] 
+				),
+				'registered_to_donor_funnel'       => array_merge(
+					$error,
+					[
+						'stages'            => [],
+						'visibility'        => 'visible',
+						'visibility_reason' => null,
+					] 
+				),
 				// 2.4 — Subscriber → Donor: local-only; stays populated (visibility-gated).
 				'subscriber_to_donor_funnel'       => [
 					'state'             => 'populated',
@@ -203,8 +218,22 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'reader_lifecycle_funnel'          => $empty_stages,
 				// Section 2.
 				'anonymous_to_registered_funnel'   => $empty_stages,
-				'registered_to_subscriber_funnel'  => $empty_stages,
-				'registered_to_donor_funnel'       => $empty_stages,
+				// Config-matrix legs (NPPD-1742): configured (visible) but no rows →
+				// the component renders the funnel-shaped no_opportunity treatment.
+				'registered_to_subscriber_funnel'  => array_merge(
+					$empty_stages,
+					[
+						'visibility'        => 'visible',
+						'visibility_reason' => null,
+					] 
+				),
+				'registered_to_donor_funnel'       => array_merge(
+					$empty_stages,
+					[
+						'visibility'        => 'visible',
+						'visibility_reason' => null,
+					] 
+				),
 				'subscriber_to_donor_funnel'       => [
 					'state'             => 'populated',
 					'stages'            => [],
@@ -513,13 +542,18 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 					'state'  => 'populated',
 					'stages' => $a2r_stages,
 				],
+				// Config-matrix legs (NPPD-1742): visible in the populated fixture.
 				'registered_to_subscriber_funnel'  => [
-					'state'  => 'populated',
-					'stages' => $r2s_stages,
+					'state'             => 'populated',
+					'stages'            => $r2s_stages,
+					'visibility'        => 'visible',
+					'visibility_reason' => null,
 				],
 				'registered_to_donor_funnel'       => [
-					'state'  => 'populated',
-					'stages' => $r2d_stages,
+					'state'             => 'populated',
+					'stages'            => $r2d_stages,
+					'visibility'        => 'visible',
+					'visibility_reason' => null,
 				],
 				'subscriber_to_donor_funnel'       => [
 					'state'             => 'populated',
@@ -573,6 +607,26 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			$deferred()
 		);
 	};
+
+	// --- Config-matrix smoke variant (NPPD-1742): registrations-only publisher. ---
+	// Both conversion-endpoint legs hidden ('not_configured'); the component omits
+	// their cells, leaving only the registration and cross-upsell cells.
+	if ( 'conversion_registrations_only' === $variant ) {
+		$current = $build( 1.0, $window );
+		foreach ( [ 'registered_to_subscriber_funnel', 'registered_to_donor_funnel' ] as $leg ) {
+			$current[ $leg ] = [
+				'state'             => 'empty',
+				'stages'            => [],
+				'visibility'        => 'hidden',
+				'visibility_reason' => 'not_configured',
+			];
+		}
+		return [
+			'tab_error' => false,
+			'current'   => $current,
+			'previous'  => null,
+		];
+	}
 
 	return [
 		'tab_error' => false,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -142,6 +142,8 @@ final class Conversion_Metric {
 	private ?bool $subscription_leg_configured = null;
 
 	/**
+	 * Donation-leg config-matrix gate memo; see $subscription_leg_configured.
+	 *
 	 * @var bool|null
 	 */
 	private ?bool $donation_leg_configured = null;

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -132,6 +132,21 @@ final class Conversion_Metric {
 	private Donors_Metric $donors_metric;
 
 	/**
+	 * Per-request memo for the subscription/donation configuration-matrix gates
+	 * (NPPD-1742). Null until first resolved; both are current-state (not
+	 * windowed), so they're computed once and reused across the current/previous
+	 * windows the controller builds.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $subscription_leg_configured = null;
+
+	/**
+	 * @var bool|null
+	 */
+	private ?bool $donation_leg_configured = null;
+
+	/**
 	 * Minimum cohort size required to show the Subscriber → Donor funnel
 	 * (active subscribers AND active donors must both meet this threshold).
 	 *
@@ -475,6 +490,69 @@ final class Conversion_Metric {
 	}
 
 	/**
+	 * Whether the subscription conversion leg should render (NPPD-1742).
+	 *
+	 * "Configured" is proxied by the presence of at least one active non-donation
+	 * subscription — there is no single Newspack-mapped subscription product to
+	 * check (unlike donations), and the Subscribers tab is likewise activity-gated.
+	 * Memoized: current-state, identical across the current/previous windows.
+	 *
+	 * @return bool
+	 */
+	private function is_subscription_leg_configured(): bool {
+		if ( null === $this->subscription_leg_configured ) {
+			$this->subscription_leg_configured = count( $this->subscribers_metric->get_active_non_donation_subscriber_customer_ids() ) > 0;
+		}
+		return $this->subscription_leg_configured;
+	}
+
+	/**
+	 * Whether the donation conversion leg should render (NPPD-1742).
+	 *
+	 * Activity-based (active donors > 0), NOT product-existence: every Newspack
+	 * site ships the canonical donation product on install, so a product check is
+	 * true everywhere. Mirrors the Donors tab's own activity-based visibility gate.
+	 * Memoized like {@see self::is_subscription_leg_configured()}.
+	 *
+	 * @return bool
+	 */
+	private function is_donation_leg_configured(): bool {
+		if ( null === $this->donation_leg_configured ) {
+			$this->donation_leg_configured = $this->donors_metric->get_active_donors() > 0;
+		}
+		return $this->donation_leg_configured;
+	}
+
+	/**
+	 * The hidden-leg payload for an unconfigured conversion stream (NPPD-1742).
+	 * `state: 'empty'` keeps the leg out of the all-error tab-banner check; the
+	 * `visibility: 'hidden'` flag is what the component reads to omit the cell.
+	 *
+	 * @return array{state: string, stages: array, visibility: string, visibility_reason: string}
+	 */
+	private function unconfigured_leg(): array {
+		return [
+			'state'             => 'empty',
+			'stages'            => [],
+			'visibility'        => 'hidden',
+			'visibility_reason' => 'not_configured',
+		];
+	}
+
+	/**
+	 * Stamp a configured (rendering) leg payload with `visibility: 'visible'`, so
+	 * every leg carries the same shape regardless of configuration (NPPD-1742).
+	 *
+	 * @param array $leg The computed funnel payload.
+	 * @return array
+	 */
+	private function with_leg_visibility( array $leg ): array {
+		$leg['visibility']        = 'visible';
+		$leg['visibility_reason'] = null;
+		return $leg;
+	}
+
+	/**
 	 * Registered → Subscriber funnel (C10 / 2.2) — three stages, non-donation
 	 * subscriptions only. Dispatches
 	 * `conversion_journey_funnel_registered_to_subscriber`; the hub returns
@@ -487,6 +565,24 @@ final class Conversion_Metric {
 	 * @return array{state: string, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
 	 */
 	public function get_registered_to_subscriber_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		// Configuration matrix (NPPD-1742): when the publisher has no active
+		// non-donation subscription product, the subscription leg is not a
+		// reader-revenue stream for them — hide the leg rather than render a zero
+		// funnel. Component omits the cell on `visibility: 'hidden'`.
+		if ( ! $this->is_subscription_leg_configured() ) {
+			return $this->unconfigured_leg();
+		}
+		return $this->with_leg_visibility( $this->compute_registered_to_subscriber_funnel( $start, $end ) );
+	}
+
+	/**
+	 * Build the Registered → Subscriber funnel payload (no visibility gating).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{state: string, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
+	 */
+	private function compute_registered_to_subscriber_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
 		$rows = $this->proxy->query( 'conversion_journey_funnel_registered_to_subscriber', $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_collection( 'stages', $rows );
@@ -546,6 +642,26 @@ final class Conversion_Metric {
 	 * @return array{state: string, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
 	 */
 	public function get_registered_to_donor_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		// Configuration matrix (NPPD-1742): hide the donation leg when the
+		// publisher has no active donors. Activity-based on purpose — every
+		// Newspack site ships the canonical donation product on install, so a
+		// product-existence check (Donation_Product_Classifier) is true
+		// everywhere and would never hide the leg. This mirrors how the Donors
+		// tab itself gates visibility on activity, not product presence.
+		if ( ! $this->is_donation_leg_configured() ) {
+			return $this->unconfigured_leg();
+		}
+		return $this->with_leg_visibility( $this->compute_registered_to_donor_funnel( $start, $end ) );
+	}
+
+	/**
+	 * Build the Registered → Donor funnel payload (no visibility gating).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{state: string, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
+	 */
+	private function compute_registered_to_donor_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
 		$rows = $this->proxy->query( 'conversion_journey_funnel_registered_to_donor', $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_collection( 'stages', $rows );

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -47,7 +47,10 @@ export type ConversionPlaceholderType = 'count' | 'rate' | 'currency' | 'decimal
  * below threshold; visible when the live cohort sizes meet the threshold.
  */
 export type ConversionVisibility = 'hidden' | 'visible';
-export type ConversionVisibilityReason = 'insufficient_data' | null;
+// 'insufficient_data' — cohort below threshold (2.4 / 4.4 cross-upsell gates).
+// 'not_configured' — the conversion stream isn't a reader-revenue product for
+// this publisher (NPPD-1742 config matrix: subscription / donation legs).
+export type ConversionVisibilityReason = 'insufficient_data' | 'not_configured' | null;
 
 /**
  * Collection metrics report all four states; scalars use
@@ -208,8 +211,11 @@ export interface ConversionWindow {
 	reader_lifecycle_funnel: ConversionFunnelData;
 	// Section 2 — Per-journey conversion funnels.
 	anonymous_to_registered_funnel: ConversionFunnelData;
-	registered_to_subscriber_funnel: ConversionFunnelData;
-	registered_to_donor_funnel: ConversionFunnelData;
+	// Subscription / donation legs carry the config-matrix visibility gate
+	// (NPPD-1742): `visibility: 'hidden'` + reason `'not_configured'` when the
+	// publisher doesn't run that reader-revenue stream.
+	registered_to_subscriber_funnel: ConversionGatedFunnelData;
+	registered_to_donor_funnel: ConversionGatedFunnelData;
 	subscriber_to_donor_funnel: ConversionGatedFunnelData;
 	// Section 3 — Where conversions come from.
 	source_mix_registrations: ConversionSourceMixData;
@@ -263,6 +269,16 @@ const queryString = ( query: ConversionQuery ): string => {
 	if ( query.compare_start && query.compare_end ) {
 		params.set( 'compare_start', query.compare_start );
 		params.set( 'compare_end', query.compare_end );
+	}
+	// Forward the `_fixture_state` URL param so fixture mode's render variants
+	// (empty / error / conversion_registrations_only) are reachable from the UI
+	// for smoke testing. A no-op in production: the server ignores it unless
+	// NEWSPACK_INSIGHTS_FIXTURE_MODE is enabled. Mirrors api/gates.ts.
+	if ( typeof window !== 'undefined' ) {
+		const fixtureState = new URLSearchParams( window.location.search ).get( '_fixture_state' );
+		if ( fixtureState ) {
+			params.set( '_fixture_state', fixtureState );
+		}
 	}
 	return params.toString();
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
@@ -108,7 +108,7 @@ describe( 'PerJourneyConversionFunnelsSection — per-leg states (NPPD-1742)', (
 		expect( screen.queryByText( /No registered readers entered the subscription journey/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'subscription good-zero / pass-through: renders the normal funnel with no empty-state note', () => {
+	it( 'subscription with conversions: renders the normal funnel with no empty-state note', () => {
 		render(
 			<PerJourneyConversionFunnelsSection
 				current={ makeConversionWindow( {
@@ -118,6 +118,22 @@ describe( 'PerJourneyConversionFunnelsSection — per-leg states (NPPD-1742)', (
 		);
 		expect( screen.queryByText( /No registered readers entered the subscription journey/ ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( /but none subscribed/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'subscription with registrations but zero prior-stage base: normal funnel, no contradictory no_conversions note', () => {
+		// Registered readers exist, but nobody reached the prior (saw-prompt) stage,
+		// so there is no conversion "opportunity" base. Must NOT render the
+		// no_conversions note (which would claim "0 saw a prompt"); the funnel's own
+		// drop-off tells the story. Guards against the priorStage===0 edge.
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					registeredToSubscriberFunnel: conversionLeg( { entry: 1000, prior: 0, conversion: 0 } ),
+				} ) }
+			/>
+		);
+		expect( screen.queryByText( /saw a subscription prompt/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /No registered readers entered the subscription journey/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'donation no_conversions: annotates the donation leg with {N} = prior-stage base', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
@@ -1,7 +1,9 @@
 /**
  * Tests for PerJourneyConversionFunnelsSection (Section 2).
  *
- * Covers section structure, 2.4 visibility gate, and state-driven rendering.
+ * Covers section structure, the 2.4 cohort visibility gate, the NPPD-1742
+ * configuration matrix (which legs render), and the funnel-shaped per-leg
+ * empty states for the subscription and donation legs.
  */
 
 /**
@@ -13,16 +15,18 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import PerJourneyConversionFunnelsSection from './PerJourneyConversionFunnelsSection';
-import { makeConversionWindow } from './fixtures';
+import { makeConversionWindow, conversionLeg } from './fixtures';
+
+const heading = ( name: string ) => screen.queryByRole( 'heading', { name } );
 
 describe( 'PerJourneyConversionFunnelsSection', () => {
 	it( 'renders the heading and all four journey funnel titles', () => {
 		render( <PerJourneyConversionFunnelsSection current={ makeConversionWindow() } /> );
 		expect( screen.getByRole( 'heading', { name: 'Per-journey conversion funnels' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'heading', { name: 'Anonymous → Registered' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'heading', { name: 'Registered → Subscriber' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'heading', { name: 'Registered → Donor' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'heading', { name: 'Subscriber → Donor (cross-upsell)' } ) ).toBeInTheDocument();
+		expect( heading( 'Anonymous → Registered' ) ).toBeInTheDocument();
+		expect( heading( 'Registered → Subscriber' ) ).toBeInTheDocument();
+		expect( heading( 'Registered → Donor' ) ).toBeInTheDocument();
+		expect( heading( 'Subscriber → Donor (cross-upsell)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the cross-upsell gated note when 2.4 visibility is hidden', () => {
@@ -33,5 +37,97 @@ describe( 'PerJourneyConversionFunnelsSection', () => {
 	it( 'shows the funnel when 2.4 visibility is visible and state is populated', () => {
 		render( <PerJourneyConversionFunnelsSection current={ makeConversionWindow( { crossUpsellVisibility: 'visible' } ) } /> );
 		expect( screen.queryByText( /Cross-upsell view appears/ ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'PerJourneyConversionFunnelsSection — configuration matrix (NPPD-1742)', () => {
+	it( 'registrations only: hides both the subscription and donation legs', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( { subscriptionVisibility: 'hidden', donationVisibility: 'hidden' } ) }
+			/>
+		);
+		expect( heading( 'Anonymous → Registered' ) ).toBeInTheDocument();
+		expect( heading( 'Registered → Subscriber' ) ).not.toBeInTheDocument();
+		expect( heading( 'Registered → Donor' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'registrations + subscriptions: shows subscription, hides donation', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( { subscriptionVisibility: 'visible', donationVisibility: 'hidden' } ) }
+			/>
+		);
+		expect( heading( 'Registered → Subscriber' ) ).toBeInTheDocument();
+		expect( heading( 'Registered → Donor' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'registrations + donations: shows donation, hides subscription', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( { subscriptionVisibility: 'hidden', donationVisibility: 'visible' } ) }
+			/>
+		);
+		expect( heading( 'Registered → Donor' ) ).toBeInTheDocument();
+		expect( heading( 'Registered → Subscriber' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'all three: shows every leg', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( { subscriptionVisibility: 'visible', donationVisibility: 'visible' } ) }
+			/>
+		);
+		expect( heading( 'Registered → Subscriber' ) ).toBeInTheDocument();
+		expect( heading( 'Registered → Donor' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'PerJourneyConversionFunnelsSection — per-leg states (NPPD-1742)', () => {
+	it( 'subscription no_opportunity: empty leg swaps the funnel for the no-opportunity note', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( { registeredToSubscriberFunnel: conversionLeg( { state: 'empty' } ) } ) }
+			/>
+		);
+		// The cell still renders (configured), with the no_opportunity copy.
+		expect( heading( 'Registered → Subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( /No registered readers entered the subscription journey in this timeframe/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'subscription no_conversions: keeps the funnel and annotates with {N} = prior-stage base', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					registeredToSubscriberFunnel: conversionLeg( { entry: 1000, prior: 400, conversion: 0 } ),
+				} ) }
+			/>
+		);
+		expect( screen.getByText( /400 registered readers saw a subscription prompt, but none subscribed/ ) ).toBeInTheDocument();
+		// Not the no_opportunity treatment — the funnel is kept.
+		expect( screen.queryByText( /No registered readers entered the subscription journey/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'subscription good-zero / pass-through: renders the normal funnel with no empty-state note', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					registeredToSubscriberFunnel: conversionLeg( { entry: 1000, prior: 400, conversion: 80 } ),
+				} ) }
+			/>
+		);
+		expect( screen.queryByText( /No registered readers entered the subscription journey/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /but none subscribed/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'donation no_conversions: annotates the donation leg with {N} = prior-stage base', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					registeredToDonorFunnel: conversionLeg( { entry: 900, prior: 250, conversion: 0 } ),
+				} ) }
+			/>
+		);
+		expect( screen.getByText( /250 registered readers saw a donation prompt, but none donated/ ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -1,14 +1,29 @@
 /**
- * PerJourneyConversionFunnelsSection (NPPD-1609, Section 2).
+ * PerJourneyConversionFunnelsSection (NPPD-1609, Section 2; empty states NPPD-1742).
  *
- * Four small funnels in a 2-column grid: anonymous → registered (2.1),
- * registered → subscriber (2.2), registered → donor (2.3), and the
- * visibility-gated subscriber → donor cross-upsell (2.4).
+ * Funnels in a grid: anonymous → registered (2.1), registered → subscriber
+ * (2.2), registered → donor (2.3), and the visibility-gated subscriber → donor
+ * cross-upsell (2.4).
  *
- * Phase 2: each funnel's rendering is gated on the metric's `state`
- * envelope (populated / empty / error / coming_soon). Section 2.4
- * also respects the `visibility` gate independently of state: when
- * `visibility === 'hidden'` the gated note is shown regardless of state.
+ * Configuration matrix (NPPD-1742): the subscription (2.2) and donation (2.3)
+ * legs are reader-revenue endpoints that only render when that stream is
+ * configured. When the server reports `visibility: 'hidden'`
+ * (`visibility_reason: 'not_configured'`) the leg's whole cell is omitted — a
+ * registrations-only publisher sees just the registration leg, never zero
+ * funnels. Within a rendered leg, the funnel-shaped empty states apply:
+ *   - zero entries (nobody entered the funnel) → swap the funnel for the
+ *     in-cell `no_opportunity` note (nothing to draw);
+ *   - entries but zero conversions → keep the funnel (the populated entry bar
+ *     collapsing to zero is the signal) and annotate with the `no_conversions`
+ *     note, `{N}` = the prior-stage base;
+ *   - otherwise → the normal funnel.
+ *
+ * The registration leg (2.1) is intentionally left as-is — its empty-state
+ * treatment needs hub-side registration counts and is tracked in NPPD-1743.
+ * Section 2.4 keeps its own cohort-size visibility gate, unchanged.
+ *
+ * Body copy here is provisional, mirroring the sibling shape; final wording is
+ * owned by the voice-and-tone audit (NPPD-1698).
  */
 
 /**
@@ -21,6 +36,8 @@ import { __ } from '@wordpress/i18n';
  */
 import type { ConversionFunnelData, ConversionGatedFunnelData, ConversionWindow } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
+import SectionEmpty from '../components/SectionEmpty';
+import { formatNumber } from '../components/format';
 import Funnel from '../components/Funnel';
 import SectionState from './SectionState';
 
@@ -77,70 +94,156 @@ const GatedFunnelCell = ( { data, emptyMessage }: GatedFunnelCellProps ) => {
 	);
 };
 
-const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFunnelsSectionProps ) => (
-	<section
-		className="newspack-insights__section newspack-insights__section--per-journey-funnels"
-		aria-labelledby="newspack-insights-conversion-per-journey-heading"
-	>
-		<SectionHeading
-			id="newspack-insights-conversion-per-journey-heading"
-			title={ __( 'Per-journey conversion funnels', 'newspack-plugin' ) }
-			description={ __(
-				'Focused conversion paths. Each funnel shows where readers drop off within a specific journey — anonymous to registered, registered to paid, paid to donor.',
-				'newspack-plugin'
-			) }
-		/>
-		<div className="newspack-insights__conversion-journey-grid">
-			<JourneyFunnel
-				title={ __( 'Anonymous → Registered', 'newspack-plugin' ) }
-				caption={ __(
-					'The free-conversion path. Combines gate and prompt impressions to make the funnel readable; per-surface breakdowns live in Tabs 4 and 5.',
+interface ConversionLegCellProps {
+	data: ConversionGatedFunnelData;
+	/** Shown for an unexpected error/empty render path. */
+	emptyMessage: string;
+	/** Shown (in-cell) when the leg is configured but nobody entered the funnel. */
+	noOpportunityMessage: string;
+	/** Annotation when entries exist but none converted; may contain `{N}`. */
+	noConversionsBody: string;
+}
+
+/** Substitute `{N}` with a formatted count; render verbatim otherwise. */
+const interpolateCount = ( body: string, count: number ): string =>
+	body.includes( '{N}' ) ? body.split( '{N}' ).join( formatNumber( count ) ) : body;
+
+/**
+ * Section 2.2 / 2.3 conversion leg (NPPD-1742). Assumes the leg is configured —
+ * the parent omits the cell entirely when `visibility === 'hidden'`. Applies the
+ * funnel-shaped empty states; otherwise renders the funnel (with the shared
+ * state treatment for error).
+ */
+const ConversionLegCell = ( { data, emptyMessage, noOpportunityMessage, noConversionsBody }: ConversionLegCellProps ) => {
+	// Defensive: the parent gates on visibility, but never render a hidden leg.
+	if ( data.visibility === 'hidden' ) {
+		return null;
+	}
+	if ( data.state === 'populated' && data.stages.length > 0 ) {
+		const entry = data.stages[ 0 ].count;
+		const conversion = data.stages[ data.stages.length - 1 ].count;
+		// Prior-stage base — the population that had the opportunity to convert.
+		const priorStage = data.stages.length >= 2 ? data.stages[ data.stages.length - 2 ].count : entry;
+		// Nobody entered → nothing to draw: no_opportunity in place of the funnel.
+		if ( entry === 0 ) {
+			return <SectionEmpty>{ noOpportunityMessage }</SectionEmpty>;
+		}
+		// Entered but none converted → keep the funnel (the drop-off is the
+		// signal) and annotate. {N} = prior-stage base.
+		if ( conversion === 0 ) {
+			return (
+				<>
+					<Funnel stages={ data.stages } />
+					<p className="newspack-insights__conversion-gated-note">{ interpolateCount( noConversionsBody, priorStage ) }</p>
+				</>
+			);
+		}
+		return <Funnel stages={ data.stages } />;
+	}
+	// A successful query with no rows is a configured-but-quiet leg: no_opportunity.
+	if ( data.state === 'empty' ) {
+		return <SectionEmpty>{ noOpportunityMessage }</SectionEmpty>;
+	}
+	// error (and any other state) → shared section-state treatment.
+	return (
+		<SectionState state={ data.state } emptyMessage={ emptyMessage }>
+			<Funnel stages={ data.stages } />
+		</SectionState>
+	);
+};
+
+const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFunnelsSectionProps ) => {
+	const subscriptionVisible = current.registered_to_subscriber_funnel.visibility !== 'hidden';
+	const donationVisible = current.registered_to_donor_funnel.visibility !== 'hidden';
+
+	return (
+		<section
+			className="newspack-insights__section newspack-insights__section--per-journey-funnels"
+			aria-labelledby="newspack-insights-conversion-per-journey-heading"
+		>
+			<SectionHeading
+				id="newspack-insights-conversion-per-journey-heading"
+				title={ __( 'Per-journey conversion funnels', 'newspack-plugin' ) }
+				description={ __(
+					'Focused conversion paths. Each funnel shows where readers drop off within a specific journey — anonymous to registered, registered to paid, paid to donor.',
 					'newspack-plugin'
 				) }
-			>
-				<StandardFunnelCell
-					data={ current.anonymous_to_registered_funnel }
-					emptyMessage={ __(
-						'No registration funnel data yet. This will populate once registrations occur in this timeframe.',
+			/>
+			<div className="newspack-insights__conversion-journey-grid">
+				<JourneyFunnel
+					title={ __( 'Anonymous → Registered', 'newspack-plugin' ) }
+					caption={ __(
+						'The free-conversion path. Combines gate and prompt impressions to make the funnel readable; per-surface breakdowns live in Tabs 4 and 5.',
 						'newspack-plugin'
 					) }
-				/>
-			</JourneyFunnel>
-			<JourneyFunnel
-				title={ __( 'Registered → Subscriber', 'newspack-plugin' ) }
-				caption={ __(
-					'The paid-upsell path. Subscription excludes donation products; donor conversions are in the next funnel.',
-					'newspack-plugin'
+				>
+					<StandardFunnelCell
+						data={ current.anonymous_to_registered_funnel }
+						emptyMessage={ __(
+							'No registration funnel data yet. This will populate once registrations occur in this timeframe.',
+							'newspack-plugin'
+						) }
+					/>
+				</JourneyFunnel>
+				{ subscriptionVisible && (
+					<JourneyFunnel
+						title={ __( 'Registered → Subscriber', 'newspack-plugin' ) }
+						caption={ __(
+							'The paid-upsell path. Subscription excludes donation products; donor conversions are in the next funnel.',
+							'newspack-plugin'
+						) }
+					>
+						<ConversionLegCell
+							data={ current.registered_to_subscriber_funnel }
+							emptyMessage={ __(
+								'No subscription funnel data yet. This will populate once subscriptions occur in this timeframe.',
+								'newspack-plugin'
+							) }
+							noOpportunityMessage={ __(
+								'No registered readers entered the subscription journey in this timeframe. Try a wider date range.',
+								'newspack-plugin'
+							) }
+							noConversionsBody={ __(
+								'No new subscribers in this timeframe. {N} registered readers saw a subscription prompt, but none subscribed — the funnel below shows where they dropped off.',
+								'newspack-plugin'
+							) }
+						/>
+					</JourneyFunnel>
 				) }
-			>
-				<StandardFunnelCell
-					data={ current.registered_to_subscriber_funnel }
-					emptyMessage={ __(
-						'No subscription funnel data yet. This will populate once subscriptions occur in this timeframe.',
-						'newspack-plugin'
-					) }
-				/>
-			</JourneyFunnel>
-			<JourneyFunnel
-				title={ __( 'Registered → Donor', 'newspack-plugin' ) }
-				caption={ __( 'The donation-conversion path.', 'newspack-plugin' ) }
-			>
-				<StandardFunnelCell
-					data={ current.registered_to_donor_funnel }
-					emptyMessage={ __( 'No donor funnel data yet. This will populate once donations occur in this timeframe.', 'newspack-plugin' ) }
-				/>
-			</JourneyFunnel>
-			<JourneyFunnel
-				title={ __( 'Subscriber → Donor (cross-upsell)', 'newspack-plugin' ) }
-				caption={ __( 'Cross-upsell visibility for publishers running both subscriptions and donations.', 'newspack-plugin' ) }
-			>
-				<GatedFunnelCell
-					data={ current.subscriber_to_donor_funnel }
-					emptyMessage={ __( 'No cross-upsell data yet. This will populate once cross-upsell conversions occur.', 'newspack-plugin' ) }
-				/>
-			</JourneyFunnel>
-		</div>
-	</section>
-);
+				{ donationVisible && (
+					<JourneyFunnel
+						title={ __( 'Registered → Donor', 'newspack-plugin' ) }
+						caption={ __( 'The donation-conversion path.', 'newspack-plugin' ) }
+					>
+						<ConversionLegCell
+							data={ current.registered_to_donor_funnel }
+							emptyMessage={ __(
+								'No donor funnel data yet. This will populate once donations occur in this timeframe.',
+								'newspack-plugin'
+							) }
+							noOpportunityMessage={ __(
+								'No registered readers entered the donation journey in this timeframe. Try a wider date range.',
+								'newspack-plugin'
+							) }
+							noConversionsBody={ __(
+								'No new donors in this timeframe. {N} registered readers saw a donation prompt, but none donated — the funnel below shows where they dropped off.',
+								'newspack-plugin'
+							) }
+						/>
+					</JourneyFunnel>
+				) }
+				<JourneyFunnel
+					title={ __( 'Subscriber → Donor (cross-upsell)', 'newspack-plugin' ) }
+					caption={ __( 'Cross-upsell visibility for publishers running both subscriptions and donations.', 'newspack-plugin' ) }
+				>
+					<GatedFunnelCell
+						data={ current.subscriber_to_donor_funnel }
+						emptyMessage={ __( 'No cross-upsell data yet. This will populate once cross-upsell conversions occur.', 'newspack-plugin' ) }
+					/>
+				</JourneyFunnel>
+			</div>
+		</section>
+	);
+};
 
 export default PerJourneyConversionFunnelsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -128,9 +128,15 @@ const ConversionLegCell = ( { data, emptyMessage, noOpportunityMessage, noConver
 		if ( entry === 0 ) {
 			return <SectionEmpty>{ noOpportunityMessage }</SectionEmpty>;
 		}
-		// Entered but none converted → keep the funnel (the drop-off is the
-		// signal) and annotate. {N} = prior-stage base.
-		if ( conversion === 0 ) {
+		// Entered, the prior stage HAS a base, but none converted out of it → keep
+		// the funnel (the drop-off is the signal) and annotate. {N} = prior-stage
+		// base. The `priorStage > 0` guard matters: a leg where readers registered
+		// but nobody reached the prior stage (e.g. no prompt shown) has no
+		// "opportunity" base, so the no_conversions copy ("{N} saw a prompt, but
+		// none converted") would be a self-contradicting "0 saw a prompt". That
+		// case falls through to the normal funnel, which honestly shows the
+		// drop-off at the prior stage.
+		if ( conversion === 0 && priorStage > 0 ) {
 			return (
 				<>
 					<Funnel stages={ data.stages } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
@@ -22,6 +22,7 @@ import type {
 	ConversionSourceMixData,
 	ConversionTopPagesTable,
 	ConversionVisibility,
+	ConversionVisibilityReason,
 	ConversionWeeklyTrendsData,
 	ConversionWindow,
 	ConversionCumulativeSingle,
@@ -49,6 +50,40 @@ const gatedFunnel = ( visibility: ConversionVisibility, state: ConversionMetricS
 	visibility,
 	visibility_reason: visibility === 'hidden' ? 'insufficient_data' : null,
 } );
+
+/**
+ * A config-matrix conversion leg (NPPD-1742) — Section 2.2 / 2.3. Builds a
+ * three-stage gated funnel with controllable entry/prior/conversion counts so
+ * tests can drive the funnel-shaped states: entry 0 → no_opportunity; entry > 0
+ * & conversion 0 → no_conversions; all > 0 → normal. `visibility: 'hidden'`
+ * models an unconfigured stream (reason `'not_configured'`).
+ */
+export const conversionLeg = (
+	opts: {
+		visibility?: ConversionVisibility;
+		state?: ConversionMetricState;
+		entry?: number;
+		prior?: number;
+		conversion?: number;
+		reason?: ConversionVisibilityReason;
+	} = {}
+): ConversionGatedFunnelData => {
+	const { visibility = 'visible', state = 'populated', entry = 1000, prior = 400, conversion = 80, reason } = opts;
+	const top = entry > 0 ? entry : 1;
+	return {
+		state,
+		stages:
+			state === 'populated'
+				? [
+						{ label: 'Registered', count: entry, pct_of_top: entry / top },
+						{ label: 'Saw a conversion-intent surface', count: prior, pct_of_top: prior / top },
+						{ label: 'Converted', count: conversion, pct_of_top: conversion / top },
+				  ]
+				: [],
+		visibility,
+		visibility_reason: reason ?? ( visibility === 'hidden' ? 'not_configured' : null ),
+	};
+};
 
 const sourceMix = ( state: ConversionMetricState = 'coming_soon' ): ConversionSourceMixData => ( {
 	state,
@@ -98,6 +133,14 @@ const topPages = ( state: ConversionMetricState = 'coming_soon' ): ConversionTop
 export interface ConversionWindowOverrides {
 	crossUpsellVisibility?: ConversionVisibility;
 	lagVisibility?: ConversionVisibility;
+	/** Config-matrix visibility for the subscription leg (2.2), NPPD-1742. */
+	subscriptionVisibility?: ConversionVisibility;
+	/** Config-matrix visibility for the donation leg (2.3), NPPD-1742. */
+	donationVisibility?: ConversionVisibility;
+	/** Full override of the subscription leg (for the funnel-shaped states). */
+	registeredToSubscriberFunnel?: ConversionGatedFunnelData;
+	/** Full override of the donation leg (for the funnel-shaped states). */
+	registeredToDonorFunnel?: ConversionGatedFunnelData;
 	/** Override the lifecycle funnel state (Section 1). */
 	lifecycleState?: ConversionMetricState;
 	/** Override the source-mix state (Section 3, all three pies). */
@@ -126,8 +169,9 @@ export const makeConversionWindow = ( overrides: ConversionWindowOverrides = {} 
 	),
 	// Section 2 — Phase A, wired.
 	anonymous_to_registered_funnel: funnel( 'populated', 'Anonymous', 'Saw a conversion surface', 'Registered' ),
-	registered_to_subscriber_funnel: funnel( 'populated', 'Registered', 'Saw a subscription-intent surface', 'Became subscriber' ),
-	registered_to_donor_funnel: funnel( 'populated', 'Registered', 'Saw a donation-intent surface', 'Became donor' ),
+	registered_to_subscriber_funnel:
+		overrides.registeredToSubscriberFunnel ?? conversionLeg( { visibility: overrides.subscriptionVisibility ?? 'visible' } ),
+	registered_to_donor_funnel: overrides.registeredToDonorFunnel ?? conversionLeg( { visibility: overrides.donationVisibility ?? 'visible' } ),
 	subscriber_to_donor_funnel: gatedFunnel( overrides.crossUpsellVisibility ?? 'hidden', 'populated', 'Active subscriber', 'Also donor' ),
 	// Section 3 — Phase A, wired.
 	source_mix_registrations: sourceMix( overrides.sourceMixState ?? 'populated' ),

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1197,6 +1197,9 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	private function subscribers_metric_returning_count( int $return ): Subscribers_Metric {
 		$mock = $this->createMock( Subscribers_Metric::class );
 		$mock->method( 'count_active_non_donation_subscribers_by_customer_ids' )->willReturn( $return );
+		// NPPD-1742: a non-empty active-subscriber set marks the subscription leg
+		// configured, so the funnel logic runs instead of returning the hidden leg.
+		$mock->method( 'get_active_non_donation_subscriber_customer_ids' )->willReturn( [ 101 ] );
 		return $mock;
 	}
 
@@ -1209,6 +1212,9 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	private function donors_metric_returning_count( int $return ): Donors_Metric {
 		$mock = $this->createMock( Donors_Metric::class );
 		$mock->method( 'count_completed_donation_order_customers_by_customer_ids' )->willReturn( $return );
+		// NPPD-1742: active donors > 0 marks the donation leg configured, so the
+		// funnel logic runs instead of returning the hidden leg.
+		$mock->method( 'get_active_donors' )->willReturn( 1 );
 		return $mock;
 	}
 
@@ -1237,14 +1243,14 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		];
 
 		$proxy = $this->proxy_returning( $rows );
-		$subs  = $this->createMock( Subscribers_Metric::class );
-		$subs->method( 'count_active_non_donation_subscribers_by_customer_ids' )->willReturn( 1 );
+		$subs  = $this->subscribers_metric_returning_count( 1 );
 
 		$metric          = new Conversion_Metric( $proxy, null, $subs );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
 		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 'visible', $result['visibility'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
 		$this->assertCount( 3, $result['stages'] );
 
@@ -1270,12 +1276,14 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C10 empty: proxy returns [] → state 'empty', empty stages.
 	 */
 	public function test_registered_to_subscriber_funnel_returns_empty_state_on_no_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), null, $this->createMock( Subscribers_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), null, $this->subscribers_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['stages'] );
+		// Configured (visible) but no rows → the component renders no_opportunity.
+		$this->assertSame( 'visible', $result['visibility'] );
 	}
 
 	/**
@@ -1283,7 +1291,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_registered_to_subscriber_funnel_returns_error_on_proxy_error() {
 		$wp_error        = new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' );
-		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), null, $this->createMock( Subscribers_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), null, $this->subscribers_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1296,7 +1304,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C10 malformed: proxy returns non-array first row → state 'error' (malformed).
 	 */
 	public function test_registered_to_subscriber_funnel_returns_error_on_malformed_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), null, $this->createMock( Subscribers_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), null, $this->subscribers_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1314,7 +1322,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			'uid'                      => 1,
 			'saw_subscription_surface' => 1,
 		];
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, $this->createMock( Subscribers_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, $this->subscribers_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1350,14 +1358,14 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		];
 
 		$proxy  = $this->proxy_returning( $rows );
-		$donors = $this->createMock( Donors_Metric::class );
-		$donors->method( 'count_completed_donation_order_customers_by_customer_ids' )->willReturn( 2 );
+		$donors = $this->donors_metric_returning_count( 2 );
 
 		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
 		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 'visible', $result['visibility'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
 		$this->assertCount( 3, $result['stages'] );
 
@@ -1382,12 +1390,13 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C11 empty: proxy returns [] → state 'empty', empty stages.
 	 */
 	public function test_registered_to_donor_funnel_returns_empty_state_on_no_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), null, null, $this->createMock( Donors_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), null, null, $this->donors_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['stages'] );
+		$this->assertSame( 'visible', $result['visibility'] );
 	}
 
 	/**
@@ -1395,7 +1404,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_registered_to_donor_funnel_returns_error_on_proxy_error() {
 		$wp_error        = new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 502' );
-		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), null, null, $this->createMock( Donors_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), null, null, $this->donors_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
@@ -1408,7 +1417,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C11 malformed: proxy returns non-array first row → state 'error' (malformed).
 	 */
 	public function test_registered_to_donor_funnel_returns_error_on_malformed_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), null, null, $this->createMock( Donors_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), null, null, $this->donors_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
@@ -1426,12 +1435,55 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			'uid'                  => 1,
 			'saw_donation_surface' => 1,
 		];
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, null, $this->createMock( Donors_Metric::class ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, null, $this->donors_metric_returning_count( 0 ) );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
 		$this->assertSame( 'error', $result['state'] );
 		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( [], $result['stages'] );
+	}
+
+	// --- NPPD-1742: configuration matrix (leg visibility) -------------------
+
+	/**
+	 * Subscription leg is hidden ('not_configured') when the publisher has no
+	 * active non-donation subscription — and no BQ query is issued for it.
+	 */
+	public function test_registered_to_subscriber_funnel_hidden_when_not_configured() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_active_non_donation_subscriber_customer_ids' )->willReturn( [] );
+
+		$metric          = new Conversion_Metric( $proxy, null, $subs );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
+
+		$this->assertSame( 'hidden', $result['visibility'] );
+		$this->assertSame( 'not_configured', $result['visibility_reason'] );
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['stages'] );
+	}
+
+	/**
+	 * Donation leg is hidden ('not_configured') when there are no active donors —
+	 * activity-based, not product-existence (every site ships a donation product).
+	 * No BQ query is issued for it.
+	 */
+	public function test_registered_to_donor_funnel_hidden_when_not_configured() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_active_donors' )->willReturn( 0 );
+
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
+
+		$this->assertSame( 'hidden', $result['visibility'] );
+		$this->assertSame( 'not_configured', $result['visibility_reason'] );
+		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['stages'] );
 	}
 


### PR DESCRIPTION
## What & why

Applies the empty-state pattern ([NPPD-1694](https://github.com/Automattic/newspack-workspace/pull/291)) to the **Conversion Journeys** tab, scoped (per [NPPD-1742](https://linear.app/a8c/issue/NPPD-1742)) to the parts with no upstream dependency: the **configuration matrix** (which legs render) and the **subscription / donation conversion legs**. The registration leg is left exactly as-is — its treatment needs hub-side registration counts and is tracked in **NPPD-1743**.

## Behavior

**Config matrix** — each conversion-endpoint leg renders only when that stream is configured:
- Subscription leg ⟺ an active non-donation subscription exists.
- Donation leg ⟺ active donors exist.
- Unconfigured → `visibility: 'hidden'` (`reason: 'not_configured'`) → the component **omits the whole cell** (registrations-only publishers see just the registration + cross-upsell cells, never zero funnels). No BQ query is issued for a hidden leg.

**Per-leg states (configured legs)** — funnel-shaped, since these are funnels not scorecards:
- Zero entries → swap the funnel for an in-cell `no_opportunity` note (nothing to draw).
- Entries but zero conversions → **keep the funnel** (the drop-off is the signal) + a `no_conversions` annotation, `{N}` = prior-stage base.
- Otherwise → the normal funnel.

## Testing

- **PHP**: `Test_Conversion_Metric` 79/79, `Test_Conversion_REST_Controller` 15/15. New: leg hidden-when-unconfigured (+ asserts no query issued), visibility stamping; existing leg tests updated for the new config-gate precondition.
- **JS**: full suite 76 suites / 588 pass, incl. the matrix (all 4 combinations) and per-leg states in `PerJourneyConversionFunnelsSection.test.tsx`.
- PHPCS + ESLint clean, `tsc` clean for the conversion files.
- **Smoke-tested** in fixture mode: default (all legs), `conversion_registrations_only` (both conversion legs omitted), and `empty` (funnel-shaped `no_opportunity` in both configured legs). The `.test.tsx` NPPD-1683 caveat applies but is fixed, so these run in CI.