### PR TITLE
fix(group-subscription): gate management UX behind content gates flag (NPPD-1752)

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-api.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-api.php
@@ -25,6 +25,12 @@ class Group_Subscription_API {
 	 * Register REST API routes.
 	 */
 	public static function register_routes() {
+		// The group management REST routes back the reader-facing My Account UX
+		// and the admin meta box, both gated behind the Access Control feature
+		// flag. Don't register the routes on un-migrated sites.
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return;
+		}
 		\register_rest_route(
 			self::NAMESPACE,
 			'/search-users',

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -60,6 +60,13 @@ class Group_Subscription_Invite {
 	 * Initialize hooks.
 	 */
 	public static function init() {
+		// Invite acceptance and the invite email config are part of the group
+		// management UX, gated behind the Access Control feature flag. The
+		// static invite helpers remain available regardless; only the hooks are
+		// gated.
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return;
+		}
 		add_filter( 'newspack_email_configs', [ __CLASS__, 'add_email_config' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_invite_request' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_link_invite_request' ] );

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -47,6 +47,15 @@ class Group_Subscription_MyAccount {
 	 * Register hooks for the My Account group subscription UI.
 	 */
 	public static function init() {
+		// Gate the entire reader-facing group management surface behind the
+		// Access Control feature flag. None of these hooks need to run on sites
+		// that haven't been migrated, and the `group` endpoint / management
+		// flows should not exist there. The flag composes with the
+		// `Memberships::is_active()` redirect in `resolve_group_landing()`: the
+		// flag is the outer gate, the Memberships check the inner redirect.
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return;
+		}
 		add_action( 'init', [ __CLASS__, 'flush_rewrite_rules' ] );
 		add_filter( 'woocommerce_get_query_vars', [ __CLASS__, 'add_manage_members_endpoint' ] );
 		add_filter( 'woocommerce_get_query_vars', [ __CLASS__, 'add_group_endpoint' ] );
@@ -63,9 +72,16 @@ class Group_Subscription_MyAccount {
 
 	/**
 	 * Flush rewrite rules for My Account endpoints for group subscriptions.
+	 *
+	 * The `group` endpoint is now only registered (via `add_group_endpoint()`)
+	 * when the Access Control feature flag is on. The option version is bumped
+	 * so the first request after the flag turns on re-flushes and regenerates
+	 * the endpoint's rewrite rule, regardless of any rules persisted by an
+	 * earlier ungated release. On flag-off sites this never runs (the hook is
+	 * not registered), so the option stays unset and a later flag flip flushes.
 	 */
 	public static function flush_rewrite_rules() {
-		$rewrite_rules_updated_option_name = 'newspack_group_subscription_rewrite_rules_updated_v2';
+		$rewrite_rules_updated_option_name = 'newspack_group_subscription_rewrite_rules_updated_v3';
 		if ( false === get_option( $rewrite_rules_updated_option_name ) ) {
 			flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
 			update_option( $rewrite_rules_updated_option_name, true );

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -7,6 +7,7 @@
 
 namespace Newspack;
 
+use Newspack\Content_Gate;
 use Newspack\Group_Subscription;
 use Newspack\Memberships;
 use Newspack\Reader_Activation;
@@ -287,10 +288,11 @@ class My_Account_UI_V1 {
 			unset( $items['payment-methods'] );
 		}
 
-		// Sidebar entry for native group management. Visibility gated by manager-of-at-least-one-group
-		// AND the existing `Memberships::is_active()` suppression already used by group-subscription UI.
+		// Sidebar entry for native group management. Visibility gated by the Access Control
+		// feature flag, manager-of-at-least-one-group, AND the existing `Memberships::is_active()`
+		// suppression already used by group-subscription UI.
 		// Inserted immediately after Subscriptions so the two related entries stay adjacent.
-		if ( ! Memberships::is_active() ) {
+		if ( Content_Gate::is_newspack_feature_enabled() && ! Memberships::is_active() ) {
 			$managed = Group_Subscription::get_managed_subscriptions_for_user( \get_current_user_id() );
 			$count   = count( $managed );
 			if ( $count > 0 ) {

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/group-management-nav.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/group-management-nav.php
@@ -22,8 +22,16 @@ class Test_Group_Management_Nav extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		// The group management nav + endpoint are gated behind the Access Control
+		// feature flag; turn it on so the surface under test is wired.
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
 		// Register the menu-items filter under test; production wires it in My_Account_UI_V1::init().
 		add_filter( 'woocommerce_account_menu_items', [ \Newspack\My_Account_UI_V1::class, 'my_account_menu_items' ], 1001 );
+		// Register the `group` query-var filter under test; production wires it in
+		// Group_Subscription_MyAccount::init() (gated behind the flag).
+		add_filter( 'woocommerce_get_query_vars', [ \Newspack\Group_Subscription_MyAccount::class, 'add_group_endpoint' ] );
 	}
 
 	/**
@@ -33,6 +41,7 @@ class Test_Group_Management_Nav extends \WP_UnitTestCase {
 		global $subscriptions_database;
 		$subscriptions_database = [];
 		remove_filter( 'woocommerce_account_menu_items', [ \Newspack\My_Account_UI_V1::class, 'my_account_menu_items' ], 1001 );
+		remove_filter( 'woocommerce_get_query_vars', [ \Newspack\Group_Subscription_MyAccount::class, 'add_group_endpoint' ] );
 		delete_option( 'newspack_group_subscription_label_singular' );
 		delete_option( 'newspack_group_subscription_label_plural' );
 		parent::tear_down();

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/group-subscriptions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/group-subscriptions.php
@@ -24,6 +24,18 @@ class Test_Group_Subscriptions extends \WP_UnitTestCase {
 	protected $user_ids = [];
 
 	/**
+	 * Setup before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// The group subscription REST routes and invite flows are gated behind the
+		// Access Control feature flag; turn it on so the surfaces under test are wired.
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
 	 * Teardown after tests.
 	 */
 	public function tear_down() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The group subscription management UX shipped in #148 (live since `newspack@6.44.0-alpha.1`) was not gated behind the Access Control feature flag (`NEWSPACK_CONTENT_GATES`). On un-migrated sites still running Woo Memberships, the reader-facing group endpoint and management flows could surface even though Access Control is not the source of truth.

This gates the entire reader-facing group management surface behind the flag, composing cleanly with the existing `Memberships::is_active()` suppression:

- **`Group_Subscription_MyAccount::init()`** – early-returns when the flag is off, so the `/group/` My Account endpoint, its rewrite rule, query var, and management UX are never registered. The rewrite-rules option version was bumped (`_v2` → `_v3`) so the first request after the flag turns on re-flushes and regenerates the endpoint's rewrite rule.
- **`Group_Subscription_Invite::init()`** – early-returns before registering its email-config hooks. Static helpers remain callable.
- **`Group_Subscription_API::register_routes()`** – early-returns before registering the REST routes that back the reader UX and the admin meta box.
- **`My_Account_UI_v1`** – the group nav entry now requires `Content_Gate::is_newspack_feature_enabled()` in addition to the existing `! Memberships::is_active()` check.

The publisher-facing group-label controls (`Group_Subscription_Settings`, `Audience_Wizard`) were already gated per-callback; no change needed there.

This is an alpha-hotfix: the management UX is already on `alpha`, so this PRs to `alpha` first. A companion PR targets `main` (merges post-release).

#### Note on gating style

This gates at the single registration chokepoint (`init()` / `register_routes()`) rather than per-callback like `Group_Subscription_Settings`. These classes are pure-UX with no must-always-run hooks, so the chokepoint is sufficient and clearer. `Group_Subscription_Settings::admin_enqueue_scripts()` remains ungated (pre-existing, out of scope).

Closes NPPD-1752.

### How to test the changes in this Pull Request:

1. With `NEWSPACK_CONTENT_GATES` **undefined/off** and Woo Memberships active, confirm the `/my-account/group/` endpoint 404s, the `newspack-group-subscription/v1` REST routes are absent, and no group nav entry shows in My Account.
2. Define `NEWSPACK_CONTENT_GATES` (true) and load any page once (to flush rewrite rules). Confirm the `/my-account/group/` endpoint resolves, the REST routes register, and the group nav entry appears for an eligible group owner/manager.
3. Run the unit tests: `n test-php --filter Group_Subscription` and `n test-php --filter Group_Management_Nav` (both green).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?