### PR TITLE
feat(insights): warn on scalar cards missing required data

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -79,6 +79,17 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Response-shape version for the conversion cache key. Bump
+	 * {@see Conversion_Metric::CACHE_PREFIX} whenever the Tab 3 response shape
+	 * changes so cached payloads from a prior shape don't survive a deploy.
+	 *
+	 * @return string
+	 */
+	protected function cache_schema_version(): string {
+		return Conversion_Metric::CACHE_PREFIX;
+	}
+
+	/**
 	 * Register the Tab 3 routes.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
@@ -28,6 +28,16 @@ trait Cached_Controller_Trait {
 	abstract protected function tab_slug(): string;
 
 	/**
+	 * Response-shape version mixed into the cache key. Override and bump it when
+	 * a controller's payload shape changes so cached payloads from a prior shape
+	 * don't survive a deploy. Default empty: no version component, so controllers
+	 * that don't opt in keep their existing key shape (no surprise cache-bust).
+	 */
+	protected function cache_schema_version(): string {
+		return '';
+	}
+
+	/**
 	 * Cache-aware GET wrapper.
 	 *
 	 * @param WP_REST_Request $request       Incoming request.
@@ -37,7 +47,7 @@ trait Cached_Controller_Trait {
 		$envelope = Cache::store(
 			$this->tab_slug(),
 			$this->cache_source(),
-			self::cache_key_parts( $request ),
+			$this->versioned_cache_key_parts( $request ),
 			$build_payload
 		);
 		$response = rest_ensure_response( self::wrap_envelope( $envelope ) );
@@ -58,7 +68,7 @@ trait Cached_Controller_Trait {
 		$envelope = Cache::refresh(
 			$this->tab_slug(),
 			$this->cache_source(),
-			self::cache_key_parts( $request ),
+			$this->versioned_cache_key_parts( $request ),
 			$build_payload
 		);
 		$response = rest_ensure_response( self::wrap_envelope( $envelope ) );
@@ -79,6 +89,23 @@ trait Cached_Controller_Trait {
 			$request->get_param( 'compare_start' ) ? (string) $request->get_param( 'compare_start' ) : null,
 			$request->get_param( 'compare_end' ) ? (string) $request->get_param( 'compare_end' ) : null,
 		];
+	}
+
+	/**
+	 * Canonical window key parts with the response-shape version prepended when
+	 * the controller sets one. An empty version leaves the window parts
+	 * untouched, so a non-overriding controller's cache key is unchanged.
+	 *
+	 * @param WP_REST_Request $request Incoming request.
+	 * @return array
+	 */
+	private function versioned_cache_key_parts( WP_REST_Request $request ): array {
+		$parts   = self::cache_key_parts( $request );
+		$version = $this->cache_schema_version();
+		if ( '' !== $version ) {
+			array_unshift( $parts, $version );
+		}
+		return $parts;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -220,6 +220,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			'computable'       => false,
 			'denominator'      => null,
 			'placeholder_type' => 'rate',
+			'data_missing'     => false,
 			'error_code'       => 'bigquery_proxy_http_error',
 			'error_message'    => 'HTTP 500',
 		];
@@ -289,6 +290,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 					'computable'       => true,
 					'denominator'      => null,
 					'placeholder_type' => 'count',
+					'data_missing'     => false,
 				],
 				'at_risk_subscriber_count'         => [
 					'state'            => 'populated',
@@ -296,6 +298,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 					'computable'       => true,
 					'denominator'      => null,
 					'placeholder_type' => 'count',
+					'data_missing'     => false,
 				],
 				'lapsed_donor_count'               => [
 					'state'            => 'populated',
@@ -303,6 +306,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 					'computable'       => true,
 					'denominator'      => null,
 					'placeholder_type' => 'count',
+					'data_missing'     => false,
 				],
 			],
 			$deferred()
@@ -336,6 +340,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'computable'       => false,
 				'denominator'      => 'rate' === $type ? 0 : null,
 				'placeholder_type' => $type,
+				'data_missing'     => false,
 			];
 		};
 		$current = array_merge(
@@ -412,6 +417,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			'computable'       => $computable,
 			'denominator'      => $denominator,
 			'placeholder_type' => $type,
+			'data_missing'     => false,
 		];
 	};
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -66,6 +66,7 @@ use Newspack\Insights\Subscribers_Metric;
  *   computable: bool,
  *   denominator: int|null,
  *   placeholder_type: string,
