### PR TITLE
feat(insights): direct subscription + paywall conversion/revenue from order meta (NPPD-1746)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -277,7 +277,7 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	): array {
 		$current  = $this->build_window( $metric, $start, $end );
 		$response = [
-			'tab_error' => self::is_window_all_error( $current ),
+			'tab_error' => self::is_window_all_error( $current, $metric->woocommerce_active() ),
 			'current'   => $current,
 			'previous'  => null,
 		];
@@ -288,29 +288,49 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Whether every metric in a window payload reports `state: 'error'`.
+	 * Whether every HUB-BACKED metric in a window payload reports `state: 'error'`
+	 * — i.e. the whole tab failed to load (e.g. the BigQuery proxy is down).
 	 *
-	 * Returns `false` as soon as any metric is not in the error state (the `window`
-	 * key is date metadata, not a metric, so it's skipped). A metric missing a
-	 * `state` key is treated as non-error, so the banner only shows on an
-	 * unambiguous all-failed window.
+	 * Scoped to hub-backed metrics via {@see Gates_Metric::METRIC_SOURCES} (NPPD-1746):
+	 * `local` cards (paywall revenue-direct, sourced from Woo order meta) keep
+	 * rendering during a hub outage, so including them would silently suppress the
+	 * banner even when every hub query failed. `hybrid` cards count as hub-backed (a
+	 * hub denominator failure makes them error). Returns `false` as soon as any
+	 * hub-backed metric is not in the error state, and `false` for a window that
+	 * surfaced no hub-backed metric at all (nothing to declare "all failed").
 	 *
-	 * @param array $window The shape returned by `build_window()`.
+	 * NPPD-1745 #1 (banner hole on non-WC, mirrored from the Prompts tab): a `hybrid`
+	 * card short-circuits to a not-applicable empty state on a non-WooCommerce
+	 * publisher BEFORE it ever calls the hub — so a hub outage can't make it error,
+	 * and treating its surviving empty state as a healthy hub-backed card would mask
+	 * the outage. On a non-WC publisher, hybrid cards are therefore skipped (treated
+	 * like `local`); the genuinely hub-backed `hub` cards still drive the decision.
+	 *
+	 * @param array $window             The shape returned by `build_window()`.
+	 * @param bool  $woocommerce_active Whether WooCommerce is active for this publisher.
 	 * @return bool
 	 */
-	private static function is_window_all_error( array $window ): bool {
-		foreach ( $window as $key => $value ) {
-			// Skip the date metadata and the scalar section-total fields
-			// (`paywall_*_total`, NPPD-1694; `registration_impressions_total` /
-			// `registrations_total`, NPPD-1702 — int|null) — none is a metric.
-			if ( 'window' === $key || ! is_array( $value ) ) {
+	private static function is_window_all_error( array $window, bool $woocommerce_active ): bool {
+		$saw_hub_backed = false;
+		foreach ( Gates_Metric::METRIC_SOURCES as $key => $source ) {
+			if ( 'local' === $source ) {
 				continue;
 			}
-			if ( ! isset( $value['state'] ) || 'error' !== $value['state'] ) {
+			// On a non-WC publisher a hybrid card never reaches the hub (it empties out
+			// first), so it can't error on a hub outage — don't let its surviving empty
+			// state mask the outage.
+			if ( ! $woocommerce_active && 'hybrid' === $source ) {
+				continue;
+			}
+			if ( ! isset( $window[ $key ] ) || ! is_array( $window[ $key ] ) || ! isset( $window[ $key ]['state'] ) ) {
+				continue;
+			}
+			$saw_hub_backed = true;
+			if ( 'error' !== $window[ $key ]['state'] ) {
 				return false;
 			}
 		}
-		return true;
+		return $saw_hub_backed;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -24,6 +24,7 @@ defined( 'ABSPATH' ) || exit;
 use DateTimeInterface;
 use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
+use Newspack\Insights\Subscribers_Metric;
 use Newspack\Insights\Woo_Order_Resolver;
 
 /**
@@ -51,6 +52,38 @@ final class Gates_Metric {
 	const CACHE_PREFIX = 'newspack_insights_tab4_v1:';
 
 	/**
+	 * Data-source classification per metric key (NPPD-1746), the Gates-tab twin of
+	 * {@see Prompts_Metric::METRIC_SOURCES}:
+	 *
+	 *  - 'hub'    — fully hub-backed; errors when the proxy is down.
+	 *  - 'local'  — fully local (Woo order meta); survives a hub outage.
+	 *  - 'hybrid' — local numerator + hub denominator; a hub failure makes it
+	 *               genuinely uncomputable, so it counts as hub-backed for the banner.
+	 *
+	 * Read by {@see \Newspack\Insights\Gates_REST_Controller::is_window_all_error()}
+	 * so the "whole tab failed" banner fires when all hub-backed metrics error, even
+	 * though a surviving local card (paywall revenue, sourced from order meta) still
+	 * renders. Keys mirror {@see Gates_REST_Controller::build_window()}.
+	 *
+	 * @var array<string, string>
+	 */
+	public const METRIC_SOURCES = [
+		'total_gate_impressions'             => 'hub',
+		'unique_readers_reached'             => 'hub',
+		'avg_exposures_per_reader'           => 'hub',
+		'sessions_with_gate'                 => 'hub',
+		'regwall_conversion_direct'          => 'hub',
+		'regwall_conversion_influenced_7d'   => 'hub',
+		'paywall_conversion_direct'          => 'hybrid', // NPPD-1746: local order-meta (gate) numerator + hub per-gate-impressions denominator.
+		'paywall_conversion_influenced_14d'  => 'hub',
+		'total_paywall_revenue_direct'       => 'local',  // NPPD-1746: pure Woo order meta (gate surface); survives a hub outage.
+		'avg_revenue_per_paywall_conversion' => 'local',  // NPPD-1746: derived from the same order-meta source as total revenue.
+		'conversion_funnel'                  => 'hub',
+		'exposures_distribution'             => 'hub',
+		'performance_by_gate'                => 'hub',
+	];
+
+	/**
 	 * Proxy client used to dispatch catalog queries to the hub.
 	 *
 	 * @var BigQuery_Proxy_Client
@@ -65,29 +98,94 @@ final class Gates_Metric {
 	private Woo_Order_Resolver $woo_resolver;
 
 	/**
-	 * Per-request memoization for `fetch_paywall_direct_woo_join`.
+	 * Per-request memo for `gates_performance_by_gate` hub rows, keyed by `Ymd|Ymd`
+	 * window (NPPD-1746). The direct paywall-rate denominator
+	 * ({@see self::fetch_gate_impressions_by_gate()}) and the per-gate table
+	 * ({@see self::get_performance_by_gate()}) both read this query for the same
+	 * window in one request; memoizing avoids the duplicate hub round-trip (the same
+	 * fix NPPD-1745 applied to the prompts performance query).
 	 *
-	 * Keyed by `Ymd|Ymd` of the (start, end) UTC dates. The two revenue methods
-	 * (`get_total_paywall_revenue_direct` and `get_avg_revenue_per_paywall_conversion`)
-	 * both source from `gates_paywall_revenue_direct`; this cache avoids issuing
-	 * two identical HTTP round-trips to the hub for the same window.
-	 *
-	 * @var array<string, array{rows:array, conversions:int, revenue:float}|\WP_Error>
+	 * @var array<string, array|\WP_Error>
 	 */
-	private array $paywall_direct_cache = [];
+	private array $performance_by_gate_cache = [];
+
+	/**
+	 * Subscribers_Metric collaborator (NPPD-1746). Owns the WC-native subscription
+	 * storage used to source the DIRECT paywall conversion + revenue metrics (gate
+	 * surface) from order meta instead of the GA4 attempt → Woo_Order_Resolver join.
+	 * Lazily built on first direct-paywall call ({@see self::subscribers_metric()}).
+	 * Influenced (14d) paywall metrics still use the resolver.
+	 *
+	 * @var Subscribers_Metric|null
+	 */
+	private ?Subscribers_Metric $subscribers_metric;
 
 	/**
 	 * Constructor. Optionally inject collaborators (used in tests).
 	 *
-	 * @param BigQuery_Proxy_Client|null $proxy        Injected proxy client, or null to lazy-resolve.
-	 * @param Woo_Order_Resolver|null    $woo_resolver Injected Woo resolver, or null to lazy-create.
+	 * @param BigQuery_Proxy_Client|null $proxy              Injected proxy client, or null to lazy-resolve.
+	 * @param Woo_Order_Resolver|null    $woo_resolver       Injected Woo resolver, or null to lazy-create.
+	 * @param Subscribers_Metric|null    $subscribers_metric Injected subscribers collaborator (NPPD-1746), or null to lazy-create.
 	 */
 	public function __construct(
 		?BigQuery_Proxy_Client $proxy = null,
-		?Woo_Order_Resolver $woo_resolver = null
+		?Woo_Order_Resolver $woo_resolver = null,
+		?Subscribers_Metric $subscribers_metric = null
 	) {
-		$this->proxy        = $proxy ?? new BigQuery_Proxy_Client();
-		$this->woo_resolver = $woo_resolver ?? new Woo_Order_Resolver();
+		$this->proxy              = $proxy ?? new BigQuery_Proxy_Client();
+		$this->woo_resolver       = $woo_resolver ?? new Woo_Order_Resolver();
+		$this->subscribers_metric = $subscribers_metric;
+	}
+
+	/**
+	 * Lazily resolve the Subscribers_Metric collaborator (NPPD-1746).
+	 *
+	 * @return Subscribers_Metric
+	 */
+	private function subscribers_metric(): Subscribers_Metric {
+		if ( null === $this->subscribers_metric ) {
+			$this->subscribers_metric = new Subscribers_Metric();
+		}
+		return $this->subscribers_metric;
+	}
+
+	/**
+	 * Whether WooCommerce is active. The direct paywall conversion/revenue metrics
+	 * read local Woo orders (NPPD-1746), so they no-op to an empty state on non-WC
+	 * publishers. Filterable so tests can exercise both paths without toggling a
+	 * global class (the class is `final`, so it can't be doubled). Mirrors
+	 * {@see Prompts_Metric::woocommerce_active()}. Public because the REST controller
+	 * reads it to scope the tab-error banner (a non-WC hybrid card short-circuits
+	 * before reaching the hub, so it must not count as a hub-backed survivor).
+	 *
+	 * @return bool
+	 */
+	public function woocommerce_active(): bool {
+		/** This filter is documented in includes/wizards/insights/metrics/class-prompts-metric.php */
+		return (bool) apply_filters( 'newspack_insights_woocommerce_active', class_exists( 'WooCommerce' ) );
+	}
+
+	/**
+	 * Coherence-guarded conversion-rate value (NPPD-1746), the gate-surface twin of
+	 * {@see Prompts_Metric::rate_value()}. Numerator is an order-meta (local,
+	 * anonymous-inclusive) conversion count; denominator is the anonymous-inclusive
+	 * hub impressions of the SAME gates. Returns a float (a genuine 0.0 when there
+	 * are impressions but no conversions) or null when not computable: no impressions
+	 * (em-dash), or conversions > impressions (a cross-surface incoherence that must
+	 * not render as a >100% rate).
+	 *
+	 * @param int $conversions Gate-attributed subscription conversions (order meta).
+	 * @param int $impressions Matched-population gate impressions (hub).
+	 * @return float|null
+	 */
+	private function rate_value( int $conversions, int $impressions ): ?float {
+		if ( $impressions <= 0 ) {
+			return null;
+		}
+		if ( $conversions > $impressions ) {
+			return null;
+		}
+		return (float) $conversions / $impressions;
 	}
 
 	/**
@@ -353,48 +451,74 @@ final class Gates_Metric {
 		return $this->populated_scalar( $denominator > 0 ? $numerator / $denominator : 0.0, true, $denominator, 'rate', $numerator );
 	}
 
+
 	/**
-	 * Fetch paywall direct rows and return matched-order count + summed revenue.
-	 *
-	 * Used by both `get_total_paywall_revenue_direct` and
-	 * `get_avg_revenue_per_paywall_conversion` (derived).
+	 * Fetch (memoized per window) the `gates_performance_by_gate` hub rows, so the
+	 * direct paywall-rate denominator and the per-gate table share one round-trip
+	 * per request (NPPD-1746).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array{rows:array, conversions:int, revenue:float}|\WP_Error WP_Error on proxy failure.
+	 * @return array|\WP_Error Rows, or the proxy error.
 	 */
-	private function fetch_paywall_direct_woo_join(
-		DateTimeInterface $start,
-		DateTimeInterface $end
-	) {
-		// Normalize both bounds to UTC Ymd so callers passing different timezone
-		// objects don't bust the cache for the same logical window. Matches the
-		// proxy client's own UTC normalization.
-		$utc       = new \DateTimeZone( 'UTC' );
+	private function fetch_performance_by_gate_rows( DateTimeInterface $start, DateTimeInterface $end ) {
+		$utc       = new DateTimeZone( 'UTC' );
 		$cache_key = \DateTimeImmutable::createFromInterface( $start )->setTimezone( $utc )->format( 'Ymd' )
 			. '|'
 			. \DateTimeImmutable::createFromInterface( $end )->setTimezone( $utc )->format( 'Ymd' );
-
-		if ( array_key_exists( $cache_key, $this->paywall_direct_cache ) ) {
-			return $this->paywall_direct_cache[ $cache_key ];
+		if ( ! array_key_exists( $cache_key, $this->performance_by_gate_cache ) ) {
+			$this->performance_by_gate_cache[ $cache_key ] = $this->proxy->query( 'gates_performance_by_gate', $start, $end );
 		}
+		return $this->performance_by_gate_cache[ $cache_key ];
+	}
 
-		$rows = $this->proxy->query( 'gates_paywall_revenue_direct', $start, $end );
+	/**
+	 * Per-gate impressions map from the hub's `gates_performance_by_gate` rows
+	 * (NPPD-1746), keyed by gate_post_id (string). Used as the per-gate-keyed
+	 * denominator source for the direct paywall rate: the rate restricts its
+	 * denominator to the impressions of the gates that actually converted (see
+	 * {@see self::get_paywall_conversion_direct()}).
+	 *
+	 * NOTE (denominator precision): the hub query computes `checkout_impressions`
+	 * (impressions on gates carrying a checkout button — the paywall-capable subset)
+	 * but does NOT expose it as an output column; it is consumed only inside the
+	 * hub's `paywall_attempt_rate`. The exposed per-gate `impressions` IS true gate
+	 * impressions (anonymous-inclusive `np_gate_interaction(seen)` count) and equals
+	 * `checkout_impressions` exactly for a pure paywall gate; the two diverge only
+	 * for a gate that sometimes shows a checkout button and sometimes doesn't (where
+	 * `impressions` runs slightly larger → the rate reads slightly lower, i.e.
+	 * conservative). Until the hub follow-up NPPD-1749 exposes `checkout_impressions`
+	 * as an output column, `impressions` is the precise available denominator; the
+	 * swap is then one line here. Anonymous-inclusive either way, so no anonymous-at-
+	 * attempt bias is reintroduced.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string, int>|\WP_Error gate_post_id => impressions, or the proxy error.
+	 */
+	private function fetch_gate_impressions_by_gate( DateTimeInterface $start, DateTimeInterface $end ) {
+		$rows = $this->fetch_performance_by_gate_rows( $start, $end );
 		if ( is_wp_error( $rows ) ) {
-			$this->paywall_direct_cache[ $cache_key ] = $rows;
 			return $rows;
 		}
-
-		// A successful but empty response is real "no conversions", not an error:
-		// zero conversions / zero revenue, which the callers render as $0.00.
-		$rows   = is_array( $rows ) ? $rows : [];
-		$result = [
-			'rows'        => $rows,
-			'conversions' => $this->woo_resolver->count_completed_orders( $rows ),
-			'revenue'     => $this->woo_resolver->sum_completed_revenue( $rows ),
-		];
-		$this->paywall_direct_cache[ $cache_key ] = $result;
-		return $result;
+		if ( ! is_array( $rows ) ) {
+			// Malformed hub response (not an array of rows): surface it so the paywall
+			// rate errors instead of silently dividing by a fabricated 0 denominator
+			// (NPPD-1745 #3, mirrored proactively to the paywall rate).
+			return new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) );
+		}
+		$map = [];
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$gate_id = (string) ( $row['gate_post_id'] ?? '' );
+			if ( '' === $gate_id || '0' === $gate_id ) {
+				continue;
+			}
+			$map[ $gate_id ] = (int) ( $row['impressions'] ?? 0 );
+		}
+		return $map;
 	}
 
 	// --- Section 1: Gate exposure ---------------------------------------
@@ -477,7 +601,39 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_paywall_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_paywall_rate_from_proxy( 'gates_paywall_conversion_direct', $start, $end );
+		// NPPD-1746: rate = gate-attributed subscription conversions (Woo order meta,
+		// anonymous-inclusive) ÷ impressions of the SAME gates (hub,
+		// `gates_performance_by_gate`). PER-GATE keyed: the denominator is restricted
+		// to the gates that actually converted, keeping numerator and denominator on
+		// the same population. Numerator local, denominator hub → 'hybrid' (see the
+		// Gates controller METRIC_SOURCES): a hub impressions failure makes the rate
+		// genuinely uncomputable and counts toward the tab-error banner. Same
+		// coherence guard as the prompts subscription/donation rate-direct. Replaces
+		// the prior attempt-row denominator (`gates_paywall_conversion_direct`), which
+		// undercounted via the GA4 cookie → customer_id join.
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no local conversions to count. Empty state, not a fake
+			// 0% (NPPD-1737 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'rate', 0 );
+		}
+
+		$impressions_by_gate = $this->fetch_gate_impressions_by_gate( $start, $end );
+		if ( is_wp_error( $impressions_by_gate ) ) {
+			return $this->error_scalar( 'rate', $impressions_by_gate );
+		}
+
+		$by_gate     = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_gate'];
+		$conversions = 0;
+		$impressions = 0;
+		foreach ( $by_gate as $gate_id => $row ) {
+			$conversions += (int) $row['conversions'];
+			$impressions += (int) ( $impressions_by_gate[ (string) $gate_id ] ?? 0 );
+		}
+
+		$rate = $this->rate_value( $conversions, $impressions );
+		return null === $rate
+			? $this->populated_scalar( 0.0, false, $impressions, 'rate', $conversions )
+			: $this->populated_scalar( $rate, true, $impressions, 'rate', $conversions );
 	}
 
 	/**
@@ -499,11 +655,40 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_total_paywall_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paywall_direct_woo_join( $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_scalar( 'currency', $joined );
+		// NPPD-1746: source DIRECT paywall revenue from order meta (gate surface —
+		// `_gate_post_id` on initial subscription orders) instead of the GA4 attempt
+		// → customer_id join. Mirrors the prompts subscription revenue-direct. Local /
+		// hub-resilient: the em-dash is conversions-based ("no gate-attributed
+		// subscriptions"), not impressions-based — revenue does not fetch impressions
+		// by design, so its em-dash semantics differ on purpose from the sibling
+		// (hybrid) rate card.
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no orders to read. Empty state, not a real $0.
+			return $this->populated_scalar( 0.0, false, 0, 'currency' );
 		}
-		return $this->populated_scalar( $joined['revenue'], true, $joined['conversions'], 'currency' );
+		[ $conversions, $revenue ] = $this->sum_gate_attributed_subscriptions( $start, $end );
+		return $this->populated_scalar( $revenue, $conversions > 0, $conversions, 'currency' );
+	}
+
+	/**
+	 * Sum gate-attributed subscription conversions + revenue (order meta) for the
+	 * window — the shared local numerator behind both paywall revenue-direct cards
+	 * (NPPD-1746), so total revenue and average-per-conversion read one source and
+	 * reconcile (total = avg × conversions).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{0:int, 1:float} [ conversions, revenue ].
+	 */
+	private function sum_gate_attributed_subscriptions( DateTimeInterface $start, DateTimeInterface $end ): array {
+		$by_gate     = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_gate'];
+		$conversions = 0;
+		$revenue     = 0.0;
+		foreach ( $by_gate as $row ) {
+			$conversions += (int) $row['conversions'];
+			$revenue     += (float) $row['revenue'];
+		}
+		return [ $conversions, $revenue ];
 	}
 
 	/**
@@ -514,14 +699,16 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_avg_revenue_per_paywall_conversion( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paywall_direct_woo_join( $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_scalar( 'currency', $joined );
+		// NPPD-1746: derived from the SAME order-meta source as
+		// get_total_paywall_revenue_direct() so the two reconcile (total = avg ×
+		// conversions). On a non-WC publisher there are no orders → empty state.
+		if ( ! $this->woocommerce_active() ) {
+			return $this->populated_scalar( 0.0, false, 0, 'currency' );
 		}
-		$conversions = $joined['conversions'];
+		[ $conversions, $revenue ] = $this->sum_gate_attributed_subscriptions( $start, $end );
 		// No conversions → a real $0.00 average, flagged non-computable.
 		return $this->populated_scalar(
-			$conversions > 0 ? $joined['revenue'] / $conversions : 0.0,
+			$conversions > 0 ? $revenue / $conversions : 0.0,
 			$conversions > 0,
 			$conversions,
 			'currency'
@@ -728,7 +915,7 @@ final class Gates_Metric {
 	 * @return array{state: string, rows: array, error_code?: string, error_message?: string}
 	 */
 	public function get_performance_by_gate( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$rows = $this->proxy->query( 'gates_performance_by_gate', $start, $end );
+		$rows = $this->fetch_performance_by_gate_rows( $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_collection( 'rows', $rows );
 		}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -39,6 +39,7 @@ defined( 'ABSPATH' ) || exit;
 use DateTimeInterface;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Donors_Metric;
+use Newspack\Insights\Subscribers_Metric;
 use Newspack\Insights\Woo_Order_Resolver;
 
 /**
@@ -168,11 +169,11 @@ final class Prompts_Metric {
 		'newsletter_signup_conversion_influenced_7d' => 'hub',
 		'donation_conversion_direct'                 => 'hybrid', // Local order-meta numerator + hub donation-impressions denominator.
 		'donation_conversion_influenced_14d'         => 'hub',
-		'subscription_conversion_direct'             => 'hub',     // NPPD-1745 follow-up ticket migrates this.
+		'subscription_conversion_direct'             => 'hybrid', // NPPD-1746: local order-meta (popup) numerator + hub per-popup-impressions denominator.
 		'subscription_conversion_influenced_14d'     => 'hub',
 		'donation_revenue_direct'                    => 'local',   // Pure Woo order meta; survives a hub outage.
 		'donation_revenue_influenced_14d'            => 'hub',
-		'subscription_revenue_direct'                => 'hub',     // NPPD-1745 follow-up ticket migrates this.
+		'subscription_revenue_direct'                => 'local',   // NPPD-1746: pure Woo order meta (popup surface); survives a hub outage.
 		'subscription_revenue_influenced_14d'        => 'hub',
 		'conversion_funnel'                          => 'hub',
 		'exposures_distribution'                     => 'hub',
@@ -207,6 +208,19 @@ final class Prompts_Metric {
 	 * @var Donors_Metric|null
 	 */
 	private ?Donors_Metric $donors_metric;
+
+	/**
+	 * Subscribers_Metric collaborator (NPPD-1746). Owns the WC-native subscription
+	 * storage + caching used to source the DIRECT prompt-subscription metrics
+	 * (popup surface) from order meta instead of the GA4 attempt → Woo_Order_Resolver
+	 * join — the subscription counterpart to {@see self::$donors_metric}. Lazily
+	 * built on first direct-subscription call ({@see self::subscribers_metric()}).
+	 * Influenced (14d) subscription metrics still use the resolver and do NOT use
+	 * this collaborator.
+	 *
+	 * @var Subscribers_Metric|null
+	 */
+	private ?Subscribers_Metric $subscribers_metric;
 
 	/**
 	 * Per-request memoization for paid-conversion BQ row fetches.
@@ -258,17 +272,20 @@ final class Prompts_Metric {
 	 * @param callable|null              $prompt_provider Injected active-prompt provider (test seam),
 	 *                                                    or null to read published prompt content via get_posts().
 	 * @param Donors_Metric|null         $donors_metric   Injected donors collaborator (NPPD-1685), or null to lazy-create.
+	 * @param Subscribers_Metric|null    $subscribers_metric Injected subscribers collaborator (NPPD-1746), or null to lazy-create.
 	 */
 	public function __construct(
 		?BigQuery_Proxy_Client $proxy = null,
 		?Woo_Order_Resolver $woo_resolver = null,
 		?callable $prompt_provider = null,
-		?Donors_Metric $donors_metric = null
+		?Donors_Metric $donors_metric = null,
+		?Subscribers_Metric $subscribers_metric = null
 	) {
-		$this->proxy           = $proxy ?? new BigQuery_Proxy_Client();
-		$this->woo_resolver    = $woo_resolver ?? new Woo_Order_Resolver();
-		$this->prompt_provider = $prompt_provider;
-		$this->donors_metric   = $donors_metric;
+		$this->proxy              = $proxy ?? new BigQuery_Proxy_Client();
+		$this->woo_resolver       = $woo_resolver ?? new Woo_Order_Resolver();
+		$this->prompt_provider    = $prompt_provider;
+		$this->donors_metric      = $donors_metric;
+		$this->subscribers_metric = $subscribers_metric;
 	}
 
 	/**
@@ -283,6 +300,20 @@ final class Prompts_Metric {
 			$this->donors_metric = new Donors_Metric();
 		}
 		return $this->donors_metric;
+	}
+
+	/**
+	 * Lazily resolve the Subscribers_Metric collaborator (NPPD-1746). Built on first
+	 * use so requests that never hit a direct-subscription card don't pay for the
+	 * storage detector + donation-product classifier.
+	 *
+	 * @return Subscribers_Metric
+	 */
+	private function subscribers_metric(): Subscribers_Metric {
+		if ( null === $this->subscribers_metric ) {
+			$this->subscribers_metric = new Subscribers_Metric();
+		}
+		return $this->subscribers_metric;
 	}
 
 	/**
@@ -626,45 +657,6 @@ final class Prompts_Metric {
 		return $result;
 	}
 
-	/**
-	 * Compute per-popup Woo-completed counts for an intent's attempt rows.
-	 *
-	 * Fetches the intent's BQ attempt rows (cached via fetch_paid_attempts_woo_join),
-	 * groups them by popup_id, and returns a map<popup_id, completed_count>.
-	 * Returns an empty map on proxy failure so the per-prompt breakdown still
-	 * renders the engagement columns even if the Woo-join augmentation fails —
-	 * the engagement data is the load-bearing part of the table; the Woo
-	 * augmentation is a bonus.
-	 *
-	 * @param string            $query_name Catalog `query_name` (e.g. 'prompts_donation_conversion_direct').
-	 * @param DateTimeInterface $start      Window start.
-	 * @param DateTimeInterface $end        Window end.
-	 * @return array<int, int> popup_id => completed_count
-	 */
-	private function fetch_per_popup_woo_counts(
-		string $query_name,
-		DateTimeInterface $start,
-		DateTimeInterface $end
-	): array {
-		$joined = $this->fetch_paid_attempts_woo_join( $query_name, $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return []; // Graceful degradation: render zeros, not error the whole table.
-		}
-		$by_popup = [];
-		foreach ( $joined['rows'] as $row ) {
-			$popup_id = (int) ( $row['popup_id'] ?? 0 );
-			if ( $popup_id <= 0 ) {
-				continue;
-			}
-			$by_popup[ $popup_id ][] = $row;
-		}
-		$counts = [];
-		foreach ( $by_popup as $popup_id => $rows_for_popup ) {
-			$counts[ $popup_id ] = $this->woo_resolver->count_completed_orders( $rows_for_popup );
-		}
-		return $counts;
-	}
-
 	// --- Section 1: Prompt exposure -------------------------------------
 
 	/**
@@ -849,42 +841,44 @@ final class Prompts_Metric {
 		// donation_conversion_rate, so the two rates can't diverge). null = not
 		// computable (no impressions, or the >100% cross-surface case); a float
 		// (incl. a genuine 0.0) = a real rate.
-		$rate = $this->donation_rate_value( $conversions, $impressions );
+		$rate = $this->rate_value( $conversions, $impressions );
 		return null === $rate
 			? $this->populated_scalar( 0.0, false, $impressions, 'rate' )
 			: $this->populated_scalar( $rate, true, $impressions, 'rate' );
 	}
 
 	/**
-	 * The direct donation conversion-rate value (NPPD-1745). The tab-level card
-	 * ({@see self::get_donation_conversion_direct()}) and the per-prompt table
-	 * ({@see self::get_performance_by_prompt()}) both route through this one helper,
-	 * so they share the same formula, coherence guard, and em-dash semantics. Their
-	 * VALUES still differ by design — the tab card divides window-aggregate
-	 * conversions by aggregate impressions, while each table row uses that prompt's
-	 * own counts — but neither can drift to a different rule (e.g. one rendering a
-	 * >100% rate the other suppresses), which is the divergence that matters.
+	 * Coherence-guarded conversion-rate value, shared by the direct donation rate
+	 * (NPPD-1745) and the direct subscription rate (NPPD-1746) so a tab-level card
+	 * and its per-prompt table row route through one helper. The numerator is always
+	 * an order-meta (local, anonymous-inclusive) conversion count and the denominator
+	 * an anonymous-inclusive hub impressions count for the SAME population (the
+	 * donation-intent prompts, or — per-popup keyed for subscriptions — the popups
+	 * that converted). The tab card and its per-row table value still differ by design
+	 * (aggregate vs per-prompt inputs), but neither can drift to a different RULE —
+	 * e.g. one rendering a >100% rate the other suppresses — which is the divergence
+	 * that matters.
 	 *
 	 * Returns the rate as a float — a genuine 0.0 when there are impressions but no
 	 * conversions ("viewed but no conversion") — or null when not computable:
 	 *  - no impressions → no denominator (em-dash); or
 	 *  - conversions > impressions → a cross-surface incoherence (order-meta
-	 *    numerator vs GA4 impressions) that must not render as a >100% rate.
+	 *    numerator vs hub impressions) that must not render as a >100% rate.
 	 *
-	 * KNOWN LIMITATION (NPPD-1745 #2): the numerator is complete + server-side, but
-	 * the GA4 impressions denominator is consent/adblock-undercounted — different
+	 * KNOWN LIMITATION (NPPD-1745 #2): the numerator is complete + server-side, but the
+	 * hub impressions denominator is consent/adblock-undercounted — different
 	 * populations, so the denominator can legitimately be the smaller of the two. The
 	 * guard then nulls the rate to an em-dash, which is the honest render (a fabricated
 	 * >100% would be worse), but it means the headline rate is fragile by construction
 	 * when impressions run low. Same denominator-fidelity issue as the gate
 	 * `checkout_impressions` case; a more complete impressions source is a tracked
-	 * follow-up, out of scope for this PR.
+	 * follow-up.
 	 *
-	 * @param int $conversions Prompt-attributed donation conversions (order meta).
-	 * @param int $impressions Donation-intent prompt impressions (hub).
+	 * @param int $conversions Prompt-attributed conversions (order meta).
+	 * @param int $impressions Matched-population prompt impressions (hub).
 	 * @return float|null
 	 */
-	private function donation_rate_value( int $conversions, int $impressions ): ?float {
+	private function rate_value( int $conversions, int $impressions ): ?float {
 		if ( $impressions <= 0 ) {
 			return null;
 		}
@@ -925,6 +919,45 @@ final class Prompts_Metric {
 			}
 		}
 		return $impressions;
+	}
+
+	/**
+	 * Per-popup impressions map from the hub's `prompts_performance_by_prompt` rows
+	 * (NPPD-1746), keyed by popup id (string). Used as the per-popup-keyed
+	 * denominator source for the direct subscription rate: subscription-intent
+	 * popups share `action_type=registration` with pure-registration popups, so the
+	 * subscription rate restricts its denominator to the impressions of the SAME
+	 * popups that converted (see {@see self::get_subscription_conversion_direct()})
+	 * rather than summing a tab-level intent bucket. Impressions are anonymous-
+	 * inclusive `np_prompt_interaction(seen)` counts.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string, int>|\WP_Error popup_id => impressions, or the proxy error.
+	 */
+	private function fetch_prompt_impressions_by_popup( DateTimeInterface $start, DateTimeInterface $end ) {
+		$rows = $this->fetch_performance_by_prompt_rows( $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		if ( ! is_array( $rows ) ) {
+			// Malformed hub response (not an array of rows): surface it so the
+			// subscription rate errors instead of silently dividing by a fabricated 0
+			// denominator (NPPD-1745 #3, mirrored proactively to the subscription rate).
+			return new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) );
+		}
+		$map = [];
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$popup_id = (string) ( $row['popup_id'] ?? '' );
+			if ( '' === $popup_id || '0' === $popup_id ) {
+				continue;
+			}
+			$map[ $popup_id ] = (int) ( $row['impressions'] ?? 0 );
+		}
+		return $map;
 	}
 
 	/**
@@ -977,18 +1010,40 @@ final class Prompts_Metric {
 	 * @return array
 	 */
 	public function get_subscription_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_direct', $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_scalar( 'rate', $joined );
+		// NPPD-1746: rate = popup-attributed subscription conversions (Woo order meta,
+		// anonymous-inclusive) ÷ impressions of the SAME popups (hub,
+		// `prompts_performance_by_prompt`). PER-POPUP keyed, not tab-level:
+		// subscription-intent popups share `action_type=registration` with pure
+		// registration popups, so a tab-level denominator would mix in registration-
+		// only impressions and break numerator/denominator population matching (the
+		// spike's >100% incoherence class). Restricting the denominator to the popups
+		// that actually converted keeps both sides describing the same population.
+		// Numerator local, denominator hub → 'hybrid' (see METRIC_SOURCES): a hub
+		// impressions failure makes the rate genuinely uncomputable and counts toward
+		// the tab-error banner. Same coherence guard as the donation rate-direct.
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no local conversions to count. Empty state, not a fake
+			// 0% (NPPD-1737 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'rate' );
 		}
-		$denominator = count( $joined['rows'] );
-		$numerator   = $joined['conversions'];
-		return $this->populated_scalar(
-			$denominator > 0 ? $numerator / $denominator : 0.0,
-			$denominator > 0,
-			$denominator,
-			'rate'
-		);
+
+		$impressions_by_popup = $this->fetch_prompt_impressions_by_popup( $start, $end );
+		if ( is_wp_error( $impressions_by_popup ) ) {
+			return $this->error_scalar( 'rate', $impressions_by_popup );
+		}
+
+		$by_popup    = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_popup'];
+		$conversions = 0;
+		$impressions = 0;
+		foreach ( $by_popup as $popup_id => $row ) {
+			$conversions += (int) $row['conversions'];
+			$impressions += (int) ( $impressions_by_popup[ (string) $popup_id ] ?? 0 );
+		}
+
+		$rate = $this->rate_value( $conversions, $impressions );
+		return null === $rate
+			? $this->populated_scalar( 0.0, false, $impressions, 'rate' )
+			: $this->populated_scalar( $rate, true, $impressions, 'rate' );
 	}
 
 	/**
@@ -1087,15 +1142,32 @@ final class Prompts_Metric {
 	 * @return array
 	 */
 	public function get_subscription_revenue_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_direct', $start, $end );
-		if ( is_wp_error( $joined ) ) {
-			return $this->error_scalar( 'currency', $joined );
+		// NPPD-1746: source DIRECT subscription revenue from order meta (popup
+		// surface — `_newspack_popup_id` on initial subscription orders) instead of
+		// the GA4 attempt → customer_id join, which silently dropped anonymous-at-
+		// attempt subscribers. Mirrors donation revenue-direct (NPPD-1685/1745).
+		// Influenced (14d) revenue still uses the join — see
+		// get_subscription_revenue_influenced_14d().
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no orders to read. Empty state, not a real $0
+			// (NPPD-1737 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'currency' );
 		}
-		// Computable only when at least one paid-intent prompt was viewed (mirrors
-		// the matching conversion-rate method's `count( rows ) > 0` gate). An empty
-		// window is "no in-intent prompts viewed", not a real $0 — so it renders the
-		// not-computable em-dash, consistent with its sibling rate card (NPPD-1704).
-		return $this->populated_scalar( $joined['revenue'], count( $joined['rows'] ) > 0, $joined['conversions'], 'currency' );
+
+		$by_popup    = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_popup'];
+		$revenue     = 0.0;
+		$conversions = 0;
+		foreach ( $by_popup as $row ) {
+			$revenue     += (float) $row['revenue'];
+			$conversions += (int) $row['conversions'];
+		}
+
+		// Local / hub-resilient, like donation revenue-direct: the em-dash is
+		// conversions-based ("no popup-attributed subscriptions"), NOT impressions-
+		// based — revenue does not fetch impressions by design, so its em-dash
+		// semantics differ on purpose from the sibling (hybrid) rate card. Do not
+		// "fix" this to match the rate card without making revenue hub-dependent.
+		return $this->populated_scalar( $revenue, $conversions > 0, $conversions, 'currency' );
 	}
 
 	/**
@@ -1279,16 +1351,15 @@ final class Prompts_Metric {
 			];
 		}
 
-		// Per-popup conversion augmentation. Donations come from order meta
-		// (NPPD-1685/1745 — anonymous-inclusive, keyed by popup id, no GA4 join);
-		// subscriptions still use the Woo-resolver path until their own ticket
-		// migrates them. BOTH are gated on WooCommerce being active: the resolver
-		// path calls wc_get_orders(), so on a non-WC publisher the subscription
-		// fetch would fatal if the hub ever returned attempt rows. Both maps are
-		// empty on a non-WC publisher.
-		$wc                  = $this->woocommerce_active();
-		$donation_map        = $wc ? $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end ) : [];
-		$subscription_counts = $wc ? $this->fetch_per_popup_woo_counts( 'prompts_subscription_conversion_direct', $start, $end ) : [];
+		// Per-popup conversion augmentation. Both donations (NPPD-1685/1745) and
+		// subscriptions (NPPD-1746) now come from order meta — anonymous-inclusive,
+		// keyed by popup id, no GA4 join. Subscriptions read the popup surface of the
+		// two-key reader (`by_popup`); gate-attributed subscriptions live on the Gates
+		// tab, not here. Both are gated on WooCommerce being active (the storage
+		// readers hit local Woo tables), so both maps are empty on a non-WC publisher.
+		$wc               = $this->woocommerce_active();
+		$donation_map     = $wc ? $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end ) : [];
+		$subscription_map = $wc ? $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_popup'] : [];
 
 		$mapped = [];
 		foreach ( $rows as $row ) {
@@ -1303,15 +1374,15 @@ final class Prompts_Metric {
 			$impressions = (int) ( $row['impressions'] ?? 0 );
 
 			$donation_conversions = 'donation' === $intent ? (int) ( $donation_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
-			// Subscription-intent prompts share `action_type=registration` at
-			// the data layer; the Woo product-type filter on the hub-side
-			// subscription query already scopes attempts correctly.
-			$subscription_conversions = 'registration' === $intent ? (int) ( $subscription_counts[ $popup_id ] ?? 0 ) : 0;
+			// Subscription-intent prompts share `action_type=registration` at the data
+			// layer; subscription conversions are now sourced per-popup from order meta
+			// (NPPD-1746), keyed by popup id, anonymous-inclusive — no GA4 join.
+			$subscription_conversions = 'registration' === $intent ? (int) ( $subscription_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
 
-			// donation_conversion_rate shares the tab-level coherence guard + em-dash
-			// semantics via donation_rate_value() (null = not computable: no
-			// impressions or a >100% cross-surface ratio; a float incl. 0.0 = real
-			// rate). null also covers intent mismatch + non-WC (the column is N/A).
+			// Both rates share the tab-level coherence guard + em-dash semantics via
+			// rate_value() (null = not computable: no impressions or a >100% cross-
+			// surface ratio; a float incl. 0.0 = real rate). null also covers intent
+			// mismatch + non-WC (the column is N/A).
 			$mapped[] = [
 				'popup_id'                     => $popup_id,
 				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),
@@ -1325,9 +1396,9 @@ final class Prompts_Metric {
 				'registrations'                => (int) ( $row['registrations'] ?? 0 ),
 				'newsletter_signups'           => (int) ( $row['newsletter_signups'] ?? 0 ),
 				'donation_conversions'         => $donation_conversions,
-				'donation_conversion_rate'     => ( 'donation' === $intent && $wc ) ? $this->donation_rate_value( $donation_conversions, $impressions ) : null,
+				'donation_conversion_rate'     => ( 'donation' === $intent && $wc ) ? $this->rate_value( $donation_conversions, $impressions ) : null,
 				'subscription_conversions'     => $subscription_conversions,
-				'subscription_conversion_rate' => ( 'registration' === $intent && $wc && $impressions > 0 ) ? $subscription_conversions / $impressions : null,
+				'subscription_conversion_rate' => ( 'registration' === $intent && $wc ) ? $this->rate_value( $subscription_conversions, $impressions ) : null,
 			];
 		}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -477,6 +477,89 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Prompt/gate-attributed subscription conversions in a window, bucketed by
+	 * surface with gate precedence (NPPD-1746). Delegates the per-order read to the
+	 * storage backend, then folds the orders into two surface maps:
+	 *
+	 *   [ 'by_gate'  => [ gate_id  => { conversions, revenue } ],
+	 *     'by_popup' => [ popup_id => { conversions, revenue } ] ]
+	 *
+	 * The Gates tab consumes `by_gate`; the Prompts tab consumes `by_popup`. Each
+	 * order lands in exactly one surface (see the precedence note on
+	 * {@see bucket_attributed_subscription_orders()}), so the two per-surface rates
+	 * never double-count an order.
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array{by_gate: array<string, array{conversions:int, revenue:float}>, by_popup: array<string, array{conversions:int, revenue:float}>}
+	 */
+	public function get_attributed_subscription_conversions( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return (array) $this->cached(
+			'attributed_subscription_conversions',
+			$this->window_key( $start, $end ),
+			self::TTL_DEFAULT,
+			function () use ( $start, $end ) {
+				return self::bucket_attributed_subscription_orders(
+					$this->storage->get_attributed_subscription_orders( $start, $end )
+				);
+			}
+		);
+	}
+
+	/**
+	 * Fold per-order attributed-subscription rows into per-surface conversion +
+	 * revenue maps, applying gate precedence. Pure function (no storage, no cache),
+	 * exposed `static` so the precedence rule can be unit-tested directly.
+	 *
+	 * GATE PRECEDENCE (NPPD-1746): a subscription that passed through a paywall gate
+	 * is a gate conversion. An order carrying BOTH `_gate_post_id` and
+	 * `_newspack_popup_id` is bucketed to the gate ONLY — never both — so one order
+	 * is counted in exactly one surface and the gate-rate and popup-rate can never
+	 * double-count it. Zero dual-key orders were observed across both Phase-1
+	 * publishers measured, so this branch is dormant on today's data; it is
+	 * defined defensively because "never fires today" is exactly what silently
+	 * becomes a double-count once the write paths shift and the assumption is
+	 * forgotten. The one-id-per-order MIN() resolution in the storage reader and
+	 * this gate-over-popup rule together make the bucketing fully deterministic.
+	 *
+	 * @param array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}> $orders Per-order rows.
+	 * @return array{by_gate: array<string, array{conversions:int, revenue:float}>, by_popup: array<string, array{conversions:int, revenue:float}>}
+	 */
+	public static function bucket_attributed_subscription_orders( array $orders ): array {
+		$by_gate  = [];
+		$by_popup = [];
+		foreach ( $orders as $order ) {
+			$gate_id  = isset( $order['gate_id'] ) ? (string) $order['gate_id'] : '';
+			$popup_id = isset( $order['popup_id'] ) ? (string) $order['popup_id'] : '';
+			$total    = (float) ( $order['order_total'] ?? 0 );
+
+			if ( '' !== $gate_id ) {
+				if ( ! isset( $by_gate[ $gate_id ] ) ) {
+					$by_gate[ $gate_id ] = [
+						'conversions' => 0,
+						'revenue'     => 0.0,
+					];
+				}
+				++$by_gate[ $gate_id ]['conversions'];
+				$by_gate[ $gate_id ]['revenue'] += $total;
+			} elseif ( '' !== $popup_id ) {
+				if ( ! isset( $by_popup[ $popup_id ] ) ) {
+					$by_popup[ $popup_id ] = [
+						'conversions' => 0,
+						'revenue'     => 0.0,
+					];
+				}
+				++$by_popup[ $popup_id ]['conversions'];
+				$by_popup[ $popup_id ]['revenue'] += $total;
+			}
+		}
+		return [
+			'by_gate'  => $by_gate,
+			'by_popup' => $by_popup,
+		];
+	}
+
+	/**
 	 * Flush ALL Tab 6 metric caches. Use after a manual data correction
 	 * or from the future NPPD-1605 invalidation system; not wired to any
 	 * automatic trigger today because the WP transient API has no key

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1174,4 +1174,108 @@ class HPOS_Storage implements Storage_Interface {
 		}
 		return $map;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
+	 */
+	public function get_attributed_subscription_orders( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix        = $wpdb->prefix;
+		$donations     = $this->id_list( $this->donation_product_ids );
+		$subscriptions = $this->subscription_product_ids_sql();
+
+		// NPPD-1746: structurally mirrors the legacy reader — both `_gate_post_id`
+		// and `_newspack_popup_id` can be written more than once per order, so each
+		// is derived via correlated MIN() and matched with EXISTS (never a
+		// multiplying JOIN); `total_amount` is a column on the orders table (no meta
+		// multiplication). One row per attributed order; gate-precedence is applied
+		// in Subscribers_Metric. Initial orders only; renewals excluded via
+		// `_subscription_renewal`; scoped to non-donation subscription products.
+		//
+		// UNVERIFIED AGAINST LIVE HPOS DATA (NPPD-1746): both Phase-1 subscription
+		// publishers measured are legacy-storage, so this HPOS query has not
+		// executed against real HPOS subscription orders. It is mirrored from the
+		// legacy shape and exercised by the DDL integration test; confirm the count +
+		// revenue at first HPOS-publisher contact. Same posture as the NPPD-1685
+		// donation HPOS reader.
+		$sql = $wpdb->prepare(
+			"SELECT
+				ord.id AS order_id,
+				(
+					SELECT MIN(g.meta_value)
+					FROM {$prefix}wc_orders_meta g
+					WHERE g.order_id = ord.id AND g.meta_key = '_gate_post_id'
+					  AND g.meta_value NOT IN ('', '0')
+				) AS gate_id,
+				(
+					SELECT MIN(pop.meta_value)
+					FROM {$prefix}wc_orders_meta pop
+					WHERE pop.order_id = ord.id AND pop.meta_key = '_newspack_popup_id'
+					  AND pop.meta_value NOT IN ('', '0')
+				) AS popup_id,
+				ord.total_amount AS order_total
+			FROM {$prefix}wc_orders ord
+			WHERE ord.type = 'shop_order'
+			  AND ord.status IN ('wc-completed', 'wc-processing')
+			  AND ord.date_created_gmt BETWEEN %s AND %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM {$prefix}wc_orders_meta rn
+			      WHERE rn.order_id = ord.id AND rn.meta_key = '_subscription_renewal'
+			        AND rn.meta_value NOT IN ('', '0')
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+			      WHERE opl.order_id = ord.id
+			        AND opl.product_id IN ($subscriptions)
+			        AND opl.product_id NOT IN ($donations)
+			  )
+			  AND (
+			      EXISTS (
+			          SELECT 1 FROM {$prefix}wc_orders_meta g
+			          WHERE g.order_id = ord.id AND g.meta_key = '_gate_post_id'
+			            AND g.meta_value NOT IN ('', '0')
+			      )
+			      OR EXISTS (
+			          SELECT 1 FROM {$prefix}wc_orders_meta pop
+			          WHERE pop.order_id = ord.id AND pop.meta_key = '_newspack_popup_id'
+			            AND pop.meta_value NOT IN ('', '0')
+			      )
+			  )",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return $this->shape_attributed_subscription_rows( (array) $wpdb->get_results( $sql, ARRAY_A ) );
+	}
+
+	/**
+	 * Normalize raw attributed-subscription-order rows to the typed per-order shape.
+	 * A null gate/popup id (no such meta on the order) stays null so the orchestrator
+	 * can apply gate precedence; `order_total` is coerced to float. Shared row shape
+	 * with Legacy_Storage so both backends return identically-typed rows.
+	 *
+	 * @param array<int, array<string, mixed>> $rows Raw `$wpdb` rows.
+	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
+	 */
+	private function shape_attributed_subscription_rows( array $rows ): array {
+		$out = [];
+		foreach ( $rows as $row ) {
+			$gate_id  = isset( $row['gate_id'] ) && '' !== (string) $row['gate_id'] ? (string) $row['gate_id'] : null;
+			$popup_id = isset( $row['popup_id'] ) && '' !== (string) $row['popup_id'] ? (string) $row['popup_id'] : null;
+			if ( null === $gate_id && null === $popup_id ) {
+				continue;
+			}
+			$out[] = [
+				'order_id'    => (int) ( $row['order_id'] ?? 0 ),
+				'gate_id'     => $gate_id,
+				'popup_id'    => $popup_id,
+				'order_total' => (float) ( $row['order_total'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1108,4 +1108,109 @@ class Legacy_Storage implements Storage_Interface {
 		}
 		return $map;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
+	 */
+	public function get_attributed_subscription_orders( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix        = $wpdb->prefix;
+		$donations     = $this->id_list( $this->donation_product_ids );
+		$subscriptions = $this->subscription_product_ids_sql();
+
+		// NPPD-1746: two-key subscription attribution, the subscription counterpart
+		// to the NPPD-1685 donation reader. A subscription/paywall order can carry
+		// `_gate_post_id` (paywall gate) OR `_newspack_popup_id` (popup) — written
+		// through different code paths — OR neither (organic). Both meta keys can be
+		// written more than once per order, so JOINing either would multiply
+		// COUNT/SUM (the NPPD-1685 2x defect): instead derive exactly ONE gate id and
+		// ONE popup id per order via correlated MIN(), and match prompt/gate orders
+		// with EXISTS. One row per attributed order is returned; gate-vs-popup
+		// precedence is applied in Subscribers_Metric (gate wins). Scoped to INITIAL
+		// completed/processing orders containing a non-donation subscription product;
+		// renewals inherit the parent meta and are excluded via `_subscription_renewal`.
+		$sql = $wpdb->prepare(
+			"SELECT
+				p.ID AS order_id,
+				(
+					SELECT MIN(g.meta_value)
+					FROM {$prefix}postmeta g
+					WHERE g.post_id = p.ID AND g.meta_key = '_gate_post_id'
+					  AND g.meta_value NOT IN ('', '0')
+				) AS gate_id,
+				(
+					SELECT MIN(pop.meta_value)
+					FROM {$prefix}postmeta pop
+					WHERE pop.post_id = p.ID AND pop.meta_key = '_newspack_popup_id'
+					  AND pop.meta_value NOT IN ('', '0')
+				) AS popup_id,
+				(
+					SELECT MAX(CAST(tot.meta_value AS DECIMAL(15,2)))
+					FROM {$prefix}postmeta tot
+					WHERE tot.post_id = p.ID AND tot.meta_key = '_order_total'
+				) AS order_total
+			FROM {$prefix}posts p
+			WHERE p.post_type = 'shop_order'
+			  AND p.post_status IN ('wc-completed', 'wc-processing')
+			  AND p.post_date_gmt BETWEEN %s AND %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM {$prefix}postmeta rn
+			      WHERE rn.post_id = p.ID AND rn.meta_key = '_subscription_renewal'
+			        AND rn.meta_value NOT IN ('', '0')
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+			      WHERE opl.order_id = p.ID
+			        AND opl.product_id IN ($subscriptions)
+			        AND opl.product_id NOT IN ($donations)
+			  )
+			  AND (
+			      EXISTS (
+			          SELECT 1 FROM {$prefix}postmeta g
+			          WHERE g.post_id = p.ID AND g.meta_key = '_gate_post_id'
+			            AND g.meta_value NOT IN ('', '0')
+			      )
+			      OR EXISTS (
+			          SELECT 1 FROM {$prefix}postmeta pop
+			          WHERE pop.post_id = p.ID AND pop.meta_key = '_newspack_popup_id'
+			            AND pop.meta_value NOT IN ('', '0')
+			      )
+			  )",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return $this->shape_attributed_subscription_rows( (array) $wpdb->get_results( $sql, ARRAY_A ) );
+	}
+
+	/**
+	 * Normalize raw attributed-subscription-order rows to the typed per-order shape.
+	 * A null gate/popup id (no such meta on the order) stays null so the orchestrator
+	 * can apply gate precedence; `order_total` is coerced to float. Shared row shape
+	 * with HPOS_Storage so both backends return identically-typed rows.
+	 *
+	 * @param array<int, array<string, mixed>> $rows Raw `$wpdb` rows.
+	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
+	 */
+	private function shape_attributed_subscription_rows( array $rows ): array {
+		$out = [];
+		foreach ( $rows as $row ) {
+			$gate_id  = isset( $row['gate_id'] ) && '' !== (string) $row['gate_id'] ? (string) $row['gate_id'] : null;
+			$popup_id = isset( $row['popup_id'] ) && '' !== (string) $row['popup_id'] ? (string) $row['popup_id'] : null;
+			if ( null === $gate_id && null === $popup_id ) {
+				continue;
+			}
+			$out[] = [
+				'order_id'    => (int) ( $row['order_id'] ?? 0 ),
+				'gate_id'     => $gate_id,
+				'popup_id'    => $popup_id,
+				'order_total' => (float) ( $row['order_total'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -325,4 +325,34 @@ interface Storage_Interface {
 	 * @return array<int, \DateTimeImmutable> customer_id => first subscription start (UTC).
 	 */
 	public function get_first_subscription_order_dates( array $customer_ids ): array;
+
+	/**
+	 * Prompt/gate-attributed subscription conversion orders in a window, sourced
+	 * from order meta rather than the GA4 attempt → customer_id join (NPPD-1746,
+	 * the subscription counterpart to the donation reader in
+	 * {@see Donors_Storage_Interface::get_prompt_attributed_donation_conversions()}).
+	 *
+	 * A subscription/paywall order can carry `_gate_post_id` (it stemmed from a
+	 * paywall gate) OR `_newspack_popup_id` (it stemmed from a popup) OR neither
+	 * (the subscriptions landing page / organic). This is therefore a TWO-KEY
+	 * surface: the method returns, per order, the one gate id and the one popup id
+	 * resolved off the order, leaving gate-vs-popup precedence and bucketing to the
+	 * orchestrator ({@see \Newspack\Insights\Subscribers_Metric}). Meta-absence is
+	 * not a coverage gap — organic orders carry neither key and are correctly
+	 * excluded from a prompt/gate conversion metric. No fallback, no union.
+	 *
+	 * Scope: INITIAL completed/processing orders containing a NON-donation
+	 * subscription product — renewal orders inherit the parent's meta and are
+	 * excluded via `_subscription_renewal`. Both `_gate_post_id` and
+	 * `_newspack_popup_id` can be written more than once per order (and through
+	 * different code paths), so each id is derived via a correlated `MIN()` and the
+	 * order is matched with `EXISTS` — never a multiplying JOIN — so duplicate meta
+	 * cannot re-inflate counts or revenue (the NPPD-1685 2x defect). Only orders
+	 * carrying at least one of the two keys are returned.
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
+	 */
+	public function get_attributed_subscription_orders( DateTimeInterface $start, DateTimeInterface $end ): array;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-attributed-subscription-reader.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-attributed-subscription-reader.php
@@ -1,0 +1,399 @@
+<?php
+/**
+ * DB-backed integration tests for the NPPD-1746 two-key attributed-subscription
+ * reader (get_attributed_subscription_orders) on BOTH storage backends.
+ *
+ * The subscription counterpart to {@see Test_Prompt_Attributed_Donation_Reader}.
+ * Where the donation reader is single-key (`_newspack_popup_id`), a subscription
+ * order can carry `_gate_post_id` (paywall gate) OR `_newspack_popup_id` (popup)
+ * OR neither (organic). The reader returns ONE gate id and ONE popup id per order
+ * (correlated MIN, never a multiplying JOIN), scoped to INITIAL completed orders
+ * containing a non-donation subscription product, renewals excluded.
+ *
+ * Anchor cases:
+ *   - the NPPD-1685 2x defect, now on BOTH keys: `_gate_post_id` and
+ *     `_newspack_popup_id` are each written through different code paths, so each
+ *     duplicate-meta case is exercised independently to prove neither double-counts.
+ *   - the dual-key order: an order carrying BOTH keys must surface BOTH ids on its
+ *     single row, so the orchestrator's gate-precedence fold has something to apply
+ *     precedence to (the precedence rule itself — gate wins, counted once — is pinned
+ *     in isolation by {@see Test_Subscribers_Metric}, since zero dual-key orders exist
+ *     in live data and this is the only thing exercising it).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Integration tests for the two-key attributed-subscription reader.
+ *
+ * @group insights
+ */
+class Test_Attributed_Subscription_Reader extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id (excluded from the subscription set even though it is
+	 * itself subscription-typed — recurring donations are subscriptions).
+	 */
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id (membership/paywall product), created
+	 * fresh per test and tagged `product_type=subscription`.
+	 *
+	 * @var int
+	 */
+	private $sub_product_id;
+
+	/**
+	 * Stand up the WC order tables once (InnoDB → per-test inserts roll back).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Per test: ensure the `product_type` taxonomy exists, then create the
+	 * non-donation subscription product and the (excluded) donation product, both
+	 * tagged subscription-typed so the reader's `subscription_product_ids_sql()`
+	 * taxonomy query returns them and the donation NOT IN filter is exercised.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		if ( ! taxonomy_exists( 'product_type' ) ) {
+			register_taxonomy( 'product_type', 'product' );
+		}
+		$this->sub_product_id = (int) wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Membership',
+			]
+		);
+		wp_set_object_terms( $this->sub_product_id, 'subscription', 'product_type' );
+
+		// The donation product is ALSO subscription-typed (recurring donation), so it
+		// only stays out of the subscription set via the donation NOT IN filter.
+		wp_insert_post(
+			[
+				'import_id'   => self::DONATION_PRODUCT_ID,
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Recurring donation',
+			]
+		);
+		wp_set_object_terms( self::DONATION_PRODUCT_ID, 'subscription', 'product_type' );
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The reader under test for a backend, scoped to exclude the donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function reader_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert an order into the given backend (defaults product to the subscription
+	 * product so callers only specify attribution meta).
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait).
+	 * @return void
+	 */
+	private function insert_order( string $backend, array $args ): void {
+		$args['product_id'] = $args['product_id'] ?? $this->sub_product_id;
+		if ( 'hpos' === $backend ) {
+			$this->insert_hpos_order( $args );
+		} else {
+			$this->insert_legacy_order( $args );
+		}
+	}
+
+	/**
+	 * A window that brackets the fixtures' order dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-15 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Run the reader and index its per-order rows by order_id for assertions.
+	 *
+	 * @param string $backend Backend key.
+	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
+	 */
+	private function run_reader_indexed( string $backend ): array {
+		[ $start, $end ] = $this->window();
+		$rows            = $this->reader_for( $backend )->get_attributed_subscription_orders( $start, $end );
+		$by_id           = [];
+		foreach ( $rows as $row ) {
+			$by_id[ (int) $row['order_id'] ] = $row;
+		}
+		return $by_id;
+	}
+
+	/**
+	 * POPUP-only order: surfaces a popup id, no gate id.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_popup_only_order( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6001,
+				'total'     => 60.00,
+				'popup_ids' => [ '4242' ],
+			] 
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertArrayHasKey( 6001, $rows );
+		$this->assertNull( $rows[6001]['gate_id'] );
+		$this->assertSame( '4242', $rows[6001]['popup_id'] );
+		$this->assertSame( 60.00, $rows[6001]['order_total'] );
+	}
+
+	/**
+	 * GATE-only order: surfaces a gate id, no popup id.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_gate_only_order( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id' => 6002,
+				'total'    => 75.00,
+				'gate_ids' => [ '888' ],
+			] 
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertArrayHasKey( 6002, $rows );
+		$this->assertSame( '888', $rows[6002]['gate_id'] );
+		$this->assertNull( $rows[6002]['popup_id'] );
+		$this->assertSame( 75.00, $rows[6002]['order_total'] );
+	}
+
+	/**
+	 * DUAL-KEY order: an order carrying BOTH keys surfaces BOTH ids on its single
+	 * row (one row, not two) — the input the gate-precedence fold acts on. The
+	 * precedence DECISION (gate wins, counted once) is asserted in isolation by
+	 * Test_Subscribers_Metric::test_bucket_dual_key_order_is_gate_only().
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_dual_key_order_surfaces_both_ids_on_one_row( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6003,
+				'total'     => 90.00,
+				'gate_ids'  => [ '888' ],
+				'popup_ids' => [ '4242' ],
+			]
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertArrayHasKey( 6003, $rows );
+		$this->assertCount( 1, $rows, 'a dual-key order must produce exactly one row, not one per key' );
+		$this->assertSame( '888', $rows[6003]['gate_id'] );
+		$this->assertSame( '4242', $rows[6003]['popup_id'] );
+	}
+
+	/**
+	 * ORGANIC order (neither key) is NOT returned — meta-absence is "not
+	 * prompt/gate-driven", correctly excluded, not a coverage gap.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_organic_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id' => 6004,
+				'total'    => 50.00,
+			] 
+		);
+
+		$this->assertSame( [], $this->run_reader_indexed( $backend ) );
+	}
+
+	/**
+	 * ANCHOR (2x defect, POPUP key): two identical `_newspack_popup_id` rows on one
+	 * order resolve to ONE row with one popup id — not two, not doubled.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_duplicate_popup_meta_counted_once( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6005,
+				'total'     => 30.00,
+				'popup_ids' => [ '4242', '4242' ],
+			] 
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( '4242', $rows[6005]['popup_id'] );
+		$this->assertSame( 30.00, $rows[6005]['order_total'] );
+	}
+
+	/**
+	 * ANCHOR (2x defect, GATE key): two identical `_gate_post_id` rows on one order
+	 * resolve to ONE row with one gate id. The gate key is written through a
+	 * different code path (class-memberships.php) than the popup key, so it gets its
+	 * own duplicate-meta proof rather than relying on the popup case.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_duplicate_gate_meta_counted_once( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id' => 6006,
+				'total'    => 45.00,
+				'gate_ids' => [ '888', '888' ],
+			] 
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( '888', $rows[6006]['gate_id'] );
+		$this->assertSame( 45.00, $rows[6006]['order_total'] );
+	}
+
+	/**
+	 * DIVERGENT meta resolves to the MIN id (deterministic), counted once — pins the
+	 * reader against a future write-side change emitting divergent ids per key.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_divergent_meta_resolves_to_min( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6007,
+				'total'     => 20.00,
+				'gate_ids'  => [ '900', '300' ],
+				'popup_ids' => [ '700', '500' ],
+			]
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( '300', $rows[6007]['gate_id'], 'MIN gate id' );
+		$this->assertSame( '500', $rows[6007]['popup_id'], 'MIN popup id' );
+	}
+
+	/**
+	 * RENEWAL EXCLUSION: a renewal order (carries `_subscription_renewal`, inherits
+	 * the parent's attribution meta) is excluded; the initial order is kept.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_renewal_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id' => 6008,
+				'total'    => 40.00,
+				'gate_ids' => [ '888' ],
+			] 
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id' => 6009,
+				'total'    => 40.00,
+				'gate_ids' => [ '888' ],
+				'renewal'  => '6008',
+			]
+		);
+
+		$rows = $this->run_reader_indexed( $backend );
+
+		$this->assertArrayHasKey( 6008, $rows );
+		$this->assertArrayNotHasKey( 6009, $rows, 'renewal order must be excluded' );
+	}
+
+	/**
+	 * DONATION-PRODUCT EXCLUSION: an attributed order whose only product is the
+	 * (subscription-typed) donation product is excluded from the subscription
+	 * reader via the donation NOT IN filter — it belongs to the donation reader.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donation_product_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'   => 6010,
+				'total'      => 25.00,
+				'product_id' => self::DONATION_PRODUCT_ID,
+				'popup_ids'  => [ '4242' ],
+			]
+		);
+
+		$this->assertSame( [], $this->run_reader_indexed( $backend ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -11,7 +11,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Gates_Metric;
-use Newspack\Insights\Woo_Order_Resolver;
+use Newspack\Insights\Subscribers_Metric;
 use WP_UnitTestCase;
 
 /**
@@ -190,58 +190,112 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'bigquery_proxy_malformed_value', $result['error_code'] );
 	}
 
+	// --- NPPD-1746: direct paywall rate + revenue from order meta (gate surface) ---
+
 	/**
-	 * Paywall direct conversion rate: matched orders / BQ row count.
+	 * Remove the WC-active seam filter set by the direct-paywall test helpers.
 	 */
-	public function test_paywall_conversion_direct_uses_woo_join() {
-		$bq_rows = [
-			[
-				'user_pseudo_id' => '1',
-				'session_id'     => 's1',
-				'attempt_ts'     => '1000000000000000',
-			],
-			[
-				'user_pseudo_id' => '2',
-				'session_id'     => 's2',
-				'attempt_ts'     => '1000001000000000',
-			],
-			[
-				'user_pseudo_id' => '3',
-				'session_id'     => 's3',
-				'attempt_ts'     => '1000002000000000',
-			],
-			[
-				'user_pseudo_id' => '4',
-				'session_id'     => 's4',
-				'attempt_ts'     => '1000003000000000',
-			],
-		];
-
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->once() )
-			->method( 'query' )
-			->with( 'gates_paywall_conversion_direct', $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
-			->willReturn( $bq_rows );
-
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 ); // 1 of 4 attempts converted.
-
-		$metric = new Gates_Metric( $proxy, $resolver );
-		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertSame( 0.25, $result['value'] );
-		$this->assertSame( 'populated', $result['state'] );
-		$this->assertSame( 4, $result['denominator'] );
+	public function tear_down(): void {
+		remove_all_filters( 'newspack_insights_woocommerce_active' );
+		parent::tear_down();
 	}
 
 	/**
-	 * Paywall direct conversion rate: no attempts -> non-computable 0% (not error).
+	 * Build a Gates_Metric for the direct paywall cards with an injected proxy +
+	 * Subscribers_Metric and a forced `woocommerce_active()` (via filter — the class
+	 * is final). The proxy feeds the rate card's per-gate impressions denominator;
+	 * revenue passes null. Filter removed in tear_down().
+	 *
+	 * @param BigQuery_Proxy_Client|null $proxy       Injected proxy (rate) or null (revenue).
+	 * @param Subscribers_Metric         $subscribers Injected subscribers collaborator.
+	 * @param bool                       $wc          What woocommerce_active() should return.
+	 * @return Gates_Metric
 	 */
-	public function test_paywall_conversion_direct_with_zero_denominator() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [] );
+	private function make_direct_paywall_metric( ?BigQuery_Proxy_Client $proxy, Subscribers_Metric $subscribers, bool $wc ): Gates_Metric {
+		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
+		return new Gates_Metric( $proxy, null, $subscribers );
+	}
 
-		$metric = new Gates_Metric( $proxy );
+	/**
+	 * Stub Subscribers_Metric whose gate surface holds one gate (id 77) with the
+	 * given conversions + revenue, and an empty popup surface.
+	 *
+	 * @param int   $conversions Gate-attributed subscription conversions.
+	 * @param float $revenue     Gate-attributed subscription revenue.
+	 * @return Subscribers_Metric
+	 */
+	private function subscribers_with_gate( int $conversions, float $revenue ): Subscribers_Metric {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [
+					'77' => [
+						'conversions' => $conversions,
+						'revenue'     => $revenue,
+					],
+				],
+				'by_popup' => [],
+			]
+		);
+		return $subscribers;
+	}
+
+	/**
+	 * Proxy whose `gates_performance_by_gate` reports impressions for gate 77 (the
+	 * converting gate) PLUS an unrelated gate 88. Gate 88 must NOT enter the
+	 * denominator — the rate is per-gate keyed to the gates that actually converted.
+	 *
+	 * @param int $gate_77_impressions Impressions to report for gate 77.
+	 * @return BigQuery_Proxy_Client
+	 */
+	private function proxy_with_gate_impressions( int $gate_77_impressions ): BigQuery_Proxy_Client {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'gate_post_id' => 77,
+					'impressions'  => $gate_77_impressions,
+				],
+				[
+					'gate_post_id' => 88,
+					'impressions'  => 500,
+				],
+			]
+		);
+		return $proxy;
+	}
+
+	/**
+	 * Direct paywall rate = gate-attributed conversions ÷ impressions of the SAME
+	 * gates. Gate 88's 500 impressions are excluded (no conversions there) — proving
+	 * the per-gate keying (denominator 4, not 504).
+	 */
+	public function test_paywall_conversion_direct_per_gate_over_impressions() {
+		$metric = $this->make_direct_paywall_metric(
+			$this->proxy_with_gate_impressions( 4 ),
+			$this->subscribers_with_gate( 1, 0.0 ),
+			true
+		);
+
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 0.25, $result['value'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 4, $result['denominator'], 'denominator is gate 77 only, not the unrelated gate 88' );
+		$this->assertSame( 1, $result['numerator'] );
+	}
+
+	/**
+	 * No impressions for the converting gate → no denominator → not computable.
+	 */
+	public function test_paywall_conversion_direct_not_computable_without_impressions() {
+		$metric = $this->make_direct_paywall_metric(
+			$this->proxy_with_gate_impressions( 0 ),
+			$this->subscribers_with_gate( 3, 0.0 ),
+			true
+		);
+
 		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'populated', $result['state'] );
@@ -249,69 +303,118 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Total paywall revenue (Direct): sum_completed_revenue passthrough.
+	 * Coherence guard: gate-surface conversions exceeding that gate's impressions
+	 * must not fabricate a >100% rate — suppress to not-computable.
 	 */
-	public function test_total_paywall_revenue_direct_sums_woo() {
-		$bq_rows = [
-			[
-				'user_pseudo_id' => '1',
-				'session_id'     => 's1',
-				'attempt_ts'     => '1000000000000000',
-			],
-		];
+	public function test_paywall_conversion_direct_coherence_guard_suppresses_over_100() {
+		$metric = $this->make_direct_paywall_metric(
+			$this->proxy_with_gate_impressions( 2 ),
+			$this->subscribers_with_gate( 10, 0.0 ),
+			true
+		);
 
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'], 'a >100% cross-surface ratio is suppressed, not shown' );
+	}
+
+	/**
+	 * Hybrid card: if the hub impressions call errors, the rate is genuinely
+	 * uncomputable → error state (counts toward the tab-error banner).
+	 */
+	public function test_paywall_conversion_direct_errors_when_impressions_hub_errors() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( $bq_rows );
+		$proxy->method( 'query' )->willReturn( new \WP_Error( 'bigquery_proxy_error', 'down' ) );
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 99.99 );
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 1, 0.0 ), true );
 
-		$metric = new Gates_Metric( $proxy, $resolver );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'error', $result['state'] );
+	}
+
+	/**
+	 * NPPD-1745 #3 (mirrored to paywall): a malformed impressions response (the hub
+	 * succeeded but returned a non-array shape) errors the rate rather than collapsing
+	 * to a fabricated "0 impressions → em-dash".
+	 */
+	public function test_paywall_conversion_direct_errors_on_malformed_impressions() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( 'not-an-array' ); // Malformed (non-array) hub response.
+
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 1, 0.0 ), true );
+
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'error', $result['state'], 'malformed impressions errors, not a fabricated 0%' );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+	}
+
+	/**
+	 * Non-WC publisher: the paywall rate is an empty state (not a fake 0%), and the
+	 * order-meta numerator is never queried.
+	 */
+	public function test_paywall_conversion_direct_empty_state_when_not_woocommerce() {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->expects( $this->never() )->method( 'get_attributed_subscription_conversions' );
+
+		$metric = $this->make_direct_paywall_metric( null, $subscribers, false );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+	}
+
+	/**
+	 * Total paywall revenue sums the gate surface of the two-key order-meta map.
+	 */
+	public function test_total_paywall_revenue_direct_sums_order_meta() {
+		$metric = $this->make_direct_paywall_metric( null, $this->subscribers_with_gate( 2, 99.99 ), true );
+
 		$result = $metric->get_total_paywall_revenue_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
-		$this->assertSame( 99.99, $result['value'] );
 		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 99.99, $result['value'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 2, $result['denominator'] );
 	}
 
 	/**
-	 * Avg revenue per conversion is derived from the two queries it depends on.
+	 * Non-WC publisher: total paywall revenue is a not-computable empty state.
 	 */
