### PR TITLE
hotfix(wc-memberships): skip expiry filter for non-subscription memberships

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-membership-expiry.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-membership-expiry.php
@@ -28,11 +28,16 @@ class Membership_Expiry {
 	/**
 	 * Prevent membership expiration if there are other active subscriptions.
 	 *
-	 * @param bool                                                      $cancel_membership Whether to cancel the membership when the subscription is cancelled (default true).
-	 * @param \WC_Memberships_Integration_Subscriptions_User_Membership $user_membership The subscription-tied membership.
+	 * @param bool                            $cancel_membership Whether to cancel the membership when the subscription is cancelled (default true).
+	 * @param \WC_Memberships_User_Membership $user_membership   The membership. Only subscription-tied memberships (\WC_Memberships_Integration_Subscriptions_User_Membership) expose get_subscription_id()/set_subscription_id().
 	 */
 	public static function prevent_membership_expiration( $cancel_membership, $user_membership ) {
 		if ( ! function_exists( 'wcs_get_subscription' ) ) {
+			return $cancel_membership;
+		}
+		// `wc_memberships_expire_user_membership` fires for every membership, but only the
+		// Subscriptions integration class exposes get_subscription_id()/set_subscription_id().
+		if ( ! method_exists( $user_membership, 'get_subscription_id' ) ) {
 			return $cancel_membership;
 		}
 		$membership_product_id = $user_membership->get_product_id();

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/membership-expiry.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/membership-expiry.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for the WC Memberships expiry handler.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Membership_Expiry;
+
+require_once dirname( __DIR__, 3 ) . '/mocks/wc-mocks.php';
+
+/**
+ * Test Membership_Expiry::prevent_membership_expiration().
+ *
+ * @group membership-expiry
+ */
+class Test_Membership_Expiry extends WP_UnitTestCase {
+
+	/**
+	 * The wc_memberships_expire_user_membership filter fires for every user membership,
+	 * not just subscription-tied ones. Plain WC_Memberships_User_Membership objects do
+	 * not expose get_subscription_id(); calling it must not fatal.
+	 *
+	 * Reproduces the production fatal observed at v6.39.3 of newspack-plugin:
+	 *   Uncaught Error: Call to undefined method WC_Memberships_User_Membership::get_subscription_id()
+	 *   in includes/plugins/wc-memberships/class-membership-expiry.php:39
+	 */
+	public function test_passes_through_non_subscription_membership() {
+		$non_subscription_membership = new class() {
+			/**
+			 * Return a product id.
+			 *
+			 * @return int
+			 */
+			public function get_product_id() {
+				return 123;
+			}
+
+			/**
+			 * Return a user id.
+			 *
+			 * @return int
+			 */
+			public function get_user_id() {
+				return 456;
+			}
+
+			// Deliberately no get_subscription_id() — only the Subscriptions integration class has it.
+		};
+
+		$result = Membership_Expiry::prevent_membership_expiration( true, $non_subscription_membership );
+		$this->assertTrue( $result, 'Filter should return the incoming $cancel_membership unchanged when the membership is not subscription-tied.' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `wc_memberships_expire_user_membership` filter fires for **every** user membership, not only subscription-tied ones. `Membership_Expiry::prevent_membership_expiration()` assumed a `\WC_Memberships_Integration_Subscriptions_User_Membership` and called `get_subscription_id()` on the passed object. For a plain `\WC_Memberships_User_Membership` (a membership not linked to a subscription) that method does not exist, so the call threw:

```
PHP Fatal error: Uncaught Error: Call to undefined method WC_Memberships_User_Membership::get_subscription_id() in .../wc-memberships/class-membership-expiry.php:39
```

The handler now bails out early via `method_exists()` when the membership is not subscription-tied, and the docblock type is widened to the base class.

This is a hotfix onto `release`: the fix already landed on `main`/`alpha` (`9b37834a`, originally Automattic/newspack-plugin#4743) but is missing from the released 6.43.x line, which is what production sites hitting this fatal are running – this should have been a hotfix from the get-go. 

### How to test the changes in this Pull Request:

1. On a site with WooCommerce Memberships, create a membership that is **not** tied to a subscription (e.g. a manually-assigned or order-based membership).
2. Trigger the membership expiry path for that membership (or expire a subscription-linked membership for a user who also holds a non-subscription one).
3. Before this change the request fatals with the undefined-method error above; after it, expiry proceeds without error.

A unit test (`tests/unit-tests/plugins/wc-memberships/membership-expiry.php`) covering the non-subscription bail-out is included.

### Other information:

* [x] Have you written new tests for your changes, as applicable?
* [x] The change is a cherry-pick of an already-reviewed-and-merged commit (`9b37834a`, Automattic/newspack-plugin#4743) on `main`/`alpha`.