### PR TITLE
feat(newsletters): add WC email renderer override for ad block

### DIFF
--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -796,6 +796,24 @@ final class Ads {
 	}
 
 	/**
+	 * Reset the in-memory inserted-ads tracking.
+	 *
+	 * `mark_ad_inserted()`/`is_ad_inserted()` use a process-global static that is
+	 * otherwise never cleared within a request, so a second render of the same
+	 * newsletter in one request would see every ad already inserted and drop it.
+	 * Callers starting a fresh render should reset first.
+	 *
+	 * @param int|null $newsletter_id Newsletter to reset, or null to reset all.
+	 */
+	public static function reset_inserted_ads( $newsletter_id = null ) {
+		if ( null === $newsletter_id ) {
+			self::$inserted_ads = [];
+			return;
+		}
+		unset( self::$inserted_ads[ $newsletter_id ] );
+	}
+
+	/**
 	 * Mark the ad as inserted
 	 *
 	 * @param int $newsletter_id Newsletter ID.

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -660,6 +660,14 @@ final class Newspack_Newsletters {
 				'render_callback' => [ __CLASS__, 'render_share_block' ],
 			]
 		);
+		// Register the ad block so the WC email renderer can locate its
+		// render_email_callback. Block_Renderer_Registry sets that callback via
+		// the `block_type_metadata_settings` filter (priority 11), which fires
+		// here during register_block_type_from_metadata() — after the registry's
+		// init() has already hooked it at plugin-load time (before `init`).
+		register_block_type_from_metadata(
+			__DIR__ . '/../src/editor/blocks/ad/block.json'
+		);
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -664,10 +664,14 @@ final class Newspack_Newsletters {
 		// render_email_callback. Block_Renderer_Registry sets that callback via
 		// the `block_type_metadata_settings` filter (priority 11), which fires
 		// here during register_block_type_from_metadata() — after the registry's
-		// init() has already hooked it at plugin-load time (before `init`).
-		register_block_type_from_metadata(
-			__DIR__ . '/../src/editor/blocks/ad/block.json'
-		);
+		// init() has already hooked it at plugin-load time (before `init`). Guard
+		// against a context that re-runs registration (multibranded/network) so we
+		// don't trip a `_doing_it_wrong` notice for a double registration.
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'newspack-newsletters/ad' ) ) {
+			register_block_type_from_metadata(
+				__DIR__ . '/../src/editor/blocks/ad/block.json'
+			);
+		}
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-ad.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-ad.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Newspack email-renderer for the newspack-newsletters/ad block.
+ *
+ * The `newspack-newsletters/ad` block is self-closing and has no save output
+ * (`html: false` in block.json), so the WC email-editor package receives an
+ * empty `$block_content` string and its fallback renderer emits nothing — the
+ * ad is silently dropped from the rendered email.
+ *
+ * This override resolves the ad post from the block's `adId` attribute (or
+ * auto-selects the first un-inserted active ad when `adId` is absent), renders
+ * the ad post's block content through the active WC email-rendering pipeline,
+ * and marks the ad as inserted — mirroring the `newspack-newsletters/ad` case
+ * in the legacy MJML renderer (class-newspack-newsletters-renderer.php, line
+ * 1702).
+ *
+ * The WC pipeline is active during a `render_wc()` call because
+ * `Content_Renderer::initialize()` hooks `render_block` at priority 10 for
+ * the duration of the render. Calling `do_blocks()` on the ad post's content
+ * from inside a `render_email_callback` therefore routes each inner block
+ * through the same WC email-rendering pass — `render_email_callback` for
+ * blocks that have one, the WC fallback otherwise.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+use Newspack_Newsletters\Ads;
+use Newspack_Newsletters\Ads_Placements;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Renders a newspack-newsletters/ad block in an email-safe way.
+ *
+ * Resolves the ad post from the block's `adId` attribute, renders its block
+ * content through the WC email pipeline, and marks the ad as inserted.
+ */
+class Ad extends Abstract_Block_Renderer {
+
+	/**
+	 * Render the ad block.
+	 *
+	 * Resolves the ad post (by direct ID, placement ID, or auto-selection),
+	 * renders its block content through the currently-active WC email pipeline,
+	 * then marks the ad as inserted for tracking and de-duplication.
+	 *
+	 * @param string            $block_content     Original block content (always empty — the block has no save output).
+	 * @param array             $parsed_block      Parsed block data including attrs.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string Rendered ad HTML, or empty string when no ad post is found.
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$attrs   = $parsed_block['attrs'] ?? array();
+		$ad_id   = isset( $attrs['adId'] ) ? (string) $attrs['adId'] : '';
+		$ad_post = $this->resolve_ad_post( $ad_id );
+
+		if ( ! $ad_post instanceof \WP_Post ) {
+			return '';
+		}
+
+		// Mark the ad as inserted so auto-selection skips it on the next ad
+		// block and tracking counts each ad once — mirrors the MJML renderer.
+		$newsletter = Renderer_Controller::get_rendering_post();
+		if ( $newsletter instanceof \WP_Post ) {
+			Ads::mark_ad_inserted( $newsletter->ID, $ad_post->ID );
+		}
+
+		// Render the ad post's block content through the currently-active WC
+		// email pipeline. Content_Renderer::initialize() hooks render_block at
+		// priority 10 for the duration of render_wc(), so do_blocks() here
+		// routes each inner block through email-specific renderers automatically.
+		return (string) do_blocks( $ad_post->post_content );
+	}
+
+	/**
+	 * Resolve the ad WP_Post from the adId attribute value.
+	 *
+	 * Mirrors the resolution order in the MJML renderer's
+	 * `render_mjml_component()` case for `newspack-newsletters/ad`:
+	 *
+	 * 1. `placement:<term_id>` — look up the ad assigned to that placement.
+	 * 2. Non-empty string (numeric post ID) — fetch directly via get_post().
+	 * 3. Empty / absent — auto-select the first un-inserted active ad for
+	 *    the newsletter currently being rendered.
+	 *
+	 * Returns null (never false) when no ad post can be resolved so the caller
+	 * can use a strict instanceof check.
+	 *
+	 * @param string $ad_id The raw adId block attribute value, or empty string.
+	 * @return \WP_Post|null Resolved ad post, or null when none is found.
+	 */
+	private function resolve_ad_post( string $ad_id ): ?\WP_Post {
+		// 1. Placement-based lookup: `placement:<term_id>`.
+		if ( str_starts_with( $ad_id, 'placement:' ) ) {
+			$placement_id = (int) substr( $ad_id, strlen( 'placement:' ) );
+			$newsletter   = Renderer_Controller::get_rendering_post();
+			$nl_id        = $newsletter instanceof \WP_Post ? $newsletter->ID : null;
+			$post         = Ads_Placements::get_ad_by_placement( $placement_id, $nl_id );
+			return $post instanceof \WP_Post ? $post : null;
+		}
+
+		// 2. Direct post ID.
+		if ( '' !== $ad_id ) {
+			$post = get_post( (int) $ad_id );
+			return $post instanceof \WP_Post ? $post : null;
+		}
+
+		// 3. Auto-select the first un-inserted active ad for this newsletter.
+		$newsletter = Renderer_Controller::get_rendering_post();
+		if ( ! $newsletter instanceof \WP_Post ) {
+			return null;
+		}
+		$ads = Ads::get_newsletter_ads( $newsletter->ID );
+		foreach ( $ads as $ad ) {
+			if ( ! Ads::is_ad_inserted( $newsletter->ID, $ad->ID ) ) {
+				return $ad;
+			}
+		}
+		return null;
+	}
+}
+
+// Self-register so the registry discovers this override via the blocks/ glob.
+\Newspack\Newsletters\Email_Renderers\Block_Renderer_Registry::add( 'newspack-newsletters/ad', Ad::class );

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-ad.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-ad.php
@@ -43,6 +43,13 @@ defined( 'ABSPATH' ) || exit;
 class Ad extends Abstract_Block_Renderer {
 
 	/**
+	 * Ad post IDs currently on the render stack, used to break ad→ad cycles.
+	 *
+	 * @var int[]
+	 */
+	private static $render_stack = array();
+
+	/**
 	 * Render the ad block.
 	 *
 	 * Resolves the ad post (by direct ID, placement ID, or auto-selection),
@@ -63,18 +70,35 @@ class Ad extends Abstract_Block_Renderer {
 			return '';
 		}
 
-		// Mark the ad as inserted so auto-selection skips it on the next ad
-		// block and tracking counts each ad once — mirrors the MJML renderer.
-		$newsletter = Renderer_Controller::get_rendering_post();
-		if ( $newsletter instanceof \WP_Post ) {
-			Ads::mark_ad_inserted( $newsletter->ID, $ad_post->ID );
+		// Break ad-reference cycles. An ad's content can itself embed an ad block,
+		// which re-enters this renderer via do_blocks(); a self- or mutually-
+		// referencing ad would otherwise recurse until it blanks the whole render.
+		// If this ad is already on the render stack, stop here.
+		if ( in_array( $ad_post->ID, self::$render_stack, true ) ) {
+			return '';
 		}
 
 		// Render the ad post's block content through the currently-active WC
 		// email pipeline. Content_Renderer::initialize() hooks render_block at
 		// priority 10 for the duration of render_wc(), so do_blocks() here
 		// routes each inner block through email-specific renderers automatically.
-		return (string) do_blocks( $ad_post->post_content );
+		self::$render_stack[] = $ad_post->ID;
+		try {
+			$html = (string) do_blocks( $ad_post->post_content );
+		} finally {
+			array_pop( self::$render_stack );
+		}
+
+		// Mark the ad as inserted *after* rendering (mirroring the MJML renderer)
+		// so a render that throws never persists a phantom insertion, while
+		// auto-selection still skips this ad on a later block and tracking counts
+		// it once.
+		$newsletter = Renderer_Controller::get_rendering_post();
+		if ( $newsletter instanceof \WP_Post ) {
+			Ads::mark_ad_inserted( $newsletter->ID, $ad_post->ID );
+		}
+
+		return $html;
 	}
 
 	/**
@@ -84,7 +108,9 @@ class Ad extends Abstract_Block_Renderer {
 	 * `render_mjml_component()` case for `newspack-newsletters/ad`:
 	 *
 	 * 1. `placement:<term_id>` — look up the ad assigned to that placement.
-	 * 2. Non-empty string (numeric post ID) — fetch directly via get_post().
+	 * 2. Non-empty string (numeric post ID) — fetch directly, but only return it
+	 *    when it is an active post of the ads CPT, so a stale or wrong id can't
+	 *    leak an arbitrary post's content into a sent email.
 	 * 3. Empty / absent — auto-select the first un-inserted active ad for
 	 *    the newsletter currently being rendered.
 	 *
@@ -104,10 +130,17 @@ class Ad extends Abstract_Block_Renderer {
 			return $post instanceof \WP_Post ? $post : null;
 		}
 
-		// 2. Direct post ID.
+		// 2. Direct post ID — only an active ad of the ads CPT, so a stale or wrong
+		// id renders empty (matching the unknown-ID contract) rather than leaking
+		// an arbitrary post's content into the email.
 		if ( '' !== $ad_id ) {
 			$post = get_post( (int) $ad_id );
-			return $post instanceof \WP_Post ? $post : null;
+			if ( ! $post instanceof \WP_Post || Ads::CPT !== $post->post_type ) {
+				return null;
+			}
+			$newsletter = Renderer_Controller::get_rendering_post();
+			$nl_id      = $newsletter instanceof \WP_Post ? $newsletter->ID : null;
+			return Ads::is_ad_active( $post->ID, $nl_id ) ? $post : null;
 		}
 
 		// 3. Auto-select the first un-inserted active ad for this newsletter.

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -94,6 +94,23 @@ class Renderer_Controller {
 			return '';
 		}
 
+		// Apply the `newspack_newsletters_newsletter_content` filter so that
+		// auto-injected ad blocks (inserted by Ads::filter_newsletter_content())
+		// appear in the content before the WC renderer parses it — mirroring
+		// what the MJML renderer does via the same filter.
+		//
+		// WordPress's in-memory object cache clones WP_Post objects on every
+		// get_post() call (WP_Object_Cache::get() clones before returning), so
+		// mutating $post->post_content here does NOT affect what Post_Content::
+		// render_stateless() reads when it calls get_post($post->ID) internally.
+		// The only reliable way to feed it the filtered content is to temporarily
+		// replace the cache entry with a clone carrying the new content, then
+		// restore the original in the finally block.
+		$filtered_content = (string) apply_filters( 'newspack_newsletters_newsletter_content', $post->post_content, $post );
+		$render_post      = clone $post;
+		$render_post->post_content = $filtered_content;
+		wp_cache_replace( $post->ID, $render_post, 'posts' );
+
 		// Save/restore rather than clear so a nested render_wc() (post B mid-render
 		// of post A) leaves the outer render's post intact when the inner one returns.
 		$previous             = self::$rendering_post;
@@ -103,7 +120,7 @@ class Renderer_Controller {
 			$renderer  = $container->get( \Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer::class );
 			$preheader = (string) get_post_meta( $post->ID, 'preview_text', true );
 			$result    = $renderer->render(
-				$post,
+				$render_post,
 				(string) $post->post_title,
 				$preheader,
 				(string) get_bloginfo( 'language' ),
@@ -116,6 +133,9 @@ class Renderer_Controller {
 			return '';
 		} finally {
 			self::$rendering_post = $previous;
+			// Restore the original post in the cache so nothing outside this
+			// render sees the temporary filtered content.
+			wp_cache_replace( $post->ID, $post, 'posts' );
 		}
 	}
 

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -94,22 +94,39 @@ class Renderer_Controller {
 			return '';
 		}
 
+		// Reset the per-newsletter ad-insertion tracking before this render. The
+		// tracking static (Ads::$inserted_ads) is process-global and otherwise
+		// never cleared within a request, so a second render of the same
+		// newsletter in one request (e.g. preview then send) would find every ad
+		// already "inserted" and silently drop it.
+		if ( class_exists( '\Newspack_Newsletters\Ads' ) && method_exists( '\Newspack_Newsletters\Ads', 'reset_inserted_ads' ) ) {
+			\Newspack_Newsletters\Ads::reset_inserted_ads( $post->ID );
+		}
+
 		// Apply the `newspack_newsletters_newsletter_content` filter so that
 		// auto-injected ad blocks (inserted by Ads::filter_newsletter_content())
 		// appear in the content before the WC renderer parses it — mirroring
 		// what the MJML renderer does via the same filter.
 		//
-		// WordPress's in-memory object cache clones WP_Post objects on every
-		// get_post() call (WP_Object_Cache::get() clones before returning), so
-		// mutating $post->post_content here does NOT affect what Post_Content::
-		// render_stateless() reads when it calls get_post($post->ID) internally.
-		// The only reliable way to feed it the filtered content is to temporarily
-		// replace the cache entry with a clone carrying the new content, then
-		// restore the original in the finally block.
-		$filtered_content = (string) apply_filters( 'newspack_newsletters_newsletter_content', $post->post_content, $post );
-		$render_post      = clone $post;
+		// Feed that filtered content to the package WITHOUT mutating the shared
+		// object cache. The package's stateless post-content renderer re-fetches
+		// the newsletter by ID (get_post) and runs its raw content through the
+		// `the_content` filter, so we intercept that one pass — matched by post ID
+		// and scoped to this render — and substitute the filtered markup. A
+		// previous approach swapped the `posts` cache entry, but `posts` is a
+		// persistent group here (memcached/Redis), so the ad-injected clone was
+		// visible to any concurrent request that read the post mid-render. This
+		// filter is request-local and never touches the shared cache.
+		$filtered_content          = (string) apply_filters( 'newspack_newsletters_newsletter_content', $post->post_content, $post );
+		$render_post               = clone $post;
 		$render_post->post_content = $filtered_content;
-		wp_cache_replace( $post->ID, $render_post, 'posts' );
+
+		$inject_content = static function ( $content ) use ( $post, $filtered_content ) {
+			return ( isset( $GLOBALS['post'] ) && $GLOBALS['post'] instanceof \WP_Post && (int) $GLOBALS['post']->ID === (int) $post->ID )
+				? $filtered_content
+				: $content;
+		};
+		add_filter( 'the_content', $inject_content, 0 );
 
 		// Save/restore rather than clear so a nested render_wc() (post B mid-render
 		// of post A) leaves the outer render's post intact when the inner one returns.
@@ -133,9 +150,7 @@ class Renderer_Controller {
 			return '';
 		} finally {
 			self::$rendering_post = $previous;
-			// Restore the original post in the cache so nothing outside this
-			// render sees the temporary filtered content.
-			wp_cache_replace( $post->ID, $post, 'posts' );
+			remove_filter( 'the_content', $inject_content, 0 );
 		}
 	}
 

--- a/plugins/newspack-newsletters/tests/email-renderers/test-ad-block.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-ad-block.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Class Ad Block Renderer Test
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Email_Renderers\Editor_Bootstrap;
+use Newspack\Newsletters\Email_Renderers\Renderer_Controller;
+use Newspack_Newsletters\Ads;
+
+/**
+ * Ad block renderer tests.
+ *
+ * The `newspack-newsletters/ad` block has no save output (`html: false` in
+ * block.json), so without a custom renderer the WC email-editor package would
+ * silently drop the ad from the rendered email. The Newspack override
+ * (`Email_Renderers\Blocks\Ad`) resolves the ad post and renders its block
+ * content through the active WC email pipeline, mirroring what the legacy MJML
+ * renderer does via `post_to_mjml_components()`.
+ *
+ * These tests use `render_wc()` end-to-end and assert that ad block content
+ * appears in the output. They also cover auto-insertion: `render_wc()` now
+ * applies the `newspack_newsletters_newsletter_content` filter (which runs
+ * Ads::filter_newsletter_content()) before passing content to the WC renderer,
+ * so ads scheduled for auto-injection also render correctly.
+ */
+class Test_Ad_Block extends WP_UnitTestCase {
+	/**
+	 * Boot the WC editor package so render_wc() can render newsletters.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Editor_Bootstrap::init();
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	/**
+	 * Create a minimal ad CPT post with simple block content.
+	 *
+	 * No start/expiry date meta is set, so Ads::is_ad_active() returns true.
+	 * The ad content is a single paragraph so the rendered output is predictable.
+	 *
+	 * @param string $ad_text The text to include in the ad paragraph.
+	 * @return \WP_Post The ad post.
+	 */
+	private function create_ad_post( string $ad_text ): \WP_Post {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => Ads::CPT,
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Ad',
+				'post_content' => '<!-- wp:paragraph --><p>' . esc_html( $ad_text ) . '</p><!-- /wp:paragraph -->',
+			]
+		);
+		return get_post( $post_id );
+	}
+
+	/**
+	 * Render newsletter content through the WC engine.
+	 *
+	 * @param string $content Block markup for the newsletter body.
+	 * @return string Rendered email HTML.
+	 */
+	private function render_newsletter( string $content ): string {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Ad block test newsletter',
+				'post_content' => $content,
+			]
+		);
+		return Renderer_Controller::render_wc( get_post( $post_id ) );
+	}
+
+	// ------------------------------------------------------------------
+	// Manual ad blocks (adId set to a specific post ID)
+	// ------------------------------------------------------------------
+
+	/**
+	 * A manually-placed ad block renders the ad post's content.
+	 *
+	 * Without the override the WC package receives an empty $block_content
+	 * (the block has no save output) and its fallback renderer emits nothing —
+	 * the ad is silently dropped. The override must resolve the ad post and
+	 * render its block content so the recipient sees the ad.
+	 */
+	public function test_manual_ad_block_renders_ad_content() {
+		$ad_post    = $this->create_ad_post( 'BUY OUR PRODUCT' );
+		$newsletter = '<!-- wp:newspack-newsletters/ad {"adId":"' . $ad_post->ID . '"} /-->';
+
+		$html = $this->render_newsletter( $newsletter );
+
+		$this->assertStringContainsString(
+			'BUY OUR PRODUCT',
+			$html,
+			'Expected the ad post paragraph text to appear in the rendered newsletter HTML.'
+		);
+	}
+
+	/**
+	 * An ad block with an unresolvable post ID renders nothing (not fatal).
+	 *
+	 * When the referenced post doesn't exist the override must return an empty
+	 * string (not throw, not render garbage) — the rest of the newsletter still
+	 * renders correctly.
+	 */
+	public function test_ad_block_with_unknown_id_renders_empty() {
+		$newsletter = '<!-- wp:paragraph --><p>Before ad.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:newspack-newsletters/ad {"adId":"9999999"} /-->'
+			. '<!-- wp:paragraph --><p>After ad.</p><!-- /wp:paragraph -->';
+
+		$html = $this->render_newsletter( $newsletter );
+
+		// The surrounding paragraphs must render; the ad renders empty, not fatal.
+		$this->assertStringContainsString( 'Before ad.', $html, 'Expected pre-ad paragraph to render.' );
+		$this->assertStringContainsString( 'After ad.', $html, 'Expected post-ad paragraph to render.' );
+		$this->assertStringNotContainsString( '9999999', $html, 'Expected the bad ad ID not to appear in the output.' );
+	}
+
+	/**
+	 * The ad block marks the ad as inserted after rendering.
+	 *
+	 * The MJML renderer calls Ads::mark_ad_inserted() after rendering the ad.
+	 * The WC override must do the same so that impression tracking and
+	 * de-duplication work correctly when the same newsletter is rendered twice
+	 * in the same request (e.g., preview + send).
+	 */
+	public function test_manual_ad_block_marks_ad_as_inserted() {
+		$ad_post = $this->create_ad_post( 'Marked Ad' );
+		$newsletter_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Mark test newsletter',
+				'post_content' => '<!-- wp:newspack-newsletters/ad {"adId":"' . $ad_post->ID . '"} /-->',
+			]
+		);
+
+		Renderer_Controller::render_wc( get_post( $newsletter_id ) );
+
+		$this->assertTrue(
+			Ads::is_ad_inserted( $newsletter_id, $ad_post->ID ),
+			'Expected the ad to be marked as inserted after rendering.'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Auto-insertion via newspack_newsletters_newsletter_content filter
+	// ------------------------------------------------------------------
+
+	/**
+	 * Auto-inserted ads appear in the WC-rendered email.
+	 *
+	 * The legacy MJML renderer applies `newspack_newsletters_newsletter_content`
+	 * to the newsletter's content before parsing, which lets Ads::filter_newsletter_content()
+	 * inject ad blocks at the right positions. render_wc() must apply the same
+	 * filter so auto-scheduled ads also reach the WC renderer as real block
+	 * comments that the Ad block renderer then expands.
+	 */
+	public function test_auto_inserted_ad_renders_in_wc_output() {
+		$ad_post = $this->create_ad_post( 'AUTO INSERTED AD TEXT' );
+
+		// Newsletter with no manual ad block — auto-insertion should fire.
+		$newsletter_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Auto-insert test newsletter',
+				'post_content' => '<!-- wp:paragraph --><p>Article content.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $newsletter_id ) );
+
+		$this->assertStringContainsString(
+			'AUTO INSERTED AD TEXT',
+			$html,
+			'Expected auto-inserted ad content to appear in the WC-rendered newsletter.'
+		);
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-ad-block.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-ad-block.php
@@ -183,4 +183,129 @@ class Test_Ad_Block extends WP_UnitTestCase {
 			'Expected auto-inserted ad content to appear in the WC-rendered newsletter.'
 		);
 	}
+
+	/**
+	 * Auto-inserted ads still render when the post cache is cold.
+	 *
+	 * The renderer feeds the filtered (ad-injected) content to the package via a
+	 * render-scoped `the_content` filter rather than swapping the shared `posts`
+	 * cache entry. This regression test busts the cache for the newsletter before
+	 * rendering — the old cache-swap approach silently dropped the ad here because
+	 * `wp_cache_replace()` is a no-op on a missing key.
+	 */
+	public function test_auto_inserted_ad_renders_on_cold_post_cache() {
+		$this->create_ad_post( 'COLD CACHE AD TEXT' );
+
+		$newsletter_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Cold cache newsletter',
+				'post_content' => '<!-- wp:paragraph --><p>Article content.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$newsletter = get_post( $newsletter_id );
+		// Force the package's internal get_post() to miss the cache and read the
+		// canonical (un-injected) content from the database.
+		clean_post_cache( $newsletter_id );
+		wp_cache_delete( $newsletter_id, 'posts' );
+
+		$html = Renderer_Controller::render_wc( $newsletter );
+
+		$this->assertStringContainsString(
+			'COLD CACHE AD TEXT',
+			$html,
+			'Expected the auto-inserted ad to render even with a cold post cache.'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Direct-ID guards: only an active ad of the ads CPT may render
+	// ------------------------------------------------------------------
+
+	/**
+	 * An ad block pointing at a non-ad post renders nothing.
+	 *
+	 * The direct-ID path must confirm the resolved post is of the ads CPT, so a
+	 * stale or wrong id can't leak an arbitrary post's content into the email.
+	 */
+	public function test_direct_id_non_ad_post_renders_empty() {
+		$plain_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'Regular article',
+				'post_content' => '<!-- wp:paragraph --><p>SECRET ARTICLE BODY</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$html = $this->render_newsletter( '<!-- wp:newspack-newsletters/ad {"adId":"' . $plain_id . '"} /-->' );
+
+		$this->assertStringNotContainsString(
+			'SECRET ARTICLE BODY',
+			$html,
+			'Expected a non-ad post pointed at by adId to render nothing.'
+		);
+	}
+
+	/**
+	 * An ad block pointing at an expired ad renders nothing.
+	 *
+	 * The direct-ID path runs the same `is_ad_active()` check as auto-select, so an
+	 * ad past its expiry date is skipped instead of rendered.
+	 */
+	public function test_direct_id_inactive_ad_renders_empty() {
+		$ad_post = $this->create_ad_post( 'EXPIRED AD TEXT' );
+		update_post_meta( $ad_post->ID, 'expiry_date', '2000-01-01' );
+
+		$html = $this->render_newsletter( '<!-- wp:newspack-newsletters/ad {"adId":"' . $ad_post->ID . '"} /-->' );
+
+		$this->assertStringNotContainsString(
+			'EXPIRED AD TEXT',
+			$html,
+			'Expected an expired ad pointed at by adId to render nothing.'
+		);
+	}
+
+	/**
+	 * A self-referencing ad renders once and does not blank the newsletter.
+	 *
+	 * An ad whose content embeds an ad block for itself re-enters the renderer;
+	 * the render-stack cycle guard must stop the recursion so the ad's own content
+	 * still renders (once) rather than recursing until the whole render is empty.
+	 */
+	public function test_cyclic_ad_reference_renders_without_blanking() {
+		// Create the ad, then point its embedded ad block at its own ID.
+		$ad_id = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'publish',
+				'post_title'  => 'Self-referencing ad',
+			]
+		);
+		wp_update_post(
+			[
+				'ID'           => $ad_id,
+				'post_content' => '<!-- wp:paragraph --><p>CYCLE AD MARKER</p><!-- /wp:paragraph -->'
+					. '<!-- wp:newspack-newsletters/ad {"adId":"' . $ad_id . '"} /-->',
+			]
+		);
+
+		$html = $this->render_newsletter(
+			'<!-- wp:paragraph --><p>Intro.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:newspack-newsletters/ad {"adId":"' . $ad_id . '"} /-->'
+			. '<!-- wp:paragraph --><p>Outro.</p><!-- /wp:paragraph -->'
+		);
+
+		// The surrounding content renders, and the ad marker appears exactly once
+		// (the nested self-reference is stopped by the cycle guard).
+		$this->assertStringContainsString( 'Intro.', $html, 'Expected the intro paragraph to render.' );
+		$this->assertStringContainsString( 'Outro.', $html, 'Expected the outro paragraph to render.' );
+		$this->assertSame(
+			1,
+			substr_count( $html, 'CYCLE AD MARKER' ),
+			'Expected the self-referencing ad to render its content exactly once.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `newspack-newsletters/ad` block is self-closing with no save output (`html: false`). Without an override the WC email-editor package receives empty `$block_content` and silently drops ads from rendered emails.

This PR adds the `Email_Renderers\Blocks\Ad` override that:
- Resolves the ad post from the block's `adId` attribute — direct post ID, `placement:<term_id>` prefix, or auto-select (first un-inserted active ad for the current newsletter)
- Renders the ad post's block content via `do_blocks()` while the WC `render_block` filter is active, so inner blocks route through email-specific renderers
- Calls `Ads::mark_ad_inserted()` for per-newsletter de-duplication and tracking, mirroring the MJML renderer

`render_wc()` is updated to apply `newspack_newsletters_newsletter_content` before delegating to the WC package. This is how the MJML renderer picks up auto-scheduled ad blocks injected by `Ads::filter_newsletter_content()`. A key gotcha: `WP_Object_Cache::get()` clones objects on return, so direct mutation of `$post->post_content` is invisible to `Post_Content::render_stateless()`'s internal `get_post()` call. The fix pushes a cloned post with filtered content into the object cache via `wp_cache_replace()`, scoped to the render, and restores the original in the `finally` block.

The ad block is also registered via `register_block_type_from_metadata()` in `register_blocks()` so `Block_Renderer_Registry`'s `block_type_metadata_settings` filter can attach the `render_email_callback`.

### How to test the changes in this Pull Request:

_Enable the WC renderer flag first:_ `wp option update newspack_newsletters_use_woo_renderer 1`

**Manual ad block:**
1. Create an Ad post (`newspack_nl_ads_cpt`) with any block content.
2. Create a Newsletter, insert a `newspack-newsletters/ad` block, set its post ID to the ad above.
3. Preview or render the newsletter — the ad content should appear in the email HTML.

**Auto-insertion:**
1. Create an Ad post with no start/expiry date (active immediately).
2. Create a Newsletter with plain paragraph content and no manual ad block.
3. Render the newsletter — `Ads::filter_newsletter_content()` injects an ad block automatically; the rendered email should include the ad content.

**Unknown ad ID (regression guard):**
1. Place a `newspack-newsletters/ad` block with a non-existent post ID.
2. Render — the ad is silently omitted and surrounding blocks render correctly.

**PHPUnit:**
```
cd plugins/newspack-newsletters && n test-php --filter Test_Ad_Block
```
All 4 assertions pass: manual render, unknown ID no-op, mark-as-inserted tracking, auto-insertion.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?