-	public function test_avg_revenue_per_paywall_conversion_derives_from_two_queries() {
-		$bq_rows = [
-			[
-				'user_pseudo_id' => '1',
-				'session_id'     => 's1',
-				'attempt_ts'     => '1000000000000000',
-			],
-			[
-				'user_pseudo_id' => '2',
-				'session_id'     => 's2',
-				'attempt_ts'     => '1000001000000000',
-			],
-		];
+	public function test_total_paywall_revenue_direct_empty_state_when_not_woocommerce() {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->expects( $this->never() )->method( 'get_attributed_subscription_conversions' );
 
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( $bq_rows );
+		$metric = $this->make_direct_paywall_metric( null, $subscribers, false );
+		$result = $metric->get_total_paywall_revenue_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 2 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 200.00 );
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 0.0, $result['value'] );
+	}
 
-		$metric = new Gates_Metric( $proxy, $resolver );
+	/**
+	 * Avg revenue per paywall conversion is revenue ÷ conversions from the same
+	 * order-meta gate surface.
+	 */
+	public function test_avg_revenue_per_paywall_conversion_from_order_meta() {
+		$metric = $this->make_direct_paywall_metric( null, $this->subscribers_with_gate( 2, 200.00 ), true );
+
 		$result = $metric->get_avg_revenue_per_paywall_conversion( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
-		$this->assertSame( 100.0, $result['value'] );
 		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 100.0, $result['value'] );
+		$this->assertTrue( $result['computable'] );
 	}
 
 	/**
-	 * Avg revenue per conversion: zero conversions -> non-computable $0.00, not divide-by-zero.
+	 * Avg revenue: zero conversions → non-computable $0.00, not divide-by-zero.
 	 */
 	public function test_avg_revenue_per_paywall_conversion_with_zero_conversions() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [] );
