### PR TITLE
feat(env): support standalone-repo worktrees in isolated envs

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -2,6 +2,7 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/repos.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/worktree-mounts.sh"
 
 # Sanitize env name for use as a database name (replace dashes with underscores).
 db_name_for_env() {
@@ -42,12 +43,14 @@ ip_for_env() {
     grep -o '127\.0\.0\.[0-9]*' "$1" | head -1
 }
 
-# Parse a docker-compose volume line for a worktree mount and emit "repo|branch".
-# Handles both shapes:
-#   legacy (pre-monorepo): "- ./worktrees/<repo>/<branch>:/newspack-repos/<repo>"
-#   monorepo:              "- ./worktrees/<safe_branch>/plugins/<repo>:/newspack-plugins/<repo>"
-#                          "- ./worktrees/<safe_branch>/themes/<repo>:/newspack-themes/<repo>"
-# Returns non-zero for lines that don't match either shape.
+# Parse a docker-compose volume line for a worktree mount and emit "repo|branch|kind".
+# Handles three shapes (kind):
+#   legacy    : "- ./worktrees/<repo>/<branch>:/newspack-repos/<repo>"
+#   monorepo  : "- ./worktrees/<safe_branch>/plugins/<repo>:/newspack-plugins/<repo>"
+#               "- ./worktrees/<safe_branch>/themes/<repo>:/newspack-themes/<repo>"
+#   standalone: "- ./worktrees/standalone/<repo>/<branch>:/newspack-plugins/<repo>"
+#               (tier 2: a worktree of a repos/{plugins,themes}/<repo> checkout)
+# Returns non-zero for lines that don't match any shape.
 parse_worktree_mount() {
     local line="$1"
     # Use regex extraction so the parser tolerates exactly what the grep
@@ -62,24 +65,32 @@ parse_worktree_mount() {
     # display form for the monorepo case. Keeping the parser mount-path-only
     # ensures filesystem operations (e.g., worktree.sh remove) get a stable
     # identifier that doesn't drift when the worktree's git state changes.
+    # Tier 2 (standalone) is matched first (most specific): host =
+    # ./worktrees/standalone/<repo>/<safe_branch>, served at /newspack-{plugins,themes}/<repo>.
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+\./worktrees/standalone/([^/]+)/([^[:space:]:]+):/newspack-(plugins|themes)/([^[:space:]:]+) ]]; then
+        echo "${BASH_REMATCH[1]}|${BASH_REMATCH[2]}|standalone"
+        return 0
+    fi
     [[ "$line" =~ ^[[:space:]]*-[[:space:]]+\./worktrees/([^[:space:]:]+):/newspack-(repos|plugins|themes)/([^[:space:]:]+) ]] || return 1
     local host_rel="worktrees/${BASH_REMATCH[1]}"
     local container_type="${BASH_REMATCH[2]}"
     local repo="${BASH_REMATCH[3]}"
-    local branch=""
+    local branch="" kind=""
     case "$container_type" in
         repos)
             # Legacy: host = ./worktrees/<repo>/<branch> (slashes preserved in directory name).
             branch="${host_rel#worktrees/$repo/}"
+            kind="legacy"
             ;;
         plugins|themes)
             # Monorepo: host = ./worktrees/<safe_branch>/{plugins,themes}/<repo>.
             branch="${host_rel#worktrees/}"
             branch="${branch%/*/$repo}"
+            kind="monorepo"
             ;;
     esac
     [[ -n "$repo" && -n "$branch" ]] || return 1
-    echo "$repo|$branch"
+    echo "$repo|$branch|$kind"
 }
 
 # Resolve the unsanitized git branch name for a worktree directory.
@@ -136,35 +147,48 @@ case $1 in
                     validate_name "$wt_branch" "branch"
                     # Sanitize branch for directory name (feat/foo -> feat-foo).
                     safe_branch=$(echo "$wt_branch" | tr '/' '-')
-                    # Create a monorepo worktree at this branch if it doesn't exist.
-                    if [[ ! -d "$NABSPATH/worktrees/$safe_branch" ]]; then
-                        echo "Creating worktree at branch $wt_branch..."
-                        "$NABSPATH/bin/worktree.sh" add "$wt_branch" || exit 1
-                    fi
-                    # Mount the specific plugin/theme subdirectory from the worktree.
+                    # Resolve the project's host path. A monorepo plugin/theme
+                    # resolves to plugins/<name> or themes/<name>; otherwise look for
+                    # a standalone checkout at repos/{plugins,themes}/<name> (tier 2,
+                    # discovered by path -- no registration).
                     wt_host_path=$(get_repo_host_path "$wt_repo")
                     if [[ -z "$wt_host_path" ]]; then
-                        echo "Error: unknown project '$wt_repo'"
+                        if [[ -d "$NABSPATH/repos/plugins/$wt_repo" ]]; then
+                            wt_host_path="repos/plugins/$wt_repo"
+                        elif [[ -d "$NABSPATH/repos/themes/$wt_repo" ]]; then
+                            wt_host_path="repos/themes/$wt_repo"
+                        fi
+                    fi
+                    if [[ -z "$wt_host_path" ]]; then
+                        echo "Error: unknown project '$wt_repo' (no monorepo plugin/theme, and no repos/{plugins,themes}/$wt_repo checkout)"
                         exit 1
                     fi
