### PR TITLE
fix(google-site-kit): add filter to override forced GA4 snippet

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -124,6 +124,38 @@ class GoogleSiteKit {
 	}
 
 	/**
+	 * Whether Newspack should turn on Site Kit's GA4 gtag snippet during GA4 setup.
+	 *
+	 * Newspack enables the gtag snippet so its reader custom dimensions ride along with the
+	 * GA4 page_view. On a site that already tags GA4 through a Google Tag Manager container,
+	 * the gtag is a second GA4 page_view feed (duplicate counting); reader params also reach
+	 * GTM through the dataLayer (see print_data_layer_params), so the gtag is not required to
+	 * deliver them there.
+	 *
+	 * Defaults to true (enable the snippet). WordPress cannot see whether a placed GTM
+	 * container actually carries a GA4 tag, so leaving the gtag off by default would remove
+	 * GA4 entirely from any site whose GTM does not carry it. Newspack Manager, which observes
+	 * the real GA4 beacons, hooks the filter below to return false once it has confirmed a
+	 * container is independently sending GA4 for the property.
+	 *
+	 * @param string $measurement_id The GA4 measurement ID being set up, if known.
+	 * @return bool Whether to enable the GA4 gtag snippet.
+	 */
+	public static function should_force_ga4_snippet( string $measurement_id = '' ): bool {
+		/**
+		 * Filters whether Newspack turns on Site Kit's GA4 gtag snippet during GA4 setup.
+		 *
+		 * Return false to leave the gtag snippet off. Do so only when GA4 is known to be
+		 * tagged through another source (e.g. a GTM container that carries GA4), otherwise
+		 * the site will have no GA4 tag at all.
+		 *
+		 * @param bool   $force_snippet  Whether to enable the gtag snippet. Default true.
+		 * @param string $measurement_id The GA4 measurement ID being set up, if known.
+		 */
+		return (bool) apply_filters( 'newspack_googlesitekit_force_ga4_snippet', true, $measurement_id );
+	}
+
+	/**
 	 * Fetch data for the GA account data and set up GA4.
 	 */
 	public static function setup_sitekit_ga4() {
@@ -162,7 +194,7 @@ class GoogleSiteKit {
 				return;
 			}
 			$ga4_settings['ownerID']    = get_current_user_id();
-			$ga4_settings['useSnippet'] = true;
+			$ga4_settings['useSnippet'] = self::should_force_ga4_snippet( $ga4_settings['measurementID'] ?? '' );
 
 			$sitekit_ga4_option_name = self::get_sitekit_ga4_settings_option_name();
 			Logger::log( 'Updating Site Kit GA4 settings option.' );

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit-ga4-snippet.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit-ga4-snippet.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for whether Newspack forces Site Kit's GA4 gtag snippet on during setup.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\GoogleSiteKit;
+
+/**
+ * Test the GA4 gtag snippet-forcing decision.
+ *
+ * Newspack enables Site Kit's GA4 gtag snippet during setup so its reader custom
+ * dimensions ride along with the GA4 page_view. On a site that already tags GA4 through
+ * a Google Tag Manager container, that gtag is a second GA4 page_view feed (duplicate
+ * counting). This decision is the seam Newspack Manager uses to turn the gtag off once it
+ * has confirmed - from real GA4 beacons - that a container is independently sending GA4.
+ *
+ * @group GoogleSiteKit_Snippet
+ */
+class Newspack_Test_GoogleSiteKit_Force_GA4_Snippet extends WP_UnitTestCase {
+
+	/**
+	 * Clean up filters between tests so the default-behaviour test is not polluted.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'newspack_googlesitekit_force_ga4_snippet' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The snippet is forced on by default. This is the safe choice: WordPress cannot see
+	 * whether a placed GTM container actually carries a GA4 tag, so dropping the gtag by
+	 * default would leave any site whose GTM lacks GA4 with no GA4 tag at all.
+	 */
+	public function test_forces_snippet_by_default() {
+		$this->assertTrue( GoogleSiteKit::should_force_ga4_snippet( 'G-ABC123' ) );
+	}
+
+	/**
+	 * The decision is overridable via filter, so Newspack Manager can switch the gtag off
+	 * once it has confirmed a GTM container feeds the GA4 property.
+	 */
+	public function test_filter_can_disable_snippet() {
+		add_filter( 'newspack_googlesitekit_force_ga4_snippet', '__return_false' );
+		$this->assertFalse( GoogleSiteKit::should_force_ga4_snippet( 'G-ABC123' ) );
+	}
+
+	/**
+	 * The measurement ID is passed to the filter so the decision can be made per-property -
+	 * the manager keys its "GTM carries GA4" confirmation on the specific property.
+	 */
+	public function test_filter_receives_measurement_id() {
+		$seen_measurement_id = null;
+		add_filter(
+			'newspack_googlesitekit_force_ga4_snippet',
+			function ( $force_snippet, $measurement_id ) use ( &$seen_measurement_id ) {
+				$seen_measurement_id = $measurement_id;
+				return $force_snippet;
+			},
+			10,
+			2
+		);
+
+		GoogleSiteKit::should_force_ga4_snippet( 'G-XYZ789' );
+
+		$this->assertSame( 'G-XYZ789', $seen_measurement_id );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Newspack's `GoogleSiteKit::setup_sitekit_ga4()` runs once per site and **unconditionally forces Site Kit's GA4 gtag snippet on** (`useSnippet = true`), so Newspack's reader custom dimensions ride along with the GA4 `page_view`. That assumes the gtag is the *sole* GA4 feed.

A platform audit found that assumption false for ~1/3 of live sites: **114 sites tag GA4 through a GTM container via Site Kit, and 107 of those also run the forced gtag snippet** – two GA4 `page_view` feeds, i.e. duplicate page views (the root cause behind NPPM-2907 / the `>2 pageviews per request` Slack alerts).

This PR makes the snippet-forcing **overridable** instead of unconditional:

- Extracts the decision into a pure, testable `GoogleSiteKit::should_force_ga4_snippet( $measurement_id )`.
- Adds a `newspack_googlesitekit_force_ga4_snippet` filter, **defaulting to `true`** (current behaviour – no change on its own).
- The call site now uses the helper instead of the hard-coded `true`.

This is an **inert seam by design.** WordPress cannot see whether a placed GTM container actually carries a GA4 tag, so the plugin must not decide to drop the snippet on its own – doing so blindly would remove GA4 entirely from any site whose GTM does *not* carry it. The *evidence* lives in Newspack Manager, whose service-worker monitor already observes the real GA4 beacons: a same-property double **proves** GTM is independently feeding that property, which is exactly the green light to drop the gtag. The manager follow-up will hook this filter (and persist a sticky, windowed confirmation + a zero-pageview regression alarm).

Depends on (stacked on) #311 – reader params must reach GTM via the dataLayer before the gtag can be dropped on any site, or GTM-tier sites would lose their reader dimensions.

Part of NPPM-2933.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-plugin && n test-php --group GoogleSiteKit_Snippet` → 3 passing tests.
2. Confirm the default is unchanged: with no filter hooked, `GoogleSiteKit::should_force_ga4_snippet( 'G-X' )` returns `true`.
3. Confirm overridability: `add_filter( 'newspack_googlesitekit_force_ga4_snippet', '__return_false' )` makes it return `false`, and the filter receives the measurement ID as its 2nd arg.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

> [!NOTE]
> Stacked on #311 (base branch `nppm-2907-ga4-datalayer`). Re-target to `release` once #311 merges. Ships no behaviour change until the Newspack Manager follow-up hooks the filter.