+		$metric = $this->make_direct_paywall_metric( null, $this->subscribers_with_gate( 0, 0.0 ), true );
 
-		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_avg_revenue_per_paywall_conversion( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'populated', $result['state'] );
@@ -319,77 +422,23 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Avg revenue per conversion: non-empty BQ rows but zero matched orders -> placeholder.
-	 *
-	 * The realistic production case: paywall impressions led to checkout attempts,
-	 * but none completed within the 30-min window. Distinct from the empty-rows
-	 * path (no impressions at all).
+	 * Total revenue and avg-per-conversion read ONE order-meta source, so they
+	 * reconcile: total === avg × conversions. Replaces the prior "share a single
+	 * proxy call" regression — both now source from the cached Subscribers_Metric
+	 * gate surface, not a hub query.
 	 */
-	public function test_avg_revenue_per_paywall_conversion_with_zero_matched_orders() {
-		$bq_rows = [
-			[
-				'user_pseudo_id' => '1',
-				'session_id'     => 's1',
-				'attempt_ts'     => '1000000000000000',
-			],
-			[
-				'user_pseudo_id' => '2',
-				'session_id'     => 's2',
-				'attempt_ts'     => '1000001000000000',
-			],
-		];
+	public function test_revenue_methods_reconcile_from_one_source() {
+		$start = $this->make_date( '2026-03-22' );
+		$end   = $this->make_date( '2026-04-21' );
 
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( $bq_rows );
-
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
-
-		$metric = new Gates_Metric( $proxy, $resolver );
-		$result = $metric->get_avg_revenue_per_paywall_conversion( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertSame( 'populated', $result['state'] );
-		$this->assertFalse( $result['computable'] );
-	}
-
-	/**
-	 * Two revenue-side methods in the same request share a single BQ proxy call.
-	 *
-	 * Regression test: `get_total_paywall_revenue_direct` and
-	 * `get_avg_revenue_per_paywall_conversion` both source from
-	 * `gates_paywall_revenue_direct`. The orchestrator memoizes the join result
-	 * so we never round-trip the hub twice per request for identical data.
-	 */
-	public function test_revenue_methods_share_single_proxy_call() {
-		$bq_rows = [
-			[
-				'user_pseudo_id' => '1',
-				'session_id'     => 's1',
-				'attempt_ts'     => '1000000000000000',
-			],
-		];
-
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		// `expects($this->once())` is the regression guard: a second call fails the test.
-		$proxy->expects( $this->once() )
-			->method( 'query' )
-			->with( 'gates_paywall_revenue_direct', $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
-			->willReturn( $bq_rows );
-
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 50.00 );
-
-		$metric = new Gates_Metric( $proxy, $resolver );
-		$start  = $this->make_date( '2026-03-22' );
-		$end    = $this->make_date( '2026-04-21' );
+		$metric = $this->make_direct_paywall_metric( null, $this->subscribers_with_gate( 2, 150.00 ), true );
 
 		$total = $metric->get_total_paywall_revenue_direct( $start, $end );
 		$avg   = $metric->get_avg_revenue_per_paywall_conversion( $start, $end );
 
-		$this->assertSame( 50.00, $total['value'] );
-		$this->assertSame( 50.0, $avg['value'] );
+		$this->assertSame( 150.00, $total['value'] );
+		$this->assertSame( 75.0, $avg['value'] );
+		$this->assertSame( $total['value'], $avg['value'] * $total['denominator'], 'total === avg × conversions' );
 	}
 
 	/**
@@ -663,44 +712,55 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	// --- NPPD-1694: envelope additions for the empty-state pattern ----------
 
 	/**
-	 * A paywall rate scorecard surfaces both numerator (matched Woo orders) and
-	 * denominator (attempts) so the card can render "0 of N".
+	 * Stub Subscribers_Metric with empty surfaces — for the no-conversions paywall
+	 * cases (the gate map only ever contains gates that converted).
+	 *
+	 * @return Subscribers_Metric
+	 */
+	private function empty_subscribers(): Subscribers_Metric {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [],
+			]
+		);
+		return $subscribers;
+	}
+
+	/**
+	 * A populated paywall rate scorecard surfaces both numerator (gate-attributed
+	 * conversions) and denominator (impressions of those gates) so the card can
+	 * render "N of M" (NPPD-1694).
 	 */
 	public function test_paywall_rate_surfaces_numerator_and_denominator() {
-		$bq_rows = array_map(
-			static function ( $i ) {
-				return [
-					'user_pseudo_id' => (string) $i,
-					'session_id'     => 's' . $i,
-					'attempt_ts'     => (string) ( 1000000000000000 + $i ),
-				];
-			},
-			range( 1, 17 )
+		$metric = $this->make_direct_paywall_metric(
+			$this->proxy_with_gate_impressions( 17 ),
+			$this->subscribers_with_gate( 3, 0.0 ),
+			true
 		);
 
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( $bq_rows );
-
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 0 ); // 0 of 17 attempts converted.
-
-		$metric = new Gates_Metric( $proxy, $resolver );
 		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
-		$this->assertSame( 0, $result['numerator'] );
+		$this->assertSame( 3, $result['numerator'] );
 		$this->assertSame( 17, $result['denominator'] );
 		$this->assertTrue( $result['computable'] );
 	}
 
 	/**
-	 * No paywall attempts → numerator and denominator are both an explicit 0 (not
-	 * null), so the card distinguishes "no attempts" (—) from "0 of N".
+	 * No gate-attributed conversions → the gate map is empty, so numerator and
+	 * denominator are both an explicit 0 and the rate is not computable (the em-dash
+	 * "no paywall conversions" state). In the per-gate-keyed model there is no
+	 * attempt-based "0 of N": the denominator is impressions of CONVERTING gates,
+	 * and with none converting there is nothing to divide by.
 	 */
