### PR TITLE
fix(insights): scope Tab 3 tab-error banner to hub-backed metrics

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -261,10 +261,12 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	/**
 	 * Assemble the top-level response.
 	 *
-	 * `tab_error` is true only when every metric in the current window reports
-	 * `state: 'error'` — i.e. the whole tab failed to load (e.g. the BigQuery
-	 * proxy is down/misconfigured). React renders a tab-level error banner in
-	 * that case; otherwise each section renders its own error/empty/populated
+	 * `tab_error` is true only when every **hub-backed** metric in the current
+	 * window reports `state: 'error'` — i.e. the hub (BigQuery proxy) is
+	 * down/misconfigured. Local (Woo order-meta / storage-layer) cards survive a
+	 * hub outage and do not suppress the banner (NPPD-1745; see
+	 * {@see self::is_window_all_error()}). React renders a tab-level error banner
+	 * in that case; otherwise each section renders its own error/empty/populated
 	 * treatment.
 	 *
 	 * Snapshot metrics (Section 5 cohorts, Sections 8.1–8.3) are
@@ -296,7 +298,7 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 
 		$current  = $this->build_window( $metric, $start, $end ) + $snapshot;
 		$response = [
-			'tab_error' => self::is_window_all_error( $current ),
+			'tab_error' => self::is_window_all_error( $current, $metric->woocommerce_active() ),
 			'current'   => $current,
 			'previous'  => null,
 		];
@@ -307,27 +309,53 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Whether every metric in a window payload reports `state: 'error'`.
+	 * Whether every **hub-backed** metric in a window reports `state: 'error'`.
 	 *
-	 * Returns `false` as soon as any metric is not in the error state (the `window`
-	 * key is date metadata, not a metric, so it's skipped). A metric missing a
-	 * `state` key is treated as non-error, so the banner only shows on an
-	 * unambiguous all-failed window. States 'coming_soon', 'populated', and
-	 * 'empty' are NOT errors — tab_error requires ONLY state === 'error'.
+	 * Scoped to hub-backed metrics (NPPD-1745): Tab 3 has many Woo-local cards
+	 * (subscriber→donor funnel, opportunity counts, coming_soon stubs). Under the
+	 * old "every metric errored" rule the banner could never fire when the hub is
+	 * down — a local card always survives. So the banner now fires when all
+	 * hub-backed (and hybrid-when-WC-active) metrics error, even though surviving
+	 * local cards still render. The classification is declared explicitly on
+	 * {@see \Newspack\Insights\Conversion_Metric::METRIC_SOURCES}.
 	 *
-	 * @param array $window The shape returned by `build_window()` merged with `build_snapshot()`.
+	 * Returns `false` as soon as any hub-backed metric is not in the error state.
+	 * Returns `false` for a window with no recognizable hub-backed metric at all
+	 * (nothing to declare failed).
+	 *
+	 * NPPD-1745 (banner hole on non-WC): a `hybrid` card (local order-meta numerator
+	 * over a hub denominator) short-circuits to a not-applicable empty state on a
+	 * non-WooCommerce publisher BEFORE it ever calls the hub — so a hub outage
+	 * can't make it error, and treating its surviving empty state as a healthy
+	 * hub-backed card would mask the outage and suppress the banner. On a non-WC
+	 * publisher, hybrid cards are therefore skipped (treated like `local`); the
+	 * genuinely hub-backed cards (pure `hub`) still drive the decision.
+	 *
+	 * @param array $window             The shape returned by `build_window()` merged with `build_snapshot()`.
+	 * @param bool  $woocommerce_active Whether WooCommerce is active for this publisher.
 	 * @return bool
 	 */
