### PR TITLE
fix(insights): autoscale 5.1 cohort chart, drop default reference line

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -189,14 +189,11 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'visibility'        => 'hidden',
 				'visibility_reason' => 'insufficient_data',
 			],
-			// 5.1 — registration-to-conversion cohort (reference_line preserved).
+			// 5.1 — registration-to-conversion cohort (reference_line off; autoscaled).
 			'registration_to_conversion_cohort'    => [
 				'state'          => 'coming_soon',
 				'cohorts'        => [],
-				'reference_line' => [
-					'value' => 0.15,
-					'label' => __( '15% at 6 months', 'newspack-plugin' ),
-				],
+				'reference_line' => null,
 			],
 			// 5.2 — subscriber retention cohort (reference_line preserved).
 			'subscriber_retention_cohort'          => [

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1441,15 +1441,19 @@ final class Conversion_Metric {
 	}
 
 	/**
-	 * 5.1 reference line (hardcoded per spec): 15% conversion at 6 months.
+	 * 5.1 reference line. Currently returns null: the 5.1 cohort chart autoscales
+	 * and shows no default line. The hardcoded 15% was removed because no fixed-%
+	 * default fits the network (publisher conversion models diverge widely). Kept
+	 * as the single seam where the dynamic baseline will be computed.
 	 *
-	 * @return array{value: float, label: string}
+	 * TODO: replace this null with a self-relative baseline — the median cumulative
+	 * conversion of mature (>=12-month) cohorts at the 6-month mark — and expose it
+	 * as a configurable Newspack publisher setting.
+	 *
+	 * @return array{value: float, label: string}|null
 	 */
-	private function registration_reference_line(): array {
-		return [
-			'value' => 0.15,
-			'label' => __( '15% at 6 months', 'newspack-plugin' ),
-		];
+	private function registration_reference_line(): ?array {
+		return null;
 	}
 
 	/**
@@ -1461,7 +1465,7 @@ final class Conversion_Metric {
 	 * and each months-since offset N (0..age, capped 12), the value is the
 	 * CUMULATIVE fraction of the cohort converted by month N.
 	 *
-	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}}
+	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}|null}
 	 */
 	public function compute_registration_to_conversion_cohort(): array {
 		$readers = $this->subscribers_metric->get_reader_registration_dates();
@@ -1548,7 +1552,7 @@ final class Conversion_Metric {
 	 *
 	 * @param DateTimeInterface $start Window start (ignored — snapshot).
 	 * @param DateTimeInterface $end   Window end (ignored — snapshot).
-	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}}
+	 * @return array{state:string, cohorts:array, reference_line:array{value:float, label:string}|null}
 	 */
 	public function get_registration_to_conversion_cohort( DateTimeInterface $start, DateTimeInterface $end ): array {
 		unset( $start, $end );

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1548,7 +1548,8 @@ final class Conversion_Metric {
 	 * Reads the weekly pre-warmed snapshot via Cache::peek; on a cold cache it
 	 * schedules a one-off background refresh and returns the graceful
 	 * `coming_soon` envelope (never computes the expensive curve inline). The
-	 * `reference_line` key React reads unconditionally is always present.
+	 * `reference_line` key is always present in the envelope (null for 5.1 — the
+	 * chart autoscales with no default line).
 	 *
 	 * @param DateTimeInterface $start Window start (ignored — snapshot).
 	 * @param DateTimeInterface $end   Window end (ignored — snapshot).

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -169,7 +169,7 @@ export interface ConversionCohortSeries {
 export interface ConversionCohortData extends ConversionErrorFields {
 	state: ConversionMetricState;
 	cohorts: ConversionCohortSeries[];
-	reference_line: ConversionReferenceLine;
+	reference_line: ConversionReferenceLine | null;
 }
 
 /* --- Section 6: weekly conversion-rate trends ----------------------- */

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
@@ -84,8 +84,9 @@ describe( 'CohortRetentionSection', () => {
 		// First cohort cell is 5.1 (Registration → conversion).
 		const cell51 = container.querySelectorAll( '.newspack-insights__conversion-cohort-cell' )[ 0 ];
 		const ys = Array.from( cell51.querySelectorAll( '.newspack-insights__line-point' ) ).map( p => parseFloat( p.getAttribute( 'cy' ) ?? '0' ) );
-		// Autoscaled: the 0.02 peak reaches the top band (cy small). With yMax=1 it
-		// would sit near the bottom (cy ≈ 149 of the 160-tall chart).
-		expect( Math.min( ...ys ) ).toBeLessThan( 80 );
+		// Autoscaled: the 0.02 peak reaches the top band (cy ≈ 8). With the old
+		// yMax=1 it would sit near the bottom (cy ≈ 149 of the 160-tall chart),
+		// so a tight ceiling guards against a regression to the fixed axis.
+		expect( Math.min( ...ys ) ).toBeLessThan( 20 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
@@ -18,6 +18,21 @@ import { render, screen } from '@testing-library/react';
  */
 import CohortRetentionSection from './CohortRetentionSection';
 import { makeConversionWindow } from './fixtures';
+import type { ConversionCohortData, ConversionReferenceLine } from '../../api/conversion';
+
+const populatedCohort = ( referenceLine: ConversionReferenceLine | null ): ConversionCohortData => ( {
+	state: 'populated',
+	cohorts: [
+		{
+			label: '2026-01',
+			points: [
+				{ period: 0, value: 0 },
+				{ period: 1, value: 0.02 },
+			],
+		},
+	],
+	reference_line: referenceLine,
+} );
 
 describe( 'CohortRetentionSection', () => {
 	it( 'renders the heading and both cohort titles', () => {
@@ -42,5 +57,35 @@ describe( 'CohortRetentionSection', () => {
 		render( <CohortRetentionSection current={ makeConversionWindow( { cohortState: 'error' } ) } /> );
 		expect( screen.getAllByRole( 'alert' ) ).toHaveLength( 2 );
 		expect( screen.getAllByText( /Unable to load this section/ ) ).toHaveLength( 2 );
+	} );
+
+	it( 'shows the 5.2 reference line but suppresses the 5.1 one even when present', () => {
+		const current = {
+			...makeConversionWindow( { cohortState: 'populated' } ),
+			// 5.1 deliberately carries a value to prove the parent never wires a
+			// 5.1 reference line, independent of payload (real payload is null).
+			registration_to_conversion_cohort: populatedCohort( { value: 0.15, label: '15% at 6 months' } ),
+			subscriber_retention_cohort: populatedCohort( { value: 0.7, label: '70% at 12 months' } ),
+		};
+		const { container } = render( <CohortRetentionSection current={ current } /> );
+		expect( screen.getByText( '70% at 12 months' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '15% at 6 months' ) ).not.toBeInTheDocument();
+		expect( container.querySelectorAll( '.newspack-insights__line-reference' ) ).toHaveLength( 1 );
+		expect( container.querySelectorAll( '.newspack-insights__line-reference-label' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'autoscales the 5.1 axis so small-magnitude cohort curves fill the chart', () => {
+		const current = {
+			...makeConversionWindow( { cohortState: 'populated' } ),
+			registration_to_conversion_cohort: populatedCohort( null ),
+			subscriber_retention_cohort: populatedCohort( { value: 0.7, label: '70% at 12 months' } ),
+		};
+		const { container } = render( <CohortRetentionSection current={ current } /> );
+		// First cohort cell is 5.1 (Registration → conversion).
+		const cell51 = container.querySelectorAll( '.newspack-insights__conversion-cohort-cell' )[ 0 ];
+		const ys = Array.from( cell51.querySelectorAll( '.newspack-insights__line-point' ) ).map( p => parseFloat( p.getAttribute( 'cy' ) ?? '0' ) );
+		// Autoscaled: the 0.02 peak reaches the top band (cy small). With yMax=1 it
+		// would sit near the bottom (cy ≈ 149 of the 160-tall chart).
+		expect( Math.min( ...ys ) ).toBeLessThan( 80 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -19,7 +19,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { ConversionCohortData } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
-import LineChart, { type LineSeries } from '../components/LineChart';
+import LineChart, { type LineSeries, type LineReferenceLine } from '../components/LineChart';
 import SectionState from './SectionState';
 
 export interface CohortRetentionSectionProps {
@@ -39,16 +39,18 @@ const toCohortSeries = ( data: ConversionCohortData ): LineSeries[] =>
 interface CohortChartProps {
 	title: string;
 	data: ConversionCohortData;
+	yMax?: number;
+	referenceLine?: LineReferenceLine;
 }
 
-const CohortChart = ( { title, data }: CohortChartProps ) => (
+const CohortChart = ( { title, data, yMax, referenceLine }: CohortChartProps ) => (
 	<div className="newspack-insights__conversion-cohort-cell">
 		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
 		<SectionState state={ data.state } emptyMessage={ __( 'Cohort data will appear after the first weekly refresh.', 'newspack-plugin' ) }>
 			<LineChart
 				series={ toCohortSeries( data ) }
-				referenceLine={ data.reference_line }
-				yMax={ 1 }
+				referenceLine={ referenceLine }
+				yMax={ yMax }
 				emptyMessage={ __( 'Cohort data will appear after the first weekly refresh.', 'newspack-plugin' ) }
 			/>
 		</SectionState>
@@ -69,8 +71,24 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
 			) }
 		/>
 		<div className="newspack-insights__conversion-cohort-stack">
-			<CohortChart title={ __( 'Registration → conversion', 'newspack-plugin' ) } data={ current.registration_to_conversion_cohort } />
-			<CohortChart title={ __( 'Subscriber retention', 'newspack-plugin' ) } data={ current.subscriber_retention_cohort } />
+			<CohortChart
+				/*
+				 * TODO: default a self-relative reference line here — the median
+				 * cumulative conversion of mature (>=12-month) cohorts at the 6-month
+				 * mark — and expose it as a configurable Newspack publisher setting.
+				 * For now the 5.1 axis autoscales (no yMax) and shows no reference
+				 * line; the hardcoded 15% was removed because no fixed-% default fits
+				 * the network (publisher conversion models diverge widely).
+				 */
+				title={ __( 'Registration → conversion', 'newspack-plugin' ) }
+				data={ current.registration_to_conversion_cohort }
+			/>
+			<CohortChart
+				title={ __( 'Subscriber retention', 'newspack-plugin' ) }
+				data={ current.subscriber_retention_cohort }
+				yMax={ 1 }
+				referenceLine={ current.subscriber_retention_cohort.reference_line ?? undefined }
+			/>
 		</div>
 	</section>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -2,7 +2,9 @@
  * CohortRetentionSection (NPPD-1609, Section 5).
  *
  * Two stacked multi-series cohort LineCharts (registration → conversion,
- * subscriber retention), each with a hardcoded reference-line target.
+ * subscriber retention). 5.2 keeps a fixed 0–100% axis with a 70% retention
+ * target line; 5.1 autoscales with no default reference line (the hardcoded
+ * 15% benchmark was removed — a self-relative baseline is planned).
  * Snapshot — refreshed weekly, independent of the date picker.
  *
  * Phase 2: both metrics (5.1, 5.2) are `coming_soon` (Phase B). Each

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
@@ -18,6 +18,7 @@ import type {
 	ConversionGatedCumulativeSingle,
 	ConversionGatedFunnelData,
 	ConversionMetricState,
+	ConversionReferenceLine,
 	ConversionScalarMetric,
 	ConversionSourceMixData,
 	ConversionTopPagesTable,
@@ -116,10 +117,10 @@ const cumulativeMulti = ( state: ConversionMetricState = 'coming_soon' ): Conver
 	],
 } );
 
-const cohort = ( value: number, label: string, state: ConversionMetricState = 'coming_soon' ): ConversionCohortData => ( {
+const cohort = ( referenceLine: ConversionReferenceLine | null, state: ConversionMetricState = 'coming_soon' ): ConversionCohortData => ( {
 	state,
 	cohorts: [],
-	reference_line: { value, label },
+	reference_line: referenceLine,
 } );
 
 const weekly = ( state: ConversionMetricState = 'coming_soon' ): ConversionWeeklyTrendsData => ( {
@@ -183,8 +184,8 @@ export const makeConversionWindow = ( overrides: ConversionWindowOverrides = {} 
 	time_to_donate_distribution: cumulativeMulti( 'coming_soon' ),
 	subscriber_to_donor_lag_distribution: gatedCumulativeSingle( overrides.lagVisibility ?? 'hidden', 'coming_soon' ),
 	// Section 5 — Phase B coming_soon.
-	registration_to_conversion_cohort: cohort( 0.15, '15% at 6 months', overrides.cohortState ?? 'coming_soon' ),
-	subscriber_retention_cohort: cohort( 0.7, '70% at 12 months', overrides.cohortState ?? 'coming_soon' ),
+	registration_to_conversion_cohort: cohort( null, overrides.cohortState ?? 'coming_soon' ),
+	subscriber_retention_cohort: cohort( { value: 0.7, label: '70% at 12 months' }, overrides.cohortState ?? 'coming_soon' ),
 	// Section 6 — Phase A, wired.
 	weekly_conversion_rates: weekly( overrides.weeklyTrendsState ?? 'populated' ),
 	// Section 7 — Phase A, wired (scalar).

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -180,7 +180,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 
 	/**
 	 * C23 coming_soon: returns state 'coming_soon' with an empty 'cohorts'
-	 * collection, preserved reference_line (0.15), and no 'pending' key.
+	 * collection, reference_line null (default line off), and no 'pending' key.
 	 */
 	public function test_registration_to_conversion_cohort_is_coming_soon() {
 		[ $start, $end ] = $this->window();
@@ -190,8 +190,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'cohorts', $result );
 		$this->assertSame( [], $result['cohorts'] );
 		$this->assertArrayHasKey( 'reference_line', $result );
-		$this->assertSame( 0.15, $result['reference_line']['value'] );
-		$this->assertNotSame( '', $result['reference_line']['label'] );
+		$this->assertNull( $result['reference_line'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
 	}
 
@@ -1867,10 +1866,10 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'hidden', $current['subscriber_to_donor_lag_distribution']['visibility'] );
 		$this->assertSame( 'insufficient_data', $current['subscriber_to_donor_lag_distribution']['visibility_reason'] );
 
-		// 5.1 — registration cohort (reference_line).
+		// 5.1 — registration cohort (reference_line off; autoscaled).
 		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
 		$this->assertSame( [], $current['registration_to_conversion_cohort']['cohorts'] );
-		$this->assertSame( 0.15, $current['registration_to_conversion_cohort']['reference_line']['value'] );
+		$this->assertNull( $current['registration_to_conversion_cohort']['reference_line'] );
 
 		// 5.2 — subscriber retention cohort (reference_line).
 		$this->assertSame( 'coming_soon', $current['subscriber_retention_cohort']['state'] );
@@ -2725,7 +2724,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0.25, $points[1] );
 		$this->assertSame( 0.25, $points[2] );
 		$this->assertSame( 0.5, $points[3] );
-		$this->assertSame( 0.15, $result['reference_line']['value'] );
+		$this->assertNull( $result['reference_line'] );
 	}
 
 	/**
@@ -2751,7 +2750,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * 5.1 compute: no readers → empty state, reference_line preserved.
+	 * 5.1 compute: no readers → empty state, reference_line null.
 	 */
 	public function test_compute_registration_cohort_empty() {
 		$subs_metric = $this->createMock( Subscribers_Metric::class );
@@ -2764,7 +2763,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$result = $metric->compute_registration_to_conversion_cohort();
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['cohorts'] );
-		$this->assertSame( 0.15, $result['reference_line']['value'] );
+		$this->assertNull( $result['reference_line'] );
 	}
 
 	/**
@@ -2962,10 +2961,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 						],
 					],
 				],
-				'reference_line' => [
-					'value' => 0.15,
-					'label' => 'x',
-				],
+				'reference_line' => null,
 			],
 			'subscriber_retention_cohort'       => [
 				'state'          => 'empty',
@@ -2985,14 +2981,14 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Cold cache → coming_soon envelope with reference_line preserved (no throw).
+	 * Cold cache → coming_soon envelope with reference_line null (no throw).
 	 */
 	public function test_registration_cohort_getter_cold_cache_coming_soon() {
 		[ $start, $end ] = $this->window();
 		$result          = $this->metric->get_registration_to_conversion_cohort( $start, $end );
 		$this->assertSame( 'coming_soon', $result['state'] );
 		$this->assertSame( [], $result['cohorts'] );
-		$this->assertSame( 0.15, $result['reference_line']['value'] );
+		$this->assertNull( $result['reference_line'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

> Base branch: **`feat/insights-rsm`** (Insights epic), not `main`.

Makes the Insights → Conversion Journey **5.1 "Registration → conversion"** cohort chart legible. On real sites the cumulative reader→paid conversion rate is small (≈2% on richlandsource — a registered base dominated by newsletter-only signups), so the curves flatlined: the chart was pinned to a 0–100% axis, and a hardcoded `15% at 6 months` reference line dragged the y-domain up further, pressing every cohort onto the x-axis.

This PR:

- **Autoscales the 5.1 y-axis** so small-magnitude curves fill the chart.
- **Removes the default 5.1 reference line.** A fixed 15% is wrong for most of the network — publisher conversion models diverge widely (donation/newsletter-heavy sites ≈1–3% of registered readers; hard-paywall sites ≈10–20%), so no constant default fits.
- **Leaves 5.2 "Subscriber retention" unchanged** — its 0–100% axis and 70% reference line are correct for a true retention curve.

Product decision by Katie Rethman in the NPPD-1692 thread (the "Now" half). The deferred "Later" work — a self-relative computed baseline (median cumulative conversion of mature ≥12-month cohorts at the 6-month mark) exposed as a configurable publisher setting — is tracked as **NPPD-1814** and marked with inline `TODO`s at the two seams (the PHP `registration_reference_line()` method and the React 5.1 chart call site).

### How to test the changes in this Pull Request:

1. On a site with real cohort data and a low reader→paid conversion rate (e.g. richlandsource, post-deploy), open **Insights → Conversion Journey** and scroll to the **Cohort retention** section.
2. Confirm the **Registration → conversion** (5.1) chart now shows visible curves that fill the vertical space (autoscaled), with **no** `15% at 6 months` reference line.
3. Confirm the **Subscriber retention** (5.2) chart is unchanged: it still spans 0–100% and still shows the `70% at 12 months` reference line.
4. Run the PHP insights suite: `cd plugins/newspack-plugin && n test-php --group insights` — all green (458). The 5.1 envelope now carries `reference_line: null` (key still present); 5.2 still carries `{value: 0.70, …}`.
5. Run the JS suite: `cd plugins/newspack-plugin && npm test` — all green (661), including the two new `CohortRetentionSection` tests: one proves the 5.1 chart renders no reference line even when a value is present in the payload; the other asserts the 5.1 axis autoscales (the small-magnitude peak reaches the top band).
6. `npm run tsc` and `npm run lint:js` — clean for the changed files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