-	public function test_paywall_rate_zero_attempts_sets_zero_counts() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [] );
+	public function test_paywall_rate_not_computable_when_no_conversions() {
+		$metric = $this->make_direct_paywall_metric(
+			$this->proxy_with_gate_impressions( 17 ),
+			$this->empty_subscribers(),
+			true
+		);
 
-		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 0, $result['numerator'] );
@@ -709,13 +769,14 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The error scalar carries a null numerator alongside the null denominator.
+	 * The error scalar carries a null numerator alongside the null denominator: when
+	 * the hub impressions denominator errors, the hybrid rate is an error state.
 	 */
 	public function test_error_scalar_includes_null_numerator() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )->willReturn( new \WP_Error( 'bigquery_query_failed', 'BQ down' ) );
 
-		$metric = new Gates_Metric( $proxy );
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 1, 0.0 ), true );
 		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'error', $result['state'] );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Test Gates_REST_Controller — tab-error banner scoping (NPPD-1746).
+ *
+ * Mirrors the Prompts controller's banner coverage for the Gates tab: the
+ * "whole tab failed" banner is scoped to hub-backed metrics via
+ * {@see Gates_Metric::METRIC_SOURCES} so a surviving `local` card (paywall
+ * revenue from order meta) can't suppress it, and — the NPPD-1745 #1 banner-hole
+ * fix, mirrored here — a non-WC `hybrid` card that short-circuits before reaching
+ * the hub doesn't count as a hub-backed survivor either. A drift guard pins that
+ * every state-bearing build_window metric is classified in METRIC_SOURCES.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Cache;
+use Newspack\Insights\Gates_Metric;
+use Newspack\Insights\Gates_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * Gates_REST_Controller test class.
+ *
+ * @group insights
+ */
+class Test_Gates_REST_Controller extends WP_UnitTestCase {
+
+	const ROUTE = '/newspack-insights/v1/gates';
+
+	/**
+	 * REST server.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up: an admin user + a registered Gates route on a fresh server.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_action( 'rest_api_init', [ $this, 'register_gates_route' ] );
+
+		global $wp_rest_server;
+		$this->server   = new WP_REST_Server();
+		$wp_rest_server = $this->server;
+		do_action( 'rest_api_init' );
+
+		Cache::purge( 'gates' );
+	}
+
+	/**
+	 * Register the Gates route. Hooked to rest_api_init in set_up().
+	 *
+	 * @return void
+	 */
+	public function register_gates_route() {
+		( new Gates_REST_Controller() )->register_routes();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_action( 'rest_api_init', [ $this, 'register_gates_route' ] );
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		Cache::purge( 'gates' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Build + dispatch a GET request to the Gates route.
+	 *
+	 * @param array $params Query params.
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch( array $params ) {
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Invoke the private static is_window_all_error() on a synthetic window.
+	 *
+	 * @param array $window             Window payload.
+	 * @param bool  $woocommerce_active Whether WC is active (defaults to the WC-active path).
+	 * @return bool
+	 */
+	private function invoke_is_window_all_error( array $window, bool $woocommerce_active = true ): bool {
+		$method = new \ReflectionMethod( Gates_REST_Controller::class, 'is_window_all_error' );
+		$method->setAccessible( true );
+		return (bool) $method->invoke( null, $window, $woocommerce_active );
+	}
+
+	/**
+	 * Build a window where every hub-backed metric errors and every local card is
+	 * populated (the WC-active hub-outage-with-local-survivor scenario).
+	 *
+	 * @return array
+	 */
+	private function window_hub_down_local_alive(): array {
+		$window = [
+			'window' => [
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			],
+		];
+		foreach ( Gates_Metric::METRIC_SOURCES as $key => $source ) {
+			$window[ $key ] = [ 'state' => 'local' === $source ? 'populated' : 'error' ];
+		}
+		return $window;
+	}
+
+	/**
+	 * Build the non-WC hub-outage window: every pure-hub card errors, while the
+	 * hybrid cards short-circuit to a populated empty state (they never reach the
+	 * hub on a non-WC publisher) and the local cards render.
+	 *
+	 * @return array
+	 */
+	private function window_non_wc_hub_down(): array {
+		$window = [
+			'window' => [
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			],
+		];
+		foreach ( Gates_Metric::METRIC_SOURCES as $key => $source ) {
+			$window[ $key ] = [ 'state' => 'hub' === $source ? 'error' : 'populated' ];
+		}
+		return $window;
+	}
+
+	/**
+	 * The banner STILL fires when every hub-backed metric errors, even though a
+	 * surviving local card (paywall revenue) renders.
+	 */
+	public function test_tab_error_fires_on_hub_outage_despite_local_survivor() {
+		$window = $this->window_hub_down_local_alive();
+
+		$this->assertSame( 'local', Gates_Metric::METRIC_SOURCES['total_paywall_revenue_direct'] );
+		$this->assertSame( 'populated', $window['total_paywall_revenue_direct']['state'] );
+
+		$this->assertTrue(
+			$this->invoke_is_window_all_error( $window ),
+			'all hub-backed errored → banner fires even though the local card rendered'
+		);
+	}
+
+	/**
+	 * The banner does NOT fire if any hub-backed metric recovers.
+	 */
+	public function test_tab_error_does_not_fire_when_a_hub_metric_recovers() {
+		$window = $this->window_hub_down_local_alive();
+		$window['total_gate_impressions'] = [ 'state' => 'populated' ]; // one hub card recovers.
+
+		$this->assertFalse( $this->invoke_is_window_all_error( $window ) );
+	}
+
+	/**
+	 * NPPD-1745 #1 banner-hole fix, mirrored to Gates: on a non-WC publisher the
+	 * paywall rate (hybrid) short-circuits to a populated empty state without ever
+	 * calling the hub, so it must NOT count as a hub-backed survivor. With every
+	 * pure-hub card erroring, the banner fires even though the hybrid + local cards
+	 * render. (Pre-fix, the populated hybrid card returned false here, silently
+	 * suppressing the banner.)
+	 */
+	public function test_tab_error_fires_on_non_wc_hub_outage() {
+		$window = $this->window_non_wc_hub_down();
+
+		// Sanity: the paywall rate is a hybrid card, genuinely populated here.
+		$this->assertSame( 'hybrid', Gates_Metric::METRIC_SOURCES['paywall_conversion_direct'] );
+		$this->assertSame( 'populated', $window['paywall_conversion_direct']['state'] );
+
+		$this->assertTrue(
+			$this->invoke_is_window_all_error( $window, false ),
+			'non-WC: the hybrid card is skipped, so all-pure-hub-errored fires the banner'
+		);
+		// Guard: were WC active, the same populated hybrid card would be a genuine
+		// hub-backed survivor and (correctly) suppress the banner.
+		$this->assertFalse(
+			$this->invoke_is_window_all_error( $window, true ),
+			'WC-active: a populated hybrid card is a real survivor → no banner'
+		);
+	}
+
+	/**
+	 * NPPD-1745 #5 drift guard, mirrored to Gates: every state-bearing metric that
+	 * build_window() emits must have a METRIC_SOURCES entry, or it would silently
+	 * drop out of the banner decision with no test to catch it.
+	 */
+	public function test_every_window_metric_is_classified_in_metric_sources() {
+		$data = $this->dispatch(
+			[
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			]
+		)->get_data()['data'];
+
+		$missing = [];
+		foreach ( $data['current'] as $key => $value ) {
+			// Skip date metadata and non-metric scalar section-totals (int|null); only
+			// state-bearing metric envelopes participate in the banner decision.
+			if ( 'window' === $key || ! is_array( $value ) || ! isset( $value['state'] ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( $key, Gates_Metric::METRIC_SOURCES ) ) {
+				$missing[] = $key;
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$missing,
+			'every state-bearing build_window metric must be classified in Gates_Metric::METRIC_SOURCES'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -32,6 +32,7 @@ use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Donors_Metric;
 use Newspack\Insights\Prompts_Metric;
+use Newspack\Insights\Subscribers_Metric;
 use Newspack\Insights\Woo_Order_Resolver;
 use WP_UnitTestCase;
 
@@ -358,17 +359,18 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	/**
 	 * Data provider for the proxy-backed paid-conversion rate methods.
 	 *
-	 * NPPD-1745: `get_donation_conversion_direct` is intentionally absent — it no
-	 * longer dispatches `prompts_donation_conversion_direct`. It's now hybrid:
-	 * order-meta conversions ÷ hub donation-impressions (see
-	 * test_donation_conversion_direct_*). The other three are still proxy-backed.
+	 * NPPD-1745/1746: `get_donation_conversion_direct` AND
+	 * `get_subscription_conversion_direct` are intentionally absent — neither
+	 * dispatches a paid-attempt proxy query any more. Both are hybrid order-meta
+	 * conversions ÷ hub impressions (see test_donation_conversion_direct_* and
+	 * test_subscription_conversion_direct_*). Only the influenced pair is still
+	 * proxy-backed.
 	 *
 	 * @return array
 	 */
 	public function provide_paid_conversion_rate_methods(): array {
 		return [
 			'donation_influenced'     => [ 'get_donation_conversion_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
-			'subscription_direct'     => [ 'get_subscription_conversion_direct', 'prompts_subscription_conversion_direct' ],
 			'subscription_influenced' => [ 'get_subscription_conversion_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
 		];
 	}
@@ -466,17 +468,18 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	 * underlying conversion-query name (revenue methods share the cache with their
 	 * rate counterparts; the hub's revenue alias is byte-identical).
 	 *
-	 * NPPD-1685: `get_donation_revenue_direct` is intentionally absent — it no
-	 * longer dispatches a proxy query; it sources from order meta via
-	 * Donors_Metric (see test_donation_revenue_direct_*). The other three are
-	 * still proxy/resolver-backed.
+	 * NPPD-1685/1746: `get_donation_revenue_direct` AND
+	 * `get_subscription_revenue_direct` are intentionally absent — neither
+	 * dispatches a proxy query; both source from order meta (Donors_Metric /
+	 * Subscribers_Metric — see test_donation_revenue_direct_* and
+	 * test_subscription_revenue_direct_*). Only the influenced pair is still
+	 * proxy/resolver-backed.
 	 *
 	 * @return array
 	 */
 	public function provide_paid_revenue_methods(): array {
 		return [
 			'donation_influenced'     => [ 'get_donation_revenue_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
-			'subscription_direct'     => [ 'get_subscription_revenue_direct', 'prompts_subscription_conversion_direct' ],
 			'subscription_influenced' => [ 'get_subscription_revenue_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
 		];
 	}
@@ -727,6 +730,250 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0.0, $rate['value'] );
 	}
 
+	// --- NPPD-1746: direct subscription rate + revenue from order meta (popup surface) ---
+
+	/**
+	 * Build a Prompts_Metric for the direct subscription cards with an injected
+	 * proxy + Subscribers_Metric and a forced `woocommerce_active()` (via filter —
+	 * the class is final). The proxy feeds the rate card's per-popup hub impressions
+	 * denominator; revenue passes null. Filter removed in tear_down().
+	 *
+	 * @param BigQuery_Proxy_Client|null $proxy       Injected proxy (rate) or null (revenue).
+	 * @param Subscribers_Metric         $subscribers Injected subscribers collaborator.
+	 * @param bool                       $wc          What woocommerce_active() should return.
+	 * @return Prompts_Metric
+	 */
+	private function make_direct_subscription_metric( ?BigQuery_Proxy_Client $proxy, Subscribers_Metric $subscribers, bool $wc ): Prompts_Metric {
+		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
+		return new Prompts_Metric( $proxy, null, null, null, $subscribers );
+	}
+
+	/**
+	 * Stub Subscribers_Metric with empty surfaces — for tests that exercise the
+	 * donation columns on a WC-active publisher and need the subscription
+	 * augmentation to no-op without hitting a real storage backend.
+	 *
+	 * @return Subscribers_Metric
+	 */
+	private function empty_subscribers(): Subscribers_Metric {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [],
+			]
+		);
+		return $subscribers;
+	}
+
+	/**
+	 * Stub Subscribers_Metric whose popup surface holds one popup (id 1) with the
+	 * given conversions + revenue, and an empty gate surface.
+	 *
+	 * @param int   $conversions Popup-attributed subscription conversions.
+	 * @param float $revenue     Popup-attributed subscription revenue.
+	 * @return Subscribers_Metric
+	 */
+	private function subscribers_with_popup( int $conversions, float $revenue ): Subscribers_Metric {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [
+					'1' => [
+						'conversions' => $conversions,
+						'revenue'     => $revenue,
+					],
+				],
+			]
+		);
+		return $subscribers;
+	}
+
+	/**
+	 * Proxy whose `prompts_performance_by_prompt` reports impressions for popup 1
+	 * (the converting popup) PLUS an unrelated registration-intent popup 9. Popup 9
+	 * must NOT enter the denominator — the rate is per-popup keyed to the popups that
+	 * actually converted, which is the whole point of not using a tab-level bucket.
+	 *
+	 * @param int $popup_one_impressions Impressions to report for popup 1.
+	 * @return BigQuery_Proxy_Client
+	 */
+	private function proxy_with_popup_impressions( int $popup_one_impressions ): BigQuery_Proxy_Client {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'popup_id'    => 1,
+					'intent'      => 'registration',
+					'impressions' => $popup_one_impressions,
+				],
+				[
+					'popup_id'    => 9,
+					'intent'      => 'registration',
+					'impressions' => 500,
+				],
+			]
+		);
+		return $proxy;
+	}
+
+	/**
+	 * Direct subscription revenue sums the popup surface of the two-key order-meta
+	 * map (anonymous-inclusive), NOT the GA4 attempt → resolver join.
+	 */
+	public function test_subscription_revenue_direct_sources_from_order_meta() {
+		$metric = $this->make_direct_subscription_metric( null, $this->subscribers_with_popup( 3, 75.0 ), true );
+
+		$revenue = $metric->get_subscription_revenue_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $revenue['state'] );
+		$this->assertSame( 75.0, $revenue['value'], 'revenue is the summed popup-surface map' );
+		$this->assertTrue( $revenue['computable'] );
+		$this->assertSame( 3, $revenue['denominator'], 'denominator is the summed conversion count' );
+	}
+
+	/**
+	 * Non-WC publisher: direct subscription revenue is a not-computable empty state,
+	 * and the order-meta numerator is never queried.
+	 */
+	public function test_subscription_revenue_direct_empty_state_when_not_woocommerce() {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->expects( $this->never() )->method( 'get_attributed_subscription_conversions' );
+
+		$metric  = $this->make_direct_subscription_metric( null, $subscribers, false );
+		$revenue = $metric->get_subscription_revenue_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $revenue['state'] );
+		$this->assertFalse( $revenue['computable'] );
+		$this->assertSame( 0.0, $revenue['value'] );
+	}
+
+	/**
+	 * Direct subscription rate = popup-attributed conversions ÷ impressions of the
+	 * SAME popups. Popup 9's 500 impressions are excluded because popup 9 had no
+	 * subscription conversions — proving the per-popup keying (denominator 200, not
+	 * 700).
+	 */
+	public function test_subscription_conversion_direct_rate_per_popup_over_impressions() {
+		$metric = $this->make_direct_subscription_metric(
+			$this->proxy_with_popup_impressions( 200 ),
+			$this->subscribers_with_popup( 50, 0.0 ),
+			true
+		);
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertSame( 0.25, $rate['value'] );
+		$this->assertTrue( $rate['computable'] );
+		$this->assertSame( 200, $rate['denominator'], 'denominator is popup 1 only, not the unrelated popup 9' );
+	}
+
+	/**
+	 * No impressions for the converting popup → no denominator → not computable
+	 * (em-dash), distinct from a real 0%.
+	 */
+	public function test_subscription_conversion_direct_not_computable_without_impressions() {
+		$metric = $this->make_direct_subscription_metric(
+			$this->proxy_with_popup_impressions( 0 ),
+			$this->subscribers_with_popup( 5, 0.0 ),
+			true
+		);
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertFalse( $rate['computable'] );
+		$this->assertSame( 0.0, $rate['value'] );
+	}
+
+	/**
+	 * Impressions exist but zero conversions is a REAL 0% (computable), distinct
+	 * from the not-computable no-impressions case.
+	 */
+	public function test_subscription_conversion_direct_real_zero_percent_when_no_conversions() {
+		$metric = $this->make_direct_subscription_metric(
+			$this->proxy_with_popup_impressions( 200 ),
+			$this->subscribers_with_popup( 0, 0.0 ),
+			true
+		);
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertTrue( $rate['computable'], 'viewed-but-no-conversion is a real 0%, not an em-dash' );
+		$this->assertSame( 0.0, $rate['value'] );
+		$this->assertSame( 200, $rate['denominator'] );
+	}
+
+	/**
+	 * Coherence guard: popup-surface conversions exceeding that popup's impressions
+	 * must not fabricate a >100% rate — suppress to not-computable.
+	 */
+	public function test_subscription_conversion_direct_coherence_guard_suppresses_over_100() {
+		$metric = $this->make_direct_subscription_metric(
+			$this->proxy_with_popup_impressions( 10 ),
+			$this->subscribers_with_popup( 50, 0.0 ),
+			true
+		);
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertFalse( $rate['computable'], 'a >100% cross-surface ratio is suppressed, not shown' );
+		$this->assertSame( 0.0, $rate['value'] );
+	}
+
+	/**
+	 * Hybrid card: if the hub impressions call errors, the rate is genuinely
+	 * uncomputable → error state (counts toward the tab-error banner).
+	 */
+	public function test_subscription_conversion_direct_errors_when_impressions_hub_errors() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( new \WP_Error( 'bigquery_proxy_error', 'down' ) );
+
+		$metric = $this->make_direct_subscription_metric( $proxy, $this->subscribers_with_popup( 5, 0.0 ), true );
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $rate['state'] );
+	}
+
+	/**
+	 * NPPD-1745 #3 (mirrored to subscriptions): a malformed impressions response (the
+	 * hub succeeded but returned a non-array shape) errors the rate rather than
+	 * collapsing to a fabricated "0 impressions → em-dash".
+	 */
+	public function test_subscription_conversion_direct_errors_on_malformed_impressions() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( 'not-an-array' ); // Malformed (non-array) hub response.
+
+		$metric = $this->make_direct_subscription_metric( $proxy, $this->subscribers_with_popup( 5, 0.0 ), true );
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $rate['state'], 'malformed impressions errors, not a fabricated 0%' );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $rate['error_code'] );
+	}
+
+	/**
+	 * Non-WC publisher: empty state (not a fake 0%); the order-meta numerator is
+	 * never queried.
+	 */
+	public function test_subscription_conversion_direct_empty_state_when_not_woocommerce() {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->expects( $this->never() )->method( 'get_attributed_subscription_conversions' );
+
+		$metric = $this->make_direct_subscription_metric( null, $subscribers, false );
+
+		$rate = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertFalse( $rate['computable'] );
+		$this->assertSame( 0.0, $rate['value'] );
+	}
+
 	/**
 	 * Remove the WC-active seam filter set by make_donation_revenue_metric().
 	 */
