### PR TITLE
fix(insights): capability framing for reg/newsletter/donation conversion copy (NPPD-1765)

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -858,7 +858,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sum of Woo donation order totals from same-session completions after a prompt impression with a donation block
+                Sum of Woo donation order totals from same-session completions after a donation-intent prompt impression
               </div>
             </div>
           </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -442,7 +442,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sessions with a registration after a registration-intent prompt impression ÷ sessions with a registration-intent prompt impression
+                Sessions with a registration after a prompt impression with a registration block ÷ sessions with a prompt impression with a registration block
               </div>
             </div>
           </div>
@@ -487,7 +487,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Readers who registered in a later session within 7 days of seeing a registration-intent prompt ÷ readers who saw a registration-intent prompt
+                Readers who registered in a later session within 7 days of seeing a prompt with a registration block ÷ readers who saw a prompt with a registration block
               </div>
             </div>
           </div>
@@ -532,7 +532,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sessions with a newsletter signup after a newsletter-intent prompt impression ÷ sessions with a newsletter-intent prompt impression
+                Sessions with a newsletter signup after a prompt impression with a newsletter block ÷ sessions with a prompt impression with a newsletter block
               </div>
             </div>
           </div>
@@ -577,7 +577,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Readers who signed up for a newsletter in a later session within 7 days of seeing a newsletter-intent prompt ÷ readers who saw a newsletter-intent prompt
+                Readers who signed up for a newsletter in a later session within 7 days of seeing a prompt with a newsletter block ÷ readers who saw a prompt with a newsletter block
               </div>
             </div>
           </div>
@@ -650,7 +650,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sessions with a completed donation after a donation-intent prompt impression ÷ sessions with a donation-intent prompt impression
+                Sessions with a completed donation after a prompt impression with a donation block ÷ sessions with a prompt impression with a donation block
               </div>
             </div>
           </div>
@@ -858,7 +858,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sum of Woo donation order totals from same-session completions after a donation-intent prompt impression
+                Sum of Woo donation order totals from same-session completions after a prompt impression with a donation block
               </div>
             </div>
           </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -41,7 +41,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Registration Conversion (Direct)', 'newspack-plugin' ),
 					description: __(
-						'Sessions with a registration after a registration-intent prompt impression ÷ sessions with a registration-intent prompt impression',
+						'Sessions with a registration after a prompt impression with a registration block ÷ sessions with a prompt impression with a registration block',
 						'newspack-plugin'
 					),
 					current: current.registration_conversion_direct,
@@ -67,7 +67,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Newsletter Signup Conversion (Direct)', 'newspack-plugin' ),
 					description: __(
-						'Sessions with a newsletter signup after a newsletter-intent prompt impression ÷ sessions with a newsletter-intent prompt impression',
+						'Sessions with a newsletter signup after a prompt impression with a newsletter block ÷ sessions with a prompt impression with a newsletter block',
 						'newspack-plugin'
 					),
 					current: current.newsletter_signup_conversion_direct,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -54,7 +54,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Registration Conversion (Influenced, 7d)', 'newspack-plugin' ),
 					description: __(
-						'Readers who registered in a later session within 7 days of seeing a registration-intent prompt ÷ readers who saw a registration-intent prompt',
+						'Readers who registered in a later session within 7 days of seeing a prompt with a registration block ÷ readers who saw a prompt with a registration block',
 						'newspack-plugin'
 					),
 					current: current.registration_conversion_influenced_7d,
@@ -80,7 +80,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Newsletter Signup Conversion (Influenced, 7d)', 'newspack-plugin' ),
 					description: __(
-						'Readers who signed up for a newsletter in a later session within 7 days of seeing a newsletter-intent prompt ÷ readers who saw a newsletter-intent prompt',
+						'Readers who signed up for a newsletter in a later session within 7 days of seeing a prompt with a newsletter block ÷ readers who saw a prompt with a newsletter block',
 						'newspack-plugin'
 					),
 					current: current.newsletter_signup_conversion_influenced_7d,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -42,7 +42,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Donation Conversion (Direct)', 'newspack-plugin' ),
 					description: __(
-						'Sessions with a completed donation after a donation-intent prompt impression ÷ sessions with a donation-intent prompt impression',
+						'Sessions with a completed donation after a prompt impression with a donation block ÷ sessions with a prompt impression with a donation block',
 						'newspack-plugin'
 					),
 					current: current.donation_conversion_direct,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
@@ -26,8 +26,8 @@ import { __ } from '@wordpress/i18n';
 export const NOT_COMPUTABLE_COPY = {
 	/** Form submission rate — denominator is impressions on any form-bearing prompt. */
 	formBearing: __( 'No form-bearing prompts viewed in this timeframe.', 'newspack-plugin' ),
-	newsletter: __( 'No newsletter-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
-	registration: __( 'No registration-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+	newsletter: __( 'No prompts with a newsletter block viewed in this timeframe.', 'newspack-plugin' ),
+	registration: __( 'No prompts with a registration block viewed in this timeframe.', 'newspack-plugin' ),
 	donation: __( 'No donation-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
 	subscription: __( 'No subscription-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
@@ -28,6 +28,6 @@ export const NOT_COMPUTABLE_COPY = {
 	formBearing: __( 'No form-bearing prompts viewed in this timeframe.', 'newspack-plugin' ),
 	newsletter: __( 'No prompts with a newsletter block viewed in this timeframe.', 'newspack-plugin' ),
 	registration: __( 'No prompts with a registration block viewed in this timeframe.', 'newspack-plugin' ),
-	donation: __( 'No donation-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+	donation: __( 'No prompts with a donation block viewed in this timeframe.', 'newspack-plugin' ),
 	subscription: __( 'No subscription-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
 };


### PR DESCRIPTION
**Copy-only.** Follows the hub denominator change (NPPD-1765, newspack-manager-admin#465): updates the prompts-tab card descriptions + not-computable messages from "**X-intent** prompt" → "prompt **with an X block**" for **registration** and **newsletter** (direct + influenced), so the copy matches the now-capability-gated denominators.

Also fixes **stale donation copy** while here: the donation *direct* card still said "donation-intent prompt impressions" even though NPPD-1757 capability-gated that denominator. Now reads "with a donation block."

### Left untouched (deliberately)
- **Subscription** copy — still map-/per-popup-keyed, not capability-gated (NPPD-1759 pending), so "subscription-intent" stays accurate.
- **Donation influenced** description — its denominator wasn't migrated (resolver-based), so its wording is unchanged.

### Notes
ESLint clean. No test references the changed strings (the `MetricCard.test` "donation-intent" strings are independent local fixtures for the generic component, not the real copy constants).

Refs: NPPD-1765
