### PR TITLE
chore(release): reconcile release → main (resolve audience setup conflict)

### DIFF
--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.43.2](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.1...newspack@6.43.2) (2026-06-19)
+
+
+### Bug Fixes
+
+* **audience:** gate Group labels settings behind Content_Gate feature flag ([#297](https://github.com/Automattic/newspack-workspace/issues/297)) ([cfe7901](https://github.com/Automattic/newspack-workspace/commit/cfe7901d1207d6af4352eabc563ebc2f81277fec)), closes [#148](https://github.com/Automattic/newspack-workspace/issues/148) [#newspack-engineering-public](https://github.com/Automattic/newspack-workspace/issues/newspack-engineering-public)
+
 ## newspack [6.43.1](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.0...newspack@6.43.1) (2026-06-17)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.43.3](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.2...newspack@6.43.3) (2026-06-19)
+
+
+### Bug Fixes
+
+* **woocommerce:** scope payment notice to recoverable statuses ([#301](https://github.com/Automattic/newspack-workspace/issues/301)) ([1f55c11](https://github.com/Automattic/newspack-workspace/commit/1f55c117bff9626fe5bb8ab53e2937cec2f40083))
+
 ## newspack [6.43.2](https://github.com/Automattic/newspack-workspace/compare/newspack@6.43.1...newspack@6.43.2) (2026-06-19)
 
 

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -117,6 +117,17 @@ class Content_Gate {
 	/**
 	 * Whether the first-party Newspack feature is enabled.
 	 *
+	 * Memoized per request — the underlying constant is immutable for the
+	 * lifetime of a request, and call sites (admin menu, REST registration,
+	 * wizard data, gated callbacks across Group_Subscription_*) consult this
+	 * many times per page. The cache keeps that footprint flat if the check
+	 * grows beyond a constant lookup in the future (license, remote call,
+	 * etc.).
+	 *
+	 * Tests under PHPUnit boot the plugin once and `define()` the constant
+	 * later in per-suite `setUp()` calls. To keep those defines effective,
+	 * skip the cache when `IS_TEST_ENV` is on.
+	 *
 	 * @return bool
 	 */
 	public static function is_newspack_feature_enabled() {
@@ -131,7 +142,14 @@ class Content_Gate {
 		 *
 		 * @example define( 'NEWSPACK_CONTENT_GATES', true );
 		 */
-		return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		}
+		static $enabled = null;
+		if ( null === $enabled ) {
+			$enabled = defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		}
+		return $enabled;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -857,6 +857,9 @@ class Group_Subscription_Settings {
 	 * Register the publisher-configurable group label settings.
 	 */
 	public static function register_label_settings() {
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return;
+		}
 		// Group name is unused (no settings_fields() form); registers sanitize_callback via update_option().
 		\register_setting(
 			'newspack_group_subscription',

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -18,6 +18,22 @@ class WooCommerce_Update_Payment_Notice {
 	const NOTICE_INTERVAL = 60 * 60 * 24; // 24 hours.
 
 	/**
+	 * Subscription statuses for which the "needs payment" notice is actionable.
+	 * Only states where paying actually restores the subscription. Terminal
+	 * statuses (expired, cancelled, switched) and states where the reader still
+	 * has access (active, pending-cancel) are intentionally excluded. NPPM-2926.
+	 *
+	 * Closed set of core WCS statuses. A publisher's custom "recoverable but
+	 * unpaid" status would not match, so readers in it would silently miss the
+	 * notice; both callers fail closed, so the only effect is a missed nudge,
+	 * never a wrong action. Extend this constant (or add a filter) only if such
+	 * a status is found in the field.
+	 *
+	 * @var string[]
+	 */
+	const NOTICE_RECOVERABLE_STATUSES = [ 'on-hold', 'pending' ];
+
+	/**
 	 * Initialize the class.
 	 */
 	public static function init() {
@@ -137,7 +153,9 @@ class WooCommerce_Update_Payment_Notice {
 		$notices = [];
 
 		foreach ( $subscriptions as $subscription ) {
-			if ( 'cancelled' === $subscription->get_status() ) {
+			// Only nag for statuses where paying can restore the subscription (NPPM-2926);
+			// see NOTICE_RECOVERABLE_STATUSES for why terminal/has-access statuses are excluded.
+			if ( ! $subscription->has_status( self::NOTICE_RECOVERABLE_STATUSES ) ) {
 				continue;
 			}
 			if ( ! $subscription->needs_payment() ) {

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
@@ -114,6 +114,8 @@ class Audience_Wizard extends Wizard {
 			'has_metering'    => Content_Gate::is_metering_enabled( Memberships::GATE_CPT ),
 		];
 
+		$data['is_newspack_feature_enabled'] = Content_Gate::is_newspack_feature_enabled();
+
 		wp_enqueue_script( 'newspack-wizards' );
 
 		wp_localize_script(
@@ -381,6 +383,9 @@ class Audience_Wizard extends Wizard {
 		);
 
 		// Group label settings (publisher-overridable singular/plural for group subscriptions).
+		// The callbacks short-circuit on Content_Gate::is_newspack_feature_enabled() so
+		// stale clients hitting the route after a flag flip get a descriptive error
+		// instead of reading or writing the option directly.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/group-labels',
@@ -1056,9 +1061,13 @@ class Audience_Wizard extends Wizard {
 	 * Get the publisher-configurable group subscription labels. Empty values fall back
 	 * to the defaults baked into Group_Subscription::get_label().
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function api_get_group_labels() {
+		$disabled = self::group_labels_feature_disabled_error();
+		if ( $disabled ) {
+			return $disabled;
+		}
 		return rest_ensure_response(
 			[
 				'label_singular'         => (string) get_option( 'newspack_group_subscription_label_singular', '' ),
@@ -1074,9 +1083,13 @@ class Audience_Wizard extends Wizard {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function api_update_group_labels( $request ) {
+		$disabled = self::group_labels_feature_disabled_error();
+		if ( $disabled ) {
+			return $disabled;
+		}
 		$params = $request->get_params();
 		foreach ( [ 'label_singular', 'label_plural' ] as $field ) {
 			if ( ! array_key_exists( $field, $params ) ) {
@@ -1090,6 +1103,23 @@ class Audience_Wizard extends Wizard {
 			}
 		}
 		return $this->api_get_group_labels();
+	}
+
+	/**
+	 * Shared guard for the /group-labels callbacks: returns a 403 WP_Error when
+	 * the Newspack Content Gate feature flag is off, or null when it's on.
+	 *
+	 * @return WP_Error|null
+	 */
+	private static function group_labels_feature_disabled_error() {
+		if ( Content_Gate::is_newspack_feature_enabled() ) {
+			return null;
+		}
+		return new WP_Error(
+			'newspack_content_gate_disabled',
+			__( 'Group subscription label settings are unavailable: the Newspack Content Gate feature is not enabled on this site.', 'newspack-plugin' ),
+			[ 'status' => 403 ]
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.43.1
+ * Version: 6.43.2
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.43.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.43.2' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.43.2
+ * Version: 6.43.3
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.43.2' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.43.3' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.43.1",
+	"version": "6.43.2",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.43.2",
+	"version": "6.43.3",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/index.js
@@ -111,7 +111,9 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 			label: __( 'Checkout & Payment', 'newspack-plugin' ),
 			path: '/payment',
 		},
-		{
+		// "Advanced settings" hosts the Group labels override, which only makes
+		// sense when the Newspack Content Gate / Group subscriptions feature is on.
+		newspackAudience.is_newspack_feature_enabled && {
 			label: __( 'Advanced settings', 'newspack-plugin' ),
 			path: '/groups',
 		},
@@ -163,7 +165,7 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 					<Route path="/" exact render={ () => <Setup { ...props } /> } />
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
-					<Route path="/groups" render={ () => <Groups { ...props } /> } />
+					{ newspackAudience.is_newspack_feature_enabled && <Route path="/groups" render={ () => <Groups { ...props } /> } /> }
 					<Route path="/campaign" render={ () => <Campaign { ...props } /> } />
 					<Route path="/complete" render={ () => <Complete { ...props } /> } />
 					<Redirect to="/" />

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -432,6 +432,12 @@ class WC_Subscription {
 		}
 		return (float) ( $wcs_mock_items_sign_up_fee ?? 0 );
 	}
+	public function needs_payment() {
+		return ! empty( $this->data['needs_payment'] );
+	}
+	public function get_view_order_url() {
+		return $this->data['view_order_url'] ?? 'https://example.test/my-account/view-order/' . $this->get_id();
+	}
 	public function save() {
 		return true;
 	}
@@ -635,6 +641,21 @@ function wcs_get_users_subscriptions( $user_id ) {
 	// subs the user is only a member of). Tests that need ownership semantics
 	// must guard against this just like production code.
 	return apply_filters( 'wcs_get_users_subscriptions', $user_subscriptions, $user_id );
+}
+function wcs_get_subscriptions( $args = [] ) {
+	// Minimal mock: implements only the `customer_id` filter, the sole arg the code
+	// under test passes. If a future test needs status/paging args
+	// (subscription_status, subscriptions_per_page, paged, offset), extend the filter
+	// here rather than relying on this returning the full set.
+	global $subscriptions_database;
+	$customer_id = $args['customer_id'] ?? null;
+	$matches     = [];
+	foreach ( $subscriptions_database as $id => $subscription ) {
+		if ( null === $customer_id || $subscription->get_customer_id() === $customer_id ) {
+			$matches[ $id ] = $subscription;
+		}
+	}
+	return $matches;
 }
 function wcs_get_canonical_product_id( $item ) {
 	if ( is_object( $item ) && method_exists( $item, 'get_product_id' ) ) {

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-update-payment-notice.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Tests the WooCommerce Update Payment Notice status gate (NPPM-2926, Gap B).
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Update_Payment_Notice;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * Tests for WooCommerce_Update_Payment_Notice status allowlist logic.
+ *
+ * @group update_payment_notice
+ */
+class Newspack_Test_WooCommerce_Update_Payment_Notice extends WP_UnitTestCase {
+	/**
+	 * Reset the mock subscription registry before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database, $orders_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$orders_database        = [];
+	}
+
+	/**
+	 * Call the private get_notices() via reflection.
+	 *
+	 * @return string[]
+	 */
+	private function get_notices() {
+		$method = new ReflectionMethod( WooCommerce_Update_Payment_Notice::class, 'get_notices' );
+		$method->setAccessible( true );
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Register a logged-in customer and return its ID.
+	 *
+	 * @return int
+	 */
+	private function make_current_customer() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Build a minimal line item exposing the methods the notice path uses.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return object
+	 */
+	private function make_line_item( $product_id ) {
+		return new class( $product_id ) {
+			/**
+			 * Product ID this line item refers to.
+			 *
+			 * @var int
+			 */
+			private $product_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $product_id Product ID.
+			 */
+			public function __construct( $product_id ) {
+				$this->product_id = $product_id;
+			}
+
+			/**
+			 * Return the product ID.
+			 *
+			 * @return int
+			 */
+			public function get_product_id() {
+				return $this->product_id;
+			}
+
+			/**
+			 * Return the WC_Product object for this line item.
+			 *
+			 * @return WC_Product|false
+			 */
+			public function get_product() {
+				return wc_get_product( $this->product_id );
+			}
+		};
+	}
+
+	/**
+	 * Register a subscription that needs payment, owned by the current customer.
+	 *
+	 * @param int    $customer_id Customer ID.
+	 * @param string $status      Subscription status.
+	 * @param int    $product_id  Product ID granted by the subscription.
+	 * @return WC_Subscription
+	 */
+	private function make_needs_payment_subscription( $customer_id, $status, $product_id ) {
+		return wcs_create_subscription(
+			[
+				'customer_id'   => $customer_id,
+				'status'        => $status,
+				'needs_payment' => true,
+				'products'      => [ $product_id ],
+				'items'         => [ $this->make_line_item( $product_id ) ],
+			]
+		);
+	}
+
+	/**
+	 * Statuses that must NOT produce a notice even when needs_payment() is true.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function non_recoverable_status_provider() {
+		return [
+			'expired'        => [ 'expired' ],
+			'switched'       => [ 'switched' ],
+			'active'         => [ 'active' ],
+			'pending-cancel' => [ 'pending-cancel' ],
+			'cancelled'      => [ 'cancelled' ],
+		];
+	}
+
+	/**
+	 * Non-recoverable statuses must not produce a payment notice even if needs_payment() is true.
+	 *
+	 * @dataProvider non_recoverable_status_provider
+	 *
+	 * @param string $status Subscription status.
+	 */
+	public function test_no_notice_for_non_recoverable_status( $status ) {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		$this->make_needs_payment_subscription( $customer_id, $status, $product->get_id() );
+
+		$this->assertSame( [], $this->get_notices(), "Status '$status' must not produce a payment notice." );
+	}
+
+	/**
+	 * The documented incident: an expired subscription with a stale unpaid renewal order.
+	 */
+	public function test_no_notice_for_expired_with_stale_unpaid_order() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 54427,
+				'name' => 'Newsroom Pro – Monthly',
+			]
+		);
+		// needs_payment() true models the stale unpaid failed-renewal order still attached.
+		$this->make_needs_payment_subscription( $customer_id, 'expired', $product->get_id() );
+
+		$this->assertSame( [], $this->get_notices(), 'An expired subscription with a stale unpaid order must not nag.' );
+	}
+
+	/**
+	 * Recoverable statuses still fire (regression guard).
+	 */
+	public function test_notice_fires_for_on_hold() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		$this->make_needs_payment_subscription( $customer_id, 'on-hold', $product->get_id() );
+
+		$notices = $this->get_notices();
+		$this->assertCount( 1, $notices, 'An on-hold subscription that needs payment must produce a notice.' );
+		$this->assertStringContainsString( 'Newsroom Pro', $notices[0] );
+	}
+
+	/**
+	 * A pending subscription that needs payment fires a notice (regression guard).
+	 */
+	public function test_notice_fires_for_pending() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		$this->make_needs_payment_subscription( $customer_id, 'pending', $product->get_id() );
+
+		$this->assertCount( 1, $this->get_notices(), 'A pending subscription that needs payment must produce a notice.' );
+	}
+
+	/**
+	 * A recoverable status that does NOT need payment produces nothing.
+	 */
+	public function test_no_notice_when_payment_not_needed() {
+		$customer_id = $this->make_current_customer();
+		$product     = wc_create_mock_product(
+			[
+				'id'   => 4242,
+				'name' => 'Newsroom Pro',
+			]
+		);
+		wcs_create_subscription(
+			[
+				'customer_id'   => $customer_id,
+				'status'        => 'on-hold',
+				'needs_payment' => false,
+				'products'      => [ $product->get_id() ],
+				'items'         => [ $this->make_line_item( $product->get_id() ) ],
+			]
+		);
+
+		$this->assertSame( [], $this->get_notices(), 'No notice when the subscription does not need payment.' );
+	}
+
+	/**
+	 * Pin the recoverable-status allowlist to its reviewed value. This does NOT
+	 * auto-detect new WooCommerce Subscriptions statuses — the known set is listed
+	 * here, not queried. It fails when the allowlist itself changes, or gains a
+	 * status outside the known set, forcing a human to confirm a new status is
+	 * genuinely recoverable before it ships. NPPM-2926.
+	 */
+	public function test_allowlist_is_pinned_against_known_wcs_statuses() {
+		$known_wcs_statuses = [ 'pending', 'active', 'on-hold', 'cancelled', 'switched', 'expired', 'pending-cancel' ];
+
+		$reflection = new ReflectionClass( \Newspack\WooCommerce_Update_Payment_Notice::class );
+		$allowlist  = $reflection->getConstant( 'NOTICE_RECOVERABLE_STATUSES' );
+
+		$unknown = array_diff( $allowlist, $known_wcs_statuses );
+		$this->assertSame( [], array_values( $unknown ), 'Allowlist contains a status not in the known WCS set.' );
+
+		$this->assertEqualSets(
+			[ 'on-hold', 'pending' ],
+			$allowlist,
+			'Allowlist changed. Confirm any new status is genuinely recoverable before updating this guard.'
+		);
+	}
+}

--- a/themes/newspack-theme/CHANGELOG.md
+++ b/themes/newspack-theme/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-theme [2.23.3](https://github.com/Automattic/newspack-workspace/compare/newspack-theme@2.23.2...newspack-theme@2.23.3) (2026-06-19)
+
+
+### Bug Fixes
+
+* **separator:** restore Default separator width on WP 7.0 ([#324](https://github.com/Automattic/newspack-workspace/issues/324)) ([8a8b315](https://github.com/Automattic/newspack-workspace/commit/8a8b3158daba9774022e64b9ef929d6509856acc))
+
 ## newspack-theme [2.23.2](https://github.com/Automattic/newspack-workspace/compare/newspack-theme@2.23.1...newspack-theme@2.23.2) (2026-06-17)
 
 

--- a/themes/newspack-theme/newspack-joseph/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-joseph/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-katharine/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-katharine/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-nelson/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-nelson/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-sacha/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-sacha/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-scott/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-scott/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
+++ b/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
@@ -1097,6 +1097,17 @@ hr {
 	}
 }
 
+// Default-width separators need a short max-width. Historically WordPress core
+// pinned this with `.wp-block-separator { width: 100px }` (the separator block's
+// theme.css). WordPress 7.0 stopped enqueuing that rule in separate-block-assets
+// mode, exposing that inside post content `.entry .entry-content > *` (0,2,0)
+// out-specifies the base `.wp-block-separator` (0,1,0) max-width above, so a
+// Default separator stretched to full width. Re-assert the short width for the
+// default style with a higher-specificity selector (0,3,0). See NPPM-2930.
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	max-width: #{5 * structure.$size__spacing-unit};
+}
+
 .entry .entry-content,
 [id="pico"] {
 	> .wp-block-separator,

--- a/themes/newspack-theme/newspack-theme/sass/theme-description.scss
+++ b/themes/newspack-theme/newspack-theme/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.9
 Tested up to: 7.0
-Version: 2.23.2
+Version: 2.23.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: newspack-theme

--- a/themes/newspack-theme/package.json
+++ b/themes/newspack-theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-theme",
-	"version": "2.23.2",
+	"version": "2.23.3",
 	"description": "A theme for Newspack. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-theme/issues"


### PR DESCRIPTION
## What this is

A **branch-sync reconcile**: merges `release` back into `main`. The automated post-release branch-sync job (`.github/scripts/post-release.sh`) had been failing on a single merge conflict and aborting after every release for ~25h, leaving `main` 8 commits behind `release`. Several shipped hotfixes were stranded off `main` and at risk on the next stable cut:

- `#324` — `fix(separator): restore Default separator width on WP 7.0`
- `#297` — `fix(audience): gate Group labels settings behind Content_Gate feature flag`
- `#301` — `fix(woocommerce): scope payment notice to recoverable statuses`
- plus the associated version-bump / changelog chores (`6.43.2`, `6.43.3`, `2.23.3`).

This PR carries all 8 of those commits plus the one hand-resolved conflict, so the branches reconcile.

> **Merge with a *merge commit*, not squash** — this is a branch sync; preserving the individual commit history is intentional (and it's what keeps the next automated `release → main` clean — see below).

## The conflict

Everything auto-merged cleanly **except one file**:
`plugins/newspack-plugin/src/wizards/audience/views/setup/index.js` (merge-base `a03772d75`).

- **`main`** had heavily restructured the audience-wizard component (platform "chooser" gate, platform-gated *Checkout & Payment* tab, `configLoaded && !config.enabled` redirect guards on `/campaign` and `/complete`).
- **`release`** carried `#297`, which gates the *Advanced settings* (`/groups`) tab **and** its React route behind `newspackAudience.is_newspack_feature_enabled`.

**Resolution intent:** keep `main`'s restructured structure, and re-apply `#297`'s two JS gates. `#297`'s PHP side (REST 403 guard + memoized flag helper) auto-merged cleanly and is unaffected.

## Proof the resolution is faithful (raw diffs)

The net change vs `main` is *exactly* `#297`'s two JS gates re-applied onto `main`'s structure — nothing of `main`'s restructure was altered. Compare:

<details><summary><strong>Resolution diff — <code>git diff origin/main...HEAD -- …/setup/index.js</code></strong></summary>

```diff
@@ -110,7 +110,9 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 					label: __( 'Checkout & Payment', 'newspack-plugin' ),
 					path: '/payment',
 				},
-				{
+				// "Advanced settings" hosts the Group labels override, which only makes
+				// sense when the Newspack Content Gate / Group subscriptions feature is on.
+				newspackAudience.is_newspack_feature_enabled && {
 					label: __( 'Advanced settings', 'newspack-plugin' ),
 					path: '/groups',
 				},
@@ -184,7 +186,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
-					<Route path="/groups" render={ () => <Groups { ...props } /> } />
+					{ newspackAudience.is_newspack_feature_enabled && <Route path="/groups" render={ () => <Groups { ...props } /> } /> }
 					<Route path="/campaign" render={ () => ( configLoaded && ! config.enabled ? <Redirect to="/" /> : <Campaign { ...props } /> ) } />
 					<Route path="/complete" render={ () => ( configLoaded && ! config.enabled ? <Redirect to="/" /> : <Complete { ...props } /> ) } />
```
</details>

<details><summary><strong><code>#297</code>'s original JS edits — <code>git show cfe7901d1 -- '*.js'</code></strong></summary>

```diff
@@ -111,7 +111,9 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch },
 			label: __( 'Checkout & Payment', 'newspack-plugin' ),
 			path: '/payment',
 		},
-		{
+		// "Advanced settings" hosts the Group labels override, which only makes
+		// sense when the Newspack Content Gate / Group subscriptions feature is on.
+		newspackAudience.is_newspack_feature_enabled && {
 			label: __( 'Advanced settings', 'newspack-plugin' ),
 			path: '/groups',
 		},
@@ -163,7 +165,7 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch },
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
-					<Route path="/groups" render={ () => <Groups { ...props } /> } />
+					{ newspackAudience.is_newspack_feature_enabled && <Route path="/groups" render={ () => <Groups { ...props } /> } /> }
 					<Route path="/campaign" render={ () => <Campaign { ...props } /> } />
 					<Route path="/complete" render={ () => <Complete { ...props } /> } />
```
</details>

The gate lines are identical; only the surrounding context (main's restructure) differs.

## Verification

- ✅ Auto-merged PHP still localizes the flag the JS reads — `$data['is_newspack_feature_enabled'] = Content_Gate::is_newspack_feature_enabled();` (`class-audience-wizard.php`), so the gate is live, not dead.
- ✅ `pnpm install --frozen-lockfile` — clean (lockfile consistent; release already carries `workspace:*` deps, so no restore step was needed).
- ✅ `pnpm --filter newspack run build` (webpack) — clean compile.
- ✅ `wp-scripts lint-js` on the resolved file (project eslint config) — 0 findings.
- ✅ Re-merging this branch into `main` is conflict-free; all 8 release commits reconciled.
- ✅ An independent multi-model LLM review pass (3 models) read the resolution as faithfully preserving both branches' intent — no code blockers.

## Will the next automated `release → main` stay clean?

Yes for the routine case. After this lands as a merge commit, `release`'s tip becomes an ancestor of `main`, so the next merge-base advances past the conflicting commits and **this conflict cannot recur**. A simulated routine next release (version bump) test-merges clean.

One bounded caveat: `release`'s copy of this file stays structurally *behind* `main` until the audience-wizard restructure promotes down through the normal `main → alpha → release` flow. Until then, a *new* hotfix that edits **this same file** directly on `release` would need a one-time hand-resolve (same intent). The normal promotion converges the file and removes even that.

## Out-of-scope follow-up candidates (NOT changed here)

Surfaced by the review pass; deliberately left out of this faithful sync:

1. **Routing-guard asymmetry** — `/content-gating` and `/payment` routes stay mounted (reachable by hash) even when their tabs are conditionally hidden; only `/groups` is render-gated. This is **pre-existing** `main` behavior and faithful to `#297`'s intent (server-side REST 403 bounds impact). Worth a separate consistency pass if desired.
2. **Strict-boolean coercion of the localized flag** — `is_newspack_feature_enabled && {…}` is safe today (the value is a `wp_localize_script`'d bool → `"1"`/`""`), but a `!!`/explicit-compare would harden the JSX pattern. This is `#297`'s shipped pattern; changing it here would diverge `main` from `release` in this exact file, so it belongs in a separate hardening PR if pursued.

cc @dkoo (author of `#297`) for a sanity check on the semantic resolution.