@@ -753,11 +1000,12 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
 
 		$metric = new Prompts_Metric( $proxy, $resolver );
-		// NPPD-1745: get_donation_conversion_direct no longer dispatches a paid-attempt
-		// query (it's hybrid order-meta ÷ impressions). Use two still-proxy-backed
-		// intents with distinct query_names to exercise per-query_name cache keying.
+		// NPPD-1745/1746: the direct donation AND subscription rates no longer dispatch
+		// a paid-attempt query (both are hybrid order-meta ÷ impressions). Use two
+		// still-proxy-backed influenced intents with distinct query_names to exercise
+		// per-query_name cache keying.
 		$metric->get_donation_conversion_influenced_14d( $this->start(), $this->end() );
-		$metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+		$metric->get_subscription_conversion_influenced_14d( $this->start(), $this->end() );
 	}
 
 	// --- Section 6: Conversion funnel + exposures distribution ---------
@@ -965,18 +1213,20 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	 * @param array|\WP_Error $donation_rows     Unused since NPPD-1745 (donations come
 	 *                                           from order meta, not the proxy); kept for
 	 *                                           call-site compatibility.
-	 * @param array|\WP_Error $subscription_rows Rows for `prompts_subscription_conversion_direct`.
-	 * @param int             $expected_queries  Expected proxy `query()` count: 2 on a
-	 *                                           WC-active publisher (perf + subscription),
-	 *                                           1 on a non-WC publisher (perf only).
+	 * @param array|\WP_Error $subscription_rows Unused since NPPD-1746 (subscriptions come
+	 *                                           from order meta, not the proxy); kept for
+	 *                                           call-site compatibility.
+	 * @param int             $expected_queries  Expected proxy `query()` count: 1 — only the
+	 *                                           perf table hits the proxy now; both donation
+	 *                                           (NPPD-1745) and subscription (NPPD-1746)
+	 *                                           augmentation read order meta off-proxy.
 	 * @return BigQuery_Proxy_Client
 	 */
