### PR TITLE
fix(build): content-hash async CSS chunks so they cache-bust on deploy

### DIFF
--- a/plugins/newspack-plugin/webpack.config.js
+++ b/plugins/newspack-plugin/webpack.config.js
@@ -93,6 +93,18 @@ const webpackConfig = getBaseWebpackConfig( {
 
 webpackConfig.output.chunkFilename = '[name].[contenthash].js';
 
+// Content-hash async CSS chunks too. The line above only governs JS chunks; the
+// async CSS chunks emitted by mini-css-extract-plugin (e.g. audience-wizards.css)
+// otherwise keep a bare, unversioned name and get served stale by CDNs/proxies
+// after a deploy (they're loaded by webpack's runtime, not wp_enqueue_style, so
+// they never pick up a ?ver). Hashing matches the JS chunks' cache-busting.
+const miniCssExtractPlugin = webpackConfig.plugins.find(
+	plugin => plugin.constructor && plugin.constructor.name === 'MiniCssExtractPlugin'
+);
+if ( miniCssExtractPlugin && miniCssExtractPlugin.options ) {
+	miniCssExtractPlugin.options.chunkFilename = '[name].[contenthash].css';
+}
+
 // Overwrite default optimisation.
 webpackConfig.optimization.splitChunks.cacheGroups.commons = {
 	name: 'commons',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`webpack.config.js` content-hashes JS chunks (`output.chunkFilename = '[name].[contenthash].js'`) but not the async **CSS** chunks emitted by `mini-css-extract-plugin`. Those keep a bare `[name].css` name (e.g. `audience-wizards.css`), and because async chunks are loaded by webpack's runtime — not `wp_enqueue_style` — they never pick up a `?ver` either. The result is that CDNs/proxies can serve a stale chunk stylesheet after a deploy.

This sets the plugin's `MiniCssExtractPlugin` instance's `chunkFilename` to `[name].[contenthash].css`, so async CSS chunks cache-bust on every deploy exactly like the JS chunks already do. The webpack runtime resolves the hashed names from the chunk manifest, so nothing else needs to change. PHP-enqueued entry styles are unaffected — they already version through `NEWSPACK_PLUGIN_VERSION`.

### How to test the changes in this Pull Request:

1. Build the plugin: `n build newspack-plugin` (or `npm run build` in `plugins/newspack-plugin`).
2. `ls plugins/newspack-plugin/dist | grep audience-wizards` — the CSS chunk is now `audience-wizards.<hash>.css` (previously the bare `audience-wizards.css`).
3. Open **Audience → Pricing Rules** in wp-admin and confirm the wizard styles load; the network request for the audience CSS chunk now carries the content hash in its filename.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — N/A; this is a build-config change with no unit-testable surface.
* [x] Have you successfully run tests with your changes locally? — `npm run build` runs green and the hashed CSS chunk output is verified.
