### PR TITLE
feat(insights): direct donation conversion metrics from order meta (NPPD-1745)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -256,11 +256,12 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	/**
 	 * Assemble the top-level response.
 	 *
-	 * `tab_error` is true only when every metric in the current window reports
-	 * `state: 'error'` — i.e. the whole tab failed to load (e.g. the BigQuery
-	 * proxy is down/misconfigured). React renders a tab-level error banner in
-	 * that case; otherwise each section renders its own error/empty/populated
-	 * treatment.
+	 * `tab_error` is true only when every **hub-backed** metric in the current
+	 * window reports `state: 'error'` — i.e. the hub (BigQuery proxy) is
+	 * down/misconfigured. Local (Woo order-meta) cards survive a hub outage and do
+	 * not suppress the banner (NPPD-1745; see {@see self::is_window_all_error()}).
+	 * React renders a tab-level error banner in that case; otherwise each section
+	 * renders its own error/empty/populated treatment.
 	 *
 	 * @param Prompts_Metric         $metric        Orchestrator.
 	 * @param DateTimeImmutable      $start         Current window start.
@@ -289,26 +290,39 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Whether every metric in a window payload reports `state: 'error'`.
+	 * Whether every **hub-backed** metric in a window reports `state: 'error'`.
 	 *
-	 * Returns `false` as soon as any metric is not in the error state (the `window`
-	 * key is date metadata, not a metric, so it's skipped). A metric missing a
-	 * `state` key is treated as non-error, so the banner only shows on an
-	 * unambiguous all-failed window.
+	 * Scoped to hub-backed metrics (NPPD-1745): as cards move to local Woo order-meta
+	 * sourcing, a local card always succeeds even when the hub is fully down. Under
+	 * the old "every metric errored" rule the "whole tab failed" banner could then
+	 * never fire — a half-broken tab that looks trustworthy. So the banner now fires
+	 * when all hub-backed (and hybrid) metrics error, even though a surviving local
+	 * card still renders. The hub-backed-vs-local classification is declared
+	 * explicitly on {@see \Newspack\Insights\Prompts_Metric::METRIC_SOURCES}, not
+	 * inferred and not hardcoded here.
+	 *
+	 * Returns `false` as soon as any hub-backed metric is not in the error state.
+	 * Returns `false` for a window with no recognizable hub-backed metric at all
+	 * (nothing to declare failed).
 	 *
 	 * @param array $window The shape returned by `build_window()`.
 	 * @return bool
 	 */
 	private static function is_window_all_error( array $window ): bool {
-		foreach ( $window as $key => $value ) {
-			if ( 'window' === $key ) {
+		$saw_hub_backed = false;
+		foreach ( Prompts_Metric::METRIC_SOURCES as $key => $source ) {
+			if ( 'local' === $source ) {
 				continue;
 			}
-			if ( ! is_array( $value ) || ! isset( $value['state'] ) || 'error' !== $value['state'] ) {
+			if ( ! isset( $window[ $key ] ) || ! is_array( $window[ $key ] ) || ! isset( $window[ $key ]['state'] ) ) {
+				continue;
+			}
+			$saw_hub_backed = true;
+			if ( 'error' !== $window[ $key ]['state'] ) {
 				return false;
 			}
 		}
-		return true;
+		return $saw_hub_backed;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -418,6 +418,30 @@ class Donors_Metric {
 	}
 
 	/**
+	 * NPPD-1685: prompt-attributed completed donation conversions for the window,
+	 * sourced from order meta (`_newspack_popup_id`) — the anonymous-inclusive,
+	 * join-free source for the DIRECT prompt-donation metrics, replacing the GA4
+	 * attempt → {@see Woo_Order_Resolver} path that dropped anonymous-at-attempt
+	 * donors. Keyed by popup id: `{ conversions, revenue }`. Reused by
+	 * {@see Prompts_Metric::get_donation_revenue_direct()} (and the direct
+	 * conversion-rate / per-prompt cards).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string, array{conversions:int, revenue:float}>
+	 */
+	public function get_prompt_attributed_donation_conversions( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return (array) $this->cached(
+			'prompt_attributed_donation_conversions',
+			$this->window_key( $start, $end ),
+			self::TTL_DEFAULT,
+			function () use ( $start, $end ) {
+				return $this->storage->get_prompt_attributed_donation_conversions( $start, $end );
+			}
+		);
+	}
+
+	/**
 	 * Flush all Tab 7 metric caches. Hook point for NPPD-1605.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -38,6 +38,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DateTimeInterface;
 use Newspack\Insights\BigQuery_Proxy_Client;
+use Newspack\Insights\Donors_Metric;
 use Newspack\Insights\Woo_Order_Resolver;
 
 /**
@@ -134,6 +135,53 @@ final class Prompts_Metric {
 	];
 
 	/**
+	 * Data-source classification per metric key (NPPD-1745). Declares, explicitly,
+	 * whether each card depends on the hub (BigQuery proxy), on local Woo order
+	 * data, or both:
+	 *
+	 *  - 'hub'    — fully hub-backed; errors when the proxy is down.
+	 *  - 'local'  — fully local (Woo order meta); survives a hub outage.
+	 *  - 'hybrid' — local numerator + hub denominator (or vice-versa); a hub
+	 *               failure makes it genuinely uncomputable, so it counts as
+	 *               hub-backed for the tab-error banner.
+	 *
+	 * Read by {@see \Newspack\Insights\Prompts_REST_Controller::is_window_all_error()}
+	 * so the "whole tab failed" banner fires when **all hub-backed metrics** error,
+	 * even though a surviving local card still renders — instead of being silently
+	 * suppressed by that one local card.
+	 *
+	 * MIGRATION CHECKLIST: when a card moves from hub to order-meta sourcing, update
+	 * its entry here (→ 'local' or 'hybrid'). Keys mirror {@see Prompts_REST_Controller::build_window()}.
+	 *
+	 * @var array<string, string>
+	 */
+	public const METRIC_SOURCES = [
+		'total_prompt_impressions'                   => 'hub',
+		'unique_readers_reached'                     => 'hub',
+		'avg_prompts_per_reader'                     => 'hub',
+		'click_through_rate'                         => 'hub',
+		'form_submission_rate'                       => 'hub',
+		'dismissal_rate'                             => 'hub',
+		'registration_conversion_direct'             => 'hub',
+		'registration_conversion_influenced_7d'      => 'hub',
+		'newsletter_signup_conversion_direct'        => 'hub',
+		'newsletter_signup_conversion_influenced_7d' => 'hub',
+		'donation_conversion_direct'                 => 'hybrid', // Local order-meta numerator + hub donation-impressions denominator.
+		'donation_conversion_influenced_14d'         => 'hub',
+		'subscription_conversion_direct'             => 'hub',     // NPPD-1745 follow-up ticket migrates this.
+		'subscription_conversion_influenced_14d'     => 'hub',
+		'donation_revenue_direct'                    => 'local',   // Pure Woo order meta; survives a hub outage.
+		'donation_revenue_influenced_14d'            => 'hub',
+		'subscription_revenue_direct'                => 'hub',     // NPPD-1745 follow-up ticket migrates this.
+		'subscription_revenue_influenced_14d'        => 'hub',
+		'conversion_funnel'                          => 'hub',
+		'exposures_distribution'                     => 'hub',
+		'performance_by_prompt'                      => 'hub',
+		'performance_by_intent'                      => 'hub',
+		'performance_by_placement'                   => 'hub',
+	];
+
+	/**
 	 * Proxy client used to dispatch catalog queries to the hub.
 	 *
 	 * @var BigQuery_Proxy_Client
@@ -146,6 +194,19 @@ final class Prompts_Metric {
 	 * @var Woo_Order_Resolver
 	 */
 	private Woo_Order_Resolver $woo_resolver;
+
+	/**
+	 * Donors_Metric collaborator (NPPD-1685). Owns the WC-native donation
+	 * storage + caching used to source the DIRECT prompt-donation metrics from
+	 * order meta instead of the GA4 attempt → Woo_Order_Resolver join. Lazily
+	 * built on first direct-donation call ({@see self::donors_metric()}) so the
+	 * storage detector + classifier don't run for requests that never touch a
+	 * direct-donation card. Influenced (14d) donation metrics still use the
+	 * resolver and do NOT use this collaborator.
+	 *
+	 * @var Donors_Metric|null
+	 */
+	private ?Donors_Metric $donors_metric;
 
 	/**
 	 * Per-request memoization for paid-conversion BQ row fetches.
@@ -185,15 +246,51 @@ final class Prompts_Metric {
 	 * @param Woo_Order_Resolver|null    $woo_resolver    Injected Woo resolver, or null to lazy-create.
 	 * @param callable|null              $prompt_provider Injected active-prompt provider (test seam),
 	 *                                                    or null to read published prompt content via get_posts().
+	 * @param Donors_Metric|null         $donors_metric   Injected donors collaborator (NPPD-1685), or null to lazy-create.
 	 */
 	public function __construct(
 		?BigQuery_Proxy_Client $proxy = null,
 		?Woo_Order_Resolver $woo_resolver = null,
-		?callable $prompt_provider = null
+		?callable $prompt_provider = null,
+		?Donors_Metric $donors_metric = null
 	) {
 		$this->proxy           = $proxy ?? new BigQuery_Proxy_Client();
 		$this->woo_resolver    = $woo_resolver ?? new Woo_Order_Resolver();
 		$this->prompt_provider = $prompt_provider;
+		$this->donors_metric   = $donors_metric;
+	}
+
+	/**
+	 * Lazily resolve the Donors_Metric collaborator (NPPD-1685). Built on first
+	 * use so requests that never hit a direct-donation card don't pay for the
+	 * storage detector + donation-product classifier.
+	 *
+	 * @return Donors_Metric
+	 */
+	private function donors_metric(): Donors_Metric {
+		if ( null === $this->donors_metric ) {
+			$this->donors_metric = new Donors_Metric();
+		}
+		return $this->donors_metric;
+	}
+
+	/**
+	 * Whether WooCommerce is active. The direct donation/subscription metrics read
+	 * local Woo orders, so they no-op to an empty state on non-WC publishers
+	 * (NPPD-1685). Filterable so tests can exercise both the WC-active and non-WC
+	 * paths without toggling a global class (the class is `final`, so it can't be
+	 * doubled).
+	 *
+	 * @return bool
+	 */
+	protected function woocommerce_active(): bool {
+		/**
+		 * Filters whether Insights treats WooCommerce as active for the direct
+		 * order-meta donation/subscription metrics.
+		 *
+		 * @param bool $active Whether the WooCommerce class is loaded.
+		 */
+		return (bool) apply_filters( 'newspack_insights_woocommerce_active', class_exists( 'WooCommerce' ) );
 	}
 
 	/**
@@ -712,18 +809,92 @@ final class Prompts_Metric {
 	 * @return array
 	 */
 	public function get_donation_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_direct', $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_scalar( 'rate', $joined );
+		// NPPD-1685/1745: rate = prompt-attributed donation conversions (Woo order
+		// meta, anonymous-inclusive) ÷ donation-intent prompt impressions (hub,
+		// anonymous-inclusive — `prompts_performance_by_prompt`). Numerator is local,
+		// denominator is hub, so this card is 'hybrid' (see METRIC_SOURCES): a hub
+		// impressions failure makes the rate genuinely uncomputable and counts toward
+		// the tab-error banner.
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher (third-party donations): no local conversions to count.
+			// Empty state, not a fake 0% (NPPD-1737/1738 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'rate' );
 		}
-		$denominator = count( $joined['rows'] );
-		$numerator   = $joined['conversions'];
-		return $this->populated_scalar(
-			$denominator > 0 ? $numerator / $denominator : 0.0,
-			$denominator > 0,
-			$denominator,
-			'rate'
-		);
+
+		$impressions = $this->fetch_donation_prompt_impressions( $start, $end );
+		if ( is_wp_error( $impressions ) ) {
+			return $this->error_scalar( 'rate', $impressions );
+		}
+
+		$by_popup    = $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end );
+		$conversions = 0;
+		foreach ( $by_popup as $row ) {
+			$conversions += (int) $row['conversions'];
+		}
+
+		// Shared coherence guard + em-dash semantics (also drives the per-prompt
+		// donation_conversion_rate, so the two rates can't diverge). null = not
+		// computable (no impressions, or the >100% cross-surface case); a float
+		// (incl. a genuine 0.0) = a real rate.
+		$rate = $this->donation_rate_value( $conversions, $impressions );
+		return null === $rate
+			? $this->populated_scalar( 0.0, false, $impressions, 'rate' )
+			: $this->populated_scalar( $rate, true, $impressions, 'rate' );
+	}
+
+	/**
+	 * The direct donation conversion-rate value, with the coherence guard and
+	 * em-dash semantics shared by the tab-level card
+	 * ({@see self::get_donation_conversion_direct()}) and the per-prompt table
+	 * ({@see self::get_performance_by_prompt()}) so the two rates cannot diverge
+	 * (NPPD-1745).
+	 *
+	 * Returns the rate as a float — a genuine 0.0 when there are impressions but no
+	 * conversions ("viewed but no conversion") — or null when not computable:
+	 *  - no impressions → no denominator (em-dash); or
+	 *  - conversions > impressions → a cross-surface incoherence (order-meta
+	 *    numerator vs GA4 impressions) that must not render as a >100% rate.
+	 *
+	 * @param int $conversions Prompt-attributed donation conversions (order meta).
+	 * @param int $impressions Donation-intent prompt impressions (hub).
+	 * @return float|null
+	 */
+	private function donation_rate_value( int $conversions, int $impressions ): ?float {
+		if ( $impressions <= 0 ) {
+			return null;
+		}
+		if ( $conversions > $impressions ) {
+			return null;
+		}
+		return (float) $conversions / $impressions;
+	}
+
+	/**
+	 * Total donation-intent prompt impressions in the window, summed from the hub's
+	 * `prompts_performance_by_prompt` per-popup rows (NPPD-1745). Anonymous-inclusive
+	 * (impressions are `np_prompt_interaction(seen)` counts, no identity filter), so
+	 * reusing it as the conversion-rate denominator does not reintroduce the
+	 * anonymous-at-attempt bias the order-meta numerator escapes.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return int|\WP_Error Total donation-intent impressions, or the proxy error.
+	 */
+	private function fetch_donation_prompt_impressions( DateTimeInterface $start, DateTimeInterface $end ) {
+		$rows = $this->proxy->query( 'prompts_performance_by_prompt', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		if ( ! is_array( $rows ) ) {
+			return 0;
+		}
+		$impressions = 0;
+		foreach ( $rows as $row ) {
+			if ( is_array( $row ) && 'donation' === (string) ( $row['intent'] ?? '' ) ) {
+				$impressions += (int) ( $row['impressions'] ?? 0 );
+			}
+		}
+		return $impressions;
 	}
 
 	/**
@@ -807,15 +978,34 @@ final class Prompts_Metric {
 	 * @return array
 	 */
 	public function get_donation_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_direct', $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_scalar( 'currency', $joined );
+		// NPPD-1685: source DIRECT donation revenue from order meta
+		// (`_newspack_popup_id` on initial donation orders) instead of the GA4
+		// attempt → customer_id join, which silently dropped anonymous-at-attempt
+		// donors (~100% non-joinable). Order meta carries a real customer_id +
+		// total and is anonymous-inclusive. Influenced (14d) revenue still uses the
+		// join — see get_donation_revenue_influenced_14d().
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher (e.g. third-party donation platform): no orders to
+			// read. Empty state, not a real $0 (NPPD-1737/1738 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'currency' );
 		}
-		// Computable only when at least one paid-intent prompt was viewed (mirrors
-		// the matching conversion-rate method's `count( rows ) > 0` gate). An empty
-		// window is "no in-intent prompts viewed", not a real $0 — so it renders the
-		// not-computable em-dash, consistent with its sibling rate card (NPPD-1704).
-		return $this->populated_scalar( $joined['revenue'], count( $joined['rows'] ) > 0, $joined['conversions'], 'currency' );
+
+		$by_popup    = $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end );
+		$revenue     = 0.0;
+		$conversions = 0;
+		foreach ( $by_popup as $row ) {
+			$revenue     += (float) $row['revenue'];
+			$conversions += (int) $row['conversions'];
+		}
+
+		// Computable when there was prompt-attributed donation activity in the
+		// window. With the order-meta source there are no GA4 "attempt" rows to gate
+		// on, so the gate is now `conversions > 0` rather than "≥1 prompt viewed".
+		// NOTE (NPPD-1685): this narrows the not-computable em-dash from "no
+		// in-intent prompts viewed" to "no prompt-attributed donations" — restoring
+		// the impressions-based distinction is folded into the direct conversion-RATE
+		// work (which brings in the prompt-impressions denominator).
+		return $this->populated_scalar( $revenue, $conversions > 0, $conversions, 'currency' );
 	}
 
 	/**
@@ -1037,10 +1227,12 @@ final class Prompts_Metric {
 			];
 		}
 
-		// Fetch per-popup Woo augmentation once for each direction; the cache
-		// in fetch_paid_attempts_woo_join means this is free if the matching
-		// paid-rate / revenue method has already run this request.
-		$donation_counts     = $this->fetch_per_popup_woo_counts( 'prompts_donation_conversion_direct', $start, $end );
+		// Per-popup conversion augmentation. Donations come from order meta
+		// (NPPD-1685/1745 — anonymous-inclusive, keyed by popup id, no GA4 join);
+		// subscriptions still use the Woo-resolver path until their own ticket
+		// migrates them. On a non-WC publisher the donation map is empty.
+		$wc                  = $this->woocommerce_active();
+		$donation_map        = $wc ? $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end ) : [];
 		$subscription_counts = $this->fetch_per_popup_woo_counts( 'prompts_subscription_conversion_direct', $start, $end );
 
 		$mapped = [];
@@ -1055,15 +1247,16 @@ final class Prompts_Metric {
 			$intent      = (string) ( $row['intent'] ?? '' );
 			$impressions = (int) ( $row['impressions'] ?? 0 );
 
-			$donation_conversions = 'donation' === $intent ? (int) ( $donation_counts[ $popup_id ] ?? 0 ) : 0;
+			$donation_conversions = 'donation' === $intent ? (int) ( $donation_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
 			// Subscription-intent prompts share `action_type=registration` at
 			// the data layer; the Woo product-type filter on the hub-side
 			// subscription query already scopes attempts correctly.
 			$subscription_conversions = 'registration' === $intent ? (int) ( $subscription_counts[ $popup_id ] ?? 0 ) : 0;
 
-			// When the popup's intent matches but the Woo-side proxy failed (degraded),
-			// the rate is a real 0.0 — the impression denominator is still applicable;
-			// the null branch covers only intent mismatch (the column is N/A).
+			// donation_conversion_rate shares the tab-level coherence guard + em-dash
+			// semantics via donation_rate_value() (null = not computable: no
+			// impressions or a >100% cross-surface ratio; a float incl. 0.0 = real
+			// rate). null also covers intent mismatch + non-WC (the column is N/A).
 			$mapped[] = [
 				'popup_id'                     => $popup_id,
 				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),
@@ -1077,7 +1270,7 @@ final class Prompts_Metric {
 				'registrations'                => (int) ( $row['registrations'] ?? 0 ),
 				'newsletter_signups'           => (int) ( $row['newsletter_signups'] ?? 0 ),
 				'donation_conversions'         => $donation_conversions,
-				'donation_conversion_rate'     => ( 'donation' === $intent && $impressions > 0 ) ? $donation_conversions / $impressions : null,
+				'donation_conversion_rate'     => ( 'donation' === $intent && $wc ) ? $this->donation_rate_value( $donation_conversions, $impressions ) : null,
 				'subscription_conversions'     => $subscription_conversions,
 				'subscription_conversion_rate' => ( 'registration' === $intent && $impressions > 0 ) ? $subscription_conversions / $impressions : null,
 			];

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -220,6 +220,17 @@ final class Prompts_Metric {
 	private array $paid_attempt_cache = [];
 
 	/**
+	 * Per-request memo for `prompts_performance_by_prompt` hub rows, keyed by
+	 * `Ymd|Ymd` window (NPPD-1745). The direct donation-rate denominator
+	 * ({@see self::fetch_donation_prompt_impressions()}) and the per-prompt table
+	 * ({@see self::get_performance_by_prompt()}) both read this query for the same
+	 * window in one request; memoizing avoids the duplicate hub round-trip.
+	 *
+	 * @var array<string, array|\WP_Error>
+	 */
+	private array $performance_by_prompt_cache = [];
+
+	/**
 	 * Per-request memoization for the prompt-capability scan (NPPD-1720). Null
 	 * until the first `compute_prompt_capabilities()` call; thereafter the four
 	 * capability booleans are reused across both windows and all 13 gated metrics
@@ -881,7 +892,7 @@ final class Prompts_Metric {
 	 * @return int|\WP_Error Total donation-intent impressions, or the proxy error.
 	 */
 	private function fetch_donation_prompt_impressions( DateTimeInterface $start, DateTimeInterface $end ) {
-		$rows = $this->proxy->query( 'prompts_performance_by_prompt', $start, $end );
+		$rows = $this->fetch_performance_by_prompt_rows( $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $rows;
 		}
@@ -895,6 +906,26 @@ final class Prompts_Metric {
 			}
 		}
 		return $impressions;
