### PR TITLE
feat(insights): per-gate paywall conversions on the gates table (NPPD-1686)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -80,7 +80,7 @@ final class Gates_Metric {
 		'avg_revenue_per_paywall_conversion' => 'local',  // NPPD-1746: derived from the same order-meta source as total revenue.
 		'conversion_funnel'                  => 'hub',
 		'exposures_distribution'             => 'hub',
-		'performance_by_gate'                => 'hub',
+		'performance_by_gate'                => 'hybrid', // NPPD-1686: hub per-gate rows + local order-meta paywall conversions.
 	];
 
 	/**
@@ -932,18 +932,37 @@ final class Gates_Metric {
 			];
 		}
 
+		// NPPD-1686: per-gate PAYWALL CONVERSIONS replace the old engagement-intent
+		// paywall_attempts. Numerator = gate-attributed subscription conversions from Woo
+		// order meta (`_gate_post_id`), anonymous-inclusive, keyed per gate; denominator = the
+		// gate's checkout-capable impressions (`checkout_impressions`, NPPD-1749). Same
+		// order-meta + capability model as the scalar paywall rate-direct and the prompts
+		// donation column (NPPD-1746/1757): a gate is paywall-capable when checkout_impressions
+		// > 0, so a regwall-only gate (0) gets null paywall columns (em-dash) while a capable
+		// gate with zero completions shows a real 0 / 0%. Both are WC-gated (order meta + Woo
+		// tables) → non-WC publishers get nulls. Unlike the scalar, the table does NOT fall back
+		// to total impressions when checkout_impressions is absent: a paywall rate over total
+		// (regwall-inclusive) impressions would badly overcount, so an absent column degrades to
+		// em-dash rather than a wrong number.
+		$wc      = $this->woocommerce_active();
+		$by_gate = $wc ? $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_gate'] : [];
+
 		$mapped = [];
 		foreach ( $rows as $row ) {
-			$gate_post_id = (int) ( $row['gate_post_id'] ?? 0 );
-			$mapped[]     = [
+			$gate_post_id        = (int) ( $row['gate_post_id'] ?? 0 );
+			$paywall_impressions = isset( $row['checkout_impressions'] ) ? (int) $row['checkout_impressions'] : null;
+			$paywall_capable     = $wc && null !== $paywall_impressions && $paywall_impressions > 0;
+			$paywall_conversions = $paywall_capable ? (int) ( $by_gate[ $gate_post_id ]['conversions'] ?? 0 ) : 0;
+
+			$mapped[] = [
 				'gate_post_id'            => $gate_post_id,
 				'gate_name'               => null, // filled below by enrich_with_gate_titles().
 				'impressions'             => (int) ( $row['impressions'] ?? 0 ),
 				'unique_viewers'          => (int) ( $row['unique_viewers'] ?? 0 ),
 				'registrations'           => (int) ( $row['registrations'] ?? 0 ),
 				'regwall_conversion_rate' => isset( $row['regwall_conversion_rate'] ) && null !== $row['regwall_conversion_rate'] ? (float) $row['regwall_conversion_rate'] : null,
-				'paywall_attempts'        => (int) ( $row['paywall_attempts'] ?? 0 ),
-				'paywall_attempt_rate'    => isset( $row['paywall_attempt_rate'] ) && null !== $row['paywall_attempt_rate'] ? (float) $row['paywall_attempt_rate'] : null,
+				'paywall_conversions'     => $paywall_capable ? $paywall_conversions : null,
+				'paywall_conversion_rate' => $paywall_capable ? $this->rate_value( $paywall_conversions, (int) $paywall_impressions ) : null,
 			];
 		}
 

--- a/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
@@ -88,8 +88,11 @@ export interface GatesPerformanceRow {
 	unique_viewers: number;
 	registrations: number;
 	regwall_conversion_rate: number | null;
-	paywall_attempts: number;
-	paywall_attempt_rate: number | null;
+	// NPPD-1686: true paid OUTCOMES per gate (Woo order-meta conversions ÷ the gate's
+	// checkout-capable impressions), replacing the old engagement-intent paywall_attempts.
+	// null = not paywall-capable (regwall-only gate) or non-WC publisher → em-dash.
+	paywall_conversions: number | null;
+	paywall_conversion_rate: number | null;
 }
 
 export interface GatesPerformanceTable extends GatesErrorFields {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for PerformanceByGateSection (NPPD-1686): the per-gate paywall columns
+ * surface true conversions (count + rate), with an em-dash for a non-paywall-capable
+ * (regwall-only) gate — replacing the old engagement-intent attempt columns.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PerformanceByGateSection from './PerformanceByGateSection';
+import type { GatesPerformanceRow, GatesPerformanceTable } from '../../api/gates';
+
+const row = ( over: Partial< GatesPerformanceRow > = {} ): GatesPerformanceRow => ( {
+	gate_post_id: 1,
+	gate_name: 'Gate',
+	impressions: 1000,
+	unique_viewers: 800,
+	registrations: 0,
+	regwall_conversion_rate: null,
+	paywall_conversions: null,
+	paywall_conversion_rate: null,
+	...over,
+} );
+
+const table = ( rows: GatesPerformanceRow[] ): GatesPerformanceTable => ( {
+	state: 'populated',
+	rows,
+} );
+
+describe( 'PerformanceByGateSection paywall conversion columns', () => {
+	it( 'renders the conversion column headers, not the old attempt columns', () => {
+		render( <PerformanceByGateSection data={ table( [] ) } /> );
+		expect( screen.getByText( 'Paywall conversions' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Paywall conversion rate' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Paywall attempts' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Paywall attempt rate' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the count + rate for a paywall-capable gate', () => {
+		render(
+			<PerformanceByGateSection
+				data={ table( [
+					row( {
+						gate_post_id: 77,
+						gate_name: 'Member paywall',
+						impressions: 5000,
+						paywall_conversions: 3,
+						paywall_conversion_rate: 0.01,
+					} ),
+				] ) }
+			/>
+		);
+		expect( screen.getByText( '3' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders an em-dash for a regwall-only gate (null paywall columns)', () => {
+		render(
+			<PerformanceByGateSection
+				data={ table( [
+					row( {
+						gate_post_id: 88,
+						gate_name: 'Regwall only',
+						impressions: 3000,
+						registrations: 150,
+						regwall_conversion_rate: 0.07,
+						paywall_conversions: null,
+						paywall_conversion_rate: null,
+					} ),
+				] ) }
+			/>
+		);
+		// Exactly the two paywall cells render the N/A em-dash (regwall rate is 7%).
+		expect( screen.getAllByText( '—' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'renders a real 0 (not em-dash) for a capable gate that converted nobody', () => {
+		render(
+			<PerformanceByGateSection
+				data={ table( [
+					row( {
+						gate_post_id: 77,
+						gate_name: 'Member paywall',
+						impressions: 5000,
+						registrations: 12, // distinct value so "0" uniquely identifies paywall_conversions
+						regwall_conversion_rate: 0.07, // non-null so the only em-dash candidates are paywall cells
+						paywall_conversions: 0,
+						paywall_conversion_rate: 0,
+					} ),
+				] ) }
+			/>
+		);
+		expect( screen.getByText( '0' ) ).toBeInTheDocument();
+		expect( screen.getByText( '0%' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '—' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
@@ -49,8 +49,8 @@ type SortKey =
 	| 'unique_viewers'
 	| 'registrations'
 	| 'regwall_conversion_rate'
-	| 'paywall_attempts'
-	| 'paywall_attempt_rate';
+	| 'paywall_conversions'
+	| 'paywall_conversion_rate';
 
 type SortDir = 'asc' | 'desc';
 
@@ -68,6 +68,10 @@ const NotApplicable = () => (
 
 const renderPercent = ( v: number | null ) => ( v === null ? <NotApplicable /> : formatPercent( v ) );
 
+// Counts that can be N/A (paywall conversions on a regwall-only gate / non-WC) render
+// an em-dash, matching the rate columns; a real 0 still renders as "0".
+const renderCount = ( v: number | null ) => ( v === null ? <NotApplicable /> : formatNumber( v ) );
+
 const renderRow = ( row: GatesPerformanceRow ) => (
 	<tr key={ row.gate_post_id }>
 		<td>
@@ -77,8 +81,8 @@ const renderRow = ( row: GatesPerformanceRow ) => (
 		<td className="newspack-insights__table-num">{ formatNumber( row.unique_viewers ) }</td>
 		<td className="newspack-insights__table-num">{ formatNumber( row.registrations ) }</td>
 		<td className="newspack-insights__table-num">{ renderPercent( row.regwall_conversion_rate ) }</td>
-		<td className="newspack-insights__table-num">{ formatNumber( row.paywall_attempts ) }</td>
-		<td className="newspack-insights__table-num">{ renderPercent( row.paywall_attempt_rate ) }</td>
+		<td className="newspack-insights__table-num">{ renderCount( row.paywall_conversions ) }</td>
+		<td className="newspack-insights__table-num">{ renderPercent( row.paywall_conversion_rate ) }</td>
 	</tr>
 );
 
@@ -150,8 +154,8 @@ const PerformanceByGateSection = ( { data }: PerformanceByGateSectionProps ) => 
 		{ key: 'unique_viewers', label: __( 'Unique viewers', 'newspack-plugin' ), numeric: true },
 		{ key: 'registrations', label: __( 'Registrations', 'newspack-plugin' ), numeric: true },
 		{ key: 'regwall_conversion_rate', label: __( 'Regwall conversion rate', 'newspack-plugin' ), numeric: true },
-		{ key: 'paywall_attempts', label: __( 'Paywall attempts', 'newspack-plugin' ), numeric: true },
-		{ key: 'paywall_attempt_rate', label: __( 'Paywall attempt rate', 'newspack-plugin' ), numeric: true },
+		{ key: 'paywall_conversions', label: __( 'Paywall conversions', 'newspack-plugin' ), numeric: true },
+		{ key: 'paywall_conversion_rate', label: __( 'Paywall conversion rate', 'newspack-plugin' ), numeric: true },
 	];
 
 	const [ sortKey, setSortKey ] = useState< SortKey >( 'impressions' );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -629,8 +629,7 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 						'unique_viewers'          => 1200,
 						'registrations'           => 0,
 						'regwall_conversion_rate' => null,
-						'paywall_attempts'        => 80,
-						'paywall_attempt_rate'    => 0.04,
+						'checkout_impressions'    => 200,
 					],
 					[
 						'gate_post_id'            => (string) $gate_b,
@@ -638,12 +637,14 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 						'unique_viewers'          => 900,
 						'registrations'           => 150,
 						'regwall_conversion_rate' => 0.07,
-						'paywall_attempts'        => 0,
-						'paywall_attempt_rate'    => null,
+						'checkout_impressions'    => 0,
 					],
 				]
 			);
 
+		// WC off → paywall columns are null (covered with WC on by the dedicated
+		// per-gate paywall tests below). Title enrichment is independent of WC.
+		add_filter( 'newspack_insights_woocommerce_active', '__return_false' );
 		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_performance_by_gate( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
@@ -652,8 +653,8 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 
 		// Lock the canonical row-key contract the React layer consumes
 		// (`GatesPerformanceRow` in src/wizards/insights/api/gates.ts). These keys
-		// mirror the `gates_performance_by_gate` catalog columns one-for-one; a
-		// rename on either side silently blanks the table, so assert the exact set.
+		// mirror the table's output one-for-one; a rename on either side silently
+		// blanks the table, so assert the exact set.
 		$this->assertSame(
 			[
 				'gate_post_id',
@@ -662,8 +663,8 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 				'unique_viewers',
 				'registrations',
 				'regwall_conversion_rate',
-				'paywall_attempts',
-				'paywall_attempt_rate',
+				'paywall_conversions',
+				'paywall_conversion_rate',
 			],
 			array_keys( $result['rows'][0] )
 		);
@@ -673,14 +674,14 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertSame( 1200, $result['rows'][0]['unique_viewers'] );
 		$this->assertSame( 0, $result['rows'][0]['registrations'] );
 		$this->assertNull( $result['rows'][0]['regwall_conversion_rate'] );
-		$this->assertSame( 80, $result['rows'][0]['paywall_attempts'] );
-		$this->assertSame( 0.04, $result['rows'][0]['paywall_attempt_rate'] );
+		$this->assertNull( $result['rows'][0]['paywall_conversions'], 'WC inactive → paywall columns null' );
+		$this->assertNull( $result['rows'][0]['paywall_conversion_rate'] );
 
 		$this->assertSame( 'Member regwall', $result['rows'][1]['gate_name'] );
 		$this->assertSame( 150, $result['rows'][1]['registrations'] );
 		$this->assertSame( 0.07, $result['rows'][1]['regwall_conversion_rate'] );
-		$this->assertSame( 0, $result['rows'][1]['paywall_attempts'] );
-		$this->assertNull( $result['rows'][1]['paywall_attempt_rate'] );
+		$this->assertNull( $result['rows'][1]['paywall_conversions'] );
+		$this->assertNull( $result['rows'][1]['paywall_conversion_rate'] );
 	}
 
 	/**
@@ -710,6 +711,92 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['rows'] );
+	}
+
+	/**
+	 * NPPD-1686: per-gate PAYWALL CONVERSIONS — gate-attributed subscription conversions
+	 * (Woo order meta, `by_gate`) ÷ that gate's checkout-capable impressions. A
+	 * paywall-capable gate (checkout_impressions > 0) surfaces its conversions + rate; a
+	 * regwall-only gate (checkout_impressions 0) gets null paywall columns (em-dash).
+	 */
+	public function test_performance_by_gate_paywall_conversions_per_gate() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'gate_post_id'         => 77, // Paywall-capable + converted (subscribers_with_gate keys gate 77).
+					'impressions'          => 5000,
+					'checkout_impressions' => 300,
+				],
+				[
+					'gate_post_id'         => 88, // Regwall-only: no checkout impressions.
+					'impressions'          => 3000,
+					'registrations'        => 150,
+					'checkout_impressions' => 0,
+				],
+			]
+		);
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 3, 150.0 ), true );
+		$result = $metric->get_performance_by_gate( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		// Gate 77: 3 order-meta conversions over 300 checkout impressions.
+		$this->assertSame( 3, $result['rows'][0]['paywall_conversions'] );
+		$this->assertEqualsWithDelta( 0.01, $result['rows'][0]['paywall_conversion_rate'], 0.0001, '3 / 300 checkout impressions, not / 5000 total' );
+		// Gate 88: regwall-only → paywall columns null, not a misleading 0.
+		$this->assertNull( $result['rows'][1]['paywall_conversions'] );
+		$this->assertNull( $result['rows'][1]['paywall_conversion_rate'] );
+	}
+
+	/**
+	 * NPPD-1686: a paywall-capable gate (checkout_impressions > 0) that converted nobody
+	 * is a real 0 / 0%, not an em-dash — distinct from the regwall-only null above.
+	 */
+	public function test_performance_by_gate_capable_gate_zero_completions_is_real_zero() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'gate_post_id'         => 77,
+					'impressions'          => 5000,
+					'checkout_impressions' => 300,
+				],
+			]
+		);
+		// Gate 77 is paywall-capable but drove zero subscriptions.
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 0, 0.0 ), true );
+		$result = $metric->get_performance_by_gate( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 0, $result['rows'][0]['paywall_conversions'], 'capable gate shows a real 0, not null' );
+		$this->assertSame( 0.0, $result['rows'][0]['paywall_conversion_rate'], 'real 0%, not an em-dash' );
+	}
+
+	/**
+	 * NPPD-1686: the per-gate table and the scalar paywall denominator both read
+	 * `gates_performance_by_gate`; the per-window memo collapses them to a single
+	 * round-trip (no second hub call when both render on the same request).
+	 */
+	public function test_performance_by_gate_shares_hub_fetch_with_scalar() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->once() )
+			->method( 'query' )
+			->with( 'gates_performance_by_gate', $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
+			->willReturn(
+				[
+					[
+						'gate_post_id'         => 77,
+						'impressions'          => 5000,
+						'checkout_impressions' => 300,
+					],
+				]
+			);
+		$metric = $this->make_direct_paywall_metric( $proxy, $this->subscribers_with_gate( 3, 150.0 ), true );
+		$start  = $this->make_date( '2026-03-22' );
+		$end    = $this->make_date( '2026-04-21' );
+
+		$metric->get_performance_by_gate( $start, $end );
+		$metric->get_paywall_conversion_direct( $start, $end );
+		// expects( $this->once() ) asserts the single shared fetch across both callers.
 	}
 
 	/**


### PR DESCRIPTION
Replaces the per-gate **engagement-intent** columns (`paywall_attempts` / `paywall_attempt_rate`) on the Tab 4 "Performance by gate" table with true paid **outcomes** — `paywall_conversions` / `paywall_conversion_rate` — sourced from Woo order meta. The Gates-table sibling of the prompts donation work (NPPD-1746/1757).

### Unblocked, not a column-add
NPPD-1686 was On Hold pending an attribution-model decision + hub CTE restructure (the old GA4 session-join model). Two merged pieces dissolved both blockers: **NPPD-1746** (orders carry `_gate_post_id` → per-gate conversions via `get_attributed_subscription_conversions()['by_gate']`) and **NPPD-1749** (per-gate `checkout_impressions`). The scalar `get_paywall_conversion_direct()` already proved the data path; this applies it to the table.

### Changes
- **`Gates_Metric::get_performance_by_gate()`** — paywall columns = `by_gate` order-meta conversions ÷ per-gate `checkout_impressions`, WC-gated + **capability-gated** (`checkout_impressions > 0`):
  - regwall-only gate (0) → null paywall columns (em-dash)
  - capable gate, zero completions → real `0` / `0%`
  - `METRIC_SOURCES['performance_by_gate']` flipped `hub` → `hybrid` (local numerator + hub denominator) so a hub-impressions failure scopes to the tab-error banner.
  - The GA4 session-join path is untouched (still backs the Paid-section attempt scorecards). The catalog still emits `paywall_attempts` (now unconsumed by the table); removing it is out of scope.
- **UI** (`PerformanceByGateSection.tsx` + `gates.ts`) — column swap, null-safe count renderer, sort + em-dash treatment, shared `formatPercent` (`<0.1%`).
- **Docs** — `formulas/tab-4-gates.md` + `specs/gates.md` updated to the order-meta + `checkout_impressions` model (committed on the docs repo).

### Tests
- **PHP** (`Test_Gates_Metric`): +3 — per-gate slicing; capable-but-zero → real `0`/`0%`; regwall-only → null/null; shared-fetch memoization (single hub round-trip across table + scalar). **441 insights tests green.**
- **JS** (`PerformanceByGateSection.test.tsx`, new): +4 — conversion headers, capable count+rate, regwall-only em-dash, capable-zero real `0`. **617 JS tests green.** ESLint + tsc clean.

Refs: NPPD-1686