### PR TITLE
fix(insights): non-WC tab-error banner hole + malformed impressions (NPPD-1745 follow-ups)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -279,7 +279,7 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	): array {
 		$current  = $this->build_window( $metric, $start, $end );
 		$response = [
-			'tab_error' => self::is_window_all_error( $current ),
+			'tab_error' => self::is_window_all_error( $current, $metric->woocommerce_active() ),
 			'current'   => $current,
 			'previous'  => null,
 		];
@@ -305,13 +305,28 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	 * Returns `false` for a window with no recognizable hub-backed metric at all
 	 * (nothing to declare failed).
 	 *
-	 * @param array $window The shape returned by `build_window()`.
+	 * NPPD-1745 (banner hole on non-WC): a `hybrid` card (local order-meta numerator
+	 * over a hub denominator) short-circuits to a not-applicable empty state on a
+	 * non-WooCommerce publisher BEFORE it ever calls the hub — so a hub outage can't
+	 * make it error, and treating its surviving empty state as a healthy hub-backed
+	 * card would mask the outage and suppress the banner. On a non-WC publisher,
+	 * hybrid cards are therefore skipped (treated like `local`); the genuinely
+	 * hub-backed cards (pure `hub`) still drive the decision.
+	 *
+	 * @param array $window             The shape returned by `build_window()`.
+	 * @param bool  $woocommerce_active Whether WooCommerce is active for this publisher.
 	 * @return bool
 	 */
-	private static function is_window_all_error( array $window ): bool {
+	private static function is_window_all_error( array $window, bool $woocommerce_active ): bool {
 		$saw_hub_backed = false;
 		foreach ( Prompts_Metric::METRIC_SOURCES as $key => $source ) {
 			if ( 'local' === $source ) {
+				continue;
+			}
+			// On a non-WC publisher a hybrid card never reaches the hub (it empties out
+			// first), so it can't error on a hub outage — don't let its surviving empty
+			// state mask the outage.
+			if ( ! $woocommerce_active && 'hybrid' === $source ) {
 				continue;
 			}
 			if ( ! isset( $window[ $key ] ) || ! is_array( $window[ $key ] ) || ! isset( $window[ $key ]['state'] ) ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -290,11 +290,13 @@ final class Prompts_Metric {
 	 * local Woo orders, so they no-op to an empty state on non-WC publishers
 	 * (NPPD-1685). Filterable so tests can exercise both the WC-active and non-WC
 	 * paths without toggling a global class (the class is `final`, so it can't be
-	 * doubled).
+	 * doubled). Public because the REST controller reads it to scope the tab-error
+	 * banner: on a non-WC publisher a hybrid card short-circuits before reaching the
+	 * hub, so it must not count as a hub-backed survivor (NPPD-1745).
 	 *
 	 * @return bool
 	 */
-	protected function woocommerce_active(): bool {
+	public function woocommerce_active(): bool {
 		/**
 		 * Filters whether Insights treats WooCommerce as active for the direct
 		 * order-meta donation/subscription metrics.
@@ -854,17 +856,29 @@ final class Prompts_Metric {
 	}
 
 	/**
-	 * The direct donation conversion-rate value, with the coherence guard and
-	 * em-dash semantics shared by the tab-level card
+	 * The direct donation conversion-rate value (NPPD-1745). The tab-level card
 	 * ({@see self::get_donation_conversion_direct()}) and the per-prompt table
-	 * ({@see self::get_performance_by_prompt()}) so the two rates cannot diverge
-	 * (NPPD-1745).
+	 * ({@see self::get_performance_by_prompt()}) both route through this one helper,
+	 * so they share the same formula, coherence guard, and em-dash semantics. Their
+	 * VALUES still differ by design — the tab card divides window-aggregate
+	 * conversions by aggregate impressions, while each table row uses that prompt's
+	 * own counts — but neither can drift to a different rule (e.g. one rendering a
+	 * >100% rate the other suppresses), which is the divergence that matters.
 	 *
 	 * Returns the rate as a float — a genuine 0.0 when there are impressions but no
 	 * conversions ("viewed but no conversion") — or null when not computable:
 	 *  - no impressions → no denominator (em-dash); or
 	 *  - conversions > impressions → a cross-surface incoherence (order-meta
 	 *    numerator vs GA4 impressions) that must not render as a >100% rate.
+	 *
+	 * KNOWN LIMITATION (NPPD-1745 #2): the numerator is complete + server-side, but
+	 * the GA4 impressions denominator is consent/adblock-undercounted — different
+	 * populations, so the denominator can legitimately be the smaller of the two. The
+	 * guard then nulls the rate to an em-dash, which is the honest render (a fabricated
+	 * >100% would be worse), but it means the headline rate is fragile by construction
+	 * when impressions run low. Same denominator-fidelity issue as the gate
+	 * `checkout_impressions` case; a more complete impressions source is a tracked
+	 * follow-up, out of scope for this PR.
 	 *
 	 * @param int $conversions Prompt-attributed donation conversions (order meta).
 	 * @param int $impressions Donation-intent prompt impressions (hub).
@@ -897,7 +911,12 @@ final class Prompts_Metric {
 			return $rows;
 		}
 		if ( ! is_array( $rows ) ) {
-			return 0;
+			// A successful-but-malformed hub response (not an array of rows) is a data
+			// fault, not "0 impressions". The sibling per-prompt table surfaces it as
+			// malformed_collection; mirror that here so the hybrid rate card errors
+			// (counting toward the tab-error banner) instead of silently rendering an
+			// em-dash off a fabricated 0 denominator (NPPD-1745 review #3).
+			return new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) );
 		}
 		$impressions = 0;
 		foreach ( $rows as $row ) {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -693,6 +693,24 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1745 #3: a malformed impressions response (the hub succeeded but returned a
+	 * non-array shape) must error, NOT collapse to a fabricated "0 impressions → em-
+	 * dash". Mirrors the sibling per-prompt table's malformed_collection so a hub
+	 * fault counts toward the banner instead of hiding.
+	 */
+	public function test_donation_conversion_direct_errors_on_malformed_impressions() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( 'not-an-array' ); // Malformed (non-array) hub response.
+
+		$metric = $this->make_direct_donation_metric( $proxy, $this->donors_with_conversions( 5 ), true );
+
+		$rate = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $rate['state'], 'malformed impressions errors, not a fabricated 0%' );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $rate['error_code'] );
+	}
+
+	/**
 	 * Non-WC publisher: empty state (not a fake 0%); the order-meta numerator is
 	 * never queried.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -123,13 +123,14 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'tab_pending', $data );
 		$this->assertArrayHasKey( 'tab_error', $data );
 		// NPPD-1745: tab_error is scoped to hub-backed metrics. The test env has an
-		// unconfigured proxy (every hub metric errors) AND no WooCommerce, so the two
-		// migrated donation cards return a NON-error empty state (revenue: local;
-		// rate: hybrid, short-circuited on non-WC). A hub-backed card
-		// (donation_conversion_direct) is therefore not in 'error', so the window is
-		// not "all hub-backed errored" → no banner. The banner-fires-on-hub-outage
-		// path is pinned directly in test_tab_error_* below.
-		$this->assertFalse( $data['tab_error'] );
+		// unconfigured proxy (every hub metric errors) AND no WooCommerce. The two
+		// migrated donation cards still render a NON-error empty state (revenue: local;
+		// rate: hybrid, short-circuited on non-WC) — but a non-WC hybrid card never
+		// reaches the hub, so it is NOT a hub-backed survivor and must not mask the
+		// outage. Every genuinely hub-backed (pure-hub) card errored, so the banner
+		// fires. Before the banner-hole fix this asserted false — that was asserting
+		// the bug, where the empty hybrid card silently suppressed the banner.
+		$this->assertTrue( $data['tab_error'] );
 		$this->assertArrayHasKey( 'current', $data );
 		$this->assertNull( $data['previous'] );
 		$this->assertSame( 'populated', $data['current']['donation_revenue_direct']['state'], 'local card is non-error' );
@@ -441,13 +442,14 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 	/**
 	 * Invoke the private static is_window_all_error() on a synthetic window.
 	 *
-	 * @param array $window Window payload.
+	 * @param array $window             Window payload.
+	 * @param bool  $woocommerce_active Whether WC is active (defaults to the WC-active path).
 	 * @return bool
 	 */
-	private function invoke_is_window_all_error( array $window ): bool {
+	private function invoke_is_window_all_error( array $window, bool $woocommerce_active = true ): bool {
 		$method = new \ReflectionMethod( Prompts_REST_Controller::class, 'is_window_all_error' );
 		$method->setAccessible( true );
-		return (bool) $method->invoke( null, $window );
+		return (bool) $method->invoke( null, $window, $woocommerce_active );
 	}
 
 	/**
@@ -495,5 +497,88 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 		$window['total_prompt_impressions'] = [ 'state' => 'populated' ]; // one hub card recovers.
 
 		$this->assertFalse( $this->invoke_is_window_all_error( $window ) );
+	}
+
+	/**
+	 * Build the non-WC hub-outage window: every pure-hub card errors, while the
+	 * hybrid cards short-circuit to a populated empty state (they never reach the
+	 * hub on a non-WC publisher) and the local cards render. The banner-hole case.
+	 *
+	 * @return array
+	 */
+	private function window_non_wc_hub_down(): array {
+		$window = [
+			'window' => [
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			],
+		];
+		foreach ( Prompts_Metric::METRIC_SOURCES as $key => $source ) {
+			// hub → error (outage); hybrid + local → populated (non-WC: a hybrid card
+			// empties out before it reaches the hub; local is always local).
+			$window[ $key ] = [ 'state' => 'hub' === $source ? 'error' : 'populated' ];
+		}
+		return $window;
+	}
+
+	/**
+	 * NPPD-1745 banner-hole fix: on a non-WC publisher a hybrid card short-circuits
+	 * to a populated empty state without ever calling the hub, so it must NOT count
+	 * as a hub-backed survivor. With every pure-hub card erroring, the banner fires
+	 * even though the hybrid + local cards render. (Pre-fix, the populated hybrid
+	 * card returned false here, silently suppressing the banner.)
+	 */
+	public function test_tab_error_fires_on_non_wc_hub_outage() {
+		$window = $this->window_non_wc_hub_down();
+
+		// Sanity: a hybrid card is genuinely populated (not error) in this window.
+		$this->assertSame( 'hybrid', Prompts_Metric::METRIC_SOURCES['donation_conversion_direct'] );
+		$this->assertSame( 'populated', $window['donation_conversion_direct']['state'] );
+
+		$this->assertTrue(
+			$this->invoke_is_window_all_error( $window, false ),
+			'non-WC: the hybrid card is skipped, so all-pure-hub-errored fires the banner'
+		);
+		// Guard: were WC active, the same populated hybrid card would be a genuine
+		// hub-backed survivor and (correctly) suppress the banner.
+		$this->assertFalse(
+			$this->invoke_is_window_all_error( $window, true ),
+			'WC-active: a populated hybrid card is a real survivor → no banner'
+		);
+	}
+
+	/**
+	 * NPPD-1745 #5 drift guard: every state-bearing metric that build_window()
+	 * emits must have a METRIC_SOURCES entry. is_window_all_error() iterates
+	 * METRIC_SOURCES, so a card added to the window but never classified in the map
+	 * would silently drop out of the tab-error banner with no test to catch it. The
+	 * cleaner long-term fix is to carry the source on the metric envelope itself
+	 * (tracked as a follow-up); this guard closes the silent-failure path now.
+	 */
+	public function test_every_window_metric_is_classified_in_metric_sources() {
+		$data = $this->dispatch(
+			[
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			]
+		)->get_data()['data'];
+
+		$missing = [];
+		foreach ( $data['current'] as $key => $value ) {
+			// Skip date metadata and non-metric scalar section-totals (int|null); only
+			// state-bearing metric envelopes participate in the banner decision.
+			if ( 'window' === $key || ! is_array( $value ) || ! isset( $value['state'] ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( $key, Prompts_Metric::METRIC_SOURCES ) ) {
+				$missing[] = $key;
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$missing,
+			'every state-bearing build_window metric must be classified in Prompts_Metric::METRIC_SOURCES'
+		);
 	}
 }


### PR DESCRIPTION
Follow-up fixes for the [#377](https://github.com/Automattic/newspack-workspace/pull/377) (NPPD-1745) code review. They were committed but missed #377's merge window, so they're split out here as a standalone PR to land independently of the subscription work (NPPD-1746).

### Fixed
- **1 — non-WC + hub-down tab-error banner hole.** On a non-WooCommerce publisher the `hybrid` donation rate card short-circuits to a populated empty state *before* reaching the hub, so during a full hub outage `is_window_all_error` saw a non-error hub-backed card and suppressed the "whole tab failed" banner — the exact gap `METRIC_SOURCES` was added to close, reopened for non-WC sites. It now skips `hybrid` cards when WooCommerce is inactive (threading `Prompts_Metric::woocommerce_active()`, made public). Flipped the controller test that asserted the bug; added a non-WC-outage test pinning both directions.
- **3 — malformed hub response swallowed as 0.** `fetch_donation_prompt_impressions` now returns `bigquery_proxy_malformed_rows` (mirroring the sibling table's `malformed_collection`) instead of a fabricated `0` denominator, so a hub fault errors the card and counts toward the banner. Added a test.
- **5 — `METRIC_SOURCES` drift guard.** Added a test asserting every state-bearing `build_window` key has a `METRIC_SOURCES` entry, so a future card can't silently drop out of the banner. (Moving the source onto the metric envelope is a tracked follow-up.)

### Docs only
- **6** — softened the "cannot diverge" docblock: the tab card and per-prompt rows share one formula + coherence guard, but their values legitimately differ (aggregate vs per-row inputs); what they can't do is drift to a different rule.
- **2** — documented the coherence guard's known limitation (order-meta numerator vs consent/adblock-undercounted hub impressions → rate fragile when impressions run low; follow-up for a more complete impressions source).

`insights` group green (370 tests). Original review items: [#377 review thread](https://github.com/Automattic/newspack-workspace/pull/377#issuecomment-4763791504).
