### PR TITLE
feat(insights): conversion cohorts (5.1/5.2) + weekly pre-warm

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -20,6 +20,10 @@ final class Cache {
 	const SOURCE_EXTERNAL = 'external';
 	const SOURCE_LOCAL    = 'local';
 
+	const SOURCE_SNAPSHOT = 'snapshot';
+
+	const TTL_SNAPSHOT = 9 * DAY_IN_SECONDS;
+
 	const TTL_BIGQUERY        = DAY_IN_SECONDS;
 	const TTL_EXTERNAL        = 10 * MINUTE_IN_SECONDS;
 	const BQ_COOLDOWN_SECONDS = 10 * MINUTE_IN_SECONDS;
@@ -77,7 +81,9 @@ final class Cache {
 			'source'      => $envelope['source'],
 		];
 		set_transient( $key, $store, self::ttl_for( $source ) );
-		self::index_add( $tab, $key );
+		if ( self::SOURCE_SNAPSHOT !== $source ) {
+			self::index_add( $tab, $key );
+		}
 
 		$envelope['cooldown_until'] = $cooldown_until;
 		return $envelope;
@@ -111,6 +117,26 @@ final class Cache {
 	}
 
 	/**
+	 * Read a cached envelope WITHOUT computing on miss. Returns the stored
+	 * `{ payload, computed_at, source }` array, or null when nothing usable is
+	 * cached or caching is disabled. The read-only primitive the snapshot
+	 * pre-warm pattern needs: request-path callers peek and, on null, schedule a
+	 * background refresh rather than computing an expensive payload inline.
+	 *
+	 * @param string   $tab       Tab slug.
+	 * @param string   $source    SOURCE_* constant.
+	 * @param string[] $key_parts Canonicalized key components.
+	 * @return array{ payload: array, computed_at: string, source: string }|null
+	 */
+	public static function peek( string $tab, string $source, array $key_parts ): ?array {
+		unset( $source ); // Reserved for parity with store()/refresh(); key is tab+parts.
+		if ( self::is_disabled() ) {
+			return null;
+		}
+		return self::read_cached( $tab, $key_parts );
+	}
+
+	/**
 	 * Get the TTL for a given source.
 	 *
 	 * @param string $source SOURCE_* constant.
@@ -119,6 +145,9 @@ final class Cache {
 	private static function ttl_for( string $source ): int {
 		if ( self::SOURCE_BIGQUERY === $source ) {
 			return self::TTL_BIGQUERY;
+		}
+		if ( self::SOURCE_SNAPSHOT === $source ) {
+			return self::TTL_SNAPSHOT;
 		}
 		return self::TTL_EXTERNAL;
 	}
@@ -254,7 +283,9 @@ final class Cache {
 			];
 			// set_transient() overwrites in place — no need to delete_transient() first.
 			set_transient( $key, $store, self::ttl_for( $source ) );
-			self::index_add( $tab, $key );
+			if ( self::SOURCE_SNAPSHOT !== $source ) {
+				self::index_add( $tab, $key );
+			}
 		}
 
 		// BigQuery refreshes always come back with the active cooldown stamp

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -119,21 +119,25 @@ final class Cache {
 	/**
 	 * Read a cached envelope WITHOUT computing on miss. Returns the stored
 	 * `{ payload, computed_at, source }` array, or null when nothing usable is
-	 * cached or caching is disabled. The read-only primitive the snapshot
+	 * cached, caching is disabled, or the cached envelope's source does not
+	 * match the requested $source. The read-only primitive the snapshot
 	 * pre-warm pattern needs: request-path callers peek and, on null, schedule a
 	 * background refresh rather than computing an expensive payload inline.
 	 *
 	 * @param string   $tab       Tab slug.
-	 * @param string   $source    SOURCE_* constant.
+	 * @param string   $source    SOURCE_* constant. Must match the stored envelope's source.
 	 * @param string[] $key_parts Canonicalized key components.
 	 * @return array{ payload: array, computed_at: string, source: string }|null
 	 */
 	public static function peek( string $tab, string $source, array $key_parts ): ?array {
-		unset( $source ); // Reserved for parity with store()/refresh(); key is tab+parts.
 		if ( self::is_disabled() ) {
 			return null;
 		}
-		return self::read_cached( $tab, $key_parts );
+		$cached = self::read_cached( $tab, $key_parts );
+		if ( null === $cached || $cached['source'] !== $source ) {
+			return null;
+		}
+		return $cached;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -77,6 +77,10 @@ class Insights_Section_Conversion {
 		// weekly recurring refresh; the recurring schedule is ensured on init.
 		add_action( Conversion_Metric::COHORT_REFRESH_ACTION, [ Conversion_Metric::class, 'run_cohort_refresh' ] );
 		add_action( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [ Conversion_Metric::class, 'run_cohort_refresh' ] );
-		add_action( 'init', [ Conversion_Metric::class, 'maybe_schedule_cohort_prewarm' ] );
+		// register_hooks() is called from Wizards::init_wizards(), which itself
+		// runs on the 'init' action. Adding another 'init' callback here would
+		// be a no-op (the hook has already fired). Call directly — the method is
+		// idempotent (guards with function_exists + as_next_scheduled_action).
+		Conversion_Metric::maybe_schedule_cohort_prewarm();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -21,6 +21,7 @@
 
 namespace Newspack;
 
+use Newspack\Insights\Conversion_Metric;
 use Newspack\Insights\Conversion_REST_Controller;
 
 defined( 'ABSPATH' ) || exit;
@@ -60,7 +61,7 @@ class Insights_Section_Conversion {
 	}
 
 	/**
-	 * Register the Tab 3 REST route.
+	 * Register the Tab 3 REST route and cohort pre-warm hooks.
 	 *
 	 * @return void
 	 */
@@ -72,5 +73,10 @@ class Insights_Section_Conversion {
 				$controller->register_routes();
 			}
 		);
+		// Cohort pre-warm: handler runs both the one-off (cold-cache) and the
+		// weekly recurring refresh; the recurring schedule is ensured on init.
+		add_action( Conversion_Metric::COHORT_REFRESH_ACTION, [ Conversion_Metric::class, 'run_cohort_refresh' ] );
+		add_action( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [ Conversion_Metric::class, 'run_cohort_refresh' ] );
+		add_action( 'init', [ Conversion_Metric::class, 'maybe_schedule_cohort_prewarm' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -59,6 +59,7 @@ class Insights_Section_Subscribers {
 	 */
 	private static function load_dependencies(): void {
 		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'storage/trait-reader-population.php';
 		include_once $base . 'storage/class-storage-interface.php';
 		include_once $base . 'storage/class-storage-detector.php';
 		include_once $base . 'storage/class-hpos-storage.php';

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -2102,6 +2102,22 @@ final class Conversion_Metric {
 	}
 
 	/**
+	 * Timestamp of the next weekly pre-warm slot: this week's Monday 06:00 UTC,
+	 * or next week's if that instant has already passed. Computed relative to
+	 * $now so it never skips the upcoming Monday when called early on a Monday.
+	 *
+	 * @param \DateTimeImmutable $now Reference time (UTC).
+	 * @return int Unix timestamp.
+	 */
+	public static function next_weekly_prewarm_timestamp( \DateTimeImmutable $now ): int {
+		$monday = $now->modify( 'monday this week' )->setTime( 6, 0 );
+		if ( $monday <= $now ) {
+			$monday = $monday->modify( '+1 week' );
+		}
+		return $monday->getTimestamp();
+	}
+
+	/**
 	 * Ensure a weekly recurring cohort pre-warm is scheduled (Monday 06:00 UTC).
 	 * No-op if Action Scheduler is unavailable or the recurring action already
 	 * exists. Hooked on `init` by the conversion section.
@@ -2115,7 +2131,7 @@ final class Conversion_Metric {
 		if ( false !== as_next_scheduled_action( self::COHORT_REFRESH_WEEKLY_ACTION, [], self::COHORT_REFRESH_GROUP ) ) {
 			return;
 		}
-		$next = ( new \DateTimeImmutable( 'next monday 06:00', new \DateTimeZone( 'UTC' ) ) )->getTimestamp();
+		$next = self::next_weekly_prewarm_timestamp( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) );
 		as_schedule_recurring_action( $next, WEEK_IN_SECONDS, self::COHORT_REFRESH_WEEKLY_ACTION, [], self::COHORT_REFRESH_GROUP );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1993,10 +1993,10 @@ final class Conversion_Metric {
 			for ( $n = 0; $n <= $age; $n++ ) {
 				$active = 0;
 				foreach ( $members as $cid => $first_start ) {
-					$t = ( new \DateTimeImmutable( '@' . $first_start ) )
-						->setTimezone( $utc )
-						->modify( '+' . $n . ' months' )
-						->getTimestamp();
+					$t = $this->add_months_clamped(
+						( new \DateTimeImmutable( '@' . $first_start ) )->setTimezone( $utc ),
+						$n
+					)->getTimestamp();
 					foreach ( $by_customer[ $cid ] as $interval ) {
 						if ( $interval['start'] <= $t && ( null === $interval['terminus'] || $interval['terminus'] > $t ) ) {
 							$active++;
@@ -2022,6 +2022,30 @@ final class Conversion_Metric {
 			],
 			[ 'reference_line' => $this->retention_reference_line() ]
 		);
+	}
+
+	/**
+	 * Add N months to a DateTimeImmutable, clamping end-of-month overflow.
+	 *
+	 * PHP's `modify('+N months')` overflows end-of-month dates into the next month
+	 * (e.g. Jan 31 + 1 month → Mar 3). For retention cohorts this shifts the
+	 * comparison instant T, flipping the strict `terminus > T` boundary for
+	 * end-of-month subscription starts. This helper clamps the result back to
+	 * the last day of the target month when overflow occurs, while preserving the
+	 * original time-of-day (e.g. Jan 31 +1mo → Feb 28/29 same time, not Mar 3).
+	 * All date math is performed in the timezone of $base.
+	 *
+	 * @param \DateTimeImmutable $base The base datetime (must be in the desired timezone).
+	 * @param int                $n    Number of months to add (non-negative).
+	 * @return \DateTimeImmutable
+	 */
+	private function add_months_clamped( \DateTimeImmutable $base, int $n ): \DateTimeImmutable {
+		$t = $base->modify( '+' . $n . ' months' );
+		// If the day-of-month changed, the month overflowed — clamp to last day of previous month.
+		if ( $t->format( 'j' ) !== $base->format( 'j' ) ) {
+			$t = $t->modify( 'last day of previous month' );
+		}
+		return $t;
 	}
 
 	// --- Section 5: Action Scheduler handlers and pre-warm scheduling -------

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -233,6 +233,13 @@ final class Conversion_Metric {
 	const MIN_COHORT_FOR_SUB_TO_DONOR = 50;
 
 	/**
+	 * Maximum months-since offset rendered on a cohort retention series (5.1/5.2).
+	 *
+	 * @var int
+	 */
+	const COHORT_MAX_MONTHS = 12;
+
+	/**
 	 * Constructor. Optionally inject collaborators (used in tests).
 	 *
 	 * @param BigQuery_Proxy_Client|null $proxy              Injected proxy client, or null to lazy-resolve.
@@ -1405,6 +1412,116 @@ final class Conversion_Metric {
 	// --- Section 5: Cohort retention ------------------------------------
 	// Snapshot metrics: pre-computed weekly, independent of the date picker.
 	// The $start/$end params are accepted for signature parity and ignored.
+
+	/**
+	 * Calendar-month index for cohort bucketing: year*12 + (month-1). The
+	 * difference of two indices is the whole-calendar-months between them.
+	 *
+	 * @param \DateTimeInterface $d Date.
+	 * @return int
+	 */
+	private function month_index( \DateTimeInterface $d ): int {
+		return ( (int) $d->format( 'Y' ) ) * 12 + ( (int) $d->format( 'n' ) - 1 );
+	}
+
+	/**
+	 * 5.1 reference line (hardcoded per spec): 15% conversion at 6 months.
+	 *
+	 * @return array{value: float, label: string}
+	 */
+	private function registration_reference_line(): array {
+		return [
+			'value' => 0.15,
+			'label' => __( '15% at 6 months', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * Compute the 5.1 registration → conversion cohort retention curve (the
+	 * expensive snapshot work; called by the weekly/one-off pre-warm handler,
+	 * never on the request hot path). Cohort = readers grouped by
+	 * `user_registered` month (trailing 365 days). Conversion = the earlier of
+	 * the reader's first subscription or first donation order. For each cohort
+	 * and each months-since offset N (0..age, capped 12), the value is the
+	 * CUMULATIVE fraction of the cohort converted by month N.
+	 *
+	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}}
+	 */
+	public function compute_registration_to_conversion_cohort(): array {
+		$readers = $this->subscribers_metric->get_reader_registration_dates();
+		if ( empty( $readers ) ) {
+			return array_merge(
+				[
+					'state'   => 'empty',
+					'cohorts' => [],
+				],
+				[ 'reference_line' => $this->registration_reference_line() ]
+			);
+		}
+
+		$ids  = array_keys( $readers );
+		$subs = $this->subscribers_metric->get_first_subscription_order_dates( $ids );
+		$dons = $this->donors_metric->get_first_donation_order_dates( $ids );
+
+		$now_index = $this->month_index( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) );
+
+		// Per-cohort tallies: denominator (cohort size) and a histogram of
+		// months_since at first conversion (only for converters).
+		$denominator   = []; // cohort_index => reader count.
+		$converted_at  = []; // cohort_index => [ months_since => converter count ].
+		$cohort_labels = []; // cohort_index => 'YYYY-MM'.
+		foreach ( $readers as $id => $reg ) {
+			$cohort_index                   = $this->month_index( $reg );
+			$cohort_labels[ $cohort_index ] = $reg->format( 'Y-m' );
+			$denominator[ $cohort_index ]   = ( $denominator[ $cohort_index ] ?? 0 ) + 1;
+
+			$sub  = $subs[ $id ] ?? null;
+			$don  = $dons[ $id ] ?? null;
+			$conv = null;
+			if ( $sub && $don ) {
+				$conv = $sub <= $don ? $sub : $don;
+			} else {
+				$conv = $sub ?? $don;
+			}
+			if ( null === $conv ) {
+				continue;
+			}
+			$months_since = $this->month_index( $conv ) - $cohort_index;
+			if ( $months_since < 0 ) {
+				continue;
+			}
+			$months_since = min( $months_since, self::COHORT_MAX_MONTHS );
+			$converted_at[ $cohort_index ][ $months_since ] = ( $converted_at[ $cohort_index ][ $months_since ] ?? 0 ) + 1;
+		}
+
+		ksort( $denominator );
+		$cohorts = [];
+		foreach ( $denominator as $cohort_index => $size ) {
+			$age     = min( self::COHORT_MAX_MONTHS, $now_index - $cohort_index );
+			$age     = max( 0, $age );
+			$points  = [];
+			$running = 0;
+			for ( $n = 0; $n <= $age; $n++ ) {
+				$running += $converted_at[ $cohort_index ][ $n ] ?? 0;
+				$points[] = [
+					'period' => $n,
+					'value'  => round( $running / $size, 4 ),
+				];
+			}
+			$cohorts[] = [
+				'label'  => $cohort_labels[ $cohort_index ],
+				'points' => $points,
+			];
+		}
+
+		return array_merge(
+			[
+				'state'   => empty( $cohorts ) ? 'empty' : 'populated',
+				'cohorts' => $cohorts,
+			],
+			[ 'reference_line' => $this->registration_reference_line() ]
+		);
+	}
 
 	/**
 	 * Registration → conversion cohort retention (5.1). Snapshot — ignores

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -82,6 +82,42 @@ final class Conversion_Metric {
 	const CACHE_PREFIX = 'newspack_insights_tab3_v1:';
 
 	/**
+	 * Tab slug used as the Cache namespace for Section 5 snapshots.
+	 *
+	 * @var string
+	 */
+	const TAB_SLUG = 'conversion';
+
+	/**
+	 * Cache key parts for the combined cohort snapshot entry.
+	 *
+	 * @var string
+	 */
+	const SNAPSHOT_KEY = 'cohorts';
+
+	/**
+	 * Action Scheduler action name for a one-off cohort snapshot refresh
+	 * (triggered on cold-cache misses from the request path).
+	 *
+	 * @var string
+	 */
+	const COHORT_REFRESH_ACTION = 'newspack_insights_conversion_cohort_refresh';
+
+	/**
+	 * Action Scheduler action name for the weekly recurring cohort pre-warm.
+	 *
+	 * @var string
+	 */
+	const COHORT_REFRESH_WEEKLY_ACTION = 'newspack_insights_conversion_cohort_refresh_weekly';
+
+	/**
+	 * Action Scheduler group for all cohort-refresh jobs.
+	 *
+	 * @var string
+	 */
+	const COHORT_REFRESH_GROUP = 'newspack-insights';
+
+	/**
 	 * The three acquisition surfaces every source-attributed metric splits
 	 * by. Machine keys (not translated) — the React layer maps them to
 	 * display labels. Shared by the Section 3 PieCharts and the Section 4
@@ -1524,50 +1560,54 @@ final class Conversion_Metric {
 	}
 
 	/**
-	 * Registration → conversion cohort retention (5.1). Snapshot — ignores
-	 * the window. The reference line (15% at 6 months) is hardcoded per the
-	 * spec; Phase B `coming_soon` placeholder preserves the `reference_line`
-	 * key React reads unconditionally.
+	 * Registration → conversion cohort (5.1). Snapshot — ignores the window.
+	 * Reads the weekly pre-warmed snapshot via Cache::peek; on a cold cache it
+	 * schedules a one-off background refresh and returns the graceful
+	 * `coming_soon` envelope (never computes the expensive curve inline). The
+	 * `reference_line` key React reads unconditionally is always present.
 	 *
 	 * @param DateTimeInterface $start Window start (ignored — snapshot).
 	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
-	 * @return array{state: string, cohorts: array, reference_line: array{value: float, label: string}}
+	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}}
 	 */
 	public function get_registration_to_conversion_cohort( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
+		if ( Cache::is_disabled() ) {
+			return $this->compute_registration_to_conversion_cohort();
+		}
+		$snapshot = Cache::peek( self::TAB_SLUG, Cache::SOURCE_SNAPSHOT, [ self::SNAPSHOT_KEY ] );
+		if ( null !== $snapshot && isset( $snapshot['payload']['registration_to_conversion_cohort'] ) ) {
+			return $snapshot['payload']['registration_to_conversion_cohort'];
+		}
+		self::schedule_cohort_refresh();
 		return array_merge(
 			$this->coming_soon_collection( 'cohorts' ),
-			[
-				'reference_line' => [
-					'value' => 0.15,
-					'label' => __( '15% at 6 months', 'newspack-plugin' ),
-				],
-			]
+			[ 'reference_line' => $this->registration_reference_line() ]
 		);
 	}
 
 	/**
-	 * Subscriber retention cohort (5.2). Snapshot — ignores the window.
-	 * Reference line (70% at 12 months) hardcoded per the spec.
-	 *
-	 * Local-only (Woo-only): does NOT belong in the BQ catalog. Phase B
-	 * `coming_soon` placeholder preserves the `reference_line` key React
-	 * reads unconditionally.
+	 * Subscriber retention cohort (5.2). Snapshot — ignores the window. Same
+	 * pre-warmed-snapshot read + cold-cache schedule-and-degrade contract as
+	 * {@see get_registration_to_conversion_cohort()}.
 	 *
 	 * @param DateTimeInterface $start Window start (ignored — snapshot).
 	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
-	 * @return array{state: string, cohorts: array, reference_line: array{value: float, label: string}}
+	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}}
 	 */
 	public function get_subscriber_retention_cohort( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );
+		if ( Cache::is_disabled() ) {
+			return $this->compute_subscriber_retention_cohort();
+		}
+		$snapshot = Cache::peek( self::TAB_SLUG, Cache::SOURCE_SNAPSHOT, [ self::SNAPSHOT_KEY ] );
+		if ( null !== $snapshot && isset( $snapshot['payload']['subscriber_retention_cohort'] ) ) {
+			return $snapshot['payload']['subscriber_retention_cohort'];
+		}
+		self::schedule_cohort_refresh();
 		return array_merge(
 			$this->coming_soon_collection( 'cohorts' ),
-			[
-				'reference_line' => [
-					'value' => 0.70,
-					'label' => __( '70% at 12 months', 'newspack-plugin' ),
-				],
-			]
+			[ 'reference_line' => $this->retention_reference_line() ]
 		);
 	}
 
@@ -1982,5 +2022,76 @@ final class Conversion_Metric {
 			],
 			[ 'reference_line' => $this->retention_reference_line() ]
 		);
+	}
+
+	// --- Section 5: Action Scheduler handlers and pre-warm scheduling -------
+
+	/**
+	 * Action Scheduler handler (one-off and weekly recurring): recompute both
+	 * cohort snapshots and write them to the snapshot cache. Constructs a
+	 * dependency-free metric (lazy storage), matching the REST controller.
+	 *
+	 * @return void
+	 */
+	public static function run_cohort_refresh(): void {
+		self::store_cohort_snapshot( new self() );
+	}
+
+	/**
+	 * Compute both cohorts from the given metric and write them to the snapshot
+	 * cache under one key. Split from run_cohort_refresh() so tests can inject a
+	 * metric with mocked storage-backed collaborators.
+	 *
+	 * @param self $metric Metric whose compute_* methods produce the payload.
+	 * @return void
+	 */
+	public static function store_cohort_snapshot( self $metric ): void {
+		Cache::refresh(
+			self::TAB_SLUG,
+			Cache::SOURCE_SNAPSHOT,
+			[ self::SNAPSHOT_KEY ],
+			static function () use ( $metric ) {
+				return [
+					'registration_to_conversion_cohort' => $metric->compute_registration_to_conversion_cohort(),
+					'subscriber_retention_cohort'       => $metric->compute_subscriber_retention_cohort(),
+				];
+			}
+		);
+	}
+
+	/**
+	 * Schedule a one-off background refresh of the cohort snapshot if Action
+	 * Scheduler is available and no such job is already queued. Called from the
+	 * request-path getters when the snapshot cache is cold, so it warms within
+	 * minutes instead of waiting for the weekly run.
+	 *
+	 * @return void
+	 */
+	private static function schedule_cohort_refresh(): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		if ( as_has_scheduled_action( self::COHORT_REFRESH_ACTION, [], self::COHORT_REFRESH_GROUP ) ) {
+			return;
+		}
+		as_schedule_single_action( time(), self::COHORT_REFRESH_ACTION, [], self::COHORT_REFRESH_GROUP );
+	}
+
+	/**
+	 * Ensure a weekly recurring cohort pre-warm is scheduled (Monday 06:00 UTC).
+	 * No-op if Action Scheduler is unavailable or the recurring action already
+	 * exists. Hooked on `init` by the conversion section.
+	 *
+	 * @return void
+	 */
+	public static function maybe_schedule_cohort_prewarm(): void {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_next_scheduled_action' ) ) {
+			return;
+		}
+		if ( false !== as_next_scheduled_action( self::COHORT_REFRESH_WEEKLY_ACTION, [], self::COHORT_REFRESH_GROUP ) ) {
+			return;
+		}
+		$next = ( new \DateTimeImmutable( 'next monday 06:00', new \DateTimeZone( 'UTC' ) ) )->getTimestamp();
+		as_schedule_recurring_action( $next, WEEK_IN_SECONDS, self::COHORT_REFRESH_WEEKLY_ACTION, [], self::COHORT_REFRESH_GROUP );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1866,4 +1866,121 @@ final class Conversion_Metric {
 			'threshold_pageviews' => 100,
 		];
 	}
+
+	// --- Section 5: Cohorts (5.2 retention) --------------------------------
+
+	/**
+	 * 5.2 reference line (hardcoded per spec): 70% retention at 12 months.
+	 *
+	 * @return array{value: float, label: string}
+	 */
+	private function retention_reference_line(): array {
+		return [
+			'value' => 0.70,
+			'label' => __( '70% at 12 months', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * Compute the 5.2 subscriber retention cohort curve (expensive snapshot
+	 * work; called by the pre-warm handler, never on the request hot path).
+	 * Cohort = customers grouped by their first non-donation subscription month
+	 * (trailing 365 days). For offset N (0..age, capped 12), the value is the
+	 * fraction of the cohort with ANY subscription active at their own
+	 * (first_start + N months): start <= T AND not cancelled/ended before T.
+	 *
+	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}}
+	 */
+	public function compute_subscriber_retention_cohort(): array {
+		$rows = $this->subscribers_metric->get_new_subscriber_cohort_intervals();
+		if ( empty( $rows ) ) {
+			return array_merge(
+				[
+					'state'   => 'empty',
+					'cohorts' => [],
+				],
+				[ 'reference_line' => $this->retention_reference_line() ]
+			);
+		}
+
+		$utc = new \DateTimeZone( 'UTC' );
+
+		// Group intervals by customer. Each interval: start_ts and nullable terminus_ts.
+		$by_customer = [];
+		foreach ( $rows as $row ) {
+			$cid = (int) $row['customer_id'];
+			if ( empty( $row['start'] ) ) {
+				continue;
+			}
+			$start_ts = ( new \DateTimeImmutable( $row['start'], $utc ) )->getTimestamp();
+
+			$terminus_ts = null;
+			foreach ( [ $row['cancelled'] ?? null, $row['end'] ?? null ] as $raw ) {
+				if ( null === $raw || '' === $raw || '0' === $raw ) {
+					continue;
+				}
+				$ts = ( new \DateTimeImmutable( $raw, $utc ) )->getTimestamp();
+				if ( null === $terminus_ts || $ts < $terminus_ts ) {
+					$terminus_ts = $ts;
+				}
+			}
+			$by_customer[ $cid ][] = [
+				'start'    => $start_ts,
+				'terminus' => $terminus_ts,
+			];
+		}
+
+		$now_index = $this->month_index( new \DateTimeImmutable( 'now', $utc ) );
+
+		// Per cohort (by first-start month): the set of customers and, for each
+		// offset, the count still active.
+		$cohort_members = []; // cohort_index => [ customer_id => first_start_ts ].
+		$cohort_labels  = [];
+		foreach ( $by_customer as $cid => $intervals ) {
+			$first_start  = min( array_column( $intervals, 'start' ) );
+			$first_dt     = ( new \DateTimeImmutable( '@' . $first_start ) )->setTimezone( $utc );
+			$cohort_index = $this->month_index( $first_dt );
+			$cohort_labels[ $cohort_index ]        = $first_dt->format( 'Y-m' );
+			$cohort_members[ $cohort_index ][ $cid ] = $first_start;
+		}
+
+		ksort( $cohort_members );
+		$cohorts = [];
+		foreach ( $cohort_members as $cohort_index => $members ) {
+			$size   = count( $members );
+			$age    = max( 0, min( self::COHORT_MAX_MONTHS, $now_index - $cohort_index ) );
+			$points = [];
+			for ( $n = 0; $n <= $age; $n++ ) {
+				$active = 0;
+				foreach ( $members as $cid => $first_start ) {
+					$t = ( new \DateTimeImmutable( '@' . $first_start ) )
+						->setTimezone( $utc )
+						->modify( '+' . $n . ' months' )
+						->getTimestamp();
+					foreach ( $by_customer[ $cid ] as $interval ) {
+						if ( $interval['start'] <= $t && ( null === $interval['terminus'] || $interval['terminus'] > $t ) ) {
+							$active++;
+							break;
+						}
+					}
+				}
+				$points[] = [
+					'period' => $n,
+					'value'  => round( $active / $size, 4 ),
+				];
+			}
+			$cohorts[] = [
+				'label'  => $cohort_labels[ $cohort_index ],
+				'points' => $points,
+			];
+		}
+
+		return array_merge(
+			[
+				'state'   => empty( $cohorts ) ? 'empty' : 'populated',
+				'cohorts' => $cohorts,
+			],
+			[ 'reference_line' => $this->retention_reference_line() ]
+		);
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -596,6 +596,16 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Trailing-365-day new-subscriber cohort subscription intervals (5.2 input).
+	 * Uncached pass-through — caching is the weekly pre-warmed snapshot.
+	 *
+	 * @return array<int, array{customer_id:int, start:string, cancelled:?string, end:?string}>
+	 */
+	public function get_new_subscriber_cohort_intervals(): array {
+		return $this->storage->get_new_subscriber_cohort_intervals();
+	}
+
+	/**
 	 * Flush ALL Tab 6 metric caches. Use after a manual data correction
 	 * or from the future NPPD-1605 invalidation system; not wired to any
 	 * automatic trigger today because the WP transient API has no key

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -477,6 +477,17 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Reader registration dates (trailing 365 days), keyed by user ID. Snapshot
+	 * input for the 5.1 cohort. Uncached pass-through — the cohort's caching
+	 * layer is the weekly pre-warmed snapshot, not this delegation.
+	 *
+	 * @return array<int, \DateTimeImmutable>
+	 */
+	public function get_reader_registration_dates(): array {
+		return $this->storage->get_reader_registration_dates();
+	}
+
+	/**
 	 * New non-donation subscriber records for source-mix attribution (3.2).
 	 * Each record carries customer_id, first-sub epoch ts, and source meta
 	 * (gate_post_id, popup_id) read from the subscription's parent shop_order.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1549,6 +1549,7 @@ class HPOS_Storage implements Storage_Interface {
 			JOIN {$prefix}woocommerce_order_itemmeta oim
 				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 			WHERE o.type = 'shop_subscription'
+			  AND o.customer_id > 0 -- exclude guest subscriptions (mirrors get_new_subscriber_records_in_window)
 			  AND oim.meta_value NOT IN ($donations)
 			  AND sm.meta_value != ''
 			  AND o.customer_id IN (
@@ -1562,6 +1563,7 @@ class HPOS_Storage implements Storage_Interface {
 					JOIN {$prefix}woocommerce_order_itemmeta oim2
 						ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
 					WHERE o2.type = 'shop_subscription'
+					  AND o2.customer_id > 0 -- exclude guest subscriptions
 					  AND oim2.meta_value NOT IN ($donations)
 					  AND sm2.meta_value != ''
 					GROUP BY o2.customer_id

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1509,4 +1509,76 @@ class HPOS_Storage implements Storage_Interface {
 		}
 		return $out;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{customer_id:int, start:string, cancelled:?string, end:?string}>
+	 */
+	public function get_new_subscriber_cohort_intervals(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Trailing-365-day cohort cutoff in UTC, bound via prepare (not NOW()).
+		$cutoff = $this->fmt( ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->modify( '-365 days' ) );
+
+		// Inner subquery: customers whose earliest non-donation subscription
+		// start is within the window (the cohort). Mirrors the first-start
+		// definition in get_first_subscription_order_dates(). MIN(meta_value)
+		// is a lexical comparison; _schedule_start is zero-padded `Y-m-d H:i:s`,
+		// so lexical order == chronological order.
+		// Outer query: every non-donation subscription of those customers, with
+		// its start/cancelled/end schedule meta.
+		$sql = $wpdb->prepare(
+			"SELECT o.customer_id,
+				sm.meta_value AS sched_start,
+				cm.meta_value AS sched_cancelled,
+				em.meta_value AS sched_end
+			FROM {$prefix}wc_orders o
+			JOIN {$prefix}wc_orders_meta sm
+				ON sm.order_id = o.id AND sm.meta_key = '_schedule_start'
+			LEFT JOIN {$prefix}wc_orders_meta cm
+				ON cm.order_id = o.id AND cm.meta_key = '_schedule_cancelled'
+			LEFT JOIN {$prefix}wc_orders_meta em
+				ON em.order_id = o.id AND em.meta_key = '_schedule_end'
+			JOIN {$prefix}woocommerce_order_items oi
+				ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+			JOIN {$prefix}woocommerce_order_itemmeta oim
+				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+			WHERE o.type = 'shop_subscription'
+			  AND oim.meta_value NOT IN ($donations)
+			  AND sm.meta_value != ''
+			  AND o.customer_id IN (
+				SELECT cohort.customer_id FROM (
+					SELECT o2.customer_id, MIN(sm2.meta_value) AS first_start
+					FROM {$prefix}wc_orders o2
+					JOIN {$prefix}wc_orders_meta sm2
+						ON sm2.order_id = o2.id AND sm2.meta_key = '_schedule_start'
+					JOIN {$prefix}woocommerce_order_items oi2
+						ON oi2.order_id = o2.id AND oi2.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim2
+						ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
+					WHERE o2.type = 'shop_subscription'
+					  AND oim2.meta_value NOT IN ($donations)
+					  AND sm2.meta_value != ''
+					GROUP BY o2.customer_id
+					HAVING first_start >= %s
+				) cohort
+			  )",
+			$cutoff
+		);
+
+		$rows   = $wpdb->get_results( $sql, ARRAY_A );
+		$result = [];
+		foreach ( (array) $rows as $row ) {
+			$result[] = [
+				'customer_id' => (int) $row['customer_id'],
+				'start'       => (string) $row['sched_start'],
+				'cancelled'   => null === $row['sched_cancelled'] ? null : (string) $row['sched_cancelled'],
+				'end'         => null === $row['sched_end'] ? null : (string) $row['sched_end'],
+			];
+		}
+		return $result;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1520,8 +1520,10 @@ class HPOS_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Trailing-365-day cohort cutoff in UTC, bound via prepare (not NOW()).
+		// Trailing-365-day cohort window in UTC, both bounds via prepare (not NOW()).
 		$cutoff = $this->fmt( ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->modify( '-365 days' ) );
+		// Upper bound excludes subscriptions with a future _schedule_start (scheduled/pending).
+		$now = gmdate( 'Y-m-d H:i:s', ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->getTimestamp() );
 
 		// Inner subquery: customers whose earliest non-donation subscription
 		// start is within the window (the cohort). Mirrors the first-start
@@ -1563,10 +1565,11 @@ class HPOS_Storage implements Storage_Interface {
 					  AND oim2.meta_value NOT IN ($donations)
 					  AND sm2.meta_value != ''
 					GROUP BY o2.customer_id
-					HAVING first_start >= %s
+					HAVING first_start >= %s AND first_start <= %s
 				) cohort
 			  )",
-			$cutoff
+			$cutoff,
+			$now
 		);
 
 		$rows   = $wpdb->get_results( $sql, ARRAY_A );

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -46,6 +46,8 @@ use Newspack\Logger;
  */
 class HPOS_Storage implements Storage_Interface {
 
+	use Reader_Population_Trait;
+
 	/**
 	 * Donation product IDs to exclude from non-donation metric queries.
 	 *

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1438,4 +1438,75 @@ class Legacy_Storage implements Storage_Interface {
 		}
 		return $out;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, array{customer_id:int, start:string, cancelled:?string, end:?string}>
+	 */
+	public function get_new_subscriber_cohort_intervals(): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		$cutoff = $this->fmt( ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->modify( '-365 days' ) );
+
+		// Legacy CPT equivalent of HPOS_Storage::get_new_subscriber_cohort_intervals().
+		// _customer_user is cast to UNSIGNED (stored as a string) to align with the
+		// other list-scoped legacy queries.
+		$sql = $wpdb->prepare(
+			"SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id,
+				sm.meta_value AS sched_start,
+				cm.meta_value AS sched_cancelled,
+				em.meta_value AS sched_end
+			FROM {$prefix}posts p
+			JOIN {$prefix}postmeta cust
+				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+			JOIN {$prefix}postmeta sm
+				ON sm.post_id = p.ID AND sm.meta_key = '_schedule_start'
+			LEFT JOIN {$prefix}postmeta cm
+				ON cm.post_id = p.ID AND cm.meta_key = '_schedule_cancelled'
+			LEFT JOIN {$prefix}postmeta em
+				ON em.post_id = p.ID AND em.meta_key = '_schedule_end'
+			JOIN {$prefix}woocommerce_order_items oi
+				ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+			JOIN {$prefix}woocommerce_order_itemmeta oim
+				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+			WHERE p.post_type = 'shop_subscription'
+			  AND oim.meta_value NOT IN ($donations)
+			  AND sm.meta_value != ''
+			  AND CAST(cust.meta_value AS UNSIGNED) IN (
+				SELECT cohort.customer_id FROM (
+					SELECT CAST(cust2.meta_value AS UNSIGNED) AS customer_id, MIN(sm2.meta_value) AS first_start
+					FROM {$prefix}posts p2
+					JOIN {$prefix}postmeta cust2
+						ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
+					JOIN {$prefix}postmeta sm2
+						ON sm2.post_id = p2.ID AND sm2.meta_key = '_schedule_start'
+					JOIN {$prefix}woocommerce_order_items oi2
+						ON oi2.order_id = p2.ID AND oi2.order_item_type = 'line_item'
+					JOIN {$prefix}woocommerce_order_itemmeta oim2
+						ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
+					WHERE p2.post_type = 'shop_subscription'
+					  AND oim2.meta_value NOT IN ($donations)
+					  AND sm2.meta_value != ''
+					GROUP BY CAST(cust2.meta_value AS UNSIGNED)
+					HAVING first_start >= %s
+				) cohort
+			  )",
+			$cutoff
+		);
+
+		$rows   = $wpdb->get_results( $sql, ARRAY_A );
+		$result = [];
+		foreach ( (array) $rows as $row ) {
+			$result[] = [
+				'customer_id' => (int) $row['customer_id'],
+				'start'       => (string) $row['sched_start'],
+				'cancelled'   => null === $row['sched_cancelled'] ? null : (string) $row['sched_cancelled'],
+				'end'         => null === $row['sched_end'] ? null : (string) $row['sched_end'],
+			];
+		}
+		return $result;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1475,6 +1475,7 @@ class Legacy_Storage implements Storage_Interface {
 			JOIN {$prefix}woocommerce_order_itemmeta oim
 				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 			WHERE p.post_type = 'shop_subscription'
+			  AND CAST(cust.meta_value AS UNSIGNED) > 0 -- exclude guest subscriptions (mirrors get_new_subscriber_records_in_window)
 			  AND oim.meta_value NOT IN ($donations)
 			  AND sm.meta_value != ''
 			  AND CAST(cust.meta_value AS UNSIGNED) IN (
@@ -1490,6 +1491,7 @@ class Legacy_Storage implements Storage_Interface {
 					JOIN {$prefix}woocommerce_order_itemmeta oim2
 						ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
 					WHERE p2.post_type = 'shop_subscription'
+					  AND CAST(cust2.meta_value AS UNSIGNED) > 0 -- exclude guest subscriptions
 					  AND oim2.meta_value NOT IN ($donations)
 					  AND sm2.meta_value != ''
 					GROUP BY CAST(cust2.meta_value AS UNSIGNED)

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -49,6 +49,8 @@ use Newspack\Logger;
  */
 class Legacy_Storage implements Storage_Interface {
 
+	use Reader_Population_Trait;
+
 	/**
 	 * Donation product IDs to exclude from non-donation metric queries.
 	 *

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1450,6 +1450,8 @@ class Legacy_Storage implements Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 
 		$cutoff = $this->fmt( ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->modify( '-365 days' ) );
+		// Upper bound excludes subscriptions with a future _schedule_start (scheduled/pending).
+		$now = gmdate( 'Y-m-d H:i:s', ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->getTimestamp() );
 
 		// Legacy CPT equivalent of HPOS_Storage::get_new_subscriber_cohort_intervals().
 		// _customer_user is cast to UNSIGNED (stored as a string) to align with the
@@ -1491,10 +1493,11 @@ class Legacy_Storage implements Storage_Interface {
 					  AND oim2.meta_value NOT IN ($donations)
 					  AND sm2.meta_value != ''
 					GROUP BY CAST(cust2.meta_value AS UNSIGNED)
-					HAVING first_start >= %s
+					HAVING first_start >= %s AND first_start <= %s
 				) cohort
 			  )",
-			$cutoff
+			$cutoff,
+			$now
 		);
 
 		$rows   = $wpdb->get_results( $sql, ARRAY_A );

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -327,6 +327,21 @@ interface Storage_Interface {
 	public function get_first_subscription_order_dates( array $customer_ids ): array;
 
 	/**
+	 * Registration dates of READER accounts created in the trailing 365 days,
+	 * keyed by user ID. "Reader" matches the base population of
+	 * {@see get_stale_registered_users()}: users bearing the `np_reader` meta,
+	 * or holding a 'subscriber'/'customer' role, excluding administrators and
+	 * editors. The full reader set is returned — converters AND non-converters —
+	 * because 5.1 uses it as the cohort denominator.
+	 *
+	 * Phase-A reader-role approximation applies (hardcoded roles, no filter
+	 * layer), same caveat as get_stale_registered_users().
+	 *
+	 * @return array<int, \DateTimeImmutable> user_id => user_registered (UTC).
+	 */
+	public function get_reader_registration_dates(): array;
+
+	/**
 	 * New non-donation subscribers in the window, each with the epoch timestamp
 	 * (UTC seconds) of their FIRST subscription start plus order-meta sourced from
 	 * the subscription's parent shop_order. Same population as

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -397,4 +397,23 @@ interface Storage_Interface {
 	 * @return array<int, array{order_id:int, gate_id:?string, popup_id:?string, order_total:float}>
 	 */
 	public function get_attributed_subscription_orders( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
+	 * Subscription schedule intervals for the trailing-365-day new-subscriber
+	 * cohort (5.2 retention input). One row per (customer, non-donation
+	 * subscription) for every customer whose EARLIEST non-donation subscription
+	 * `_schedule_start` falls within the last 365 days. All of those customers'
+	 * non-donation subscriptions are returned (not just the first) so the metric
+	 * can evaluate "active at month N" across any active subscription, matching
+	 * the {@see Donors_Storage_Interface::get_recurring_donor_retention()}
+	 * active-at-T predicate.
+	 *
+	 * `start` is `_schedule_start` (`Y-m-d H:i:s` UTC, non-empty). `cancelled`
+	 * and `end` are the raw `_schedule_cancelled` / `_schedule_end` meta values
+	 * (may be `''`, `'0'`, or null — WCS's "not terminated" sentinels). Epoch
+	 * conversion is the metric layer's job (tz-safe DateTimeImmutable).
+	 *
+	 * @return array<int, array{customer_id:int, start:string, cancelled:?string, end:?string}>
+	 */
+	public function get_new_subscriber_cohort_intervals(): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/trait-reader-population.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/trait-reader-population.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Shared reader-population query for Insights order-storage backends.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
+
+/**
+ * Provides get_reader_registration_dates() to both order-storage backends.
+ *
+ * The reader population is queried entirely from wp_users / wp_usermeta, which
+ * are identical regardless of WooCommerce order storage (HPOS vs legacy CPT),
+ * so the query lives here once and is shared by HPOS_Storage and Legacy_Storage
+ * via `use` rather than duplicated. Self-contained — depends on no property or
+ * helper of the using class.
+ */
+trait Reader_Population_Trait {
+
+	/**
+	 * Registration dates of READER accounts created in the trailing 365 days,
+	 * keyed by user ID. "Reader" matches the base population of
+	 * get_stale_registered_users(): users bearing the `np_reader` meta, or
+	 * holding a 'subscriber'/'customer' role, excluding administrators and
+	 * editors. The full reader set is returned — converters AND non-converters —
+	 * because 5.1 uses it as the cohort denominator.
+	 *
+	 * Phase-A reader-role approximation applies (hardcoded roles, no filter
+	 * layer), same caveat as get_stale_registered_users().
+	 *
+	 * @return array<int, \DateTimeImmutable> user_id => user_registered (UTC).
+	 */
+	public function get_reader_registration_dates(): array {
+		global $wpdb;
+		$prefix = $wpdb->prefix;
+
+		// Trailing-365-day cutoff computed in PHP (UTC) and bound via prepare,
+		// not SQL NOW(), so the window is stable regardless of the MySQL session
+		// timezone. user_registered is stored in UTC.
+		$cutoff = gmdate(
+			'Y-m-d H:i:s',
+			( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->modify( '-365 days' )->getTimestamp()
+		);
+
+		// Reader base population mirrors get_stale_registered_users(): np_reader
+		// meta OR subscriber/customer role, excluding admins/editors. No
+		// conversion exclusions — the full reader set is the 5.1 denominator.
+		$sql = $wpdb->prepare(
+			"SELECT u.ID, u.user_registered
+			FROM {$prefix}users u
+			WHERE (
+				EXISTS (
+					SELECT 1 FROM {$prefix}usermeta um
+					WHERE um.user_id = u.ID
+					  AND um.meta_key = 'np_reader'
+					  AND um.meta_value != ''
+				)
+				OR EXISTS (
+					SELECT 1 FROM {$prefix}usermeta um2
+					WHERE um2.user_id = u.ID
+					  AND um2.meta_key = '{$prefix}capabilities'
+					  AND (
+						um2.meta_value LIKE '%\"subscriber\"%'
+						OR um2.meta_value LIKE '%\"customer\"%'
+					  )
+				)
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM {$prefix}usermeta um3
+				WHERE um3.user_id = u.ID
+				  AND um3.meta_key = '{$prefix}capabilities'
+				  AND (
+					um3.meta_value LIKE '%\"administrator\"%'
+					OR um3.meta_value LIKE '%\"editor\"%'
+				  )
+			)
+			AND u.user_registered >= %s",
+			$cutoff
+		);
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$map  = [];
+		foreach ( (array) $rows as $row ) {
+			if ( empty( $row['user_registered'] ) ) {
+				continue;
+			}
+			$map[ (int) $row['ID'] ] = new \DateTimeImmutable( $row['user_registered'], new \DateTimeZone( 'UTC' ) );
+		}
+		return $map;
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/trait-reader-population.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/trait-reader-population.php
@@ -12,7 +12,6 @@ defined( 'ABSPATH' ) || exit;
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 // phpcs:disable WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
 
 /**
@@ -87,7 +86,7 @@ trait Reader_Population_Trait {
 			$cutoff
 		);
 
-		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$rows = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is built with $wpdb->prepare().
 		$map  = [];
 		foreach ( (array) $rows as $row ) {
 			if ( empty( $row['user_registered'] ) ) {

--- a/plugins/newspack-plugin/tests/unit-tests/insights-cache.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-cache.php
@@ -457,6 +457,24 @@ class Newspack_Test_Insights_Cache extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Peek returns null when the cached envelope's source does not match the
+	 * requested source (source-mismatch guard added in fix 3).
+	 */
+	public function test_peek_returns_null_on_source_mismatch(): void {
+		$payload = [ 'a' => 1 ];
+		Cache::refresh( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => $payload );
+
+		// Correct source must return the envelope.
+		$hit = Cache::peek( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] );
+		$this->assertIsArray( $hit );
+		$this->assertSame( $payload, $hit['payload'] );
+
+		// Wrong source must return null even though the transient exists.
+		$miss = Cache::peek( 'conversion', Cache::SOURCE_EXTERNAL, [ 'cohorts' ] );
+		$this->assertNull( $miss, 'Source mismatch must return null.' );
+	}
+
+	/**
 	 * Snapshot keys are kept out of the per-tab index, so purge() leaves them.
 	 */
 	public function test_snapshot_survives_purge(): void {

--- a/plugins/newspack-plugin/tests/unit-tests/insights-cache.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-cache.php
@@ -468,7 +468,42 @@ class Newspack_Test_Insights_Cache extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Snapshot written via store() is also excluded from the index, so purge() leaves it.
+	 */
+	public function test_snapshot_store_survives_purge(): void {
+		Cache::store( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => [ 'y' => 2 ] );
+		Cache::purge( 'conversion' );
+		$peeked = Cache::peek( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] );
+		$this->assertIsArray( $peeked );
+		$this->assertSame( [ 'y' => 2 ], $peeked['payload'] );
+	}
+
+	/**
+	 * Snapshot source uses 9-day TTL.
+	 */
+	public function test_snapshot_source_uses_9day_ttl(): void {
+		Cache::refresh(
+			'conversion',
+			Cache::SOURCE_SNAPSHOT,
+			[ 'cohorts' ],
+			function () {
+				return [ 'value' => 1 ];
+			}
+		);
+
+		$key       = self::transient_key_for_test( 'conversion', [ 'cohorts' ] );
+		$timeout   = get_option( '_transient_timeout_' . $key );
+		$remaining = $timeout - time();
+
+		$this->assertGreaterThan( 8 * DAY_IN_SECONDS, $remaining, 'Snapshot TTL should be ~9 days.' );
+		$this->assertLessThanOrEqual( Cache::TTL_SNAPSHOT, $remaining );
+	}
+
+	/**
 	 * Peek returns null when caching is disabled.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_snapshot_peek_null_when_disabled(): void {
 		Cache::refresh( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => [ 'x' => 1 ] );

--- a/plugins/newspack-plugin/tests/unit-tests/insights-cache.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-cache.php
@@ -431,6 +431,54 @@ class Newspack_Test_Insights_Cache extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Peek returns null when nothing is cached.
+	 */
+	public function test_snapshot_peek_returns_null_on_miss(): void {
+		$this->assertNull( Cache::peek( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] ) );
+	}
+
+	/**
+	 * Refresh with SOURCE_SNAPSHOT writes a snapshot peek can read back.
+	 */
+	public function test_snapshot_refresh_writes_then_peek_reads(): void {
+		$payload = [
+			'a' => 1,
+			'b' => 2,
+		];
+		$env     = Cache::refresh( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => $payload );
+
+		$this->assertSame( $payload, $env['payload'] );
+		$this->assertSame( Cache::SOURCE_SNAPSHOT, $env['source'] );
+
+		$peeked = Cache::peek( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] );
+		$this->assertIsArray( $peeked );
+		$this->assertSame( $payload, $peeked['payload'] );
+		$this->assertSame( Cache::SOURCE_SNAPSHOT, $peeked['source'] );
+	}
+
+	/**
+	 * Snapshot keys are kept out of the per-tab index, so purge() leaves them.
+	 */
+	public function test_snapshot_survives_purge(): void {
+		Cache::refresh( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => [ 'x' => 1 ] );
+		Cache::purge( 'conversion' );
+		$peeked = Cache::peek( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] );
+		$this->assertIsArray( $peeked );
+		$this->assertSame( [ 'x' => 1 ], $peeked['payload'] );
+	}
+
+	/**
+	 * Peek returns null when caching is disabled.
+	 */
+	public function test_snapshot_peek_null_when_disabled(): void {
+		Cache::refresh( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => [ 'x' => 1 ] );
+		if ( ! defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) ) {
+			define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true );
+		}
+		$this->assertNull( Cache::peek( 'conversion', Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] ) );
+	}
+
+	/**
 	 * Mirror the production transient-key formula so tests can reach into storage.
 	 *
 	 * @param string $tab Tab slug.

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -627,4 +627,40 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$this->assertSame( $rows, $metric->get_subscriber_to_donor_lags() );
 		$this->assertSame( [], $metric->get_subscriber_to_donor_lags() );
 	}
+
+	// =========================================================================
+	// New-subscriber cohort intervals — Task 3 (5.2 retention input).
+	// =========================================================================
+
+	/**
+	 * HPOS + Legacy storage expose get_new_subscriber_cohort_intervals().
+	 */
+	public function test_storages_implement_cohort_intervals(): void {
+		$this->assertTrue( method_exists( new HPOS_Storage( [] ), 'get_new_subscriber_cohort_intervals' ) );
+		$this->assertTrue( method_exists( new Legacy_Storage( [] ), 'get_new_subscriber_cohort_intervals' ) );
+		$this->assertTrue(
+			( new \ReflectionClass( Storage_Interface::class ) )->hasMethod( 'get_new_subscriber_cohort_intervals' )
+		);
+	}
+
+	/**
+	 * Subscribers_Metric::get_new_subscriber_cohort_intervals() delegates.
+	 */
+	public function test_subscribers_metric_cohort_intervals_delegates(): void {
+		$rows = [
+			[
+				'customer_id' => 7,
+				'start'       => '2026-01-10 00:00:00',
+				'cancelled'   => null,
+				'end'         => null,
+			],
+		];
+		$mock = $this->createMock( Storage_Interface::class );
+		$mock->expects( $this->once() )
+			->method( 'get_new_subscriber_cohort_intervals' )
+			->willReturn( $rows );
+
+		$metric = $this->make_subscribers_metric( $mock );
+		$this->assertSame( $rows, $metric->get_new_subscriber_cohort_intervals() );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -576,6 +576,38 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$this->assertSame( [], $metric->get_donation_conversion_lags() );
 	}
 
+	// =========================================================================
+	// Reader registration dates — Task 2 (5.1 cohort population).
+	// =========================================================================
+
+	/**
+	 * HPOS + Legacy storage expose get_reader_registration_dates().
+	 */
+	public function test_storages_implement_reader_registration_dates(): void {
+		$this->assertTrue( method_exists( new HPOS_Storage( [] ), 'get_reader_registration_dates' ) );
+		$this->assertTrue( method_exists( new Legacy_Storage( [] ), 'get_reader_registration_dates' ) );
+		$this->assertTrue(
+			( new \ReflectionClass( Storage_Interface::class ) )->hasMethod( 'get_reader_registration_dates' )
+		);
+	}
+
+	/**
+	 * Subscribers_Metric::get_reader_registration_dates() delegates to storage.
+	 */
+	public function test_subscribers_metric_reader_registration_dates_delegates(): void {
+		$dates = [
+			1 => $this->make_date( '2026-01-15' ),
+			2 => $this->make_date( '2026-02-20' ),
+		];
+		$mock = $this->createMock( Storage_Interface::class );
+		$mock->expects( $this->once() )
+			->method( 'get_reader_registration_dates' )
+			->willReturn( $dates );
+
+		$metric = $this->make_subscribers_metric( $mock );
+		$this->assertSame( $dates, $metric->get_reader_registration_dates() );
+	}
+
 	/**
 	 * Donor storages expose get_subscriber_to_donor_lags.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2975,6 +2975,46 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0.70, $result['reference_line']['value'] );
 	}
 
+	// --- 5.2 month-overflow clamp (end-of-month subscription start) ---------
+
+	/**
+	 * 5.2 clamp: Jan 31 start, sub expires Feb 28 12:00 — N=1 active-at-T check.
+	 *
+	 * Without the clamp: Jan 31 + 1 month = Mar 3 00:00:00 (PHP overflow).
+	 *   terminus Feb 28 12:00 < Mar 3 00:00 → NOT active → value 0.0.
+	 *
+	 * With the clamp: Jan 31 + 1 month clamped to Feb 28 00:00:00.
+	 *   terminus Feb 28 12:00 > Feb 28 00:00 → ACTIVE → value 1.0.
+	 *
+	 * This test is written to fail with the buggy `+N months` code and pass
+	 * only after the add_months_clamped() helper is in place.
+	 */
+	public function test_compute_retention_cohort_clamps_end_of_month_overflow() {
+		$rows = [
+			[
+				'customer_id' => 1,
+				'start'       => '2026-01-31 00:00:00',
+				'cancelled'   => null,
+				'end'         => '2026-02-28 12:00:00', // expires midday Feb 28.
+			],
+		];
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_new_subscriber_cohort_intervals' )->willReturn( $rows );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, null );
+		$result = $metric->compute_subscriber_retention_cohort();
+
+		$this->assertSame( 'populated', $result['state'] );
+		$points = array_column( $result['cohorts'][0]['points'], 'value', 'period' );
+
+		// N=0: anchor is Jan 31 00:00 — well before terminus Feb 28 12:00 → active.
+		$this->assertSame( 1.0, $points[0] );
+
+		// N=1: clamped anchor is Feb 28 00:00 — terminus Feb 28 12:00 > Feb 28 00:00 → active.
+		// A buggy +1 months would produce Mar 3 00:00, making terminus < T → 0.0.
+		$this->assertSame( 1.0, $points[1] );
+	}
+
 	// --- Task 6: Snapshot getters + store_cohort_snapshot -------------------
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -3131,6 +3131,35 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Next_weekly_prewarm_timestamp() returns the correct Monday 06:00 UTC for
+	 * several fixed anchors, covering the Monday-before-06:00 edge case that
+	 * 'next monday 06:00' would incorrectly skip to the following week.
+	 */
+	public function test_next_weekly_prewarm_timestamp_anchors(): void {
+		$utc = new DateTimeZone( 'UTC' );
+
+		// Monday 05:00 UTC — slot has not yet passed this week, must stay on SAME Monday.
+		$now    = new DateTimeImmutable( '2026-06-22 05:00:00', $utc );
+		$result = gmdate( 'D Y-m-d H:i', Conversion_Metric::next_weekly_prewarm_timestamp( $now ) );
+		$this->assertSame( 'Mon 2026-06-22 06:00', $result, 'Monday before 06:00 must schedule THIS Monday.' );
+
+		// Monday 06:00 UTC exactly — slot is at this instant (<= $now), must roll to next week.
+		$now    = new DateTimeImmutable( '2026-06-22 06:00:00', $utc );
+		$result = gmdate( 'D Y-m-d H:i', Conversion_Metric::next_weekly_prewarm_timestamp( $now ) );
+		$this->assertSame( 'Mon 2026-06-29 06:00', $result, 'Monday at exactly 06:00 must schedule NEXT Monday.' );
+
+		// Wednesday mid-day — this week's Monday is in the past, must return next Monday.
+		$now    = new DateTimeImmutable( '2026-06-24 10:00:00', $utc );
+		$result = gmdate( 'D Y-m-d H:i', Conversion_Metric::next_weekly_prewarm_timestamp( $now ) );
+		$this->assertSame( 'Mon 2026-06-29 06:00', $result, 'Mid-week must schedule next Monday.' );
+
+		// Sunday night — next Monday is tomorrow.
+		$now    = new DateTimeImmutable( '2026-06-28 23:00:00', $utc );
+		$result = gmdate( 'D Y-m-d H:i', Conversion_Metric::next_weekly_prewarm_timestamp( $now ) );
+		$this->assertSame( 'Mon 2026-06-29 06:00', $result, 'Sunday night must schedule next-day Monday.' );
+	}
+
+	/**
 	 * Clear the cohort snapshot transient between tests.
 	 */
 	public function tear_down() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2902,4 +2902,76 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 1, $by['prompt']['count'] ); // from BQ matcher.
 		$this->assertSame( 1, $by['direct']['count'] ); // BQ-unmatched.
 	}
+
+	// --- 5.2 compute_subscriber_retention_cohort ----------------------------
+
+	/**
+	 * 5.2 compute: active spanning the curve; cancellation drops at the offset.
+	 */
+	public function test_compute_retention_cohort_cancellation_drops() {
+		// Two customers, cohort 2026-01. Cust 10 stays active (no terminus).
+		// Cust 11 cancels at 2026-03 (active at N=0,1; gone by N=2).
+		$rows = [
+			[
+				'customer_id' => 10,
+				'start'       => '2026-01-10 00:00:00',
+				'cancelled'   => null,
+				'end'         => null,
+			],
+			[
+				'customer_id' => 11,
+				'start'       => '2026-01-10 00:00:00',
+				'cancelled'   => '2026-03-10 00:00:00',
+				'end'         => null,
+			],
+		];
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_new_subscriber_cohort_intervals' )->willReturn( $rows );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, null );
+		$result = $metric->compute_subscriber_retention_cohort();
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( '2026-01', $result['cohorts'][0]['label'] );
+		$points = array_column( $result['cohorts'][0]['points'], 'value', 'period' );
+		$this->assertSame( 1.0, $points[0] ); // both active at start.
+		$this->assertSame( 1.0, $points[1] ); // cust 11 cancel (Mar) > Feb → still active.
+		$this->assertSame( 0.5, $points[2] ); // cust 11 cancelled before Mar+ → only cust 10.
+		$this->assertSame( 0.70, $result['reference_line']['value'] );
+	}
+
+	/**
+	 * 5.2 compute: natural expiry (_schedule_end) also ends activity.
+	 */
+	public function test_compute_retention_cohort_expiry_drops() {
+		$rows = [
+			[
+				'customer_id' => 20,
+				'start'       => '2026-01-10 00:00:00',
+				'cancelled'   => null,
+				'end'         => '2026-02-10 00:00:00', // expires after 1 month.
+			],
+		];
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_new_subscriber_cohort_intervals' )->willReturn( $rows );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, null );
+		$points = array_column( $metric->compute_subscriber_retention_cohort()['cohorts'][0]['points'], 'value', 'period' );
+		$this->assertSame( 1.0, $points[0] ); // active at start.
+		$this->assertSame( 0.0, $points[1] ); // end (Feb 10) <= start+1mo (Feb 10) → not active.
+	}
+
+	/**
+	 * 5.2 compute: no cohort rows → empty, reference_line preserved.
+	 */
+	public function test_compute_retention_cohort_empty() {
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_new_subscriber_cohort_intervals' )->willReturn( [] );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, null );
+		$result = $metric->compute_subscriber_retention_cohort();
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['cohorts'] );
+		$this->assertSame( 0.70, $result['reference_line']['value'] );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -3049,11 +3049,55 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'empty', $peeked['payload']['registration_to_conversion_cohort']['state'] );
 	}
 
+	// --- Cohort pre-warm scheduling ------------------------------------------
+
+	/**
+	 * Maybe_schedule_cohort_prewarm() schedules the weekly recurring action
+	 * when none exists yet.
+	 */
+	public function test_maybe_schedule_cohort_prewarm_schedules_when_none_exists() {
+		if ( ! function_exists( 'as_next_scheduled_action' ) || ! function_exists( 'as_schedule_recurring_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available in this test harness.' );
+		}
+		// Ensure no action is already scheduled (clean slate).
+		as_unschedule_all_actions( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP );
+		$this->assertFalse( as_next_scheduled_action( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP ) );
+
+		Conversion_Metric::maybe_schedule_cohort_prewarm();
+
+		$timestamp = as_next_scheduled_action( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP );
+		$this->assertNotFalse( $timestamp, 'Recurring weekly prewarm action should be scheduled.' );
+		$this->assertIsInt( $timestamp );
+	}
+
+	/**
+	 * Maybe_schedule_cohort_prewarm() is idempotent: a second call does not
+	 * schedule a duplicate action.
+	 */
+	public function test_maybe_schedule_cohort_prewarm_is_idempotent() {
+		if ( ! function_exists( 'as_next_scheduled_action' ) || ! function_exists( 'as_schedule_recurring_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available in this test harness.' );
+		}
+		as_unschedule_all_actions( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP );
+
+		Conversion_Metric::maybe_schedule_cohort_prewarm();
+		$first_timestamp = as_next_scheduled_action( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP );
+
+		// Second call must not throw and must not change the scheduled timestamp.
+		Conversion_Metric::maybe_schedule_cohort_prewarm();
+		$second_timestamp = as_next_scheduled_action( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP );
+
+		$this->assertSame( $first_timestamp, $second_timestamp, 'Second call must not reschedule the action.' );
+	}
+
 	/**
 	 * Clear the cohort snapshot transient between tests.
 	 */
 	public function tear_down() {
 		delete_transient( 'newspack_insights_conversion_' . md5( (string) wp_json_encode( [ 'cohorts' ] ) ) );
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( Conversion_Metric::COHORT_REFRESH_WEEKLY_ACTION, [], Conversion_Metric::COHORT_REFRESH_GROUP );
+		}
 		parent::tear_down();
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2974,4 +2974,86 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( [], $result['cohorts'] );
 		$this->assertSame( 0.70, $result['reference_line']['value'] );
 	}
+
+	// --- Task 6: Snapshot getters + store_cohort_snapshot -------------------
+
+	/**
+	 * Getter returns the cached snapshot slice when the snapshot is warm.
+	 */
+	public function test_registration_cohort_getter_reads_warm_snapshot() {
+		$payload = [
+			'registration_to_conversion_cohort' => [
+				'state'          => 'populated',
+				'cohorts'        => [
+					[
+						'label'  => '2026-01',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 0.0,
+							],
+						],
+					],
+				],
+				'reference_line' => [
+					'value' => 0.15,
+					'label' => 'x',
+				],
+			],
+			'subscriber_retention_cohort'       => [
+				'state'          => 'empty',
+				'cohorts'        => [],
+				'reference_line' => [
+					'value' => 0.70,
+					'label' => 'y',
+				],
+			],
+		];
+		\Newspack\Insights\Cache::refresh( 'conversion', \Newspack\Insights\Cache::SOURCE_SNAPSHOT, [ 'cohorts' ], fn() => $payload );
+
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->get_registration_to_conversion_cohort( $start, $end );
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( '2026-01', $result['cohorts'][0]['label'] );
+	}
+
+	/**
+	 * Cold cache → coming_soon envelope with reference_line preserved (no throw).
+	 */
+	public function test_registration_cohort_getter_cold_cache_coming_soon() {
+		[ $start, $end ] = $this->window();
+		$result          = $this->metric->get_registration_to_conversion_cohort( $start, $end );
+		$this->assertSame( 'coming_soon', $result['state'] );
+		$this->assertSame( [], $result['cohorts'] );
+		$this->assertSame( 0.15, $result['reference_line']['value'] );
+	}
+
+	/**
+	 * Store_cohort_snapshot writes both cohort slices to the snapshot cache.
+	 */
+	public function test_store_cohort_snapshot_writes_both_slices() {
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_reader_registration_dates' )->willReturn( [] );
+		$subs_metric->method( 'get_first_subscription_order_dates' )->willReturn( [] );
+		$subs_metric->method( 'get_new_subscriber_cohort_intervals' )->willReturn( [] );
+		$donors_metric = $this->createMock( Donors_Metric::class );
+		$donors_metric->method( 'get_first_donation_order_dates' )->willReturn( [] );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, $donors_metric );
+		Conversion_Metric::store_cohort_snapshot( $metric );
+
+		$peeked = \Newspack\Insights\Cache::peek( 'conversion', \Newspack\Insights\Cache::SOURCE_SNAPSHOT, [ 'cohorts' ] );
+		$this->assertIsArray( $peeked );
+		$this->assertArrayHasKey( 'registration_to_conversion_cohort', $peeked['payload'] );
+		$this->assertArrayHasKey( 'subscriber_retention_cohort', $peeked['payload'] );
+		$this->assertSame( 'empty', $peeked['payload']['registration_to_conversion_cohort']['state'] );
+	}
+
+	/**
+	 * Clear the cohort snapshot transient between tests.
+	 */
+	public function tear_down() {
+		delete_transient( 'newspack_insights_conversion_' . md5( (string) wp_json_encode( [ 'cohorts' ] ) ) );
+		parent::tear_down();
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -2760,6 +2760,86 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0, $by['direct']['count'] );
 	}
 
