### PR TITLE
feat(insights): prompt donation rate uses donation_impressions denom (NPPD-1757)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -914,7 +914,20 @@ final class Prompts_Metric {
 		}
 		$impressions = 0;
 		foreach ( $rows as $row ) {
-			if ( is_array( $row ) && 'donation' === (string) ( $row['intent'] ?? '' ) ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			if ( isset( $row['donation_impressions'] ) ) {
+				// NPPD-1756/1757: per-popup donation-CAPABLE impressions — seen events where
+				// the prompt carried a donate block (`prompt_has_donation`) — summed across
+				// all popups. Prefer this when the hub exposes it: it's the population matched
+				// to the order-meta donation numerator, and it catches a multi-block prompt
+				// that has a donate block but a different primary intent.
+				$impressions += (int) $row['donation_impressions'];
+			} elseif ( 'donation' === (string) ( $row['intent'] ?? '' ) ) {
+				// Fallback until the hub ships `donation_impressions`: donation-INTENT
+				// impressions. Misses the multi-block-donate-prompt case above (where
+				// `action_type` collapses to 'undefined'); the capability column closes it.
 				$impressions += (int) ( $row['impressions'] ?? 0 );
 			}
 		}
@@ -1373,23 +1386,30 @@ final class Prompts_Metric {
 			$intent      = (string) ( $row['intent'] ?? '' );
 			$impressions = (int) ( $row['impressions'] ?? 0 );
 
-			$donation_conversions = 'donation' === $intent ? (int) ( $donation_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
 			// Subscription conversions are sourced per-popup from order meta (NPPD-1746),
-			// keyed by popup id, anonymous-inclusive — and NOT gated on the popup's declared
-			// intent: the order carries `_newspack_popup_id` regardless of action_type, so an
-			// "Undefined"-intent prompt (e.g. a generic "50% off" promo) can still drive
-			// subscriptions. Gating on `intent=registration` hid those and contradicted the
-			// scalar subscription card (caught on live data; the scalar already sums the whole
-			// `by_popup` map). The donation column keeps its intent gate — donations on this
-			// tab are gated on a donation block being present, so the same case doesn't arise.
+			// keyed by popup id, anonymous-inclusive — NOT gated on the popup's declared
+			// intent (the order carries the popup id regardless of `action_type`, so an
+			// "Undefined"-intent "50% off" promo can still drive a subscription). Until a
+			// checkout-capability signal exists (NPPD-1755/1756), the rate below is gated on
+			// map membership (a converting popup) as the interim.
 			$subscription_conversions = (int) ( $subscription_map[ $popup_id ]['conversions'] ?? 0 );
 
-			// Both rates share the tab-level coherence guard + em-dash semantics via
-			// rate_value() (null = not computable: no impressions or a >100% cross-surface
-			// ratio; a float incl. 0.0 = real rate). A rate is rendered only where the metric
-			// applies: donation for donation-intent prompts, subscription for prompts that
-			// actually drove a subscription (present in the map); null = N/A everywhere else,
-			// including non-WC.
+			// Donation is CAPABILITY-gated: a prompt is donation-capable when its per-popup
+			// `donation_impressions` (seen events carrying a donate block) is non-zero — or,
+			// until the hub exposes that column (NPPD-1756), when `action_type` is 'donation'
+			// (the legacy single-block signal). The capability column additionally catches a
+			// multi-block donate prompt whose primary intent collapsed to 'undefined'. The
+			// rate denominator is those donation-capable impressions, else total impressions.
+			$donation_impressions = (int) ( $row['donation_impressions'] ?? $impressions );
+			$donation_capable     = isset( $row['donation_impressions'] )
+				? $donation_impressions > 0
+				: 'donation' === $intent;
+			$donation_conversions = $donation_capable ? (int) ( $donation_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
+
+			// Both rates share the coherence guard + em-dash semantics via rate_value() (null =
+			// not computable: no impressions, or a >100% cross-surface ratio; a float incl. 0.0
+			// = a real rate, e.g. a donation-capable prompt that converted nobody). null = N/A
+			// for a prompt the metric doesn't apply to, and on non-WC.
 			$mapped[] = [
 				'popup_id'                     => $popup_id,
 				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),
@@ -1403,7 +1423,7 @@ final class Prompts_Metric {
 				'registrations'                => (int) ( $row['registrations'] ?? 0 ),
 				'newsletter_signups'           => (int) ( $row['newsletter_signups'] ?? 0 ),
 				'donation_conversions'         => $donation_conversions,
-				'donation_conversion_rate'     => ( 'donation' === $intent && $wc ) ? $this->rate_value( $donation_conversions, $impressions ) : null,
+				'donation_conversion_rate'     => ( $wc && $donation_capable ) ? $this->rate_value( $donation_conversions, $donation_impressions ) : null,
 				'subscription_conversions'     => $subscription_conversions,
 				'subscription_conversion_rate' => ( $wc && isset( $subscription_map[ $popup_id ] ) ) ? $this->rate_value( $subscription_conversions, $impressions ) : null,
 			];

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -626,6 +626,42 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1756/1757: when the hub exposes the per-popup `donation_impressions`
+	 * capability column, the donation-rate denominator uses it (summed across all
+	 * popups) instead of the `action_type='donation'` impression sum. This catches a
+	 * multi-block / Undefined-intent prompt that carries a donate block — which the
+	 * old intent-sum would have dropped entirely (denominator 0 → not computable).
+	 */
+	public function test_donation_conversion_direct_prefers_donation_impressions_column() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				// Donation-CAPABLE but NOT donation-intent (multi-block / Undefined).
+				[
+					'popup_id'             => 1,
+					'intent'               => 'undefined',
+					'impressions'          => 1000,
+					'donation_impressions' => 200,
+				],
+				// Not donation-capable — must not enter the denominator.
+				[
+					'popup_id'             => 9,
+					'intent'               => 'registration',
+					'impressions'          => 500,
+					'donation_impressions' => 0,
+				],
+			]
+		);
+
+		$metric = $this->make_direct_donation_metric( $proxy, $this->donors_with_conversions( 50 ), true );
+		$rate   = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertSame( 200, $rate['denominator'], 'denominator is the capability column, not action_type=donation (which would be 0 here)' );
+		$this->assertSame( 0.25, $rate['value'], '50 conversions / 200 donation-capable impressions' );
+	}
+
+	/**
 	 * No donation impressions → no denominator → not computable (em-dash),
 	 * distinct from the real 0% below.
 	 */
@@ -1372,6 +1408,39 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		// map): a null rate, not a misleading 0%.
 		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
 		$this->assertNull( $result['rows'][0]['donation_conversion_rate'] );
+	}
+
+	/**
+	 * NPPD-1756/1757 (capability path): a prompt that is donation-CAPABLE via the hub
+	 * `donation_impressions` column but is NOT donation-intent (multi-block /
+	 * Undefined) still surfaces its donations + a rate, with the donation-capable
+	 * impressions as the denominator. Pre-column, the `action_type='donation'` gate
+	 * hid it (rendered 0 / null).
+	 */
+	public function test_performance_by_prompt_shows_donations_for_non_donation_intent_when_capable() {
+		$row = array_merge(
+			$this->performance_row( 42, 'Member campaign', 'undefined', 1000 ),
+			[ 'donation_impressions' => 500 ] // Donation-capable (carries a donate block) despite intent.
+		);
+		$proxy = $this->make_performance_proxy( [ $row ], [], [] );
+
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tear_down.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
+			[
+				'42' => [
+					'conversions' => 3,
+					'revenue'     => 0.0,
+				],
+			]
+		);
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $this->empty_subscribers() );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'undefined', $result['rows'][0]['intent'], 'guard: row is non-donation intent' );
+		$this->assertSame( 3, $result['rows'][0]['donation_conversions'], 'a donation-capable prompt surfaces its donations regardless of intent' );
+		$this->assertEqualsWithDelta( 0.006, $result['rows'][0]['donation_conversion_rate'], 0.0001, '3 / 500 donation-capable impressions, not / 1000 total' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -1486,6 +1486,29 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1756/1757 (capability path): a donation-CAPABLE prompt (non-zero
+	 * `donation_impressions`) that converted nobody is a real 0% — over the
+	 * donation-capable impressions, not total — and is shown regardless of intent.
+	 * The sibling test above covers the same semantics on the legacy intent path.
+	 */
+	public function test_per_prompt_donation_rate_real_zero_percent_on_capability_path() {
+		$row = array_merge(
+			$this->performance_row( 42, 'Member campaign', 'undefined', 1000 ),
+			[ 'donation_impressions' => 300 ] // Capable (carries a donate block) despite non-donation intent.
+		);
+		$proxy = $this->make_performance_proxy( [ $row ], [], [] );
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn( [] ); // No conversions for popup 42.
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $this->empty_subscribers() );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
+		$this->assertSame( 0.0, $result['rows'][0]['donation_conversion_rate'], 'capable-but-no-conversion is a real 0% over donation_impressions, not an em-dash' );
+	}
+
+	/**
 	 * Performance by prompt: locks the canonical row-key contract the React
 	 * layer consumes (`PromptPerformanceRow`). A column rename on either side
 	 * silently blanks the table, so assert the exact set + order.


### PR DESCRIPTION
Consumer side of the prompts donation-denominator unification — prefers the hub's new `donation_impressions` column (NPPD-1756) as the donation conversion-rate denominator, with a fallback to today's `action_type='donation'` impression sum. **Forward-compatible:** behavior-identical to today until the hub column lands, then auto-upgrades — so deploy order doesn't matter.

### Changes (`Prompts_Metric`)
- **Scalar** (`fetch_donation_prompt_impressions`): sum `donation_impressions` when present, else the legacy intent-sum.
- **Per-prompt table**: the donation column is now **capability-gated** (donation-capable = `donation_impressions > 0`, else legacy `intent='donation'`), with `donation_impressions` as its denominator. This also catches a multi-block donate prompt whose primary intent is `'undefined'`, and resolves the donation/subscription gating asymmetry — donation now keys on its capability signal; subscription stays map-gated until its own `checkout_impressions` lands (NPPD-1755 → 1756).

### Tests
+2 (scalar prefers the column; a non-donation-intent *capable* prompt surfaces its donations). **437 insights tests green**, PHPCS clean. The fallback path is behavior-identical to today, so the existing donation tests are unchanged.

The **subscription half** of NPPD-1757 is deferred — blocked on `checkout_impressions` (NPPD-1755 → 1756).

Refs: NPPD-1757