+	}
+
+	/**
+	 * Fetch (memoized per window) the `prompts_performance_by_prompt` hub rows, so
+	 * the rate-denominator and the per-prompt table share one round-trip per request
+	 * (NPPD-1745).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array|\WP_Error Rows, or the proxy error.
+	 */
+	private function fetch_performance_by_prompt_rows( DateTimeInterface $start, DateTimeInterface $end ) {
+		$utc       = new \DateTimeZone( 'UTC' );
+		$cache_key = \DateTimeImmutable::createFromInterface( $start )->setTimezone( $utc )->format( 'Ymd' )
+			. '|'
+			. \DateTimeImmutable::createFromInterface( $end )->setTimezone( $utc )->format( 'Ymd' );
+		if ( ! array_key_exists( $cache_key, $this->performance_by_prompt_cache ) ) {
+			$this->performance_by_prompt_cache[ $cache_key ] = $this->proxy->query( 'prompts_performance_by_prompt', $start, $end );
+		}
+		return $this->performance_by_prompt_cache[ $cache_key ];
 	}
 
 	/**
@@ -1001,10 +1032,12 @@ final class Prompts_Metric {
 		// Computable when there was prompt-attributed donation activity in the
 		// window. With the order-meta source there are no GA4 "attempt" rows to gate
 		// on, so the gate is now `conversions > 0` rather than "≥1 prompt viewed".
-		// NOTE (NPPD-1685): this narrows the not-computable em-dash from "no
-		// in-intent prompts viewed" to "no prompt-attributed donations" — restoring
-		// the impressions-based distinction is folded into the direct conversion-RATE
-		// work (which brings in the prompt-impressions denominator).
+		// NOTE (NPPD-1745): this card is intentionally local / hub-resilient, so its
+		// em-dash is conversions-based ("no prompt-attributed donations"), NOT
+		// impressions-based. The —/0% impressions distinction lives only on the
+		// sibling rate card (which is hybrid). Revenue does not fetch impressions by
+		// design, so the two cards' em-dash semantics differ on purpose — do not
+		// "fix" this to match the rate card without making revenue hub-dependent.
 		return $this->populated_scalar( $revenue, $conversions > 0, $conversions, 'currency' );
 	}
 
@@ -1213,7 +1246,7 @@ final class Prompts_Metric {
 	 * @return array{state: string, rows: array, error_code?: string, error_message?: string}
 	 */
 	public function get_performance_by_prompt( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$rows = $this->proxy->query( 'prompts_performance_by_prompt', $start, $end );
+		$rows = $this->fetch_performance_by_prompt_rows( $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_collection( 'rows', $rows );
 		}
@@ -1230,10 +1263,13 @@ final class Prompts_Metric {
 		// Per-popup conversion augmentation. Donations come from order meta
 		// (NPPD-1685/1745 — anonymous-inclusive, keyed by popup id, no GA4 join);
 		// subscriptions still use the Woo-resolver path until their own ticket
-		// migrates them. On a non-WC publisher the donation map is empty.
+		// migrates them. BOTH are gated on WooCommerce being active: the resolver
+		// path calls wc_get_orders(), so on a non-WC publisher the subscription
+		// fetch would fatal if the hub ever returned attempt rows. Both maps are
+		// empty on a non-WC publisher.
 		$wc                  = $this->woocommerce_active();
 		$donation_map        = $wc ? $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end ) : [];
-		$subscription_counts = $this->fetch_per_popup_woo_counts( 'prompts_subscription_conversion_direct', $start, $end );
+		$subscription_counts = $wc ? $this->fetch_per_popup_woo_counts( 'prompts_subscription_conversion_direct', $start, $end ) : [];
 
 		$mapped = [];
 		foreach ( $rows as $row ) {
@@ -1272,7 +1308,7 @@ final class Prompts_Metric {
 				'donation_conversions'         => $donation_conversions,
 				'donation_conversion_rate'     => ( 'donation' === $intent && $wc ) ? $this->donation_rate_value( $donation_conversions, $impressions ) : null,
 				'subscription_conversions'     => $subscription_conversions,
-				'subscription_conversion_rate' => ( 'registration' === $intent && $impressions > 0 ) ? $subscription_conversions / $impressions : null,
+				'subscription_conversion_rate' => ( 'registration' === $intent && $wc && $impressions > 0 ) ? $subscription_conversions / $impressions : null,
 			];
 		}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -332,4 +332,25 @@ interface Donors_Storage_Interface {
 	 * @return array<int, \DateTimeImmutable> customer_id => first donation date (UTC).
 	 */
 	public function get_first_donation_order_dates( array $customer_ids ): array;
+
+	/**
+	 * Prompt-attributed completed donation conversions in a window, sourced from
+	 * order meta (`_newspack_popup_id`) rather than the GA4 attempt → customer_id
+	 * join (NPPD-1685). The originating prompt id is written onto the order at
+	 * checkout ({@see \Newspack\Donations::checkout_create_order_line_item()}),
+	 * alongside a real `customer_id` and total — so this captures the
+	 * anonymous-at-attempt donors the {@see \Newspack\Insights\Woo_Order_Resolver}
+	 * join silently dropped.
+	 *
+	 * Scope: INITIAL completed/processing donation orders only — recurring renewal
+	 * orders inherit the parent's `_newspack_popup_id` and are excluded via
+	 * `_subscription_renewal` — with `date_created_gmt` in [start, end], grouped by
+	 * popup id. Meta-absence is NOT a coverage gap: orders without the meta did not
+	 * stem from a prompt and are correctly excluded. No fallback, no union.
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<string, array{conversions:int, revenue:float}> popup_id => { conversions, revenue }.
+	 */
+	public function get_prompt_attributed_donation_conversions( DateTimeInterface $start, DateTimeInterface $end ): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -1121,4 +1121,79 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 		}
 		return __( 'Variation', 'newspack-plugin' );
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<string, array{conversions:int, revenue:float}>
+	 */
+	public function get_prompt_attributed_donation_conversions( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// NPPD-1685 audit fix: structurally mirrors the legacy reader — `_newspack_popup_id`
+		// is written more than once per order, so it must NOT be JOINed (that multiplies
+		// COUNT/SUM). Filter prompt-attributed orders with EXISTS and derive exactly ONE
+		// popup id per order via a correlated MIN() subquery; `total_amount` is a column
+		// on the orders table (no meta multiplication). Renewals excluded via NOT EXISTS.
+		//
+		// UNVERIFIED AGAINST LIVE HPOS DATA (NPPD-1685): the legacy path is proven on
+		// real publishers (Evanston 27 / $2,294.84, New Bedford Light 5 / $533.79), but
+		// every reachable HPOS-on publisher had zero order volume, so this HPOS query has
+		// not executed against real HPOS orders. It is mirrored from the proven legacy
+		// shape; confirm the count + revenue at first HPOS-publisher contact.
+		$sql = $wpdb->prepare(
+			"SELECT o.popup_id,
+				COUNT(*) AS conversions,
+				SUM(o.order_total) AS revenue
+			FROM (
+				SELECT ord.id AS order_id,
+					(
+						SELECT MIN(pop.meta_value)
+						FROM {$prefix}wc_orders_meta pop
+						WHERE pop.order_id = ord.id
+						  AND pop.meta_key = '_newspack_popup_id'
+						  AND pop.meta_value NOT IN ('', '0')
+					) AS popup_id,
+					ord.total_amount AS order_total
+				FROM {$prefix}wc_orders ord
+				WHERE ord.type = 'shop_order'
+				  AND ord.status IN ('wc-completed', 'wc-processing')
+				  AND ord.date_created_gmt BETWEEN %s AND %s
+				  AND NOT EXISTS (
+				      SELECT 1 FROM {$prefix}wc_orders_meta rn
+				      WHERE rn.order_id = ord.id AND rn.meta_key = '_subscription_renewal'
+				        AND rn.meta_value NOT IN ('', '0')
+				  )
+				  AND EXISTS (
+				      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+				      WHERE opl.order_id = ord.id AND opl.product_id IN ($donations)
+				  )
+				  AND EXISTS (
+				      SELECT 1 FROM {$prefix}wc_orders_meta pop
+				      WHERE pop.order_id = ord.id AND pop.meta_key = '_newspack_popup_id'
+				        AND pop.meta_value NOT IN ('', '0')
+				  )
+			) AS o
+			GROUP BY o.popup_id",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$out = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$popup_id = (string) ( $row['popup_id'] ?? '' );
+			if ( '' === $popup_id ) {
+				continue;
+			}
+			$out[ $popup_id ] = [
+				'conversions' => (int) ( $row['conversions'] ?? 0 ),
+				'revenue'     => (float) ( $row['revenue'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -1078,4 +1078,82 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		}
 		return __( 'Variation', 'newspack-plugin' );
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<string, array{conversions:int, revenue:float}>
+	 */
+	public function get_prompt_attributed_donation_conversions( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// NPPD-1685 audit fix: `_newspack_popup_id` is written more than once per
+		// order (the checkout hook adds it without `unique = true`), so JOINing that
+		// meta multiplies COUNT/SUM by the number of duplicate rows. Don't
+		// join-then-dedupe — filter prompt-attributed orders with EXISTS and derive
+		// exactly ONE popup id per order via a correlated MIN() subquery, so
+		// duplicate meta cannot re-inflate even if an order ever carried two
+		// different popup ids. Donation membership and renewal exclusion are also
+		// EXISTS / NOT EXISTS so neither can multiply rows. Renewal orders inherit
+		// the parent's popup meta and are excluded via `_subscription_renewal`.
+		// Proven on Evanston (27 / $2,294.84) and New Bedford Light (5 / $533.79).
+		$sql = $wpdb->prepare(
+			"SELECT o.popup_id,
+				COUNT(*) AS conversions,
+				SUM(o.order_total) AS revenue
+			FROM (
+				SELECT p.ID AS order_id,
+					(
+						SELECT MIN(pop.meta_value)
+						FROM {$prefix}postmeta pop
+						WHERE pop.post_id = p.ID
+						  AND pop.meta_key = '_newspack_popup_id'
+						  AND pop.meta_value NOT IN ('', '0')
+					) AS popup_id,
+					(
+						SELECT MAX(CAST(tot.meta_value AS DECIMAL(15,2)))
+						FROM {$prefix}postmeta tot
+						WHERE tot.post_id = p.ID AND tot.meta_key = '_order_total'
+					) AS order_total
+				FROM {$prefix}posts p
+				WHERE p.post_type = 'shop_order'
+				  AND p.post_status IN ('wc-completed', 'wc-processing')
+				  AND p.post_date_gmt BETWEEN %s AND %s
+				  AND NOT EXISTS (
+				      SELECT 1 FROM {$prefix}postmeta rn
+				      WHERE rn.post_id = p.ID AND rn.meta_key = '_subscription_renewal'
+				        AND rn.meta_value NOT IN ('', '0')
+				  )
+				  AND EXISTS (
+				      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+				      WHERE opl.order_id = p.ID AND opl.product_id IN ($donations)
+				  )
+				  AND EXISTS (
+				      SELECT 1 FROM {$prefix}postmeta pop
+				      WHERE pop.post_id = p.ID AND pop.meta_key = '_newspack_popup_id'
+				        AND pop.meta_value NOT IN ('', '0')
+				  )
+			) AS o
+			GROUP BY o.popup_id",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$out = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$popup_id = (string) ( $row['popup_id'] ?? '' );
+			if ( '' === $popup_id ) {
+				continue;
+			}
+			$out[ $popup_id ] = [
+				'conversions' => (int) ( $row['conversions'] ?? 0 ),
+				'revenue'     => (float) ( $row['revenue'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompt-attributed-donation-reader.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompt-attributed-donation-reader.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * DB-backed integration tests for the NPPD-1685 prompt-attributed donation
+ * reader (get_prompt_attributed_donation_conversions) on BOTH storage backends.
+ *
+ * The rest of the insights storage suite mocks WooCommerce and cannot reach the
+ * storage SQL (see class-test-conversion-journey-storage.php → "What these tests
+ * do NOT cover"). This is the DB-backed integration harness that file
+ * anticipated: it stands up the real WooCommerce order tables (via
+ * {@see Insights_Woo_Order_Fixtures}) so the reader SQL runs against actual rows,
+ * on both legacy and HPOS.
+ *
+ * Anchor case = the NPPD-1685 2x bug: `_newspack_popup_id` is written more than
+ * once per order, so a JOIN on that meta double-counted COUNT and SUM. The
+ * duplicate-meta fixture asserts the order is counted ONCE — it FAILS against the
+ * pre-fix JOIN reader and PASSES against the EXISTS + correlated-MIN reader.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Donors_Storage_Interface;
+use Newspack\Insights\HPOS_Donors_Storage;
+use Newspack\Insights\Legacy_Donors_Storage;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Integration tests for the prompt-attributed donation reader.
+ *
+ * @group insights
+ */
+class Test_Prompt_Attributed_Donation_Reader extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Stand up the WC order tables once (InnoDB → per-test inserts roll back).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The reader under test for a backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Donors_Storage_Interface
+	 */
+	private function reader_for( string $backend ): Donors_Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Donors_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Donors_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert an order into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait).
+	 * @return void
+	 */
+	private function insert_order( string $backend, array $args ): void {
+		if ( 'hpos' === $backend ) {
+			$this->insert_hpos_order( $args );
+		} else {
+			$this->insert_legacy_order( $args );
+		}
+	}
+
+	/**
+	 * A window that brackets the fixtures' order dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-15 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Run the reader for the window.
+	 *
+	 * @param string $backend Backend key.
+	 * @return array
+	 */
+	private function run_reader( string $backend ): array {
+		[ $start, $end ] = $this->window();
+		return $this->reader_for( $backend )->get_prompt_attributed_donation_conversions( $start, $end );
+	}
+
+	/**
+	 * ANCHOR (NPPD-1685 2x bug): one order, TWO identical `_newspack_popup_id`
+	 * rows must be counted ONCE — both conversions and revenue. Fails against the
+	 * pre-fix JOIN reader.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_duplicate_popup_meta_counted_once( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5001,
+				'total'     => 100.00,
+				'popup_ids' => [ '194959', '194959' ],
+			]
+		);
+
+		$result = $this->run_reader( $backend );
+
+		$this->assertEquals(
+			[
+				'194959' => [
+					'conversions' => 1,
+					'revenue'     => 100.00,
+				],
+			],
+			$result 
+		);
+		$this->assertSame( 1, $result['194959']['conversions'], 'count must not double' );
+		$this->assertSame( 100.00, $result['194959']['revenue'], 'revenue must not double' );
+	}
+
+	/**
+	 * DEFENSIVENESS: an order carrying two DIFFERENT popup ids resolves to one
+	 * defined popup id (the MIN) and is counted once — no duplication, no error.
+	 * Pins the reader against a future write-side change emitting divergent ids.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_divergent_popup_meta_resolves_to_single_min( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5002,
+				'total'     => 50.00,
+				'popup_ids' => [ '300', '200' ],
+			]
+		);
+
+		$result = $this->run_reader( $backend );
+
+		// MIN('300','200') === '200'; one order, counted once.
+		$this->assertEquals(
+			[
+				'200' => [
+					'conversions' => 1,
+					'revenue'     => 50.00,
+				],
+			],
+			$result 
+		);
+	}
+
+	/**
+	 * RENEWAL EXCLUSION: an initial donation (no `_subscription_renewal`) is
+	 * counted; a renewal order (carries `_subscription_renewal`, and inherits the
+	 * parent's popup meta) is excluded.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_renewal_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5003,
+				'total'     => 40.00,
+				'popup_ids' => [ '777' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5004,
+				'total'     => 25.00,
+				'popup_ids' => [ '777' ],
+				'renewal'   => '9001',
+			]
+		);
+
+		$result = $this->run_reader( $backend );
+
+		// Only the initial order counts; renewal excluded.
+		$this->assertEquals(
+			[
+				'777' => [
+					'conversions' => 1,
+					'revenue'     => 40.00,
+				],
+			],
+			$result 
+		);
+	}
+
+	/**
+	 * RECONCILIATION: a known set must produce exact per-popup count AND revenue —
+	 * revenue is the dimension that hid the 2x, so it is asserted explicitly.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_reconciliation_count_and_revenue( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5005,
+				'total'     => 10.00,
+				'popup_ids' => [ '111' ],
+			] 
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5006,
+				'total'     => 20.00,
+				'popup_ids' => [ '111' ],
+			] 
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5007,
+				'total'     => 30.00,
+				'popup_ids' => [ '222' ],
+			] 
+		);
+
+		$result = $this->run_reader( $backend );
+
+		$this->assertEquals(
+			[
+				'111' => [
+					'conversions' => 2,
+					'revenue'     => 30.00,
+				],
+				'222' => [
+					'conversions' => 1,
+					'revenue'     => 30.00,
+				],
+			],
+			$result
+		);
+	}
+
+	/**
+	 * An order with no popup meta (organic / direct donation) is NOT counted —
+	 * meta-absence is correctly "not prompt-attributed", not a coverage gap.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_order_without_popup_meta_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 5008,
+				'total'     => 99.00,
+				'popup_ids' => [],
+			] 
+		);
+
+		$this->assertSame( [], $this->run_reader( $backend ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -30,6 +30,7 @@ namespace Newspack\Tests\Insights;
 use DateTimeImmutable;
 use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
+use Newspack\Insights\Donors_Metric;
 use Newspack\Insights\Prompts_Metric;
 use Newspack\Insights\Woo_Order_Resolver;
 use WP_UnitTestCase;
@@ -355,13 +356,17 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for the 4 paid-conversion rate methods.
+	 * Data provider for the proxy-backed paid-conversion rate methods.
+	 *
+	 * NPPD-1745: `get_donation_conversion_direct` is intentionally absent — it no
+	 * longer dispatches `prompts_donation_conversion_direct`. It's now hybrid:
+	 * order-meta conversions ÷ hub donation-impressions (see
+	 * test_donation_conversion_direct_*). The other three are still proxy-backed.
 	 *
 	 * @return array
 	 */
 	public function provide_paid_conversion_rate_methods(): array {
 		return [
-			'donation_direct'         => [ 'get_donation_conversion_direct', 'prompts_donation_conversion_direct' ],
 			'donation_influenced'     => [ 'get_donation_conversion_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
 			'subscription_direct'     => [ 'get_subscription_conversion_direct', 'prompts_subscription_conversion_direct' ],
 			'subscription_influenced' => [ 'get_subscription_conversion_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
@@ -457,15 +462,19 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for the 4 revenue methods. The `query_name` is the
-	 * underlying conversion-query name (revenue methods share the cache with
-	 * their rate counterparts; the hub's revenue alias is byte-identical).
+	 * Data provider for the proxy-backed revenue methods. The `query_name` is the
+	 * underlying conversion-query name (revenue methods share the cache with their
+	 * rate counterparts; the hub's revenue alias is byte-identical).
+	 *
+	 * NPPD-1685: `get_donation_revenue_direct` is intentionally absent — it no
+	 * longer dispatches a proxy query; it sources from order meta via
+	 * Donors_Metric (see test_donation_revenue_direct_*). The other three are
+	 * still proxy/resolver-backed.
 	 *
 	 * @return array
 	 */
 	public function provide_paid_revenue_methods(): array {
 		return [
-			'donation_direct'         => [ 'get_donation_revenue_direct', 'prompts_donation_conversion_direct' ],
 			'donation_influenced'     => [ 'get_donation_revenue_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
 			'subscription_direct'     => [ 'get_subscription_revenue_direct', 'prompts_subscription_conversion_direct' ],
 			'subscription_influenced' => [ 'get_subscription_revenue_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
@@ -473,37 +482,239 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Per-(query_name, window) memoization: the matching rate + revenue
-	 * methods for the same intent + direction share one proxy round-trip.
-	 *
-	 * `expects($this->once())` is the regression guard — a second call fails
-	 * the test. The two methods read different fields from the same Woo-joined
-	 * result, so they must dispatch the underlying conversion query exactly
-	 * once.
+	 * NPPD-1685: direct donation revenue sums the prompt-attributed order-meta map
+	 * from Donors_Metric (anonymous-inclusive), NOT the GA4 attempt → resolver
+	 * join. Inject a stub Donors_Metric; assert revenue + conversion count are the
+	 * map totals and the card is computable.
 	 */
-	public function test_paid_methods_share_single_proxy_call_per_window() {
-		$rows  = $this->paid_attempt_rows();
+	public function test_donation_revenue_direct_sources_from_order_meta() {
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
+			[
+				'194959' => [
+					'conversions' => 2,
+					'revenue'     => 50.0,
+				],
+				'244419' => [
+					'conversions' => 1,
+					'revenue'     => 25.0,
+				],
+			]
+		);
+
+		$metric = $this->make_donation_revenue_metric( $donors, true );
+
+		$revenue = $metric->get_donation_revenue_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $revenue['state'] );
+		$this->assertSame( 75.0, $revenue['value'], 'revenue is the summed order-meta map' );
+		$this->assertTrue( $revenue['computable'] );
+		$this->assertSame( 3, $revenue['denominator'], 'denominator is the summed conversion count' );
+	}
+
+	/**
+	 * NPPD-1685: on a non-WooCommerce publisher the direct donation revenue card
+	 * is a not-computable empty state (em-dash), NOT a fake $0.
+	 */
+	public function test_donation_revenue_direct_empty_state_when_not_woocommerce() {
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->expects( $this->never() )->method( 'get_prompt_attributed_donation_conversions' );
+
+		$metric = $this->make_donation_revenue_metric( $donors, false );
+
+		$revenue = $metric->get_donation_revenue_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $revenue['state'] );
+		$this->assertFalse( $revenue['computable'] );
+		$this->assertSame( 0.0, $revenue['value'] );
+	}
+
+	/**
+	 * Build a Prompts_Metric with an injected Donors_Metric and a forced
+	 * `woocommerce_active()` return (the seam), so both the WC-active and non-WC
+	 * paths are testable without toggling a global class.
+	 *
+	 * @param Donors_Metric $donors Injected donors collaborator.
+	 * @param bool          $wc     What woocommerce_active() should return.
+	 * @return Prompts_Metric
+	 */
+	private function make_donation_revenue_metric( Donors_Metric $donors, bool $wc ): Prompts_Metric {
+		return $this->make_direct_donation_metric( null, $donors, $wc );
+	}
+
+	/**
+	 * Build a Prompts_Metric for the direct donation cards with an injected proxy +
+	 * Donors_Metric and a forced `woocommerce_active()` (via filter — the class is
+	 * final). The proxy feeds the rate card's hub impressions denominator; revenue
+	 * passes null. Filter removed in tearDown().
+	 *
+	 * @param BigQuery_Proxy_Client|null $proxy  Injected proxy (rate) or null (revenue).
+	 * @param Donors_Metric              $donors Injected donors collaborator.
+	 * @param bool                       $wc     What woocommerce_active() should return.
+	 * @return Prompts_Metric
+	 */
+	private function make_direct_donation_metric( ?BigQuery_Proxy_Client $proxy, Donors_Metric $donors, bool $wc ): Prompts_Metric {
+		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
+		return new Prompts_Metric( $proxy, null, null, $donors );
+	}
+
+	/**
+	 * Stub Donors_Metric whose order-meta map sums to $conversions conversions.
+	 *
+	 * @param int $conversions Total conversions to spread across two popups.
+	 * @return Donors_Metric
+	 */
+	private function donors_with_conversions( int $conversions ): Donors_Metric {
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
+			[
+				'1' => [
+					'conversions' => $conversions,
+					'revenue'     => 0.0,
+				],
+			]
+		);
+		return $donors;
+	}
+
+	/**
+	 * Proxy whose `prompts_performance_by_prompt` returns the given total
+	 * donation-intent impressions (plus an unrelated registration row).
+	 *
+	 * @param int $donation_impressions Donation-intent impressions to report.
+	 * @return BigQuery_Proxy_Client
+	 */
+	private function proxy_with_donation_impressions( int $donation_impressions ): BigQuery_Proxy_Client {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->once() )
-			->method( 'query' )
-			->with( 'prompts_donation_conversion_direct', $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
-			->willReturn( $rows );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'popup_id'    => 1,
+					'intent'      => 'donation',
+					'impressions' => $donation_impressions,
+				],
+				[
+					'popup_id'    => 9,
+					'intent'      => 'registration',
+					'impressions' => 500,
+				],
+			]
+		);
+		return $proxy;
+	}
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+	/**
+	 * NPPD-1745: direct donation rate = order-meta conversions ÷ hub
+	 * donation-intent impressions, anonymous-inclusive on both sides.
+	 */
+	public function test_donation_conversion_direct_rate_from_order_meta_over_impressions() {
+		$metric = $this->make_direct_donation_metric(
+			$this->proxy_with_donation_impressions( 200 ),
+			$this->donors_with_conversions( 50 ),
+			true
+		);
 
-		$metric = new Prompts_Metric( $proxy, $resolver );
-		$start  = $this->start();
-		$end    = $this->end();
-
-		$rate    = $metric->get_donation_conversion_direct( $start, $end );
-		$revenue = $metric->get_donation_revenue_direct( $start, $end );
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
 
 		$this->assertSame( 'populated', $rate['state'] );
-		$this->assertSame( 0.5, $rate['value'] );
-		$this->assertSame( 'populated', $revenue['state'] );
-		$this->assertSame( 25.0, $revenue['value'] );
+		$this->assertSame( 0.25, $rate['value'] );
+		$this->assertTrue( $rate['computable'] );
+		$this->assertSame( 200, $rate['denominator'] );
+	}
+
+	/**
+	 * No donation impressions → no denominator → not computable (em-dash),
+	 * distinct from the real 0% below.
+	 */
+	public function test_donation_conversion_direct_not_computable_without_impressions() {
+		$metric = $this->make_direct_donation_metric(
+			$this->proxy_with_donation_impressions( 0 ),
+			$this->donors_with_conversions( 5 ),
+			true
+		);
+
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertFalse( $rate['computable'] );
+		$this->assertSame( 0.0, $rate['value'] );
+	}
+
+	/**
+	 * Em-dash unification: impressions exist but zero conversions is a REAL 0%
+	 * (computable), distinct from the not-computable no-impressions case.
+	 */
+	public function test_donation_conversion_direct_real_zero_percent_when_no_conversions() {
+		$metric = $this->make_direct_donation_metric(
+			$this->proxy_with_donation_impressions( 200 ),
+			$this->donors_with_conversions( 0 ),
+			true
+		);
+
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertTrue( $rate['computable'], 'viewed-but-no-conversion is a real 0%, not an em-dash' );
+		$this->assertSame( 0.0, $rate['value'] );
+		$this->assertSame( 200, $rate['denominator'] );
+	}
+
+	/**
+	 * Coherence guard: conversions (order-meta surface) exceeding impressions
+	 * (GA4 surface) must not fabricate a >100% rate — suppress to not-computable.
+	 */
+	public function test_donation_conversion_direct_coherence_guard_suppresses_over_100() {
+		$metric = $this->make_direct_donation_metric(
+			$this->proxy_with_donation_impressions( 10 ),
+			$this->donors_with_conversions( 50 ),
+			true
+		);
+
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertFalse( $rate['computable'], 'a >100% cross-surface ratio is suppressed, not shown' );
+		$this->assertSame( 0.0, $rate['value'] );
+	}
+
+	/**
+	 * Hybrid card: if the hub impressions call errors, the rate is genuinely
+	 * uncomputable → error state (so it counts toward the tab-error banner).
+	 */
+	public function test_donation_conversion_direct_errors_when_impressions_hub_errors() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( new \WP_Error( 'bigquery_proxy_error', 'down' ) );
+
+		$metric = $this->make_direct_donation_metric( $proxy, $this->donors_with_conversions( 5 ), true );
+
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $rate['state'] );
+	}
+
+	/**
+	 * Non-WC publisher: empty state (not a fake 0%); the order-meta numerator is
+	 * never queried.
+	 */
+	public function test_donation_conversion_direct_empty_state_when_not_woocommerce() {
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->expects( $this->never() )->method( 'get_prompt_attributed_donation_conversions' );
+
+		$metric = $this->make_direct_donation_metric( null, $donors, false );
+
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertFalse( $rate['computable'] );
+		$this->assertSame( 0.0, $rate['value'] );
+	}
+
+	/**
+	 * Remove the WC-active seam filter set by make_donation_revenue_metric().
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'newspack_insights_woocommerce_active' );
+		parent::tearDown();
 	}
 
 	/**
@@ -524,7 +735,10 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
 
 		$metric = new Prompts_Metric( $proxy, $resolver );
-		$metric->get_donation_conversion_direct( $this->start(), $this->end() );
+		// NPPD-1745: get_donation_conversion_direct no longer dispatches a paid-attempt
+		// query (it's hybrid order-meta ÷ impressions). Use two still-proxy-backed
+		// intents with distinct query_names to exercise per-query_name cache keying.
+		$metric->get_donation_conversion_influenced_14d( $this->start(), $this->end() );
 		$metric->get_subscription_conversion_direct( $this->start(), $this->end() );
 	}
 
@@ -730,14 +944,17 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	 * augmentation queries (in dispatch order).
 	 *
 	 * @param array           $perf_rows         Rows for `prompts_performance_by_prompt`.
-	 * @param array|\WP_Error $donation_rows Rows for `prompts_donation_conversion_direct`.
+	 * @param array|\WP_Error $donation_rows     Unused since NPPD-1745 (donations come
+	 *                                           from order meta, not the proxy); kept for
+	 *                                           call-site compatibility.
 	 * @param array|\WP_Error $subscription_rows Rows for `prompts_subscription_conversion_direct`.
 	 * @return BigQuery_Proxy_Client
 	 */
 	protected function make_performance_proxy( array $perf_rows, $donation_rows, $subscription_rows ): BigQuery_Proxy_Client {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		// Dispatch order: perf table, donation augmentation, subscription augmentation.
-		$proxy->expects( $this->exactly( 3 ) )
+		// Two queries now: the perf table + the subscription augmentation. Donations
+		// are sourced from order meta via Donors_Metric (NPPD-1745), not the proxy.
+		$proxy->expects( $this->exactly( 2 ) )
 			->method( 'query' )
 			->willReturnCallback(
 				function ( $query_name ) use ( $perf_rows, $donation_rows, $subscription_rows ) {
@@ -790,13 +1007,18 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$proxy = $this->make_performance_proxy( $perf_rows, $donation_attempts, $subscription_attempts );
 
 		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		// Each per-popup augmentation call gets its own scoped row subset; we
-		// stub a fixed return per call regardless of which subset arrived. The
-		// per-popup grouping itself is what the test exercises.
+		// Subscriptions still use the resolver path; donations now come from order
+		// meta via an injected Donors_Metric (NPPD-1745).
 		$resolver->method( 'count_completed_orders' )->willReturn( 5 );
 		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
 
-		$metric = new Prompts_Metric( $proxy, $resolver );
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tearDown.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
+			[ '42' => [ 'conversions' => 5, 'revenue' => 0.0 ] ]
+		);
+
+		$metric = new Prompts_Metric( $proxy, $resolver, null, $donors );
 		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
 
 		$this->assertSame( 'populated', $result['state'] );
@@ -823,6 +1045,43 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 1000, $result['rows'][0]['impressions'] );
 		$this->assertSame( 0.1, $result['rows'][0]['ctr'] );
 		$this->assertSame( 0.05, $result['rows'][0]['form_submission_rate'] );
+	}
+
+	/**
+	 * NPPD-1745: the per-prompt donation_conversion_rate shares the tab-level
+	 * coherence guard (donation_rate_value) — conversions exceeding a popup's
+	 * impressions suppress the rate to null, never a >100% value.
+	 */
+	public function test_per_prompt_donation_rate_coherence_guard_suppresses_over_100() {
+		$proxy = $this->make_performance_proxy( [ $this->performance_row( 42, 'Donate', 'donation', 10 ) ], [], [] );
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
+			[ '42' => [ 'conversions' => 50, 'revenue' => 0.0 ] ]
+		);
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 50, $result['rows'][0]['donation_conversions'] );
+		$this->assertNull( $result['rows'][0]['donation_conversion_rate'], 'per-prompt rate uses the shared coherence guard' );
+	}
+
+	/**
+	 * NPPD-1745: per-prompt em-dash semantics match the tab-level card —
+	 * impressions with zero conversions is a real 0%, not a null em-dash.
+	 */
+	public function test_per_prompt_donation_rate_real_zero_percent_when_no_conversions() {
+		$proxy = $this->make_performance_proxy( [ $this->performance_row( 42, 'Donate', 'donation', 200 ) ], [], [] );
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn( [] ); // No conversions for popup 42.
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
+		$this->assertSame( 0.0, $result['rows'][0]['donation_conversion_rate'], 'real 0% per-prompt, not an em-dash' );
 	}
 
 	/**
@@ -936,46 +1195,30 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Performance by prompt: when the donation-augmentation proxy call fails,
-	 * the table still renders with engagement columns intact; donation
-	 * columns degrade to 0 / null (no error envelope, no exception).
+	 * Performance by prompt: on a non-WooCommerce publisher the donation columns
+	 * degrade to 0 / null (no order data) while the engagement table still renders
+	 * — and the order-meta reader is never queried (NPPD-1745). Replaces the old
+	 * donation-proxy-failure degradation test; donations no longer hit the proxy.
 	 */
-	public function test_performance_by_prompt_degrades_gracefully_on_woo_query_failure() {
+	public function test_performance_by_prompt_donation_columns_degrade_on_non_woocommerce() {
 		$perf_rows = [ $this->performance_row( 42, 'Donate now', 'donation', 1000 ) ];
+		$proxy     = $this->make_performance_proxy( $perf_rows, [], [] );
 
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->exactly( 3 ) )
-			->method( 'query' )
-			->willReturnCallback(
-				function ( $query_name ) use ( $perf_rows ) {
-					switch ( $query_name ) {
-						case 'prompts_performance_by_prompt':
-							return $perf_rows;
-						case 'prompts_donation_conversion_direct':
-							return new \WP_Error( 'bigquery_query_failed', 'donation BQ down' );
-						case 'prompts_subscription_conversion_direct':
-							return [];
-					}
-					return null;
-				}
-			);
+		// No WC filter → woocommerce_active() is false; the order-meta reader must
+		// not be queried.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->expects( $this->never() )->method( 'get_prompt_attributed_donation_conversions' );
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
-
-		$metric = new Prompts_Metric( $proxy, $resolver );
+		$metric = new Prompts_Metric( $proxy, null, null, $donors );
 		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
 
 		// Table renders successfully — engagement data is load-bearing.
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertSame( 1000, $result['rows'][0]['impressions'] );
 		$this->assertSame( 0.1, $result['rows'][0]['ctr'] );
-		// Donation augmentation degraded to zero conversions; the rate stays
-		// computable (0/impressions = 0.0) since the intent matches and the
-		// engagement denominator is real — only the numerator is missing.
+		// Donation columns degrade to N/A on a non-WC publisher.
 		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
-		$this->assertEqualsWithDelta( 0.0, $result['rows'][0]['donation_conversion_rate'], 0.0001 );
+		$this->assertNull( $result['rows'][0]['donation_conversion_rate'], 'non-WC donation column is N/A, not 0%' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -712,9 +712,9 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	/**
 	 * Remove the WC-active seam filter set by make_donation_revenue_metric().
 	 */
-	public function tearDown(): void {
+	public function tear_down(): void {
 		remove_all_filters( 'newspack_insights_woocommerce_active' );
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	/**
@@ -948,13 +948,18 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	 *                                           from order meta, not the proxy); kept for
 	 *                                           call-site compatibility.
 	 * @param array|\WP_Error $subscription_rows Rows for `prompts_subscription_conversion_direct`.
+	 * @param int             $expected_queries  Expected proxy `query()` count: 2 on a
+	 *                                           WC-active publisher (perf + subscription),
+	 *                                           1 on a non-WC publisher (perf only).
 	 * @return BigQuery_Proxy_Client
 	 */
-	protected function make_performance_proxy( array $perf_rows, $donation_rows, $subscription_rows ): BigQuery_Proxy_Client {
+	protected function make_performance_proxy( array $perf_rows, $donation_rows, $subscription_rows, int $expected_queries = 2 ): BigQuery_Proxy_Client {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		// Two queries now: the perf table + the subscription augmentation. Donations
-		// are sourced from order meta via Donors_Metric (NPPD-1745), not the proxy.
-		$proxy->expects( $this->exactly( 2 ) )
+		// On a WC-active publisher the perf table + the subscription augmentation run
+		// (2 queries); on a non-WC publisher the subscription augmentation is gated off,
+		// so only the perf query runs (1). Donations come from order meta via
+		// Donors_Metric (NPPD-1745), not the proxy.
+		$proxy->expects( $this->exactly( $expected_queries ) )
 			->method( 'query' )
 			->willReturnCallback(
 				function ( $query_name ) use ( $perf_rows, $donation_rows, $subscription_rows ) {
@@ -1101,7 +1106,7 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	 */
 	public function test_performance_by_prompt_row_schema_is_locked() {
 		$perf_rows = [ $this->performance_row( 42, 'Donate now', 'donation', 100 ) ];
-		$proxy     = $this->make_performance_proxy( $perf_rows, [], [] );
+		$proxy     = $this->make_performance_proxy( $perf_rows, [], [], 1 ); // Non-WC env: perf query only.
 
 		$resolver = $this->createMock( Woo_Order_Resolver::class );
 		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
@@ -1212,7 +1217,7 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	 */
 	public function test_performance_by_prompt_donation_columns_degrade_on_non_woocommerce() {
 		$perf_rows = [ $this->performance_row( 42, 'Donate now', 'donation', 1000 ) ];
-		$proxy     = $this->make_performance_proxy( $perf_rows, [], [] );
+		$proxy     = $this->make_performance_proxy( $perf_rows, [], [], 1 ); // Non-WC: subscription augmentation is gated off too.
 
 		// No WC filter → woocommerce_active() is false; the order-meta reader must
 		// not be queried.
@@ -1229,6 +1234,10 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		// Donation columns degrade to N/A on a non-WC publisher.
 		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
 		$this->assertNull( $result['rows'][0]['donation_conversion_rate'], 'non-WC donation column is N/A, not 0%' );
+		// Subscription columns degrade too — the resolver path also requires WC, so it
+		// is gated off on a non-WC publisher (no wc_get_orders() call).
+		$this->assertSame( 0, $result['rows'][0]['subscription_conversions'] );
+		$this->assertNull( $result['rows'][0]['subscription_conversion_rate'], 'non-WC subscription column is N/A' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -1015,7 +1015,12 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tearDown.
 		$donors = $this->createMock( Donors_Metric::class );
 		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
-			[ '42' => [ 'conversions' => 5, 'revenue' => 0.0 ] ]
+			[
+				'42' => [
+					'conversions' => 5,
+					'revenue'     => 0.0,
+				],
+			]
 		);
 
 		$metric = new Prompts_Metric( $proxy, $resolver, null, $donors );
@@ -1057,7 +1062,12 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
 		$donors = $this->createMock( Donors_Metric::class );
 		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
-			[ '42' => [ 'conversions' => 50, 'revenue' => 0.0 ] ]
+			[
+				'42' => [
+					'conversions' => 50,
+					'revenue'     => 0.0,
+				],
+			]
 		);
 
 		$metric = new Prompts_Metric( $proxy, null, null, $donors );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -122,9 +122,18 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		// not leak through to the wire format.
 		$this->assertArrayNotHasKey( 'tab_pending', $data );
 		$this->assertArrayHasKey( 'tab_error', $data );
-		$this->assertTrue( $data['tab_error'], 'Test env has an unconfigured proxy → every metric errors → tab_error: true.' );
+		// NPPD-1745: tab_error is scoped to hub-backed metrics. The test env has an
+		// unconfigured proxy (every hub metric errors) AND no WooCommerce, so the two
+		// migrated donation cards return a NON-error empty state (revenue: local;
+		// rate: hybrid, short-circuited on non-WC). A hub-backed card
+		// (donation_conversion_direct) is therefore not in 'error', so the window is
+		// not "all hub-backed errored" → no banner. The banner-fires-on-hub-outage
+		// path is pinned directly in test_tab_error_* below.
+		$this->assertFalse( $data['tab_error'] );
 		$this->assertArrayHasKey( 'current', $data );
 		$this->assertNull( $data['previous'] );
+		$this->assertSame( 'populated', $data['current']['donation_revenue_direct']['state'], 'local card is non-error' );
+		$this->assertSame( 'populated', $data['current']['donation_conversion_direct']['state'], 'hybrid card empties on non-WC' );
 
 		// Window echo + one representative metric per section is present.
 		$current = $data['current'];
@@ -427,5 +436,64 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		$this->assertIsArray( $payload['previous'] );
 		$this->assertArrayHasKey( 'total_prompt_impressions', $payload['previous'] );
 		$this->assertSame( 'populated', $payload['previous']['total_prompt_impressions']['state'] );
+	}
+
+	/**
+	 * Invoke the private static is_window_all_error() on a synthetic window.
+	 *
+	 * @param array $window Window payload.
+	 * @return bool
+	 */
+	private function invoke_is_window_all_error( array $window ): bool {
+		$method = new \ReflectionMethod( Prompts_REST_Controller::class, 'is_window_all_error' );
+		$method->setAccessible( true );
+		return (bool) $method->invoke( null, $window );
+	}
+
+	/**
+	 * Build a window where every hub-backed metric errors and every local card is
+	 * populated (the hub-outage-with-local-survivor scenario).
+	 *
+	 * @return array
+	 */
+	private function window_hub_down_local_alive(): array {
+		$window = [
+			'window' => [
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			],
+		];
+		foreach ( Prompts_Metric::METRIC_SOURCES as $key => $source ) {
+			$window[ $key ] = [ 'state' => 'local' === $source ? 'populated' : 'error' ];
+		}
+		return $window;
+	}
+
+	/**
+	 * NPPD-1745 regression guard: the "whole tab failed" banner STILL fires when
+	 * every hub-backed metric errors, even though a surviving local card renders.
+	 * This is the exact thing the old all-error logic would have silently killed.
+	 */
+	public function test_tab_error_fires_on_hub_outage_despite_local_survivor() {
+		$window = $this->window_hub_down_local_alive();
+
+		// The local survivor is genuinely present and populated.
+		$this->assertSame( 'local', Prompts_Metric::METRIC_SOURCES['donation_revenue_direct'] );
+		$this->assertSame( 'populated', $window['donation_revenue_direct']['state'] );
+
+		$this->assertTrue(
+			$this->invoke_is_window_all_error( $window ),
+			'all hub-backed errored → banner fires even though the local card rendered'
+		);
+	}
+
+	/**
+	 * The banner does NOT fire if any hub-backed metric recovers.
+	 */
+	public function test_tab_error_does_not_fire_when_a_hub_metric_recovers() {
+		$window = $this->window_hub_down_local_alive();
+		$window['total_prompt_impressions'] = [ 'state' => 'populated' ]; // one hub card recovers.
+
+		$this->assertFalse( $this->invoke_is_window_all_error( $window ) );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Reusable WooCommerce-order DB fixtures for insights storage integration tests
+ * (NPPD-1685).
+ *
+ * The insights unit suite mocks WooCommerce and ships no WC order tables, so no
+ * storage SQL has ever been exercised against real tables (that is how the 2x
+ * duplicate-meta bug survived). This trait stands up the real order tables —
+ * legacy (`wc_order_product_lookup`; `posts`/`postmeta` already exist) and HPOS
+ * (`wc_orders`, `wc_orders_meta`, `wc_order_product_lookup`) — and inserts orders
+ * with arbitrary meta, including the duplicate `_newspack_popup_id` rows that
+ * trigger the bug.
+ *
+ * Reused by the prompt-attributed donation reader test today; the rate-direct,
+ * per-prompt, and source-mix reader tests will reuse the same tables + the same
+ * duplicate-meta anchor.
+ *
+ * Tables are InnoDB and created in setUpBeforeClass (outside the per-test
+ * transaction) so per-test row inserts roll back automatically.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+/**
+ * DDL + row-insert helpers for legacy and HPOS WooCommerce order fixtures.
+ */
+trait Insights_Woo_Order_Fixtures {
+
+	/**
+	 * Create the WC order tables (idempotent). Call from setUpBeforeClass().
+	 *
+	 * @return void
+	 */
+	protected static function create_woo_order_tables(): void {
+		global $wpdb;
+		$p = $wpdb->prefix;
+		// HPOS authoritative store.
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders ( id BIGINT UNSIGNED NOT NULL PRIMARY KEY, status VARCHAR(20) NULL, type VARCHAR(20) NULL, date_created_gmt DATETIME NULL, total_amount DECIMAL(26,8) NULL ) ENGINE=InnoDB" );
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders_meta ( id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, order_id BIGINT UNSIGNED NULL, meta_key VARCHAR(255) NULL, meta_value LONGTEXT NULL, KEY order_id ( order_id ) ) ENGINE=InnoDB" );
+		// Product lookup (both backends maintain this).
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_order_product_lookup ( order_id BIGINT UNSIGNED NOT NULL, product_id BIGINT UNSIGNED NOT NULL, PRIMARY KEY ( order_id, product_id ) ) ENGINE=InnoDB" );
+	}
+
+	/**
+	 * Drop the WC order tables. Call from tearDownAfterClass().
+	 *
+	 * @return void
+	 */
+	protected static function drop_woo_order_tables(): void {
+		global $wpdb;
+		$p = $wpdb->prefix;
+		$wpdb->query( "DROP TABLE IF EXISTS {$p}wc_orders" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$p}wc_orders_meta" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$p}wc_order_product_lookup" );
+	}
+
+	/**
+	 * Default order creation date (GMT) — inside any sane test window.
+	 *
+	 * @return string Y-m-d H:i:s
+	 */
+	private function default_order_date_gmt(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '-5 days' ) );
+	}
+
+	/**
+	 * Insert a legacy (posts/postmeta) order with its product-lookup row.
+	 *
+	 * @param array $args Order spec: `product_id`, `total` (`_order_total`),
+	 *                    `popup_ids` (one `_newspack_popup_id` row per element,
+	 *                    duplicates allowed), `renewal` (`_subscription_renewal`),
+	 *                    `status` (default 'wc-completed'), `date` (GMT 'Y-m-d H:i:s').
+	 * @return int The created order's post ID.
+	 */
+	protected function insert_legacy_order( array $args ): int {
+		global $wpdb;
+		$date     = $args['date'] ?? $this->default_order_date_gmt();
+		$order_id = wp_insert_post(
+			[
+				'post_type'   => 'shop_order',
+				'post_status' => $args['status'] ?? 'wc-completed',
+				'post_title'  => 'Order',
+			]
+		);
+		// Force the GMT date deterministically (wp_insert_post derives it from site tz).
+		$wpdb->update( $wpdb->posts, [ 'post_date_gmt' => $date ], [ 'ID' => $order_id ] );
+
+		$wpdb->insert(
+			"{$wpdb->prefix}wc_order_product_lookup",
+			[
+				'order_id'   => $order_id,
+				'product_id' => $args['product_id'] ?? self::DONATION_PRODUCT_ID,
+			]
+		);
+		foreach ( (array) ( $args['popup_ids'] ?? [] ) as $pid ) {
+			add_post_meta( $order_id, '_newspack_popup_id', $pid ); // unique = false → duplicates allowed.
+		}
+		if ( isset( $args['total'] ) ) {
+			add_post_meta( $order_id, '_order_total', $args['total'] );
+		}
+		if ( ! empty( $args['renewal'] ) ) {
+			add_post_meta( $order_id, '_subscription_renewal', $args['renewal'] );
+		}
+		return (int) $order_id;
+	}
+
+	/**
+	 * Insert an HPOS (wc_orders) order with its product-lookup + meta rows.
+	 *
+	 * @param array $args Same shape as {@see insert_legacy_order()}; `order_id` is required.
+	 * @return int The order ID.
+	 */
+	protected function insert_hpos_order( array $args ): int {
+		global $wpdb;
+		$p        = $wpdb->prefix;
+		$order_id = (int) $args['order_id'];
+		$wpdb->insert(
+			"{$p}wc_orders",
+			[
+				'id'               => $order_id,
+				'status'           => $args['status'] ?? 'wc-completed',
+				'type'             => 'shop_order',
+				'date_created_gmt' => $args['date'] ?? $this->default_order_date_gmt(),
+				'total_amount'     => $args['total'] ?? 0,
+			]
+		);
+		$wpdb->insert(
+			"{$p}wc_order_product_lookup",
+			[
+				'order_id'   => $order_id,
+				'product_id' => $args['product_id'] ?? self::DONATION_PRODUCT_ID,
+			]
+		);
+		foreach ( (array) ( $args['popup_ids'] ?? [] ) as $pid ) {
+			$wpdb->insert(
+				"{$p}wc_orders_meta",
+				[
+					'order_id'   => $order_id,
+					'meta_key'   => '_newspack_popup_id',
+					'meta_value' => $pid,
+				]
+			);
+		}
+		if ( ! empty( $args['renewal'] ) ) {
+			$wpdb->insert(
+				"{$p}wc_orders_meta",
+				[
+					'order_id'   => $order_id,
+					'meta_key'   => '_subscription_renewal',
+					'meta_value' => $args['renewal'],
+				]
+			);
+		}
+		return $order_id;
+	}
+}


### PR DESCRIPTION
## What

Migrates the **direct donation** conversion metrics (Tab 5 / Prompts) off the GA4-attempt → `Woo_Order_Resolver` join and onto **WooCommerce order meta** (`_newspack_popup_id`), which is anonymous-inclusive and carries a real `customer_id`. This is the NPPD-1685 spike's recommended direct-metric fix.

The GA4 attempt event has no usable `customer_id` (GA4 `user_id` is unpopulated; the only id is the cookie `user_pseudo_id`), so the cookie→`customer_id` cast can't match real orders — dropping anonymous-at-attempt donors. The originating prompt id is already written onto the cleared order, so the direct metrics read it directly with no hub join.

Investigation + measurements (internal): `Automattic/newspack-insights` → `investigations/nppd-1685.md`. Ticket: **NPPD-1745**.

## Changes (commits, dependency order)

- **Storage reader** `get_prompt_attributed_donation_conversions` (legacy + HPOS): initial completed donation orders carrying the popup id, renewals excluded, grouped by popup id. Dedupe is **EXISTS + correlated `MIN`**, not a JOIN — the popup-id meta is written more than once per order, so a JOIN double-counts both count and revenue.
- **`Donors_Metric`** cached delegator for the reader.
- **`get_donation_revenue_direct`** sums the order-meta map (pure-local; survives a hub outage). **`get_donation_conversion_direct`** + **per-prompt rate** use an order-meta numerator ÷ hub donation-impressions denominator, via a shared `donation_rate_value()` with a coherence guard (no fabricated >100% across the two surfaces) and unified —/0% em-dash semantics.
- **Tab-error banner** scoped to hub-backed metrics (`METRIC_SOURCES` classification + `is_window_all_error`) so a surviving local card doesn't suppress the "whole tab failed" banner.
- **Tests:** a DB-backed integration harness (reusable fixtures trait stands up the WC order tables; legacy + HPOS), the duplicate-meta 2× regression anchor, coherence-guard + em-dash coverage, and the scoped-banner regression.

## Tests

`n test-php --group insights` → **365/365** green.

## Scope / not in this PR

- **Influenced-14d** metrics still use `Woo_Order_Resolver` (genuine cross-session linkage) — separate effort; the resolver is now influenced-only.
- **Source-mix (Tab 3)** and the **Tab-3 banner scoping** are on the #373 track (coordination), not here.
- A lower-urgency write-side cleanup (make the popup-id order meta `unique`) to be filed separately; the reader is robust to historical duplicates regardless.