-	protected function make_performance_proxy( array $perf_rows, $donation_rows, $subscription_rows, int $expected_queries = 2 ): BigQuery_Proxy_Client {
+	protected function make_performance_proxy( array $perf_rows, $donation_rows, $subscription_rows, int $expected_queries = 1 ): BigQuery_Proxy_Client {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		// On a WC-active publisher the perf table + the subscription augmentation run
-		// (2 queries); on a non-WC publisher the subscription augmentation is gated off,
-		// so only the perf query runs (1). Donations come from order meta via
-		// Donors_Metric (NPPD-1745), not the proxy.
+		// Only the perf table hits the proxy now. Donation (NPPD-1745) and subscription
+		// (NPPD-1746) per-popup counts both come from order meta (Donors_Metric /
+		// Subscribers_Metric), so neither augmentation dispatches a proxy query.
 		$proxy->expects( $this->exactly( $expected_queries ) )
 			->method( 'query' )
 			->willReturnCallback(
@@ -1029,13 +1279,10 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 
 		$proxy = $this->make_performance_proxy( $perf_rows, $donation_attempts, $subscription_attempts );
 
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		// Subscriptions still use the resolver path; donations now come from order
-		// meta via an injected Donors_Metric (NPPD-1745).
-		$resolver->method( 'count_completed_orders' )->willReturn( 5 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
-
 		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tearDown.
+		// NPPD-1745/1746: both donation AND subscription per-popup counts now come
+		// from order meta (Donors_Metric / Subscribers_Metric), not the resolver. The
+		// subscription count is the popup surface of the two-key map, keyed by popup id.
 		$donors = $this->createMock( Donors_Metric::class );
 		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
 			[
@@ -1045,8 +1292,20 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 				],
 			]
 		);
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [
+					'99' => [
+						'conversions' => 5,
+						'revenue'     => 0.0,
+					],
+				],
+			]
+		);
 