+	// --- 5.1 compute_registration_to_conversion_cohort ---------------------
+
+	/**
+	 * 5.1 compute: one cohort, cumulative monotonic conversion curve.
+	 */
+	public function test_compute_registration_cohort_cumulative_curve() {
+		$tz = new DateTimeZone( 'UTC' );
+		// 4 readers all registered 2026-01. 2 convert (sub) at month 1 and month 3.
+		$readers = [
+			1 => new DateTimeImmutable( '2026-01-05', $tz ),
+			2 => new DateTimeImmutable( '2026-01-10', $tz ),
+			3 => new DateTimeImmutable( '2026-01-15', $tz ),
+			4 => new DateTimeImmutable( '2026-01-20', $tz ),
+		];
+		$subs = [
+			1 => new DateTimeImmutable( '2026-02-05', $tz ), // months_since 1.
+			2 => new DateTimeImmutable( '2026-04-10', $tz ), // months_since 3.
+		];
+
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_reader_registration_dates' )->willReturn( $readers );
+		$subs_metric->method( 'get_first_subscription_order_dates' )->willReturn( $subs );
+		$donors_metric = $this->createMock( Donors_Metric::class );
+		$donors_metric->method( 'get_first_donation_order_dates' )->willReturn( [] );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, $donors_metric );
+		$result = $metric->compute_registration_to_conversion_cohort();
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertCount( 1, $result['cohorts'] );
+		$cohort = $result['cohorts'][0];
+		$this->assertSame( '2026-01', $cohort['label'] );
+		$points = array_column( $cohort['points'], 'value', 'period' );
+		// Cumulative: 0 at month 0, 1/4 at month 1, still 1/4 at month 2, 2/4 at month 3.
+		$this->assertSame( 0.0, $points[0] );
+		$this->assertSame( 0.25, $points[1] );
+		$this->assertSame( 0.25, $points[2] );
+		$this->assertSame( 0.5, $points[3] );
+		$this->assertSame( 0.15, $result['reference_line']['value'] );
+	}
+
+	/**
+	 * 5.1 compute: earlier of sub/donation wins; donation-only converter counts.
+	 */
+	public function test_compute_registration_cohort_combines_sub_and_donation() {
+		$tz      = new DateTimeZone( 'UTC' );
+		$readers = [ 5 => new DateTimeImmutable( '2026-01-01', $tz ) ];
+		$subs    = [ 5 => new DateTimeImmutable( '2026-05-01', $tz ) ]; // month 4.
+		$dons    = [ 5 => new DateTimeImmutable( '2026-03-01', $tz ) ]; // month 2 (earlier wins).
+
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_reader_registration_dates' )->willReturn( $readers );
+		$subs_metric->method( 'get_first_subscription_order_dates' )->willReturn( $subs );
+		$donors_metric = $this->createMock( Donors_Metric::class );
+		$donors_metric->method( 'get_first_donation_order_dates' )->willReturn( $dons );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, $donors_metric );
+		$result = $metric->compute_registration_to_conversion_cohort();
+		$points = array_column( $result['cohorts'][0]['points'], 'value', 'period' );
+		$this->assertSame( 0.0, $points[1] );
+		$this->assertSame( 1.0, $points[2] ); // converted by month 2 (donation).
+	}
+
+	/**
+	 * 5.1 compute: no readers → empty state, reference_line preserved.
+	 */
+	public function test_compute_registration_cohort_empty() {
+		$subs_metric = $this->createMock( Subscribers_Metric::class );
+		$subs_metric->method( 'get_reader_registration_dates' )->willReturn( [] );
+		$subs_metric->method( 'get_first_subscription_order_dates' )->willReturn( [] );
+		$donors_metric = $this->createMock( Donors_Metric::class );
+		$donors_metric->method( 'get_first_donation_order_dates' )->willReturn( [] );
+
+		$metric = new Conversion_Metric( null, null, $subs_metric, $donors_metric );
+		$result = $metric->compute_registration_to_conversion_cohort();
+		$this->assertSame( 'empty', $result['state'] );
+		$this->assertSame( [], $result['cohorts'] );
+		$this->assertSame( 0.15, $result['reference_line']['value'] );
+	}
+
 	/**
 	 * C12 mixed: some subscriber records have parent-order meta (classified
 	 * without BQ), others do not (go to matcher). BQ is called once for the


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Wires the **Conversion Journey** tab's Section 5 cohort-retention charts (5.1 and 5.2) to live WP/Woo data, replacing the `coming_soon` placeholders, and serves them from a weekly pre-warmed snapshot so the expensive queries never run on a reader request.

- **5.1 Registration → Conversion cohort** — for each monthly cohort of registered readers (by `user_registered`), the cumulative share that converted to subscriber **or** donor by month N. Reference line: 15% at 6 months.
- **5.2 Subscriber Retention cohort** — for each monthly cohort of new subscribers (by first non-donation subscription), the share still active at month N. Both cancellations and natural expirations count as churn. Reference line: 70% at 12 months.
- **Weekly pre-warm** — a recurring Action Scheduler job (Monday 06:00 UTC) computes both cohorts and stores them in a new, reusable window-independent snapshot cache tier. Reader requests read the snapshot; on a cold cache they degrade gracefully to the existing "coming soon" state and schedule a one-off background refresh, so cohorts never block or slow a page load.

Both cohorts are window-independent snapshots, so the React layer and the tab's response contract are unchanged. The demo/fixture payloads intentionally remain "coming soon" (live demo curves are out of scope here).

Part of NPPD-1692 (Conversion Journey Phase B); targets the `feat/insights-rsm` epic branch. (The original cohort-pre-warm ticket NPPD-1606 was canceled; its per-publisher pre-warm objection was specific to the BigQuery cache, whereas these cohorts are pure WP/Woo, so a local weekly pre-warm is the right layer.)

### How to test the changes in this Pull Request:

> ⚠️ **Live verification is the mandatory gate.** The WooCommerce SQL (reader population, subscription cohort intervals, HPOS + legacy) cannot be exercised by the PHPUnit harness (no WC tables), so it must be checked on a real Audience site. The unit suite proves the cache tier, the cohort math, and the request-path/snapshot wiring only.

1. **Unit tests** — from `plugins/newspack-plugin`: `n test-php --group insights` (expect all green) and `n test-php --filter Newspack_Test_Insights_Cache` (snapshot tier). PHPCS clean on the host.
2. **Live site (e.g. blockclub)** — load the Insights → Conversion Journey tab. On first load the two Section 5 charts may show "coming soon" while the one-off refresh runs; reload after the background job completes and confirm both cohort charts render with data.
3. **5.1** — confirm the reader population and per-cohort cumulative conversion look plausible, the oldest cohort reaches ~12 months, and the 15%-at-6-months reference line shows.
4. **5.2** — spot-check a known **cancelled** subscription and a known **expired** (`_schedule_end`) subscription: each should drop out of the active count at the correct month offset. Confirm the 70%-at-12-months reference line.
5. **HPOS + legacy parity** — verify on both a HPOS site and a legacy-CPT-order site that the cohorts populate equivalently.
6. **Pre-warm** — trigger `run_cohort_refresh` (WP-CLI / Action Scheduler admin) and confirm the snapshot transient `newspack_insights_conversion_<md5(["cohorts"])>` populates and the request path then serves it warm. Confirm the **weekly recurring** action is scheduled: `as_next_scheduled_action( 'newspack_insights_conversion_cohort_refresh_weekly', [], 'newspack-insights' )` returns a timestamp.
7. **Graceful degradation** — with the snapshot cold/cleared, confirm the tab still renders (cohorts show "coming soon") and does not error or hang.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?