### PR TITLE
fix(newsletters): ad publish meta error, invalid dates, advertiser counts

### DIFF
--- a/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
@@ -10,7 +10,9 @@ namespace Newspack\Newsletters\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use Newspack_Newsletters\Ads;
+use WP_Error;
 use WP_Post;
+use WP_REST_Request;
 
 /**
  * Adds a read-only `newspack_newsletters_ad_status` REST field on the
@@ -47,6 +49,62 @@ class Ads_List_REST {
 			2
 		);
 		add_filter( 'posts_clauses', [ __CLASS__, 'apply_meta_sort_clauses' ], 10, 2 );
+		add_filter( 'rest_request_before_callbacks', [ __CLASS__, 'guard_invalid_dates' ], 10, 3 );
+	}
+
+	/**
+	 * Reject REST writes that supply a non-empty but non-ISO start_date or
+	 * expiry_date — e.g. '06/29/2026'. An empty string is an intentional
+	 * clear and is allowed through; sanitize_ad_date normalises valid ISO
+	 * datetime strings to a bare Y-m-d before they reach the meta table.
+	 *
+	 * @param mixed           $response Earlier filter result; passed through if non-null.
+	 * @param array           $handler  Route handler details.
+	 * @param WP_REST_Request $request  Incoming REST request.
+	 * @return mixed WP_Error with status 400 when an invalid date is found, otherwise $response.
+	 */
+	public static function guard_invalid_dates( $response, $handler, $request ) {
+		unset( $handler );
+
+		if ( null !== $response ) {
+			return $response;
+		}
+
+		if ( ! $request instanceof WP_REST_Request ) {
+			return $response;
+		}
+
+		$route   = $request->get_route();
+		$pattern = '#^/wp/v2/' . preg_quote( Ads::CPT, '#' ) . '(?:/\d+)?$#';
+		if ( ! preg_match( $pattern, $route ) ) {
+			return $response;
+		}
+
+		$method = $request->get_method();
+		if ( ! in_array( $method, [ 'POST', 'PUT', 'PATCH' ], true ) ) {
+			return $response;
+		}
+
+		$meta = $request->get_param( 'meta' );
+		if ( ! is_array( $meta ) ) {
+			return $response;
+		}
+
+		foreach ( [ 'start_date', 'expiry_date' ] as $key ) {
+			if ( ! isset( $meta[ $key ] ) ) {
+				continue;
+			}
+			$value = $meta[ $key ];
+			if ( is_string( $value ) && '' !== $value && '' === Ads::sanitize_ad_date( $value ) ) {
+				return new WP_Error(
+					'newspack_newsletters_ad_invalid_date',
+					__( 'Start and expiration dates must be valid YYYY-MM-DD dates.', 'newspack-newsletters' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		return $response;
 	}
 
 	/**
@@ -128,7 +186,7 @@ class Ads_List_REST {
 		}
 
 		global $wpdb;
-		$today = gmdate( 'Y-m-d' );
+		$today = current_time( 'Y-m-d' );
 
 		$post_status_set = [];
 		$bucket_clauses  = [];
@@ -147,14 +205,14 @@ class Ads_List_REST {
 				case 'expired':
 					$post_status_set    = array_merge( $post_status_set, [ 'publish', 'private' ] );
 					$bucket_clauses[]   = $wpdb->prepare(
-						"( {$wpdb->posts}.post_status IN ( 'publish', 'private' ) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = 'expiry_date' AND meta_value <> '' AND meta_value < %s ) )",
+						"( {$wpdb->posts}.post_status IN ( 'publish', 'private' ) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = 'expiry_date' AND ( STR_TO_DATE( LEFT( meta_value, 10 ), '%%Y-%%m-%%d' ) + INTERVAL 0 DAY ) < %s ) )",
 						$today
 					);
 					break;
 				case 'scheduled':
 					$post_status_set    = array_merge( $post_status_set, [ 'publish', 'private', 'future' ] );
 					$bucket_clauses[]   = $wpdb->prepare(
-						"( ( {$wpdb->posts}.post_status IN ( 'publish', 'private' ) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = 'start_date' AND meta_value <> '' AND meta_value > %s ) ) OR {$wpdb->posts}.post_status = 'future' )",
+						"( ( {$wpdb->posts}.post_status IN ( 'publish', 'private' ) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = 'start_date' AND ( STR_TO_DATE( LEFT( meta_value, 10 ), '%%Y-%%m-%%d' ) + INTERVAL 0 DAY ) > %s ) ) OR {$wpdb->posts}.post_status = 'future' )",
 						$today
 					);
 					break;
@@ -162,10 +220,10 @@ class Ads_List_REST {
 					$post_status_set    = array_merge( $post_status_set, [ 'publish', 'private' ] );
 					$bucket_clauses[]   = $wpdb->prepare(
 						"( {$wpdb->posts}.post_status IN ( 'publish', 'private' )"
-						. " AND ( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} sm1 WHERE sm1.post_id = {$wpdb->posts}.ID AND sm1.meta_key = 'start_date' AND sm1.meta_value <> '' )"
-						. " OR EXISTS ( SELECT 1 FROM {$wpdb->postmeta} sm2 WHERE sm2.post_id = {$wpdb->posts}.ID AND sm2.meta_key = 'start_date' AND sm2.meta_value <> '' AND sm2.meta_value <= %s ) )"
-						. " AND ( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} em1 WHERE em1.post_id = {$wpdb->posts}.ID AND em1.meta_key = 'expiry_date' AND em1.meta_value <> '' )"
-						. " OR EXISTS ( SELECT 1 FROM {$wpdb->postmeta} em2 WHERE em2.post_id = {$wpdb->posts}.ID AND em2.meta_key = 'expiry_date' AND em2.meta_value <> '' AND em2.meta_value >= %s ) ) )",
+						. " AND ( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} sm1 WHERE sm1.post_id = {$wpdb->posts}.ID AND sm1.meta_key = 'start_date' AND ( STR_TO_DATE( LEFT( sm1.meta_value, 10 ), '%%Y-%%m-%%d' ) + INTERVAL 0 DAY ) IS NOT NULL )"
+						. " OR EXISTS ( SELECT 1 FROM {$wpdb->postmeta} sm2 WHERE sm2.post_id = {$wpdb->posts}.ID AND sm2.meta_key = 'start_date' AND ( STR_TO_DATE( LEFT( sm2.meta_value, 10 ), '%%Y-%%m-%%d' ) + INTERVAL 0 DAY ) <= %s ) )"
+						. " AND ( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} em1 WHERE em1.post_id = {$wpdb->posts}.ID AND em1.meta_key = 'expiry_date' AND ( STR_TO_DATE( LEFT( em1.meta_value, 10 ), '%%Y-%%m-%%d' ) + INTERVAL 0 DAY ) IS NOT NULL )"
+						. " OR EXISTS ( SELECT 1 FROM {$wpdb->postmeta} em2 WHERE em2.post_id = {$wpdb->posts}.ID AND em2.meta_key = 'expiry_date' AND ( STR_TO_DATE( LEFT( em2.meta_value, 10 ), '%%Y-%%m-%%d' ) + INTERVAL 0 DAY ) >= %s ) ) )",
 						$today,
 						$today
 					);
@@ -311,9 +369,10 @@ class Ads_List_REST {
 		}
 
 		if ( in_array( $post->post_status, [ 'publish', 'private' ], true ) ) {
-			$today       = gmdate( 'Y-m-d' );
-			$start_date  = (string) get_post_meta( $post->ID, 'start_date', true );
-			$expiry_date = (string) get_post_meta( $post->ID, 'expiry_date', true );
+			$today = current_time( 'Y-m-d' );
+			// Normalize legacy ISO datetime meta to bare dates.
+			$start_date  = Ads::sanitize_ad_date( get_post_meta( $post->ID, 'start_date', true ) );
+			$expiry_date = Ads::sanitize_ad_date( get_post_meta( $post->ID, 'expiry_date', true ) );
 
 			// Noon UTC so the timestamp lands on the intended calendar day in any reasonable site timezone; date-only meta makes the time-of-day a presentation safeguard.
 			if ( '' !== $start_date ) {

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -39,6 +39,7 @@ final class Ads {
 		add_action( 'init', [ __CLASS__, 'register_ads_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_newsletter_meta' ] );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_recount_advertiser_terms' ] );
 		add_action( 'save_post_' . self::CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_ads_page' ] );
@@ -88,22 +89,24 @@ final class Ads {
 			'post',
 			'start_date',
 			[
-				'object_subtype' => self::CPT,
-				'show_in_rest'   => true,
-				'type'           => 'string',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
+				'object_subtype'    => self::CPT,
+				'show_in_rest'      => true,
+				'type'              => 'string',
+				'single'            => true,
+				'auth_callback'     => '__return_true',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_ad_date' ],
 			]
 		);
 		\register_meta(
 			'post',
 			'expiry_date',
 			[
-				'object_subtype' => self::CPT,
-				'show_in_rest'   => true,
-				'type'           => 'string',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
+				'object_subtype'    => self::CPT,
+				'show_in_rest'      => true,
+				'type'              => 'string',
+				'single'            => true,
+				'auth_callback'     => '__return_true',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_ad_date' ],
 			]
 		);
 		\register_meta(
@@ -297,7 +300,7 @@ final class Ads {
 			self::ADVERTISER_TAX,
 			[ self::CPT, Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ],
 			[
-				'labels'            => [
+				'labels'                => [
 					'name'                     => __( 'Advertisers', 'newspack-newsletters' ),
 					'singular_name'            => __( 'Advertiser', 'newspack-newsletters' ),
 					'search_items'             => __( 'Search Advertisers', 'newspack-newsletters' ),
@@ -318,11 +321,12 @@ final class Ads {
 					'no_terms'                 => __( 'No advertisers', 'newspack-newsletters' ),
 					'filter_by_item'           => __( 'Filter by advertiser', 'newspack-newsletters' ),
 				],
-				'description'       => __( 'Newspack Newsletters Ads Advertisers', 'newspack-newsletters' ),
-				'public'            => true,
-				'hierarchical'      => true,
-				'show_in_rest'      => true,
-				'show_admin_column' => true,
+				'description'           => __( 'Newspack Newsletters Ads Advertisers', 'newspack-newsletters' ),
+				'public'                => true,
+				'hierarchical'          => true,
+				'show_in_rest'          => true,
+				'show_admin_column'     => true,
+				'update_count_callback' => [ __CLASS__, 'update_advertiser_term_count' ],
 			]
 		);
 	}
@@ -340,6 +344,100 @@ final class Ads {
 			return;
 		}
 		update_post_meta( $post_id, 'position_in_content', 100 );
+
+		// Seed the read-only counters so the editor's round-trip of the
+		// default value is an unchanged no-op, not a denied meta insert.
+		add_post_meta( $post_id, 'tracking_impressions', 0, true );
+		add_post_meta( $post_id, 'tracking_clicks', 0, true );
+	}
+
+	/**
+	 * Normalize an ad date meta value to `Y-m-d`.
+	 *
+	 * Accepts only a leading ISO `Y-m-d` (optionally followed by a time
+	 * component, e.g. `2026-06-29T23:59:59`), matching the SQL filter's
+	 * `STR_TO_DATE(LEFT(meta_value,10),'%Y-%m-%d')` exactly. Any value
+	 * that does not begin with a valid calendar date returns ''.
+	 *
+	 * @param mixed $value Raw meta value.
+	 * @return string `Y-m-d`, or '' when empty or not a valid leading ISO date.
+	 */
+	public static function sanitize_ad_date( $value ) {
+		$value = trim( (string) $value );
+		if ( '' === $value ) {
+			return '';
+		}
+		if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})/', $value, $matches )
+			&& checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] ) ) {
+			return "{$matches[1]}-{$matches[2]}-{$matches[3]}";
+		}
+		return '';
+	}
+
+	/**
+	 * Count only ads (self::CPT) tagged with each advertiser term, across
+	 * the same statuses the Ads list shows. Registered as the taxonomy's
+	 * `update_count_callback` so newsletter posts tagged with an advertiser
+	 * do not inflate the count.
+	 *
+	 * @param int[]               $terms    Array of term-taxonomy IDs to update.
+	 * @param \WP_Taxonomy|string $taxonomy The taxonomy object or name.
+	 */
+	public static function update_advertiser_term_count( $terms, $taxonomy ) {
+		global $wpdb;
+
+		$taxonomy_name = is_object( $taxonomy ) ? $taxonomy->name : $taxonomy;
+		$statuses      = [ 'publish', 'private', 'future', 'draft', 'pending' ];
+
+		foreach ( $terms as $tt_id ) {
+			$tt_id = (int) $tt_id;
+			$count = (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->term_relationships} tr
+					INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id
+					WHERE tr.term_taxonomy_id = %d
+					AND p.post_type = %s
+					AND p.post_status IN ( %s, %s, %s, %s, %s )",
+					$tt_id,
+					self::CPT,
+					$statuses[0],
+					$statuses[1],
+					$statuses[2],
+					$statuses[3],
+					$statuses[4]
+				)
+			);
+
+			do_action( 'edit_term_taxonomy', $tt_id, $taxonomy_name );
+			$wpdb->update( $wpdb->term_taxonomy, [ 'count' => $count ], [ 'term_taxonomy_id' => $tt_id ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			do_action( 'edited_term_taxonomy', $tt_id, $taxonomy_name );
+		}
+	}
+
+	/**
+	 * One-time recount of existing advertiser terms so counts predating
+	 * the custom count callback refresh without waiting for the next edit.
+	 */
+	public static function maybe_recount_advertiser_terms() {
+		$option = 'newspack_nl_advertiser_count_recounted_v2';
+		if ( get_option( $option ) ) {
+			return;
+		}
+
+		$term_ids = get_terms(
+			[
+				'taxonomy'   => self::ADVERTISER_TAX,
+				'hide_empty' => false,
+				'fields'     => 'tt_ids',
+			]
+		);
+		if ( is_wp_error( $term_ids ) ) {
+			return;
+		}
+		if ( ! empty( $term_ids ) ) {
+			wp_update_term_count_now( $term_ids, self::ADVERTISER_TAX );
+		}
+		update_option( $option, 1 );
 	}
 
 	/**
@@ -450,15 +548,15 @@ final class Ads {
 	 */
 	public static function is_ad_active( $ad_id, $post_id = null ) {
 
-		$start_date  = get_post_meta( $ad_id, 'start_date', true );
-		$expiry_date = get_post_meta( $ad_id, 'expiry_date', true );
+		$start_date  = self::sanitize_ad_date( get_post_meta( $ad_id, 'start_date', true ) );
+		$expiry_date = self::sanitize_ad_date( get_post_meta( $ad_id, 'expiry_date', true ) );
 
 		if ( ! $start_date && ! $expiry_date ) {
 			return true;
 		}
 
 		$date_format = 'Y-m-d';
-		$date        = gmdate( $date_format );
+		$date        = current_time( $date_format );
 		if ( $post_id ) {
 			$date = get_the_date( $date_format, $post_id );
 		}

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -345,8 +345,7 @@ final class Ads {
 		}
 		update_post_meta( $post_id, 'position_in_content', 100 );
 
-		// Seed the read-only counters so the editor's round-trip of the
-		// default value is an unchanged no-op, not a denied meta insert.
+		// Seed the read-only counters so their meta rows exist and the list shows 0.
 		add_post_meta( $post_id, 'tracking_impressions', 0, true );
 		add_post_meta( $post_id, 'tracking_clicks', 0, true );
 	}