-                    if [[ "$wt_host_path" == themes/* ]]; then
-                        wt_container_path="/newspack-themes/$wt_repo"
+                    case "$wt_host_path" in
+                        themes/*|repos/themes/*) wt_container_path="/newspack-themes/$wt_repo" ;;
+                        *)                       wt_container_path="/newspack-plugins/$wt_repo" ;;
+                    esac
+                    if [[ "$wt_host_path" == repos/* ]]; then
+                        # Tier 2: worktree of the whole standalone checkout, served
+                        # (only) at its plugin/theme path. worktree_volume_lines emits a
+                        # single serving mount -- a standalone repo is not a pnpm
+                        # workspace member, so it gets no /newspack-monorepo mount.
+                        worktree_dir="./worktrees/standalone/$wt_repo/$safe_branch"
+                        if [[ ! -d "$NABSPATH/worktrees/standalone/$wt_repo/$safe_branch" ]]; then
+                            echo "Creating worktree of $wt_repo at branch $wt_branch..."
+                            "$NABSPATH/bin/worktree.sh" add "$wt_branch" --repo "$wt_repo" || exit 1
+                        fi
                     else
-                        wt_container_path="/newspack-plugins/$wt_repo"
+                        # Tier 1: monorepo worktree; mount the plugin/theme subdir at
+                        # BOTH the serving path and the pnpm workspace-member path so the
+                        # JS toolchain (n build / n test-js, resolved under
+                        # /newspack-monorepo) builds/tests the worktree's source in place.
+                        worktree_dir="./worktrees/$safe_branch/$wt_host_path"
+                        if [[ ! -d "$NABSPATH/worktrees/$safe_branch" ]]; then
+                            echo "Creating worktree at branch $wt_branch..."
+                            "$NABSPATH/bin/worktree.sh" add "$wt_branch" || exit 1
+                        fi
                     fi
-                    worktree_dir="./worktrees/$safe_branch/$wt_host_path"
-                    # Mount the worktree subdir at BOTH container roots:
-                    #   - the site-serving path (/newspack-plugins|themes/<repo>), and
-                    #   - the pnpm-workspace path (/newspack-monorepo/<host_path>).
-                    # The site reads the first; the JS toolchain (n build / n test-js /
-                    # jest, all resolved under /newspack-monorepo) reads the second. Without
-                    # the workspace mount the toolchain builds/tests the *main* checkout's
-                    # source, never the worktree's, and the worktree's own node_modules has
-                    # relative pnpm symlinks (../../../packages/*) that only resolve when the
-                    # plugin sits at its real workspace location. Mounting here makes both
-                    # work, so builds land in the worktree's dist and are served immediately.
-                    worktree_volumes+="      - $worktree_dir:$wt_container_path"$'\n'
-                    worktree_volumes+="      - $worktree_dir:/newspack-monorepo/$wt_host_path"$'\n'
+                    worktree_volumes+="$(worktree_volume_lines "$worktree_dir" "$wt_container_path" "$wt_host_path")"$'\n'
                     shift 2
                     ;;
                 --domain)
@@ -487,8 +511,14 @@ MIGRATE
                 wt_path=$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*//' | cut -d: -f1)
                 container_path=$(echo "$line" | cut -d: -f2)
                 repo=$(basename "$container_path")
-                # Resolve the source from the monorepo layout.
+                # Resolve the source from the monorepo layout. A standalone repo
+                # (tier 2) has no monorepo source to copy from -- its worktree is a
+                # full checkout; skip and let the user build it (n build <repo>).
                 repo_host_path=$(get_repo_host_path "$repo")
+                if [[ -z "$repo_host_path" ]]; then
+                    echo "Skipping asset copy for standalone repo $repo (build with: n build $repo)"
+                    continue
+                fi
                 src="$NABSPATH/$repo_host_path"
                 dst="$NABSPATH/${wt_path#./}"
                 echo "Copying built assets for $repo..."
@@ -582,8 +612,12 @@ MIGRATE
         # across create/destroy cycles. A proper fix removes the dir by safe
         # name and deletes the branch by its resolved real name separately.
         for entry in "${worktree_entries[@]}"; do
-            IFS='|' read -r wt_repo wt_branch <<< "$entry"
-            "$NABSPATH/bin/worktree.sh" remove --yes "$wt_repo" "$wt_branch"
+            IFS='|' read -r wt_repo wt_branch wt_kind <<< "$entry"
+            if [[ "$wt_kind" == standalone ]]; then
+                "$NABSPATH/bin/worktree.sh" remove "$wt_branch" --repo "$wt_repo" --yes
+            else
+                "$NABSPATH/bin/worktree.sh" remove --yes "$wt_repo" "$wt_branch"
+            fi
         done
         echo "Destroyed environment '$env_name'"
         ;;
@@ -609,7 +643,7 @@ MIGRATE
             # worktrees while leaving filesystem-operation paths to the safe
             # form.
             worktrees=""
-            while IFS='|' read -r repo safe_branch; do
+            while IFS='|' read -r repo safe_branch wt_kind; do
                 branch=$(resolve_unsanitized_branch "$safe_branch")
                 [[ -n "$worktrees" ]] && worktrees="$worktrees,"
                 worktrees="${worktrees}${repo}:${branch}"
@@ -619,7 +653,7 @@ MIGRATE
             else
                 echo "  $name ($status) https://${domain}/"
                 # Show worktrees mounted by this environment.
-                while IFS='|' read -r repo safe_branch; do
+                while IFS='|' read -r repo safe_branch wt_kind; do
                     branch=$(resolve_unsanitized_branch "$safe_branch")
                     echo "    └ $repo ($branch)"
                 done < <(each_worktree_in_env "$f")

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -99,8 +99,11 @@ parse_worktree_mount() {
 # branch ref can't be resolved (e.g., detached HEAD).
 resolve_unsanitized_branch() {
     local safe_branch="$1"
+    # Optional explicit worktree dir. Tier-2 worktrees live at
+    # worktrees/standalone/<repo>/<safe_branch>; default to the tier-1 location.
+    local wt_dir="${2:-$NABSPATH/worktrees/$safe_branch}"
     local resolved
-    resolved=$(git -C "$NABSPATH/worktrees/$safe_branch" branch --show-current 2>/dev/null)
+    resolved=$(git -C "$wt_dir" branch --show-current 2>/dev/null)
     [[ -n "$resolved" ]] && echo "$resolved" || echo "$safe_branch"
 }
 
@@ -153,9 +156,9 @@ case $1 in
                     # discovered by path -- no registration).
                     wt_host_path=$(get_repo_host_path "$wt_repo")
                     if [[ -z "$wt_host_path" ]]; then
-                        if [[ -d "$NABSPATH/repos/plugins/$wt_repo" ]]; then
+                        if [[ -e "$NABSPATH/repos/plugins/$wt_repo/.git" ]]; then
                             wt_host_path="repos/plugins/$wt_repo"
-                        elif [[ -d "$NABSPATH/repos/themes/$wt_repo" ]]; then
+                        elif [[ -e "$NABSPATH/repos/themes/$wt_repo/.git" ]]; then
                             wt_host_path="repos/themes/$wt_repo"
                         fi
                     fi
@@ -644,7 +647,11 @@ MIGRATE
             # form.
             worktrees=""
             while IFS='|' read -r repo safe_branch wt_kind; do
-                branch=$(resolve_unsanitized_branch "$safe_branch")
+                if [[ "$wt_kind" == standalone ]]; then
+                    branch=$(resolve_unsanitized_branch "$safe_branch" "$NABSPATH/worktrees/standalone/$repo/$safe_branch")
+                else
+                    branch=$(resolve_unsanitized_branch "$safe_branch")
+                fi
                 [[ -n "$worktrees" ]] && worktrees="$worktrees,"
                 worktrees="${worktrees}${repo}:${branch}"
             done < <(each_worktree_in_env "$f")
@@ -654,7 +661,11 @@ MIGRATE
                 echo "  $name ($status) https://${domain}/"
                 # Show worktrees mounted by this environment.
                 while IFS='|' read -r repo safe_branch wt_kind; do
-                    branch=$(resolve_unsanitized_branch "$safe_branch")
+                    if [[ "$wt_kind" == standalone ]]; then
+                        branch=$(resolve_unsanitized_branch "$safe_branch" "$NABSPATH/worktrees/standalone/$repo/$safe_branch")
+                    else
+                        branch=$(resolve_unsanitized_branch "$safe_branch")
+                    fi
                     echo "    └ $repo ($branch)"
                 done < <(each_worktree_in_env "$f")
             fi

--- a/bin/worktree-mounts.sh
+++ b/bin/worktree-mounts.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Sourceable, host-testable helpers for isolated-env worktree volume mounts.
+# A tier-1 monorepo plugin/theme worktree is mounted BOTH at its serving path
+# (/newspack-plugins|themes/<name>) AND at the pnpm workspace-member path
+# (/newspack-monorepo/<host>), so `pnpm --filter` builds the worktree in place.
+# Tier-2 standalone (repos/*) worktrees get only the serving mount.
+
+# worktree_volume_lines <worktree_dir> <serving_container_path> <wt_host_path>
+#   Emits the compose volume line(s) (6-space + "- " indented). Tier-1 hosts
+#   (plugins/*, themes/*) emit serving + workspace-member lines; tier-2 (repos/*)
+#   emits only the serving line.
+worktree_volume_lines() {
+    local worktree_dir="${1:-}" serving_path="${2:-}" host_path="${3:-}"
+    printf '      - %s:%s\n' "$worktree_dir" "$serving_path"
+    case "$host_path" in
+        plugins/*|themes/*)
+            printf '      - %s:/newspack-monorepo/%s\n' "$worktree_dir" "$host_path"
+            ;;
+    esac
+}
+
+# worktree_member_lines_to_add <compose_file>
+#   Emits the workspace-member volume line(s) missing for tier-1 worktree serving
+#   mounts already present in <compose_file>. Idempotent: a member line already in
+#   the file yields nothing. Tier-2 (standalone) serving mounts are ignored.
+worktree_member_lines_to_add() {
+    local compose="${1:-}"
+    [ -r "$compose" ] || return 0
+    local line wt_dir host_path target
+    while IFS= read -r line; do
+        # tier-1 serving mount: ./worktrees/<sb>/(plugins|themes)/<name>:/newspack-(plugins|themes)/<name>
+        # Anchored at start-of-line (after optional whitespace) so a commented-out
+        # volume line (`# - ./worktrees/...`) can't false-match — mirrors the
+        # comment-safe anchoring in env.sh's parse_env_worktrees.
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(\./worktrees/[^/:]+/((plugins|themes)/[^[:space:]:]+)):/newspack-(plugins|themes)/[^[:space:]:]+[[:space:]]*$ ]]; then
+            wt_dir="${BASH_REMATCH[1]}"
+            host_path="${BASH_REMATCH[2]}"
+            target="${wt_dir}:/newspack-monorepo/${host_path}"
+            grep -qF "$target" "$compose" || printf '      - %s\n' "$target"
+        fi
+    done < "$compose"
+}

--- a/bin/worktree-mounts.sh
+++ b/bin/worktree-mounts.sh
@@ -18,25 +18,3 @@ worktree_volume_lines() {
             ;;
     esac
 }
-
-# worktree_member_lines_to_add <compose_file>
-#   Emits the workspace-member volume line(s) missing for tier-1 worktree serving
-#   mounts already present in <compose_file>. Idempotent: a member line already in
-#   the file yields nothing. Tier-2 (standalone) serving mounts are ignored.
-worktree_member_lines_to_add() {
-    local compose="${1:-}"
-    [ -r "$compose" ] || return 0
-    local line wt_dir host_path target
-    while IFS= read -r line; do
-        # tier-1 serving mount: ./worktrees/<sb>/(plugins|themes)/<name>:/newspack-(plugins|themes)/<name>
-        # Anchored at start-of-line (after optional whitespace) so a commented-out
-        # volume line (`# - ./worktrees/...`) can't false-match — mirrors the
-        # comment-safe anchoring in env.sh's parse_env_worktrees.
-        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(\./worktrees/[^/:]+/((plugins|themes)/[^[:space:]:]+)):/newspack-(plugins|themes)/[^[:space:]:]+[[:space:]]*$ ]]; then
-            wt_dir="${BASH_REMATCH[1]}"
-            host_path="${BASH_REMATCH[2]}"
-            target="${wt_dir}:/newspack-monorepo/${host_path}"
-            grep -qF "$target" "$compose" || printf '      - %s\n' "$target"
-        fi
-    done < "$compose"
-}

--- a/bin/worktree.sh
+++ b/bin/worktree.sh
@@ -3,34 +3,90 @@
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/repos.sh"
 
-# In the monorepo, all worktrees are of the single workspace repo.
-# A worktree at branch "feat/foo" lives at worktrees/feat-foo/ and
-# contains the entire monorepo tree. The env system mounts specific
-# subdirectories (plugins/<name>, themes/<name>) into the container.
+# Two kinds of worktrees:
+#
+#   Tier 1 (default) — workspace worktrees of the monorepo itself. A worktree
+#   at branch "feat/foo" lives at worktrees/feat-foo/ and contains the entire
+#   monorepo tree. The env system mounts specific subdirectories
+#   (plugins/<name>, themes/<name>) into the container.
+#
+#   Tier 2 (opt-in via --repo) — worktrees of a standalone checkout at
+#   repos/{plugins,themes}/<name>/. Lives at worktrees/standalone/<name>/<safe_branch>/,
+#   created from the standalone repo's own git history. The checkout is
+#   discovered by path -- no registration needed.
 
 # Sanitize a branch name for use as a directory: feat/foo -> feat-foo.
 sanitize_branch() {
     echo "$1" | tr '/' '-'
 }
 
+# Resolve a standalone repos/ checkout's host path by auto-discovery: a checkout
+# at repos/{plugins,themes}/<name>/ is matched by path (no registration). Prints
+# the relative host path (repos/plugins/<name>) or nothing if none is found.
+resolve_standalone_host_path() {
+    local name="$1"
+    if [[ -e "$NABSPATH/repos/plugins/$name/.git" ]]; then
+        echo "repos/plugins/$name"
+    elif [[ -e "$NABSPATH/repos/themes/$name/.git" ]]; then
+        echo "repos/themes/$name"
+    fi
+}
+
 case $1 in
     add)
-        # Usage: worktree.sh add <branch>
-        # Or legacy compat: worktree.sh add <repo> <branch>
-        # (repo is ignored since there's only one git repo now)
-        if [[ -n "$3" ]]; then
-            # Legacy two-arg form: worktree.sh add <repo> <branch>
-            branch="$3"
+        # Usage: worktree.sh add <branch>                 # tier 1 (workspace)
+        #    or: worktree.sh add <repo> <branch>          # legacy tier 1 (repo informational)
+        #    or: worktree.sh add <branch> --repo <name>   # tier 2 (standalone repo)
+        shift  # consume "add"
+        repo=""
+        positionals=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --repo) repo="$2"; shift 2 ;;
+                *) positionals+=("$1"); shift ;;
+            esac
+        done
+        if [[ ${#positionals[@]} -eq 1 ]]; then
+            branch="${positionals[0]}"
+        elif [[ ${#positionals[@]} -eq 2 && -z "$repo" ]]; then
+            # Legacy two-arg form: add <repo> <branch>. The repo arg is informational
+            # for tier 1 (there's one workspace repo); use the second positional as branch.
+            branch="${positionals[1]}"
         else
-            branch="$2"
-        fi
-        if [[ -z "$branch" ]]; then
-            echo "Usage: n worktree add <branch>"
-            echo "   or: n worktree add <plugin> <branch>  (plugin name is informational only)"
+            echo "Usage: n worktree add <branch> [--repo <name>]"
+            echo "   or: n worktree add <repo> <branch>  (legacy; repo arg ignored for tier 1)"
             exit 1
         fi
-        validate_name "$(sanitize_branch "$branch")" "branch"
+        validate_name "$branch" "branch"
         safe_branch=$(sanitize_branch "$branch")
+
+        if [[ -n "$repo" ]]; then
+            # Tier 2: worktree of a standalone repos/ checkout (auto-discovered by path).
+            repo_path=$(resolve_standalone_host_path "$repo")
+            if [[ -z "$repo_path" ]]; then
+                echo "Error: no repos/plugins/$repo or repos/themes/$repo checkout found (standalone repos are discovered by path)"
+                exit 1
+            fi
+            standalone_dir="$NABSPATH/$repo_path"
+            worktree_dir="$NABSPATH/worktrees/standalone/$repo/$safe_branch"
+            if [[ -d "$worktree_dir" ]]; then
+                echo "Worktree already exists at worktrees/standalone/$repo/$safe_branch"
+                exit 0
+            fi
+            mkdir -p "$(dirname "$worktree_dir")"
+            cd "$standalone_dir" || exit 1
+            git fetch origin "$branch" 2>/dev/null
+            if git show-ref --verify --quiet "refs/heads/$branch" || git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+                git worktree add "$worktree_dir" "$branch" || exit 1
+            else
+                echo "Creating branch '$branch' in $repo from $(git rev-parse --abbrev-ref HEAD)..."
+                git worktree add -b "$branch" "$worktree_dir" || exit 1
+            fi
+            echo "Created worktree at worktrees/standalone/$repo/$safe_branch"
+            exit 0
+        fi
+
+        # Tier 1: workspace worktree.
         worktree_dir="$NABSPATH/worktrees/$safe_branch"
         if [[ -d "$worktree_dir" ]]; then
             echo "Worktree already exists at worktrees/$safe_branch"
@@ -38,7 +94,6 @@ case $1 in
         fi
         mkdir -p "$(dirname "$worktree_dir")"
         cd "$NABSPATH" || exit 1
-        # Fetch so we see remote branches.
         git fetch origin "$branch" 2>/dev/null
         if git show-ref --verify --quiet "refs/heads/$branch" || git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
             git worktree add "$worktree_dir" "$branch" || exit 1
@@ -51,29 +106,107 @@ case $1 in
     list)
         cd "$NABSPATH" || exit 1
         git worktree list
+        # Also enumerate worktrees of standalone repos (tier 2). Standalone
+        # checkouts live at repos/{plugins,themes}/<name> (typed); enumerate both
+        # typed dirs by path rather than assuming a flat repos/.
+        for kind in plugins themes; do
+            for d in "$NABSPATH/repos/$kind"/*/; do
+                [[ -e "${d}.git" ]] || continue
+                r=$(basename "$d")
+                echo ""
+                echo "[$r]"
+                ( cd "$d" && git worktree list )
+            done
+        done
         ;;
     remove)
+        # Usage: worktree.sh remove <branch> [--yes]                  # tier 1
+        #    or: worktree.sh remove <repo> <branch> [--yes]           # legacy tier 1
+        #    or: worktree.sh remove <branch> --repo <name> [--yes]    # tier 2
         skip_confirm=false
         shift  # consume "remove"
-        # Parse flags.
-        args=()
-        for arg in "$@"; do
-            if [[ "$arg" == "--yes" ]]; then
-                skip_confirm=true
-            else
-                args+=("$arg")
-            fi
+        repo=""
+        positionals=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --yes) skip_confirm=true; shift ;;
+                --repo) repo="$2"; shift 2 ;;
+                *) positionals+=("$1"); shift ;;
+            esac
         done