+ *   data_missing: bool,
  *   error_code?: string,
  *   error_message?: string,
  * }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -74,12 +74,14 @@ use Newspack\Insights\Subscribers_Metric;
 final class Conversion_Metric {
 
 	/**
-	 * Cache key prefix. Bumped when the response shape changes so cached
-	 * payloads from a prior shape don't break a deploy.
+	 * Response-shape version mixed into the conversion cache key via the REST
+	 * controller's `cache_schema_version()`. Bump the v-suffix whenever the Tab 3
+	 * response shape changes so cached payloads from a prior shape don't survive
+	 * a deploy. Bumped to v2 for the `data_missing` scalar field.
 	 *
 	 * @var string
 	 */
-	const CACHE_PREFIX = 'newspack_insights_tab3_v1:';
+	const CACHE_PREFIX = 'newspack_insights_tab3_v2:';
 
 	/**
 	 * Tab slug used as the Cache namespace for Section 5 snapshots.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -389,9 +389,11 @@ final class Conversion_Metric {
 	/**
 	 * Run a scalar catalog query and extract a single value from the first row.
 	 *
-	 * A proxy WP_Error becomes state 'error'. A successful query with no usable
-	 * value (empty rows, missing key, non-numeric, or count drift) becomes a
-	 * 'populated' non-computable zero.
+	 * A proxy WP_Error becomes state 'error'. An empty result or a SAFE_DIVIDE
+	 * null becomes a benign 'populated' non-computable zero. A row present but
+	 * missing the required column becomes a non-computable zero flagged
+	 * `data_missing` (schema drift). A non-numeric or count-drift value becomes
+	 * state 'error'.
 	 *
 	 * @param string            $query_name        Catalog `query_name`.
 	 * @param string            $row_key           Column to extract from the first row.
@@ -424,7 +426,8 @@ final class Conversion_Metric {
 		$value = $rows[0][ $row_key ];
 		// SAFE_DIVIDE returns NULL when the denominator is zero — a legitimate
 		// "no eligible events to compute a rate" case, not a schema regression.
-		// Same handling as the missing-key branch above: non-computable zero.
+		// Benign → non-computable zero, NOT flagged data_missing (unlike the
+		// missing-column branch above).
 		if ( null === $value ) {
 			return $this->populated_scalar( $zero, false, null, $placeholder_type );
 		}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -327,6 +327,7 @@ final class Conversion_Metric {
 			'computable'       => false,
 			'denominator'      => null,
 			'placeholder_type' => $placeholder_type,
+			'data_missing'     => false,
 			'error_code'       => $error->get_error_code(),
 			'error_message'    => $error->get_error_message(),
 		];
@@ -341,15 +342,17 @@ final class Conversion_Metric {
 	 * @param bool      $computable       Whether the value is a real computed figure.
 	 * @param int|null  $denominator      Optional denominator.
 	 * @param string    $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @param bool      $data_missing     True when the row is present but lacks required columns (schema drift).
 	 * @return array
 	 */
-	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type ): array {
+	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type, bool $data_missing = false ): array {
 		return [
 			'state'            => 'populated',
 			'value'            => $value,
 			'computable'       => $computable,
 			'denominator'      => $denominator,
 			'placeholder_type' => $placeholder_type,
+			'data_missing'     => $data_missing,
 		];
 	}
 
@@ -409,9 +412,14 @@ final class Conversion_Metric {
 			return $this->error_scalar( $placeholder_type, $rows );
 		}
 		$zero = 'decimal' === $placeholder_type ? 0.0 : 0;
