### PR TITLE
feat(env): serve repos/ plugins and themes in isolated envs

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -210,6 +210,7 @@ services:
       - .:/newspack-monorepo
       - ./plugins:/newspack-plugins
       - ./themes:/newspack-themes
+      - ./repos:/newspack-repos
 ${worktree_volumes}      - ./envs/${env_name}/html:/var/www/html
       - ./manager-html:/var/www/manager-html
       - ./additional-sites-html:/var/www/additional-sites-html


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Isolated envs now serve `repos/plugins/*` and `repos/themes/*` checkouts the same way the main `newspack_dev` site does.

**The fix is one line:** mount `./repos:/newspack-repos` in the generated env compose (`bin/env.sh`). `bin/link-repos.sh` already runs at container startup in env containers (via `bin/run.sh`) and already symlinks `repos/{plugins,themes}/*` into the site, with the tracked monorepo copy taking precedence over a same-named `repos/` checkout — it was simply a no-op in envs because the mount was missing. No other code needed.

**Why:** the main dev site mounts `repos/`, but its `localhost` cert is baked into the Docker image with an in-container mkcert CA (`OU=root@buildkitsandbox`) the host never trusted, so headless browsers (Playwright/Chromium) reject it with `ERR_CERT_AUTHORITY_INVALID`. An isolated env's `<name>.test` cert is minted by the **host** mkcert CA, which the host trust store accepts — so an env is the right place to browser-test a `repos/` unit (e.g. a `newspack-manager` PR), but until now you had to hand-copy the checkout into the env's html dir. Now it's automatic.

`n env create --worktree` still only targets monorepo plugins/themes/packages — that's unchanged and remains the path for testing a *branch* of a monorepo unit.

### How to test the changes in this Pull Request:

1. `n env create repostest && n env up repostest`
2. Inside the container, confirm `repos/`-only plugins are symlinked from `/newspack-repos`:
   `docker exec newspack_env_repostest bash -c 'ls -la /var/www/html/wp-content/plugins/ | grep newspack-repos'`
   → e.g. `newspack-manager -> /newspack-repos/plugins/newspack-manager/`, `perfmatters -> /newspack-repos/plugins/perfmatters/`, etc.
3. Confirm precedence is preserved: a name present in both `plugins/` and `repos/plugins/` (e.g. `woocommerce`) still resolves to `/newspack-plugins/woocommerce` (monorepo wins).
4. Confirm the monorepo plugins are still symlinked as before.

Verified locally: a fresh env symlinked all 7 repos-only plugins from `/newspack-repos`, kept all 17 monorepo symlinks, and `woocommerce` (in both) resolved to the monorepo copy.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (dev-env tooling; verified by the manual steps above)
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)