@@ -354,10 +353,11 @@ final class Ads {
 	/**
 	 * Normalize an ad date meta value to `Y-m-d`.
 	 *
-	 * Accepts only a leading ISO `Y-m-d` (optionally followed by a time
-	 * component, e.g. `2026-06-29T23:59:59`), matching the SQL filter's
-	 * `STR_TO_DATE(LEFT(meta_value,10),'%Y-%m-%d')` exactly. Any value
-	 * that does not begin with a valid calendar date returns ''.
+	 * Accepts only a leading, zero-padded ISO `Y-m-d` (an optional time
+	 * component is ignored, e.g. `2026-06-29T23:59:59`). Stricter than the SQL
+	 * filter's `STR_TO_DATE(LEFT(meta_value,10),'%Y-%m-%d')` on single-digit
+	 * components, but values are normalized here so stored data always agrees.
+	 * Any value not beginning with a valid calendar date returns ''.
 	 *
 	 * @param mixed $value Raw meta value.
 	 * @return string `Y-m-d`, or '' when empty or not a valid leading ISO date.
@@ -387,7 +387,8 @@ final class Ads {
 		global $wpdb;
 
 		$taxonomy_name = is_object( $taxonomy ) ? $taxonomy->name : $taxonomy;
-		$statuses      = [ 'publish', 'private', 'future', 'draft', 'pending' ];
+		// Include auto-draft to match the Ads list's draft bucket.
+		$statuses = [ 'publish', 'private', 'future', 'draft', 'pending', 'auto-draft' ];
 
 		foreach ( $terms as $tt_id ) {
 			$tt_id = (int) $tt_id;
@@ -397,14 +398,15 @@ final class Ads {
 					INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id
 					WHERE tr.term_taxonomy_id = %d
 					AND p.post_type = %s
-					AND p.post_status IN ( %s, %s, %s, %s, %s )",
+					AND p.post_status IN ( %s, %s, %s, %s, %s, %s )",
 					$tt_id,
 					self::CPT,
 					$statuses[0],
 					$statuses[1],
 					$statuses[2],
 					$statuses[3],
-					$statuses[4]
+					$statuses[4],
+					$statuses[5]
 				)
 			);
 
@@ -417,9 +419,11 @@ final class Ads {
 	/**
 	 * One-time recount of existing advertiser terms so counts predating
 	 * the custom count callback refresh without waiting for the next edit.
+	 * Bump the sentinel whenever the counted statuses change so already
+	 * recounted sites pick up the new semantics (v3: added auto-draft).
 	 */
 	public static function maybe_recount_advertiser_terms() {
-		$option = 'newspack_nl_advertiser_count_recounted_v2';
+		$option = 'newspack_nl_advertiser_count_recounted_v3';
 		if ( get_option( $option ) ) {
 			return;
 		}

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -174,14 +174,16 @@ export function getFields( { advertisers = [], placements = [] } = {} ) {
 			id: 'start_date',
 			label: __( 'Start date', 'newspack-newsletters' ),
 			enableSorting: true,
-			getValue: ( { item } ) => item?.meta?.start_date || '',
+			// Slice legacy ISO datetime to Y-m-d for consistent sort/export.
+			getValue: ( { item } ) => String( item?.meta?.start_date || '' ).slice( 0, 10 ),
 			render: renderStartDate,
 		},
 		{
 			id: 'expiry_date',
 			label: __( 'Expiration date', 'newspack-newsletters' ),
 			enableSorting: true,
-			getValue: ( { item } ) => item?.meta?.expiry_date || '',
+			// Slice legacy ISO datetime to Y-m-d for consistent sort/export.
+			getValue: ( { item } ) => String( item?.meta?.expiry_date || '' ).slice( 0, 10 ),
 			render: renderExpiryDate,
 		},
 		{

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -32,14 +32,14 @@ const formatTimestampAsDate = timestamp => {
 	return dateI18n( format, timestamp * 1000 );
 };
 
-const formatDate = ymd => {
-	if ( ! ymd ) {
+const formatDate = value => {
+	if ( ! value ) {
 		return '';
 	}
 	const settings = getDateSettings();
 	const format = settings.formats?.date || 'M j, Y';
-	// Append a noon UTC time so the parsed Date object lands on the
-	// intended calendar day in any reasonable site timezone.
+	// Tolerate ISO datetime meta; noon UTC keeps the parsed day timezone-safe.
+	const ymd = String( value ).slice( 0, 10 );
 	return dateI18n( format, `${ ymd }T12:00:00Z` );
 };
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -40,8 +40,9 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 	const initialAdvertiserSelections = useMemo( () => initialSelectionsForTaxonomy( item, 'newspack_nl_advertiser' ), [ item ] );
 	const initialPlacementSelections = useMemo( () => initialSelectionsForTaxonomy( item, 'newspack_nl_ad_placement' ), [ item ] );
 	const initialCategorySelections = useMemo( () => initialSelectionsForTaxonomy( item, 'category' ), [ item ] );
-	const initialStartDate = item?.meta?.start_date || '';
-	const initialExpiryDate = item?.meta?.expiry_date || '';
+	// Slice to `Y-m-d` so legacy datetime meta still fills the date input.
+	const initialStartDate = ( item?.meta?.start_date || '' ).slice( 0, 10 );
+	const initialExpiryDate = ( item?.meta?.expiry_date || '' ).slice( 0, 10 );
 	const initialPrice = ( () => {
 		const value = item?.meta?.price;
 		return value ? String( value ) : '';

--- a/plugins/newspack-newsletters/src/ads/editor/index.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.js
@@ -2,14 +2,30 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Fragment, useState } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel, store as editPostStore } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { ToggleControl, TextControl, DatePicker, Notice, RangeControl, Button, Modal } from '@wordpress/components';
-import { format, isInTheFuture } from '@wordpress/date';
+import { date as wpDate, format, isInTheFuture } from '@wordpress/date';
 import { SelectControl } from 'newspack-components';
 import AdPlacements from '../../components/ad-placements';
+
+// Strip the read-only counters from ad saves: the editor round-trips the full
+// meta object, and a stale counter value would trip their `auth_callback`.
+const AD_REST_PATH = /\/wp\/v2\/newspack_nl_ads_cpt(\/|\?|$)/;
+apiFetch.use( ( options, next ) => {
+	const method = ( options.method || 'GET' ).toUpperCase();
+	const target = options.path || options.url || '';
+	if ( ( method === 'POST' || method === 'PUT' ) && options.data?.meta && AD_REST_PATH.test( target ) ) {
+		const meta = { ...options.data.meta };
+		delete meta.tracking_impressions;
+		delete meta.tracking_clicks;
+		options.data = { ...options.data, meta };
+	}
+	return next( options );
+} );
 
 function AdEdit() {
 	const { price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
@@ -45,7 +61,8 @@ function AdEdit() {
 	const { saveEntityRecord } = useDispatch( 'core' );
 	const { removeEditorPanel } = useDispatch( editPostStore );
 	const messages = [];
-	if ( expiryDate && expiryDate < format( 'Y-m-d', new Date() ) ) {
+	// Site-timezone "today" so this advisory agrees with the server.
+	if ( expiryDate && expiryDate < wpDate( 'Y-m-d' ) ) {
 		messages.push( __( 'The expiration date is set in the past. This ad will not be displayed.', 'newspack-newsletters' ) );
 	}
 	if ( startDate && startDate > expiryDate ) {

--- a/plugins/newspack-newsletters/src/ads/editor/index.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.js
@@ -17,8 +17,10 @@ function AdEdit() {
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
 			price: meta.price,
-			startDate: meta.start_date,
-			expiryDate: meta.expiry_date,
+			// Normalize to Y-m-d on read so all client-side date comparisons are
+			// plain string compares regardless of any legacy ISO-datetime value.
+			startDate: meta.start_date ? String( meta.start_date ).slice( 0, 10 ) : meta.start_date,
+			expiryDate: meta.expiry_date ? String( meta.expiry_date ).slice( 0, 10 ) : meta.expiry_date,
 			insertionStrategy: meta.insertion_strategy,
 			positionInContent: meta.position_in_content,
 			positionBlockCount: meta.position_block_count,
@@ -43,7 +45,7 @@ function AdEdit() {
 	const { saveEntityRecord } = useDispatch( 'core' );
 	const { removeEditorPanel } = useDispatch( editPostStore );
 	const messages = [];
-	if ( expiryDate && ! isInTheFuture( expiryDate ) ) {
+	if ( expiryDate && expiryDate < format( 'Y-m-d', new Date() ) ) {
 		messages.push( __( 'The expiration date is set in the past. This ad will not be displayed.', 'newspack-newsletters' ) );
 	}
 	if ( startDate && startDate > expiryDate ) {
@@ -247,14 +249,14 @@ function AdEdit() {
 						if ( startDate ) {
 							editPost( { meta: { start_date: null } } );
 						} else {
-							editPost( { meta: { start_date: new Date() } } );
+							editPost( { meta: { start_date: format( 'Y-m-d', new Date() ) } } );
 						}
 					} }
 				/>
 				{ startDate ? (
 					<DatePicker
 						currentDate={ startDate }
-						onChange={ start_date => editPost( { meta: { start_date } } ) }
+						onChange={ next => editPost( { meta: { start_date: format( 'Y-m-d', next ) } } ) }
 						isInvalidDate={ date => ! isInTheFuture( date ) }
 					/>
 				) : null }
@@ -268,7 +270,7 @@ function AdEdit() {
 						} else {
 							editPost( {
 								meta: {
-									expiry_date: startDate ? new Date( startDate ) : new Date(),
+									expiry_date: format( 'Y-m-d', startDate ? startDate : new Date() ),
 								},
 							} );
 						}
@@ -277,9 +279,9 @@ function AdEdit() {
 				{ expiryDate ? (
 					<DatePicker
 						currentDate={ expiryDate }
-						onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
+						onChange={ next => editPost( { meta: { expiry_date: format( 'Y-m-d', next ) } } ) }
 						isInvalidDate={ date => {
-							return startDate ? date < new Date( startDate ) : ! isInTheFuture( date );
+							return startDate ? format( 'Y-m-d', date ) < startDate : ! isInTheFuture( date );
 						} }
 					/>
 				) : null }

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -1167,4 +1167,238 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 		$this->assertNotContains( $scheduled, $query->posts );
 		$this->assertNotContains( $draft, $query->posts );
 	}
+
+	/**
+	 * `sanitize_ad_date` keeps a bare date and trims the time component
+	 * off ISO datetime values without shifting the calendar day. Non-ISO
+	 * parseable strings (e.g. natural language or US-format dates) are
+	 * rejected so PHP and SQL classification stays in sync.
+	 */
+	public function test_sanitize_ad_date_normalizes_datetime_to_date() {
+		$this->assertSame( '2026-06-29', Ads::sanitize_ad_date( '2026-06-29' ) );
+		$this->assertSame( '2026-06-29', Ads::sanitize_ad_date( '2026-06-29T00:00:00' ) );
+		$this->assertSame( '2026-06-29', Ads::sanitize_ad_date( '2026-06-29T23:59:59.000Z' ) );
+		$this->assertSame( '', Ads::sanitize_ad_date( '' ) );
+		$this->assertSame( '', Ads::sanitize_ad_date( 'not-a-date' ) );
+		$this->assertSame( '', Ads::sanitize_ad_date( 'June 30, 2026' ) );
+		$this->assertSame( '', Ads::sanitize_ad_date( '06/29/2026' ) );
+	}
+
+	/**
+	 * A published ad whose dates were stored as ISO datetime still reports
+	 * the right kind and a clean `starts_at` (the "Invalid Date" cause).
+	 *
+	 * Because `sanitize_ad_date` is registered as a `sanitize_callback`,
+	 * `meta_input` normalises the value on insert. Write the raw datetime
+	 * directly into postmeta via $wpdb to exercise the legacy path.
+	 */
+	public function test_get_status_tolerates_iso_datetime_meta() {
+		global $wpdb;
+
+		$future  = gmdate( 'Y-m-d', strtotime( '+10 days' ) ) . 'T00:00:00';
+		$post_id = $this->make_ad( [ 'post_status' => 'publish' ] );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->postmeta,
+			[
+				'post_id'    => $post_id,
+				'meta_key'   => 'start_date',
+				'meta_value' => $future, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		clean_post_cache( $post_id );
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		$status = Ads_List_REST::get_status_for_post( get_post( $post_id ) );
+
+		$this->assertSame( 'scheduled', $status['kind'] );
+		$this->assertIsInt( $status['starts_at'] );
+	}
+
+	/**
+	 * A published ad with a legacy ISO datetime `start_date` stored today
+	 * must agree between `get_status_for_post` (kind=active) and the REST
+	 * filter (appears in active bucket, not in scheduled bucket).
+	 */
+	public function test_active_filter_matches_status_for_legacy_datetime_meta() {
+		global $wpdb;
+
+		$today_iso = gmdate( 'Y-m-d' ) . 'T00:00:00';
+		$post_id   = $this->make_ad( [ 'post_status' => 'publish' ] );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->postmeta,
+			[
+				'post_id'    => $post_id,
+				'meta_key'   => 'start_date',
+				'meta_value' => $today_iso, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		clean_post_cache( $post_id );
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		$status = Ads_List_REST::get_status_for_post( get_post( $post_id ) );
+		$this->assertSame( 'active', $status['kind'] );
+
+		$active_query = new WP_Query(
+			array_merge(
+				Ads_List_REST::filter_rest_query(
+					[],
+					$this->rest_request( [ Ads_List_REST::STATUS_QUERY_PARAM => 'active' ] )
+				),
+				[
+					'post_type'      => Ads::CPT,
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				]
+			)
+		);
+		$this->assertContains( $post_id, $active_query->posts );
+
+		$scheduled_query = new WP_Query(
+			array_merge(
+				Ads_List_REST::filter_rest_query(
+					[],
+					$this->rest_request( [ Ads_List_REST::STATUS_QUERY_PARAM => 'scheduled' ] )
+				),
+				[
+					'post_type'      => Ads::CPT,
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				]
+			)
+		);
+		$this->assertNotContains( $post_id, $scheduled_query->posts );
+	}
+
+	/**
+	 * Impossible calendar dates (month 13, day 30 of February) must
+	 * normalise to '' — they pass the regex but fail `checkdate`.
+	 */
+	public function test_sanitize_ad_date_rejects_impossible_dates() {
+		$this->assertSame( '', Ads::sanitize_ad_date( '2026-13-01' ) );
+		$this->assertSame( '', Ads::sanitize_ad_date( '2026-02-30' ) );
+	}
+
+	/**
+	 * An impossible date stored raw in postmeta (bypassing sanitize_ad_date)
+	 * must be treated as "no constraint" by both get_status_for_post and the
+	 * SQL filter — the ad is active, not expired.
+	 *
+	 * STR_TO_DATE returns NULL for an impossible calendar date like 2026-02-30,
+	 * so the SQL bucket ignores it, matching what sanitize_ad_date returns ''.
+	 */
+	public function test_filter_matches_status_for_impossible_date_meta() {
+		global $wpdb;
+
+		$post_id = $this->make_ad( [ 'post_status' => 'publish' ] );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->postmeta,
+			[
+				'post_id'    => $post_id,
+				'meta_key'   => 'expiry_date',
+				'meta_value' => '2026-02-30', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		clean_post_cache( $post_id );
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		$this->assertSame( 'active', Ads_List_REST::get_status_for_post( get_post( $post_id ) )['kind'] );
+
+		$active_query = new WP_Query(
+			array_merge(
+				Ads_List_REST::filter_rest_query(
+					[],
+					$this->rest_request( [ Ads_List_REST::STATUS_QUERY_PARAM => 'active' ] )
+				),
+				[
+					'post_type'      => Ads::CPT,
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				]
+			)
+		);
+		$this->assertContains( $post_id, $active_query->posts );
+
+		$expired_query = new WP_Query(
+			array_merge(
+				Ads_List_REST::filter_rest_query(
+					[],
+					$this->rest_request( [ Ads_List_REST::STATUS_QUERY_PARAM => 'expired' ] )
+				),
+				[
+					'post_type'      => Ads::CPT,
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				]
+			)
+		);
+		$this->assertNotContains( $post_id, $expired_query->posts );
+	}
+
+	/**
+	 * A REST write with an invalid date format returns 400 and leaves
+	 * existing meta unchanged. A valid ISO datetime is accepted and
+	 * normalized to a bare Y-m-d date.
+	 */
+	public function test_rest_write_rejects_invalid_date_and_preserves_existing() {
+		Ads::register_meta();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->make_ad(
+			[
+				'post_status' => 'publish',
+				'meta_input'  => [ 'start_date' => '2026-01-01' ],
+			]
+		);
+
+		// Invalid US-format date: must be rejected with 400.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . Ads::CPT . '/' . $post_id );
+		$request->set_param( 'meta', [ 'start_date' => '06/29/2026' ] );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( '2026-01-01', get_post_meta( $post_id, 'start_date', true ) );
+
+		// Valid ISO datetime: must be accepted and stored as a bare date.
+		$request2 = new WP_REST_Request( 'POST', '/wp/v2/' . Ads::CPT . '/' . $post_id );
+		$request2->set_param( 'meta', [ 'start_date' => '2026-06-29T00:00:00' ] );
+		$response2 = rest_do_request( $request2 );
+
+		$this->assertSame( 200, $response2->get_status() );
+		wp_cache_delete( $post_id, 'post_meta' );
+		$this->assertSame( '2026-06-29', get_post_meta( $post_id, 'start_date', true ) );
+
+		$wp_rest_server = null;
+	}
+
+	/**
+	 * `ad_default_fields` seeds the read-only counters on a new ad so the
+	 * editor's round-trip is an unchanged no-op, not a denied meta insert.
+	 */
+	public function test_new_ad_seeds_tracking_counter_rows() {
+		Ads_List_REST::register_meta();
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Seed test ad',
+			]
+		);
+
+		$this->assertSame( '0', get_post_meta( $post_id, 'tracking_impressions', true ) );
+		$this->assertSame( '0', get_post_meta( $post_id, 'tracking_clicks', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, 'tracking_impressions', false ) );
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
@@ -130,6 +130,64 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The Ads list `draft` bucket also surfaces `auto-draft` ads, so the
+	 * advertiser count must include them too — otherwise the count and the
+	 * list disagree by any auto-draft rows.
+	 */
+	public function test_advertiser_count_includes_auto_draft_ads() {
+		$term = wp_insert_term( 'Auto-draft Advertiser', Ads::ADVERTISER_TAX );
+		$this->assertIsArray( $term );
+		$term_id = (int) $term['term_id'];
+
+		$ad = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'auto-draft',
+			]
+		);
+		wp_set_object_terms( $ad, [ $term_id ], Ads::ADVERTISER_TAX );
+
+		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
+		$fresh = get_term( $term_id, Ads::ADVERTISER_TAX );
+		$this->assertSame( 1, (int) $fresh->count );
+	}
+
+	/**
+	 * A site that already ran the prior one-time recount must still pick up
+	 * the new auto-draft semantics: the bumped sentinel re-runs the recount
+	 * and refreshes stale term counts.
+	 */
+	public function test_recount_refreshes_stale_counts_after_sentinel_bump() {
+		update_option( 'newspack_nl_advertiser_count_recounted_v2', 1 );
+		delete_option( 'newspack_nl_advertiser_count_recounted_v3' );
+
+		$term = wp_insert_term( 'Stale-count Advertiser', Ads::ADVERTISER_TAX );
+		$this->assertIsArray( $term );
+		$term_id = (int) $term['term_id'];
+
+		$ad = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'auto-draft',
+			]
+		);
+		wp_set_object_terms( $ad, [ $term_id ], Ads::ADVERTISER_TAX );
+
+		// Force a stale count as if it predated the auto-draft semantics.
+		global $wpdb;
+		$tt_id = (int) get_term( $term_id, Ads::ADVERTISER_TAX )->term_taxonomy_id;
+		$wpdb->update( $wpdb->term_taxonomy, [ 'count' => 0 ], [ 'term_taxonomy_id' => $tt_id ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
+		$this->assertSame( 0, (int) get_term( $term_id, Ads::ADVERTISER_TAX )->count );
+
+		Ads::maybe_recount_advertiser_terms();
+
+		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
+		$this->assertSame( 1, (int) get_term( $term_id, Ads::ADVERTISER_TAX )->count );
+		$this->assertEquals( 1, get_option( 'newspack_nl_advertiser_count_recounted_v3' ) );
+	}
+
+	/**
 	 * A newsletter tagged with an advertiser must not inflate the count —
 	 * only ads (Ads::CPT) should be counted.
 	 */

--- a/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
@@ -108,4 +108,54 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 		$this->assertSame( 'Top-level advertiser', $data['name'] );
 		$this->assertSame( 0, $data['parent'] );
 	}
+
+	/**
+	 * The advertiser count must match the Ads list, which shows non-publish
+	 * ads too — so a draft ad should count, not leave the advertiser at `0`.
+	 */
+	public function test_advertiser_count_includes_non_publish_ads() {
+		$term = wp_insert_term( 'Acme', Ads::ADVERTISER_TAX );
+		$this->assertIsArray( $term );
+
+		$ad = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'draft',
+			]
+		);
+		wp_set_object_terms( $ad, [ (int) $term['term_id'] ], Ads::ADVERTISER_TAX );
+
+		$fresh = get_term( $term['term_id'], Ads::ADVERTISER_TAX );
+		$this->assertSame( 1, (int) $fresh->count );
+	}
+
+	/**
+	 * A newsletter tagged with an advertiser must not inflate the count —
+	 * only ads (Ads::CPT) should be counted.
+	 */
+	public function test_advertiser_count_excludes_newsletters() {
+		$term = wp_insert_term( 'Newsletter-free Advertiser', Ads::ADVERTISER_TAX );
+		$this->assertIsArray( $term );
+		$term_id = (int) $term['term_id'];
+
+		$ad = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_object_terms( $ad, [ $term_id ], Ads::ADVERTISER_TAX );
+
+		$newsletter = self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_object_terms( $newsletter, [ $term_id ], Ads::ADVERTISER_TAX );
+
+		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
+		$fresh = get_term( $term_id, Ads::ADVERTISER_TAX );
+		$this->assertSame( 1, (int) $fresh->count );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes issues found in June 29 alpha testing of the Newsletters admin UX modernization (#2163, #4735). All changes are in `newspack-newsletters` (Newsletter Ads / Advertisers admin).

### NPPM-2950 — "not allowed to edit tracking_impressions" + "Invalid Date"

- A new ad had no `tracking_impressions` / `tracking_clicks` meta row, so the block editor's round-trip of the registered default `0` was rejected by `auth_callback => __return_false` on publish. We seed those rows in `ad_default_fields`, so the round-trip is an unchanged no-op and the read-only contract is preserved.
- The legacy ad editor stored `start_date` / `expiry_date` as ISO datetime, which rendered as "Invalid Date". A `sanitize_callback` normalizes the meta to `Y-m-d` on save (strictly ISO + `checkdate`), and the status helper / list / Quick Edit JS tolerate legacy datetime values.

### NPPM-2945 — advertiser ad counts wrong

WP's term count was publish-only while the Ads list shows draft / scheduled / pending ads, so an advertiser whose only ad was non-published showed `0`. The advertiser taxonomy also spans the newsletters CPT, so newsletters tagged with an advertiser inflated the count. Both are fixed with a custom `update_count_callback` that counts only ads (`Ads::CPT`) across the relevant statuses, plus a one-time recount (on `admin_init`) for existing terms.

### NPPM-2946 — layouts "won't open"

Working as designed: prebuilt layouts are read-only (Duplicate only); duplicate or create a layout first, then it opens in the editor. No code change.

## Hardening (from multi-reviewer pass)

- Ad lifecycle "today" anchored to the site timezone (`current_time`) across the status helper, the SQL status filter, and `is_ad_active`.
- SQL status buckets normalize date meta (`STR_TO_DATE(LEFT(meta_value,10), '%Y-%m-%d') + INTERVAL 0 DAY`) so the list filter agrees with the status badge for legacy datetime and rejects malformed dates exactly as PHP does.
- A REST guard rejects invalid `start_date` / `expiry_date` writes with `400` and leaves existing meta unchanged, instead of silently clearing the boundary.
- The legacy ad editor emits and compares site-local `Y-m-d` (normalized on read), fixing UTC day-shift and same-day expiry selection.

## Testing

- `n test-php` ads / advertisers / tracking suites pass; new tests cover the meta seeding, date normalization, legacy-datetime filter agreement, invalid-date rejection, the REST guard, and ads-only counts.
- Verified end-to-end against a real REST publish: `200` with the seed in place, the exact `403` without it; `start_date` persists as `Y-m-d`.

Fixes NPPM-2950, NPPM-2945.
