### PR TITLE
fix(group-subscription): include owner in member counts

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -360,10 +360,26 @@ class Group_Subscription_Settings {
 		$product  = \wc_get_product( WooCommerce_Subscriptions::get_subscription_product_id( $subscription ) );
 		$members  = Group_Subscription::get_members( $subscription );
 		$managers = Group_Subscription::get_managers( $subscription );
-		// The owner/manager(s) are rendered (non-removable) at the top of the list below,
-		// so exclude any manager that also carries member meta to avoid a duplicate row.
-		$member_only = array_values( array_diff( array_map( 'intval', $members ), array_map( 'intval', $managers ) ) );
 		$invites  = Group_Subscription_Invite::get_invites( $subscription );
+		// Resolve the rows once, applying the same guards used when rendering below, so the
+		// header count always matches the rendered list (and the admin JS, which re-tallies the
+		// list items on add/remove/invite). The owner/manager(s) render as non-removable rows;
+		// members exclude any manager that also carries member meta (avoiding a duplicate row)
+		// and must be readers.
+		$manager_users = [];
+		foreach ( array_map( 'intval', $managers ) as $manager_id ) {
+			$manager_user = get_user_by( 'id', $manager_id );
+			if ( $manager_user ) {
+				$manager_users[] = $manager_user;
+			}
+		}
+		$member_users = [];
+		foreach ( array_diff( array_map( 'intval', $members ), array_map( 'intval', $managers ) ) as $member_id ) {
+			$member_user = get_user_by( 'id', $member_id );
+			if ( $member_user && Reader_Activation::is_user_reader( $member_user ) ) {
+				$member_users[] = $member_user;
+			}
+		}
 		?>
 		<div class="newspack-group-subscription__container" data-subscription-id="<?php echo \esc_attr( $subscription->get_id() ); ?>">
 			<div class="newspack-group-subscription__settings">
@@ -427,8 +443,9 @@ class Group_Subscription_Settings {
 						sprintf(
 							// translators: %d: The number of group members.
 							__( 'Group members (<span class="newspack-group-subscription__members-count">%d</span>)', 'newspack-plugin' ),
-							// The owner counts as a member, so include managers alongside members and pending invites.
-							Group_Subscription::get_member_count( $subscription ) + count( array_values( $invites ) )
+							// Count exactly the rows rendered below (owner(s) + reader-members + invites)
+							// so the header never drifts from the list.
+							count( $manager_users ) + count( $member_users ) + count( $invites )
 						)
 					);
 					?>
@@ -437,11 +454,7 @@ class Group_Subscription_Settings {
 					<?php
 					// The owner counts as a member of the group, so render the manager(s) first
 					// as non-removable rows. The JS keeps the count in sync by tallying list items.
-					foreach ( $managers as $manager_id ) :
-						$manager_user = get_user_by( 'id', $manager_id );
-						if ( ! $manager_user ) {
-							continue;
-						}
+					foreach ( $manager_users as $manager_user ) :
 						?>
 						<li>
 							<a class="newspack-group-subscription__member-user-link" href="<?php echo \esc_url( \get_edit_user_link( $manager_user->ID ) ); ?>"><?php echo \esc_html( $manager_user->user_email ); ?></a>
@@ -449,11 +462,7 @@ class Group_Subscription_Settings {
 						</li>
 						<?php
 					endforeach;
-					foreach ( $member_only as $member_id ) :
-						$user = get_user_by( 'id', $member_id );
-						if ( ! $user || ! Reader_Activation::is_user_reader( $user ) ) {
-							continue;
-						}
+					foreach ( $member_users as $user ) :
 						?>
 						<li>
 							<a class="newspack-group-subscription__member-user-link" href="<?php echo \esc_url( \get_edit_user_link( $user->ID ) ); ?>"><?php echo \esc_html( $user->user_email ); ?></a>

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -157,9 +157,9 @@ class Group_Subscription_Settings {
 		$custom_product_pricing_options['newspack_group_subscription_limit'] = [
 			'id'                => self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit',
 			'wrapper_class'     => 'show_if_newspack_group_subscription_enabled',
-			'label'             => __( 'Group subscription member limit', 'newspack-plugin' ),
+			'label'             => __( 'Group subscription member limit (in addition to owner)', 'newspack-plugin' ),
 			'desc_tip'          => true,
-			'description'       => __( 'Set the maximum number of members for group subscriptions. Set to 0 to allow an unlimited number of group members.', 'newspack-plugin' ),
+			'description'       => __( 'Set the maximum number of members allowed in addition to the owner. Set to 0 to allow an unlimited number of group members.', 'newspack-plugin' ),
 			'default'           => self::DEFAULT_SETTINGS['limit'],
 			'product_types'     => [ 'subscription', 'subscription_variation' ],
 			'type'              => 'number',
@@ -188,11 +188,13 @@ class Group_Subscription_Settings {
 		if ( ! Group_Subscription::is_group_subscription( $subscription ) ) {
 			return $column_content;
 		}
-		$settings     = self::get_subscription_settings( $subscription );
-		$members      = Group_Subscription::get_members( $subscription );
-		$member_count = count( $members );
-		$limit        = $settings['limit'] > 0
-			? $settings['limit']
+		$settings = self::get_subscription_settings( $subscription );
+		// The owner counts as a member, so use the owner-inclusive count and a capacity
+		// (limit + owner) so this matches the member-facing card and Members tab.
+		$member_count = Group_Subscription::get_member_count( $subscription );
+		$capacity     = Group_Subscription::get_member_capacity( $subscription );
+		$limit        = null !== $capacity
+			? $capacity
 			: __( 'unlimited', 'newspack-plugin' );
 
 		$group_markup = sprintf(
@@ -201,7 +203,7 @@ class Group_Subscription_Settings {
 			\esc_html( $settings['name'] ),
 			\esc_html(
 				sprintf(
-					/* translators: 1: member count, 2: member limit or "unlimited" */
+					/* translators: 1: member count, 2: member capacity or "unlimited" */
 					__( '%1$s of %2$s members', 'newspack-plugin' ),
 					$member_count,
 					$limit
@@ -356,8 +358,12 @@ class Group_Subscription_Settings {
 		}
 		$settings = self::get_subscription_settings( $subscription );
 		$product  = \wc_get_product( WooCommerce_Subscriptions::get_subscription_product_id( $subscription ) );
-		$members = Group_Subscription::get_members( $subscription );
-		$invites = Group_Subscription_Invite::get_invites( $subscription );
+		$members  = Group_Subscription::get_members( $subscription );
+		$managers = Group_Subscription::get_managers( $subscription );
+		// The owner/manager(s) are rendered (non-removable) at the top of the list below,
+		// so exclude any manager that also carries member meta to avoid a duplicate row.
+		$member_only = array_values( array_diff( array_map( 'intval', $members ), array_map( 'intval', $managers ) ) );
+		$invites  = Group_Subscription_Invite::get_invites( $subscription );
 		?>
 		<div class="newspack-group-subscription__container" data-subscription-id="<?php echo \esc_attr( $subscription->get_id() ); ?>">
 			<div class="newspack-group-subscription__settings">
@@ -421,14 +427,29 @@ class Group_Subscription_Settings {
 						sprintf(
 							// translators: %d: The number of group members.
 							__( 'Group members (<span class="newspack-group-subscription__members-count">%d</span>)', 'newspack-plugin' ),
-							count( $members ) + count( array_values( $invites ) )
+							// The owner counts as a member, so include managers alongside members and pending invites.
+							Group_Subscription::get_member_count( $subscription ) + count( array_values( $invites ) )
 						)
 					);
 					?>
 				</h3>
 				<ul class="newspack-group-subscription__members-list">
 					<?php
-					foreach ( $members as $member_id ) :
+					// The owner counts as a member of the group, so render the manager(s) first
+					// as non-removable rows. The JS keeps the count in sync by tallying list items.
+					foreach ( $managers as $manager_id ) :
+						$manager_user = get_user_by( 'id', $manager_id );
+						if ( ! $manager_user ) {
+							continue;
+						}
+						?>
+						<li>
+							<a class="newspack-group-subscription__member-user-link" href="<?php echo \esc_url( \get_edit_user_link( $manager_user->ID ) ); ?>"><?php echo \esc_html( $manager_user->user_email ); ?></a>
+							<span class="newspack-group-subscription__member-role"><?php \esc_html_e( '(owner)', 'newspack-plugin' ); ?></span>
+						</li>
+						<?php
+					endforeach;
+					foreach ( $member_only as $member_id ) :
 						$user = get_user_by( 'id', $member_id );
 						if ( ! $user || ! Reader_Activation::is_user_reader( $user ) ) {
 							continue;

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -306,8 +306,10 @@ class Group_Subscription {
 	 *
 	 * The configured member limit is the number of members allowed *in addition to*
 	 * the manager(s)/owner, so the total capacity is the limit plus the number of
-	 * managers. This keeps "X of Y members" displays consistent with get_member_count(),
-	 * which counts the owner.
+	 * managers. The manager count is filtered the same way get_all_members() filters
+	 * empty IDs, so the capacity (denominator) and get_member_count() (numerator) always
+	 * agree about the owner — including the edge case of an ownerless subscription, where
+	 * neither counts a phantom owner.
 	 *
 	 * @param \WC_Subscription|int $subscription The subscription object or ID.
 	 *
@@ -323,7 +325,7 @@ class Group_Subscription {
 		if ( $limit <= 0 ) {
 			return null;
 		}
-		return $limit + count( self::get_managers( $subscription ) );
+		return $limit + count( array_filter( array_map( 'intval', self::get_managers( $subscription ) ) ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -271,6 +271,62 @@ class Group_Subscription {
 	}
 
 	/**
+	 * Get the combined, de-duplicated list of a group's people: the manager(s)/owner
+	 * and the members. The owner is part of the group, so they count as a member for
+	 * display purposes (see get_member_count()).
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 *
+	 * @return int[] De-duplicated user IDs of managers and members.
+	 */
+	public static function get_all_members( $subscription ) {
+		$members  = array_map( 'intval', self::get_members( $subscription ) );
+		$managers = array_map( 'intval', self::get_managers( $subscription ) );
+		// array_filter drops empty IDs (e.g. a subscription with no owner); array_unique
+		// guards against a user who is both a manager and a member being counted twice.
+		return array_values( array_unique( array_filter( array_merge( $managers, $members ) ) ) );
+	}
+
+	/**
+	 * Get the total member count for a group, including the manager(s)/owner.
+	 *
+	 * A group is never empty as long as it has an owner, so the owner is always
+	 * included in this count.
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 *
+	 * @return int The number of people in the group (managers + members).
+	 */
+	public static function get_member_count( $subscription ) {
+		return count( self::get_all_members( $subscription ) );
+	}
+
+	/**
+	 * Get the total member capacity for a group, or null when there is no limit.
+	 *
+	 * The configured member limit is the number of members allowed *in addition to*
+	 * the manager(s)/owner, so the total capacity is the limit plus the number of
+	 * managers. This keeps "X of Y members" displays consistent with get_member_count(),
+	 * which counts the owner.
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 *
+	 * @return int|null The total capacity, or null when unlimited.
+	 */
+	public static function get_member_capacity( $subscription ) {
+		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		if ( ! $subscription ) {
+			return null;
+		}
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+		$limit    = isset( $settings['limit'] ) ? (int) $settings['limit'] : 0;
+		if ( $limit <= 0 ) {
+			return null;
+		}
+		return $limit + count( self::get_managers( $subscription ) );
+	}
+
+	/**
 	 * Update the member IDs for a group subscription.
 	 *
 	 * @param \WC_Subscription|int $subscription The subscription object or ID.

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-picker.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-picker.php
@@ -43,16 +43,17 @@ usort(
 	<div class="newspack-ui__grid">
 		<?php foreach ( $managed as $subscription ) : ?>
 			<?php
-			$settings            = Group_Subscription_Settings::get_subscription_settings( $subscription );
-			$members             = Group_Subscription::get_members( $subscription );
-			$member_count        = count( $members );
-			$limit               = $settings['limit'] > 0 ? $settings['limit'] : null;
-			$count_label         = $limit
+			$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+			// The owner counts as a member, so use the owner-inclusive count and a
+			// capacity (limit + owner) so the card matches the group's Members tab.
+			$member_count        = Group_Subscription::get_member_count( $subscription );
+			$capacity            = Group_Subscription::get_member_capacity( $subscription );
+			$count_label         = $capacity
 				? sprintf(
-					/* translators: 1: member count, 2: member limit */
+					/* translators: 1: member count, 2: member capacity */
 					_x( '%1$d of %2$d members', 'group member count', 'newspack-plugin' ),
 					$member_count,
-					$limit
+					$capacity
 				)
 				: sprintf(
 					/* translators: %d: member count */

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Tests for Group_Subscription member-count helpers.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ */
+
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * Test Group_Subscription member counting (managers/owner are counted as members).
+ */
+class Test_Group_Subscription extends WP_UnitTestCase {
+
+	/**
+	 * Track created user IDs for cleanup.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = [];
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Include WC mocks.
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Set up: reset subscriptions and products databases.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$this->user_ids         = [];
+	}
+
+	/**
+	 * Tear down: reset subscriptions and products databases and delete users.
+	 */
+	public function tear_down() {
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a reader user and track it for cleanup.
+	 *
+	 * @return int The new user ID.
+	 */
+	private function create_reader_user(): int {
+		$user_id = wp_insert_user(
+			[
+				'user_login' => 'reader-' . wp_generate_password( 6, false ),
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'reader-' . wp_generate_password( 6, false ) . '@test.com',
+				'role'       => 'subscriber',
+			]
+		);
+		if ( ! is_wp_error( $user_id ) ) {
+			update_user_meta( $user_id, '_newspack_reader', true );
+			$this->user_ids[] = $user_id;
+		}
+		return $user_id;
+	}
+
+	/**
+	 * Create an enabled group subscription owned by $customer_id, optionally with a member limit.
+	 *
+	 * @param int      $customer_id The owner user ID.
+	 * @param int|null $limit       Optional member limit to set on the subscription.
+	 *
+	 * @return WC_Subscription
+	 */
+	private function create_group_subscription( int $customer_id, $limit = null ): WC_Subscription {
+		$sub = wcs_create_subscription(
+			[
+				'customer_id'    => $customer_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		if ( null !== $limit ) {
+			$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', (string) $limit );
+		}
+		return $sub;
+	}
+
+	/**
+	 * Add $member_id as a member of $subscription.
+	 *
+	 * @param int             $member_id    The user ID to add as a member.
+	 * @param WC_Subscription $subscription The group subscription.
+	 */
+	private function add_member( int $member_id, WC_Subscription $subscription ): void {
+		add_user_meta( $member_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $subscription->get_id() );
+	}
+
+	/**
+	 * The owner counts as a member even when there are no other members.
+	 */
+	public function test_member_count_includes_owner_when_only_member() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id );
+
+		$this->assertSame(
+			1,
+			Group_Subscription::get_member_count( $sub ),
+			'A group whose only member is the owner should report a count of 1, not 0.'
+		);
+	}
+
+	/**
+	 * The owner is counted alongside added members.
+	 */
+	public function test_member_count_includes_owner_and_members() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id );
+		$this->add_member( $this->create_reader_user(), $sub );
+		$this->add_member( $this->create_reader_user(), $sub );
+
+		$this->assertSame(
+			3,
+			Group_Subscription::get_member_count( $sub ),
+			'Two added members plus the owner should report a count of 3.'
+		);
+	}
+
+	/**
+	 * The get_all_members() helper returns owner + members, de-duplicated, without empty IDs.
+	 */
+	public function test_get_all_members_returns_owner_and_members() {
+		$owner_id  = $this->create_reader_user();
+		$member_id = $this->create_reader_user();
+		$sub       = $this->create_group_subscription( $owner_id );
+		$this->add_member( $member_id, $sub );
+
+		$all = Group_Subscription::get_all_members( $sub );
+		sort( $all );
+		$expected = [ $owner_id, $member_id ];
+		sort( $expected );
+
+		$this->assertSame( $expected, $all, 'get_all_members should return the owner and member IDs.' );
+	}
+
+	/**
+	 * A user who is both the owner and carries member meta is only counted once.
+	 */
+	public function test_member_count_dedupes_owner_with_member_meta() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id );
+		// Owner also carries member meta (edge case).
+		$this->add_member( $owner_id, $sub );
+		$this->add_member( $this->create_reader_user(), $sub );
+
+		$this->assertSame(
+			2,
+			Group_Subscription::get_member_count( $sub ),
+			'The owner should be counted once even if they also carry member meta.'
+		);
+	}
+
+	/**
+	 * Capacity is the configured limit plus the owner (limit is "in addition to owner").
+	 */
+	public function test_member_capacity_is_limit_plus_owner() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id, 10 );
+
+		$this->assertSame(
+			11,
+			Group_Subscription::get_member_capacity( $sub ),
+			'A limit of 10 should yield a total capacity of 11 (10 members in addition to the owner).'
+		);
+	}
+
+	/**
+	 * Capacity is null when there is no limit (unlimited).
+	 */
+	public function test_member_capacity_null_when_unlimited() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id, 0 );
+
+		$this->assertNull(
+			Group_Subscription::get_member_capacity( $sub ),
+			'A limit of 0 (unlimited) should yield a null capacity.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -200,4 +200,25 @@ class Test_Group_Subscription extends WP_UnitTestCase {
 			'A limit of 0 (unlimited) should yield a null capacity.'
 		);
 	}
+
+	/**
+	 * For an ownerless subscription the capacity (denominator) and count (numerator)
+	 * agree about the owner: neither counts a phantom owner, so it reads "0 of limit",
+	 * not "0 of limit + 1".
+	 */
+	public function test_member_capacity_excludes_phantom_owner_when_ownerless() {
+		// customer_id 0 -> get_managers() returns [0], an empty/phantom owner.
+		$sub = $this->create_group_subscription( 0, 10 );
+
+		$this->assertSame(
+			0,
+			Group_Subscription::get_member_count( $sub ),
+			'An ownerless group with no members should report a count of 0.'
+		);
+		$this->assertSame(
+			10,
+			Group_Subscription::get_member_capacity( $sub ),
+			'An ownerless group should not add a phantom owner to capacity (10, not 11), keeping numerator and denominator consistent.'
+		);
+	}
 }


### PR DESCRIPTION
## Description

Fixes [NPPM-2949](https://linear.app/a8c/issue/NPPM-2949/june-29-alpha-testing-bug-group-counts-are-off-on-cards) — group member counts excluded the owner/manager, so cards read "0 of X members" when the owner was the only member, and disagreed with the group's Members tab.

**Root cause:** `Group_Subscription::get_members()` returns only users carrying the `_newspack_group_subscription` meta — it excludes the owner (the subscription customer, returned by `get_managers()`). Surfaces that did `count( get_members() )` were off by one. The Members tab was already correct because it merges managers + members.

This is an **alpha-hotfix** (based off `alpha`).

## Changes

- **New additive helpers** on `Group_Subscription` (backward compatible — this contract is consumed by `newspack-manager`/`newspack-blocks`):
  - `get_all_members()` — deduped managers ∪ members
  - `get_member_count()` — owner-inclusive member count
  - `get_member_capacity()` — `limit + managers`, or `null` when unlimited
- **Group picker cards** — owner-inclusive count + capacity.
- **Admin subscription list-table column** — owner-inclusive count + capacity.
- **Admin meta box** — header count includes the owner; the owner is now rendered as a non-removable "(owner)" row so the header matches the list (the admin JS tallies `<li>` count, so it stays in sync after add/remove/invite).
- **Members tab badge** — unchanged (already owner-inclusive).
- **Setting label** — "Group subscription member limit" → **"Group subscription member limit (in addition to owner)"**, with a matching description. Limit enforcement is unchanged: the limit genuinely is the number of members allowed *in addition to* the owner.

### Display semantics

The configured limit is "members in addition to the owner", so the total capacity shown in "X of Y members" is `limit + owner`:

| State (limit = 10) | Card / column |
|---|---|
| Owner only | `1 of 11 members` |
| Owner + 1 member | `2 of 11 members` |
| Full | `11 of 11 members` |

## Testing

Automated:
- New `tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php` (6 tests covering owner inclusion, dedup, and capacity).
- Full `WooCommerce_Subscriptions_Integration` group: **44/44 pass**. PHPCS clean.

Manual:
1. As a user owning multiple group subscriptions, visit `/my-account/group/`. With only the owner, a card reads **"1 of N members"** (not "0 of N").
2. Open a group → the Members tab badge and the card agree.
3. Add a member → card increments and still matches the Members tab.
4. In wp-admin → Subscriptions, the list-table column and the group meta box both count the owner; the meta box shows the owner as a non-removable "(owner)" row.
5. Edit a subscription product → the member-limit field reads "… (in addition to owner)".