-		$metric = new Prompts_Metric( $proxy, $resolver, null, $donors );
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $subscribers );
 		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
 
 		$this->assertSame( 'populated', $result['state'] );
@@ -1093,7 +1352,7 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 			]
 		);
 
-		$metric = new Prompts_Metric( $proxy, null, null, $donors );
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $this->empty_subscribers() );
 		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
 
 		$this->assertSame( 50, $result['rows'][0]['donation_conversions'] );
@@ -1110,7 +1369,7 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$donors = $this->createMock( Donors_Metric::class );
 		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn( [] ); // No conversions for popup 42.
 
-		$metric = new Prompts_Metric( $proxy, null, null, $donors );
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $this->empty_subscribers() );
 		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
 
 		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
@@ -1242,7 +1501,7 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$donors = $this->createMock( Donors_Metric::class );
 		$donors->expects( $this->never() )->method( 'get_prompt_attributed_donation_conversions' );
 
-		$metric = new Prompts_Metric( $proxy, null, null, $donors );
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $this->empty_subscribers() );
 		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
 
 		// Table renders successfully — engagement data is load-bearing.

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscribers-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscribers-metric.php
@@ -68,4 +68,106 @@ class Test_Subscribers_Metric extends WP_UnitTestCase {
 			'all signals present'          => [ 8, 2, 900.0, 850.0, true, 'A fully populated window is active.' ],
 		];
 	}
