### PR TITLE
feat(popups): emit prompt_has_checkout on prompt interaction event (NPPD-1755)

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
@@ -117,6 +117,12 @@ final class Newspack_Popups_Data_Api {
 			'registration'             => 'newspack/reader-registration',
 			'donation'                 => 'newspack-blocks/donate',
 			'newsletters_subscription' => 'newspack-newsletters/subscribe',
+			// NPPD-1755: subscription/paywall capability. Emits `prompt_has_checkout`
+			// on the seen event so Insights can build a checkout-capable impressions
+			// denominator (the prompts analog of the gate `checkout_impressions`),
+			// matched to subscription orders carrying the popup id. Also gives a
+			// checkout-only prompt the `action_type='checkout'` intent (was 'undefined').
+			'checkout'                 => 'newspack-blocks/checkout-button',
 		];
 
 		$data['prompt_blocks']    = [];


### PR DESCRIPTION
> **Hotfix retargeted to `release`.** Supersedes #395 (which was cut from `main`). Per hotfix policy this must be based off **and** merge into `release`; `main` is 282 commits ahead, so the single commit was cleanly cherry-picked onto a fresh `release`-based branch (identical 6-line diff, zero conflicts). #395 is closed in favor of this PR.

---

Adds the checkout-button block to the `np_prompt_interaction` event's `$watched_blocks`, so a prompt containing a `newspack-blocks/checkout-button` block emits **`prompt_has_checkout = 1`** on its `seen` event (and a checkout-only prompt gets **`action_type = 'checkout'`** instead of `'undefined'`).

### Why
Insights' subscription conversion rate needs a *checkout-capable impressions* denominator — the prompts analog of the gate `checkout_impressions` (NPPD-1749, merged) — matched to subscription orders carrying the popup id. But the prompt `seen` event only carried capability flags for **registration, donation, newsletters_subscription** — checkout was missing, so there was no signal to count and the Insights plugin had to fall back to a per-popup-keying workaround. (The plugin *already* watches this block in `Prompts_Metric::WATCHED_BLOCKS`; the two lists had simply drifted by one entry.)

This is the write-side blocker for the prompts-subscription denominator fix: NPPD-1756 (hub `COUNTIF(prompt_has_checkout)`) → NPPD-1757 (plugin denominator swap).

### The change (one entry)
```php
$watched_blocks = [
    'registration'             => 'newspack/reader-registration',
    'donation'                 => 'newspack-blocks/donate',
    'newsletters_subscription' => 'newspack-newsletters/subscribe',
    'checkout'                 => 'newspack-blocks/checkout-button',  // ← added
];
```
The existing loop (`$sanitized['prompt_has_' . $block] = 1`) emits the param and derives `action_type`; no other code needed. The param is `prompt_has_checkout` (int `1`, matching the `prompt_has_<key>` convention).

### Impact — `action_type='checkout'` is a NEW intent value (additive; scanned)
Forward-only (no historical data). Verified nothing breaks on the new value:
- newspack-popups only *assigns* `action_type` — no switch on its value.
- Insights `INTENT_LABELS` falls back to the raw string for an unknown intent (`INTENT_LABELS[$intent] ?? $intent`) → renders "checkout"; a friendlier label is a tracked follow-up (NPPD-1758).
- All intent filters are positive matches (`'donation' === $intent`, etc.) — `'checkout'` matches none, so no mis-gating.
- The hub conversion-rate queries filter the **attempt** event (`action_type='checkout_button'`), not the `seen` event — unaffected; only the per-prompt / per-intent breakdowns gain a `'checkout'` row.

No existing tests pinned the `watched_blocks` / `action_type` behavior, so nothing breaks. `php -l` clean.

Refs: NPPD-1755