-	private static function is_window_all_error( array $window ): bool {
-		foreach ( $window as $key => $value ) {
-			if ( 'window' === $key ) {
+	private static function is_window_all_error( array $window, bool $woocommerce_active ): bool {
+		$saw_hub_backed = false;
+		foreach ( Conversion_Metric::METRIC_SOURCES as $key => $source ) {
+			if ( 'local' === $source ) {
 				continue;
 			}
-			if ( ! is_array( $value ) || ! isset( $value['state'] ) || 'error' !== $value['state'] ) {
+			// On a non-WC publisher a hybrid card never reaches the hub (it empties out
+			// first), so it can't error on a hub outage — don't let its surviving empty
+			// state mask the outage.
+			if ( ! $woocommerce_active && 'hybrid' === $source ) {
+				continue;
+			}
+			if ( ! isset( $window[ $key ] ) || ! is_array( $window[ $key ] ) || ! isset( $window[ $key ]['state'] ) ) {
+				continue;
+			}
+			$saw_hub_backed = true;
+			if ( 'error' !== $window[ $key ]['state'] ) {
 				return false;
 			}
 		}
-		return true;
+		return $saw_hub_backed;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -181,7 +181,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			$deferred()
 		);
 		return [
-			'tab_error' => false, // snapshot + deferred are non-error, so tab is not all-error.
+			'tab_error' => true, // NPPD-1745: all hub-backed metrics error → banner fires.
 			'current'   => $current,
 			'previous'  => null,
 		];

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -91,6 +91,61 @@ final class Conversion_Metric {
 	const SOURCES = [ 'gate', 'prompt', 'direct' ];
 
 	/**
+	 * Data-source classification per metric key (NPPD-1745 fix for Tab 3). Declares,
+	 * explicitly, whether each card depends on the hub (BigQuery proxy), on local Woo
+	 * order data, or both:
+	 *
+	 *  - 'hub'    — fully hub-backed; errors when the proxy is down.
+	 *  - 'local'  — fully local (Woo order meta or Woo storage layer); survives a
+	 *               hub outage.
+	 *  - 'hybrid' — local numerator + hub denominator (or vice-versa); a hub
+	 *               failure makes it genuinely uncomputable, so it counts as
+	 *               hub-backed for the tab-error banner.
+	 *
+	 * Read by {@see \Newspack\Insights\Conversion_REST_Controller::is_window_all_error()}
+	 * so the "whole tab failed" banner fires when **all hub-backed metrics** error,
+	 * even though surviving local cards still render — instead of being silently
+	 * suppressed by a Woo-only card.
+	 *
+	 * MIGRATION CHECKLIST: when a card moves from hub to order-meta sourcing, update
+	 * its entry here (→ 'local' or 'hybrid'). Keys mirror
+	 * {@see Conversion_REST_Controller::build_window()} +
+	 * {@see Conversion_REST_Controller::build_snapshot()}.
+	 *
+	 * NOTE: source_mix_subscribers and source_mix_donors are 'hybrid' because their
+	 * numerator is local Woo order-meta and their denominator (total registrations
+	 * bucket) comes from the hub. They will migrate to 'local' when the order-meta
+	 * rework is complete.
+	 *
+	 * @var array<string, string>
+	 */
+	public const METRIC_SOURCES = [
+		'reader_lifecycle_funnel'              => 'hub',
+		'anonymous_to_registered_funnel'       => 'hub',
+		'registered_to_subscriber_funnel'      => 'hub',
+		'registered_to_donor_funnel'           => 'hub',
+		'subscriber_to_donor_funnel'           => 'local',   // 2.4 — Woo-only, visibility-gated.
+		'source_mix_registrations'             => 'hub',
+		'source_mix_subscribers'               => 'hybrid',  // Woo records numerator + hub source; errors on hub outage.
+		'source_mix_donors'                    => 'hybrid',  // Woo records numerator + hub source; errors on hub outage.
+		'time_to_register_distribution'        => 'hub',     // 4.1 — BQ.
+		'time_to_subscribe_distribution'       => 'local',   // 4.2 — coming_soon stub; never errors.
+		'time_to_donate_distribution'          => 'local',   // 4.3 — coming_soon stub; never errors.
+		'subscriber_to_donor_lag_distribution' => 'local',   // 4.4 — Woo.
+		'registration_to_conversion_cohort'    => 'local',   // 5.1 — coming_soon / Woo.
+		'subscriber_retention_cohort'          => 'local',   // 5.2 — Woo.
+		'weekly_conversion_rates'              => 'hub',
+		'influenced_registration_rate_7d'      => 'hub',
+		'influenced_subscription_rate_14d'     => 'hub',
+		'influenced_donation_rate_14d'         => 'hub',
+		'influenced_newsletter_rate_7d'        => 'hub',
+		'top_pages_no_conversion'              => 'hub',
+		'stale_registered_count'               => 'local',   // 8.1 — Woo.
+		'at_risk_subscriber_count'             => 'local',   // 8.2 — Woo.
+		'lapsed_donor_count'                   => 'local',   // 8.3 — Woo.
+	];
+
+	/**
 	 * Proxy client used to dispatch catalog queries to the hub.
 	 *
 	 * @var BigQuery_Proxy_Client
@@ -174,6 +229,28 @@ final class Conversion_Metric {
 		$this->woo_resolver       = $woo_resolver ?? new Woo_Order_Resolver();
 		$this->subscribers_metric = $subscribers_metric ?? new Subscribers_Metric();
 		$this->donors_metric      = $donors_metric ?? new Donors_Metric();
+	}
+
+	/**
+	 * Whether WooCommerce is active. Local-only metrics (subscriber→donor funnel,
+	 * opportunity counts, lag distribution) read Woo storage, so they no-op on
+	 * non-WC publishers. Filterable so tests can exercise both paths without toggling
+	 * a global class (the class is `final`, so it can't be doubled). Public because
+	 * the REST controller reads it to scope the tab-error banner: on a non-WC
+	 * publisher a hybrid card short-circuits before reaching the hub, so it must not
+	 * count as a hub-backed survivor (mirrors the identical pattern in
+	 * {@see \Newspack\Insights\Prompts_Metric::woocommerce_active()}, NPPD-1745).
+	 *
+	 * @return bool
+	 */
+	public function woocommerce_active(): bool {
+		/**
+		 * Filters whether Insights treats WooCommerce as active for the
+		 * local Woo order-meta and storage-layer metrics on Tab 3.
+		 *
+		 * @param bool $active Whether the WooCommerce class is loaded.
+		 */
+		return (bool) apply_filters( 'newspack_insights_woocommerce_active', class_exists( 'WooCommerce' ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1882,14 +1882,15 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	/**
 	 * Error fixture: BQ-backed metrics carry state:'error'; local-only metrics
 	 * (subscriber-to-donor funnel, opportunity counts) stay 'populated'; tab_error
-	 * is false because deferred + local metrics are non-error; deferred sections
-	 * stay 'coming_soon'.
+	 * is NOW true (NPPD-1745) because all hub-backed metrics are 'error' — the
+	 * scoped banner fires regardless of the local/coming_soon cards; deferred
+	 * sections stay 'coming_soon'.
 	 */
 	public function test_fixture_error_variant() {
 		$payload = Conversion_Metric::get_fixture( 'error', false );
 
-		// tab_error is false — snapshot and deferred metrics are non-error.
-		$this->assertFalse( $payload['tab_error'] );
+		// NPPD-1745: tab_error is now true — all hub-backed metrics error in the fixture.
+		$this->assertTrue( $payload['tab_error'] );
 		$current = $payload['current'];
 
 		// BQ-backed metrics → error.

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -19,6 +19,7 @@ use Newspack\Insights\Conversion_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Server;
 use WP_UnitTestCase;
+use ReflectionMethod;
 
 /**
  * Conversion_REST_Controller test class.
@@ -93,9 +94,10 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 
 	/**
 	 * A valid window returns 200 with the cache envelope wrapping the state
-	 * envelope. In the test env the BQ proxy is unconfigured — BQ-wired metrics
-	 * surface `state: 'error'`, but the snapshot and coming_soon metrics report
-	 * non-error states, so `tab_error` is false (not all metrics are 'error').
+	 * envelope. In the test env the BQ proxy is unconfigured — BQ-wired (hub)
+	 * metrics surface `state: 'error'`. After the NPPD-1745 fix the banner is
+	 * scoped to hub-backed metrics only; local / coming_soon cards are irrelevant
+	 * to the decision. With every hub card erroring, `tab_error` is now true.
 	 */
 	public function test_valid_window_returns_200_envelope() {
 		$response = $this->dispatch(
@@ -170,12 +172,23 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `tab_error` is false when at least one metric has a non-error state
-	 * (coming_soon or populated). Snapshot metrics (Section 5 cohorts, Sections
-	 * 8.1–8.3) and coming_soon placeholders return non-error states, so the tab
-	 * cannot be all-error even when BQ-wired metrics fail.
+	 * NPPD-1745 scoped-banner behavior in the test env.
+	 *
+	 * In the test env the BQ proxy is unconfigured (hub metrics error) AND there are
+	 * no active subscribers/donors, so `registered_to_subscriber_funnel` and
+	 * `registered_to_donor_funnel` short-circuit to `state: 'empty'` WITHOUT calling
+	 * the hub (the visibility-gated unconfigured-leg path). Under the scoped logic
+	 * an `empty` hub-classified metric is a legitimate non-error survivor — it did
+	 * not fail at the hub. So `tab_error` correctly remains FALSE in the test env,
+	 * even with all other hub metrics erroring.
+	 *
+	 * The banner-hole fix is verified by the synthetic-window unit tests below
+	 * (test_tab_error_fires_on_hub_outage_despite_local_survivor etc.), which craft
+	 * windows where every hub metric is in 'error' state and assert the banner fires.
+	 * The real-dispatch test here verifies the scoped logic does NOT spuriously fire
+	 * the banner when a legitimately-empty hub metric is present.
 	 */
-	public function test_tab_error_false_when_non_error_metrics_present() {
+	public function test_tab_error_false_when_hub_metrics_include_unconfigured_empty_legs() {
 		$response = $this->dispatch(
 			[
 				'start' => '2026-03-22',
@@ -184,21 +197,17 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		);
 		$data = $response->get_data()['data'];
 
-		// The Conversion Journey tab has snapshot and coming_soon metrics that are
-		// NOT 'error', so tab_error must be false even with a broken BQ proxy.
+		// The visibility-gated funnels (registered→subscriber, registered→donor)
+		// return state: 'empty' in the test env (no active subscribers/donors), so
+		// they count as non-error hub-backed survivors and keep tab_error false.
 		$this->assertFalse( $data['tab_error'] );
 	}
 
 	/**
-	 * `tab_error` is false when at least one metric has a non-error state.
-	 * The Conversion Journey has coming_soon and snapshot (populated) metrics
-	 * that always report non-error, so tab_error is always false in a real
-	 * controller response even when the BQ proxy is unconfigured.
-	 *
-	 * We verify this by dispatching a real request and asserting that
-	 * (a) tab_error is false, and (b) deferred sections carry 'coming_soon'.
+	 * Scoped-banner does not suppress coming_soon and local state checks.
+	 * Verifies deferred sections are present regardless of banner state.
 	 */
-	public function test_tab_error_false_for_coming_soon_and_populated_states() {
+	public function test_tab_error_false_with_coming_soon_and_local_states_present() {
 		$response = $this->dispatch(
 			[
 				'start' => '2026-03-22',
@@ -206,9 +215,12 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 			]
 		);
 		$data = $response->get_data()['data'];
-		$this->assertFalse( $data['tab_error'], 'tab_error must be false when coming_soon/populated metrics are present' );
 
-		// Verify that deferred (coming_soon) metrics are present in the window.
+		// See test_tab_error_false_when_hub_metrics_include_unconfigured_empty_legs
+		// for why tab_error is false in this env.
+		$this->assertFalse( $data['tab_error'] );
+
+		// Deferred (coming_soon) metrics are still present and carry the right state.
 		$current = $data['current'];
 		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
 		$this->assertSame( 'coming_soon', $current['time_to_subscribe_distribution']['state'] );
@@ -366,14 +378,15 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Fixture-mode error variant: BQ metrics are 'error', local-only metrics
-	 * stay 'populated', deferred stay 'coming_soon'.
+	 * Fixture-mode error variant: BQ (hub) metrics are 'error', local-only
+	 * metrics stay 'populated', deferred stay 'coming_soon'. NPPD-1745: with the
+	 * scoped banner, all-hub-error → tab_error true (fixture updated to match).
 	 */
 	public function test_fixture_error_variant_via_metric() {
 		$payload = Conversion_Metric::get_fixture( 'error', false );
 
-		// tab_error is false because snapshot + deferred are non-error.
-		$this->assertFalse( $payload['tab_error'] );
+		// NPPD-1745: tab_error is now true because all hub-backed metrics are 'error'.
+		$this->assertTrue( $payload['tab_error'] );
 		$current = $payload['current'];
 
 		$this->assertSame( 'error', $current['reader_lifecycle_funnel']['state'] );
@@ -412,5 +425,151 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		// First refresh seeds the BQ cooldown stamp so the React layer can render the throttle UI.
 		$this->assertNotEmpty( $body['cache']['cooldown_until'] );
 		$this->assertArrayHasKey( 'tab_error', $body['data'] );
+	}
+
+	// -----------------------------------------------------------------------
+	// NPPD-1745 scoped-banner unit tests (mirrors class-test-prompts-rest-controller.php).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Invoke the private static is_window_all_error() on a synthetic window.
+	 *
+	 * @param array $window             Window payload.
+	 * @param bool  $woocommerce_active Whether WC is active (defaults to WC-active path).
+	 * @return bool
+	 */
+	private function invoke_is_window_all_error( array $window, bool $woocommerce_active = true ): bool {
+		$method = new ReflectionMethod( Conversion_REST_Controller::class, 'is_window_all_error' );
+		$method->setAccessible( true );
+		return (bool) $method->invoke( null, $window, $woocommerce_active );
+	}
+
+	/**
+	 * Build a window where every hub-backed metric errors and every local card is
+	 * populated (the hub-outage-with-local-survivor scenario).
+	 *
+	 * @return array
+	 */
+	private function window_hub_down_local_alive(): array {
+		$window = [
+			'window' => [
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			],
+		];
+		foreach ( Conversion_Metric::METRIC_SOURCES as $key => $source ) {
+			$window[ $key ] = [ 'state' => 'local' === $source ? 'populated' : 'error' ];
+		}
+		return $window;
+	}
+
+	/**
+	 * NPPD-1745 regression guard: the "whole tab failed" banner STILL fires when
+	 * every hub-backed metric errors, even though surviving local cards render.
+	 * This is the exact thing the old all-error logic would have silently killed.
+	 */
+	public function test_tab_error_fires_on_hub_outage_despite_local_survivor() {
+		$window = $this->window_hub_down_local_alive();
+
+		// The local survivor is genuinely present and populated.
+		$this->assertSame( 'local', Conversion_Metric::METRIC_SOURCES['subscriber_to_donor_funnel'] );
+		$this->assertSame( 'populated', $window['subscriber_to_donor_funnel']['state'] );
+
+		$this->assertTrue(
+			$this->invoke_is_window_all_error( $window ),
+			'all hub-backed errored → banner fires even though local cards rendered'
+		);
+	}
+
+	/**
+	 * The banner does NOT fire if any hub-backed metric recovers.
+	 */
+	public function test_tab_error_does_not_fire_when_a_hub_metric_recovers() {
+		$window = $this->window_hub_down_local_alive();
+		$window['reader_lifecycle_funnel'] = [ 'state' => 'populated' ]; // One hub card recovers.
+
+		$this->assertFalse( $this->invoke_is_window_all_error( $window ) );
+	}
+
+	/**
+	 * Build the non-WC hub-outage window: every pure-hub card errors, while the
+	 * hybrid cards short-circuit to a populated empty state (they never reach the
+	 * hub on a non-WC publisher) and the local cards render. The banner-hole case.
+	 *
+	 * @return array
+	 */
+	private function window_non_wc_hub_down(): array {
+		$window = [
+			'window' => [
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			],
+		];
+		foreach ( Conversion_Metric::METRIC_SOURCES as $key => $source ) {
+			// hub → error (outage); hybrid + local → populated (non-WC: a hybrid card
+			// empties out before it reaches the hub; local is always local).
+			$window[ $key ] = [ 'state' => 'hub' === $source ? 'error' : 'populated' ];
+		}
+		return $window;
+	}
+
+	/**
+	 * NPPD-1745 banner-hole fix: on a non-WC publisher a hybrid card short-circuits
+	 * to a populated empty state without ever calling the hub, so it must NOT count
+	 * as a hub-backed survivor. With every pure-hub card erroring, the banner fires
+	 * even though the hybrid + local cards render. (Pre-fix, the populated hybrid
+	 * card returned false here, silently suppressing the banner.)
+	 */
+	public function test_tab_error_fires_on_non_wc_hub_outage() {
+		$window = $this->window_non_wc_hub_down();
+
+		// Sanity: a hybrid card is genuinely populated (not error) in this window.
+		$this->assertSame( 'hybrid', Conversion_Metric::METRIC_SOURCES['source_mix_subscribers'] );
+		$this->assertSame( 'populated', $window['source_mix_subscribers']['state'] );
+
+		$this->assertTrue(
+			$this->invoke_is_window_all_error( $window, false ),
+			'non-WC: the hybrid card is skipped, so all-pure-hub-errored fires the banner'
+		);
+		// Guard: were WC active, the same populated hybrid card would be a genuine
+		// hub-backed survivor and (correctly) suppress the banner.
+		$this->assertFalse(
+			$this->invoke_is_window_all_error( $window, true ),
+			'WC-active: a populated hybrid card is a real survivor → no banner'
+		);
+	}
+
+	/**
+	 * NPPD-1745 #5 drift guard: every state-bearing metric that build_window() and
+	 * build_snapshot() emit must have a METRIC_SOURCES entry. is_window_all_error()
+	 * iterates METRIC_SOURCES, so a card added to the window but never classified
+	 * in the map would silently drop out of the tab-error banner with no test to
+	 * catch it.
+	 */
+	public function test_every_window_metric_is_classified_in_metric_sources() {
+		$data = $this->dispatch(
+			[
+				'start' => '2026-03-22',
+				'end'   => '2026-04-21',
+			]
+		)->get_data()['data'];
+
+		$missing = [];
+		foreach ( $data['current'] as $key => $value ) {
+			// Skip date metadata; only state-bearing metric envelopes participate
+			// in the banner decision.
+			if ( 'window' === $key || ! is_array( $value ) || ! isset( $value['state'] ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( $key, Conversion_Metric::METRIC_SOURCES ) ) {
+				$missing[] = $key;
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$missing,
+			'every state-bearing build_window/build_snapshot metric must be classified in Conversion_Metric::METRIC_SOURCES'
+		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a live bug in the Insights → Conversion Journey (Tab 3) "whole tab failed" banner. `is_window_all_error` used the old "every metric errored" rule, but Tab 3 ships Woo-only **local** cards (the subscriber→donor funnel, subscriber-retention cohort, and the at-risk / lapsed / stale opportunity counts) that never report `error`. So during a hub/BigQuery outage those local cards keep rendering real data while the banner stays silent — the tab looks trustworthy while its entire hub-backed half is down, which is worse than a fully-dead tab.

This is the Tab 3 analog of the Tab 5 fix from [#377](https://github.com/Automattic/newspack-workspace/pull/377) (NPPD-1745) — a direct copy-from of that pattern:

- Adds `Conversion_Metric::METRIC_SOURCES`, classifying all 23 Tab 3 metrics as `hub` / `local` / `hybrid`.
- Scopes `is_window_all_error` to the hub-backed metrics only (skipping `local`, and skipping `hybrid` on non-WooCommerce publishers where those cards empty out before reaching the hub), so the banner fires when **all hub-backed cards error** even though surviving local cards still render.

Predates the Phase B feature work (#373); landing it separately so the live banner bug isn't gated behind that PR.

Part of NPPD-1692.

### How to test the changes in this Pull Request:

1. From `plugins/newspack-plugin`, run `n test-php --group insights` — all green (374 tests).
2. The key new tests in `class-test-conversion-rest-controller.php`: `test_tab_error_fires_on_hub_outage_despite_local_survivor` (banner fires when every hub card errors but a local card survives — the bug this fixes), `test_tab_error_does_not_fire_when_a_hub_metric_recovers`, `test_tab_error_fires_on_non_wc_hub_outage`, and `test_every_window_metric_is_classified_in_metric_sources` (guards against an unclassified card silently mis-scoping the banner).
3. Lint on the host: `./vendor/bin/phpcs includes/wizards/insights/metrics/class-conversion-metric.php includes/wizards/insights/api/class-conversion-rest-controller.php` — no errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<sub>Note for reviewers: in the PHPUnit env (unconfigured proxy) the real-dispatch `tab_error` stays `false` because two hub funnels (`registered_to_subscriber/donor_funnel`) are visibility-gated and short-circuit to `state:'empty'` (not `error`) when there are no subscribers/donors — so it isn't a genuine all-hub-down window. The banner-fires behavior is proven by the synthetic-window reflection tests. `source_mix_subscribers/donors` are classified `hybrid` for now; they'll migrate when their order-meta rework lands (#373).</sub>