-        # Support legacy two-arg form: remove <repo> <branch> (repo ignored).
-        if [[ ${#args[@]} -ge 2 ]]; then
-            branch="${args[1]}"
-        elif [[ ${#args[@]} -eq 1 ]]; then
-            branch="${args[0]}"
+        if [[ ${#positionals[@]} -eq 1 ]]; then
+            branch="${positionals[0]}"
+        elif [[ ${#positionals[@]} -eq 2 && -z "$repo" ]]; then
+            # Legacy: remove <repo> <branch>. Repo arg is informational for tier 1.
+            branch="${positionals[1]}"
         else
-            echo "Usage: n worktree remove <branch> [--yes]"
+            echo "Usage: n worktree remove <branch> [--repo <name>] [--yes]"
+            echo "   or: n worktree remove <repo> <branch> [--yes]  (legacy; repo arg ignored for tier 1)"
             exit 1
         fi
         safe_branch=$(sanitize_branch "$branch")
+
+        if [[ -n "$repo" ]]; then
+            # Tier 2: standalone repos/ checkout worktree (auto-discovered by path).
+            repo_path=$(resolve_standalone_host_path "$repo")
+            if [[ -z "$repo_path" ]]; then
+                echo "Error: no repos/plugins/$repo or repos/themes/$repo checkout found (standalone repos are discovered by path)"
+                exit 1
+            fi
+            standalone_dir="$NABSPATH/$repo_path"
+            worktree_dir="$NABSPATH/worktrees/standalone/$repo/$safe_branch"
+            if [[ ! -d "$worktree_dir" ]] && ! (cd "$standalone_dir" 2>/dev/null && git show-ref --verify --quiet "refs/heads/$branch"); then
+                echo "Nothing to remove: no worktree or branch '$branch' found in $repo."
+                exit 0
+            fi
+            # Block removal if an environment mounts this worktree.
+            for f in "$NABSPATH"/docker-compose.env-*.yml; do
+                [[ -f "$f" ]] || continue
+                if grep -q "worktrees/standalone/$repo/$safe_branch" "$f" 2>/dev/null; then
+                    env_name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
+                    echo "Error: worktree standalone/$repo/$safe_branch is used by environment '$env_name'."
+                    echo "Destroy the environment first: n env destroy $env_name"
+                    exit 1
+                fi
+            done
+            echo "Worktree: $worktree_dir"
+            echo "Branch:   $branch in $repo (will be deleted)"
+            if [[ -d "$worktree_dir" ]]; then
+                changes=$(cd "$worktree_dir" && git status --porcelain 2>/dev/null)
+                if [[ -n "$changes" ]]; then
+                    echo ""
+                    echo "WARNING: Worktree has uncommitted changes:"
+                    echo "$changes" | head -10
+                fi
+                unpushed=$(cd "$worktree_dir" && git log --oneline "origin/$branch..$branch" 2>/dev/null)
+                if [[ -n "$unpushed" ]]; then
+                    echo ""
+                    echo "WARNING: Branch has unpushed commits:"
+                    echo "$unpushed"
+                fi
+            fi
+            if [[ "$skip_confirm" != true ]]; then
+                echo ""
+                read -p "Remove worktree and delete branch? (y/N): " confirm
+                if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                    echo "Aborted."
+                    exit 0
+                fi
+            fi
+            cd "$standalone_dir" || exit 1
+            if [[ -d "$worktree_dir" ]]; then
+                git worktree remove --force "$worktree_dir" || exit 1
+            else
+                git worktree prune
+            fi
+            git branch -D "$branch" 2>/dev/null && echo "Deleted branch $branch in $repo"
+            # Best-effort cleanup of empty parent dirs.
+            rmdir "$NABSPATH/worktrees/standalone/$repo" 2>/dev/null
+            rmdir "$NABSPATH/worktrees/standalone" 2>/dev/null
+            exit 0
+        fi
+
+        # Tier 1: workspace worktree.
         worktree_dir="$NABSPATH/worktrees/$safe_branch"
         cd "$NABSPATH" || exit 1
         if [[ ! -d "$worktree_dir" ]] && ! git show-ref --verify --quiet "refs/heads/$branch"; then
@@ -223,10 +356,11 @@ case $1 in
         done
         ;;
     *)
-        echo "Usage: n worktree <add|list|remove|cleanup> [branch]"
-        echo "  add <branch>              Create a monorepo worktree at the given branch"
-        echo "  list                      List all worktrees"
-        echo "  remove <branch> [--yes]   Remove a worktree and delete the branch"
-        echo "  cleanup [--all] [--yes]   Interactive bulk cleanup"
+        echo "Usage: n worktree <add|list|remove|cleanup> [args]"
+        echo "  add <branch> [--repo <name>]              Create a worktree at the given branch"
+        echo "                                              (--repo: a standalone repos/{plugins,themes}/<name> checkout)"
+        echo "  list                                      List all worktrees (workspace + standalone)"
+        echo "  remove <branch> [--repo <name>] [--yes]   Remove a worktree and delete the branch"
+        echo "  cleanup [--all] [--yes]                   Interactive bulk cleanup (workspace worktrees only)"
         ;;
 esac

--- a/bin/worktree.sh
+++ b/bin/worktree.sh
@@ -155,6 +155,14 @@ case $1 in
             fi
             standalone_dir="$NABSPATH/$repo_path"
             worktree_dir="$NABSPATH/worktrees/standalone/$repo/$safe_branch"
+            # Resolve the worktree's actual branch (the caller may pass the
+            # mount-derived safe form, e.g. `n env destroy` passes "feat-foo" for
+            # branch "feat/foo"); fall back to the passed value if the worktree is gone.
+            del_branch="$branch"
+            if [[ -d "$worktree_dir" ]]; then
+                resolved=$(git -C "$worktree_dir" branch --show-current 2>/dev/null)
+                [[ -n "$resolved" ]] && del_branch="$resolved"
+            fi
             if [[ ! -d "$worktree_dir" ]] && ! (cd "$standalone_dir" 2>/dev/null && git show-ref --verify --quiet "refs/heads/$branch"); then
                 echo "Nothing to remove: no worktree or branch '$branch' found in $repo."
                 exit 0
@@ -170,7 +178,7 @@ case $1 in
                 fi
             done
             echo "Worktree: $worktree_dir"
-            echo "Branch:   $branch in $repo (will be deleted)"
+            echo "Branch:   $del_branch in $repo (will be deleted)"
             if [[ -d "$worktree_dir" ]]; then
                 changes=$(cd "$worktree_dir" && git status --porcelain 2>/dev/null)
                 if [[ -n "$changes" ]]; then
@@ -178,7 +186,7 @@ case $1 in
                     echo "WARNING: Worktree has uncommitted changes:"
                     echo "$changes" | head -10
                 fi
-                unpushed=$(cd "$worktree_dir" && git log --oneline "origin/$branch..$branch" 2>/dev/null)
+                unpushed=$(cd "$worktree_dir" && git log --oneline "origin/$del_branch..$del_branch" 2>/dev/null)
                 if [[ -n "$unpushed" ]]; then
                     echo ""
                     echo "WARNING: Branch has unpushed commits:"
@@ -199,7 +207,7 @@ case $1 in
             else
                 git worktree prune
             fi
-            git branch -D "$branch" 2>/dev/null && echo "Deleted branch $branch in $repo"
+            git branch -D "$del_branch" 2>/dev/null && echo "Deleted branch $del_branch in $repo"
             # Best-effort cleanup of empty parent dirs.
             rmdir "$NABSPATH/worktrees/standalone/$repo" 2>/dev/null
             rmdir "$NABSPATH/worktrees/standalone" 2>/dev/null

--- a/tests/env-worktree-parse.test.sh
+++ b/tests/env-worktree-parse.test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Unit tests for parse_worktree_mount (bin/env.sh): classifies a docker-compose
+# worktree volume line into "repo|branch|kind" across the three mount shapes
+# (standalone / monorepo / legacy). Host-runnable; drives env destroy + list.
+set -u
+ENVSH="$(cd "$(dirname "$0")/../bin" && pwd)/env.sh"
+FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+pass=0; fail=0
+ok(){ if [ "$2" = "$3" ]; then echo "  PASS  $1"; pass=$((pass+1)); else echo "  FAIL  $1 (got [$2] want [$3])"; fail=$((fail+1)); fi; }
+
+# Source ONLY the function under test (extracted) so env.sh's CLI dispatch never runs.
+awk '/^parse_worktree_mount\(\)/,/^}/' "$ENVSH" > "$FIX/parse.sh"
+source "$FIX/parse.sh"
+
+chk(){ local got; got=$(parse_worktree_mount "$2") || got="(no-match)"; ok "$1" "$got" "$3"; }
+
+chk "tier2 plugin"            "      - ./worktrees/standalone/newspack-community/feat-x:/newspack-plugins/newspack-community" "newspack-community|feat-x|standalone"
+chk "tier2 theme"            "      - ./worktrees/standalone/my-theme/bug-12:/newspack-themes/my-theme"                       "my-theme|bug-12|standalone"
+chk "tier2 repo w/ dashes"   "      - ./worktrees/standalone/super-cool-ad-inserter/x:/newspack-plugins/super-cool-ad-inserter" "super-cool-ad-inserter|x|standalone"
+chk "tier1 plugin"           "      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-plugins/newspack-newsletters"  "newspack-newsletters|feat-x|monorepo"
+chk "tier1 theme"            "      - ./worktrees/feat-y/themes/newspack-theme:/newspack-themes/newspack-theme"                "newspack-theme|feat-y|monorepo"
+chk "legacy"                 "      - ./worktrees/newspack-plugin/feat-z:/newspack-repos/newspack-plugin"                      "newspack-plugin|feat-z|legacy"
+chk "non-match (no mount)"   "      - .:/newspack-monorepo"                                                                    "(no-match)"
+chk "commented tier2 skipped" "      # - ./worktrees/standalone/repo-a/feat-foo:/newspack-plugins/repo-a"                      "(no-match)"
+
+echo ""; echo "RESULT: $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/tests/worktree-mounts.test.sh
+++ b/tests/worktree-mounts.test.sh
@@ -22,25 +22,4 @@ out=$(worktree_volume_lines "./worktrees/standalone/newspack-community/jl-foo" "
 ok "tier2 emits 1 line" "$(nlines "$out")" "1"
 ok "tier2 has no monorepo member" "$(printf '%s\n' "$out" | grep -c 'newspack-monorepo')" "0"
 
-# --- worktree_member_lines_to_add ---
-C1="$FIX/c1.yml"; cat > "$C1" <<'EOF'
-    volumes:
-      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-plugins/newspack-newsletters
-      - ./html:/var/www/html
-EOF
-ok "missing member -> emitted" "$(worktree_member_lines_to_add "$C1" | grep -c -- ':/newspack-monorepo/plugins/newspack-newsletters$')" "1"
-
-C2="$FIX/c2.yml"; cat > "$C2" <<'EOF'
-    volumes:
-      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-plugins/newspack-newsletters
-      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-monorepo/plugins/newspack-newsletters
-EOF
-ok "already-present member -> nothing (idempotent)" "$(nlines "$(worktree_member_lines_to_add "$C2")")" "0"
-
-C3="$FIX/c3.yml"; cat > "$C3" <<'EOF'
-    volumes:
-      - ./worktrees/standalone/newspack-community/jl-foo:/newspack-plugins/newspack-community
-EOF
-ok "tier2-only -> nothing" "$(nlines "$(worktree_member_lines_to_add "$C3")")" "0"
-
 echo ""; echo "RESULT: $pass passed, $fail failed"; [ "$fail" -eq 0 ]

--- a/tests/worktree-mounts.test.sh
+++ b/tests/worktree-mounts.test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Unit tests for bin/worktree-mounts.sh (pure mount helpers). Host-runnable.
+set -u
+BIN="$(cd "$(dirname "$0")/../bin" && pwd)"
+FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+pass=0; fail=0
+ok(){ if [ "$2" = "$3" ]; then echo "  PASS  $1"; pass=$((pass+1)); else echo "  FAIL  $1 (got [$2] want [$3])"; fail=$((fail+1)); fi; }
+nlines(){ printf '%s' "$1" | grep -c '.'; }
+
+source "$BIN/worktree-mounts.sh"
+
+# --- worktree_volume_lines ---
+out=$(worktree_volume_lines "./worktrees/feat-x/plugins/newspack-newsletters" "/newspack-plugins/newspack-newsletters" "plugins/newspack-newsletters")
+ok "tier1 plugin emits 2 lines" "$(nlines "$out")" "2"
+ok "tier1 plugin serving line" "$(printf '%s\n' "$out" | grep -c -- '- ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-plugins/newspack-newsletters$')" "1"
+ok "tier1 plugin member line" "$(printf '%s\n' "$out" | grep -c -- '- ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-monorepo/plugins/newspack-newsletters$')" "1"
+
+out=$(worktree_volume_lines "./worktrees/feat-y/themes/newspack-theme" "/newspack-themes/newspack-theme" "themes/newspack-theme")
+ok "tier1 theme member line at /newspack-monorepo/themes" "$(printf '%s\n' "$out" | grep -c -- '- ./worktrees/feat-y/themes/newspack-theme:/newspack-monorepo/themes/newspack-theme$')" "1"
+
+out=$(worktree_volume_lines "./worktrees/standalone/newspack-community/jl-foo" "/newspack-plugins/newspack-community" "repos/plugins/newspack-community")
+ok "tier2 emits 1 line" "$(nlines "$out")" "1"
+ok "tier2 has no monorepo member" "$(printf '%s\n' "$out" | grep -c 'newspack-monorepo')" "0"
+
+# --- worktree_member_lines_to_add ---
+C1="$FIX/c1.yml"; cat > "$C1" <<'EOF'
+    volumes:
+      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-plugins/newspack-newsletters
+      - ./html:/var/www/html
+EOF
+ok "missing member -> emitted" "$(worktree_member_lines_to_add "$C1" | grep -c -- ':/newspack-monorepo/plugins/newspack-newsletters$')" "1"
+
+C2="$FIX/c2.yml"; cat > "$C2" <<'EOF'
+    volumes:
+      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-plugins/newspack-newsletters
+      - ./worktrees/feat-x/plugins/newspack-newsletters:/newspack-monorepo/plugins/newspack-newsletters
+EOF
+ok "already-present member -> nothing (idempotent)" "$(nlines "$(worktree_member_lines_to_add "$C2")")" "0"
+
+C3="$FIX/c3.yml"; cat > "$C3" <<'EOF'
+    volumes:
+      - ./worktrees/standalone/newspack-community/jl-foo:/newspack-plugins/newspack-community
+EOF
+ok "tier2-only -> nothing" "$(nlines "$(worktree_member_lines_to_add "$C3")")" "0"
+
+echo ""; echo "RESULT: $pass passed, $fail failed"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Isolated environments can already mount worktrees of monorepo plugins/themes (`n env create --worktree <plugin>:<branch>`). This extends `--worktree` to **standalone checkouts** that live outside the monorepo at `repos/{plugins,themes}/<name>` — private or customer-specific plugins, licensed extensions, etc. — so they can be branch-isolated in an env the same way monorepo projects are.

A standalone checkout is discovered by path (no registration). Its worktree is created from the checkout's own git history at `worktrees/standalone/<repo>/<branch>` and mounted **serving-only**: unlike a monorepo worktree, a standalone repo is not a pnpm workspace member, so it gets no `/newspack-monorepo/...` workspace mount. `n env destroy` and `n env list` understand the new mount shape and clean it up / display it.

This is additive — monorepo (tier-1) and legacy worktree handling are unchanged.

- **`bin/worktree.sh`**: `n worktree add|remove <branch> --repo <name>` for standalone checkouts; `n worktree list` enumerates standalone worktrees alongside workspace ones.
- **`bin/worktree-mounts.sh`** (new): a small, host-testable helper that emits tier-aware compose volume lines (monorepo → serving + workspace-member; standalone → serving only). Unit-tested.
- **`bin/env.sh`**: `env create --worktree` resolves standalone checkouts by path and mounts them tier-aware; the worktree-mount parser, `env destroy`, and `env list` gain standalone awareness.

### How to test the changes in this Pull Request:

1. Drop a real standalone plugin checkout at `repos/plugins/<name>` (clone, unzip, or `git worktree add`).
2. `n env create <env> --worktree <name>:<branch> --up` — confirm the env comes up and the worktree is created at `worktrees/standalone/<name>/<branch>`.
3. Visit the env URL and confirm the standalone plugin is served from the worktree (edit a file in the worktree, `n build <name>`, see the change).
4. `n env list` — confirm the env shows the standalone worktree.
5. `n worktree list` — confirm a `[<name>]` section lists the standalone worktree.
6. `n env destroy <env>` — confirm the env, its worktree, and the branch are all removed.
7. **Regression:** repeat 2–6 with a monorepo plugin (`--worktree newspack-plugin:<branch>`) and confirm tier-1 both-path mounting and cleanup still work.
8. `bash tests/worktree-mounts.test.sh` — unit tests for the mount helper pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