-		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $row_key, $rows[0] ) ) {
-			// Query succeeded with no usable value → non-computable zero.
+		if ( empty( $rows ) ) {
+			// No rows → empty window, legitimately no data.
 			return $this->populated_scalar( $zero, false, null, $placeholder_type );
+		}
+		if ( ! is_array( $rows[0] ) || ! array_key_exists( $row_key, $rows[0] ) ) {
+			// Row present but unusable (missing required column / malformed shape)
+			// → schema drift or bad deploy. Non-computable, flagged as missing data.
+			return $this->populated_scalar( $zero, false, null, $placeholder_type, true );
 		}
 		$value = $rows[0][ $row_key ];
 		// SAFE_DIVIDE returns NULL when the denominator is zero — a legitimate
@@ -456,9 +464,13 @@ final class Conversion_Metric {
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_scalar( 'rate', $rows );
 		}
-		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $rate_key, $rows[0] ) || ! array_key_exists( $denominator_key, $rows[0] ) ) {
-			// Query succeeded with no usable row → non-computable zero.
+		if ( empty( $rows ) ) {
+			// No rows → empty window, legitimately no data.
 			return $this->populated_scalar( 0.0, false, null, 'rate' );
+		}
+		if ( ! is_array( $rows[0] ) || ! array_key_exists( $rate_key, $rows[0] ) || ! array_key_exists( $denominator_key, $rows[0] ) ) {
+			// Row present but unusable → schema drift. Non-computable, flagged.
+			return $this->populated_scalar( 0.0, false, null, 'rate', true );
 		}
 		$denominator = $rows[0][ $denominator_key ];
 		if ( ! is_numeric( $denominator ) ) {

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -75,6 +75,7 @@ export interface ConversionScalarMetric extends ConversionErrorFields {
 	computable: boolean;
 	denominator: number | null;
 	placeholder_type: ConversionPlaceholderType;
+	data_missing: boolean;
 }
 
 /* --- Section 1 / 2: funnels ----------------------------------------- */

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -68,6 +68,8 @@ export interface ConversionErrorFields {
 /**
  * Standard scorecard metric payload (Sections 7 and 8.1–8.3).
  * `state` is 'error' | 'populated' | 'coming_soon' (scalars have no 'empty' state).
+ * `data_missing` flags a non-computable zero caused by a hub row missing required
+ * column(s) (schema drift) so the card can warn instead of showing a misleading zero.
  */
 export interface ConversionScalarMetric extends ConversionErrorFields {
 	state: 'error' | 'populated' | 'coming_soon';

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -210,6 +210,15 @@ describe( 'MetricCard notCapableMessage (NPPD-1720)', () => {
 	} );
 } );
 
+describe( 'MetricCard dataMissing', () => {
+	it( 'renders the data-missing note in place of the value', () => {
+		render( <MetricCard label="Influenced subscription rate" value={ 0 } format="percent" dataMissing /> );
+		expect( screen.getByText( 'Some data could not be loaded.' ) ).toBeInTheDocument();
+		// The misleading zero is not shown.
+		expect( screen.queryByText( '0%' ) ).not.toBeInTheDocument();
+	} );
+} );
+
 describe( 'MetricCard notComputableMessage (NPPD-1704)', () => {
 	const MESSAGE = 'No donation-intent prompts viewed in this timeframe.';
 	const NUDGE = 'No donation block detected in your active prompts.';

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -84,6 +84,8 @@ export interface MetricCardProps {
 	error?: string;
 	/** Metric needs configuration (e.g. coverage area not set). */
 	notConfigured?: boolean;
+	/** A present hub row was missing required column(s) — renders the data-missing note. */
+	dataMissing?: boolean;
 	/**
 	 * Native tooltip for the value (e.g. the full amount behind an abbreviated
 	 * "$1.2M"). Overrides the title the currency formatter derives on its own.
@@ -148,19 +150,20 @@ const MetricCard = ( props: MetricCardProps ) => {
 		overlay,
 		error,
 		notConfigured,
+		dataMissing,
 		valueTitle,
 		zeroFallback,
 		notCapableMessage,
 		notComputableMessage,
 	} = props;
 
-	// Shared graceful-failure state (missing dimension / not configured / error).
-	if ( overlay || error || notConfigured ) {
+	// Shared graceful-failure state (missing dimension / not configured / error / data missing).
+	if ( overlay || error || notConfigured || dataMissing ) {
 		return (
 			<Card __experimentalCoreCard className="newspack-insights__metric-card newspack-insights__metric-card--note">
 				<div className="newspack-insights__metric-card-label">{ label }</div>
 				<div className="newspack-insights__metric-card-body">
-					<MetricNote overlay={ overlay } error={ !! error } notConfigured={ notConfigured } />
+					<MetricNote overlay={ overlay } error={ !! error } notConfigured={ notConfigured } dataMissing={ dataMissing } />
 				</div>
 				{ description && <div className="newspack-insights__metric-card-description">{ description }</div> }
 			</Card>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricNote.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricNote.tsx
@@ -28,9 +28,11 @@ export interface MetricNoteProps {
 	notConfigured?: boolean;
 	/** Generic data failure. */
 	error?: boolean;
+	/** A present hub row was missing required column(s) — schema drift / bad deploy. */
+	dataMissing?: boolean;
 }
 
-const MetricNote = ( { overlay, notConfigured }: MetricNoteProps ) => {
+const MetricNote = ( { overlay, notConfigured, dataMissing }: MetricNoteProps ) => {
 	let body: React.ReactNode;
 
 	if ( overlay && overlay.type === 'data_unavailable' ) {
@@ -49,6 +51,8 @@ const MetricNote = ( { overlay, notConfigured }: MetricNoteProps ) => {
 		);
 	} else if ( notConfigured ) {
 		body = __( 'Not configured for this site.', 'newspack-plugin' );
+	} else if ( dataMissing ) {
+		body = __( 'Some data could not be loaded.', 'newspack-plugin' );
 	} else {
 		body = __( 'Data temporarily unavailable.', 'newspack-plugin' );
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.test.tsx
@@ -26,6 +26,7 @@ const errorScalar = (): ConversionScalarMetric => ( {
 	computable: false,
 	denominator: null,
 	placeholder_type: 'rate',
+	data_missing: false,
 } );
 
 describe( 'CrossTabInfluencedAttributionSection', () => {
@@ -53,5 +54,19 @@ describe( 'CrossTabInfluencedAttributionSection', () => {
 		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		// The card must NOT fall through to showing a plain "0".
 		expect( screen.queryByText( '0' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the data-missing note when an influenced scalar is missing required data', () => {
+		const current = makeConversionWindow();
+		current.influenced_subscription_rate_14d = {
+			state: 'populated',
+			value: 0,
+			computable: false,
+			denominator: null,
+			placeholder_type: 'rate',
+			data_missing: true,
+		};
+		render( <CrossTabInfluencedAttributionSection current={ current } previous={ null } /> );
+		expect( screen.getByText( 'Some data could not be loaded.' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
@@ -39,6 +39,7 @@ const scalar = (
 	computable: state === 'populated',
 	denominator: null,
 	placeholder_type,
+	data_missing: false,
 } );
 
 const funnel = ( state: ConversionMetricState, ...labels: string[] ): ConversionFunnelData => ( {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
@@ -40,6 +40,9 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	if ( current.state === 'error' ) {
 		return { label, description, error: current.error_message ?? __( 'Data temporarily unavailable.', 'newspack-plugin' ) };
 	}
+	if ( current.state === 'populated' && current.data_missing ) {
+		return { label, description, dataMissing: true };
+	}
 	return {
 		label,
 		description,

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -675,6 +675,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
 		$this->assertTrue( $result['computable'] );
+		$this->assertFalse( $result['data_missing'] );
 		$this->assertSame( 'rate', $result['placeholder_type'] );
 		$this->assertEqualsWithDelta( 0.37, $result['value'], 1e-9 );
 	}
@@ -689,7 +690,22 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertFalse( $result['computable'] );
+		$this->assertFalse( $result['data_missing'] );
 		$this->assertEqualsWithDelta( 0.0, $result['value'], 1e-9 );
+	}
+
+	/**
+	 * C7 missing column: a non-empty row lacking the rate column → non-computable
+	 * zero flagged as missing data (schema drift), NOT a benign empty zero.
+	 */
+	public function test_influenced_registration_rate_7d_flags_data_missing_on_missing_column() {
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ [ 'unexpected_column' => 1 ] ] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_influenced_registration_rate_7d( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertTrue( $result['data_missing'] );
 	}
 
 	/**
@@ -1094,6 +1110,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0.0, $result['value'] );
 		$this->assertFalse( $result['computable'] );
 		$this->assertSame( 0, $result['denominator'] );
+		$this->assertFalse( $result['data_missing'] );
 	}
 
 	/**
@@ -1162,6 +1179,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertFalse( $result['computable'] );
 		$this->assertSame( 0.0, $result['value'] );
 		$this->assertNull( $result['denominator'] );
+		$this->assertTrue( $result['data_missing'] );
 	}
 
 	// --- C15: get_influenced_donation_rate_14d ------------------------------

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -16,6 +16,7 @@ namespace Newspack\Tests\Insights;
 use Newspack\Insights\Cache;
 use Newspack\Insights\Conversion_Metric;
 use Newspack\Insights\Conversion_REST_Controller;
+use Newspack\Insights\Cached_Controller_Trait;
 use WP_REST_Request;
 use WP_REST_Server;
 use WP_UnitTestCase;
@@ -444,6 +445,54 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$method = new ReflectionMethod( Conversion_REST_Controller::class, 'is_window_all_error' );
 		$method->setAccessible( true );
 		return (bool) $method->invoke( null, $window, $woocommerce_active );
+	}
+
+	/**
+	 * Default: a controller that doesn't override cache_schema_version() keeps
+	 * the canonical four-part window key — no version component, so unrelated
+	 * tabs aren't cache-busted by this mechanism.
+	 */
+	public function test_cache_key_has_no_version_prefix_by_default() {
+		$controller = new class() {
+			use Cached_Controller_Trait;
+
+			protected function cache_source(): string {
+				return Cache::SOURCE_BIGQUERY;
+			}
+			protected function tab_slug(): string {
+				return 'test';
+			}
+		};
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'start', '2026-01-01' );
+		$request->set_param( 'end', '2026-01-31' );
+
+		$method = new ReflectionMethod( $controller, 'versioned_cache_key_parts' );
+		$method->setAccessible( true );
+		$parts = $method->invoke( $controller, $request );
+
+		$this->assertCount( 4, $parts );
+		$this->assertSame( '2026-01-01', $parts[0] );
+	}
+
+	/**
+	 * Conversion overrides cache_schema_version() with its CACHE_PREFIX, so the
+	 * version is the first cache-key component — bumping CACHE_PREFIX on a
+	 * response-shape change busts stale-shape transients on deploy.
+	 */
+	public function test_conversion_cache_key_includes_schema_version() {
+		$controller = new Conversion_REST_Controller();
+		$request    = new WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'start', '2026-01-01' );
+		$request->set_param( 'end', '2026-01-31' );
+
+		$method = new ReflectionMethod( Conversion_REST_Controller::class, 'versioned_cache_key_parts' );
+		$method->setAccessible( true );
+		$parts = $method->invoke( $controller, $request );
+
+		$this->assertCount( 5, $parts );
+		$this->assertSame( Conversion_Metric::CACHE_PREFIX, $parts[0] );
+		$this->assertContains( '2026-01-01', $parts );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -456,9 +456,20 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$controller = new class() {
 			use Cached_Controller_Trait;
 
+			/**
+			 * Cache source for the test controller.
+			 *
+			 * @return string
+			 */
 			protected function cache_source(): string {
 				return Cache::SOURCE_BIGQUERY;
 			}
+
+			/**
+			 * Tab slug for the test controller.
+			 *
+			 * @return string
+			 */
 			protected function tab_slug(): string {
 				return 'test';
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

> Base branch: **`feat/insights-rsm`** (Insights epic), not `main`.

Makes a Conversion Journey scalar card **non-silent** when a hub query returns a row that is present but **missing required column(s)** — schema drift or a bad deploy. Previously this fell back to the same silent non-computable `0` as a legitimately empty window, so a real data-quality regression was invisible. The card now shows a short note — **"Some data could not be loaded."** — in place of the misleading zero.

The distinction is deliberate and narrow:
- **Empty result** (no rows) and **`SAFE_DIVIDE` null** (no eligible events / no converters) → unchanged benign non-computable zero, **no** warning.
- **Row present but missing a required column** → non-computable zero **flagged** and surfaced as the note.
- A non-numeric value still becomes a hard error (unchanged).

A new `data_missing` boolean flows PHP → TS → React. It's set in the two shared `Conversion_Metric` scalar proxy helpers, so the note appears on any affected Tab 3 proxy-backed scalar (the influenced rates 7.1/7.2/7.3/7.4 and other proxy scalars). The UI reuses the existing shared graceful-state note treatment (`MetricNote`, alongside `error`/`notConfigured`), so the change is additive — every existing card leaves the new prop undefined.

Follow-up decided as out of scope: collection-metric (funnel/distribution/cohort) parity, and adopting the same flag in the Gates/Prompts scalar paths (the shared card change is additive, so they can opt in later).

### How to test the changes in this Pull Request:

1. Run the PHP insights suite: `cd plugins/newspack-plugin && n test-php --group insights` — all green (459). New coverage: per helper, a row missing a required column → `data_missing=true`; empty result / `SAFE_DIVIDE` null / computed value → `data_missing=false`.
2. Run the JS suite: `cd plugins/newspack-plugin && npm test` — all green (663). New coverage: `MetricCard` renders the data-missing note (value hidden); `conversion/scalarToCard` maps the flag; `CrossTabInfluencedAttributionSection` shows the note on a drift payload.
3. `npm run tsc` and `npm run lint:js` — clean for the changed files.
4. Behavioral check (once on a deployed Audience site): if a hub conversion-journey scalar query returns a row whose expected column is absent, the corresponding scorecard (e.g. an Influenced rate) shows "Some data could not be loaded." instead of `0%`. A genuinely empty window still shows the normal non-computable zero with no warning.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
