### PR TITLE
fix(theme): stop Custom Fields box overwriting editor post meta

### DIFF
--- a/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -22,6 +22,7 @@ final class Subtitle_Block {
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'register_block_and_post_meta' ] );
 		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
+		\add_filter( 'is_protected_meta', [ __CLASS__, 'protect_post_meta' ], 10, 2 );
 	}
 
 	/**
@@ -39,11 +40,35 @@ final class Subtitle_Block {
 			'post',
 			self::POST_META_NAME,
 			[
-				'show_in_rest' => true,
-				'single'       => true,
-				'type'         => 'string',
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'string',
+				// Managed by the editor subtitle UI via REST. An explicit
+				// auth_callback keeps it REST-editable while protect_post_meta()
+				// marks it protected (see that method).
+				'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+					return current_user_can( 'edit_post', $object_id );
+				},
 			]
 		);
+	}
+
+	/**
+	 * Mark the subtitle meta as protected.
+	 *
+	 * The subtitle is edited through the editor subtitle UI (saved via the REST
+	 * API), not the classic "Custom Fields" box. Leaving it unprotected lets
+	 * that box resubmit a stale value on save and silently overwrite the
+	 * REST-saved value when a classic meta box triggers the block editor's
+	 * meta-box save. Protecting it removes it from the Custom Fields box; the
+	 * explicit auth_callback on the registration keeps it REST-editable.
+	 *
+	 * @param bool   $protected Whether the meta key is considered protected.
+	 * @param string $meta_key  The meta key.
+	 * @return bool Whether the meta key is protected.
+	 */
+	public static function protect_post_meta( $protected, $meta_key ) {
+		return self::POST_META_NAME === $meta_key ? true : $protected;
 	}
 
 	/**

--- a/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -22,7 +22,7 @@ final class Subtitle_Block {
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'register_block_and_post_meta' ] );
 		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
-		\add_filter( 'is_protected_meta', [ __CLASS__, 'protect_post_meta' ], 10, 2 );
+		\add_filter( 'is_protected_meta', [ __CLASS__, 'protect_post_meta' ], 10, 3 );
 	}
 
 	/**
@@ -65,9 +65,13 @@ final class Subtitle_Block {
 	 *
 	 * @param bool   $protected Whether the meta key is considered protected.
 	 * @param string $meta_key  The meta key.
+	 * @param string $meta_type The type of object the meta belongs to (post, term, user, etc.).
 	 * @return bool Whether the meta key is protected.
 	 */
