### PR TITLE
fix(reader-verification): change "go back" button to "skip for now"

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -1735,7 +1735,7 @@ final class Reader_Activation {
 			<?php esc_html_e( 'Send code', 'newspack-plugin' ); ?>
 		</button>
 		<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__close">
-			<?php esc_html_e( 'Go back', 'newspack-plugin' ); ?>
+			<?php esc_html_e( 'Skip for now', 'newspack-plugin' ); ?>
 		</button>
 		<?php
 		$content = ob_get_clean();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In the post-registration verification modal, changes the "Go back" button (which just closes the modal) to "Skip for now" instead. This makes it clearer what the button actually does and doesn't suggest to readers that verification is required at this point.

This PR doesn't change anything about when the verification modal appears—it will still always appear after registering via the auth modal, Registration block, or Newsletter Subscription block unless the `newspack_show_post_registration_verification` overrides this—but even if verification **is** actually required in the particular flow (such as when entering this flow from a content gate that requires verification to bypass) skipping will cause the page to refresh and continue to show the content gate but with a verification prompt until the reader completes verification.

Related to NPPD-1760.

### How to test the changes in this Pull Request:

1. Follow any of the flows from testing steps in #135 (A, B, or C)
2. When you get to the modal that says "We'll send a verification code to [email address]", confirm that the cancel button now says "Skip for now" instead of "Go back".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
