### PR TITLE
docs(agents): note one Copilot review pass per PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,8 @@ Use the `newspack` plugin skills for the full PR lifecycle:
 4. `newspack:pr-merge` — Merge after approval and checks pass
 5. `newspack:pr-test` — Test a PR in an isolated environment with automated checks and code review
 
+**One Copilot pass per PR.** Request a Copilot review once, when the PR is opened. After addressing its feedback, do **not** re-request Copilot by default — one automated pass is enough, and the next review should come from a human. Re-request Copilot only when a reviewer explicitly asks for another pass.
+
 ## External Tools
 
 - **Linear**: Use MCP tools for Linear operations when available. Write operations (creating or updating issues, comments, etc.) require explicit user confirmation.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a short note to `AGENTS.md` (the shared agent-instructions file) documenting that a PR gets **one Copilot review pass**: after `pr-feedback` addresses Copilot's comments, agents should not re-request Copilot by default – the next review should come from a human.

This codifies the team's intended flow so AI agents stop churning extra automated passes. The existing `pr-feedback` expectation (edit, commit, reply to and resolve threads) is unchanged; this only carves out the re-request step for Copilot.

### How to test the changes in this Pull Request:

1. Read the new paragraph under the **Pull Requests** section of `AGENTS.md`.

### Other information:

* [x] Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