-	public static function protect_post_meta( $protected, $meta_key ) {
+	public static function protect_post_meta( $protected, $meta_key, $meta_type ) {
+		if ( 'post' !== $meta_type ) {
+			return $protected;
+		}
 		return self::POST_META_NAME === $meta_key ? true : $protected;
 	}
 

--- a/themes/newspack-theme/newspack-theme/functions.php
+++ b/themes/newspack-theme/newspack-theme/functions.php
@@ -902,6 +902,13 @@ add_filter( 'jetpack_photon_override_image_downsize', 'newspack_override_avatar_
  * - Article Subtitle
  */
 function newspack_register_meta() {
+	// These fields are edited through dedicated editor panels via the REST API.
+	// An explicit auth_callback keeps them REST-editable even though
+	// newspack_protect_editor_meta() marks them protected (see that function).
+	$auth_callback = function ( $allowed, $meta_key, $object_id ) {
+		return current_user_can( 'edit_post', $object_id );
+	};
+
 	$featured_image_post_types = newspack_get_featured_image_post_types();
 
 	foreach ( $featured_image_post_types as $post_type ) {
@@ -909,9 +916,10 @@ function newspack_register_meta() {
 			$post_type,
 			'newspack_featured_image_position',
 			array(
-				'show_in_rest' => true,
-				'single'       => true,
-				'type'         => 'string',
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'string',
+				'auth_callback' => $auth_callback,
 			)
 		);
 	}
@@ -920,9 +928,10 @@ function newspack_register_meta() {
 		'post',
 		'newspack_post_subtitle',
 		array(
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'string',
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+			'auth_callback' => $auth_callback,
 		)
 	);
 
@@ -930,10 +939,11 @@ function newspack_register_meta() {
 		'post',
 		'newspack_article_summary_title',
 		array(
-			'default'      => esc_html__( 'Overview:', 'newspack-theme' ),
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'string',
+			'default'       => esc_html__( 'Overview:', 'newspack-theme' ),
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+			'auth_callback' => $auth_callback,
 		)
 	);
 
@@ -941,9 +951,10 @@ function newspack_register_meta() {
 		'post',
 		'newspack_article_summary',
 		array(
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'string',
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+			'auth_callback' => $auth_callback,
 		)
 	);
 
@@ -951,9 +962,10 @@ function newspack_register_meta() {
 		'page',
 		'newspack_hide_page_title',
 		array(
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'boolean',
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'boolean',
+			'auth_callback' => $auth_callback,
 		)
 	);
 
@@ -961,14 +973,44 @@ function newspack_register_meta() {
 		'page',
 		'newspack_show_share_buttons',
 		array(
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'boolean',
-			'default'      => false,
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'boolean',
+			'default'       => false,
+			'auth_callback' => $auth_callback,
 		)
 	);
 }
 add_action( 'init', 'newspack_register_meta' );
+
+/**
+ * Mark the theme's editor-managed post meta as protected.
+ *
+ * These fields are managed by dedicated block-editor panels (saved via the REST
+ * API), not by the classic "Custom Fields" box. When that box is enabled, it
+ * renders a row for each non-protected meta key and resubmits its page-load
+ * value on save; if a classic meta box triggers the block editor's separate
+ * meta-box save, that stale value silently overwrites the value the REST save
+ * just wrote. Marking these keys protected removes them from the Custom Fields
+ * box so they can't be clobbered. REST editing is preserved by the explicit
+ * auth_callback set on each registration in newspack_register_meta().
+ *
+ * @param bool   $protected Whether the meta key is considered protected.
+ * @param string $meta_key  The meta key.
+ * @return bool Whether the meta key is protected.
+ */
+function newspack_protect_editor_meta( $protected, $meta_key ) {
+	$editor_meta = array(
+		'newspack_featured_image_position',
+		'newspack_post_subtitle',
+		'newspack_article_summary_title',
+		'newspack_article_summary',
+		'newspack_hide_page_title',
+		'newspack_show_share_buttons',
+	);
+	return in_array( $meta_key, $editor_meta, true ) ? true : $protected;
+}
+add_filter( 'is_protected_meta', 'newspack_protect_editor_meta', 10, 2 );
 
 
 /**

--- a/themes/newspack-theme/newspack-theme/functions.php
+++ b/themes/newspack-theme/newspack-theme/functions.php
@@ -997,9 +997,13 @@ add_action( 'init', 'newspack_register_meta' );
  *
  * @param bool   $protected Whether the meta key is considered protected.
  * @param string $meta_key  The meta key.
+ * @param string $meta_type The type of object the meta belongs to (post, term, user, etc.).
  * @return bool Whether the meta key is protected.
  */
-function newspack_protect_editor_meta( $protected, $meta_key ) {
+function newspack_protect_editor_meta( $protected, $meta_key, $meta_type ) {
+	if ( 'post' !== $meta_type ) {
+		return $protected;
+	}
 	$editor_meta = array(
 		'newspack_featured_image_position',
 		'newspack_post_subtitle',
@@ -1010,7 +1014,7 @@ function newspack_protect_editor_meta( $protected, $meta_key ) {
 	);
 	return in_array( $meta_key, $editor_meta, true ) ? true : $protected;
 }
-add_filter( 'is_protected_meta', 'newspack_protect_editor_meta', 10, 2 );
+add_filter( 'is_protected_meta', 'newspack_protect_editor_meta', 10, 3 );
 
 
 /**

--- a/themes/newspack-theme/newspack-theme/functions.php
+++ b/themes/newspack-theme/newspack-theme/functions.php
@@ -897,9 +897,13 @@ function newspack_override_avatar_downsizing( $default_value, $args ) {
 add_filter( 'jetpack_photon_override_image_downsize', 'newspack_override_avatar_downsizing', 10, 2 );
 
 /**
- * Register meta fields:
- * - Featured Image position option
- * - Article Subtitle
+ * Register the theme's editor-managed post meta:
+ * - Featured image position
+ * - Article subtitle
+ * - Article summary title
+ * - Article summary
+ * - Hide page title (pages)
+ * - Show share buttons (pages)
  */
 function newspack_register_meta() {
 	// These fields are edited through dedicated editor panels via the REST API.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Editors who turn on the block editor's Custom Fields panel can lose edits to a post's **Subtitle** and **Featured image position**: the change saves and looks correct, then reverts when the editor reloads. This PR stops that overwrite. Reference: NPPM-2931.

**What this does**

- Hides the theme's editor-managed post meta from the classic Custom Fields box, so it can't resubmit an earlier value over the editor panel's save.
- Keeps those fields editable through their normal editor panels.
- Covers Subtitle, Featured image position, Article summary, Article summary title, Hide page title, and Show share buttons.
- Applies the same change to the Subtitle in the block theme.

### How to test the changes in this Pull Request:

Setup:

1. As an admin, open a published post in the block editor.
2. Enable the Custom Fields panel: Options → Preferences → toggle **Custom fields** on (the editor reloads).
3. Make sure a classic meta box is active (e.g. Broadstreet) — this is what triggers the second, classic save that causes the bug.
4. Edit the post **Subtitle** (and/or **Featured image position**), click **Update**, then reload the editor.

Before this change: the field returns to its previous value.

After this change:

- The new value stays.
- Subtitle / Featured image position no longer appear as rows in the Custom Fields box.
- The fields also save correctly with the Custom Fields panel off.

Also confirm no regression for normal editing: with the Custom Fields panel **off**, and as a non-admin Editor on a post they can edit, the Subtitle / Featured image position still save.

### Release risk: Medium

| Signal | Score | Evidence |
|--------|-------|----------|
| Contract surface | Low | Entirely in `themes/`; no tracked contract paths. The meta keys are read cross-repo via `get_post_meta`, but reads are unaffected by protection / `auth_callback`. |
| Surface type | Medium | Adds `auth_callback` to the registrations + new `is_protected_meta` callbacks — changes the editor meta-save permission and Custom-Fields visibility path. |
| Publisher exposure | Medium | Parent-theme code (high execution reach), but the behavior change is gated by the per-user Custom Fields setting (~1 affected user). |
| Change shape | Low | ~45 net lines of production code across 2 files; CI green (PHPCS + PHPUnit for both themes); no regression history in this area. |

Driven by surface type + publisher exposure (both Medium); contract surface and change shape are Low. Pre-review (3 agents) + Codex came back clean; 3 Copilot rounds addressed and resolved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — newspack-theme has no PHPUnit harness; behavior was validated on a staging copy of the affected site.
* [x] Have you successfully run tests with your changes locally? — phpcs clean (monorepo ruleset); fix validated end-to-end on staging.

**Notes for reviewers:** the `is_protected_meta` filter hides these REST-managed meta from the classic Custom Fields box. Each registration also defines an `auth_callback` checking `current_user_can( 'edit_post', $post_id )` — required because a protected meta key with no `auth_callback` defaults to `__return_false`, which would block REST editing. Matches `newspack-plugin/includes/class-post-date.php`. A follow-up will cover plugin-registered editor meta (same cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
