### PR TITLE
fix(group-subscription): inherit product settings on manual save

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -360,6 +360,9 @@ class Group_Subscription_Settings {
 		$invites = Group_Subscription_Invite::get_invites( $subscription );
 		?>
 		<div class="newspack-group-subscription__container" data-subscription-id="<?php echo \esc_attr( $subscription->get_id() ); ?>">
+			<input type="hidden" name="<?php echo \esc_attr( self::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled_baseline' ); ?>" value="<?php echo \esc_attr( \wc_bool_to_string( $settings['enabled'] ) ); ?>" />
+			<input type="hidden" name="<?php echo \esc_attr( self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit_baseline' ); ?>" value="<?php echo \esc_attr( (int) $settings['limit'] ); ?>" />
+			<input type="hidden" name="<?php echo \esc_attr( self::GROUP_SUBSCRIPTION_META_PREFIX . 'name_baseline' ); ?>" value="<?php echo \esc_attr( $settings['name'] ); ?>" />
 			<div class="newspack-group-subscription__settings">
 				<h3><?php \esc_html_e( 'Settings', 'newspack-plugin' ); ?></h3>
 				<p>
@@ -493,21 +496,52 @@ class Group_Subscription_Settings {
 
 		// Get subscription object.
 		$subscription = is_a( $subscription, 'WC_Subscription' ) ? $subscription : \wcs_get_subscription( $subscription_id );
-		$is_enabled   = isset( $_POST[ self::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled' ] );
-		$limit        = isset( $_POST[ self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit' ] )
-			? absint( wp_unslash( $_POST[ self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit' ] ) )
-			: 0;
-		$name         = isset( $_POST[ self::GROUP_SUBSCRIPTION_META_PREFIX . 'name' ] )
-			? sanitize_text_field( wp_unslash( $_POST[ self::GROUP_SUBSCRIPTION_META_PREFIX . 'name' ] ) )
-			: '';
-		self::update_subscription_settings(
-			$subscription,
-			[
-				'enabled' => $is_enabled,
-				'limit'   => $limit,
-				'name'    => $name,
-			]
-		);
+		$prefix       = self::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		$submitted = [
+			'enabled' => isset( $_POST[ $prefix . 'enabled' ] ),
+			'limit'   => isset( $_POST[ $prefix . 'limit' ] )
+				? absint( wp_unslash( $_POST[ $prefix . 'limit' ] ) )
+				: 0,
+			'name'    => isset( $_POST[ $prefix . 'name' ] )
+				? sanitize_text_field( wp_unslash( $_POST[ $prefix . 'name' ] ) )
+				: '',
+		];
+
+		$changed = [];
+		foreach ( [ 'enabled', 'limit', 'name' ] as $key ) {
+			$baseline_field = $prefix . $key . '_baseline';
+			if ( ! isset( $_POST[ $baseline_field ] ) ) {
+				continue;
+			}
+			$baseline_raw = sanitize_text_field( wp_unslash( $_POST[ $baseline_field ] ) );
+			switch ( $key ) {
+				case 'enabled':
+					$baseline_value = \wc_string_to_bool( $baseline_raw );
+					break;
+				case 'limit':
+					$baseline_value = absint( $baseline_raw );
+					break;
+				default:
+					$baseline_value = $baseline_raw;
+					break;
+			}
+			if ( $submitted[ $key ] !== $baseline_value ) {
+				$changed[ $key ] = $submitted[ $key ];
+			}
+		}
+
+		if ( ! empty( $changed ) ) {
+			self::update_subscription_settings( $subscription, $changed );
+		}
+
+		// Effective group status can flip via inherited product settings without a meta write; refresh the cached ID set when it changed.
+		if ( isset( $_POST[ $prefix . 'enabled_baseline' ] ) ) {
+			$baseline_enabled = \wc_string_to_bool( sanitize_text_field( wp_unslash( $_POST[ $prefix . 'enabled_baseline' ] ) ) );
+			if ( $baseline_enabled !== self::get_subscription_settings( $subscription )['enabled'] ) {
+				self::clear_group_subscription_ids_cache();
+			}
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -536,6 +536,9 @@ class Group_Subscription_Settings {
 		}
 
 		// Effective group status can flip via inherited product settings without a meta write; refresh the cached ID set when it changed.
+		// On the Add-subscription screen the product line item may not be linked yet, so this read can resolve the un-inherited
+		// default and leave the cached ID set briefly stale. That is harmless: it only drives the admin list-table group filter and
+		// self-heals via the transient's TTL plus the product save/trash/delete clear hooks. It is never an access-control path.
 		if ( isset( $_POST[ $prefix . 'enabled_baseline' ] ) ) {
 			$baseline_enabled = \wc_string_to_bool( sanitize_text_field( wp_unslash( $_POST[ $prefix . 'enabled_baseline' ] ) ) );
 			if ( $baseline_enabled !== self::get_subscription_settings( $subscription )['enabled'] ) {

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -682,6 +682,12 @@ function wc_string_to_bool( $string ) {
 function wc_bool_to_string( $bool ) {
 	return $bool ? 'yes' : 'no';
 }
+function wc_clean( $var ) {
+	if ( is_array( $var ) ) {
+		return array_map( 'wc_clean', $var );
+	}
+	return is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
+}
 function wc_prices_include_tax() {
 	global $wcs_mock_prices_include_tax;
 	return ! empty( $wcs_mock_prices_include_tax );

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -351,6 +351,57 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An unchanged name (submitted value equals the rendered baseline) writes no override.
+	 */
+	public function test_save_does_not_override_name_when_unchanged_from_baseline() {
+		$subscription = $this->make_subscription_with_product(
+			[ 'enabled' => 'yes' ],
+			[],
+			[],
+			[ 'name' => 'Daily Reader' ]
+		);
+		$prefix = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		$this->run_meta_box_save(
+			$subscription,
+			[
+				$prefix . 'enabled'          => 'yes',
+				$prefix . 'enabled_baseline' => 'yes',
+				$prefix . 'name'             => 'Daily Reader',
+				$prefix . 'name_baseline'    => 'Daily Reader',
+			]
+		);
+
+		$this->assertSame( '', $subscription->get_meta( $prefix . 'name', true ), 'No own name override should be written when the submitted name matches its baseline.' );
+		$this->assertSame( 'Daily Reader', Group_Subscription_Settings::get_subscription_settings( $subscription )['name'], 'The subscription should still inherit the product name.' );
+	}
+
+	/**
+	 * A changed name (submitted value differs from the rendered baseline) writes the override.
+	 */
+	public function test_save_writes_name_override_when_changed_from_baseline() {
+		$subscription = $this->make_subscription_with_product(
+			[ 'enabled' => 'yes' ],
+			[],
+			[],
+			[ 'name' => 'Daily Reader' ]
+		);
+		$prefix = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		$this->run_meta_box_save(
+			$subscription,
+			[
+				$prefix . 'enabled'          => 'yes',
+				$prefix . 'enabled_baseline' => 'yes',
+				$prefix . 'name'             => 'My Custom Group',
+				$prefix . 'name_baseline'    => 'Daily Reader',
+			]
+		);
+
+		$this->assertSame( 'My Custom Group', Group_Subscription_Settings::get_subscription_settings( $subscription )['name'], 'A changed name should override the inherited product name.' );
+	}
+
+	/**
 	 * A no-op save on a subscription that inherits group-enabled status from its
 	 * product still refreshes the cached group-subscription ID set, so the new
 	 * subscription appears in the admin group filters without waiting for expiry.
@@ -415,7 +466,7 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 			[
 				'id'   => 123,
 				'meta' => [ $prefix . 'enabled' => 'no' ],
-			] 
+			]
 		);
 
 		$this->run_meta_box_save(

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -242,4 +242,190 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 
 		$this->assertSame( Group_Subscription::get_label( 'singular' ), $settings['name'], 'When neither name meta nor a product name is set, the group name should fall back to the publisher singular group label.' );
 	}
+
+	/**
+	 * Run the meta-box save handler with a simulated $_POST payload.
+	 *
+	 * @param WC_Subscription $subscription The subscription being saved.
+	 * @param array           $post         POST fields (the save nonce is added automatically).
+	 */
+	private function run_meta_box_save( $subscription, array $post ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Test helper seeds $_POST to exercise save_group_subscription_meta(), which verifies the nonce itself.
+		$prev_post = $_POST;
+		$_POST     = array_merge(
+			[ 'woocommerce_meta_nonce' => wp_create_nonce( 'woocommerce_save_data' ) ],
+			$post
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		Group_Subscription_Settings::save_group_subscription_meta( $subscription->get_id(), $subscription );
+		$_POST = $prev_post;
+	}
+
+	/**
+	 * A manually-created subscription whose product enables
+	 * groups must keep inheriting when the meta box was rendered unchecked (no product
+	 * linked yet) and the admin never touched the control. Saving must not write a
+	 * spurious `enabled = 'no'` override.
+	 */
+	public function test_save_keeps_inheritance_when_unchecked_box_matches_baseline() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+		$prefix       = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		// Meta box rendered unchecked (baseline 'no'); admin submits without toggling it.
+		$this->run_meta_box_save(
+			$subscription,
+			[ $prefix . 'enabled_baseline' => 'no' ]
+		);
+
+		$this->assertSame( '', $subscription->get_meta( $prefix . 'enabled', true ), 'No own enabled override should be written when the unchecked box matches its rendered baseline.' );
+		$this->assertTrue( Group_Subscription_Settings::get_subscription_settings( $subscription )['enabled'], 'The subscription should still inherit enabled=true from the product.' );
+	}
+
+	/**
+	 * Intentional opt-out is preserved: unchecking a box that was rendered checked
+	 * writes the explicit `enabled = 'no'` override.
+	 */
+	public function test_save_writes_override_when_unchecking_rendered_checked_box() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+		$prefix       = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		// Meta box rendered checked (baseline 'yes'); admin unchecks it (no 'enabled' key posted).
+		$this->run_meta_box_save(
+			$subscription,
+			[ $prefix . 'enabled_baseline' => 'yes' ]
+		);
+
+		$this->assertSame( 'no', $subscription->get_meta( $prefix . 'enabled', true ), 'An explicit no override should be written when the admin unchecks a rendered-checked box.' );
+		$this->assertFalse( Group_Subscription_Settings::get_subscription_settings( $subscription )['enabled'], 'The subscription should be disabled by the explicit override.' );
+	}
+
+	/**
+	 * An unchanged limit (submitted value equals the rendered baseline) writes no override.
+	 */
+	public function test_save_does_not_override_limit_when_unchanged_from_baseline() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '10',
+			]
+		);
+		$prefix = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		$this->run_meta_box_save(
+			$subscription,
+			[
+				$prefix . 'enabled'          => 'yes',
+				$prefix . 'enabled_baseline' => 'yes',
+				$prefix . 'limit'            => '10',
+				$prefix . 'limit_baseline'   => '10',
+			]
+		);
+
+		$this->assertSame( '', $subscription->get_meta( $prefix . 'limit', true ), 'No own limit override should be written when the submitted limit matches its baseline.' );
+		$this->assertSame( 10, Group_Subscription_Settings::get_subscription_settings( $subscription )['limit'], 'The subscription should still inherit the product limit.' );
+	}
+
+	/**
+	 * A changed limit (submitted value differs from the rendered baseline) writes the override.
+	 */
+	public function test_save_writes_limit_override_when_changed_from_baseline() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '10',
+			]
+		);
+		$prefix = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+
+		$this->run_meta_box_save(
+			$subscription,
+			[
+				$prefix . 'enabled'          => 'yes',
+				$prefix . 'enabled_baseline' => 'yes',
+				$prefix . 'limit'            => '5',
+				$prefix . 'limit_baseline'   => '10',
+			]
+		);
+
+		$this->assertSame( 5, Group_Subscription_Settings::get_subscription_settings( $subscription )['limit'], 'A changed limit should override the inherited product limit.' );
+	}
+
+	/**
+	 * A no-op save on a subscription that inherits group-enabled status from its
+	 * product still refreshes the cached group-subscription ID set, so the new
+	 * subscription appears in the admin group filters without waiting for expiry.
+	 */
+	public function test_save_clears_group_ids_cache_when_subscription_inherits_enabled() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+		$prefix       = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+		set_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT, [ 999 ], MINUTE_IN_SECONDS );
+
+		$this->run_meta_box_save( $subscription, [ $prefix . 'enabled_baseline' => 'no' ] );
+
+		$this->assertFalse( get_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT ), 'The cached group-subscription ID set should be cleared so the inheriting subscription is discoverable.' );
+	}
+
+	/**
+	 * A no-op save on a non-group subscription leaves the cached group-subscription
+	 * ID set intact, so unrelated subscription saves do not churn the cache.
+	 */
+	public function test_save_keeps_group_ids_cache_for_non_group_subscription() {
+		$subscription = $this->make_subscription_with_product();
+		$prefix       = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+		set_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT, [ 999 ], MINUTE_IN_SECONDS );
+
+		$this->run_meta_box_save( $subscription, [ $prefix . 'enabled_baseline' => 'no' ] );
+
+		$this->assertSame( [ 999 ], get_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT ), 'A non-group subscription save should not bust the cache.' );
+	}
+
+	/**
+	 * Checking the box on a create form whose product already makes the effective
+	 * status enabled produces no meta write (the value already matches inheritance),
+	 * so the cached group-subscription ID set must still be refreshed.
+	 */
+	public function test_save_clears_group_ids_cache_when_checked_enabled_matches_inherited() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+		$prefix       = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+		set_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT, [ 999 ], MINUTE_IN_SECONDS );
+
+		$this->run_meta_box_save(
+			$subscription,
+			[
+				$prefix . 'enabled'          => 'yes',
+				$prefix . 'enabled_baseline' => 'no',
+			]
+		);
+
+		$this->assertFalse( get_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT ), 'The cache must be refreshed even when the checked value already matches the inherited state.' );
+	}
+
+	/**
+	 * When a subscription that was a group subscription loses that status through its
+	 * product (effective enabled goes from true to false) with the checkbox untouched,
+	 * the cached group-subscription ID set must be refreshed so it drops out of filters.
+	 */
+	public function test_save_clears_group_ids_cache_when_inherited_status_turns_off() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+		$prefix       = Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX;
+		set_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT, [ 999 ], MINUTE_IN_SECONDS );
+
+		// The product is no longer group-enabled at save time; the box rendered checked (baseline 'yes') and was left untouched.
+		wc_create_mock_product(
+			[
+				'id'   => 123,
+				'meta' => [ $prefix . 'enabled' => 'no' ],
+			] 
+		);
+
+		$this->run_meta_box_save(
+			$subscription,
+			[
+				$prefix . 'enabled'          => 'yes',
+				$prefix . 'enabled_baseline' => 'yes',
+			]
+		);
+
+		$this->assertFalse( get_transient( Group_Subscription_Settings::GROUP_SUBSCRIPTION_IDS_TRANSIENT ), 'The cache must be refreshed when inherited group status turns off.' );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes **NPPM-2947**, found in June 29 alpha testing of the Group Subscriptions My Account feature (#148).

When an admin manually creates a WooCommerce subscription (wp-admin → Add subscription) and assigns a product that has group subscriptions enabled, the new subscription did not inherit the product's group settings. The owner had no group controls in My Account until they manually toggled the per-subscription override, even though the helper text says the subscription inherits from the product.

### Root cause

`Group_Subscription_Settings::save_group_subscription_meta()` runs on every `woocommerce_process_shop_order_meta` save and unconditionally wrote the meta-box checkbox state, which `update_subscription_settings()` diffs against the *effective* (product-inherited) value. On the Add-subscription screen the group meta box renders **before** the product line item is linked, so the "Group subscription enabled" checkbox renders unchecked. Saving then wrote an explicit `enabled = 'no'` override that defeated product inheritance.

### Fix

Dirty-tracking via a rendered baseline. The meta box emits hidden `{key}_baseline` fields capturing the values it rendered, and the save handler only persists a setting the admin actually changed away from its baseline:

- Untouched control (e.g. the unchecked-at-creation checkbox) → no override written → the subscription keeps inheriting the product's group settings.
- Intentional opt-out (unchecking a rendered-checked box) → explicit `enabled = 'no'` override is still written.

Because an inheriting subscription can change its effective group status without writing `enabled` meta, the handler also keeps the cached group-subscription ID set (consumed by the admin group/non-group list filters) in sync: it refreshes the cache whenever the rendered baseline differs from the post-save effective status, in either direction.

No change to the read/inheritance path (already correct) and no UI redesign.

## Testing

- `n test-php --group WooCommerce_Subscriptions_Integration` passes; +8 new tests covering the save dirty-tracking and group-ID cache invalidation (inheritance on/off, checked-matches-inherited, and non-group no-op).
- Verified against real WooCommerce in an isolated env: a manually-created subscription whose product enables groups reports `is_group_subscription = true` and the owner manages it after the Add-subscription save (previously `false`).
- PHPCS clean on all changed files. Reviewed via a multi-pass adversarial review loop (Codex + a second reviewer); cache-invalidation gaps it surfaced are fixed and covered by tests.

Fixes NPPM-2947.
