### PR TITLE
fix(insights): paywall denominator + subscription table intent + <0.1% display (NPPD-1746)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -113,6 +113,16 @@ final class Conversion_Metric {
 	 * {@see Conversion_REST_Controller::build_window()} +
 	 * {@see Conversion_REST_Controller::build_snapshot()}.
 	 *
+	 * COHERENCE GUARD (NPPD-1746): any card that becomes 'hybrid' — a local order-meta
+	 * numerator over a hub denominator — inherits a cross-source mismatch: the
+	 * complete, server-side order-meta numerator can EXCEED the GA4-undercounted hub
+	 * denominator, yielding a >100% / incoherent rate. The lifecycle funnels
+	 * (registered → subscriber/donor) are still 'hub' on both sides today, but when
+	 * their numerators move to order meta they MUST adopt the same guard the
+	 * Prompts/Gates direct rates use ({@see \Newspack\Insights\Gates_Metric::rate_value()}):
+	 * suppress to not-computable (em-dash) when numerator > denominator rather than
+	 * rendering >100%. Don't let a funnel go 'hybrid' without it.
+	 *
 	 * NOTE: source_mix_subscribers and source_mix_donors are 'hybrid' because their
 	 * numerator is local Woo order-meta and their denominator (total registrations
 	 * bucket) comes from the hub. They will migrate to 'local' when the order-meta

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -479,18 +479,17 @@ final class Gates_Metric {
 	 * denominator to the impressions of the gates that actually converted (see
 	 * {@see self::get_paywall_conversion_direct()}).
 	 *
-	 * NOTE (denominator precision): the hub query computes `checkout_impressions`
-	 * (impressions on gates carrying a checkout button — the paywall-capable subset)
-	 * but does NOT expose it as an output column; it is consumed only inside the
-	 * hub's `paywall_attempt_rate`. The exposed per-gate `impressions` IS true gate
-	 * impressions (anonymous-inclusive `np_gate_interaction(seen)` count) and equals
-	 * `checkout_impressions` exactly for a pure paywall gate; the two diverge only
-	 * for a gate that sometimes shows a checkout button and sometimes doesn't (where
-	 * `impressions` runs slightly larger → the rate reads slightly lower, i.e.
-	 * conservative). Until the hub follow-up NPPD-1749 exposes `checkout_impressions`
-	 * as an output column, `impressions` is the precise available denominator; the
-	 * swap is then one line here. Anonymous-inclusive either way, so no anonymous-at-
-	 * attempt bias is reintroduced.
+	 * NOTE (denominator precision): the ideal denominator is `checkout_impressions`
+	 * (impressions on gates carrying a checkout button — the paywall-capable subset).
+	 * The hub query already COMPUTES it directly (`COUNTIF(has_checkout_button='yes')`
+	 * over `np_gate_interaction(seen)` events — not derived from attempts); NPPD-1749
+	 * adds it to the query's output columns. This reader PREFERS it when present and
+	 * falls back to total `impressions` until that hub change ships — forward-
+	 * compatible, correct both before and after. Total `impressions` equals
+	 * `checkout_impressions` for a pure paywall gate and OVERcounts for a
+	 * registration-heavy mixed gate (where the rate then reads low — conservative,
+	 * never inflated; on Tab 4's live membership gates the dilution is large, hence
+	 * NPPD-1749). Anonymous-inclusive either way, so no anonymous-at-attempt bias.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -516,7 +515,11 @@ final class Gates_Metric {
 			if ( '' === $gate_id || '0' === $gate_id ) {
 				continue;
 			}
-			$map[ $gate_id ] = (int) ( $row['impressions'] ?? 0 );
+			// Prefer the paywall-capable subset (NPPD-1749) once the hub exposes it;
+			// fall back to total gate impressions until then.
+			$map[ $gate_id ] = isset( $row['checkout_impressions'] )
+				? (int) $row['checkout_impressions']
+				: (int) ( $row['impressions'] ?? 0 );
 		}
 		return $map;
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -1374,15 +1374,22 @@ final class Prompts_Metric {
 			$impressions = (int) ( $row['impressions'] ?? 0 );
 
 			$donation_conversions = 'donation' === $intent ? (int) ( $donation_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
-			// Subscription-intent prompts share `action_type=registration` at the data
-			// layer; subscription conversions are now sourced per-popup from order meta
-			// (NPPD-1746), keyed by popup id, anonymous-inclusive — no GA4 join.
-			$subscription_conversions = 'registration' === $intent ? (int) ( $subscription_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
+			// Subscription conversions are sourced per-popup from order meta (NPPD-1746),
+			// keyed by popup id, anonymous-inclusive — and NOT gated on the popup's declared
+			// intent: the order carries `_newspack_popup_id` regardless of action_type, so an
+			// "Undefined"-intent prompt (e.g. a generic "50% off" promo) can still drive
+			// subscriptions. Gating on `intent=registration` hid those and contradicted the
+			// scalar subscription card (caught on live data; the scalar already sums the whole
+			// `by_popup` map). The donation column keeps its intent gate — donations on this
+			// tab are gated on a donation block being present, so the same case doesn't arise.
+			$subscription_conversions = (int) ( $subscription_map[ $popup_id ]['conversions'] ?? 0 );
 
 			// Both rates share the tab-level coherence guard + em-dash semantics via
-			// rate_value() (null = not computable: no impressions or a >100% cross-
-			// surface ratio; a float incl. 0.0 = real rate). null also covers intent
-			// mismatch + non-WC (the column is N/A).
+			// rate_value() (null = not computable: no impressions or a >100% cross-surface
+			// ratio; a float incl. 0.0 = real rate). A rate is rendered only where the metric
+			// applies: donation for donation-intent prompts, subscription for prompts that
+			// actually drove a subscription (present in the map); null = N/A everywhere else,
+			// including non-WC.
 			$mapped[] = [
 				'popup_id'                     => $popup_id,
 				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),
@@ -1398,7 +1405,7 @@ final class Prompts_Metric {
 				'donation_conversions'         => $donation_conversions,
 				'donation_conversion_rate'     => ( 'donation' === $intent && $wc ) ? $this->rate_value( $donation_conversions, $impressions ) : null,
 				'subscription_conversions'     => $subscription_conversions,
-				'subscription_conversion_rate' => ( 'registration' === $intent && $wc ) ? $this->rate_value( $subscription_conversions, $impressions ) : null,
+				'subscription_conversion_rate' => ( $wc && isset( $subscription_map[ $popup_id ] ) ) ? $this->rate_value( $subscription_conversions, $impressions ) : null,
 			];
 		}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.test.ts
@@ -7,7 +7,7 @@
 /**
  * Internal dependencies
  */
-import { formatCurrency } from './format';
+import { formatCurrency, formatPercent } from './format';
 
 describe( 'formatCurrency', () => {
 	it( 'keeps cents below $1,000', () => {
@@ -42,5 +42,26 @@ describe( 'formatCurrency', () => {
 
 	it( 'renders zero with cents and no title', () => {
 		expect( formatCurrency( 0 ) ).toEqual( { display: '$0.00', title: null } );
+	} );
+} );
+
+describe( 'formatPercent', () => {
+	it( 'formats a normal fraction to one decimal', () => {
+		expect( formatPercent( 0.123 ) ).toBe( '12.3%' );
+	} );
+
+	it( 'renders a genuine zero as 0%', () => {
+		expect( formatPercent( 0 ) ).toBe( '0%' );
+	} );
+
+	it( 'renders a positive-but-tiny rate as <0.1% instead of a misleading 0% (NPPD-1746)', () => {
+		// 12 conversions / 156,117 impressions = 0.0077% — would round to "0%".
+		expect( formatPercent( 12 / 156117 ) ).toBe( '<0.1%' );
+		expect( formatPercent( 0.0004 ) ).toBe( '<0.1%' );
+	} );
+
+	it( 'still rounds a rate at/above the display threshold to a real percent', () => {
+		// >= 0.05% rounds to a shown "0.1%", not the <0.1% sentinel.
+		expect( formatPercent( 0.0006 ) ).toBe( '0.1%' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
@@ -103,8 +103,20 @@ export const formatCurrency = ( value: number ): FormattedCurrency => {
 	};
 };
 
-/** Format a fraction in [0, 1] as a percent: 0.123 -> "12.3%". */
-export const formatPercent = ( fraction: number ): string => percentFormatter.format( fraction );
+/**
+ * Format a fraction in [0, 1] as a percent: 0.123 -> "12.3%".
+ *
+ * A positive-but-tiny fraction that would round to "0%" at the displayed precision
+ * (i.e. < 0.05%) renders "<0.1%" instead (NPPD-1746), so a real-but-small rate is
+ * never shown as none — e.g. a paywall gate with a handful of subscriptions over
+ * 100k+ mostly-registration impressions. Genuine zero still renders "0%".
+ */
+export const formatPercent = ( fraction: number ): string => {
+	if ( fraction > 0 && fraction < 0.0005 ) {
+		return `<${ percentFormatter.format( 0.001 ) }`;
+	}
+	return percentFormatter.format( fraction );
+};
 
 /** Format a duration in seconds as m:ss (or h:mm:ss past an hour): 142 -> "2:22". */
 export const formatDuration = ( seconds: number ): string => {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -287,6 +287,36 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1749: once the hub exposes `checkout_impressions` (the paywall-capable
+	 * subset), the rate uses it instead of total gate `impressions` — so a
+	 * registration-heavy mixed gate isn't diluted. Here 12 conversions over a gate
+	 * with 156,117 total impressions but 10,500 checkout impressions yields a rate on
+	 * the 10,500 denominator, not 156,117. Forward-compatible: when the column is
+	 * absent (rows without `checkout_impressions`), the other tests cover the
+	 * `impressions` fallback.
+	 */
+	public function test_paywall_conversion_direct_prefers_checkout_impressions() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'gate_post_id'         => 77,
+					'impressions'          => 156117,
+					'checkout_impressions' => 10500,
+				],
+			]
+		);
+
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 12, 680.70 ), true );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 10500, $result['denominator'], 'uses checkout_impressions, not the diluted total impressions' );
+		$this->assertSame( 12, $result['numerator'] );
+		$this->assertEqualsWithDelta( 12 / 10500, $result['value'], 0.000001 );
+	}
+
+	/**
 	 * No impressions for the converting gate → no denominator → not computable.
 	 */
 	public function test_paywall_conversion_direct_not_computable_without_impressions() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -1335,6 +1335,46 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1746 (live-data fix): a prompt that drove subscriptions but is NOT
+	 * registration-intent (e.g. an "Undefined"-intent "50% off" promo) still shows
+	 * its subscription count + rate in the per-prompt table — matching the scalar
+	 * card, which sums the whole `by_popup` map regardless of intent. Pre-fix this
+	 * column gated on `intent=registration` and silently rendered 0, contradicting
+	 * the scalar (found on a live publisher whose converting popups were Undefined).
+	 */
+	public function test_performance_by_prompt_shows_subscriptions_for_non_registration_intent() {
+		$perf_rows = [ $this->performance_row( 77, '50% off promo', '', 1000 ) ]; // '' = Undefined intent.
+		$proxy     = $this->make_performance_proxy( $perf_rows, [], [] );
+
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tear_down.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn( [] );
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [
+					'77' => [
+						'conversions' => 3,
+						'revenue'     => 150.0,
+					],
+				],
+			]
+		);
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $subscribers );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( '', $result['rows'][0]['intent'], 'guard: the row really is non-registration intent' );
+		$this->assertSame( 3, $result['rows'][0]['subscription_conversions'], 'an Undefined-intent prompt still surfaces its subscriptions' );
+		$this->assertEqualsWithDelta( 0.003, $result['rows'][0]['subscription_conversion_rate'], 0.0001, '3 / 1000 impressions' );
+		// Donation column is N/A on this row (non-donation intent, not in the donation
+		// map): a null rate, not a misleading 0%.
+		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
+		$this->assertNull( $result['rows'][0]['donation_conversion_rate'] );
+	}
+
+	/**
 	 * NPPD-1745: the per-prompt donation_conversion_rate shares the tab-level
 	 * coherence guard (donation_rate_value) — conversions exceeding a popup's
 	 * impressions suppress the rate to null, never a >100% value.


### PR DESCRIPTION
Three live-data follow-ups to the merged subscription/paywall order-meta work (#384, NPPD-1746), found while reviewing a live publisher's Gates + Prompts tabs.

### Paywall rate denominator → `checkout_impressions` (NPPD-1749)
The per-gate paywall conversion rate divided gate-attributed subscriptions by a gate's **total** impressions. On a registration-heavy membership gate (one gate doing both registration + paywall), almost all impressions are registration-mode views, so the rate is diluted to ~0% next to real revenue (e.g. 12 subscriptions ÷ 156k total impressions = 0.008%). `fetch_gate_impressions_by_gate` now **prefers `checkout_impressions`** (the paywall-capable subset) when the hub returns it, falling back to total `impressions` otherwise — forward-compatible, correct before and after the hub change. Hub side: Automattic/newspack-manager-admin#463 exposes the column (it was already computed, just not output).

### Per-popup subscription table un-gated from intent
The scalar Subscription Conversion card sums the whole `by_popup` order-meta map (intent-agnostic — an order carries `_newspack_popup_id` regardless of the popup's declared intent), but the per-prompt **table** still gated its subscription column on `action_type=registration`. On a publisher whose subscription-driving popups are "Undefined"-intent promos, the table showed **0** for popups that drove all of them — contradicting the scalar. The table now matches the scalar. (The donation column keeps its intent gate — donations are gated on a donation block being present, so the same case doesn't arise.)

### Tiny-but-nonzero rates render `<0.1%` instead of `0%`
`formatPercent` rounded a real-but-small rate down to a misleading "0%". A positive fraction that would round to zero now renders `<0.1%`; genuine zero still renders `0%`. Global to all rate cards/tables (single shared formatter), with the period-over-period delta deliberately excluded.

### Tests
- Gate rate prefers `checkout_impressions` when present (falls back to `impressions` otherwise).
- A per-prompt test for an Undefined-intent prompt that drove subscriptions.
- `formatPercent` unit tests for the `<0.1%` boundary.
- `insights` PHP group green (435); `format.test.ts` runs in CI.