### PR TITLE
feat(insights): conversion source-mix + time-to-convert distributions

### DIFF
--- a/plugins/newspack-newsletters/includes/tracking/class-utils.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-utils.php
@@ -19,18 +19,47 @@ final class Utils {
 		if ( empty( $provider ) ) {
 			return '';
 		}
-		$provider_name = $provider->service;
-		switch ( $provider_name ) {
-			case 'mailchimp':
-				return '*|EMAIL|*';
-			case 'campaign_monitor':
-				return '[email]';
-			case 'constant_contact':
-				return '[[emailAddress]]';
-			case 'active_campaign':
-				return '%EMAIL%';
-			default:
-				return '';
+		return match ( $provider->service ) {
+			'mailchimp'        => '*|EMAIL|*',
+			'campaign_monitor' => '[email]',
+			'constant_contact' => '[[emailAddress]]',
+			'active_campaign'  => '%EMAIL%',
+			default            => '',
+		};
+	}
+
+	/**
+	 * Get the ESP merge tag for an arbitrary merge field.
+	 *
+	 * The counterpart to get_email_address_tag() for any field: callers embed
+	 * the returned tag in newsletter content and the ESP substitutes the
+	 * recipient's value at send time. Used to carry a per-recipient field value
+	 * (e.g. a donor-status flag) into a link without Newspack needing to know
+	 * the recipient at render time.
+	 *
+	 * The field name is used verbatim, so callers must pass the exact ESP merge
+	 * tag (e.g. the Mailchimp merge field's tag, not its display label).
+	 *
+	 * @param string $field The ESP merge field tag.
+	 *
+	 * @return string The merge tag (e.g. '*|DONORSTATUS|*'), or '' when there is
+	 *                no provider, the field is empty, or the provider is unsupported.
+	 */
+	public static function get_merge_tag( $field ) {
+		$field = trim( (string) $field );
+		if ( '' === $field ) {
+			return '';
 		}
+		$provider = \Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return '';
+		}
+		return match ( $provider->service ) {
+			'mailchimp'        => '*|' . $field . '|*',
+			'campaign_monitor' => '[' . $field . ']',
+			'constant_contact' => '[[' . $field . ']]',
+			'active_campaign'  => '%' . $field . '%',
+			default            => '',
+		};
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-tracking-utils.php
+++ b/plugins/newspack-newsletters/tests/test-tracking-utils.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tests for the Tracking\Utils merge-tag helpers.
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack_Newsletters\Tracking\Utils;
+
+/**
+ * Tracking Utils Test.
+ */
+class Newsletters_Tracking_Utils_Test extends WP_UnitTestCase {
+	/**
+	 * Wraps a field in the active ESP's merge-tag delimiters.
+	 */
+	public function test_get_merge_tag_uses_active_provider_syntax() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$this->assertSame( '*|HUB-MEMBER|*', Utils::get_merge_tag( 'HUB-MEMBER' ) );
+
+		\Newspack_Newsletters::set_service_provider( 'active_campaign' );
+		$this->assertSame( '%HUB-MEMBER%', Utils::get_merge_tag( 'HUB-MEMBER' ) );
+
+		\Newspack_Newsletters::set_service_provider( 'constant_contact' );
+		$this->assertSame( '[[HUB-MEMBER]]', Utils::get_merge_tag( 'HUB-MEMBER' ) );
+	}
+
+	/**
+	 * An empty field name yields no tag, so callers can append unconditionally
+	 * and skip on an empty return.
+	 */
+	public function test_get_merge_tag_returns_empty_for_empty_field() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$this->assertSame( '', Utils::get_merge_tag( '' ) );
+		$this->assertSame( '', Utils::get_merge_tag( '   ' ) );
+	}
+}

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.43.2](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.1...newspack@6.43.2) (2026-06-19)
+
+
+### Bug Fixes
+
+* **audience:** gate Group labels settings behind Content_Gate feature flag ([#297](https://github.com/Automattic/newspack-workspace/issues/297)) ([cfe7901](https://github.com/Automattic/newspack-workspace/commit/cfe7901d1207d6af4352eabc563ebc2f81277fec)), closes [#148](https://github.com/Automattic/newspack-workspace/issues/148) [#newspack-engineering-public](https://github.com/Automattic/newspack-workspace/issues/newspack-engineering-public)
+
 ## newspack [6.43.1](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.0...newspack@6.43.1) (2026-06-17)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.43.3](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.2...newspack@6.43.3) (2026-06-19)
+
+
+### Bug Fixes
+
+* **woocommerce:** scope payment notice to recoverable statuses ([#301](https://github.com/Automattic/newspack-workspace/issues/301)) ([1f55c11](https://github.com/Automattic/newspack-workspace/commit/1f55c117bff9626fe5bb8ab53e2937cec2f40083))
+
 ## newspack [6.43.2](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.1...newspack@6.43.2) (2026-06-19)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [6.42.3](https://github.com/Automattic/newspack-plugin/compare/v6.42.2...v6.42.3) (2026-06-17)
+
+
+### Bug Fixes
+
+* **parse.ly:** update meta_type default ([#4724](https://github.com/Automattic/newspack-plugin/issues/4724)) ([d5f4ea9](https://github.com/Automattic/newspack-plugin/commit/d5f4ea9c082a3dd31900e97c4b5f725208a47b0b))
+
 ## [6.42.2](https://github.com/Automattic/newspack-plugin/compare/v6.42.1...v6.42.2) (2026-06-10)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [6.42.2](https://github.com/Automattic/newspack-plugin/compare/v6.42.1...v6.42.2) (2026-06-10)
+
+
+### Bug Fixes
+
+* **web-preview:** right-align toolbar close button ([589248d](https://github.com/Automattic/newspack-plugin/commit/589248d49eb2731f2551f86bf806626774698655))
+
 ## [6.42.1](https://github.com/Automattic/newspack-plugin/compare/v6.42.0...v6.42.1) (2026-06-02)
 
 

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -243,6 +243,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-teams-for-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-newspack-elections.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-yoast.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-parsely.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-primary-category.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';

--- a/plugins/newspack-plugin/includes/configuration_managers/class-parsely-configuration-manager.php
+++ b/plugins/newspack-plugin/includes/configuration_managers/class-parsely-configuration-manager.php
@@ -64,7 +64,7 @@ class Parsely_Configuration_Manager extends Configuration_Manager {
 				'track_page_types'            => [ 'page' ],
 				'disable_javascript'          => false,
 				'disable_amp'                 => false,
-				'meta_type'                   => 'json_ld',
+				'meta_type'                   => 'repeated_metas',
 				'logo'                        => '',
 				'metadata_secret'             => '',
 				'parsely_wipe_metadata_cache' => false,

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -117,6 +117,17 @@ class Content_Gate {
 	/**
 	 * Whether the first-party Newspack feature is enabled.
 	 *
+	 * Memoized per request — the underlying constant is immutable for the
+	 * lifetime of a request, and call sites (admin menu, REST registration,
+	 * wizard data, gated callbacks across Group_Subscription_*) consult this
+	 * many times per page. The cache keeps that footprint flat if the check
+	 * grows beyond a constant lookup in the future (license, remote call,
+	 * etc.).
+	 *
+	 * Tests under PHPUnit boot the plugin once and `define()` the constant
+	 * later in per-suite `setUp()` calls. To keep those defines effective,
+	 * skip the cache when `IS_TEST_ENV` is on.
+	 *
 	 * @return bool
 	 */
 	public static function is_newspack_feature_enabled() {
@@ -131,7 +142,14 @@ class Content_Gate {
 		 *
 		 * @example define( 'NEWSPACK_CONTENT_GATES', true );
 		 */
-		return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		}
+		static $enabled = null;
+		if ( null === $enabled ) {
+			$enabled = defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		}
+		return $enabled;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/class-parsely.php
+++ b/plugins/newspack-plugin/includes/plugins/class-parsely.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Parse.ly integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Parse.ly integration: migrates existing installs off the legacy `json_ld`
+ * meta_type default.
+ */
+class Parsely {
+	/**
+	 * Name of the option that records whether the meta_type migration has run.
+	 *
+	 * @var string
+	 */
+	const META_TYPE_MIGRATION_OPTION = 'newspack_parsely_meta_type_migrated';
+
+	/**
+	 * Register hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_init', [ __CLASS__, 'migrate_meta_type' ] );
+	}
+
+	/**
+	 * Migrate existing Parse.ly installs from the legacy `json_ld` meta_type
+	 * default to `repeated_metas`, which avoids conflicts with Yoast SEO's own
+	 * JSON-LD output.
+	 *
+	 * The switch is intentional and unconditional for any site still rendering
+	 * `json_ld`: because Parse.ly's own default for an absent `meta_type` is
+	 * also `json_ld`, a missing key is treated as the legacy default and
+	 * rewritten too. This means a deliberate publisher `json_ld` choice is
+	 * indistinguishable from the old default and gets switched as well — which
+	 * is desired, since the Yoast conflict applies regardless of intent.
+	 *
+	 * Runs on every `admin_init` until wp-parsely is active, then migrates the
+	 * site once and records completion. On sites that never activate Parse.ly
+	 * the migration simply stays pending (two cached option reads per request).
+	 */
+	public static function migrate_meta_type() {
+		if ( get_option( self::META_TYPE_MIGRATION_OPTION ) ) {
+			return;
+		}
+
+		if ( ! is_plugin_active( 'wp-parsely/wp-parsely.php' ) ) {
+			return;
+		}
+
+		$parsely_settings = get_option( 'parsely', [] );
+		if ( ! is_array( $parsely_settings ) ) {
+			$parsely_settings = [];
+		}
+
+		// Treat an absent key as the legacy default: wp-parsely merges its own
+		// `json_ld` default at read time, so a missing `meta_type` renders the
+		// same conflicting JSON-LD output we're migrating away from.
+		$meta_type = $parsely_settings['meta_type'] ?? 'json_ld';
+		if ( 'json_ld' === $meta_type ) {
+			$parsely_settings['meta_type'] = 'repeated_metas';
+			update_option( 'parsely', $parsely_settings );
+		}
+
+		update_option( self::META_TYPE_MIGRATION_OPTION, true );
+	}
+}
+Parsely::init();

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-api.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-api.php
@@ -266,7 +266,23 @@ class Group_Subscription_API {
 	 * @return \WP_REST_Response The response object.
 	 */
 	public static function api_update_members( $request ) {
-		$subscription_id   = $request->get_param( 'subscription_id' );
+		$subscription_id = $request->get_param( 'subscription_id' );
+		// Match the admin-post handlers: terminal-state subscriptions don't accept member changes.
+		// 409 Conflict (not 403) so every "can't write in this state" rejection across this
+		// endpoint shares one status with update_members()'s member-limit response.
+		if ( ! Group_Subscription_MyAccount::is_subscription_manageable( $subscription_id ) ) {
+			return \rest_ensure_response(
+				new \WP_Error(
+					'newspack_group_subscription_not_manageable',
+					sprintf(
+						/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+						__( 'This %s is no longer active, so its members can\'t be changed.', 'newspack-plugin' ),
+						Group_Subscription::get_label_lower( 'singular' )
+					),
+					[ 'status' => 409 ]
+				)
+			);
+		}
 		$members_to_add    = $request->get_param( 'members_to_add' );
 		$members_to_remove = $request->get_param( 'members_to_remove' );
 		$results           = Group_Subscription::update_members( $subscription_id, $members_to_add ?? [], $members_to_remove ?? [] );
@@ -282,7 +298,23 @@ class Group_Subscription_API {
 	 */
 	public static function api_invite( $request ) {
 		$subscription_id = $request->get_param( 'subscription_id' );
-		$email           = $request->get_param( 'email' );
+		// Email invitations are new invitations, so gate on active state for parity with
+		// api_generate_invite_link() and the admin-post handler (verify_active).
+		// 409 Conflict: a state-based rejection, matching the other member/invite gates.
+		if ( ! Group_Subscription_MyAccount::is_subscription_active( $subscription_id ) ) {
+			return \rest_ensure_response(
+				new \WP_Error(
+					'newspack_group_subscription_not_active',
+					sprintf(
+						/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+						__( 'This %s is not active, so new invitations can\'t be issued.', 'newspack-plugin' ),
+						Group_Subscription::get_label_lower( 'singular' )
+					),
+					[ 'status' => 409 ]
+				)
+			);
+		}
+		$email  = $request->get_param( 'email' );
 		$invite = Group_Subscription_Invite::generate_invite( $subscription_id, $email );
 		return \rest_ensure_response( $invite );
 	}
@@ -310,6 +342,22 @@ class Group_Subscription_API {
 	 */
 	public static function api_generate_invite_link( $request ) {
 		$subscription_id = $request->get_param( 'subscription_id' );
+		// Only active subscriptions can mint new invitations; otherwise a stale token could be
+		// left behind on an inactive sub for later reactivation. Deletion stays allowed for cleanup.
+		// 409 Conflict: a state-based rejection, matching the other member/invite gates.
+		if ( ! Group_Subscription_MyAccount::is_subscription_active( $subscription_id ) ) {
+			return \rest_ensure_response(
+				new \WP_Error(
+					'newspack_group_subscription_not_active',
+					sprintf(
+						/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+						__( 'This %s is not active, so new invitations can\'t be issued.', 'newspack-plugin' ),
+						Group_Subscription::get_label_lower( 'singular' )
+					),
+					[ 'status' => 409 ]
+				)
+			);
+		}
 		$result = Group_Subscription_Invite::generate_link_invite( $subscription_id, get_current_user_id() );
 		return \rest_ensure_response( $result );
 	}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -529,6 +529,19 @@ class Group_Subscription_Invite {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+		// update_members() returns an empty members_added both when the user could not be added
+		// (e.g. a non-reader account) AND when they are already a member (it skips the duplicate).
+		// Only the genuine non-add is a failure: leave the invite intact so it can be retried.
+		// An already-member is a fulfilled invite, so fall through to cancel it (it would otherwise
+		// keep counting toward the member limit).
+		// user_is_member() returns bool here (the invite always targets a group subscription, so the
+		// null "not a group subscription" case can't occur); a falsy result means "not a member".
+		if ( empty( $result['members_added'][ $user->ID ] ) && ! Group_Subscription::user_is_member( $user->ID, $subscription ) ) {
+			return new \WP_Error(
+				'newspack_group_subscription_invite_not_added',
+				__( 'Could not add this user to the group.', 'newspack-plugin' )
+			);
+		}
 
 		self::cancel_invite( $subscription, $email );
 		return true;
@@ -768,10 +781,17 @@ class Group_Subscription_Invite {
 		// Attempt to add the current user as a member.
 		$result = Group_Subscription::update_members( $subscription, [ $current_user->ID ] );
 		if ( is_wp_error( $result ) || empty( $result['members_added'][ $current_user->ID ] ) ) {
+			// update_members() returns either a WP_Error (subscription invalid, limit reached) or
+			// an array that can legitimately have an empty members_added (e.g. the current user is
+			// not a Reader Activation reader, so the per-member loop skipped them). Only WP_Error
+			// has get_error_message(); the array path needs its own message.
+			$error_message = is_wp_error( $result )
+				? $result->get_error_message()
+				: __( 'Could not add the current user to the group.', 'newspack-plugin' );
 			do_action(
 				'newspack_log',
 				'newspack_group_subscription_invite_link_failed',
-				$result->get_error_message(),
+				$error_message,
 				[
 					'type' => 'error',
 					'data' => [

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -857,6 +857,9 @@ class Group_Subscription_Settings {
 	 * Register the publisher-configurable group label settings.
 	 */
 	public static function register_label_settings() {
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return;
+		}
 		// Group name is unused (no settings_fields() form); registers sanitize_callback via update_option().
 		\register_setting(
 			'newspack_group_subscription',

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -282,7 +282,7 @@ class Group_Subscription {
 	public static function update_members( $subscription, $members_to_add, $members_to_remove = [] ) {
 		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
 		if ( ! $subscription ) {
-			return new \WP_Error( 'newspack_group_subscription_update_members', __( 'Subscription not found.', 'newspack-plugin' ) );
+			return new \WP_Error( 'newspack_group_subscription_update_members', __( 'Subscription not found.', 'newspack-plugin' ), [ 'status' => 404 ] );
 		}
 		$subscription_settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 
@@ -309,9 +309,14 @@ class Group_Subscription {
 			}
 		}
 
+		// Removals above are persisted before this limit check, so a single call that both removes
+		// and adds past the limit would keep the removals while returning 409. No shipped caller
+		// batches add + remove in one call (the admin JS and admin-post handlers split them into
+		// separate requests), so this can't happen today. If a caller ever combines both arrays,
+		// move this check ahead of the removal loop and compute the projected count there.
 		$existing_members = self::get_members( $subscription );
 		if ( $subscription_settings['limit'] > 0 && count( $existing_members ) + count( $members_to_add ) > $subscription_settings['limit'] ) {
-			return new \WP_Error( 'newspack_group_subscription_update_members', __( 'Member limit reached. Please remove some members or increase the limit.', 'newspack-plugin' ) );
+			return new \WP_Error( 'newspack_group_subscription_update_members', __( 'Member limit reached. Please remove some members or increase the limit.', 'newspack-plugin' ), [ 'status' => 409 ] );
 		}
 
 		// Add new members.

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -18,6 +18,22 @@ class WooCommerce_Update_Payment_Notice {
 	const NOTICE_INTERVAL = 60 * 60 * 24; // 24 hours.
 
 	/**
+	 * Subscription statuses for which the "needs payment" notice is actionable.
+	 * Only states where paying actually restores the subscription. Terminal
+	 * statuses (expired, cancelled, switched) and states where the reader still
+	 * has access (active, pending-cancel) are intentionally excluded. NPPM-2926.
+	 *
+	 * Closed set of core WCS statuses. A publisher's custom "recoverable but
+	 * unpaid" status would not match, so readers in it would silently miss the
+	 * notice; both callers fail closed, so the only effect is a missed nudge,
+	 * never a wrong action. Extend this constant (or add a filter) only if such
+	 * a status is found in the field.
+	 *
+	 * @var string[]
+	 */
+	const NOTICE_RECOVERABLE_STATUSES = [ 'on-hold', 'pending' ];
+
+	/**
 	 * Initialize the class.
 	 */
 	public static function init() {
@@ -137,7 +153,9 @@ class WooCommerce_Update_Payment_Notice {
 		$notices = [];
 
 		foreach ( $subscriptions as $subscription ) {
-			if ( 'cancelled' === $subscription->get_status() ) {
+			// Only nag for statuses where paying can restore the subscription (NPPM-2926);
+			// see NOTICE_RECOVERABLE_STATUSES for why terminal/has-access statuses are excluded.
+			if ( ! $subscription->has_status( self::NOTICE_RECOVERABLE_STATUSES ) ) {
 				continue;
 			}
 			if ( ! $subscription->needs_payment() ) {

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -15,8 +15,21 @@ use Newspack\Newspack_UI_Icons;
 defined( 'ABSPATH' ) || exit;
 
 \do_action( 'newspack_woocommerce_before_subscription_header', $subscription, $actions );
-$members              = Group_Subscription::get_members( $subscription );
-$managers_and_members = array_merge( Group_Subscription::get_managers( $subscription ), $members );
+// get_managers() returns ints while get_members() returns string IDs; normalize so the
+// strict in_array() and integer-keyed lookup below don't depend on PHP's key coercion.
+$members              = array_map( 'intval', Group_Subscription::get_members( $subscription ) );
+$managers             = array_map( 'intval', Group_Subscription::get_managers( $subscription ) );
+// array_unique() guards against a user appearing in both lists (e.g. the owner also carrying
+// member meta), which would otherwise render two rows for the same person.
+$managers_and_members = array_values( array_unique( array_merge( $managers, $members ) ) );
+// Batch-load every row's user once, instead of one get_user_by() per row. The non-empty
+// guard matters: get_users() with an empty 'include' would return every site user.
+$members_by_id = [];
+if ( ! empty( $managers_and_members ) ) {
+	foreach ( get_users( [ 'include' => $managers_and_members ] ) as $member_user ) {
+		$members_by_id[ $member_user->ID ] = $member_user;
+	}
+}
 $member_limit         = Group_Subscription_Settings::get_subscription_settings( $subscription )['limit'];
 $all_invites          = Group_Subscription_Invite::get_invites( $subscription );
 $pending_invites      = Group_Subscription_Invite::get_invites( $subscription, false );
@@ -124,12 +137,17 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 		<tbody>
 		<?php
 		foreach ( $managers_and_members as $user_id ) :
-			$user = get_user_by( 'id', $user_id );
+			$user = $members_by_id[ $user_id ] ?? null;
 			if ( ! $user ) {
 				continue;
 			}
-			$is_manager  = Group_Subscription::user_is_manager( $user_id, $subscription );
-			$is_owner    = $user_id === $subscription->get_user_id();
+			// Check membership against the hoisted manager list (which depends only on the
+			// subscription) instead of calling user_is_manager() per row, which would re-resolve
+			// the managers and group settings every iteration. Apply the same
+			// newspack_group_subscription_user_is_manager filter user_is_manager() applies, so the
+			// extension point is preserved.
+			$is_manager  = (bool) apply_filters( 'newspack_group_subscription_user_is_manager', in_array( $user_id, $managers, true ), $user_id, $subscription );
+			$is_owner    = $user_id === (int) $subscription->get_user_id();
 			$member_role = $is_manager ? __( 'Manager', 'newspack-plugin' ) : __( 'Member', 'newspack-plugin' );
 			if ( $is_owner ) {
 				$member_role = __( 'Owner', 'newspack-plugin' );

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php
@@ -56,13 +56,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php echo esc_attr( wcs_get_subscription_status_name( $subscription->get_status() ) ); ?>
 			</td>
 			<td class="subscription-next-payment order-date woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-next-payment woocommerce-orders-table__cell-order-date" data-title="<?php echo esc_attr_x( 'Next Payment', 'table heading', 'newspack-plugin' ); ?>">
-				<?php echo esc_attr( $subscription->get_date_to_display( 'next_payment' ) ); ?>
-				<?php if ( ! $subscription->is_manual() && $subscription->has_status( 'active' ) && $subscription->get_time( 'next_payment' ) > 0 && ! $is_group_member_subscription ) : ?>
-				<br/><small><?php echo esc_html( $subscription->get_payment_method_to_display( 'customer' ) ); ?></small>
+				<?php if ( $is_group_member_subscription ) : ?>
+					<?php // A group member has the owner's subscription injected into their list; the owner's next-payment date and total are private to the owner. ?>
+					—
+				<?php else : ?>
+					<?php echo esc_attr( $subscription->get_date_to_display( 'next_payment' ) ); ?>
+					<?php if ( ! $subscription->is_manual() && $subscription->has_status( 'active' ) && $subscription->get_time( 'next_payment' ) > 0 ) : ?>
+						<br/><small><?php echo esc_html( $subscription->get_payment_method_to_display( 'customer' ) ); ?></small>
+					<?php endif; ?>
 				<?php endif; ?>
 			</td>
 			<td class="subscription-total order-total woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-total woocommerce-orders-table__cell-order-total" data-title="<?php echo esc_attr_x( 'Total', 'Used in data attribute. Escaped', 'newspack-plugin' ); ?>">
-				<?php echo wp_kses_post( $subscription->get_formatted_order_total() ); ?>
+				<?php echo $is_group_member_subscription ? esc_html( '—' ) : wp_kses_post( $subscription->get_formatted_order_total() ); ?>
 			</td>
 			<td class="subscription-actions order-actions woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-actions woocommerce-orders-table__cell-order-actions">
 				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" class="woocommerce-button button view<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html_x( 'View', 'view a subscription', 'newspack-plugin' ); ?></a>

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
@@ -114,6 +114,8 @@ class Audience_Wizard extends Wizard {
 			'has_metering'    => Content_Gate::is_metering_enabled( Memberships::GATE_CPT ),
 		];
 
+		$data['is_newspack_feature_enabled'] = Content_Gate::is_newspack_feature_enabled();
+
 		wp_enqueue_script( 'newspack-wizards' );
 
 		wp_localize_script(
@@ -381,6 +383,9 @@ class Audience_Wizard extends Wizard {
 		);
 
 		// Group label settings (publisher-overridable singular/plural for group subscriptions).
+		// The callbacks short-circuit on Content_Gate::is_newspack_feature_enabled() so
+		// stale clients hitting the route after a flag flip get a descriptive error
+		// instead of reading or writing the option directly.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/group-labels',
@@ -1056,9 +1061,13 @@ class Audience_Wizard extends Wizard {
 	 * Get the publisher-configurable group subscription labels. Empty values fall back
 	 * to the defaults baked into Group_Subscription::get_label().
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function api_get_group_labels() {
+		$disabled = self::group_labels_feature_disabled_error();
+		if ( $disabled ) {
+			return $disabled;
+		}
 		return rest_ensure_response(
 			[
 				'label_singular'         => (string) get_option( 'newspack_group_subscription_label_singular', '' ),
@@ -1074,9 +1083,13 @@ class Audience_Wizard extends Wizard {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function api_update_group_labels( $request ) {
+		$disabled = self::group_labels_feature_disabled_error();
+		if ( $disabled ) {
+			return $disabled;
+		}
 		$params = $request->get_params();
 		foreach ( [ 'label_singular', 'label_plural' ] as $field ) {
 			if ( ! array_key_exists( $field, $params ) ) {
@@ -1090,6 +1103,23 @@ class Audience_Wizard extends Wizard {
 			}
 		}
 		return $this->api_get_group_labels();
+	}
+
+	/**
+	 * Shared guard for the /group-labels callbacks: returns a 403 WP_Error when
+	 * the Newspack Content Gate feature flag is off, or null when it's on.
+	 *
+	 * @return WP_Error|null
+	 */
+	private static function group_labels_feature_disabled_error() {
+		if ( Content_Gate::is_newspack_feature_enabled() ) {
+			return null;
+		}
+		return new WP_Error(
+			'newspack_content_gate_disabled',
+			__( 'Group subscription label settings are unavailable: the Newspack Content Gate feature is not enabled on this site.', 'newspack-plugin' ),
+			[ 'status' => 403 ]
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -267,11 +267,11 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	 * that case; otherwise each section renders its own error/empty/populated
 	 * treatment.
 	 *
-	 * Snapshot metrics (Section 5 cohorts, Sections 8.1–8.3) are
-	 * current-state and window-independent, so compute them once and share
-	 * the same payload across both windows. In comparison mode this avoids
-	 * re-running them for `previous`, where they become the tab's most
-	 * expensive Woo/BQ queries returning identical data.
+	 * Snapshot metrics (Sections 4.2–4.4 distributions, Section 5 cohorts,
+	 * Sections 8.1–8.3) are current-state and window-independent, so compute
+	 * them once and share the same payload across both windows. In comparison
+	 * mode this avoids re-running them for `previous` — identical data computed
+	 * at most once per request.
 	 *
 	 * @param Conversion_Metric      $metric        Orchestrator.
 	 * @param DateTimeImmutable      $start         Current window start.
@@ -287,11 +287,11 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 		?DateTimeImmutable $compare_start,
 		?DateTimeImmutable $compare_end
 	): array {
-		// Snapshot metrics (Section 5 cohorts, Sections 8.1–8.3) are
-		// current-state and window-independent, so compute them once and share
-		// the same payload across both windows. In comparison mode this avoids
-		// re-running them for `previous`, where (in Phase 2) they become the
-		// tab's most expensive Woo/BQ queries returning identical data.
+		// Snapshot metrics (Sections 4.2–4.4 distributions, Section 5 cohorts,
+		// Sections 8.1–8.3) are current-state and window-independent, so compute
+		// them once and share the same payload across both windows. In comparison
+		// mode this avoids re-running them for `previous` — identical data computed
+		// at most once per request.
 		$snapshot = $this->build_snapshot( $metric, $start, $end );
 
 		$current  = $this->build_window( $metric, $start, $end ) + $snapshot;
@@ -331,8 +331,8 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Window-bound payload: the 18 metrics that depend on the selected window,
-	 * plus the `window` echo. The 5 window-independent snapshot metrics are
+	 * Window-bound payload: the 15 metrics that depend on the selected window,
+	 * plus the `window` echo. The 8 window-independent snapshot metrics are
 	 * merged in by {@see self::build_response()} via {@see self::build_snapshot()}.
 	 *
 	 * @param Conversion_Metric $metric Orchestrator.
@@ -342,44 +342,41 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	 */
 	private function build_window( Conversion_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
 		return [
-			'window'                               => [
+			'window'                           => [
 				'start' => $start->format( 'Y-m-d' ),
 				'end'   => $end->format( 'Y-m-d' ),
 			],
 			// Section 1 — The reader lifecycle.
-			'reader_lifecycle_funnel'              => $metric->get_reader_lifecycle_funnel( $start, $end ),
+			'reader_lifecycle_funnel'          => $metric->get_reader_lifecycle_funnel( $start, $end ),
 			// Section 2 — Per-journey conversion funnels.
-			'anonymous_to_registered_funnel'       => $metric->get_anonymous_to_registered_funnel( $start, $end ),
-			'registered_to_subscriber_funnel'      => $metric->get_registered_to_subscriber_funnel( $start, $end ),
-			'registered_to_donor_funnel'           => $metric->get_registered_to_donor_funnel( $start, $end ),
-			'subscriber_to_donor_funnel'           => $metric->get_subscriber_to_donor_funnel( $start, $end ),
+			'anonymous_to_registered_funnel'   => $metric->get_anonymous_to_registered_funnel( $start, $end ),
+			'registered_to_subscriber_funnel'  => $metric->get_registered_to_subscriber_funnel( $start, $end ),
+			'registered_to_donor_funnel'       => $metric->get_registered_to_donor_funnel( $start, $end ),
+			'subscriber_to_donor_funnel'       => $metric->get_subscriber_to_donor_funnel( $start, $end ),
 			// Section 3 — Where conversions come from.
-			'source_mix_registrations'             => $metric->get_source_mix_registrations( $start, $end ),
-			'source_mix_subscribers'               => $metric->get_source_mix_subscribers( $start, $end ),
-			'source_mix_donors'                    => $metric->get_source_mix_donors( $start, $end ),
-			// Section 4 — How long conversions take (cumulative LineCharts).
-			'time_to_register_distribution'        => $metric->get_time_to_register_distribution( $start, $end ),
-			'time_to_subscribe_distribution'       => $metric->get_time_to_subscribe_distribution( $start, $end ),
-			'time_to_donate_distribution'          => $metric->get_time_to_donate_distribution( $start, $end ),
-			'subscriber_to_donor_lag_distribution' => $metric->get_subscriber_to_donor_lag_distribution( $start, $end ),
+			'source_mix_registrations'         => $metric->get_source_mix_registrations( $start, $end ),
+			'source_mix_subscribers'           => $metric->get_source_mix_subscribers( $start, $end ),
+			'source_mix_donors'                => $metric->get_source_mix_donors( $start, $end ),
+			// Section 4.1 — How long conversions take (windowed cumulative LineChart).
+			'time_to_register_distribution'    => $metric->get_time_to_register_distribution( $start, $end ),
 			// Section 6 — Conversion rate trends.
-			'weekly_conversion_rates'              => $metric->get_weekly_conversion_rates( $start, $end ),
+			'weekly_conversion_rates'          => $metric->get_weekly_conversion_rates( $start, $end ),
 			// Section 7 — Cross-tab influenced attribution (comparison-enabled).
-			'influenced_registration_rate_7d'      => $metric->get_influenced_registration_rate_7d( $start, $end ),
-			'influenced_subscription_rate_14d'     => $metric->get_influenced_subscription_rate_14d( $start, $end ),
-			'influenced_donation_rate_14d'         => $metric->get_influenced_donation_rate_14d( $start, $end ),
-			'influenced_newsletter_rate_7d'        => $metric->get_influenced_newsletter_rate_7d( $start, $end ),
+			'influenced_registration_rate_7d'  => $metric->get_influenced_registration_rate_7d( $start, $end ),
+			'influenced_subscription_rate_14d' => $metric->get_influenced_subscription_rate_14d( $start, $end ),
+			'influenced_donation_rate_14d'     => $metric->get_influenced_donation_rate_14d( $start, $end ),
+			'influenced_newsletter_rate_7d'    => $metric->get_influenced_newsletter_rate_7d( $start, $end ),
 			// Section 8.4 — Top pages that don't convert (windowed table).
-			'top_pages_no_conversion'              => $metric->get_top_pages_no_conversion( $start, $end ),
+			'top_pages_no_conversion'          => $metric->get_top_pages_no_conversion( $start, $end ),
 		];
 	}
 
 	/**
-	 * Window-independent snapshot metrics: Section 5 cohort retention (5.1,
-	 * 5.2) and Sections 8.1–8.3 opportunity counts. These are current-state —
-	 * the orchestrator methods accept the window for signature parity but
-	 * ignore it — so the controller computes them once and reuses the result
-	 * for both the current and comparison windows.
+	 * Window-independent snapshot metrics: Sections 4.2–4.4 distributions,
+	 * Section 5 cohort retention (5.1, 5.2), and Sections 8.1–8.3 opportunity
+	 * counts. These are current-state — the orchestrator methods accept the
+	 * window for signature parity but ignore it — so the controller computes
+	 * them once and reuses the result for both the current and comparison windows.
 	 *
 	 * @param Conversion_Metric $metric Orchestrator.
 	 * @param DateTimeImmutable $start  Current window start (passed for parity; ignored by the metrics).
@@ -388,13 +385,17 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	 */
 	private function build_snapshot( Conversion_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
 		return [
+			// Sections 4.2–4.4 — all-history distributions (snapshot: computed once, shared across windows).
+			'time_to_subscribe_distribution'       => $metric->get_time_to_subscribe_distribution( $start, $end ),
+			'time_to_donate_distribution'          => $metric->get_time_to_donate_distribution( $start, $end ),
+			'subscriber_to_donor_lag_distribution' => $metric->get_subscriber_to_donor_lag_distribution( $start, $end ),
 			// Section 5 — Cohort retention (snapshot).
-			'registration_to_conversion_cohort' => $metric->get_registration_to_conversion_cohort( $start, $end ),
-			'subscriber_retention_cohort'       => $metric->get_subscriber_retention_cohort( $start, $end ),
+			'registration_to_conversion_cohort'    => $metric->get_registration_to_conversion_cohort( $start, $end ),
+			'subscriber_retention_cohort'          => $metric->get_subscriber_retention_cohort( $start, $end ),
 			// Sections 8.1–8.3 — Opportunity buckets (snapshot counts).
-			'stale_registered_count'            => $metric->get_stale_registered_count( $start, $end ),
-			'at_risk_subscriber_count'          => $metric->get_at_risk_subscriber_count( $start, $end ),
-			'lapsed_donor_count'                => $metric->get_lapsed_donor_count( $start, $end ),
+			'stale_registered_count'               => $metric->get_stale_registered_count( $start, $end ),
+			'at_risk_subscriber_count'             => $metric->get_at_risk_subscriber_count( $start, $end ),
+			'lapsed_donor_count'                   => $metric->get_lapsed_donor_count( $start, $end ),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -38,8 +38,8 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		'end'   => $prev_end->format( 'Y-m-d' ),
 	];
 
-	// Deferred Phase-B sections — always 'coming_soon' regardless of variant.
-	// Each preserves the extra keys React reads unconditionally.
+	// Phase-B sections — 4.2/4.3/5.1/5.2 are 'coming_soon'; 4.4 is 'populated'
+	// (implemented). Each preserves the extra keys React reads unconditionally.
 	$deferred = static function () {
 		return [
 			// 4.2 — time-to-subscribe (multi-series).
@@ -52,9 +52,9 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'state'  => 'coming_soon',
 				'groups' => [],
 			],
-			// 4.4 — subscriber-to-donor lag (visibility-gated).
+			// 4.4 — subscriber-to-donor lag (visibility-gated single-series CDF).
 			'subscriber_to_donor_lag_distribution' => [
-				'state'             => 'coming_soon',
+				'state'             => 'populated',
 				'points'            => [],
 				'visibility'        => 'hidden',
 				'visibility_reason' => 'insufficient_data',

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -4,15 +4,16 @@
  *
  * Realistic mock data for UI smoke testing without a BigQuery proxy connection,
  * served by Conversion_REST_Controller when NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
+ * The implemented Phase-B snapshot sections (4.2/4.3 distributions, 4.4 lag) are
+ * 'populated' across every variant (they are all-history, window-independent); the
+ * still-deferred 5.1/5.2 cohorts report 'coming_soon' with their preserved keys.
  * The optional `_fixture_state` request param selects a render path:
- *   - 'populated' (default) — every Phase-A metric has data; deferred Phase-B
- *     sections report `state: 'coming_soon'` with their preserved extra keys.
- *   - 'empty'    — every collection reports the empty state (succeeded, no rows);
- *     scalars report non-computable zero; deferred sections stay 'coming_soon'.
+ *   - 'populated' (default) — every Phase-A metric has data.
+ *   - 'empty'    — every windowed collection reports the empty state (succeeded,
+ *     no rows); scalars report non-computable zero.
  *   - 'error'    — every BQ-backed metric reports the error state (tab banner
  *     would show if every metric were error; snapshot counts stay 'populated'
- *     as they are local-only, matching the real controller behaviour); deferred
- *     sections stay 'coming_soon'.
+ *     as they are local-only, matching the real controller behaviour).
  *
  * Returns a closure so the single required file can build any variant. Never
  * enable fixture mode in production.
@@ -38,19 +39,148 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		'end'   => $prev_end->format( 'Y-m-d' ),
 	];
 
-	// Phase-B sections — 4.2/4.3/5.1/5.2 are 'coming_soon'; 4.4 is 'populated'
-	// (implemented). Each preserves the extra keys React reads unconditionally.
+	// Phase-B sections — 4.2/4.3/4.4 are 'populated' (implemented; all-history
+	// snapshots, so identical across variants); 5.1/5.2 remain 'coming_soon'.
+	// Each preserves the extra keys React reads unconditionally.
 	$deferred = static function () {
 		return [
-			// 4.2 — time-to-subscribe (multi-series).
+			// 4.2 — time-to-subscribe (multi-series, per-source cumulative).
 			'time_to_subscribe_distribution'       => [
-				'state'  => 'coming_soon',
-				'groups' => [],
+				'state'  => 'populated',
+				'groups' => [
+					[
+						'label'  => 'gate',
+						'points' => [
+							[
+								'day'            => 0,
+								'cumulative_pct' => 0.34,
+							],
+							[
+								'day'            => 7,
+								'cumulative_pct' => 0.62,
+							],
+							[
+								'day'            => 30,
+								'cumulative_pct' => 0.89,
+							],
+							[
+								'day'            => 90,
+								'cumulative_pct' => 1.0,
+							],
+						],
+					],
+					[
+						'label'  => 'prompt',
+						'points' => [
+							[
+								'day'            => 0,
+								'cumulative_pct' => 0.19,
+							],
+							[
+								'day'            => 14,
+								'cumulative_pct' => 0.48,
+							],
+							[
+								'day'            => 60,
+								'cumulative_pct' => 0.83,
+							],
+							[
+								'day'            => 150,
+								'cumulative_pct' => 1.0,
+							],
+						],
+					],
+					[
+						'label'  => 'direct',
+						'points' => [
+							[
+								'day'            => 0,
+								'cumulative_pct' => 0.22,
+							],
+							[
+								'day'            => 21,
+								'cumulative_pct' => 0.55,
+							],
+							[
+								'day'            => 90,
+								'cumulative_pct' => 0.9,
+							],
+							[
+								'day'            => 200,
+								'cumulative_pct' => 1.0,
+							],
+						],
+					],
+				],
 			],
-			// 4.3 — time-to-donate (multi-series).
+			// 4.3 — time-to-donate (multi-series, per-source cumulative).
 			'time_to_donate_distribution'          => [
-				'state'  => 'coming_soon',
-				'groups' => [],
+				'state'  => 'populated',
+				'groups' => [
+					[
+						'label'  => 'gate',
+						'points' => [
+							[
+								'day'            => 0,
+								'cumulative_pct' => 0.41,
+							],
+							[
+								'day'            => 7,
+								'cumulative_pct' => 0.7,
+							],
+							[
+								'day'            => 30,
+								'cumulative_pct' => 0.92,
+							],
+							[
+								'day'            => 75,
+								'cumulative_pct' => 1.0,
+							],
+						],
+					],
+					[
+						'label'  => 'prompt',
+						'points' => [
+							[
+								'day'            => 0,
+								'cumulative_pct' => 0.28,
+							],
+							[
+								'day'            => 10,
+								'cumulative_pct' => 0.57,
+							],
+							[
+								'day'            => 45,
+								'cumulative_pct' => 0.86,
+							],
+							[
+								'day'            => 120,
+								'cumulative_pct' => 1.0,
+							],
+						],
+					],
+					[
+						'label'  => 'direct',
+						'points' => [
+							[
+								'day'            => 0,
+								'cumulative_pct' => 0.3,
+							],
+							[
+								'day'            => 14,
+								'cumulative_pct' => 0.6,
+							],
+							[
+								'day'            => 60,
+								'cumulative_pct' => 0.88,
+							],
+							[
+								'day'            => 180,
+								'cumulative_pct' => 1.0,
+							],
+						],
+					],
+				],
 			],
 			// 4.4 — subscriber-to-donor lag (visibility-gated single-series CDF).
 			'subscriber_to_donor_lag_distribution' => [

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -746,6 +746,129 @@ final class Conversion_Metric {
 	}
 
 	/**
+	 * Empirical CDF over a list of day-lags: one point per distinct day that has
+	 * conversions, with the running fraction of the cohort converted by that day.
+	 *
+	 * @param int[] $days_values Day lags (already truncated to the lookback).
+	 * @return array<int, array{day:int, cumulative_pct:float}>
+	 */
+	private function cumulative_distribution( array $days_values ): array {
+		$total = count( $days_values );
+		if ( 0 === $total ) {
+			return [];
+		}
+		$per_day = [];
+		foreach ( $days_values as $day ) {
+			$day             = (int) $day;
+			$per_day[ $day ] = ( $per_day[ $day ] ?? 0 ) + 1;
+		}
+		ksort( $per_day );
+		$running = 0;
+		$points  = [];
+		foreach ( $per_day as $day => $count ) {
+			$running += $count;
+			$points[] = [
+				'day'            => (int) $day,
+				'cumulative_pct' => round( $running / $total, 4 ),
+			];
+		}
+		return $points;
+	}
+
+	/**
+	 * Registration source events for the time-to-convert distributions, behind
+	 * the BQ probe gate. Window is a trailing 365 days ending now (snapshot).
+	 * Returns [ ['ts'=>int seconds, 'source'=>string], … ], or [] when the probe
+	 * reports no registrations or any BQ call fails (degrade to all-direct).
+	 *
+	 * @return array<int, array{ts:int, source:string}>
+	 */
+	private function registration_source_events(): array {
+		$utc   = new \DateTimeZone( 'UTC' );
+		$end   = new \DateTimeImmutable( 'now', $utc );
+		$start = $end->modify( '-365 days' );
+
+		$probe = $this->proxy->query( 'conversion_journey_has_registrations_in_window', $start, $end );
+		if ( is_wp_error( $probe ) || ! is_array( $probe ) || empty( $probe[0] ) || ! is_array( $probe[0] ) ) {
+			return [];
+		}
+		$first_row = $probe[0];
+		$count     = (int) reset( $first_row ); // Single COUNT column; read defensively regardless of alias.
+		if ( $count <= 0 ) {
+			return [];
+		}
+
+		$reg = $this->proxy->query( 'conversion_journey_registrations_with_source', $start, $end );
+		if ( is_wp_error( $reg ) || ! is_array( $reg ) ) {
+			return [];
+		}
+		$events = [];
+		foreach ( $reg as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$events[] = [
+				'ts'     => intdiv( (int) ( $row['reg_ts'] ?? 0 ), 1000000 ),
+				'source' => (string) ( $row['source'] ?? Source_Matcher::SOURCE_DIRECT ),
+			];
+		}
+		return $events;
+	}
+
+	/**
+	 * Build a multi-series time-to-convert distribution. Lag = first_ts −
+	 * registered_ts in whole days, kept to [0,365]. Each reader's source comes
+	 * from matching their user_registered to a BQ registration event within
+	 * ±WINDOW_REGISTRATION_SECONDS; unmatched → direct. Always emits the three
+	 * source groups (zero-filled when empty).
+	 *
+	 * @param array<int, array<string,int>> $rows         Conversion-lag rows.
+	 * @param string                        $first_ts_key Row key for the first-conversion epoch.
+	 * @return array{state:string, groups:array}
+	 */
+	private function build_time_to_convert_distribution( array $rows, string $first_ts_key ): array {
+		$events          = $this->registration_source_events();
+		$records         = [];
+		$lag_by_customer = [];
+		foreach ( $rows as $row ) {
+			$lag = intdiv( (int) $row[ $first_ts_key ] - (int) $row['registered_ts'], 86400 );
+			if ( $lag < 0 || $lag > 365 ) {
+				continue;
+			}
+			$cid                     = (int) $row['customer_id'];
+			$records[]               = [
+				'key' => $cid,
+				'ts'  => (int) $row['registered_ts'],
+			];
+			$lag_by_customer[ $cid ] = $lag;
+		}
+
+		$map         = Source_Matcher::attach_sources( $records, $events, Source_Matcher::WINDOW_REGISTRATION_SECONDS, Source_Matcher::WINDOW_REGISTRATION_SECONDS );
+		$days_by_src = [
+			'gate'   => [],
+			'prompt' => [],
+			'direct' => [],
+		];
+		foreach ( $lag_by_customer as $cid => $lag ) {
+			$source                   = $map[ $cid ] ?? Source_Matcher::SOURCE_DIRECT;
+			$days_by_src[ $source ][] = $lag;
+		}
+
+		$groups = [];
+		foreach ( self::SOURCES as $source ) {
+			$groups[] = [
+				'label'  => $source,
+				'points' => $this->cumulative_distribution( $days_by_src[ $source ] ),
+			];
+		}
+
+		return [
+			'state'  => empty( $lag_by_customer ) ? 'empty' : 'populated',
+			'groups' => $groups,
+		];
+	}
+
+	/**
 	 * Source-mix via the Woo identity spine. The BQ query supplies exposure
 	 * events (attempt_ts in microseconds + gate/popup params); each Woo
 	 * conversion record is matched to the nearest preceding event within
@@ -892,32 +1015,36 @@ final class Conversion_Metric {
 	}
 
 	/**
-	 * Time-to-subscribe cumulative distribution (4.2) — three series by
-	 * source (gate / prompt / direct).
+	 * Time-to-subscribe cumulative distribution (4.2) — three series by source.
+	 * Snapshot: ignores the window (all-history). May become windowed later
+	 * (e.g. holiday-season period comparison).
 	 *
-	 * Phase B `coming_soon` placeholder. Not yet wired to BigQuery.
-	 *
-	 * @param DateTimeInterface $start Window start.
-	 * @param DateTimeInterface $end   Window end.
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
 	 * @return array{state: string, groups: array}
 	 */
 	public function get_time_to_subscribe_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->coming_soon_collection( 'groups' );
+		return $this->build_time_to_convert_distribution(
+			$this->subscribers_metric->get_subscription_conversion_lags(),
+			'first_sub_ts'
+		);
 	}
 
 	/**
 	 * Time-to-donate cumulative distribution (4.3) — three series by source.
+	 * Snapshot: ignores the window (all-history). May become windowed later.
 	 *
-	 * Phase B `coming_soon` placeholder. Not yet wired to BigQuery.
-	 *
-	 * @param DateTimeInterface $start Window start.
-	 * @param DateTimeInterface $end   Window end.
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
 	 * @return array{state: string, groups: array}
 	 */
 	public function get_time_to_donate_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return $this->coming_soon_collection( 'groups' );
+		return $this->build_time_to_convert_distribution(
+			$this->donors_metric->get_donation_conversion_lags(),
+			'first_donation_ts'
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -54,6 +54,7 @@ defined( 'ABSPATH' ) || exit;
 use DateTimeInterface;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Donors_Metric;
+use Newspack\Insights\Source_Matcher;
 use Newspack\Insights\Subscribers_Metric;
 use Newspack\Insights\Woo_Order_Resolver;
 
@@ -699,59 +700,70 @@ final class Conversion_Metric {
 	/**
 	 * Source mix for new subscribers (C12 / 3.2) — gate / prompt / direct.
 	 *
-	 * Fetches `conversion_journey_source_mix_subscribers` checkout-attempt rows
-	 * from the hub, buckets them by source (gate if `gate_post_id` is non-empty;
-	 * else prompt if `popup_id` non-empty; else direct), and Woo-joins each
-	 * non-empty bucket via {@see Woo_Order_Resolver::count_completed_orders()} to
-	 * get the actual subscriber count attributable to that surface. The
-	 * `fetch_paid_attempts_woo_join` memoized cache is shared with C14
-	 * (influenced subscription rate), which reads the same rows for its
-	 * denominator.
+	 * Fetches Woo conversion records via Subscribers_Metric and BQ exposure
+	 * events via the proxy, then delegates to compute_source_mix to attribute
+	 * each record to a source via Source_Matcher timestamp proximity.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array{state: string, total: int, slices: array<int, array{source: string, count: int, pct: float}>}
 	 */
 	public function get_source_mix_subscribers( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_source_mix( 'conversion_journey_source_mix_subscribers', $start, $end );
+		$records = $this->subscribers_metric->get_new_subscriber_records_in_window( $start, $end );
+		return $this->compute_source_mix( 'conversion_journey_source_mix_subscribers', $records, $start, $end );
 	}
 
 	/**
 	 * Source mix for new donors (C13 / 3.3) — gate / prompt / direct.
 	 *
-	 * Identical logic to C12 using the `conversion_journey_source_mix_donors`
-	 * query. The memoized cache is shared with C15 (influenced donation rate),
-	 * which reads the same rows for its denominator.
+	 * Fetches Woo conversion records via Donors_Metric and BQ exposure events
+	 * via the proxy, then delegates to compute_source_mix to attribute each
+	 * record to a source via Source_Matcher timestamp proximity.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array{state: string, total: int, slices: array<int, array{source: string, count: int, pct: float}>}
 	 */
 	public function get_source_mix_donors( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_source_mix( 'conversion_journey_source_mix_donors', $start, $end );
+		$records = $this->donors_metric->get_new_donor_records_in_window( $start, $end );
+		return $this->compute_source_mix( 'conversion_journey_source_mix_donors', $records, $start, $end );
 	}
 
 	/**
-	 * Shared source-mix computation for C12 and C13.
+	 * Classify a BQ source-mix row to gate / prompt / direct.
 	 *
-	 * Fetches attempt rows via `fetch_paid_attempts_woo_join` (memoized), buckets
-	 * by source (gate → prompt → direct), Woo-joins each bucket independently,
-	 * and builds the { state, total, slices } collection.
+	 * @param array<string,mixed> $row BQ row.
+	 * @return string One of self::SOURCES.
+	 */
+	private function classify_source( array $row ): string {
+		if ( ! empty( $row['gate_post_id'] ) ) {
+			return 'gate';
+		}
+		if ( ! empty( $row['popup_id'] ) ) {
+			return 'prompt';
+		}
+		return Source_Matcher::SOURCE_DIRECT;
+	}
+
+	/**
+	 * Source-mix via the Woo identity spine. The BQ query supplies exposure
+	 * events (attempt_ts in microseconds + gate/popup params); each Woo
+	 * conversion record is matched to the nearest preceding event within
+	 * Source_Matcher::WINDOW_ORDER_SECONDS, unmatched → direct.
 	 *
-	 * @param string            $query_name Hub catalog query name.
-	 * @param DateTimeInterface $start      Window start.
-	 * @param DateTimeInterface $end        Window end.
+	 * @param string                                     $query_name Hub catalog query name.
+	 * @param array<int, array{customer_id:int, ts:int}> $records    Woo conversion records.
+	 * @param DateTimeInterface                          $start      Window start.
+	 * @param DateTimeInterface                          $end        Window end.
 	 * @return array
 	 */
-	private function compute_source_mix( string $query_name, DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paid_attempts_woo_join( $query_name, $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_collection( 'slices', $joined );
+	private function compute_source_mix( string $query_name, array $records, DateTimeInterface $start, DateTimeInterface $end ): array {
+		$bq = $this->proxy->query( $query_name, $start, $end );
+		if ( is_wp_error( $bq ) ) {
+			return $this->error_collection( 'slices', $bq );
 		}
 
-		$rows = $joined['rows'];
-
-		if ( empty( $rows ) ) {
+		if ( empty( $records ) ) {
 			return [
 				'state'  => 'empty',
 				'total'  => 0,
@@ -759,43 +771,33 @@ final class Conversion_Metric {
 			];
 		}
 
-		// Bucket rows by source. Each row's source is classified:
-		// gate   — gate_post_id is non-empty.
-		// prompt — gate_post_id is empty but popup_id is non-empty.
-		// direct — both are empty.
-		$buckets = [
-			'gate'   => [],
-			'prompt' => [],
-			'direct' => [],
-		];
-		foreach ( $rows as $row ) {
+		$events = [];
+		foreach ( (array) $bq as $row ) {
 			if ( ! is_array( $row ) ) {
-				return $this->malformed_collection( 'slices' );
+				continue;
 			}
-			if ( ! empty( $row['gate_post_id'] ) ) {
-				$buckets['gate'][] = $row;
-			} elseif ( ! empty( $row['popup_id'] ) ) {
-				$buckets['prompt'][] = $row;
-			} else {
-				$buckets['direct'][] = $row;
-			}
+			$events[] = [
+				'ts'     => intdiv( (int) ( $row['attempt_ts'] ?? 0 ), 1000000 ),
+				'source' => $this->classify_source( $row ),
+			];
 		}
 
-		// For each non-empty bucket, Woo-join to get the completed-order count.
-		$counts = [];
-		$total  = 0;
-		foreach ( self::SOURCES as $source ) {
-			$count          = empty( $buckets[ $source ] )
-				? 0
-				: $this->woo_resolver->count_completed_orders( $buckets[ $source ] );
-			$counts[ $source ] = $count;
-			$total            += $count;
+		$match_input = [];
+		foreach ( $records as $record ) {
+			$match_input[] = [
+				'key' => (int) $record['customer_id'],
+				'ts'  => (int) $record['ts'],
+			];
 		}
 
+		$map    = Source_Matcher::attach_sources( $match_input, $events, Source_Matcher::WINDOW_ORDER_SECONDS, 0 );
+		$counts = Source_Matcher::count_by_source( $map );
+		$total  = array_sum( $counts );
 		$safe   = $total > 0 ? $total : 1;
+
 		$slices = [];
 		foreach ( self::SOURCES as $source ) {
-			$count    = $counts[ $source ];
+			$count    = (int) ( $counts[ $source ] ?? 0 );
 			$slices[] = [
 				'source' => $source,
 				'count'  => $count,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -117,6 +117,16 @@ final class Conversion_Metric {
 	private array $paid_attempt_cache = [];
 
 	/**
+	 * Per-request memo for registration_source_events() BQ round-trip.
+	 *
+	 * Computed once on first call; subsequent calls within the same request
+	 * return the cached result. Nullable so null = not-yet-fetched.
+	 *
+	 * @var array<int, array{ts:int, source:string}>|null
+	 */
+	private ?array $registration_source_events_cache = null;
+
+	/**
 	 * Subscribers_Metric collaborator for Section 8 opportunity counts and
 	 * the Registered → Subscriber / Subscriber → Donor funnels.
 	 *
@@ -784,23 +794,29 @@ final class Conversion_Metric {
 	 * @return array<int, array{ts:int, source:string}>
 	 */
 	private function registration_source_events(): array {
+		if ( null !== $this->registration_source_events_cache ) {
+			return $this->registration_source_events_cache;
+		}
 		$utc   = new \DateTimeZone( 'UTC' );
 		$end   = new \DateTimeImmutable( 'now', $utc );
 		$start = $end->modify( '-365 days' );
 
 		$probe = $this->proxy->query( 'conversion_journey_has_registrations_in_window', $start, $end );
 		if ( is_wp_error( $probe ) || ! is_array( $probe ) || empty( $probe[0] ) || ! is_array( $probe[0] ) ) {
-			return [];
+			$this->registration_source_events_cache = [];
+			return $this->registration_source_events_cache;
 		}
 		$first_row = $probe[0];
 		$count     = (int) reset( $first_row ); // Single COUNT column; read defensively regardless of alias.
 		if ( $count <= 0 ) {
-			return [];
+			$this->registration_source_events_cache = [];
+			return $this->registration_source_events_cache;
 		}
 
 		$reg = $this->proxy->query( 'conversion_journey_registrations_with_source', $start, $end );
 		if ( is_wp_error( $reg ) || ! is_array( $reg ) ) {
-			return [];
+			$this->registration_source_events_cache = [];
+			return $this->registration_source_events_cache;
 		}
 		$events = [];
 		foreach ( $reg as $row ) {
@@ -812,7 +828,8 @@ final class Conversion_Metric {
 				'source' => (string) ( $row['source'] ?? Source_Matcher::SOURCE_DIRECT ),
 			];
 		}
-		return $events;
+		$this->registration_source_events_cache = $events;
+		return $this->registration_source_events_cache;
 	}
 
 	/**
@@ -827,10 +844,19 @@ final class Conversion_Metric {
 	 * @return array{state:string, groups:array}
 	 */
 	private function build_time_to_convert_distribution( array $rows, string $first_ts_key ): array {
-		$events          = $this->registration_source_events();
+		$events = $this->registration_source_events();
+		// Bound the cohort to the same trailing-365-day window that
+		// registration_source_events() covers. Converters who registered
+		// more than 365 days ago would be silently attributed 'direct'
+		// (their registration event fell outside the BQ window), biasing
+		// older cohorts. Filtering them out keeps source attribution honest.
+		$reg_cutoff      = ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->modify( '-365 days' )->getTimestamp();
 		$records         = [];
 		$lag_by_customer = [];
 		foreach ( $rows as $row ) {
+			if ( (int) $row['registered_ts'] < $reg_cutoff ) {
+				continue;
+			}
 			$lag = intdiv( (int) $row[ $first_ts_key ] - (int) $row['registered_ts'], 86400 );
 			if ( $lag < 0 || $lag > 365 ) {
 				continue;
@@ -843,6 +869,10 @@ final class Conversion_Metric {
 			$lag_by_customer[ $cid ] = $lag;
 		}
 
+		// Greedy single-consume nearest-match: on a busy site, two readers registering
+		// within WINDOW_REGISTRATION_SECONDS of each other can have their sources swapped
+		// (each consumes the event nearest to them, but which event is "nearest" is
+		// order-sensitive). This is an accepted accuracy nuance, not a bug.
 		$map         = Source_Matcher::attach_sources( $records, $events, Source_Matcher::WINDOW_REGISTRATION_SECONDS, Source_Matcher::WINDOW_REGISTRATION_SECONDS );
 		$days_by_src = [
 			'gate'   => [],
@@ -893,7 +923,15 @@ final class Conversion_Metric {
 			];
 		}
 
-		$bq = $this->proxy->query( $query_name, $start, $end );
+		// Widen the event fetch by one day before $start so that a conversion
+		// occurring just after midnight on the window's first day can still be
+		// matched to an exposure event that occurred just before midnight the
+		// preceding night. Source_Matcher::WINDOW_ORDER_SECONDS (1800 s) allows
+		// lookback up to 30 min before the conversion; a day-granular date
+		// boundary can cut off valid events without this guard.
+		// createFromInterface() produces a DateTimeImmutable so modify() returns a new instance.
+		$events_start = \DateTimeImmutable::createFromInterface( $start )->modify( '-1 day' );
+		$bq           = $this->proxy->query( $query_name, $events_start, $end );
 		if ( is_wp_error( $bq ) ) {
 			return $this->error_collection( 'slices', $bq );
 		}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -899,10 +899,18 @@ final class Conversion_Metric {
 	}
 
 	/**
-	 * Source-mix via the Woo identity spine. The BQ query supplies exposure
-	 * events (attempt_ts in microseconds + gate/popup params); each Woo
-	 * conversion record is matched to the nearest preceding event within
-	 * Source_Matcher::WINDOW_ORDER_SECONDS, unmatched → direct.
+	 * Source-mix via the Woo identity spine. For records that carry order-meta
+	 * source signals (gate_post_id / popup_id from the donor storage layer),
+	 * classification is done directly from the meta — gate wins over prompt wins
+	 * over "no meta". Records without order-meta (all subscriber records, and
+	 * donor records with no meta on the first-donation order) fall through to
+	 * the BQ temporal matcher.
+	 *
+	 * BQ round-trip cost: the proxy query is only issued when ≥1 record lacks
+	 * order-meta. If every donor record was classified via order meta the BQ
+	 * call is skipped entirely, making 3.3 hub-independent for those donations.
+	 * Subscriber records (3.2) never carry gate_post_id / popup_id so they
+	 * always go through the matcher — unchanged behaviour.
 	 *
 	 * @param string                                     $query_name Hub catalog query name.
 	 * @param array<int, array{customer_id:int, ts:int}> $records    Woo conversion records.
@@ -923,6 +931,54 @@ final class Conversion_Metric {
 			];
 		}
 
+		// Pass 1: order-meta classification (donor records only).
+		// Subscriber records carry no gate_post_id / popup_id keys so they always
+		// fall to the matcher below — behaviour is unchanged for 3.2.
+		$meta_counts    = [
+			'gate'   => 0,
+			'prompt' => 0,
+			'direct' => 0,
+		];
+		$matcher_records = []; // Records without usable order-meta → to BQ matcher.
+
+		foreach ( $records as $record ) {
+			// array_key_exists differentiates "key present but empty-string" from
+			// "key absent" (subscriber records). Both '' and '0' count as "no meta"
+			// since the SQL already guards NOT IN ('','0').
+			$has_gate  = array_key_exists( 'gate_post_id', $record ) && '' !== (string) $record['gate_post_id'];
+			$has_popup = array_key_exists( 'popup_id', $record ) && '' !== (string) $record['popup_id'];
+
+			if ( $has_gate ) {
+				++$meta_counts['gate'];
+			} elseif ( $has_popup ) {
+				++$meta_counts['prompt'];
+			} else {
+				// No order-meta (or subscriber record with no meta keys): fall to matcher.
+				$matcher_records[] = $record;
+			}
+		}
+
+		// If every record was classified via order meta, skip the BQ round-trip.
+		if ( empty( $matcher_records ) ) {
+			$total  = array_sum( $meta_counts );
+			$safe   = $total > 0 ? $total : 1;
+			$slices = [];
+			foreach ( self::SOURCES as $source ) {
+				$count    = (int) ( $meta_counts[ $source ] ?? 0 );
+				$slices[] = [
+					'source' => $source,
+					'count'  => $count,
+					'pct'    => (float) ( $count / $safe ),
+				];
+			}
+			return [
+				'state'  => 'populated',
+				'total'  => $total,
+				'slices' => $slices,
+			];
+		}
+
+		// Pass 2: BQ temporal matcher for the remaining records.
 		// Widen the event fetch by one day before $start so that a conversion
 		// occurring just after midnight on the window's first day can still be
 		// matched to an exposure event that occurred just before midnight the
@@ -954,17 +1010,25 @@ final class Conversion_Metric {
 		}
 
 		$match_input = [];
-		foreach ( $records as $record ) {
+		foreach ( $matcher_records as $record ) {
 			$match_input[] = [
 				'key' => (int) $record['customer_id'],
 				'ts'  => (int) $record['ts'],
 			];
 		}
 
-		$map    = Source_Matcher::attach_sources( $match_input, $events, Source_Matcher::WINDOW_ORDER_SECONDS, 0 );
-		$counts = Source_Matcher::count_by_source( $map );
-		$total  = array_sum( $counts );
-		$safe   = $total > 0 ? $total : 1;
+		$map            = Source_Matcher::attach_sources( $match_input, $events, Source_Matcher::WINDOW_ORDER_SECONDS, 0 );
+		$matcher_counts = Source_Matcher::count_by_source( $map );
+
+		// Merge order-meta counts with BQ matcher counts.
+		$counts = [
+			'gate'   => $meta_counts['gate'] + (int) ( $matcher_counts['gate'] ?? 0 ),
+			'prompt' => $meta_counts['prompt'] + (int) ( $matcher_counts['prompt'] ?? 0 ),
+			'direct' => $meta_counts['direct'] + (int) ( $matcher_counts['direct'] ?? 0 ),
+		];
+
+		$total = array_sum( $counts );
+		$safe  = $total > 0 ? $total : 1;
 
 		$slices = [];
 		foreach ( self::SOURCES as $source ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -882,6 +882,7 @@ final class Conversion_Metric {
 	 */
 	private function compute_source_mix( string $query_name, array $records, DateTimeInterface $start, DateTimeInterface $end ): array {
 		$bq = $this->proxy->query( $query_name, $start, $end );
+		// Precedence intentional: a genuine proxy error must surface as the 'error' envelope, not be masked as 'empty'.
 		if ( is_wp_error( $bq ) ) {
 			return $this->error_collection( 'slices', $bq );
 		}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1049,25 +1049,40 @@ final class Conversion_Metric {
 
 	/**
 	 * Subscriber → donor lag cumulative distribution (4.4) — single series,
-	 * visibility-gated.
+	 * visibility-gated at self::MIN_COHORT_FOR_SUB_TO_DONOR cross-converters.
+	 * Pure Woo. Snapshot: ignores the window (all-history). May become windowed
+	 * later.
 	 *
-	 * Local-only (Woo-only): does NOT belong in the BQ catalog. Gated at 50
-	 * cross-converters. Phase B `coming_soon` placeholder; preserves the
-	 * `visibility` / `visibility_reason` keys React reads unconditionally.
-	 *
-	 * @param DateTimeInterface $start Window start.
-	 * @param DateTimeInterface $end   Window end.
+	 * @param DateTimeInterface $start Window start (ignored — snapshot).
+	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
 	 * @return array{state: string, points: array, visibility: string, visibility_reason: string|null}
 	 */
 	public function get_subscriber_to_donor_lag_distribution( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
-		return array_merge(
-			$this->coming_soon_collection( 'points' ),
-			[
+		$days = [];
+		foreach ( $this->donors_metric->get_subscriber_to_donor_lags() as $row ) {
+			$lag = (int) $row['lag_days'];
+			if ( $lag < 0 || $lag > 365 ) {
+				continue;
+			}
+			$days[] = $lag;
+		}
+
+		if ( count( $days ) < self::MIN_COHORT_FOR_SUB_TO_DONOR ) {
+			return [
+				'state'             => 'populated',
+				'points'            => [],
 				'visibility'        => 'hidden',
 				'visibility_reason' => 'insufficient_data',
-			]
-		);
+			];
+		}
+
+		return [
+			'state'             => 'populated',
+			'points'            => $this->cumulative_distribution( $days ),
+			'visibility'        => 'visible',
+			'visibility_reason' => null,
+		];
 	}
 
 	// --- Section 5: Cohort retention ------------------------------------

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -881,12 +881,10 @@ final class Conversion_Metric {
 	 * @return array
 	 */
 	private function compute_source_mix( string $query_name, array $records, DateTimeInterface $start, DateTimeInterface $end ): array {
-		$bq = $this->proxy->query( $query_name, $start, $end );
-		// Precedence intentional: a genuine proxy error must surface as the 'error' envelope, not be masked as 'empty'.
-		if ( is_wp_error( $bq ) ) {
-			return $this->error_collection( 'slices', $bq );
-		}
-
+		// No conversions in the window → the metric is 'empty' regardless of the
+		// source layer, so skip the BQ round-trip entirely. BigQuery only attributes
+		// a source to conversions that already exist in Woo; with none there is
+		// nothing to attribute, and a proxy error here would be a false 'error'.
 		if ( empty( $records ) ) {
 			return [
 				'state'  => 'empty',
@@ -895,10 +893,21 @@ final class Conversion_Metric {
 			];
 		}
 
+		$bq = $this->proxy->query( $query_name, $start, $end );
+		if ( is_wp_error( $bq ) ) {
+			return $this->error_collection( 'slices', $bq );
+		}
+		// A non-array success body, or any non-array row, is a malformed response
+		// (consistent with the other BQ-backed metrics) — surface 'error' rather
+		// than silently degrading to all-direct.
+		if ( ! is_array( $bq ) ) {
+			return $this->malformed_collection( 'slices' );
+		}
+
 		$events = [];
-		foreach ( (array) $bq as $row ) {
+		foreach ( $bq as $row ) {
 			if ( ! is_array( $row ) ) {
-				continue;
+				return $this->malformed_collection( 'slices' );
 			}
 			$events[] = [
 				'ts'     => intdiv( (int) ( $row['attempt_ts'] ?? 0 ), 1000000 ),

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -418,6 +418,18 @@ class Donors_Metric {
 	}
 
 	/**
+	 * New donor records (customer_id + first-donation epoch ts) in the window,
+	 * for Source_Matcher anchoring. List-param — NOT cached.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return $this->storage->get_new_donor_records_in_window( $start, $end );
+	}
+
+	/**
 	 * Flush all Tab 7 metric caches. Hook point for NPPD-1605.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -418,12 +418,13 @@ class Donors_Metric {
 	}
 
 	/**
-	 * New donor records (customer_id + first-donation epoch ts) in the window,
-	 * for Source_Matcher anchoring. List-param — NOT cached.
+	 * New donor records (customer_id + first-donation epoch ts + order-meta
+	 * source signals) in the window. Used by compute_source_mix for order-meta-
+	 * primary classification. List-param — NOT cached.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
 	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
 		return $this->storage->get_new_donor_records_in_window( $start, $end );

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -440,6 +440,16 @@ class Donors_Metric {
 	}
 
 	/**
+	 * Subscriber→donor lag rows (lag_days) for the 4.4 distribution. Pure Woo.
+	 * List-param — NOT cached.
+	 *
+	 * @return array<int, array{lag_days:int}>
+	 */
+	public function get_subscriber_to_donor_lags(): array {
+		return $this->storage->get_subscriber_to_donor_lags();
+	}
+
+	/**
 	 * Flush all Tab 7 metric caches. Hook point for NPPD-1605.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -430,6 +430,16 @@ class Donors_Metric {
 	}
 
 	/**
+	 * Donation conversion-lag rows (customer_id, registered_ts, first_donation_ts)
+	 * for the 4.3 time-to-donate distribution. List-param — NOT cached.
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_donation_ts:int}>
+	 */
+	public function get_donation_conversion_lags(): array {
+		return $this->storage->get_donation_conversion_lags();
+	}
+
+	/**
 	 * Flush all Tab 7 metric caches. Hook point for NPPD-1605.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -477,6 +477,18 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * New non-donation subscriber records (customer_id + first-sub epoch ts) in
+	 * the window, for Source_Matcher anchoring. List-param — NOT cached.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return $this->storage->get_new_subscriber_records_in_window( $start, $end );
+	}
+
+	/**
 	 * Flush ALL Tab 6 metric caches. Use after a manual data correction
 	 * or from the future NPPD-1605 invalidation system; not wired to any
 	 * automatic trigger today because the WP transient API has no key

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -477,12 +477,15 @@ class Subscribers_Metric {
 	}
 
 	/**
-	 * New non-donation subscriber records (customer_id + first-sub epoch ts) in
-	 * the window, for Source_Matcher anchoring. List-param — NOT cached.
+	 * New non-donation subscriber records for source-mix attribution (3.2).
+	 * Each record carries customer_id, first-sub epoch ts, and source meta
+	 * (gate_post_id, popup_id) read from the subscription's parent shop_order.
+	 * Records without usable meta fall to the BQ temporal matcher in
+	 * compute_source_mix. List-param — NOT cached.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
 	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
 		return $this->storage->get_new_subscriber_records_in_window( $start, $end );

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -489,6 +489,16 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Subscription conversion-lag rows (customer_id, registered_ts, first_sub_ts)
+	 * for the 4.2 time-to-subscribe distribution. List-param — NOT cached.
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_sub_ts:int}>
+	 */
+	public function get_subscription_conversion_lags(): array {
+		return $this->storage->get_subscription_conversion_lags();
+	}
+
+	/**
 	 * Flush ALL Tab 6 metric caches. Use after a manual data correction
 	 * or from the future NPPD-1605 invalidation system; not wired to any
 	 * automatic trigger today because the WP transient API has no key

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -353,4 +353,14 @@ interface Donors_Storage_Interface {
 	 * @return array<int, array{customer_id:int, registered_ts:int, first_donation_ts:int}>
 	 */
 	public function get_donation_conversion_lags(): array;
+
+	/**
+	 * All-history cross-converters: customers with a first non-donation
+	 * subscription and a STRICTLY-LATER first donation. Returns the lag in whole
+	 * days (DATEDIFF(first_donation, first_sub)). Pure Woo — no wp_users join, so
+	 * it counts cross-converters regardless of registration record. Drives 4.4.
+	 *
+	 * @return array<int, array{lag_days:int}>
+	 */
+	public function get_subscriber_to_donor_lags(): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -335,13 +335,18 @@ interface Donors_Storage_Interface {
 
 	/**
 	 * New donors in the window, each with the epoch timestamp (UTC seconds) of
-	 * their FIRST completed/processing donation order. Same population as
-	 * {@see get_new_donors_in_window()} but returns one record per customer with
-	 * the anchor timestamp for Source_Matcher (Tab 3 source-mix 3.3).
+	 * their FIRST completed/processing donation order, plus order-meta source
+	 * signals. Same population as {@see get_new_donors_in_window()} but returns
+	 * one record per customer with the anchor timestamp for Source_Matcher
+	 * (Tab 3 source-mix 3.3) and order-level meta for primary attribution.
+	 *
+	 * Field notes: gate_post_id = first non-empty _gate_post_id on the first-
+	 * donation order (falls back to _memberships_content_gate if absent); '' if
+	 * none. popup_id = first non-empty _newspack_popup_id; '' if none.
 	 *
 	 * @param DateTimeInterface $start Inclusive window start.
 	 * @param DateTimeInterface $end   Inclusive window end.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
 	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array;
 

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -344,4 +344,13 @@ interface Donors_Storage_Interface {
 	 * @return array<int, array{customer_id:int, ts:int}>
 	 */
 	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
+	 * All-history: every customer with a completed/processing donation order AND
+	 * a wp_users row, with their registration epoch and first-donation epoch
+	 * (both UTC seconds). Drives the 4.3 time-to-donate distribution.
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_donation_ts:int}>
+	 */
+	public function get_donation_conversion_lags(): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -332,4 +332,16 @@ interface Donors_Storage_Interface {
 	 * @return array<int, \DateTimeImmutable> customer_id => first donation date (UTC).
 	 */
 	public function get_first_donation_order_dates( array $customer_ids ): array;
+
+	/**
+	 * New donors in the window, each with the epoch timestamp (UTC seconds) of
+	 * their FIRST completed/processing donation order. Same population as
+	 * {@see get_new_donors_in_window()} but returns one record per customer with
+	 * the anchor timestamp for Source_Matcher (Tab 3 source-mix 3.3).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -987,20 +987,76 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
 	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
 		global $wpdb;
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Same inner aggregate as get_new_donors_in_window() (first completed/
-		// processing donation per customer), filtered to the window, returning rows.
-		// Guest orders (customer_id = 0) are excluded: a guest has no user
-		// account to match against BQ registration events, so they would always
-		// collapse to 'direct' and inflate that bucket artificially.
+		// Same first-donation-per-customer population as get_new_donors_in_window()
+		// (earliest completed/processing donation order, first occurrence in window).
+		// Guest orders (customer_id = 0) excluded: no user account to match against
+		// BQ registration events — same rationale as the old implementation.
+		//
+		// Order-meta subqueries: correlated against the FIRST donation order for each
+		// customer (the order whose date_created_gmt = the outer MIN). MySQL 5.7-safe —
+		// no window functions.
+		// gate_post_id: first non-empty _gate_post_id, falling back to legacy
+		// _memberships_content_gate (both NOT IN ('','0')).
+		// popup_id:     non-empty _newspack_popup_id.
+		// Empty / missing → '' returned for that column; the metric layer uses
+		// classify_source() which treats '' as "no meta" and falls to the matcher.
+		//
+		// Same-timestamp ties (two orders with the same MIN date) are resolved by the
+		// outer GROUP BY: MySQL picks an arbitrary first-order ID for each customer,
+		// which is acceptable — the meta is only a fallback signal, not an exact ID.
 		$sql = $wpdb->prepare(
-			"SELECT first_donations.customer_id, first_donations.first_donation_date FROM (
+			"SELECT
+				fd.customer_id,
+				fd.first_donation_date,
+				COALESCE((
+					SELECT om_gate.meta_value
+					FROM {$prefix}wc_orders o_first
+					JOIN {$prefix}wc_orders_meta om_gate
+						ON om_gate.order_id = o_first.id AND om_gate.meta_key = '_gate_post_id'
+					JOIN {$prefix}wc_order_product_lookup opl_first ON opl_first.order_id = o_first.id
+					WHERE o_first.type = 'shop_order'
+					  AND o_first.status IN ('wc-completed', 'wc-processing')
+					  AND opl_first.product_id IN ($donations)
+					  AND o_first.customer_id = fd.customer_id
+					  AND o_first.date_created_gmt = fd.first_donation_date
+					  AND om_gate.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), (
+					SELECT om_legacy.meta_value
+					FROM {$prefix}wc_orders o_first
+					JOIN {$prefix}wc_orders_meta om_legacy
+						ON om_legacy.order_id = o_first.id AND om_legacy.meta_key = '_memberships_content_gate'
+					JOIN {$prefix}wc_order_product_lookup opl_first ON opl_first.order_id = o_first.id
+					WHERE o_first.type = 'shop_order'
+					  AND o_first.status IN ('wc-completed', 'wc-processing')
+					  AND opl_first.product_id IN ($donations)
+					  AND o_first.customer_id = fd.customer_id
+					  AND o_first.date_created_gmt = fd.first_donation_date
+					  AND om_legacy.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS gate_post_id,
+				COALESCE((
+					SELECT om_popup.meta_value
+					FROM {$prefix}wc_orders o_first
+					JOIN {$prefix}wc_orders_meta om_popup
+						ON om_popup.order_id = o_first.id AND om_popup.meta_key = '_newspack_popup_id'
+					JOIN {$prefix}wc_order_product_lookup opl_first ON opl_first.order_id = o_first.id
+					WHERE o_first.type = 'shop_order'
+					  AND o_first.status IN ('wc-completed', 'wc-processing')
+					  AND opl_first.product_id IN ($donations)
+					  AND o_first.customer_id = fd.customer_id
+					  AND o_first.date_created_gmt = fd.first_donation_date
+					  AND om_popup.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS popup_id
+			FROM (
 				SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
 				FROM {$prefix}wc_orders o
 				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
@@ -1009,34 +1065,35 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				  AND opl.product_id IN ($donations)
 				  AND o.customer_id > 0
 				GROUP BY o.customer_id
-			) AS first_donations
-			WHERE first_donations.first_donation_date BETWEEN %s AND %s",
+			) AS fd
+			WHERE fd.first_donation_date BETWEEN %s AND %s",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);
 
-		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_donation_date' );
+		return $this->rows_to_donor_records( $wpdb->get_results( $sql, ARRAY_A ) );
 	}
 
 	/**
-	 * Map (customer_id, <date column>) rows to [ ['customer_id'=>int,'ts'=>int], … ]
-	 * with ts as UTC epoch seconds. Blank dates skipped; UTC parse keeps the epoch
-	 * correct regardless of MySQL session timezone.
+	 * Map (customer_id, first_donation_date, gate_post_id, popup_id) rows to
+	 * donor source records with UTC epoch seconds. Blank dates are skipped.
+	 * UTC parse keeps the epoch correct regardless of MySQL session timezone.
 	 *
-	 * @param mixed  $rows     wpdb->get_results( …, ARRAY_A ) output.
-	 * @param string $date_key Row key holding the UTC `Y-m-d H:i:s` value.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @param mixed $rows wpdb->get_results( …, ARRAY_A ) output.
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
-	private function rows_to_records( $rows, string $date_key ): array {
+	private function rows_to_donor_records( $rows ): array {
 		$utc     = new \DateTimeZone( 'UTC' );
 		$records = [];
 		foreach ( (array) $rows as $row ) {
-			if ( empty( $row[ $date_key ] ) ) {
+			if ( empty( $row['first_donation_date'] ) ) {
 				continue;
 			}
 			$records[] = [
-				'customer_id' => (int) $row['customer_id'],
-				'ts'          => ( new \DateTimeImmutable( $row[ $date_key ], $utc ) )->getTimestamp(),
+				'customer_id'  => (int) $row['customer_id'],
+				'ts'           => ( new \DateTimeImmutable( $row['first_donation_date'], $utc ) )->getTimestamp(),
+				'gate_post_id' => (string) ( $row['gate_post_id'] ?? '' ),
+				'popup_id'     => (string) ( $row['popup_id'] ?? '' ),
 			];
 		}
 		return $records;

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -996,6 +996,9 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 
 		// Same inner aggregate as get_new_donors_in_window() (first completed/
 		// processing donation per customer), filtered to the window, returning rows.
+		// Guest orders (customer_id = 0) are excluded: a guest has no user
+		// account to match against BQ registration events, so they would always
+		// collapse to 'direct' and inflate that bucket artificially.
 		$sql = $wpdb->prepare(
 			"SELECT first_donations.customer_id, first_donations.first_donation_date FROM (
 				SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
@@ -1004,6 +1007,7 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				WHERE o.type = 'shop_order'
 				  AND o.status IN ('wc-completed', 'wc-processing')
 				  AND opl.product_id IN ($donations)
+				  AND o.customer_id > 0
 				GROUP BY o.customer_id
 			) AS first_donations
 			WHERE first_donations.first_donation_date BETWEEN %s AND %s",

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -1150,6 +1150,58 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_donation_ts:int}>
+	 */
+	public function get_donation_conversion_lags(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		$sql = "SELECT first_d.customer_id, u.user_registered, first_d.first_donation_date
+			FROM (
+				SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
+				WHERE o.type = 'shop_order'
+				  AND o.status IN ('wc-completed', 'wc-processing')
+				  AND opl.product_id IN ($donations)
+				GROUP BY o.customer_id
+			) AS first_d
+			JOIN {$prefix}users u ON u.ID = first_d.customer_id";
+
+		return $this->rows_to_lags( $wpdb->get_results( $sql, ARRAY_A ), 'first_donation_date', 'first_donation_ts' );
+	}
+
+	/**
+	 * Map (customer_id, user_registered, <first date>) rows to lag records with
+	 * UTC epoch seconds. Rows with a blank date are skipped. UTC parse keeps the
+	 * epochs correct regardless of MySQL session timezone. user_registered is
+	 * treated as UTC (WordPress stores it as the GMT registration instant).
+	 *
+	 * @param mixed  $rows         wpdb rows (ARRAY_A).
+	 * @param string $first_key    Row key holding the first-conversion date.
+	 * @param string $first_ts_out Output key for the first-conversion epoch.
+	 * @return array<int, array<string,int>>
+	 */
+	private function rows_to_lags( $rows, string $first_key, string $first_ts_out ): array {
+		$utc  = new \DateTimeZone( 'UTC' );
+		$out  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $first_key ] ) || empty( $row['user_registered'] ) ) {
+				continue;
+			}
+			$out[] = [
+				'customer_id'   => (int) $row['customer_id'],
+				'registered_ts' => ( new \DateTimeImmutable( $row['user_registered'], $utc ) )->getTimestamp(),
+				$first_ts_out   => ( new \DateTimeImmutable( $row[ $first_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $out;
+	}
+
+	/**
 	 * Variation label picker. Same conventions as Tab 6.
 	 *
 	 * @param string $period         _subscription_period meta value.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -983,6 +983,62 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Same inner aggregate as get_new_donors_in_window() (first completed/
+		// processing donation per customer), filtered to the window, returning rows.
+		$sql = $wpdb->prepare(
+			"SELECT first_donations.customer_id, first_donations.first_donation_date FROM (
+				SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
+				WHERE o.type = 'shop_order'
+				  AND o.status IN ('wc-completed', 'wc-processing')
+				  AND opl.product_id IN ($donations)
+				GROUP BY o.customer_id
+			) AS first_donations
+			WHERE first_donations.first_donation_date BETWEEN %s AND %s",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_donation_date' );
+	}
+
+	/**
+	 * Map (customer_id, <date column>) rows to [ ['customer_id'=>int,'ts'=>int], … ]
+	 * with ts as UTC epoch seconds. Blank dates skipped; UTC parse keeps the epoch
+	 * correct regardless of MySQL session timezone.
+	 *
+	 * @param mixed  $rows     wpdb->get_results( …, ARRAY_A ) output.
+	 * @param string $date_key Row key holding the UTC `Y-m-d H:i:s` value.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	private function rows_to_records( $rows, string $date_key ): array {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$records = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $date_key ] ) ) {
+				continue;
+			}
+			$records[] = [
+				'customer_id' => (int) $row['customer_id'],
+				'ts'          => ( new \DateTimeImmutable( $row[ $date_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $records;
+	}
+
+	/**
 	 * Aggregate flat per-variation rows into parent + nested
 	 * variations shape. Mirrors the Tab 6 pattern but with Tab 7's
 	 * five-metric column set.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -1175,6 +1175,54 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{lag_days:int}>
+	 */
+	public function get_subscriber_to_donor_lags(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// First non-donation subscription vs first donation per customer, joined
+		// where the donation strictly post-dates the subscription. DATEDIFF over
+		// the two UTC values is timezone-safe (date arithmetic, no tz interpretation).
+		$sql = "SELECT DATEDIFF(df.first_donation_date, sb.first_sub_date) AS lag_days
+			FROM (
+				SELECT o.customer_id, MIN(om.meta_value) AS first_sub_date
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_orders_meta om
+					ON om.order_id = o.id AND om.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE o.type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND om.meta_value != ''
+				GROUP BY o.customer_id
+			) AS sb
+			JOIN (
+				SELECT o.customer_id, MIN(o.date_created_gmt) AS first_donation_date
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
+				WHERE o.type = 'shop_order'
+				  AND o.status IN ('wc-completed', 'wc-processing')
+				  AND opl.product_id IN ($donations)
+				GROUP BY o.customer_id
+			) AS df ON df.customer_id = sb.customer_id
+			WHERE df.first_donation_date > sb.first_sub_date";
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		return array_map(
+			static function ( $row ) {
+				return [ 'lag_days' => (int) $row['lag_days'] ];
+			},
+			(array) $rows
+		);
+	}
+
+	/**
 	 * Map (customer_id, user_registered, <first date>) rows to lag records with
 	 * UTC epoch seconds. Rows with a blank date are skipped. UTC parse keeps the
 	 * epochs correct regardless of MySQL session timezone. user_registered is

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1174,4 +1174,67 @@ class HPOS_Storage implements Storage_Interface {
 		}
 		return $map;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Same inner aggregate as get_new_subscribers_in_window() (first
+		// non-donation _schedule_start per customer), filtered to the window,
+		// but returns the rows so the metric layer can anchor Source_Matcher on
+		// each customer's first-sub timestamp.
+		$sql = $wpdb->prepare(
+			"SELECT first_subs.customer_id, first_subs.first_start FROM (
+				SELECT o.customer_id, MIN(om.meta_value) AS first_start
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_orders_meta om
+					ON om.order_id = o.id AND om.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE o.type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND om.meta_value != ''
+				GROUP BY o.customer_id
+			) AS first_subs
+			WHERE first_subs.first_start BETWEEN %s AND %s",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_start' );
+	}
+
+	/**
+	 * Map (customer_id, <date column>) rows to [ ['customer_id'=>int,'ts'=>int], … ]
+	 * with ts as UTC epoch seconds. Blank dates are skipped. The UTC parse keeps
+	 * the epoch correct regardless of MySQL session timezone.
+	 *
+	 * @param mixed  $rows     wpdb->get_results( …, ARRAY_A ) output.
+	 * @param string $date_key Row key holding the UTC `Y-m-d H:i:s` value.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	private function rows_to_records( $rows, string $date_key ): array {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$records = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $date_key ] ) ) {
+				continue;
+			}
+			$records[] = [
+				'customer_id' => (int) $row['customer_id'],
+				'ts'          => ( new \DateTimeImmutable( $row[ $date_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $records;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1191,14 +1191,88 @@ class HPOS_Storage implements Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 
 		// Same inner aggregate as get_new_subscribers_in_window() (first
-		// non-donation _schedule_start per customer), filtered to the window,
-		// but returns the rows so the metric layer can anchor Source_Matcher on
-		// each customer's first-sub timestamp. Guest orders (customer_id = 0)
-		// are excluded: a guest has no user account to match against BQ
-		// registration events, so they would always collapse to 'direct' and
-		// inflate that bucket artificially.
+		// non-donation _schedule_start per customer), filtered to the window.
+		// Guest orders (customer_id = 0) are excluded: a guest has no user
+		// account to match against BQ registration events.
+		//
+		// Source meta lives on the PARENT shop_order (the subscription's initial
+		// checkout order), NOT on the shop_subscription row itself. Each
+		// subscription's parent_order_id in {prefix}wc_orders points to the
+		// initial shop_order; we read _gate_post_id / _memberships_content_gate
+		// / _newspack_popup_id from that parent order's meta.
+		//
+		// To identify the first subscription per customer in the window we pick
+		// the subscription whose _schedule_start = the customer's MIN. Correlated
+		// subqueries (MySQL 5.7-safe, no window functions) then read meta from
+		// that first subscription's parent order. LIMIT 1 resolves same-timestamp
+		// ties (two subscriptions sharing the same MIN _schedule_start): any one
+		// tied first-subscription's parent order meta is used — the signal is a
+		// soft fallback, not an exact ID.
+		//
+		// gate_post_id: first non-empty _gate_post_id on the parent order,
+		// falling back to legacy _memberships_content_gate (both
+		// NOT IN ('','0')).
+		// popup_id:     non-empty _newspack_popup_id on the parent order.
+		// No parent order / no meta → '' for that column; the metric layer falls
+		// those records to the BQ temporal matcher (unchanged behaviour).
 		$sql = $wpdb->prepare(
-			"SELECT first_subs.customer_id, first_subs.first_start FROM (
+			"SELECT
+				first_subs.customer_id,
+				first_subs.first_start,
+				COALESCE((
+					SELECT om_gate.meta_value
+					FROM {$prefix}wc_orders o_sub
+					JOIN {$prefix}wc_orders_meta om_start_s
+						ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
+					JOIN {$prefix}wc_orders_meta om_gate
+						ON om_gate.order_id = o_sub.parent_order_id AND om_gate.meta_key = '_gate_post_id'
+					JOIN {$prefix}woocommerce_order_items oi_s
+						ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim_s
+						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+					WHERE o_sub.type = 'shop_subscription'
+					  AND o_sub.customer_id = first_subs.customer_id
+					  AND oim_s.meta_value NOT IN ($donations)
+					  AND om_start_s.meta_value = first_subs.first_start
+					  AND om_gate.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), (
+					SELECT om_legacy.meta_value
+					FROM {$prefix}wc_orders o_sub
+					JOIN {$prefix}wc_orders_meta om_start_s
+						ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
+					JOIN {$prefix}wc_orders_meta om_legacy
+						ON om_legacy.order_id = o_sub.parent_order_id AND om_legacy.meta_key = '_memberships_content_gate'
+					JOIN {$prefix}woocommerce_order_items oi_s
+						ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim_s
+						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+					WHERE o_sub.type = 'shop_subscription'
+					  AND o_sub.customer_id = first_subs.customer_id
+					  AND oim_s.meta_value NOT IN ($donations)
+					  AND om_start_s.meta_value = first_subs.first_start
+					  AND om_legacy.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS gate_post_id,
+				COALESCE((
+					SELECT om_popup.meta_value
+					FROM {$prefix}wc_orders o_sub
+					JOIN {$prefix}wc_orders_meta om_start_s
+						ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
+					JOIN {$prefix}wc_orders_meta om_popup
+						ON om_popup.order_id = o_sub.parent_order_id AND om_popup.meta_key = '_newspack_popup_id'
+					JOIN {$prefix}woocommerce_order_items oi_s
+						ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim_s
+						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+					WHERE o_sub.type = 'shop_subscription'
+					  AND o_sub.customer_id = first_subs.customer_id
+					  AND oim_s.meta_value NOT IN ($donations)
+					  AND om_start_s.meta_value = first_subs.first_start
+					  AND om_popup.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS popup_id
+			FROM (
 				SELECT o.customer_id, MIN(om.meta_value) AS first_start
 				FROM {$prefix}wc_orders o
 				JOIN {$prefix}wc_orders_meta om
@@ -1218,7 +1292,32 @@ class HPOS_Storage implements Storage_Interface {
 			$this->fmt( $end )
 		);
 
-		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_start' );
+		return $this->rows_to_subscriber_records( $wpdb->get_results( $sql, ARRAY_A ) );
+	}
+
+	/**
+	 * Map (customer_id, first_start, gate_post_id, popup_id) rows to subscriber
+	 * source records with UTC epoch seconds. Blank dates are skipped. UTC parse
+	 * keeps the epoch correct regardless of MySQL session timezone.
+	 *
+	 * @param mixed $rows wpdb->get_results( …, ARRAY_A ) output.
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
+	 */
+	private function rows_to_subscriber_records( $rows ): array {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$records = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['first_start'] ) ) {
+				continue;
+			}
+			$records[] = [
+				'customer_id'  => (int) $row['customer_id'],
+				'ts'           => ( new \DateTimeImmutable( $row['first_start'], $utc ) )->getTimestamp(),
+				'gate_post_id' => (string) ( $row['gate_post_id'] ?? '' ),
+				'popup_id'     => (string) ( $row['popup_id'] ?? '' ),
+			];
+		}
+		return $records;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -140,7 +140,9 @@ class HPOS_Storage implements Storage_Interface {
 
 		// Customers whose earliest non-donation subscription's _schedule_start
 		// falls in the window. Inner aggregate computes first-start per
-		// customer; outer count filters that to the window.
+		// customer; outer count filters that to the window. The om.meta_value != ''
+		// guard matches the records method so the count and source-mix records
+		// agree on sites where a subscription has a blank _schedule_start.
 		$sql = $wpdb->prepare(
 			"SELECT COUNT(*) FROM (
 				SELECT o.customer_id, MIN(om.meta_value) AS first_start
@@ -153,6 +155,7 @@ class HPOS_Storage implements Storage_Interface {
 					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 				WHERE o.type = 'shop_subscription'
 				  AND oim.meta_value NOT IN ($donations)
+				  AND om.meta_value != ''
 				GROUP BY o.customer_id
 			) AS first_subs
 			WHERE first_subs.first_start BETWEEN %s AND %s",
@@ -1190,7 +1193,10 @@ class HPOS_Storage implements Storage_Interface {
 		// Same inner aggregate as get_new_subscribers_in_window() (first
 		// non-donation _schedule_start per customer), filtered to the window,
 		// but returns the rows so the metric layer can anchor Source_Matcher on
-		// each customer's first-sub timestamp.
+		// each customer's first-sub timestamp. Guest orders (customer_id = 0)
+		// are excluded: a guest has no user account to match against BQ
+		// registration events, so they would always collapse to 'direct' and
+		// inflate that bucket artificially.
 		$sql = $wpdb->prepare(
 			"SELECT first_subs.customer_id, first_subs.first_start FROM (
 				SELECT o.customer_id, MIN(om.meta_value) AS first_start
@@ -1202,6 +1208,7 @@ class HPOS_Storage implements Storage_Interface {
 				JOIN {$prefix}woocommerce_order_itemmeta oim
 					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 				WHERE o.type = 'shop_subscription'
+				  AND o.customer_id > 0
 				  AND oim.meta_value NOT IN ($donations)
 				  AND om.meta_value != ''
 				GROUP BY o.customer_id

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1237,4 +1237,64 @@ class HPOS_Storage implements Storage_Interface {
 		}
 		return $records;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_sub_ts:int}>
+	 */
+	public function get_subscription_conversion_lags(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// First non-donation subscription per customer, joined to wp_users for
+		// the registration date. All-history (snapshot). Guests (no users row)
+		// are excluded by the join, which is correct: a lag needs a registration.
+		$sql = "SELECT first_subs.customer_id, u.user_registered, first_subs.first_start
+			FROM (
+				SELECT o.customer_id, MIN(om.meta_value) AS first_start
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_orders_meta om
+					ON om.order_id = o.id AND om.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE o.type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND om.meta_value != ''
+				GROUP BY o.customer_id
+			) AS first_subs
+			JOIN {$prefix}users u ON u.ID = first_subs.customer_id";
+
+		return $this->rows_to_lags( $wpdb->get_results( $sql, ARRAY_A ), 'first_start', 'first_sub_ts' );
+	}
+
+	/**
+	 * Map (customer_id, user_registered, <first date>) rows to lag records with
+	 * UTC epoch seconds. Rows with a blank date are skipped. UTC parse keeps the
+	 * epochs correct regardless of MySQL session timezone. user_registered is
+	 * treated as UTC (WordPress stores it as the GMT registration instant).
+	 *
+	 * @param mixed  $rows         wpdb rows (ARRAY_A).
+	 * @param string $first_key    Row key holding the first-conversion date.
+	 * @param string $first_ts_out Output key for the first-conversion epoch.
+	 * @return array<int, array<string,int>>
+	 */
+	private function rows_to_lags( $rows, string $first_key, string $first_ts_out ): array {
+		$utc  = new \DateTimeZone( 'UTC' );
+		$out  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $first_key ] ) || empty( $row['user_registered'] ) ) {
+				continue;
+			}
+			$out[] = [
+				'customer_id'   => (int) $row['customer_id'],
+				'registered_ts' => ( new \DateTimeImmutable( $row['user_registered'], $utc ) )->getTimestamp(),
+				$first_ts_out   => ( new \DateTimeImmutable( $row[ $first_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -960,6 +960,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 
 		// Legacy CPT equivalent of HPOS get_new_donor_records_in_window().
+		// Guest orders (blank _customer_user → 0 when cast) are excluded from
+		// source attribution — see the HPOS variant for the rationale.
 		$sql = $wpdb->prepare(
 			"SELECT first_donations.customer_id, first_donations.first_donation_date FROM (
 				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
@@ -970,6 +972,7 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				WHERE p.post_type = 'shop_order'
 				  AND p.post_status IN ('wc-completed', 'wc-processing')
 				  AND opl.product_id IN ($donations)
+				  AND CAST(cust.meta_value AS UNSIGNED) > 0
 				GROUP BY CAST(cust.meta_value AS UNSIGNED)
 			) AS first_donations
 			WHERE first_donations.first_donation_date BETWEEN %s AND %s",

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -1135,6 +1135,56 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{lag_days:int}>
+	 */
+	public function get_subscriber_to_donor_lags(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Legacy CPT equivalent of HPOS get_subscriber_to_donor_lags().
+		$sql = "SELECT DATEDIFF(df.first_donation_date, sb.first_sub_date) AS lag_days
+			FROM (
+				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_sub_date
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start
+					ON start.post_id = p.ID AND start.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND start.meta_value != ''
+				GROUP BY CAST(cust.meta_value AS UNSIGNED)
+			) AS sb
+			JOIN (
+				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
+				WHERE p.post_type = 'shop_order'
+				  AND p.post_status IN ('wc-completed', 'wc-processing')
+				  AND opl.product_id IN ($donations)
+				GROUP BY CAST(cust.meta_value AS UNSIGNED)
+			) AS df ON df.customer_id = sb.customer_id
+			WHERE df.first_donation_date > sb.first_sub_date";
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		return array_map(
+			static function ( $row ) {
+				return [ 'lag_days' => (int) $row['lag_days'] ];
+			},
+			(array) $rows
+		);
+	}
+
+	/**
 	 * Map (customer_id, user_registered, <first date>) rows to lag records with
 	 * UTC epoch seconds. Rows with a blank date are skipped. UTC parse keeps the
 	 * epochs correct regardless of MySQL session timezone. user_registered is

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -1108,6 +1108,60 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_donation_ts:int}>
+	 */
+	public function get_donation_conversion_lags(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		$sql = "SELECT first_d.customer_id, u.user_registered, first_d.first_donation_date
+			FROM (
+				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
+				WHERE p.post_type = 'shop_order'
+				  AND p.post_status IN ('wc-completed', 'wc-processing')
+				  AND opl.product_id IN ($donations)
+				GROUP BY CAST(cust.meta_value AS UNSIGNED)
+			) AS first_d
+			JOIN {$prefix}users u ON u.ID = first_d.customer_id";
+
+		return $this->rows_to_lags( $wpdb->get_results( $sql, ARRAY_A ), 'first_donation_date', 'first_donation_ts' );
+	}
+
+	/**
+	 * Map (customer_id, user_registered, <first date>) rows to lag records with
+	 * UTC epoch seconds. Rows with a blank date are skipped. UTC parse keeps the
+	 * epochs correct regardless of MySQL session timezone. user_registered is
+	 * treated as UTC (WordPress stores it as the GMT registration instant).
+	 *
+	 * @param mixed  $rows         wpdb rows (ARRAY_A).
+	 * @param string $first_key    Row key holding the first-conversion date.
+	 * @param string $first_ts_out Output key for the first-conversion epoch.
+	 * @return array<int, array<string,int>>
+	 */
+	private function rows_to_lags( $rows, string $first_key, string $first_ts_out ): array {
+		$utc  = new \DateTimeZone( 'UTC' );
+		$out  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $first_key ] ) || empty( $row['user_registered'] ) ) {
+				continue;
+			}
+			$out[] = [
+				'customer_id'   => (int) $row['customer_id'],
+				'registered_ts' => ( new \DateTimeImmutable( $row['user_registered'], $utc ) )->getTimestamp(),
+				$first_ts_out   => ( new \DateTimeImmutable( $row[ $first_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $out;
+	}
+
+	/**
 	 * Variation label picker.
 	 *
 	 * @param string $period         _subscription_period meta value.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -948,6 +948,63 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Legacy CPT equivalent of HPOS get_new_donor_records_in_window().
+		$sql = $wpdb->prepare(
+			"SELECT first_donations.customer_id, first_donations.first_donation_date FROM (
+				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
+				WHERE p.post_type = 'shop_order'
+				  AND p.post_status IN ('wc-completed', 'wc-processing')
+				  AND opl.product_id IN ($donations)
+				GROUP BY CAST(cust.meta_value AS UNSIGNED)
+			) AS first_donations
+			WHERE first_donations.first_donation_date BETWEEN %s AND %s",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_donation_date' );
+	}
+
+	/**
+	 * Map (customer_id, <date column>) rows to [ ['customer_id'=>int,'ts'=>int], … ]
+	 * with ts as UTC epoch seconds. Blank dates skipped; UTC parse keeps the epoch
+	 * correct regardless of MySQL session timezone.
+	 *
+	 * @param mixed  $rows     wpdb->get_results( …, ARRAY_A ) output.
+	 * @param string $date_key Row key holding the UTC `Y-m-d H:i:s` value.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	private function rows_to_records( $rows, string $date_key ): array {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$records = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $date_key ] ) ) {
+				continue;
+			}
+			$records[] = [
+				'customer_id' => (int) $row['customer_id'],
+				'ts'          => ( new \DateTimeImmutable( $row[ $date_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $records;
+	}
+
+	/**
 	 * Aggregate flat per-variation rows into parent + nested variations.
 	 * Duplicated from {@see HPOS_Donors_Storage} — pure PHP transform
 	 * keeping each storage class self-contained.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -952,7 +952,7 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
 	public function get_new_donor_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
 		global $wpdb;
@@ -962,8 +962,69 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		// Legacy CPT equivalent of HPOS get_new_donor_records_in_window().
 		// Guest orders (blank _customer_user → 0 when cast) are excluded from
 		// source attribution — see the HPOS variant for the rationale.
+		//
+		// Order-meta subqueries: correlated against the FIRST donation order for each
+		// customer (the order whose post_date_gmt = the outer MIN). MySQL 5.7-safe.
+		// Legacy orders use postmeta for order meta, keyed by post ID.
+		// gate_post_id: first non-empty _gate_post_id, falling back to legacy
+		// _memberships_content_gate (both NOT IN ('','0')).
+		// popup_id:     non-empty _newspack_popup_id.
+		// Empty / missing → '' for that column.
+		//
+		// Same-timestamp tie handling: GROUP BY customer in the inner aggregate; the
+		// outer meta subqueries use LIMIT 1 so any tied first-order's meta is used.
 		$sql = $wpdb->prepare(
-			"SELECT first_donations.customer_id, first_donations.first_donation_date FROM (
+			"SELECT
+				fd.customer_id,
+				fd.first_donation_date,
+				COALESCE((
+					SELECT pm_gate.meta_value
+					FROM {$prefix}posts p_first
+					JOIN {$prefix}postmeta cust_first
+						ON cust_first.post_id = p_first.ID AND cust_first.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta pm_gate
+						ON pm_gate.post_id = p_first.ID AND pm_gate.meta_key = '_gate_post_id'
+					JOIN {$prefix}wc_order_product_lookup opl_first ON opl_first.order_id = p_first.ID
+					WHERE p_first.post_type = 'shop_order'
+					  AND p_first.post_status IN ('wc-completed', 'wc-processing')
+					  AND opl_first.product_id IN ($donations)
+					  AND CAST(cust_first.meta_value AS UNSIGNED) = fd.customer_id
+					  AND p_first.post_date_gmt = fd.first_donation_date
+					  AND pm_gate.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), (
+					SELECT pm_legacy.meta_value
+					FROM {$prefix}posts p_first
+					JOIN {$prefix}postmeta cust_first
+						ON cust_first.post_id = p_first.ID AND cust_first.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta pm_legacy
+						ON pm_legacy.post_id = p_first.ID AND pm_legacy.meta_key = '_memberships_content_gate'
+					JOIN {$prefix}wc_order_product_lookup opl_first ON opl_first.order_id = p_first.ID
+					WHERE p_first.post_type = 'shop_order'
+					  AND p_first.post_status IN ('wc-completed', 'wc-processing')
+					  AND opl_first.product_id IN ($donations)
+					  AND CAST(cust_first.meta_value AS UNSIGNED) = fd.customer_id
+					  AND p_first.post_date_gmt = fd.first_donation_date
+					  AND pm_legacy.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS gate_post_id,
+				COALESCE((
+					SELECT pm_popup.meta_value
+					FROM {$prefix}posts p_first
+					JOIN {$prefix}postmeta cust_first
+						ON cust_first.post_id = p_first.ID AND cust_first.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta pm_popup
+						ON pm_popup.post_id = p_first.ID AND pm_popup.meta_key = '_newspack_popup_id'
+					JOIN {$prefix}wc_order_product_lookup opl_first ON opl_first.order_id = p_first.ID
+					WHERE p_first.post_type = 'shop_order'
+					  AND p_first.post_status IN ('wc-completed', 'wc-processing')
+					  AND opl_first.product_id IN ($donations)
+					  AND CAST(cust_first.meta_value AS UNSIGNED) = fd.customer_id
+					  AND p_first.post_date_gmt = fd.first_donation_date
+					  AND pm_popup.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS popup_id
+			FROM (
 				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(p.post_date_gmt) AS first_donation_date
 				FROM {$prefix}posts p
 				JOIN {$prefix}postmeta cust
@@ -974,34 +1035,35 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				  AND opl.product_id IN ($donations)
 				  AND CAST(cust.meta_value AS UNSIGNED) > 0
 				GROUP BY CAST(cust.meta_value AS UNSIGNED)
-			) AS first_donations
-			WHERE first_donations.first_donation_date BETWEEN %s AND %s",
+			) AS fd
+			WHERE fd.first_donation_date BETWEEN %s AND %s",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);
 
-		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_donation_date' );
+		return $this->rows_to_donor_records( $wpdb->get_results( $sql, ARRAY_A ) );
 	}
 
 	/**
-	 * Map (customer_id, <date column>) rows to [ ['customer_id'=>int,'ts'=>int], … ]
-	 * with ts as UTC epoch seconds. Blank dates skipped; UTC parse keeps the epoch
-	 * correct regardless of MySQL session timezone.
+	 * Map (customer_id, first_donation_date, gate_post_id, popup_id) rows to
+	 * donor source records with UTC epoch seconds. Blank dates are skipped.
+	 * UTC parse keeps the epoch correct regardless of MySQL session timezone.
 	 *
-	 * @param mixed  $rows     wpdb->get_results( …, ARRAY_A ) output.
-	 * @param string $date_key Row key holding the UTC `Y-m-d H:i:s` value.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @param mixed $rows wpdb->get_results( …, ARRAY_A ) output.
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
-	private function rows_to_records( $rows, string $date_key ): array {
+	private function rows_to_donor_records( $rows ): array {
 		$utc     = new \DateTimeZone( 'UTC' );
 		$records = [];
 		foreach ( (array) $rows as $row ) {
-			if ( empty( $row[ $date_key ] ) ) {
+			if ( empty( $row['first_donation_date'] ) ) {
 				continue;
 			}
 			$records[] = [
-				'customer_id' => (int) $row['customer_id'],
-				'ts'          => ( new \DateTimeImmutable( $row[ $date_key ], $utc ) )->getTimestamp(),
+				'customer_id'  => (int) $row['customer_id'],
+				'ts'           => ( new \DateTimeImmutable( $row['first_donation_date'], $utc ) )->getTimestamp(),
+				'gate_post_id' => (string) ( $row['gate_post_id'] ?? '' ),
+				'popup_id'     => (string) ( $row['popup_id'] ?? '' ),
 			];
 		}
 		return $records;

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1108,4 +1108,66 @@ class Legacy_Storage implements Storage_Interface {
 		}
 		return $map;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Legacy CPT equivalent of HPOS get_new_subscriber_records_in_window().
+		$sql = $wpdb->prepare(
+			"SELECT first_subs.customer_id, first_subs.first_start FROM (
+				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start
+					ON start.post_id = p.ID AND start.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND start.meta_value != ''
+				GROUP BY CAST(cust.meta_value AS UNSIGNED)
+			) AS first_subs
+			WHERE first_subs.first_start BETWEEN %s AND %s",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_start' );
+	}
+
+	/**
+	 * Map (customer_id, <date column>) rows to [ ['customer_id'=>int,'ts'=>int], … ]
+	 * with ts as UTC epoch seconds. Blank dates skipped; UTC parse keeps the epoch
+	 * correct regardless of MySQL session timezone.
+	 *
+	 * @param mixed  $rows     wpdb->get_results( …, ARRAY_A ) output.
+	 * @param string $date_key Row key holding the UTC `Y-m-d H:i:s` value.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	private function rows_to_records( $rows, string $date_key ): array {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$records = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $date_key ] ) ) {
+				continue;
+			}
+			$records[] = [
+				'customer_id' => (int) $row['customer_id'],
+				'ts'          => ( new \DateTimeImmutable( $row[ $date_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $records;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -161,6 +161,9 @@ class Legacy_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
+		// The start.meta_value != '' guard matches the records method so the
+		// count and source-mix records agree on sites where a subscription has
+		// a blank _schedule_start.
 		$sql = $wpdb->prepare(
 			"SELECT COUNT(*) FROM (
 				SELECT cust.meta_value AS customer_id, MIN(start.meta_value) AS first_start
@@ -175,6 +178,7 @@ class Legacy_Storage implements Storage_Interface {
 					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 				WHERE p.post_type = 'shop_subscription'
 				  AND oim.meta_value NOT IN ($donations)
+				  AND start.meta_value != ''
 				GROUP BY cust.meta_value
 			) AS first_subs
 			WHERE first_subs.first_start BETWEEN %s AND %s",
@@ -1122,6 +1126,8 @@ class Legacy_Storage implements Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 
 		// Legacy CPT equivalent of HPOS get_new_subscriber_records_in_window().
+		// Guest orders (blank _customer_user → 0 when cast) are excluded from
+		// source attribution — see the HPOS variant for the rationale.
 		$sql = $wpdb->prepare(
 			"SELECT first_subs.customer_id, first_subs.first_start FROM (
 				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
@@ -1135,6 +1141,7 @@ class Legacy_Storage implements Storage_Interface {
 				JOIN {$prefix}woocommerce_order_itemmeta oim
 					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 				WHERE p.post_type = 'shop_subscription'
+				  AND CAST(cust.meta_value AS UNSIGNED) > 0
 				  AND oim.meta_value NOT IN ($donations)
 				  AND start.meta_value != ''
 				GROUP BY CAST(cust.meta_value AS UNSIGNED)

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1170,4 +1170,64 @@ class Legacy_Storage implements Storage_Interface {
 		}
 		return $records;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_sub_ts:int}>
+	 */
+	public function get_subscription_conversion_lags(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Legacy CPT equivalent of HPOS get_subscription_conversion_lags().
+		$sql = "SELECT first_subs.customer_id, u.user_registered, first_subs.first_start
+			FROM (
+				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start
+					ON start.post_id = p.ID AND start.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND start.meta_value != ''
+				GROUP BY CAST(cust.meta_value AS UNSIGNED)
+			) AS first_subs
+			JOIN {$prefix}users u ON u.ID = first_subs.customer_id";
+
+		return $this->rows_to_lags( $wpdb->get_results( $sql, ARRAY_A ), 'first_start', 'first_sub_ts' );
+	}
+
+	/**
+	 * Map (customer_id, user_registered, <first date>) rows to lag records with
+	 * UTC epoch seconds. Rows with a blank date are skipped. UTC parse keeps the
+	 * epochs correct regardless of MySQL session timezone. user_registered is
+	 * treated as UTC (WordPress stores it as the GMT registration instant).
+	 *
+	 * @param mixed  $rows         wpdb rows (ARRAY_A).
+	 * @param string $first_key    Row key holding the first-conversion date.
+	 * @param string $first_ts_out Output key for the first-conversion epoch.
+	 * @return array<int, array<string,int>>
+	 */
+	private function rows_to_lags( $rows, string $first_key, string $first_ts_out ): array {
+		$utc  = new \DateTimeZone( 'UTC' );
+		$out  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row[ $first_key ] ) || empty( $row['user_registered'] ) ) {
+				continue;
+			}
+			$out[] = [
+				'customer_id'   => (int) $row['customer_id'],
+				'registered_ts' => ( new \DateTimeImmutable( $row['user_registered'], $utc ) )->getTimestamp(),
+				$first_ts_out   => ( new \DateTimeImmutable( $row[ $first_key ], $utc ) )->getTimestamp(),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1128,8 +1128,77 @@ class Legacy_Storage implements Storage_Interface {
 		// Legacy CPT equivalent of HPOS get_new_subscriber_records_in_window().
 		// Guest orders (blank _customer_user → 0 when cast) are excluded from
 		// source attribution — see the HPOS variant for the rationale.
+		//
+		// Source meta lives on the PARENT shop_order (post_parent of the
+		// shop_subscription post), NOT on the shop_subscription post itself.
+		// Correlated subqueries (MySQL 5.7-safe) read _gate_post_id /
+		// _memberships_content_gate / _newspack_popup_id from {prefix}postmeta
+		// WHERE post_id = p_sub.post_parent. LIMIT 1 resolves same-timestamp
+		// ties — any one tied first-subscription's parent-order meta is used.
 		$sql = $wpdb->prepare(
-			"SELECT first_subs.customer_id, first_subs.first_start FROM (
+			"SELECT
+				first_subs.customer_id,
+				first_subs.first_start,
+				COALESCE((
+					SELECT pm_gate.meta_value
+					FROM {$prefix}posts p_sub
+					JOIN {$prefix}postmeta cust_s
+						ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta start_s
+						ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
+					JOIN {$prefix}postmeta pm_gate
+						ON pm_gate.post_id = p_sub.post_parent AND pm_gate.meta_key = '_gate_post_id'
+					JOIN {$prefix}woocommerce_order_items oi_s
+						ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim_s
+						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+					WHERE p_sub.post_type = 'shop_subscription'
+					  AND CAST(cust_s.meta_value AS UNSIGNED) = first_subs.customer_id
+					  AND oim_s.meta_value NOT IN ($donations)
+					  AND start_s.meta_value = first_subs.first_start
+					  AND pm_gate.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), (
+					SELECT pm_legacy.meta_value
+					FROM {$prefix}posts p_sub
+					JOIN {$prefix}postmeta cust_s
+						ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta start_s
+						ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
+					JOIN {$prefix}postmeta pm_legacy
+						ON pm_legacy.post_id = p_sub.post_parent AND pm_legacy.meta_key = '_memberships_content_gate'
+					JOIN {$prefix}woocommerce_order_items oi_s
+						ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim_s
+						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+					WHERE p_sub.post_type = 'shop_subscription'
+					  AND CAST(cust_s.meta_value AS UNSIGNED) = first_subs.customer_id
+					  AND oim_s.meta_value NOT IN ($donations)
+					  AND start_s.meta_value = first_subs.first_start
+					  AND pm_legacy.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS gate_post_id,
+				COALESCE((
+					SELECT pm_popup.meta_value
+					FROM {$prefix}posts p_sub
+					JOIN {$prefix}postmeta cust_s
+						ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta start_s
+						ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
+					JOIN {$prefix}postmeta pm_popup
+						ON pm_popup.post_id = p_sub.post_parent AND pm_popup.meta_key = '_newspack_popup_id'
+					JOIN {$prefix}woocommerce_order_items oi_s
+						ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim_s
+						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+					WHERE p_sub.post_type = 'shop_subscription'
+					  AND CAST(cust_s.meta_value AS UNSIGNED) = first_subs.customer_id
+					  AND oim_s.meta_value NOT IN ($donations)
+					  AND start_s.meta_value = first_subs.first_start
+					  AND pm_popup.meta_value NOT IN ('', '0')
+					LIMIT 1
+				), '') AS popup_id
+			FROM (
 				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
 				FROM {$prefix}posts p
 				JOIN {$prefix}postmeta cust
@@ -1151,7 +1220,32 @@ class Legacy_Storage implements Storage_Interface {
 			$this->fmt( $end )
 		);
 
-		return $this->rows_to_records( $wpdb->get_results( $sql, ARRAY_A ), 'first_start' );
+		return $this->rows_to_subscriber_records( $wpdb->get_results( $sql, ARRAY_A ) );
+	}
+
+	/**
+	 * Map (customer_id, first_start, gate_post_id, popup_id) rows to subscriber
+	 * source records with UTC epoch seconds. Blank dates are skipped. UTC parse
+	 * keeps the epoch correct regardless of MySQL session timezone.
+	 *
+	 * @param mixed $rows wpdb->get_results( …, ARRAY_A ) output.
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
+	 */
+	private function rows_to_subscriber_records( $rows ): array {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$records = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['first_start'] ) ) {
+				continue;
+			}
+			$records[] = [
+				'customer_id'  => (int) $row['customer_id'],
+				'ts'           => ( new \DateTimeImmutable( $row['first_start'], $utc ) )->getTimestamp(),
+				'gate_post_id' => (string) ( $row['gate_post_id'] ?? '' ),
+				'popup_id'     => (string) ( $row['popup_id'] ?? '' ),
+			];
+		}
+		return $records;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -325,4 +325,16 @@ interface Storage_Interface {
 	 * @return array<int, \DateTimeImmutable> customer_id => first subscription start (UTC).
 	 */
 	public function get_first_subscription_order_dates( array $customer_ids ): array;
+
+	/**
+	 * New non-donation subscribers in the window, each with the epoch timestamp
+	 * (UTC seconds) of their FIRST subscription start. Same population as
+	 * {@see get_new_subscribers_in_window()} but returns one record per customer
+	 * with the anchor timestamp for Source_Matcher (Tab 3 source-mix 3.2).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{customer_id:int, ts:int}>
+	 */
+	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -328,13 +328,18 @@ interface Storage_Interface {
 
 	/**
 	 * New non-donation subscribers in the window, each with the epoch timestamp
-	 * (UTC seconds) of their FIRST subscription start. Same population as
+	 * (UTC seconds) of their FIRST subscription start plus order-meta sourced from
+	 * the subscription's parent shop_order. Same population as
 	 * {@see get_new_subscribers_in_window()} but returns one record per customer
-	 * with the anchor timestamp for Source_Matcher (Tab 3 source-mix 3.2).
+	 * enriched with parent-order source attribution for Tab 3 source-mix 3.2.
+	 * gate_post_id: non-empty _gate_post_id (or legacy _memberships_content_gate)
+	 * from the first subscription's parent order; '' if absent. popup_id:
+	 * non-empty _newspack_popup_id from the parent order; '' if absent. Records
+	 * with both '' fall to the BQ temporal matcher in compute_source_mix.
 	 *
 	 * @param DateTimeInterface $start Inclusive window start.
 	 * @param DateTimeInterface $end   Inclusive window end.
-	 * @return array<int, array{customer_id:int, ts:int}>
+	 * @return array<int, array{customer_id:int, ts:int, gate_post_id:string, popup_id:string}>
 	 */
 	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array;
 

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -337,4 +337,14 @@ interface Storage_Interface {
 	 * @return array<int, array{customer_id:int, ts:int}>
 	 */
 	public function get_new_subscriber_records_in_window( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
+	 * All-history: every customer with a non-donation subscription AND a
+	 * wp_users row, with their registration epoch and first-subscription epoch
+	 * (both UTC seconds). Drives the 4.2 time-to-subscribe distribution
+	 * (lag = first_sub_ts − registered_ts) and its user_registered source anchor.
+	 *
+	 * @return array<int, array{customer_id:int, registered_ts:int, first_sub_ts:int}>
+	 */
+	public function get_subscription_conversion_lags(): array;
 }

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.42.2
+ * Version: 6.42.3
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.42.2' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.42.3' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.42.1
+ * Version: 6.42.2
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.42.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.42.2' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.43.1
+ * Version: 6.43.2
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.43.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.43.2' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.43.2
+ * Version: 6.43.3
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.43.2' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.43.3' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package-lock.json
+++ b/plugins/newspack-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack",
-	"version": "6.42.1",
+	"version": "6.42.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack",
-			"version": "6.42.1",
+			"version": "6.42.2",
 			"dependencies": {
 				"classnames": "^2.5.1",
 				"colord": "^2.9.3",

--- a/plugins/newspack-plugin/package-lock.json
+++ b/plugins/newspack-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack",
-	"version": "6.42.2",
+	"version": "6.42.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack",
-			"version": "6.42.2",
+			"version": "6.42.3",
 			"dependencies": {
 				"classnames": "^2.5.1",
 				"colord": "^2.9.3",

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.43.1",
+	"version": "6.43.2",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.43.2",
+	"version": "6.43.3",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.42.2",
+	"version": "6.42.3",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.42.1",
+	"version": "6.42.2",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/packages/components/src/web-preview/style.scss
+++ b/plugins/newspack-plugin/packages/components/src/web-preview/style.scss
@@ -103,10 +103,9 @@
 		}
 
 		&-right {
-			display: grid;
+			display: flex;
 			gap: 8px;
-			grid-template-columns: repeat(2, 1fr);
-			justify-self: end;
+			justify-content: flex-end;
 			margin-left: auto;
 		}
 	}

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
@@ -111,7 +111,9 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 			label: __( 'Checkout & Payment', 'newspack-plugin' ),
 			path: '/payment',
 		},
-		{
+		// "Advanced settings" hosts the Group labels override, which only makes
+		// sense when the Newspack Content Gate / Group subscriptions feature is on.
+		newspackAudience.is_newspack_feature_enabled && {
 			label: __( 'Advanced settings', 'newspack-plugin' ),
 			path: '/groups',
 		},
@@ -163,7 +165,7 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 					<Route path="/" exact render={ () => <Setup { ...props } /> } />
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
-					<Route path="/groups" render={ () => <Groups { ...props } /> } />
+					{ newspackAudience.is_newspack_feature_enabled && <Route path="/groups" render={ () => <Groups { ...props } /> } /> }
 					<Route path="/campaign" render={ () => <Campaign { ...props } /> } />
 					<Route path="/complete" render={ () => <Complete { ...props } /> } />
 					<Redirect to="/" />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
@@ -58,4 +58,23 @@ describe( 'HowLongConversionsTakeSection', () => {
 		// lag is visible but state is coming_soon — all three (4.2, 4.3, 4.4) show coming_soon.
 		expect( screen.getAllByText( /Coming soon/ ) ).toHaveLength( 3 );
 	} );
+
+	it( 'captions the snapshot charts as ignoring the date range', () => {
+		const emptyMulti = { state: 'empty' as const, groups: [] };
+		const baseWindow = {
+			time_to_register_distribution: { state: 'empty' as const, points: [] },
+			time_to_subscribe_distribution: emptyMulti,
+			time_to_donate_distribution: emptyMulti,
+			subscriber_to_donor_lag_distribution: {
+				state: 'empty' as const,
+				points: [],
+				visibility: 'visible' as const,
+				visibility_reason: null,
+			},
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		render( <HowLongConversionsTakeSection current={ baseWindow as any } /> );
+		const captions = screen.getAllByText( /uses all available history/i );
+		expect( captions ).toHaveLength( 3 ); // 4.2, 4.3, 4.4 — not 4.1.
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -40,18 +40,21 @@ const toLineSeries = ( data: ConversionCumulativeMulti ): LineSeries[] =>
 
 interface CurveCellProps {
 	title: string;
+	caption?: string;
 	children: React.ReactNode;
 }
 
-const CurveCell = ( { title, children }: CurveCellProps ) => (
+const CurveCell = ( { title, caption, children }: CurveCellProps ) => (
 	<div className="newspack-insights__conversion-curve-cell">
 		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
+		{ caption && <p className="newspack-insights__conversion-subcaption">{ caption }</p> }
 		{ children }
 	</div>
 );
 
 const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSectionProps ) => {
 	const lag = current.subscriber_to_donor_lag_distribution;
+	const snapshotCaption = __( 'This view always uses all available history, regardless of the selected date range.', 'newspack-plugin' );
 	return (
 		<section
 			className="newspack-insights__section newspack-insights__section--time-to-convert"
@@ -80,7 +83,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					</SectionState>
 				</CurveCell>
 				{ /* 4.2 — time to subscribe: Phase B, coming_soon */ }
-				<CurveCell title={ __( 'Time to subscribe', 'newspack-plugin' ) }>
+				<CurveCell title={ __( 'Time to subscribe', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					<SectionState
 						state={ current.time_to_subscribe_distribution.state }
 						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
@@ -93,7 +96,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					</SectionState>
 				</CurveCell>
 				{ /* 4.3 — time to donate: Phase B, coming_soon */ }
-				<CurveCell title={ __( 'Time to donate', 'newspack-plugin' ) }>
+				<CurveCell title={ __( 'Time to donate', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					<SectionState
 						state={ current.time_to_donate_distribution.state }
 						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
@@ -106,7 +109,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					</SectionState>
 				</CurveCell>
 				{ /* 4.4 — subscriber → donor lag: Phase B, coming_soon + visibility gate */ }
-				<CurveCell title={ __( 'Subscriber → donor lag', 'newspack-plugin' ) }>
+				<CurveCell title={ __( 'Subscriber → donor lag', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					{ lag.visibility === 'hidden' ? (
 						<p className="newspack-insights__conversion-gated-note">
 							{ __( 'Subscriber-to-donor lag appears when at least 50 readers have both subscribed and donated.', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -432,6 +432,12 @@ class WC_Subscription {
 		}
 		return (float) ( $wcs_mock_items_sign_up_fee ?? 0 );
 	}
+	public function needs_payment() {
+		return ! empty( $this->data['needs_payment'] );
+	}
+	public function get_view_order_url() {
+		return $this->data['view_order_url'] ?? 'https://example.test/my-account/view-order/' . $this->get_id();
+	}
 	public function save() {
 		return true;
 	}
@@ -635,6 +641,21 @@ function wcs_get_users_subscriptions( $user_id ) {
 	// subs the user is only a member of). Tests that need ownership semantics
 	// must guard against this just like production code.
 	return apply_filters( 'wcs_get_users_subscriptions', $user_subscriptions, $user_id );
+}
+function wcs_get_subscriptions( $args = [] ) {
+	// Minimal mock: implements only the `customer_id` filter, the sole arg the code
+	// under test passes. If a future test needs status/paging args
+	// (subscription_status, subscriptions_per_page, paged, offset), extend the filter
+	// here rather than relying on this returning the full set.
+	global $subscriptions_database;
+	$customer_id = $args['customer_id'] ?? null;
+	$matches     = [];
+	foreach ( $subscriptions_database as $id => $subscription ) {
+		if ( null === $customer_id || $subscription->get_customer_id() === $customer_id ) {
+			$matches[ $id ] = $subscription;
+		}
+	}
+	return $matches;
 }
 function wcs_get_canonical_product_id( $item ) {
 	if ( is_object( $item ) && method_exists( $item, 'get_product_id' ) ) {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -529,4 +529,50 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$this->assertSame( $recs, $metric->get_new_donor_records_in_window( $this->make_date( '2026-03-01' ), $this->make_date( '2026-03-31' ) ) );
 		$this->assertSame( [], $metric->get_new_donor_records_in_window( $this->make_date( '2026-04-01' ), $this->make_date( '2026-04-30' ) ) );
 	}
+
+	/**
+	 * Storages expose the conversion-lag methods.
+	 */
+	public function test_storages_implement_conversion_lag_methods(): void {
+		$this->assertTrue( method_exists( new HPOS_Storage( [] ), 'get_subscription_conversion_lags' ) );
+		$this->assertTrue( method_exists( new Legacy_Storage( [] ), 'get_subscription_conversion_lags' ) );
+		$this->assertTrue( method_exists( new HPOS_Donors_Storage( [] ), 'get_donation_conversion_lags' ) );
+		$this->assertTrue( method_exists( new Legacy_Donors_Storage( [] ), 'get_donation_conversion_lags' ) );
+	}
+
+	/**
+	 * Subscribers_Metric::get_subscription_conversion_lags delegates (NOT cached).
+	 */
+	public function test_subscribers_metric_subscription_conversion_lags_delegates(): void {
+		$rows = [
+			[
+				'customer_id'   => 1,
+				'registered_ts' => 1000,
+				'first_sub_ts'  => 1000 + 86400 * 10,
+			],
+		];
+		$mock = $this->createMock( Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )->method( 'get_subscription_conversion_lags' )->willReturnOnConsecutiveCalls( $rows, [] );
+		$metric = $this->make_subscribers_metric( $mock );
+		$this->assertSame( $rows, $metric->get_subscription_conversion_lags() );
+		$this->assertSame( [], $metric->get_subscription_conversion_lags() );
+	}
+
+	/**
+	 * Donors_Metric::get_donation_conversion_lags delegates (NOT cached).
+	 */
+	public function test_donors_metric_donation_conversion_lags_delegates(): void {
+		$rows = [
+			[
+				'customer_id'       => 2,
+				'registered_ts'     => 2000,
+				'first_donation_ts' => 2000 + 86400 * 5,
+			],
+		];
+		$mock = $this->createMock( Donors_Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )->method( 'get_donation_conversion_lags' )->willReturnOnConsecutiveCalls( $rows, [] );
+		$metric = $this->make_donors_metric( $mock );
+		$this->assertSame( $rows, $metric->get_donation_conversion_lags() );
+		$this->assertSame( [], $metric->get_donation_conversion_lags() );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -575,4 +575,24 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$this->assertSame( $rows, $metric->get_donation_conversion_lags() );
 		$this->assertSame( [], $metric->get_donation_conversion_lags() );
 	}
+
+	/**
+	 * Donor storages expose get_subscriber_to_donor_lags.
+	 */
+	public function test_donor_storages_implement_sub_to_donor_lags(): void {
+		$this->assertTrue( method_exists( new HPOS_Donors_Storage( [] ), 'get_subscriber_to_donor_lags' ) );
+		$this->assertTrue( method_exists( new Legacy_Donors_Storage( [] ), 'get_subscriber_to_donor_lags' ) );
+	}
+
+	/**
+	 * Donors_Metric::get_subscriber_to_donor_lags delegates (NOT cached).
+	 */
+	public function test_donors_metric_sub_to_donor_lags_delegates(): void {
+		$rows = [ [ 'lag_days' => 12 ], [ 'lag_days' => 40 ] ];
+		$mock = $this->createMock( Donors_Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )->method( 'get_subscriber_to_donor_lags' )->willReturnOnConsecutiveCalls( $rows, [] );
+		$metric = $this->make_donors_metric( $mock );
+		$this->assertSame( $rows, $metric->get_subscriber_to_donor_lags() );
+		$this->assertSame( [], $metric->get_subscriber_to_donor_lags() );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -481,4 +481,52 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$metric = $this->make_subscribers_metric( $mock );
 		$this->assertSame( 0, $metric->get_stale_registered_users() );
 	}
+
+	/**
+	 * HPOS storages expose the new windowed-record methods.
+	 */
+	public function test_storages_implement_windowed_record_methods(): void {
+		$this->assertTrue( method_exists( new HPOS_Storage( [] ), 'get_new_subscriber_records_in_window' ) );
+		$this->assertTrue( method_exists( new Legacy_Storage( [] ), 'get_new_subscriber_records_in_window' ) );
+		$this->assertTrue( method_exists( new HPOS_Donors_Storage( [] ), 'get_new_donor_records_in_window' ) );
+		$this->assertTrue( method_exists( new Legacy_Donors_Storage( [] ), 'get_new_donor_records_in_window' ) );
+	}
+
+	/**
+	 * Subscribers_Metric::get_new_subscriber_records_in_window delegates (list-param, NOT cached).
+	 */
+	public function test_subscribers_metric_new_subscriber_records_delegates(): void {
+		$recs = [
+			[
+				'customer_id' => 1,
+				'ts'          => 1700000000,
+			],
+		];
+		$mock = $this->createMock( Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'get_new_subscriber_records_in_window' )
+			->willReturnOnConsecutiveCalls( $recs, [] );
+		$metric = $this->make_subscribers_metric( $mock );
+		$this->assertSame( $recs, $metric->get_new_subscriber_records_in_window( $this->make_date( '2026-03-01' ), $this->make_date( '2026-03-31' ) ) );
+		$this->assertSame( [], $metric->get_new_subscriber_records_in_window( $this->make_date( '2026-04-01' ), $this->make_date( '2026-04-30' ) ) );
+	}
+
+	/**
+	 * Donors_Metric::get_new_donor_records_in_window delegates (list-param, NOT cached).
+	 */
+	public function test_donors_metric_new_donor_records_delegates(): void {
+		$recs = [
+			[
+				'customer_id' => 5,
+				'ts'          => 1700000500,
+			],
+		];
+		$mock = $this->createMock( Donors_Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'get_new_donor_records_in_window' )
+			->willReturnOnConsecutiveCalls( $recs, [] );
+		$metric = $this->make_donors_metric( $mock );
+		$this->assertSame( $recs, $metric->get_new_donor_records_in_window( $this->make_date( '2026-03-01' ), $this->make_date( '2026-03-31' ) ) );
+		$this->assertSame( [], $metric->get_new_donor_records_in_window( $this->make_date( '2026-04-01' ), $this->make_date( '2026-04-30' ) ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -909,8 +909,17 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$proxy    = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )->willReturn( $wp_error );
 
-		$resolver        = $this->createMock( Woo_Order_Resolver::class );
-		$metric          = new Conversion_Metric( $proxy, $resolver );
+		// Records exist (conversions happened); the BQ source layer fails → 'error'.
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn(
+			[
+				[
+					'customer_id' => 1,
+					'ts'          => 1700000000,
+				],
+			] 
+		);
+		$metric          = new Conversion_Metric( $proxy, null, $subs );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_source_mix_subscribers( $start, $end );
 
@@ -1047,8 +1056,17 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$proxy    = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )->willReturn( $wp_error );
 
-		$resolver        = $this->createMock( Woo_Order_Resolver::class );
-		$metric          = new Conversion_Metric( $proxy, $resolver );
+		// Records exist (conversions happened); the BQ source layer fails → 'error'.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donor_records_in_window' )->willReturn(
+			[
+				[
+					'customer_id' => 1,
+					'ts'          => 1700000000,
+				],
+			] 
+		);
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_source_mix_donors( $start, $end );
 
@@ -1843,18 +1861,17 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Deferred (Phase-B) sections are 'coming_soon' in the populated fixture variant
-	 * and carry their preserved extra keys. Note: 4.2 and 4.3 are now wired to live
-	 * data in the real metric; the fixture still hardcodes 'coming_soon' as a static
-	 * snapshot and is asserted here only for fixture shape stability.
+	 * Phase-B section states in the populated fixture variant. 4.2/4.3/4.4 are
+	 * implemented (all-history snapshots → 'populated'); 5.1/5.2 cohorts remain
+	 * 'coming_soon' stubs. Each carries its preserved extra keys.
 	 */
-	public function test_fixture_populated_deferred_sections_are_coming_soon() {
+	public function test_fixture_populated_phase_b_section_states() {
 		$current = Conversion_Metric::get_fixture( 'populated', false )['current'];
 
-		// 4.2 and 4.3 — fixture still hardcodes coming_soon (static fixture shape).
-		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
+		// 4.2 and 4.3 — implemented; the fixture carries representative curves.
+		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
 		$this->assertArrayHasKey( 'groups', $current['time_to_subscribe_distribution'] );
-		$this->assertSame( 'coming_soon', $current['time_to_donate_distribution']['state'] );
+		$this->assertSame( 'populated', $current['time_to_donate_distribution']['state'] );
 		$this->assertArrayHasKey( 'groups', $current['time_to_donate_distribution'] );
 
 		// 4.4 — lag distribution (points + visibility keys); populated but hidden when below threshold.
@@ -1910,8 +1927,8 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'empty', $current['top_pages_no_conversion']['state'] );
 		$this->assertSame( [], $current['top_pages_no_conversion']['rows'] );
 
-		// Deferred sections stay 'coming_soon'.
-		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
+		// 4.2 is an all-history snapshot → populated; the 5.1 cohort stays coming_soon.
+		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
 		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
 	}
 
@@ -1946,8 +1963,8 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $current['at_risk_subscriber_count']['state'] );
 		$this->assertSame( 'populated', $current['lapsed_donor_count']['state'] );
 
-		// Deferred sections stay 'coming_soon'.
-		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
+		// 4.2 is an all-history snapshot → populated; the 5.1 cohort stays coming_soon.
+		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
 		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
 	}
 
@@ -2024,7 +2041,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'customer_id' => 1,
 					'ts'          => 1700000000,
 				],
-			] 
+			]
 		);
 		$metric = new Conversion_Metric(
 			$this->proxy_returning( new \WP_Error( 'boom', 'nope' ) ),
@@ -2055,6 +2072,29 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$result          = $metric->get_source_mix_subscribers( $start, $end );
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( [], $result['slices'] );
+	}
+
+	/**
+	 * 3.2 source mix: a non-array BigQuery success body is a malformed response
+	 * and surfaces as an 'error' envelope (not silent all-direct) when Woo
+	 * records exist.
+	 */
+	public function test_source_mix_subscribers_malformed_bq_body(): void {
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn(
+			[
+				[
+					'customer_id' => 1,
+					'ts'          => 1700000000,
+				],
+			] 
+		);
+		$metric          = new Conversion_Metric( $this->proxy_returning( 'not-an-array' ), null, $subs );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
 		$this->assertSame( [], $result['slices'] );
 	}
 
@@ -2143,7 +2183,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'cumulative_pct' => 1.0,
 				],
 			],
-			$gate['points'] 
+			$gate['points']
 		); // customer 1.
 		$this->assertSame(
 			[
@@ -2152,7 +2192,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'cumulative_pct' => 1.0,
 				],
 			],
-			$direct['points'] 
+			$direct['points']
 		); // customer 2; customer 3 truncated.
 	}
 
@@ -2185,7 +2225,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'cumulative_pct' => 1.0,
 				],
 			],
-			$result['groups'][2]['points'] 
+			$result['groups'][2]['points']
 		); // direct.
 		$this->assertSame( [], $result['groups'][0]['points'] ); // gate empty.
 	}
@@ -2314,7 +2354,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'cumulative_pct' => 1.0,
 				],
 			],
-			$prompt['points'] 
+			$prompt['points']
 		); // customer 10.
 		$this->assertSame(
 			[
@@ -2323,7 +2363,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'cumulative_pct' => 1.0,
 				],
 			],
-			$direct['points'] 
+			$direct['points']
 		); // customer 11; customer 12 truncated.
 	}
 
@@ -2362,7 +2402,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 					'cumulative_pct' => 1.0,
 				],
 			],
-			$result['points'] 
+			$result['points']
 		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -155,32 +155,30 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	// --- C20: get_time_to_subscribe_distribution --------------------------
 
 	/**
-	 * C20 coming_soon: returns state 'coming_soon' with an empty 'groups'
-	 * collection and no 'pending' key.
+	 * C20 wired: returns a state-envelope with a 'groups' key (three groups
+	 * always present) and no 'pending' key. With no Woo data → empty state.
 	 */
-	public function test_time_to_subscribe_distribution_is_coming_soon() {
+	public function test_time_to_subscribe_distribution_returns_groups_envelope() {
 		[ $start, $end ] = $this->window();
 		$result          = $this->metric->get_time_to_subscribe_distribution( $start, $end );
 
-		$this->assertSame( 'coming_soon', $result['state'] );
+		$this->assertArrayHasKey( 'state', $result );
 		$this->assertArrayHasKey( 'groups', $result );
-		$this->assertSame( [], $result['groups'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
 	}
 
 	// --- C21: get_time_to_donate_distribution ------------------------------
 
 	/**
-	 * C21 coming_soon: returns state 'coming_soon' with an empty 'groups'
-	 * collection and no 'pending' key.
+	 * C21 wired: returns a state-envelope with a 'groups' key (three groups
+	 * always present) and no 'pending' key. With no Woo data → empty state.
 	 */
-	public function test_time_to_donate_distribution_is_coming_soon() {
+	public function test_time_to_donate_distribution_returns_groups_envelope() {
 		[ $start, $end ] = $this->window();
 		$result          = $this->metric->get_time_to_donate_distribution( $start, $end );
 
-		$this->assertSame( 'coming_soon', $result['state'] );
+		$this->assertArrayHasKey( 'state', $result );
 		$this->assertArrayHasKey( 'groups', $result );
-		$this->assertSame( [], $result['groups'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
 	}
 
@@ -1843,17 +1841,19 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Deferred (Phase-B) sections are 'coming_soon' in the populated variant and
-	 * carry their preserved extra keys.
+	 * Deferred (Phase-B) sections are 'coming_soon' in the populated fixture variant
+	 * and carry their preserved extra keys. Note: 4.2 and 4.3 are now wired to live
+	 * data in the real metric; the fixture still hardcodes 'coming_soon' as a static
+	 * snapshot and is asserted here only for fixture shape stability.
 	 */
 	public function test_fixture_populated_deferred_sections_are_coming_soon() {
 		$current = Conversion_Metric::get_fixture( 'populated', false )['current'];
 
-		// 4.2 and 4.3 — time distributions (groups key).
+		// 4.2 and 4.3 — fixture still hardcodes coming_soon (static fixture shape).
 		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
-		$this->assertSame( [], $current['time_to_subscribe_distribution']['groups'] );
+		$this->assertArrayHasKey( 'groups', $current['time_to_subscribe_distribution'] );
 		$this->assertSame( 'coming_soon', $current['time_to_donate_distribution']['state'] );
-		$this->assertSame( [], $current['time_to_donate_distribution']['groups'] );
+		$this->assertArrayHasKey( 'groups', $current['time_to_donate_distribution'] );
 
 		// 4.4 — lag distribution (points + visibility keys).
 		$this->assertSame( 'coming_soon', $current['subscriber_to_donor_lag_distribution']['state'] );
@@ -2075,5 +2075,211 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	public function test_fixture_current_window_has_24_keys() {
 		$current = Conversion_Metric::get_fixture( 'populated', false )['current'];
 		$this->assertCount( 24, $current );
+	}
+
+	/**
+	 * 4.2: per-source cumulative distribution; reg matched to a BQ source event
+	 * within ±120s; unmatched reg → direct; lag > 365 truncated.
+	 */
+	public function test_time_to_subscribe_distribution_buckets_and_truncates(): void {
+		$reg1 = 1_700_000_000;
+		$rows = [
+			// Registered, subscribed 10 days later, has a 'gate' reg event 30s after registering.
+			[
+				'customer_id'   => 1,
+				'registered_ts' => $reg1,
+				'first_sub_ts'  => $reg1 + 86400 * 10,
+			],
+			// Registered, subscribed 20 days later, no BQ reg event → direct.
+			[
+				'customer_id'   => 2,
+				'registered_ts' => $reg1 + 100000,
+				'first_sub_ts'  => $reg1 + 100000 + 86400 * 20,
+			],
+			// Registered, subscribed 400 days later → truncated out.
+			[
+				'customer_id'   => 3,
+				'registered_ts' => $reg1 + 200000,
+				'first_sub_ts'  => $reg1 + 200000 + 86400 * 400,
+			],
+		];
+		$probe = [ [ 'registration_events' => 5 ] ];
+		$reg_events = [
+			[
+				'reg_ts' => (string) ( ( $reg1 + 30 ) * 1_000_000 ),
+				'source' => 'gate',
+			],
+		];
+
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_subscription_conversion_lags' )->willReturn( $rows );
+		$metric = new Conversion_Metric(
+			$this->proxy_by_query(
+				[
+					'conversion_journey_has_registrations_in_window' => $probe,
+					'conversion_journey_registrations_with_source'   => $reg_events,
+				]
+			),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_time_to_subscribe_distribution( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 3, $result['groups'] );
+		$labels = array_column( $result['groups'], 'label' );
+		$this->assertSame( [ 'gate', 'prompt', 'direct' ], $labels );
+
+		$gate   = $result['groups'][0];
+		$direct = $result['groups'][2];
+		$this->assertSame(
+			[
+				[
+					'day'            => 10,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$gate['points'] 
+		); // customer 1.
+		$this->assertSame(
+			[
+				[
+					'day'            => 20,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$direct['points'] 
+		); // customer 2; customer 3 truncated.
+	}
+
+	/**
+	 * 4.2 degradation: probe returns 0 → no expensive query → every reg → direct.
+	 */
+	public function test_time_to_subscribe_distribution_probe_zero_all_direct(): void {
+		$reg1 = 1_700_000_000;
+		$rows = [
+			[
+				'customer_id'   => 1,
+				'registered_ts' => $reg1,
+				'first_sub_ts'  => $reg1 + 86400 * 7,
+			],
+		];
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_subscription_conversion_lags' )->willReturn( $rows );
+		$metric = new Conversion_Metric(
+			$this->proxy_by_query( [ 'conversion_journey_has_registrations_in_window' => [ [ 'registration_events' => 0 ] ] ] ),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_time_to_subscribe_distribution( $start, $end );
+		$this->assertSame(
+			[
+				[
+					'day'            => 7,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$result['groups'][2]['points'] 
+		); // direct.
+		$this->assertSame( [], $result['groups'][0]['points'] ); // gate empty.
+	}
+
+	/**
+	 * 4.2: no converters → empty state, still three groups.
+	 */
+	public function test_time_to_subscribe_distribution_empty(): void {
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_subscription_conversion_lags' )->willReturn( [] );
+		$metric = new Conversion_Metric(
+			$this->proxy_by_query( [ 'conversion_journey_has_registrations_in_window' => [ [ 'registration_events' => 0 ] ] ] ),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_time_to_subscribe_distribution( $start, $end );
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertCount( 3, $result['groups'] );
+	}
+
+	/**
+	 * 4.3: per-source cumulative distribution for donations; mirrors 4.2 bucketing
+	 * test with Donors_Metric and first_donation_ts.
+	 */
+	public function test_time_to_donate_distribution_buckets_and_truncates(): void {
+		$reg1 = 1_700_000_000;
+		$rows = [
+			// Registered, donated 15 days later, has a 'prompt' reg event 50s before registering.
+			[
+				'customer_id'       => 10,
+				'registered_ts'     => $reg1,
+				'first_donation_ts' => $reg1 + 86400 * 15,
+			],
+			// Registered, donated 30 days later, no BQ reg event → direct.
+			[
+				'customer_id'       => 11,
+				'registered_ts'     => $reg1 + 100000,
+				'first_donation_ts' => $reg1 + 100000 + 86400 * 30,
+			],
+			// Registered, donated 400 days later → truncated out.
+			[
+				'customer_id'       => 12,
+				'registered_ts'     => $reg1 + 200000,
+				'first_donation_ts' => $reg1 + 200000 + 86400 * 400,
+			],
+		];
+		$probe      = [ [ 'registration_events' => 3 ] ];
+		$reg_events = [
+			[
+				'reg_ts' => (string) ( ( $reg1 - 50 ) * 1_000_000 ),
+				'source' => 'prompt',
+			],
+		];
+
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_donation_conversion_lags' )->willReturn( $rows );
+		$metric = new Conversion_Metric(
+			$this->proxy_by_query(
+				[
+					'conversion_journey_has_registrations_in_window' => $probe,
+					'conversion_journey_registrations_with_source'   => $reg_events,
+				]
+			),
+			null,
+			null,
+			$donors
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_time_to_donate_distribution( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 3, $result['groups'] );
+		$labels = array_column( $result['groups'], 'label' );
+		$this->assertSame( [ 'gate', 'prompt', 'direct' ], $labels );
+
+		$prompt = $result['groups'][1];
+		$direct = $result['groups'][2];
+		$this->assertSame(
+			[
+				[
+					'day'            => 15,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$prompt['points'] 
+		); // customer 10.
+		$this->assertSame(
+			[
+				[
+					'day'            => 30,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$direct['points'] 
+		); // customer 11; customer 12 truncated.
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2631,4 +2631,142 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0, $by['prompt']['count'] );
 		$this->assertSame( 1, $by['direct']['count'] ); // No BQ event → direct.
 	}
+
+	// --- C12 order-meta-primary tests (3.2) ------------------------------------
+	// Subscriber records now carry gate_post_id / popup_id from the parent order.
+	// BQ must NOT be called when every record has usable order meta.
+
+	/**
+	 * C12 order-meta gate: subscriber records with gate_post_id set → classified
+	 * as 'gate' WITHOUT any BQ proxy call. Mirrors C13 donor gate test.
+	 */
+	public function test_source_mix_subscribers_gate_from_order_meta_skips_bq(): void {
+		$records = [
+			[
+				'customer_id'  => 701,
+				'ts'           => 1_700_000_000,
+				'gate_post_id' => '55',
+				'popup_id'     => '',
+			],
+			[
+				'customer_id'  => 702,
+				'ts'           => 1_700_001_000,
+				'gate_post_id' => '55',
+				'popup_id'     => '',
+			],
+		];
+
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
+
+		// Proxy whose query() would fail the test if called.
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+
+		$metric          = new Conversion_Metric( $proxy, null, $subs, null );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 2, $result['total'] );
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 2, $by['gate']['count'] );
+		$this->assertSame( 0, $by['prompt']['count'] );
+		$this->assertSame( 0, $by['direct']['count'] );
+	}
+
+	/**
+	 * C12 order-meta prompt: subscriber records with popup_id (and no
+	 * gate_post_id) set → classified as 'prompt' WITHOUT any BQ proxy call.
+	 */
+	public function test_source_mix_subscribers_prompt_from_order_meta_skips_bq(): void {
+		$records = [
+			[
+				'customer_id'  => 801,
+				'ts'           => 1_700_000_000,
+				'gate_post_id' => '',
+				'popup_id'     => '42',
+			],
+		];
+
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
+
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+
+		$metric          = new Conversion_Metric( $proxy, null, $subs, null );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 1, $result['total'] );
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 0, $by['gate']['count'] );
+		$this->assertSame( 1, $by['prompt']['count'] );
+		$this->assertSame( 0, $by['direct']['count'] );
+	}
+
+	/**
+	 * C12 mixed: some subscriber records have parent-order meta (classified
+	 * without BQ), others do not (go to matcher). BQ is called once for the
+	 * unmetered records; totals combine correctly.
+	 * 1 gate from meta + 1 prompt from BQ + 1 direct from BQ = 3 total.
+	 */
+	public function test_source_mix_subscribers_mixed_meta_and_bq(): void {
+		$order_ts = 1_700_000_000;
+		$records  = [
+			// Has gate meta → classified from parent order meta; BQ not needed.
+			[
+				'customer_id'  => 901,
+				'ts'           => $order_ts,
+				'gate_post_id' => '77',
+				'popup_id'     => '',
+			],
+			// No meta → goes to BQ matcher; BQ returns a prompt event.
+			[
+				'customer_id'  => 902,
+				'ts'           => $order_ts + 1000,
+				'gate_post_id' => '',
+				'popup_id'     => '',
+			],
+			// No meta → goes to BQ matcher; BQ has no matching event → direct.
+			[
+				'customer_id'  => 903,
+				'ts'           => $order_ts + 9000,
+				'gate_post_id' => '',
+				'popup_id'     => '',
+			],
+		];
+
+		// BQ returns a prompt event 60s before customer 902's subscription start.
+		$bq_rows = [
+			[
+				'attempt_ts'   => (string) ( ( $order_ts + 1000 - 60 ) * 1_000_000 ),
+				'gate_post_id' => '',
+				'popup_id'     => '33',
+			],
+		];
+
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
+
+		// BQ must be called exactly once (for the 2 records lacking parent-order meta).
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'conversion_journey_source_mix_subscribers' )
+			->willReturn( $bq_rows );
+
+		$metric          = new Conversion_Metric( $proxy, null, $subs, null );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 3, $result['total'] ); // 1 gate + 1 prompt + 1 direct.
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 1, $by['gate']['count'] );   // from parent order meta.
+		$this->assertSame( 1, $by['prompt']['count'] ); // from BQ matcher.
+		$this->assertSame( 1, $by['direct']['count'] ); // BQ-unmatched.
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2411,4 +2411,224 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			$result['points']
 		);
 	}
+
+	// --- C13 order-meta-primary tests (3.3) -----------------------------------
+	// Donor records now carry gate_post_id / popup_id from order meta.
+	// The BQ proxy must NOT be called when every record has usable order meta.
+
+	/**
+	 * C13 order-meta gate: donor records with gate_post_id set → classified as
+	 * 'gate' WITHOUT any BQ proxy call. A proxy whose query() throws an exception
+	 * would fail the test, proving no BQ round-trip was made.
+	 */
+	public function test_source_mix_donors_gate_from_order_meta_skips_bq(): void {
+		$records = [
+			[
+				'customer_id'  => 201,
+				'ts'           => 1_700_000_000,
+				'gate_post_id' => '55',
+				'popup_id'     => '',
+			],
+			[
+				'customer_id'  => 202,
+				'ts'           => 1_700_001_000,
+				'gate_post_id' => '55',
+				'popup_id'     => '',
+			],
+		];
+
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donor_records_in_window' )->willReturn( $records );
+
+		// Proxy whose query() would fail the test if called.
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_donors( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 2, $result['total'] );
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 2, $by['gate']['count'] );
+		$this->assertSame( 0, $by['prompt']['count'] );
+		$this->assertSame( 0, $by['direct']['count'] );
+	}
+
+	/**
+	 * C13 order-meta prompt: donor records with popup_id (and no gate_post_id)
+	 * set → classified as 'prompt' WITHOUT any BQ proxy call.
+	 */
+	public function test_source_mix_donors_prompt_from_order_meta_skips_bq(): void {
+		$records = [
+			[
+				'customer_id'  => 301,
+				'ts'           => 1_700_000_000,
+				'gate_post_id' => '',
+				'popup_id'     => '42',
+			],
+		];
+
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donor_records_in_window' )->willReturn( $records );
+
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_donors( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 1, $result['total'] );
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 0, $by['gate']['count'] );
+		$this->assertSame( 1, $by['prompt']['count'] );
+		$this->assertSame( 0, $by['direct']['count'] );
+	}
+
+	/**
+	 * C13 order-meta fallback to BQ: donor records WITHOUT order meta
+	 * (gate_post_id='' AND popup_id='') fall to the temporal BQ matcher;
+	 * BQ IS called and drives the attribution.
+	 */
+	public function test_source_mix_donors_no_meta_falls_to_bq_matcher(): void {
+		$order_ts = 1_700_000_000;
+		$records  = [
+			[
+				'customer_id'  => 401,
+				'ts'           => $order_ts,
+				'gate_post_id' => '',
+				'popup_id'     => '',
+			],
+		];
+
+		// BQ returns a gate event 60s before the order.
+		$bq_rows = [
+			[
+				'attempt_ts'   => (string) ( ( $order_ts - 60 ) * 1_000_000 ),
+				'gate_post_id' => '99',
+				'popup_id'     => '',
+			],
+		];
+
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donor_records_in_window' )->willReturn( $records );
+
+		// Proxy MUST be called once.
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'conversion_journey_source_mix_donors' )
+			->willReturn( $bq_rows );
+
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_donors( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 1, $result['total'] );
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 1, $by['gate']['count'] ); // BQ-matched as gate.
+		$this->assertSame( 0, $by['prompt']['count'] );
+		$this->assertSame( 0, $by['direct']['count'] );
+	}
+
+	/**
+	 * C13 mixed: some records have order meta (classified without BQ), others
+	 * do not (go to matcher). BQ is called once; totals combine correctly.
+	 * 1 gate from meta + 1 prompt from BQ + 1 direct from BQ = 3 total.
+	 */
+	public function test_source_mix_donors_mixed_meta_and_bq(): void {
+		$order_ts = 1_700_000_000;
+		$records  = [
+			// Has gate meta → classified from order meta; BQ not needed for this one.
+			[
+				'customer_id'  => 501,
+				'ts'           => $order_ts,
+				'gate_post_id' => '77',
+				'popup_id'     => '',
+			],
+			// No meta → goes to BQ matcher; BQ returns a prompt event.
+			[
+				'customer_id'  => 502,
+				'ts'           => $order_ts + 1000,
+				'gate_post_id' => '',
+				'popup_id'     => '',
+			],
+			// No meta → goes to BQ matcher; BQ has no event → direct.
+			[
+				'customer_id'  => 503,
+				'ts'           => $order_ts + 9000,
+				'gate_post_id' => '',
+				'popup_id'     => '',
+			],
+		];
+
+		// BQ returns a prompt event 60s before customer 502's order only.
+		$bq_rows = [
+			[
+				'attempt_ts'   => (string) ( ( $order_ts + 1000 - 60 ) * 1_000_000 ),
+				'gate_post_id' => '',
+				'popup_id'     => '33',
+			],
+		];
+
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donor_records_in_window' )->willReturn( $records );
+
+		// BQ must be called exactly once (for the 2 records lacking order meta).
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'conversion_journey_source_mix_donors' )
+			->willReturn( $bq_rows );
+
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_donors( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 3, $result['total'] ); // 1 gate + 1 prompt + 1 direct.
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 1, $by['gate']['count'] );   // from order meta.
+		$this->assertSame( 1, $by['prompt']['count'] ); // from BQ matcher.
+		$this->assertSame( 1, $by['direct']['count'] ); // BQ-unmatched.
+	}
+
+	/**
+	 * 3.2 subscribers still use the BQ temporal matcher even when the proxy
+	 * returns an empty event list. Subscriber records carry no gate_post_id /
+	 * popup_id keys, so they all fall to the matcher (unchanged behaviour).
+	 */
+	public function test_source_mix_subscribers_still_uses_bq_matcher(): void {
+		$records = [
+			[
+				'customer_id' => 601,
+				'ts'          => 1_700_000_000,
+			],
+		];
+
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
+
+		// BQ must be called (subscriber records have no meta → all go to matcher).
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'conversion_journey_source_mix_subscribers' )
+			->willReturn( [] ); // No events → subscriber goes to direct.
+
+		$metric          = new Conversion_Metric( $proxy, null, $subs, null );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 1, $result['total'] );
+		$by = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 0, $by['gate']['count'] );
+		$this->assertSame( 0, $by['prompt']['count'] );
+		$this->assertSame( 1, $by['direct']['count'] ); // No BQ event → direct.
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1864,6 +1864,106 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Mock proxy whose query() returns a value selected by query name.
+	 *
+	 * @param array<string,mixed> $map query_name => rows|WP_Error.
+	 * @return BigQuery_Proxy_Client
+	 */
+	private function proxy_by_query( array $map ): BigQuery_Proxy_Client {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturnCallback(
+			static function ( $query_name ) use ( $map ) {
+				return $map[ $query_name ] ?? [];
+			}
+		);
+		return $proxy;
+	}
+
+	/**
+	 * 3.2 source mix: each Woo record is attributed to the BQ event that precedes
+	 * its order within 1800s; unmatched → direct.
+	 */
+	public function test_source_mix_subscribers_attributes_by_timestamp(): void {
+		$order_ts = 1_700_000_000;
+		// Two subscribers; one has a gate event 60s before their order, one has none.
+		$records = [
+			[
+				'customer_id' => 1,
+				'ts'          => $order_ts,
+			],
+			[
+				'customer_id' => 2,
+				'ts'          => $order_ts + 5000,
+			],
+		];
+		$bq_rows = [
+			[
+				'attempt_ts'   => (string) ( ( $order_ts - 60 ) * 1_000_000 ),
+				'gate_post_id' => '99',
+				'popup_id'     => '',
+			],
+		];
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
+		$metric = new Conversion_Metric(
+			$this->proxy_by_query( [ 'conversion_journey_source_mix_subscribers' => $bq_rows ] ),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 2, $result['total'] );
+		$by = [];
+		foreach ( $result['slices'] as $slice ) {
+			$by[ $slice['source'] ] = $slice['count'];
+		}
+		$this->assertSame( 1, $by['gate'] );
+		$this->assertSame( 0, $by['prompt'] );
+		$this->assertSame( 1, $by['direct'] ); // customer 2 unmatched → direct.
+	}
+
+	/**
+	 * 3.2 source mix: a proxy WP_Error yields the error envelope.
+	 */
+	public function test_source_mix_subscribers_proxy_error(): void {
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( [] );
+		$metric = new Conversion_Metric(
+			$this->proxy_returning( new \WP_Error( 'boom', 'nope' ) ),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'boom', $result['error_code'] );
+		$this->assertSame( [], $result['slices'] );
+	}
+
+	/**
+	 * 3.2 source mix: no Woo records → empty envelope (no division by zero).
+	 */
+	public function test_source_mix_subscribers_empty_records(): void {
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( [] );
+		$metric = new Conversion_Metric(
+			$this->proxy_returning( [] ),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_source_mix_subscribers( $start, $end );
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( [], $result['slices'] );
+	}
+
+	/**
 	 * The fixture populates `previous` when comparison is requested.
 	 */
 	public function test_fixture_compare_populates_previous() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -185,14 +185,14 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	// --- C22: get_subscriber_to_donor_lag_distribution ---------------------
 
 	/**
-	 * C22 coming_soon: returns state 'coming_soon' with an empty 'points'
-	 * collection, preserved visibility keys, and no 'pending' key.
+	 * C22: returns state 'populated' with an empty 'points' collection when
+	 * below the cross-converter threshold, plus preserved visibility keys.
 	 */
 	public function test_lag_distribution_is_coming_soon_with_visibility_keys() {
 		[ $start, $end ] = $this->window();
 		$result          = $this->metric->get_subscriber_to_donor_lag_distribution( $start, $end );
 
-		$this->assertSame( 'coming_soon', $result['state'] );
+		$this->assertSame( 'populated', $result['state'] );
 		$this->assertArrayHasKey( 'points', $result );
 		$this->assertSame( [], $result['points'] );
 		$this->assertSame( 'hidden', $result['visibility'] );
@@ -1855,8 +1855,8 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'coming_soon', $current['time_to_donate_distribution']['state'] );
 		$this->assertArrayHasKey( 'groups', $current['time_to_donate_distribution'] );
 
-		// 4.4 — lag distribution (points + visibility keys).
-		$this->assertSame( 'coming_soon', $current['subscriber_to_donor_lag_distribution']['state'] );
+		// 4.4 — lag distribution (points + visibility keys); populated but hidden when below threshold.
+		$this->assertSame( 'populated', $current['subscriber_to_donor_lag_distribution']['state'] );
 		$this->assertSame( [], $current['subscriber_to_donor_lag_distribution']['points'] );
 		$this->assertSame( 'hidden', $current['subscriber_to_donor_lag_distribution']['visibility'] );
 		$this->assertSame( 'insufficient_data', $current['subscriber_to_donor_lag_distribution']['visibility_reason'] );
@@ -2281,5 +2281,44 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			],
 			$direct['points'] 
 		); // customer 11; customer 12 truncated.
+	}
+
+	/**
+	 * 4.4: below the 50-cross-converter gate → hidden.
+	 */
+	public function test_sub_to_donor_lag_hidden_below_threshold(): void {
+		$rows = array_map( static fn( $i ) => [ 'lag_days' => $i ], range( 1, 49 ) );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_subscriber_to_donor_lags' )->willReturn( $rows );
+		$metric = new Conversion_Metric( $this->proxy_returning( [] ), null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_subscriber_to_donor_lag_distribution( $start, $end );
+		$this->assertSame( 'hidden', $result['visibility'] );
+		$this->assertSame( 'insufficient_data', $result['visibility_reason'] );
+		$this->assertSame( [], $result['points'] );
+	}
+
+	/**
+	 * 4.4: at/above the gate → visible single-series CDF; lag > 365 truncated.
+	 */
+	public function test_sub_to_donor_lag_visible_at_threshold(): void {
+		$rows   = array_map( static fn( $i ) => [ 'lag_days' => 10 ], range( 1, 50 ) );
+		$rows[] = [ 'lag_days' => 400 ]; // truncated out, so 50 remain.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_subscriber_to_donor_lags' )->willReturn( $rows );
+		$metric = new Conversion_Metric( $this->proxy_returning( [] ), null, null, $donors );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_subscriber_to_donor_lag_distribution( $start, $end );
+		$this->assertSame( 'visible', $result['visibility'] );
+		$this->assertNull( $result['visibility_reason'] );
+		$this->assertSame(
+			[
+				[
+					'day'            => 10,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$result['points'] 
+		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -820,22 +820,54 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * C12 populated: proxy returns attempt rows; resolver assigns 1 order per
-	 * non-empty source bucket → correct total, slices, pct values.
+	 * C12 populated: Subscribers_Metric returns three records; BQ supplies one
+	 * gate event and one prompt event timed within 1800 s before two of them;
+	 * the third record has no matching event → direct. Source_Matcher attributes
+	 * gate=1, prompt=1, direct=1 → total=3, pct=1/3 each.
 	 */
 	public function test_source_mix_subscribers_returns_populated_slices_on_success() {
-		$rows  = $this->source_mix_rows();
+		$order_ts = 1_717_000_000;
+
+		$records = [
+			[
+				'customer_id' => 101,
+				'ts'          => $order_ts,
+			],
+			[
+				'customer_id' => 102,
+				'ts'          => $order_ts + 1000,
+			],
+			[
+				'customer_id' => 103,
+				'ts'          => $order_ts + 2000,
+			],
+		];
+
+		// Event 1: gate event 60 s before record 101.
+		// Event 2: prompt event 60 s before record 102.
+		// Record 103 has no matching event → attributed to direct.
+		$bq_rows = [
+			[
+				'attempt_ts'   => (string) ( ( $order_ts - 60 ) * 1_000_000 ),
+				'gate_post_id' => '55',
+				'popup_id'     => '',
+			],
+			[
+				'attempt_ts'   => (string) ( ( $order_ts + 1000 - 60 ) * 1_000_000 ),
+				'gate_post_id' => '',
+				'popup_id'     => '42',
+			],
+		];
+
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
+
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )
 			->with( 'conversion_journey_source_mix_subscribers' )
-			->willReturn( $rows );
+			->willReturn( $bq_rows );
 
-		// Each bucket gets count_completed_orders called once; return 1 for gate
-		// (2 rows), 1 for prompt (1 row), 1 for direct (1 row).
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
-
-		$metric          = new Conversion_Metric( $proxy, $resolver );
+		$metric          = new Conversion_Metric( $proxy, null, $subs );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_source_mix_subscribers( $start, $end );
 
@@ -889,44 +921,93 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * C12 populated: zero-total guard — when all buckets resolve to 0 orders,
-	 * total=0 and pct=0.0 for all slices (no div-by-zero).
+	 * C12 zero-count-slice guard — a single record with no matching BQ event
+	 * is attributed to direct; gate and prompt buckets have count=0 and must
+	 * produce pct=0.0 (no division-by-zero via the $safe guard in compute_source_mix).
+	 *
+	 * Note: the original test asserted total=0 with pct=0 on all slices. Under
+	 * the Source_Matcher mechanism total always equals the record count (every
+	 * record gets exactly one source), so a zero-total with non-empty records is
+	 * impossible; the equivalent guard is that zero-count source buckets yield
+	 * pct=0.0 rather than NaN or a division error.
 	 */
 	public function test_source_mix_subscribers_guards_zero_total() {
-		$rows  = $this->source_mix_rows();
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( $rows );
+		// One record, no matching BQ events → entire total goes to direct.
+		$records = [
+			[
+				'customer_id' => 101,
+				'ts'          => 1_717_000_000,
+			],
+		];
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( $records );
 
-		$metric          = new Conversion_Metric( $proxy, $resolver );
+		$metric          = new Conversion_Metric(
+			$this->proxy_by_query( [ 'conversion_journey_source_mix_subscribers' => [] ] ),
+			null,
+			$subs
+		);
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_source_mix_subscribers( $start, $end );
 
 		$this->assertSame( 'populated', $result['state'] );
-		$this->assertSame( 0, $result['total'] );
-		foreach ( $result['slices'] as $slice ) {
-			$this->assertSame( 0.0, $slice['pct'] );
-		}
+		$this->assertSame( 1, $result['total'] ); // 1 record, all direct.
+		$by_source = array_column( $result['slices'], null, 'source' );
+		// Zero-count buckets must produce 0.0 pct, not a division error.
+		$this->assertSame( 0.0, $by_source['gate']['pct'] );
+		$this->assertSame( 0.0, $by_source['prompt']['pct'] );
+		$this->assertSame( 0, $by_source['gate']['count'] );
+		$this->assertSame( 0, $by_source['prompt']['count'] );
 	}
 
 	// --- C13: get_source_mix_donors -----------------------------------------
 
 	/**
-	 * C13 populated: identical logic to C12, different query name.
+	 * C13 populated: identical logic to C12 using Donors_Metric and the donors
+	 * query name. Two records match BQ gate/prompt events; one is unmatched →
+	 * direct. Total=3, gate=1, prompt=1, direct=1.
 	 */
 	public function test_source_mix_donors_returns_populated_slices_on_success() {
-		$rows  = $this->source_mix_rows();
+		$order_ts = 1_717_000_000;
+
+		$records = [
+			[
+				'customer_id' => 201,
+				'ts'          => $order_ts,
+			],
+			[
+				'customer_id' => 202,
+				'ts'          => $order_ts + 1000,
+			],
+			[
+				'customer_id' => 203,
+				'ts'          => $order_ts + 2000,
+			],
+		];
+
+		$bq_rows = [
+			[
+				'attempt_ts'   => (string) ( ( $order_ts - 60 ) * 1_000_000 ),
+				'gate_post_id' => '77',
+				'popup_id'     => '',
+			],
+			[
+				'attempt_ts'   => (string) ( ( $order_ts + 1000 - 60 ) * 1_000_000 ),
+				'gate_post_id' => '',
+				'popup_id'     => '33',
+			],
+		];
+
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donor_records_in_window' )->willReturn( $records );
+
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )
 			->with( 'conversion_journey_source_mix_donors' )
-			->willReturn( $rows );
+			->willReturn( $bq_rows );
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
-
-		$metric          = new Conversion_Metric( $proxy, $resolver );
+		$metric          = new Conversion_Metric( $proxy, null, null, $donors );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_source_mix_donors( $start, $end );
 
@@ -934,6 +1015,11 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'pending', $result );
 		$this->assertSame( 3, $result['total'] );
 		$this->assertCount( 3, $result['slices'] );
+
+		$by_source = array_column( $result['slices'], null, 'source' );
+		$this->assertSame( 1, $by_source['gate']['count'] );
+		$this->assertSame( 1, $by_source['prompt']['count'] );
+		$this->assertSame( 1, $by_source['direct']['count'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2016,7 +2016,14 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_source_mix_subscribers_proxy_error(): void {
 		$subs = $this->createMock( Subscribers_Metric::class );
-		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn( [] );
+		$subs->method( 'get_new_subscriber_records_in_window' )->willReturn(
+			[
+				[
+					'customer_id' => 1,
+					'ts'          => 1700000000,
+				],
+			] 
+		);
 		$metric = new Conversion_Metric(
 			$this->proxy_returning( new \WP_Error( 'boom', 'nope' ) ),
 			null,

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -185,10 +185,12 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	// --- C22: get_subscriber_to_donor_lag_distribution ---------------------
 
 	/**
-	 * C22: returns state 'populated' with an empty 'points' collection when
-	 * below the cross-converter threshold, plus preserved visibility keys.
+	 * C22 (4.4): envelope is populated + hidden (insufficient_data) for the
+	 * default below-threshold cohort. Checks that state is 'populated', points
+	 * is empty, visibility is 'hidden', and visibility_reason is
+	 * 'insufficient_data' — and that no 'pending' key leaks through.
 	 */
-	public function test_lag_distribution_is_coming_soon_with_visibility_keys() {
+	public function test_lag_distribution_is_populated_and_hidden_below_threshold() {
 		[ $start, $end ] = $this->window();
 		$result          = $this->metric->get_subscriber_to_donor_lag_distribution( $start, $end );
 
@@ -2186,6 +2188,48 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			$result['groups'][2]['points'] 
 		); // direct.
 		$this->assertSame( [], $result['groups'][0]['points'] ); // gate empty.
+	}
+
+	/**
+	 * 4.2 degradation: probe positive but second BQ query (registrations_with_source)
+	 * returns WP_Error → registration_source_events() returns [] → every reader
+	 * attributed to direct (graceful degradation).
+	 */
+	public function test_time_to_subscribe_distribution_registrations_error_all_direct(): void {
+		$reg1 = 1_700_000_000;
+		$rows = [
+			[
+				'customer_id'   => 1,
+				'registered_ts' => $reg1,
+				'first_sub_ts'  => $reg1 + 86400 * 7,
+			],
+		];
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_subscription_conversion_lags' )->willReturn( $rows );
+		$metric = new Conversion_Metric(
+			$this->proxy_by_query(
+				[
+					'conversion_journey_has_registrations_in_window' => [ [ 'registration_events' => 5 ] ],
+					'conversion_journey_registrations_with_source'   => new \WP_Error( 'bq_down', 'nope' ),
+				]
+			),
+			null,
+			$subs,
+			null
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_time_to_subscribe_distribution( $start, $end );
+		// Second-query error degrades to all-direct: gate group empty, direct has the single point.
+		$this->assertSame( [], $result['groups'][0]['points'] ); // gate.
+		$this->assertSame(
+			[
+				[
+					'day'            => 7,
+					'cumulative_pct' => 1.0,
+				],
+			],
+			$result['groups'][2]['points']
+		); // direct.
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2124,21 +2124,24 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * within ±120s; unmatched reg → direct; lag > 365 truncated.
 	 */
 	public function test_time_to_subscribe_distribution_buckets_and_truncates(): void {
-		$reg1 = 1_700_000_000;
+		// Use current-time-relative registration timestamps so rows fall inside
+		// the trailing-365-day cohort window (registrations older than 365 days
+		// are excluded because their BQ source events are outside the window).
+		$reg1 = time() - 10 * 86400; // Registered 10 days ago.
 		$rows = [
-			// Registered, subscribed 10 days later, has a 'gate' reg event 30s after registering.
+			// Registered 10 days ago, subscribed 10 days later (today), has a 'gate' reg event 30s after registering.
 			[
 				'customer_id'   => 1,
 				'registered_ts' => $reg1,
 				'first_sub_ts'  => $reg1 + 86400 * 10,
 			],
-			// Registered, subscribed 20 days later, no BQ reg event → direct.
+			// Registered 10 days ago (offset 100000s), subscribed 20 days later, no BQ reg event → direct.
 			[
 				'customer_id'   => 2,
 				'registered_ts' => $reg1 + 100000,
 				'first_sub_ts'  => $reg1 + 100000 + 86400 * 20,
 			],
-			// Registered, subscribed 400 days later → truncated out.
+			// Registered recently but subscribed 400 days later → lag truncated out (lag > 365 days).
 			[
 				'customer_id'   => 3,
 				'registered_ts' => $reg1 + 200000,
@@ -2200,7 +2203,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * 4.2 degradation: probe returns 0 → no expensive query → every reg → direct.
 	 */
 	public function test_time_to_subscribe_distribution_probe_zero_all_direct(): void {
-		$reg1 = 1_700_000_000;
+		$reg1 = time() - 10 * 86400; // Registered 10 days ago; inside the 365-day cohort window.
 		$rows = [
 			[
 				'customer_id'   => 1,
@@ -2236,7 +2239,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * attributed to direct (graceful degradation).
 	 */
 	public function test_time_to_subscribe_distribution_registrations_error_all_direct(): void {
-		$reg1 = 1_700_000_000;
+		$reg1 = time() - 10 * 86400; // Registered 10 days ago; inside the 365-day cohort window.
 		$rows = [
 			[
 				'customer_id'   => 1,
@@ -2295,21 +2298,24 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * test with Donors_Metric and first_donation_ts.
 	 */
 	public function test_time_to_donate_distribution_buckets_and_truncates(): void {
-		$reg1 = 1_700_000_000;
+		// Use current-time-relative registration timestamps so rows fall inside
+		// the trailing-365-day cohort window (registrations older than 365 days
+		// are excluded because their BQ source events are outside the window).
+		$reg1 = time() - 10 * 86400; // Registered 10 days ago.
 		$rows = [
-			// Registered, donated 15 days later, has a 'prompt' reg event 50s before registering.
+			// Registered 10 days ago, donated 15 days later, has a 'prompt' reg event 50s before registering.
 			[
 				'customer_id'       => 10,
 				'registered_ts'     => $reg1,
 				'first_donation_ts' => $reg1 + 86400 * 15,
 			],
-			// Registered, donated 30 days later, no BQ reg event → direct.
+			// Registered 10 days ago (offset 100000s), donated 30 days later, no BQ reg event → direct.
 			[
 				'customer_id'       => 11,
 				'registered_ts'     => $reg1 + 100000,
 				'first_donation_ts' => $reg1 + 100000 + 86400 * 30,
 			],
-			// Registered, donated 400 days later → truncated out.
+			// Registered recently but donated 400 days later → lag truncated out (lag > 365 days).
 			[
 				'customer_id'       => 12,
 				'registered_ts'     => $reg1 + 200000,

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -208,10 +208,12 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$data = $response->get_data()['data'];
 		$this->assertFalse( $data['tab_error'], 'tab_error must be false when coming_soon/populated metrics are present' );
 
-		// Verify that deferred (coming_soon) metrics are present in the window.
+		// 5.1 cohort is still a coming_soon stub; the implemented 4.2 distribution
+		// reports a non-error state (empty here, with no seeded data/BQ). Both keep
+		// tab_error false.
 		$current = $data['current'];
 		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
-		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
+		$this->assertSame( 'empty', $current['time_to_subscribe_distribution']['state'] );
 	}
 
 	/**
@@ -316,8 +318,9 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $current['influenced_registration_rate_7d']['state'] );
 		$this->assertSame( 'populated', $current['top_pages_no_conversion']['state'] );
 
-		// Deferred sections are 'coming_soon'.
-		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
+		// 4.2 is implemented (all-history snapshot → populated in the fixture);
+		// 5.1/5.2 cohorts are still coming_soon stubs.
+		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
 		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
 		$this->assertSame( 'coming_soon', $current['subscriber_retention_cohort']['state'] );
 	}
@@ -361,8 +364,9 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $current['influenced_registration_rate_7d']['state'] );
 		$this->assertFalse( $current['influenced_registration_rate_7d']['computable'] );
 
-		// Deferred stay coming_soon.
-		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
+		// 4.2 is an all-history snapshot → populated in the fixture regardless of
+		// the window variant (5.1/5.2 cohorts remain coming_soon).
+		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/parsely.php
+++ b/plugins/newspack-plugin/tests/unit-tests/parsely.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests the Parse.ly meta_type migration.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Parsely;
+
+/**
+ * Tests the Parse.ly meta_type migration.
+ */
+class Newspack_Test_Parsely extends WP_UnitTestCase {
+
+	/**
+	 * Reset migration state and active plugins before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Parsely::META_TYPE_MIGRATION_OPTION );
+		delete_option( 'parsely' );
+		update_option( 'active_plugins', [] );
+	}
+
+	/**
+	 * Mark wp-parsely as active.
+	 */
+	private function activate_parsely() {
+		update_option( 'active_plugins', [ 'wp-parsely/wp-parsely.php' ] );
+	}
+
+	/**
+	 * A stored `json_ld` meta_type is switched to `repeated_metas`.
+	 */
+	public function test_migrates_explicit_json_ld() {
+		$this->activate_parsely();
+		update_option(
+			'parsely',
+			[
+				'apikey'    => 'example.com',
+				'meta_type' => 'json_ld',
+			]
+		);
+
+		Parsely::migrate_meta_type();
+
+		$settings = get_option( 'parsely' );
+		$this->assertEquals( 'repeated_metas', $settings['meta_type'] );
+		$this->assertEquals( 'example.com', $settings['apikey'] );
+		$this->assertNotEmpty( get_option( Parsely::META_TYPE_MIGRATION_OPTION ) );
+	}
+
+	/**
+	 * A missing meta_type key is treated as the legacy `json_ld` default and rewritten.
+	 */
+	public function test_migrates_absent_meta_type() {
+		$this->activate_parsely();
+		update_option( 'parsely', [ 'apikey' => 'example.com' ] );
+
+		Parsely::migrate_meta_type();
+
+		$settings = get_option( 'parsely' );
+		$this->assertEquals( 'repeated_metas', $settings['meta_type'] );
+		$this->assertEquals( 'example.com', $settings['apikey'] );
+	}
+
+	/**
+	 * An empty stored option array is migrated (absent key === legacy default).
+	 */
+	public function test_migrates_empty_option() {
+		$this->activate_parsely();
+		update_option( 'parsely', [] );
+
+		Parsely::migrate_meta_type();
+
+		$settings = get_option( 'parsely' );
+		$this->assertEquals( 'repeated_metas', $settings['meta_type'] );
+	}
+
+	/**
+	 * A non-`json_ld` meta_type is left untouched.
+	 */
+	public function test_leaves_other_meta_type_untouched() {
+		$this->activate_parsely();
+		update_option( 'parsely', [ 'meta_type' => 'repeated_metas' ] );
+
+		Parsely::migrate_meta_type();
+
+		$settings = get_option( 'parsely' );
+		$this->assertEquals( 'repeated_metas', $settings['meta_type'] );
+		$this->assertNotEmpty( get_option( Parsely::META_TYPE_MIGRATION_OPTION ) );
+	}
+
+	/**
+	 * Nothing happens — and completion is not recorded — when wp-parsely is inactive,
+	 * so the migration stays pending until the plugin is activated.
+	 */
+	public function test_skips_and_stays_pending_when_parsely_inactive() {
+		update_option( 'parsely', [ 'meta_type' => 'json_ld' ] );
+
+		Parsely::migrate_meta_type();
+
+		$settings = get_option( 'parsely' );
+		$this->assertEquals( 'json_ld', $settings['meta_type'] );
+		$this->assertFalse( get_option( Parsely::META_TYPE_MIGRATION_OPTION ) );
+	}
+
+	/**
+	 * The migration is idempotent: once recorded it does not run again, even if
+	 * the stored meta_type is later reset to `json_ld`.
+	 */
+	public function test_is_idempotent() {
+		$this->activate_parsely();
+		update_option( 'parsely', [ 'meta_type' => 'json_ld' ] );
+
+		Parsely::migrate_meta_type();
+		$this->assertEquals( 'repeated_metas', get_option( 'parsely' )['meta_type'] );
+
+		// Simulate a later manual change back to json_ld; the migration should not re-run.
+		update_option( 'parsely', [ 'meta_type' => 'json_ld' ] );
+		Parsely::migrate_meta_type();
+		$this->assertEquals( 'json_ld', get_option( 'parsely' )['meta_type'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-api.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-api.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Tests for Group_Subscription_API REST state gating.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ */
+
+use Newspack\Group_Subscription_API;
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * Test that the REST member/invite-link endpoints reject subscriptions in states
+ * the admin-post UI also refuses (terminal states for member changes; non-active
+ * for new invite links). See NPPD-1593 (S2, S3).
+ */
+class Test_Group_Subscription_API extends WP_UnitTestCase {
+
+	/**
+	 * Include WC mocks.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Owner/manager user ID, set per test.
+	 *
+	 * @var int
+	 */
+	private $owner_id = 0;
+
+	/**
+	 * Reset state between tests and create an owner/manager user.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		$this->owner_id         = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+	}
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tear_down() {
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a group subscription in a given status, owned by the manager user.
+	 *
+	 * @param string $status Subscription status.
+	 * @return WC_Subscription
+	 */
+	private function create_group_subscription( string $status = 'active' ): WC_Subscription {
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $this->owner_id,
+				'status'         => $status,
+				'billing_period' => 'month',
+			]
+		);
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		return $subscription;
+	}
+
+	/**
+	 * Build a REST request carrying a subscription_id param.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 * @return WP_REST_Request
+	 */
+	private function request_for( int $subscription_id ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/newspack-group-subscription/v1/members' );
+		$request->set_param( 'subscription_id', $subscription_id );
+		return $request;
+	}
+
+	/**
+	 * S2: member mutation must be rejected on a terminal-state (cancelled) subscription.
+	 */
+	public function test_update_members_rejected_on_cancelled_subscription() {
+		$subscription = $this->create_group_subscription( 'cancelled' );
+		$request      = $this->request_for( $subscription->get_id() );
+		$request->set_param( 'members_to_add', [ 999 ] );
+
+		$result = Group_Subscription_API::api_update_members( $request );
+
+		$this->assertWPError( $result, 'Member mutation on a cancelled subscription should return a WP_Error.' );
+		$this->assertSame( 409, $result->get_error_data()['status'], 'The rejection should carry HTTP 409.' );
+	}
+
+	/**
+	 * S2: member mutation must be rejected on an expired subscription.
+	 */
+	public function test_update_members_rejected_on_expired_subscription() {
+		$subscription = $this->create_group_subscription( 'expired' );
+		$request      = $this->request_for( $subscription->get_id() );
+		$request->set_param( 'members_to_add', [ 999 ] );
+
+		$result = Group_Subscription_API::api_update_members( $request );
+
+		$this->assertWPError( $result, 'Member mutation on an expired subscription should return a WP_Error.' );
+	}
+
+	/**
+	 * S2: an active subscription passes the manageable gate (no 409).
+	 */
+	public function test_update_members_allowed_on_active_subscription() {
+		$subscription = $this->create_group_subscription( 'active' );
+		$request      = $this->request_for( $subscription->get_id() );
+		$request->set_param( 'members_to_add', [] );
+		$request->set_param( 'members_to_remove', [] );
+
+		$result = Group_Subscription_API::api_update_members( $request );
+
+		$this->assertNotWPError( $result, 'An active subscription should pass the manageable gate.' );
+	}
+
+	/**
+	 * Email invitations (api_invite) must also be rejected on a non-active subscription,
+	 * for parity with api_generate_invite_link.
+	 */
+	public function test_email_invite_rejected_on_cancelled_subscription() {
+		$subscription = $this->create_group_subscription( 'cancelled' );
+		wp_set_current_user( $this->owner_id );
+		$request = $this->request_for( $subscription->get_id() );
+		$request->set_param( 'email', 'invitee@test.com' );
+
+		$result = Group_Subscription_API::api_invite( $request );
+
+		$this->assertWPError( $result, 'An email invite on a cancelled subscription should return a WP_Error.' );
+		$this->assertSame( 409, $result->get_error_data()['status'], 'The rejection should carry HTTP 409.' );
+	}
+
+	/**
+	 * S3: generating an invite link must be rejected on a non-active (cancelled) subscription.
+	 *
+	 * The current user is the owner/manager, so the only thing that can reject the request is the
+	 * active-state gate (not the manager permission check inside generate_link_invite()).
+	 */
+	public function test_generate_invite_link_rejected_on_cancelled_subscription() {
+		$subscription = $this->create_group_subscription( 'cancelled' );
+		wp_set_current_user( $this->owner_id );
+		$request = $this->request_for( $subscription->get_id() );
+
+		$result = Group_Subscription_API::api_generate_invite_link( $request );
+
+		$this->assertWPError( $result, 'Generating an invite link on a cancelled subscription should return a WP_Error.' );
+		$this->assertSame( 409, $result->get_error_data()['status'], 'The rejection should carry HTTP 409.' );
+	}
+
+	/**
+	 * S3: an on-hold subscription is not active (only active/pending-cancel are), so issuing a
+	 * new invite link must be rejected even for the manager.
+	 */
+	public function test_generate_invite_link_rejected_on_on_hold_subscription() {
+		$subscription = $this->create_group_subscription( 'on-hold' );
+		wp_set_current_user( $this->owner_id );
+		$request = $this->request_for( $subscription->get_id() );
+
+		$result = Group_Subscription_API::api_generate_invite_link( $request );
+
+		$this->assertWPError( $result, 'Generating an invite link on an on-hold subscription should return a WP_Error.' );
+	}
+
+	/**
+	 * S3: an active subscription passes the active gate and mints a link (manager is current user).
+	 */
+	public function test_generate_invite_link_allowed_on_active_subscription() {
+		$subscription = $this->create_group_subscription( 'active' );
+		wp_set_current_user( $this->owner_id );
+		$request = $this->request_for( $subscription->get_id() );
+
+		$result = Group_Subscription_API::api_generate_invite_link( $request );
+
+		$this->assertNotWPError( $result, 'An active subscription should pass the active gate and mint an invite link.' );
+		$data = $result->get_data();
+		$this->assertIsArray( $data, 'A successful response should carry the minted invite link data.' );
+		$this->assertArrayHasKey( 'key', $data, 'The minted invite link should include a key.' );
+	}
+
+	/**
+	 * S3: a pending-cancel subscription is still active enough to issue invitations
+	 * (ACTIVE_SUBSCRIPTION_STATUSES includes pending-cancel), so the gate must allow it.
+	 */
+	public function test_generate_invite_link_allowed_on_pending_cancel_subscription() {
+		$subscription = $this->create_group_subscription( 'pending-cancel' );
+		wp_set_current_user( $this->owner_id );
+		$request = $this->request_for( $subscription->get_id() );
+
+		$result = Group_Subscription_API::api_generate_invite_link( $request );
+
+		$this->assertNotWPError( $result, 'A pending-cancel subscription should still pass the active gate.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Tests for Group_Subscription_Invite link-invite acceptance.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ */
+
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Invite;
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * Test the link-invite acceptance flow. See NPPD-1593 (B2): a non-fatal failure
+ * (current user is not a Reader Activation reader, so update_members() returns an
+ * array with an empty members_added) must not fatal on get_error_message().
+ */
+class Test_Group_Subscription_Invite extends WP_UnitTestCase {
+
+	/**
+	 * User IDs to clean up.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = [];
+
+	/**
+	 * Include WC mocks.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database;
+		$subscriptions_database = [];
+	}
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tear_down() {
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = [];
+		wp_set_current_user( 0 );
+		unset( $_GET['action'], $_GET['subscription'], $_GET['manager'], $_GET['key'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a user, optionally flagged as a Reader Activation reader.
+	 *
+	 * @param bool $is_reader Whether to mark the user as a reader.
+	 * @return int User ID.
+	 */
+	private function create_user( bool $is_reader ): int {
+		// A reader is a subscriber flagged with the reader meta. The non-reader is an editor:
+		// is_user_reader() (non-strict) treats subscribers/customers as readers via reader roles,
+		// so a genuinely non-reader user must hold a non-reader role.
+		$user_id = wp_insert_user(
+			[
+				'user_login' => 'user-' . wp_generate_password( 6, false ),
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'user-' . wp_generate_password( 6, false ) . '@test.com',
+				'role'       => $is_reader ? 'subscriber' : 'editor',
+			]
+		);
+		$this->assertNotWPError( $user_id, 'Fixture user creation should succeed.' );
+		$this->user_ids[] = $user_id;
+		if ( $is_reader ) {
+			update_user_meta( $user_id, '_newspack_reader', true );
+		}
+		return $user_id;
+	}
+
+	/**
+	 * Drive process_link_invite_request() while capturing the newspack_log events it emits, and
+	 * unwinding at the wp_safe_redirect() so the handler's exit does not stop the test. Asserting on
+	 * the logged event (rather than the redirect URL) is deterministic: the redirect target depends
+	 * on wc_get_account_endpoint_url()/host validation, which varies by environment.
+	 *
+	 * @return string[] The newspack_log event codes emitted during the request.
+	 */
+	private function capture_link_invite_log_events(): array {
+		$events   = [];
+		$log      = function ( $event ) use ( &$events ) {
+			$events[] = $event;
+		};
+		$redirect = function ( $location ) {
+			// Unwind before the handler's exit, mimicking a completed redirect.
+			throw new \RuntimeException( 'redirected' );
+		};
+		add_action( 'newspack_log', $log, 1 );
+		add_filter( 'wp_redirect', $redirect, 1 );
+		try {
+			Group_Subscription_Invite::process_link_invite_request();
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'redirected', $e->getMessage(), 'Only the redirect-capture unwind is expected here.' );
+		} finally {
+			remove_action( 'newspack_log', $log, 1 );
+			remove_filter( 'wp_redirect', $redirect, 1 );
+		}
+		return $events;
+	}
+
+	/**
+	 * A logged-in non-reader following a valid link invite should be redirected with a
+	 * link_failed notice, not trigger a PHP fatal on get_error_message().
+	 */
+	public function test_non_reader_link_acceptance_does_not_fatal() {
+		$owner_id     = $this->create_user( true );
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $owner_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+
+		$invite = Group_Subscription_Invite::generate_link_invite( $subscription, $owner_id );
+		$this->assertIsArray( $invite, 'The fixture should generate a valid link invite.' );
+
+		// The current user is logged in but NOT a reader, so update_members() returns an array
+		// with an empty members_added — the exact branch that fataled before the fix.
+		$non_reader_id = $this->create_user( false );
+		wp_set_current_user( $non_reader_id );
+
+		$_GET['action']       = Group_Subscription_Invite::LINK_QUERY_ARG;
+		$_GET['subscription'] = (string) $subscription->get_id();
+		$_GET['manager']      = (string) $owner_id;
+		$_GET['key']          = $invite['key'];
+
+		$log_events = $this->capture_link_invite_log_events();
+
+		// Reaching the link-failed log (instead of fataling on get_error_message()) is the fix.
+		$this->assertContains(
+			'newspack_group_subscription_invite_link_failed',
+			$log_events,
+			'A non-reader accepting a valid link should hit the link-failed path without a fatal.'
+		);
+		$this->assertNotContains(
+			$subscription->get_id(),
+			Group_Subscription::get_group_subscriptions_for_user( $non_reader_id, true ),
+			'The non-reader should not have been added to the group.'
+		);
+	}
+
+	/**
+	 * Accepting an EMAIL invite when the account is not a reader must fail and leave the
+	 * invitation intact, rather than silently consuming it and reporting success.
+	 */
+	public function test_email_invite_acceptance_fails_for_non_reader_without_consuming_invite() {
+		$owner_id     = $this->create_user( true );
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $owner_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+
+		// Invite an email that has no account yet (so generate_invite's non-reader guard passes).
+		$email  = 'invitee-' . wp_generate_password( 6, false ) . '@test.com';
+		$invite = Group_Subscription_Invite::generate_invite( $subscription, $email );
+		$this->assertIsArray( $invite, 'The fixture should create an email invite.' );
+		$key = array_key_first( Group_Subscription_Invite::get_invites( $subscription ) );
+
+		// By accept time an account exists for the email, but it is not a reader.
+		$invitee_id = $this->create_user( false );
+		wp_update_user(
+			[
+				'ID'         => $invitee_id,
+				'user_email' => $email,
+			]
+		);
+
+		$result = Group_Subscription_Invite::accept_invite( $subscription, $key, $email );
+
+		$this->assertWPError( $result, 'Accepting as a non-reader should fail rather than silently succeed.' );
+		$this->assertSame( 'newspack_group_subscription_invite_not_added', $result->get_error_code(), 'The failure should be the not-added error, not a success.' );
+		$this->assertNotNull(
+			Group_Subscription_Invite::get_invite_by_key( $subscription, $key ),
+			'The invitation should remain intact for retry, not be consumed.'
+		);
+	}
+
+	/**
+	 * If the invitee was already added to the group before accepting (so update_members() returns
+	 * an empty members_added because there is nothing to add), acceptance must still succeed and
+	 * cancel the now-stale invite rather than reporting a failure.
+	 */
+	public function test_email_invite_acceptance_succeeds_for_existing_member() {
+		$owner_id     = $this->create_user( true );
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $owner_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+
+		// Invite a reader, then add them to the group before they accept (e.g. a manual add).
+		$member_id = $this->create_user( true );
+		$email     = get_userdata( $member_id )->user_email;
+		$invite    = Group_Subscription_Invite::generate_invite( $subscription, $email );
+		$this->assertIsArray( $invite, 'The fixture should create an email invite.' );
+		$key = array_key_first( Group_Subscription_Invite::get_invites( $subscription ) );
+		Group_Subscription::update_members( $subscription, [ $member_id ] );
+
+		$result = Group_Subscription_Invite::accept_invite( $subscription, $key, $email );
+
+		$this->assertTrue( $result, 'Accepting when already a member should succeed.' );
+		$this->assertNull(
+			Group_Subscription_Invite::get_invite_by_key( $subscription, $key ),
+			'The now-stale invite should be cancelled so it stops counting toward the member limit.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Tests the WooCommerce Update Payment Notice status gate (NPPM-2926, Gap B).
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Update_Payment_Notice;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * Tests for WooCommerce_Update_Payment_Notice status allowlist logic.
+ *
+ * @group update_payment_notice
+ */
+class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
+	/**
+	 * Reset the mock subscription registry before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database, $orders_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$orders_database        = [];
+	}
+
+	/**
+	 * Call the private get_notices() via reflection.
+	 *
+	 * @return string[]
+	 */
+	private function get_notices() {
+		$method = new ReflectionMethod( WooCommerce_Update_Payment_Notice::class, 'get_notices' );
+		$method->setAccessible( true );
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Register a logged-in customer and return its ID.
+	 *
+	 * @return int
+	 */
+	private function make_current_customer() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Build a minimal line item exposing the methods the notice path uses.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return object
+	 */
+	private function make_line_item( $product_id ) {
+		return new class( $product_id ) {
+			/**
+			 * Product ID this line item refers to.
+			 *
+			 * @var int
+			 */
+			private $product_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $product_id Product ID.
+			 */
+			public function __construct( $product_id ) {
+				$this->product_id = $product_id;
+			}
+
+			/**
+			 * Return the product ID.
+			 *
+			 * @return int
+			 */
+			public function get_product_id() {
+				return $this->product_id;
+			}
+
+			/**
+			 * Return the WC_Product object for this line item.
+			 *
+			 * @return WC_Product|false
+			 */
+			public function get_product() {
+				return wc_get_product( $this->product_id );
+			}
+		};
+	}
+
+	/**
+	 * Register a subscription that needs payment, owned by the current customer.
+	 *
+	 * @param int    $customer_id Customer ID.
+	 * @param string $status      Subscription status.
+	 * @param int    $product_id  Product ID granted by the subscription.
+	 * @return WC_Subscription
+	 */
+	private function make_needs_payment_subscription( $customer_id, $status, $product_id ) {
+		return wcs_create_subscription(
+			[
+				'customer_id'   => $customer_id,
+				'status'        => $status,
+				'needs_payment' => true,
+				'products'      => [ $product_id ],
+				'items'         => [ $this->make_line_item( $product_id ) ],
+			]
+		);
+	}
+
+	/**
+	 * Statuses that must NOT produce a notice even when needs_payment() is true.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function non_recoverable_status_provider() {
+		return [
+			'expired'        => [ 'expired' ],
+			'switched'       => [ 'switched' ],
+			'active'         => [ 'active' ],
+			'pending-cancel' => [ 'pending-cancel' ],
+			'cancelled'      => [ 'cancelled' ],
+		];
+	}
+
+	/**
+	 * Non-recoverable statuses must not produce a payment notice even if needs_payment() is true.
+	 *
+	 * @dataProvider non_recoverable_status_provider
+	 *
+	 * @param string $status Subscription status.
+	 */
+	public function test_no_notice_for_non_recoverable_status( $status ) {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		$this->make_needs_payment_subscription( $customer_id, $status, $product->get_id() );
+
+		$this->assertSame( [], $this->get_notices(), "Status '$status' must not produce a payment notice." );
+	}
+
+	/**
+	 * The documented incident: an expired subscription with a stale unpaid renewal order.
+	 */
+	public function test_no_notice_for_expired_with_stale_unpaid_order() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 54427,
+				'name' => 'Newsroom Pro – Monthly',
+			]
+		);
+		// needs_payment() true models the stale unpaid failed-renewal order still attached.
+		$this->make_needs_payment_subscription( $customer_id, 'expired', $product->get_id() );
+
+		$this->assertSame( [], $this->get_notices(), 'An expired subscription with a stale unpaid order must not nag.' );
+	}
+
+	/**
+	 * Recoverable statuses still fire (regression guard).
+	 */
+	public function test_notice_fires_for_on_hold() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		$this->make_needs_payment_subscription( $customer_id, 'on-hold', $product->get_id() );
+
+		$notices = $this->get_notices();
+		$this->assertCount( 1, $notices, 'An on-hold subscription that needs payment must produce a notice.' );
+		$this->assertStringContainsString( 'Newsroom Pro', $notices[0] );
+	}
+
+	/**
+	 * A pending subscription that needs payment fires a notice (regression guard).
+	 */
+	public function test_notice_fires_for_pending() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		$this->make_needs_payment_subscription( $customer_id, 'pending', $product->get_id() );
+
+		$this->assertCount( 1, $this->get_notices(), 'A pending subscription that needs payment must produce a notice.' );
+	}
+
+	/**
+	 * A recoverable status that does NOT need payment produces nothing.
+	 */
+	public function test_no_notice_when_payment_not_needed() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		wcs_create_subscription(
+			[
+				'customer_id'   => $customer_id,
+				'status'        => 'on-hold',
+				'needs_payment' => false,
+				'products'      => [ $product->get_id() ],
+				'items'         => [ $this->make_line_item( $product->get_id() ) ],
+			]
+		);
+
+		$this->assertSame( [], $this->get_notices(), 'No notice when the subscription does not need payment.' );
+	}
+
+	/**
+	 * Pin the recoverable-status allowlist to its reviewed value. This does NOT
+	 * auto-detect new WooCommerce Subscriptions statuses — the known set is listed
+	 * here, not queried. It fails when the allowlist itself changes, or gains a
+	 * status outside the known set, forcing a human to confirm a new status is
+	 * genuinely recoverable before it ships. NPPM-2926.
+	 */
+	public function test_allowlist_is_pinned_against_known_wcs_statuses() {
+		$known_wcs_statuses = [ 'pending', 'active', 'on-hold', 'cancelled', 'switched', 'expired', 'pending-cancel' ];
+
+		$reflection = new ReflectionClass( \Newspack\WooCommerce_Update_Payment_Notice::class );
+		$allowlist  = $reflection->getConstant( 'NOTICE_RECOVERABLE_STATUSES' );
+
+		$unknown = array_diff( $allowlist, $known_wcs_statuses );
+		$this->assertSame( [], array_values( $unknown ), 'Allowlist contains a status not in the known WCS set.' );
+
+		$this->assertEqualSets(
+			[ 'on-hold', 'pending' ],
+			$allowlist,
+			'Allowlist changed. Confirm any new status is genuinely recoverable before updating this guard.'
+		);
+	}
+}

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -26,6 +26,20 @@ final class Newspack_Popups_Segmentation {
 	const SEGMENTS_OPTION_NAME = 'newspack_popups_segments';
 
 	/**
+	 * Query param appended to newsletter links carrying the reader's donor
+	 * status. Its value is the ESP merge tag for the configured donor merge
+	 * field (e.g. Mailchimp's *|HUB-MEMBER|*), which the ESP substitutes with
+	 * the recipient's actual value at send time. The view script reads the
+	 * substituted value on the inbound click to flag the reader as a donor for
+	 * segmentation — no login required.
+	 *
+	 * This is an unsigned, reader-visible, forgeable signal: it must only ever
+	 * drive prompt segmentation, never content access. Restricted content stays
+	 * behind the HMAC-signed newsletter pass (see Newspack\Newsletters_Access).
+	 */
+	const DONOR_SEGMENT_QUERY_PARAM = 'np_seg_donor';
+
+	/**
 	 * Installed version number of the custom table.
 	 */
 	const TABLE_VERSION = '1.0';
@@ -66,6 +80,12 @@ final class Newspack_Popups_Segmentation {
 		) {
 			\Newspack\Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
 		}
+
+		// Append the donor-status segment param to newsletter links so readers
+		// arriving from a newsletter are segmented as donors without a login.
+		// The handler self-guards on the donor merge field being configured and
+		// the ESP being supported, so it's cheap to register unconditionally.
+		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_donor_segment_param' ], 30, 3 );
 	}
 
 	/**
@@ -183,6 +203,102 @@ final class Newspack_Popups_Segmentation {
 	 */
 	public static function reindex_segments( $segments ) {
 		return Newspack_Segments_Model::reindex_segments( $segments );
+	}
+
+	/**
+	 * Filter callback: append the donor-status segment param to first-party
+	 * newsletter links.
+	 *
+	 * The appended value is the ESP merge tag for the configured donor merge
+	 * field; the ESP substitutes the recipient's value at send time so the
+	 * inbound click carries e.g. `?np_seg_donor=true`. Skips when the Newsletters
+	 * tracking helper is unavailable, the post isn't a newsletter (ad links are
+	 * proxied separately and wouldn't forward the param), the link is
+	 * third-party, no donor merge field is configured, or the ESP is unsupported.
+	 *
+	 * @param string        $url          Processed URL (may already carry other params).
+	 * @param string        $original_url Original URL before processing.
+	 * @param \WP_Post|null $post         Newsletter post object, or null.
+	 *
+	 * @return string
+	 */
+	public static function append_donor_segment_param( $url, $original_url, $post ) {
+		// Guard on the method, not just the class: the Tracking\Utils class predates
+		// get_merge_tag(), so an older newspack-newsletters can satisfy a class_exists()
+		// check while lacking the method — calling it would fatal mid-render, breaking
+		// every newsletter on the site. method_exists() also returns false when the
+		// class is absent, so this covers both the missing-class and version-skew cases.
+		if ( ! method_exists( '\Newspack_Newsletters\Tracking\Utils', 'get_merge_tag' ) ) {
+			return $url;
+		}
+		if ( ! self::is_newsletter_post( $post ) ) {
+			return $url;
+		}
+		if ( ! self::is_first_party_url( $url ) ) {
+			return $url;
+		}
+		// Read the option directly rather than via Newspack_Popups_Settings::get_setting(),
+		// which builds the whole settings array (including a WP_Query over all pages)
+		// on every call — wasteful here since this filter fires once per newsletter link.
+		$donor_merge_field = get_option( 'newspack_popups_mc_donor_merge_field', Newspack_Popups_Settings::DEFAULT_DONOR_MERGE_FIELD );
+		// This setting is a comma-delimited list of name fragments used for substring
+		// matching at login (see reader_logged_in()). Building a query-param merge tag
+		// instead needs a single exact ESP merge tag — a multi-value list can't map to
+		// one — so use the first entry. The value must be the exact merge tag (not a
+		// display label or partial name) for the ESP to substitute it.
+		$donor_merge_field = trim( explode( ',', (string) $donor_merge_field )[0] );
+		if ( empty( $donor_merge_field ) ) {
+			return $url;
+		}
+		$merge_tag = \Newspack_Newsletters\Tracking\Utils::get_merge_tag( $donor_merge_field );
+		if ( empty( $merge_tag ) ) {
+			return $url;
+		}
+		$url = add_query_arg( self::DONOR_SEGMENT_QUERY_PARAM, $merge_tag, $url );
+		// add_query_arg() URL-encodes the value, but ESPs substitute only the raw
+		// merge-tag syntax: Mailchimp leaves the percent-encoded form (%2A%7C...%7C%2A)
+		// untouched, as verified against a live send, so the tag would never resolve.
+		// Restore the raw tag so the ESP substitutes the recipient's value at send
+		// time. An unsubstituted literal is ignored client-side, so this stays fail-safe.
+		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
+	}
+
+	/**
+	 * Whether the given post is a Newspack newsletter.
+	 *
+	 * @param \WP_Post|null $post Post object.
+	 *
+	 * @return bool
+	 */
+	private static function is_newsletter_post( $post ) {
+		if ( ! $post instanceof \WP_Post ) {
+			return false;
+		}
+		if ( ! defined( '\Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT' ) ) {
+			return false;
+		}
+		return \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $post->post_type;
+	}
+
+	/**
+	 * Whether the given URL points to this site, by host comparison.
+	 *
+	 * The donor flag is appended only to first-party links: pushing it onto
+	 * third-party URLs would leak the reader's donor status into external logs,
+	 * analytics, and Referer headers for no benefit, since only this site reads
+	 * the param. Relative URLs are first-party by definition.
+	 *
+	 * @param string $url URL to test.
+	 *
+	 * @return bool
+	 */
+	private static function is_first_party_url( $url ) {
+		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( empty( $url_host ) ) {
+			return true;
+		}
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		return strcasecmp( $url_host, (string) $site_host ) === 0;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-settings.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-settings.php
@@ -14,6 +14,14 @@ class Newspack_Popups_Settings {
 	const NEWSPACK_POPUPS_SETTINGS_PAGE = 'newspack-popups-settings-admin';
 
 	/**
+	 * Default value for the `newspack_popups_mc_donor_merge_field` option.
+	 *
+	 * Referenced both here and by Newspack_Popups_Segmentation (which reads the
+	 * option directly), so the default stays in one place.
+	 */
+	const DEFAULT_DONOR_MERGE_FIELD = 'DONAT';
+
+	/**
 	 * Set up hooks.
 	 */
 	public static function init() {
@@ -269,8 +277,8 @@ class Newspack_Popups_Settings {
 				'section'     => 'donor_settings',
 				'key'         => 'newspack_popups_mc_donor_merge_field',
 				'type'        => 'string',
-				'value'       => get_option( 'newspack_popups_mc_donor_merge_field', 'DONAT' ),
-				'default'     => 'DONAT',
+				'value'       => get_option( 'newspack_popups_mc_donor_merge_field', self::DEFAULT_DONOR_MERGE_FIELD ),
+				'default'     => self::DEFAULT_DONOR_MERGE_FIELD,
 				'description' => __( 'Mailchimp donor merge fields', 'newspack-popups' ),
 				'help'        => __(
 					'A comma-delimited list of strings to match against Mailchimp merge field names. If a Mailchimp merge field name contains one of these strings and a subscriber has a true value in this field, the subscriber will be considered a donor for segmentation purposes.',

--- a/plugins/newspack-popups/src/criteria/default/donation.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.js
@@ -1,12 +1,99 @@
 import { setMatchingFunction } from '../utils';
+import { rememberSessionSignal } from './session-signal';
 
-setMatchingFunction( 'donation', ( config, { store } ) => {
+/**
+ * Query param carrying the reader's donor status, substituted per-recipient by
+ * the ESP from the configured donor merge field (e.g. `?np_seg_donor=true`).
+ */
+const DONOR_PARAM = 'np_seg_donor';
+
+/**
+ * Session-storage key used to remember that the reader arrived from a newsletter
+ * email carrying a positive donor status during the current browsing session.
+ */
+const FROM_EMAIL_DONOR_KEY = 'newspack-popups-donor-from-email';
+
+/**
+ * Whether a donor merge-field value counts as a positive donor indicator.
+ *
+ * Mirrors Newspack_Popups_Segmentation::is_donor_merge_field_value() in PHP —
+ * keep the falsy list in sync.
+ *
+ * @param {string} value The merge-tag value from the inbound link.
+ * @return {boolean} Whether the value indicates the reader is a donor.
+ */
+const isDonorValue = value => ! [ 'no', 'none', 'false', '0', '' ].includes( String( value ).toLowerCase() );
+
+/**
+ * Whether a query-param value still contains unsubstituted ESP merge-tag syntax
+ * — i.e. the sending service failed to replace it with the actual per-recipient
+ * value. Such a value must be ignored, or every recipient of a misconfigured
+ * send would be flagged as a donor from the raw template string.
+ *
+ * Covers all four ESPs supported by Newspack Newsletters:
+ *   Mailchimp        *|FIELD|*
+ *   Constant Contact [[FIELD]]
+ *   ActiveCampaign   %FIELD%
+ *   Campaign Monitor [FIELD]
+ *
+ * Rejecting the bare-bracket Campaign Monitor form would be risky for an
+ * arbitrary query value, but `np_seg_donor` only ever carries a donor-status
+ * value (e.g. `true`, `monthly`, `$50.00`) — never a `[…]`-wrapped string — so
+ * matching it here is safe and keeps the inbound guard symmetric with every tag
+ * get_merge_tag() can emit.
+ *
+ * @param {string} value The decoded query-param value.
+ * @return {boolean} True when the value contains raw merge-tag syntax.
+ */
+const isUnsubstitutedMergeTag = value =>
+	/^\*\|[^|]+\|\*$/.test( value ) || // Mailchimp
+	/^\[\[[^\]]+\]\]$/.test( value ) || // Constant Contact
+	/^%[^%]+%$/.test( value ) || // ActiveCampaign
+	/^\[[^\][]+\]$/.test( value ); // Campaign Monitor
+
+/**
+ * Whether the reader arrived from a newsletter email flagged as a donor.
+ *
+ * A reader clicking a link in a newsletter lands on a URL carrying
+ * `np_seg_donor`, whose value the ESP substitutes per recipient from the
+ * publisher's donor merge field. A positive value is detected and remembered
+ * for the rest of the browsing session so the reader keeps matching donor
+ * segments as they navigate to clean URLs. An unsubstituted merge tag means the
+ * send was misconfigured, so it is ignored rather than treated as a donor value.
+ * See rememberSessionSignal() for the segmentation-only, transient guarantees.
+ *
+ * @return {boolean} True if the reader arrived this session as a flagged donor.
+ */
+export function isDonorFromEmail() {
+	return rememberSessionSignal( {
+		param: DONOR_PARAM,
+		sessionKey: FROM_EMAIL_DONOR_KEY,
+		isPositive: value => ! isUnsubstitutedMergeTag( value ) && isDonorValue( value ),
+	} );
+}
+
+/**
+ * Matching function for the 'donation' criteria.
+ *
+ * Readers arriving from a newsletter flagged as donors (`np_seg_donor`) match
+ * `donors`; a falsy or absent signal leaves them matching `non-donors`, the same
+ * as a reader who never clicked — the inbound flag only ever adds donors, there
+ * is no separate "unknown" state.
+ *
+ * @param {Object} config    The segment criteria config.
+ * @param {Object} ras       The reader activation object.
+ * @param {Object} ras.store The reader data library store.
+ * @return {boolean} Whether the criteria matches.
+ */
+export function matchDonation( config, { store } ) {
 	switch ( config.value ) {
 		case 'donors':
-			return store.get( 'is_donor' );
+			return store.get( 'is_donor' ) || isDonorFromEmail();
 		case 'non-donors':
-			return ! store.get( 'is_donor' );
+			return ! ( store.get( 'is_donor' ) || isDonorFromEmail() );
 		case 'formers-donors':
 			return store.get( 'is_former_donor' );
 	}
-} );
+}
+
+setMatchingFunction( 'donation', matchDonation );

--- a/plugins/newspack-popups/src/criteria/default/donation.test.js
+++ b/plugins/newspack-popups/src/criteria/default/donation.test.js
@@ -1,0 +1,91 @@
+import { matchDonation, isDonorFromEmail } from './donation';
+
+/**
+ * Build the second argument the matching function receives, with a stubbed
+ * reader data library store returning the given values.
+ *
+ * @param {Object}  values               Store values.
+ * @param {boolean} values.isDonor       Value returned by store.get( 'is_donor' ).
+ * @param {boolean} values.isFormerDonor Value returned by store.get( 'is_former_donor' ).
+ * @return {Object} Stubbed reader activation object.
+ */
+const ras = ( { isDonor = false, isFormerDonor = false } = {} ) => ( {
+	store: { get: key => ( 'is_former_donor' === key ? isFormerDonor : isDonor ) },
+} );
+
+describe( 'donation criteria matching', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'treats a non-donor arriving with no donor param as a non-donor', () => {
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( false );
+		expect( matchDonation( { value: 'non-donors' }, ras() ) ).toBe( true );
+	} );
+
+	it( 'treats a reader with the stored is_donor flag as a donor', () => {
+		expect( matchDonation( { value: 'donors' }, ras( { isDonor: true } ) ) ).toBe( true );
+		expect( matchDonation( { value: 'non-donors' }, ras( { isDonor: true } ) ) ).toBe( false );
+	} );
+
+	it( 'matches the former-donors value from the store', () => {
+		expect( matchDonation( { value: 'formers-donors' }, ras( { isFormerDonor: true } ) ) ).toBe( true );
+		expect( matchDonation( { value: 'formers-donors' }, ras() ) ).toBe( false );
+	} );
+
+	it.each( [ 'true', 'Yes', '1', 'monthly', '$50.00' ] )( 'treats a reader arriving with np_seg_donor=%s as a donor', value => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+		expect( matchDonation( { value: 'non-donors' }, ras() ) ).toBe( false );
+	} );
+
+	it.each( [ 'false', 'no', 'none', '0' ] )( 'does not treat a reader arriving with falsy np_seg_donor=%s as a donor', value => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+		expect( isDonorFromEmail() ).toBe( false );
+	} );
+
+	it( 'remembers a donor email arrival for the rest of the session', () => {
+		// Landing page carries the param and sets the session flag.
+		window.history.replaceState( {}, '', '/?np_seg_donor=true' );
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+		// Subsequent navigation to a clean URL still matches donors.
+		window.history.replaceState( {}, '', '/some-article' );
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+	} );
+
+	it.each( [
+		[ 'Mailchimp', '*|HUB-MEMBER|*' ],
+		[ 'Constant Contact', '[[DONOR]]' ],
+		[ 'ActiveCampaign', '%DONOR%' ],
+		[ 'Campaign Monitor', '[HUB-MEMBER]' ],
+	] )( 'ignores an unsubstituted %s merge tag so every recipient is not flagged', ( _esp, value ) => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=' + encodeURIComponent( value ) );
+		expect( isDonorFromEmail() ).toBe( false );
+	} );
+
+	it( 'still matches donors on an email arrival when sessionStorage writes are blocked', () => {
+		window.history.replaceState( {}, '', '/?np_seg_donor=true' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		// The URL param is authoritative; a failed write only costs cross-navigation memory.
+		expect( () => matchDonation( { value: 'donors' }, ras() ) ).not.toThrow();
+		expect( matchDonation( { value: 'donors' }, ras() ) ).toBe( true );
+		setSpy.mockRestore();
+	} );
+
+	it( 'does not throw when sessionStorage is fully unavailable', () => {
+		window.history.replaceState( {}, '', '/some-article' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		const getSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => isDonorFromEmail() ).not.toThrow();
+		expect( isDonorFromEmail() ).toBe( false );
+		setSpy.mockRestore();
+		getSpy.mockRestore();
+	} );
+} );

--- a/plugins/newspack-popups/src/criteria/default/index.php
+++ b/plugins/newspack-popups/src/criteria/default/index.php
@@ -135,7 +135,7 @@ $criteria = [
 	],
 	'donation'                 => [
 		'name'        => __( 'Donation', 'newspack-popups' ),
-		'description' => __( 'If the reader has completed an onsite donation.', 'newspack-popups' ),
+		'description' => __( 'If the reader has completed an onsite donation. Readers arriving from a newsletter email flagged as a donor are also matched as donors, for the rest of their browsing session.', 'newspack-popups' ),
 		'category'    => 'reader_revenue',
 		'options'     => [
 			[

--- a/plugins/newspack-popups/src/criteria/default/newsletter.js
+++ b/plugins/newspack-popups/src/criteria/default/newsletter.js
@@ -1,4 +1,5 @@
 import { setMatchingFunction } from '../utils';
+import { rememberSessionSignal } from './session-signal';
 
 /**
  * Session-storage key used to remember that the reader arrived from a
@@ -10,39 +11,20 @@ const FROM_EMAIL_KEY = 'newspack-popups-from-email';
  * Whether the reader is visiting from a newsletter email.
  *
  * A reader clicking a link in a Newspack newsletter lands on a URL carrying
- * `utm_medium=email` (appended by the newsletter renderer). The URL param is an
- * authoritative signal on the landing page, so it is honored even when the
- * arrival cannot be persisted. When detected, the arrival is also remembered
- * for the rest of the browsing session via sessionStorage so the reader keeps
- * matching "subscribers" segments as they navigate to clean URLs. This is
- * segmentation-only and transient — it is never written to the persisted reader
- * data store, so it does not affect analytics or ad targeting, and never
- * persists across sessions.
+ * `utm_medium=email` (appended by the newsletter renderer). The arrival is
+ * detected from the param and remembered for the rest of the browsing session
+ * so the reader keeps matching "subscribers" segments as they navigate to clean
+ * URLs. See rememberSessionSignal() for the segmentation-only, transient
+ * guarantees.
  *
  * @return {boolean} True if the reader arrived from a newsletter email this session.
  */
 export function isFromEmail() {
-	// The URL param is authoritative on the landing page, even if nothing can
-	// be persisted.
-	const medium = new URLSearchParams( window.location.search ).get( 'utm_medium' );
-	if ( medium?.toLowerCase() === 'email' ) {
-		// Remember the arrival for the rest of the session so the reader keeps
-		// matching after navigating to clean URLs. A write failure (e.g. private
-		// mode) only costs the cross-navigation memory, not this detection.
-		try {
-			window.sessionStorage.setItem( FROM_EMAIL_KEY, '1' );
-		} catch ( e ) {
-			// sessionStorage unavailable; the URL signal still stands.
-		}
-		return true;
-	}
-	// No param on this page — fall back to whatever was remembered earlier.
-	try {
-		return window.sessionStorage.getItem( FROM_EMAIL_KEY ) === '1';
-	} catch ( e ) {
-		// sessionStorage unavailable. Fail closed.
-		return false;
-	}
+	return rememberSessionSignal( {
+		param: 'utm_medium',
+		sessionKey: FROM_EMAIL_KEY,
+		isPositive: value => value.toLowerCase() === 'email',
+	} );
 }
 
 /**

--- a/plugins/newspack-popups/src/criteria/default/session-signal.js
+++ b/plugins/newspack-popups/src/criteria/default/session-signal.js
@@ -1,0 +1,42 @@
+/**
+ * Detect a URL-param arrival signal and remember it for the browsing session.
+ *
+ * Several segmentation signals are delivered as a query param on the page a
+ * reader lands on from a newsletter email (e.g. `utm_medium=email`,
+ * `np_seg_donor`). The param is authoritative on the landing page; once a
+ * positive value is seen it is remembered in sessionStorage so the reader keeps
+ * matching as they navigate on to clean URLs.
+ *
+ * The flag is segmentation-only and transient: it is never written to the
+ * persisted reader data store (so it cannot grant content access and does not
+ * affect analytics or ad targeting) and never survives the browsing session.
+ *
+ * @param {Object}   options
+ * @param {string}   options.param      Query-param name to read.
+ * @param {string}   options.sessionKey sessionStorage key under which a positive arrival is remembered.
+ * @param {Function} options.isPositive Predicate receiving the decoded (non-null) param value; returns whether it is a positive signal.
+ * @return {boolean} Whether the signal is active for this browsing session.
+ */
+export function rememberSessionSignal( { param, sessionKey, isPositive } ) {
+	// The URL param is authoritative on the landing page, even if nothing can be
+	// persisted.
+	const value = new URLSearchParams( window.location.search ).get( param );
+	if ( value !== null && isPositive( value ) ) {
+		// Remember the arrival for the rest of the session so the reader keeps
+		// matching after navigating to clean URLs. A write failure (e.g. private
+		// mode) only costs the cross-navigation memory, not this detection.
+		try {
+			window.sessionStorage.setItem( sessionKey, '1' );
+		} catch ( e ) {
+			// sessionStorage unavailable; the URL signal still stands.
+		}
+		return true;
+	}
+	// No positive param on this page — fall back to whatever was remembered earlier.
+	try {
+		return window.sessionStorage.getItem( sessionKey ) === '1';
+	} catch ( e ) {
+		// sessionStorage unavailable. Fail closed.
+		return false;
+	}
+}

--- a/plugins/newspack-popups/src/criteria/default/session-signal.test.js
+++ b/plugins/newspack-popups/src/criteria/default/session-signal.test.js
@@ -1,0 +1,60 @@
+import { rememberSessionSignal } from './session-signal';
+
+const KEY = 'newspack-popups-test-signal';
+
+/**
+ * Invoke the helper for a `flag` param that is positive when its value is `1`.
+ *
+ * @return {boolean} The helper result.
+ */
+const detect = () => rememberSessionSignal( { param: 'flag', sessionKey: KEY, isPositive: value => '1' === value } );
+
+describe( 'rememberSessionSignal', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'returns false when the param is absent and nothing is remembered', () => {
+		expect( detect() ).toBe( false );
+	} );
+
+	it( 'returns true and remembers a positive param for the session', () => {
+		window.history.replaceState( {}, '', '/?flag=1' );
+		expect( detect() ).toBe( true );
+		// Subsequent navigation to a clean URL still matches via the remembered flag.
+		window.history.replaceState( {}, '', '/some-article' );
+		expect( detect() ).toBe( true );
+	} );
+
+	it( 'returns false for a non-positive param value and does not remember it', () => {
+		window.history.replaceState( {}, '', '/?flag=0' );
+		expect( detect() ).toBe( false );
+		window.history.replaceState( {}, '', '/some-article' );
+		expect( detect() ).toBe( false );
+	} );
+
+	it( 'still detects a positive param when the sessionStorage write is blocked', () => {
+		window.history.replaceState( {}, '', '/?flag=1' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => detect() ).not.toThrow();
+		expect( detect() ).toBe( true );
+		setSpy.mockRestore();
+	} );
+
+	it( 'fails closed when sessionStorage is fully unavailable and no param is present', () => {
+		window.history.replaceState( {}, '', '/some-article' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		const getSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => detect() ).not.toThrow();
+		expect( detect() ).toBe( false );
+		setSpy.mockRestore();
+		getSpy.mockRestore();
+	} );
+} );

--- a/plugins/newspack-popups/tests/mocks/class-newspack-newsletters.php
+++ b/plugins/newspack-popups/tests/mocks/class-newspack-newsletters.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Mock of the newspack-newsletters main class for popups tests.
+ *
+ * The popups test suite loads only newspack-popups, so cross-plugin classes
+ * the code guards on are absent. This stand-in exposes just the newsletter CPT
+ * slug used by Newspack_Popups_Segmentation::append_donor_segment_param().
+ *
+ * @package Newspack_Popups
+ */
+
+if ( ! class_exists( 'Newspack_Newsletters' ) ) {
+	/**
+	 * Minimal stand-in for the newspack-newsletters main class.
+	 */
+	class Newspack_Newsletters {
+		const NEWSPACK_NEWSLETTERS_CPT = 'newspack_nl_cpt';
+	}
+}

--- a/plugins/newspack-popups/tests/mocks/class-utils.php
+++ b/plugins/newspack-popups/tests/mocks/class-utils.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Mock of the newspack-newsletters Tracking\Utils helper for popups tests.
+ *
+ * Mirrors the real helper's Mailchimp merge-tag syntax so the donor-segment
+ * link handler can be tested without the newspack-newsletters plugin loaded.
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+if ( ! class_exists( __NAMESPACE__ . '\Utils' ) ) {
+	/**
+	 * Minimal stand-in for the newspack-newsletters tracking helper.
+	 */
+	class Utils {
+		/**
+		 * Wrap a field in Mailchimp merge-tag delimiters.
+		 *
+		 * @param string $field Merge field tag.
+		 * @return string
+		 */
+		public static function get_merge_tag( $field ) {
+			$field = trim( (string) $field );
+			return '' === $field ? '' : '*|' . $field . '|*';
+		}
+	}
+}

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for the donor-status segment param appended to newsletter links by
+ * Newspack_Popups_Segmentation::append_donor_segment_param().
+ *
+ * @package Newspack_Popups
+ */
+
+// Stand-ins for the newspack-newsletters classes the handler guards on; the
+// popups test suite loads only newspack-popups.
+require_once __DIR__ . '/mocks/class-newspack-newsletters.php';
+require_once __DIR__ . '/mocks/class-utils.php';
+
+/**
+ * Test appending segment params to newsletter links.
+ */
+class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
+	const DONOR_FIELD = 'HUB-MEMBER';
+
+	/**
+	 * Set up: configure a donor merge field.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( 'newspack_popups_mc_donor_merge_field', self::DONOR_FIELD );
+	}
+
+	/**
+	 * Make a newsletter post.
+	 *
+	 * @return WP_Post
+	 */
+	private function make_newsletter() {
+		return self::factory()->post->create_and_get(
+			[ 'post_type' => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ]
+		);
+	}
+
+	/**
+	 * A first-party link in a newsletter gets the donor merge tag appended,
+	 * which the ESP substitutes per recipient at send time.
+	 */
+	public function test_appends_merge_tag_to_first_party_newsletter_link() {
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertArrayHasKey( 'np_seg_donor', $args );
+		$this->assertSame( '*|' . self::DONOR_FIELD . '|*', $args['np_seg_donor'] );
+
+		// The merge tag must appear RAW (unencoded) in the URL: ESPs substitute only
+		// the literal *|FIELD|* syntax and leave the percent-encoded form (%2A%7C…)
+		// untouched (verified against a live Mailchimp send). add_query_arg() encodes
+		// by default, so this guards the str_replace that restores the raw tag.
+		$this->assertStringContainsString( 'np_seg_donor=*|' . self::DONOR_FIELD . '|*', $result );
+		$this->assertStringNotContainsString( '%2A%7C', $result );
+	}
+
+	/**
+	 * Third-party links are left untouched so the donor flag never leaks into
+	 * external logs / Referer headers.
+	 */
+	public function test_skips_external_link() {
+		$url = 'https://example.com/elsewhere/';
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * With no donor merge field configured there's nothing to segment on.
+	 */
+	public function test_skips_when_no_donor_field_configured() {
+		update_option( 'newspack_popups_mc_donor_merge_field', '' );
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Non-newsletter posts (e.g. newsletter ads, which are proxied separately)
+	 * are not touched.
+	 */
+	public function test_skips_non_newsletter_post() {
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'post' ] );
+		$url  = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $post )
+		);
+	}
+
+	/**
+	 * Relative (host-less) links are first-party by definition and get the param.
+	 */
+	public function test_appends_to_relative_link() {
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( '/some-article/', '/some-article/', $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertArrayHasKey( 'np_seg_donor', $args );
+		$this->assertSame( '*|' . self::DONOR_FIELD . '|*', $args['np_seg_donor'] );
+	}
+
+	/**
+	 * The donor-merge-field setting is a comma-delimited substring list (used for
+	 * login matching); a query-param merge tag needs a single exact tag, so only
+	 * the first entry is used and surrounding whitespace is trimmed.
+	 */
+	public function test_uses_first_entry_of_comma_delimited_field() {
+		update_option( 'newspack_popups_mc_donor_merge_field', ' HUB-MEMBER , MEMBER ' );
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertSame( '*|HUB-MEMBER|*', $args['np_seg_donor'] );
+	}
+}

--- a/themes/newspack-theme/CHANGELOG.md
+++ b/themes/newspack-theme/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-theme [2.23.3](https://github.com/Automattic/newspack-workspace/compare/newspack-theme@2.23.2...newspack-theme@2.23.3) (2026-06-19)
+
+
+### Bug Fixes
+
+* **separator:** restore Default separator width on WP 7.0 ([#324](https://github.com/Automattic/newspack-workspace/issues/324)) ([8a8b315](https://github.com/Automattic/newspack-workspace/commit/8a8b3158daba9774022e64b9ef929d6509856acc))
+
 ## newspack-theme [2.23.2](https://github.com/Automattic/newspack-workspace/compare/newspack-theme@2.23.1...newspack-theme@2.23.2) (2026-06-17)
 
 

--- a/themes/newspack-theme/newspack-joseph/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-joseph/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-katharine/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-katharine/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-nelson/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-nelson/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-sacha/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-sacha/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-scott/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-scott/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
+++ b/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
@@ -1097,6 +1097,17 @@ hr {
 	}
 }
 
+// Default-width separators need a short max-width. Historically WordPress core
+// pinned this with `.wp-block-separator { width: 100px }` (the separator block's
+// theme.css). WordPress 7.0 stopped enqueuing that rule in separate-block-assets
+// mode, exposing that inside post content `.entry .entry-content > *` (0,2,0)
+// out-specifies the base `.wp-block-separator` (0,1,0) max-width above, so a
+// Default separator stretched to full width. Re-assert the short width for the
+// default style with a higher-specificity selector (0,3,0). See NPPM-2930.
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	max-width: #{5 * structure.$size__spacing-unit};
+}
+
 .entry .entry-content,
 [id="pico"] {
 	> .wp-block-separator,

--- a/themes/newspack-theme/newspack-theme/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-theme/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: newspack-theme

--- a/themes/newspack-theme/package.json
+++ b/themes/newspack-theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-theme",
-	"version": "2.23.2",
+	"version": "2.23.3",
 	"description": "A theme for Newspack. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-theme/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Brings five Insights → Conversion Journey (Tab 3) metrics from "coming soon" to live data, built on a WP/Woo identity spine with BigQuery supplying only the conversion **source** (gate / prompt / direct), attached to each local record by a timestamp-window match — no GA cookie is ever cast to a Woo customer ID.

- **3.2 / 3.3 Source mix (new subscribers / new donors)** — remediates the production bug where these returned ~0. Counts now come from Woo conversions in the window; each conversion's source is matched to the BigQuery checkout-exposure event just before it.
- **4.2 / 4.3 Time to subscribe / donate** — cumulative "what share converted by day N" curves, split by source. Registration→conversion lag comes from Woo; the per-source split comes from a BigQuery registration-source lookup behind a cheap presence probe. When that source layer is absent or unavailable, the curve still renders (unsegmented) instead of disappearing.
- **4.4 Subscriber → donor lag** — a pure-Woo cumulative curve of how long subscribers take to also donate, hidden until at least 50 readers have done both.

4.2 / 4.3 / 4.4 always use **all available history** regardless of the selected date range (a caption now says so on each); 3.2 / 3.3 follow the dashboard date range. This is primarily a backend change plus that one caption — the chart components and response types were already in place.

Part of NPPD-1692.

### How to test the changes in this Pull Request:

1. Check out this branch and run the PHP unit tests from `plugins/newspack-plugin`: `n test-php --filter Test_Conversion_Metric` (expect 87 passing) and `n test-php --group insights` (no regressions).
2. Run the JS tests: `npm test -- HowLongConversionsTakeSection` — the new test asserts the all-history caption renders on exactly the three snapshot charts (4.2 / 4.3 / 4.4), not on 4.1.
3. Lint on the host: from `plugins/newspack-plugin`, `./vendor/bin/phpcs includes/wizards/insights/storage includes/wizards/insights/metrics` and `npm run lint:js -- src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx` — expect no errors.
4. Confirm graceful degradation logic: the time-to-convert curves fall back to a single unsegmented (all-"direct") series when the BigQuery presence probe returns zero or the source query errors (covered by the `*_probe_zero_all_direct` and `*_registrations_error_all_direct` unit tests).
5. **Live verification (required before this ships, after the hub deploys):** on a real Audience site (e.g. blockclub), open the Conversion Journey tab and confirm 3.2 / 3.3 show non-zero, sensible source splits (vs the current ~0), the 4.2 / 4.3 / 4.4 curves populate, and 4.4 stays hidden below 50 cross-converters. The local dev site cannot exercise the hub BigQuery queries (it loads `newspack-manager-client`, not the hub).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<sub>Notes for reviewers: BigQuery `event_timestamp` is microseconds — converted to seconds before timestamp matching. Storage epochs are built in PHP from UTC datetime strings (not SQL `UNIX_TIMESTAMP`, which would use the session timezone). The new `rows_to_records` / `rows_to_lags` helpers are duplicated per storage class to match the existing self-contained convention (no shared base; `id_list`/`fmt` are likewise duplicated). `Woo_Order_Resolver` is intentionally left in place — it still backs the deferred influenced metrics and is removed in a later PR. Woo SQL bodies are live-verified rather than unit-tested (no WooCommerce tables in the PHPUnit bootstrap; Phase A precedent).</sub>