+
+	// --- NPPD-1746: gate-precedence bucketing of attributed subscription orders ---
+
+	/**
+	 * THE dual-key precedence assertion, isolated. An order carrying BOTH a gate id
+	 * and a popup id is a GATE conversion: it lands in `by_gate` ONLY — counted once,
+	 * its revenue once — and does NOT appear in `by_popup`. Zero dual-key orders
+	 * exist across both Phase-1 publishers, so this test is the only thing exercising
+	 * the precedence rule; it is deliberately standalone, not folded into a broader
+	 * fixture check.
+	 */
+	public function test_bucket_dual_key_order_is_gate_only() {
+		$result = Subscribers_Metric::bucket_attributed_subscription_orders(
+			[
+				[
+					'order_id'    => 1,
+					'gate_id'     => '888',
+					'popup_id'    => '4242',
+					'order_total' => 90.00,
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'888' => [
+					'conversions' => 1,
+					'revenue'     => 90.00,
+				],
+			],
+			$result['by_gate'],
+			'dual-key order counts once in the gate bucket'
+		);
+		$this->assertSame( [], $result['by_popup'], 'dual-key order must NOT appear in the popup bucket' );
+	}
+
+	/**
+	 * Gate-only and popup-only orders route to their own surface; an organic order
+	 * (neither id) is dropped. Revenue and counts aggregate per id.
+	 */
+	public function test_bucket_routes_each_surface_and_drops_organic() {
+		$result = Subscribers_Metric::bucket_attributed_subscription_orders(
+			[
+				[
+					'order_id'    => 1,
+					'gate_id'     => '888',
+					'popup_id'    => null,
+					'order_total' => 75.00,
+				],
+				[
+					'order_id'    => 2,
+					'gate_id'     => '888',
+					'popup_id'    => null,
+					'order_total' => 25.00,
+				],
+				[
+					'order_id'    => 3,
+					'gate_id'     => null,
+					'popup_id'    => '4242',
+					'order_total' => 60.00,
+				],
+				[
+					'order_id'    => 4,
+					'gate_id'     => null,
+					'popup_id'    => null,
+					'order_total' => 50.00,
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'888' => [
+					'conversions' => 2,
+					'revenue'     => 100.00,
+				],
+			],
+			$result['by_gate'] 
+		);
+		$this->assertSame(
+			[
+				'4242' => [
+					'conversions' => 1,
+					'revenue'     => 60.00,
+				],
+			],
+			$result['by_popup'] 
+		);
+	}
+
+	/**
+	 * Empty input yields empty surface maps (not a warning, not a null).
+	 */
+	public function test_bucket_empty_input() {
+		$this->assertSame(
+			[
+				'by_gate'  => [],
+				'by_popup' => [],
+			],
+			Subscribers_Metric::bucket_attributed_subscription_orders( [] )
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
@@ -77,7 +77,9 @@ trait Insights_Woo_Order_Fixtures {
 	 *
 	 * @param array $args Order spec: `product_id`, `total` (`_order_total`),
 	 *                    `popup_ids` (one `_newspack_popup_id` row per element,
-	 *                    duplicates allowed), `renewal` (`_subscription_renewal`),
+	 *                    duplicates allowed), `gate_ids` (one `_gate_post_id` row per
+	 *                    element, duplicates allowed — NPPD-1746),
+	 *                    `renewal` (`_subscription_renewal`),
 	 *                    `status` (default 'wc-completed'), `date` (GMT 'Y-m-d H:i:s').
 	 * @return int The created order's post ID.
 	 */
@@ -86,6 +88,10 @@ trait Insights_Woo_Order_Fixtures {
 		$date     = $args['date'] ?? $this->default_order_date_gmt();
 		$order_id = wp_insert_post(
 			[
+				// Honor an explicit order_id (via import_id) so legacy and HPOS fixtures
+				// share the same order id — readers that key results by order id can then
+				// assert identically across both backends. import_id 0 = auto-assign.
+				'import_id'   => (int) ( $args['order_id'] ?? 0 ),
 				'post_type'   => 'shop_order',
 				'post_status' => $args['status'] ?? 'wc-completed',
 				'post_title'  => 'Order',
@@ -103,6 +109,9 @@ trait Insights_Woo_Order_Fixtures {
 		);
 		foreach ( (array) ( $args['popup_ids'] ?? [] ) as $pid ) {
 			add_post_meta( $order_id, '_newspack_popup_id', $pid ); // unique = false → duplicates allowed.
+		}
+		foreach ( (array) ( $args['gate_ids'] ?? [] ) as $gid ) {
+			add_post_meta( $order_id, '_gate_post_id', $gid ); // unique = false → duplicates allowed (NPPD-1746).
 		}
 		if ( isset( $args['total'] ) ) {
 			add_post_meta( $order_id, '_order_total', $args['total'] );
@@ -147,6 +156,16 @@ trait Insights_Woo_Order_Fixtures {
 					'order_id'   => $order_id,
 					'meta_key'   => '_newspack_popup_id',
 					'meta_value' => $pid,
+				]
+			);
+		}
+		foreach ( (array) ( $args['gate_ids'] ?? [] ) as $gid ) {
+			$wpdb->insert(
+				"{$p}wc_orders_meta",
+				[
+					'order_id'   => $order_id,
+					'meta_key'   => '_gate_post_id',
+					'meta_value' => $gid,
 				]
 			);
 		}


### PR DESCRIPTION
Subscription/paywall counterpart to the donation order-meta migration (NPPD-1745). Sources **direct** subscription + paywall conversion and revenue from WooCommerce order meta instead of the GA4 attempt → `customer_id` join, which dropped anonymous-at-attempt subscribers (subscriptions were ~0%-joinable through it — the NPPD-1685 finding).


### What changed
- **Two-key reader** (`get_attributed_subscription_orders`) on the subscribers storage (legacy + HPOS): a subscription order carries `_gate_post_id` (paywall gate) OR `_newspack_popup_id` (popup) OR neither (organic). Exactly one id per key via `EXISTS` + correlated `MIN()` — never a multiplying JOIN (the NPPD-1685 2× guard, applied to **both** keys since they're written through different code paths). Initial orders only; renewals excluded.
- **Gate precedence:** an order carrying both keys is a gate conversion — counted once, never double-counted across surfaces. `Subscribers_Metric::bucket_attributed_subscription_orders()` is the fold, asserted in isolation (zero dual-key orders exist in live data, so the test is the only thing exercising it).
- **Four direct metrics rewired** to order meta: `get_subscription_conversion_direct` + `get_subscription_revenue_direct` (Prompts / popup surface); `Gates_Metric::get_paywall_conversion_direct` + `get_total_paywall_revenue_direct` (Gates / gate surface, plus avg-revenue for coherence).
- **Per-surface, per-keyed rate denominators** (no blending): the popup rate divides by that popup's `prompts_performance_by_prompt` impressions, the gate rate by that gate's `gates_performance_by_gate` impressions — restricted to the surfaces that actually converted, so numerator and denominator stay population-matched (avoiding the registration-intent conflation / >100% incoherence). Shared coherence guard; revenue is `local` / hub-resilient, rate is `hybrid`.
- **`METRIC_SOURCES`** on both tabs + the Gates tab-error banner scoped to hub-backed metrics (closes the same non-WC banner hole on the Gates tab that #383 fixes on Prompts). Proactively mirrors #383's issue 1 (non-WC banner hole) and 3 (malformed → error) to the gate/popup paths.

### Notes / known limitations (documented, by design)
- **Surface asymmetry is the model:** paywall gates drive subscriptions; popups drive donations. So popup-attributed subscriptions are a thin trickle by design, and prompt/gate-attributed subscriptions are the minority (~15% attributed vs ~85% organic across the two WC-native paywall publishers measured). Small numbers are correct, not an undercount.
- **Gate rate denominator = exposed per-gate `impressions`** (true gate impressions, anonymous-inclusive). The ideal `checkout_impressions` subset isn't exposed as an output column by the hub query; `impressions` equals it for a pure paywall gate and runs slightly conservative for a mixed gate. Hub follow-up to expose it: **NPPD-1749** (one-line plugin swap).
- **HPOS** reader is mirrored from legacy and covered by a DDL integration test, but **unverified against live HPOS subscription data** (both measured publishers are legacy-storage) — confirm at first HPOS-publisher contact.