### PR TITLE
docs(google-site-kit): GTM template for GA4 reader params (NPPM-2933)

### DIFF
--- a/plugins/newspack-plugin/.distignore
+++ b/plugins/newspack-plugin/.distignore
@@ -33,6 +33,7 @@ yarn.lock
 *.sql
 *.tar.gz
 *.zip
+*.gtm.json
 
 # directories
 node_modules

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -191,6 +191,10 @@ class GoogleSiteKit {
 	/**
 	 * Get custom parameters for a GA configuration or event body.
 	 *
+	 * If you add, rename, or remove a key here, update the companion GTM template
+	 * (Data Layer Variables + docs) at includes/plugins/google-site-kit/gtm-template/
+	 * so GTM-tagged sites keep reading the same params.
+	 *
 	 * @return array
 	 */
 	public static function get_custom_event_parameters() {

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/gtm-template/README.md
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/gtm-template/README.md
@@ -1,0 +1,117 @@
+# Newspack GA4 reader params → GTM
+
+Make Newspack's reader context (`logged_in`, `is_reader`, `is_donor`, …) available as
+GA4 custom dimensions on sites that tag GA4 **through Google Tag Manager** rather than
+through Site Kit's own gtag.
+
+## Why this is needed
+
+Newspack injects reader params into **Site Kit's gtag** config. On a site whose GA4
+pageview is fired by a **GTM container** instead, those params never reach GA4, so the
+dimensions show `(not set)` on `page_view` and the GA4-automatic events. (Newspack's own
+`np_*` events still carry the params – only the GTM-fired events are blind.)
+
+This template bridges that gap: newspack-plugin pushes the params to `window.dataLayer`,
+GTM reads them as Data Layer Variables, and you attach them to your GA4 tag.
+
+## Prerequisite
+
+The site must run a newspack-plugin version that pushes reader params to the dataLayer
+(the `window.dataLayer.push({ logged_in: … })` change). Verify on the live front-end:
+
+```js
+// In the browser console on any front-end page:
+window.dataLayer.find( e => 'logged_in' in e )
+```
+
+If that returns an object, you're good. If `undefined`, the plugin isn't pushing yet –
+stop here until it ships.
+
+## The params
+
+| dataLayer key | Scope | Values |
+|---|---|---|
+| `logged_in` | every page | `yes` / `no` |
+| `is_reader` | every page | `yes` / `no` |
+| `is_newsletter_subscriber` | every page | `yes` / `no` |
+| `is_donor` | every page | `yes` / `no` |
+| `is_subscriber` | every page | `yes` / `no` |
+| `post_id` | singular views | numeric |
+| `author` | singular views | name(s) |
+| `categories` | singular / category archive | comma-separated |
+| `group` | when Content Gate is enabled | anon group IDs / `none` |
+
+`email_hash` is intentionally **not** in the dataLayer (kept out of third-party reach).
+
+## Step 1 – Import the variables
+
+`newspack-ga4-reader-params.gtm.json` is a GTM container export containing:
+
+- the **9 Data Layer Variables** (named `DLV - Newspack - <key>`), and
+- one **`Newspack - GA4 Reader Params (config settings)`** variable that bundles all 9 as
+  Google-tag configuration parameters – so you wire them with a single reference.
+
+1. GTM → **Admin → Import Container**.
+2. Choose the JSON file.
+3. Select an **existing workspace** (create a throwaway one to review first).
+4. Choose **Merge → Rename conflicting tags, triggers, and variables** (safe; never
+   overwrites your existing config).
+5. Preview the changes (should be 10 new variables, nothing else), then **Confirm**.
+
+## Step 2 – Attach the params to your GA4 tag
+
+Open your GA4 pageview tag – the **Google Tag** / **GA4 Configuration** tag that fires on
+*All Pages* – open **Configuration settings**, and set the **Configuration settings
+variable** field to:
+
+```
+{{Newspack - GA4 Reader Params (config settings)}}
+```
+
+That's the whole wiring step – config-level params propagate to `page_view` and every
+subsequent event, so all 9 reader params now ride your existing pageview.
+
+<details>
+<summary>Manual alternative (if you'd rather not use the bundling variable)</summary>
+
+Add each param as an individual **configuration parameter** row on the tag instead:
+
+| Configuration parameter | Value |
+|---|---|
+| `logged_in` | `{{DLV - Newspack - logged_in}}` |
+| `is_reader` | `{{DLV - Newspack - is_reader}}` |
+| `is_newsletter_subscriber` | `{{DLV - Newspack - is_newsletter_subscriber}}` |
+| `is_donor` | `{{DLV - Newspack - is_donor}}` |
+| `is_subscriber` | `{{DLV - Newspack - is_subscriber}}` |
+| `post_id` | `{{DLV - Newspack - post_id}}` |
+| `author` | `{{DLV - Newspack - author}}` |
+| `categories` | `{{DLV - Newspack - categories}}` |
+| `group` | `{{DLV - Newspack - group}}` |
+
+</details>
+
+## Step 3 – Register the GA4 custom dimensions
+
+GA4 only reports event params it's told to keep. In GA4 → **Admin → Custom definitions →
+Create custom dimension**, add an **event-scoped** dimension for each param you want to
+report on (Dimension name of your choice; **Event parameter** = the exact key, e.g.
+`logged_in`). Several may already exist – don't duplicate.
+
+## Step 4 – Verify
+
+1. GTM → **Preview**, load the site.
+2. Confirm the `DLV - Newspack - *` variables resolve (e.g. `logged_in = no`).
+3. GA4 → **Admin → DebugView**: open a `page_view` and confirm `logged_in` (and the
+   others) appear as parameters with real values – not `(not set)`.
+
+## Watch-outs
+
+- **Don't run two GA4 pageview tags into the same property.** If Site Kit's gtag *and* a
+  GTM tag both fire `page_view` to the same measurement ID, pageviews are double-counted.
+  Pick one tagging path per property (for GTM-tier sites, keep GTM and turn off Site Kit's
+  GA snippet).
+- **Watch for a drifted "Google tag".** A property's Google tag (`GT-…`) can be configured
+  to deliver to a *different* measurement ID than the one you report on, sending your
+  param-rich hits to a property nobody reads. Confirm in GA4 Admin → Data streams →
+  *Configure tag settings* that the tag's destination is the property you actually report
+  on.

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/gtm-template/newspack-ga4-reader-params.gtm.json
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/gtm-template/newspack-ga4-reader-params.gtm.json
@@ -1,0 +1,240 @@
+{
+  "exportFormatVersion": 2,
+  "exportTime": "2026-06-22 00:00:00",
+  "containerVersion": {
+    "path": "accounts/0/containers/0/versions/0",
+    "accountId": "0",
+    "containerId": "0",
+    "containerVersionId": "0",
+    "container": {
+      "path": "accounts/0/containers/0",
+      "accountId": "0",
+      "containerId": "0",
+      "name": "Newspack GA4 Reader Params (template)",
+      "publicId": "GTM-XXXXXXX",
+      "usageContext": [
+        "WEB"
+      ],
+      "fingerprint": "0",
+      "tagManagerUrl": ""
+    },
+    "variable": [
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "1",
+        "name": "DLV - Newspack - logged_in",
+        "type": "v",
+        "notes": "Newspack reader param. Pushed to window.dataLayer by newspack-plugin (Site Kit integration). Values: yes | no.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "logged_in" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "2",
+        "name": "DLV - Newspack - is_reader",
+        "type": "v",
+        "notes": "Newspack reader param. Values: yes | no.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "is_reader" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "3",
+        "name": "DLV - Newspack - is_newsletter_subscriber",
+        "type": "v",
+        "notes": "Newspack reader param. Values: yes | no.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "is_newsletter_subscriber" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "4",
+        "name": "DLV - Newspack - is_donor",
+        "type": "v",
+        "notes": "Newspack reader param. Values: yes | no.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "is_donor" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "5",
+        "name": "DLV - Newspack - is_subscriber",
+        "type": "v",
+        "notes": "Newspack reader param. Active non-donation subscriptions. Values: yes | no.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "is_subscriber" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "6",
+        "name": "DLV - Newspack - post_id",
+        "type": "v",
+        "notes": "Newspack reader param. Present on singular views only.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "post_id" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "7",
+        "name": "DLV - Newspack - author",
+        "type": "v",
+        "notes": "Newspack reader param. Present on singular views only.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "author" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "8",
+        "name": "DLV - Newspack - categories",
+        "type": "v",
+        "notes": "Newspack reader param. Present on singular views and category archives.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "categories" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "9",
+        "name": "DLV - Newspack - group",
+        "type": "v",
+        "notes": "Newspack reader param. Present when the Content Gate feature is enabled. Anonymized group IDs, or 'none'.",
+        "parameter": [
+          { "type": "INTEGER", "key": "dataLayerVersion", "value": "2" },
+          { "type": "BOOLEAN", "key": "setDefaultValue", "value": "false" },
+          { "type": "TEMPLATE", "key": "name", "value": "group" }
+        ],
+        "fingerprint": "0",
+        "formatValue": {}
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "10",
+        "name": "Newspack - GA4 Reader Params (config settings)",
+        "type": "gtcs",
+        "notes": "Bundles all Newspack reader params as Google-tag configuration parameters. Reference this from your GA4 Google Tag's 'Configuration settings variable' field so the params ride every page_view.",
+        "parameter": [
+          {
+            "type": "LIST",
+            "key": "configSettingsTable",
+            "list": [
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "logged_in" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - logged_in}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "is_reader" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - is_reader}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "is_newsletter_subscriber" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - is_newsletter_subscriber}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "is_donor" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - is_donor}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "is_subscriber" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - is_subscriber}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "post_id" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - post_id}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "author" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - author}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "categories" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - categories}}" }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  { "type": "TEMPLATE", "key": "parameter", "value": "group" },
+                  { "type": "TEMPLATE", "key": "parameterValue", "value": "{{DLV - Newspack - group}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "fingerprint": "0"
+      }
+    ],
+    "fingerprint": "0"
+  }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Part of [NPPM-2933](https://linear.app/a8c/issue/NPPM-2933). Companion to #311.

Newspack injects reader params (`logged_in`, `is_reader`, …) into Site Kit's own gtag. On publishers whose GA4 pageview is fired through a **GTM container** instead, those params never reach GA4, so the dimensions show `(not set)`. PR #311 pushes the params to `window.dataLayer`; this PR adds the **GTM-side companion** so a GTM-tagged publisher can consume them with a one-time import.

Adds, under `includes/plugins/google-site-kit/gtm-template/`:

- **`newspack-ga4-reader-params.gtm.json`** – a GTM container export with the 9 reader-param **Data Layer Variables** plus a single **"Google tag: Configuration Settings"** variable (`gtcs`) that bundles all 9, so the publisher wires them by referencing one variable instead of adding 9 rows.
- **`README.md`** – import → wire (single field) → register GA4 custom dimensions → verify, plus watch-outs for double-tagging and drifted/shadow GA4 properties.

Also:

- **`.distignore`**: `+*.gtm.json` so the template doesn't ship in the plugin zip (it's a publisher/ops artifact, not runtime; the README is already excluded by the existing `README.md` rule).
- **`class-googlesitekit.php`**: a pointer comment above `get_custom_event_parameters()` so whoever adds/renames a param keeps the template in lockstep. (Comment only – no behavior change.)

### How to test the changes in this Pull Request:

1. In GTM (any container you own, a throwaway workspace), **Admin → Import Container** → choose `newspack-ga4-reader-params.gtm.json` → **Merge → Rename conflicting**.
2. Confirm **10 variables** import clean: 9 `DLV - Newspack - *` (type Data Layer Variable) + `Newspack - GA4 Reader Params (config settings)` (type Google tag: Configuration Settings), the latter carrying all 9 param rows mapped to the DLVs.
3. (End-to-end, optional – needs a site running #311's dataLayer push) Set a GA4 Google Tag's *Configuration settings variable* to `{{Newspack - GA4 Reader Params (config settings)}}`, and confirm GA4 DebugView shows `logged_in` on `page_view`.

> Import verified on a sandbox container (`GTM-5CS2GNHN`): all 10 variables round-trip cleanly and the references resolve by name.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (N/A – docs/template + a code comment; no runtime code.)
* [x] Have you successfully run tests with your changes locally? (Verified by importing the container into GTM.)