### PR TITLE
fix(memberships): sync team member end date to team expiration

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
@@ -401,10 +401,10 @@ class Teams_For_Memberships {
 	 * expires even after the team membership lapses.
 	 *
 	 * This enforces the invariant that a team member's access ends no later than the team's
-	 * expiration date, regardless of subscription status, while preserving a longer end date a
-	 * member may already hold from a separately purchased individual membership. Calling
-	 * set_end_date() also (re)schedules the per-membership expiry event, so the member expires on
-	 * time on their own.
+	 * expiration date, regardless of subscription status, unless the member already holds a longer
+	 * finite end date from a separately purchased individual membership. Calling set_end_date()
+	 * also (re)schedules the per-membership expiry event, so the member expires on time on their
+	 * own.
 	 *
 	 * @see https://linear.app/a8c/issue/NPPM-2932
 	 *
@@ -412,10 +412,11 @@ class Teams_For_Memberships {
 	 * @param \SkyVerge\WooCommerce\Memberships\Teams\Team        $team            The team instance.
 	 * @param \WC_Memberships_User_Membership                     $user_membership The related user membership instance.
 	 */
-	public static function sync_member_end_date_to_team( $member, $team, $user_membership ) {
+	public static function sync_member_end_date_to_team( $member, $team, $user_membership ): void {
 		if (
 			! is_a( $team, '\SkyVerge\WooCommerce\Memberships\Teams\Team' ) ||
-			! is_a( $user_membership, '\WC_Memberships_User_Membership' )
+			! is_a( $user_membership, '\WC_Memberships_User_Membership' ) ||
+			! method_exists( $team, 'get_membership_end_date' )
 		) {
 			return;
 		}
@@ -430,22 +431,27 @@ class Teams_For_Memberships {
 		$team_end   = (int) $team_end;
 		$member_end = (int) $user_membership->get_end_date( 'timestamp' );
 
-		// Only ever shorten access down to the team end date; never override a longer end date the
-		// member already holds (e.g. a separately purchased individual membership). A missing end
-		// date is read as 0 and corrected here.
+		// Set the member end to the team end unless the member already holds a longer finite end
+		// date (e.g. a separately purchased individual membership). A missing end date reads as 0
+		// and is corrected here.
 		if ( $member_end >= $team_end ) {
 			return;
 		}
 
-		$user_membership->set_end_date( $team_end );
+		// Pass a MySQL/UTC date string for consistency with this file's sibling set_end_date() call.
+		$user_membership->set_end_date( gmdate( 'Y-m-d H:i:s', $team_end ) );
 
-		// Mirror Team::set_membership_end_date(): reactivate if the new end date is in the future,
-		// or expire if the team has already lapsed.
-		$now = time();
-		if ( $team_end > $now && $user_membership->is_expired() ) {
+		// If the team is still current, reactivate a membership that was previously expired -- this
+		// also covers an existing, expired individual membership being absorbed into a team.
+		// is_active() does not auto-reactivate, so this has to be explicit.
+		//
+		// We intentionally do NOT force a membership added to an already-lapsed team to `expired`
+		// here. Setting the past end date is enough: is_active() lazily expires it on the next
+		// access check. Forcing the status now would synchronously fire
+		// wc_memberships_user_membership_status_changed, which removes the reader from the plan's
+		// newsletter lists at the ESP -- undesirable to trigger en masse during a (bulk) add.
+		if ( $team_end > time() && $user_membership->is_expired() ) {
 			$user_membership->update_status( 'active' );
-		} elseif ( $team_end <= $now ) {
-			$user_membership->update_status( 'expired' );
 		}
 
 		$user_membership->add_note( __( 'Membership end date synced to the team membership expiration date.', 'newspack-plugin' ) );

--- a/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
@@ -390,21 +390,27 @@ class Teams_For_Memberships {
 	}
 
 	/**
-	 * Stamp the team's expiration date onto a member's user membership when they are added.
+	 * Fill in a member's user-membership end date from the team when it has none.
 	 *
-	 * Teams only propagates the team end date to a member's user membership when the member
-	 * already had an existing membership (see Team::add_member()), or when the team is tied to a
-	 * WooCommerce subscription (see the Teams Subscriptions integration, which bails for
-	 * non-subscription teams). For manually-managed teams that have a fixed end date but no
-	 * subscription, a newly created member membership is left with the plan-relative end date,
-	 * which resolves to empty for unlimited/subscription-typed plans. The member then never
-	 * expires even after the team membership lapses.
+	 * Teams propagates the team end date to a member's user membership when the member already had
+	 * an existing membership (see Team::add_member()), or when the team is tied to a WooCommerce
+	 * subscription (see the Teams Subscriptions integration, which bails for non-subscription
+	 * teams). For manually-managed teams that have a fixed end date but no subscription, a newly
+	 * created member membership is left with the plan-relative end date, which resolves to empty
+	 * for unlimited/subscription-typed plans. The member then never expires even after the team
+	 * membership lapses.
 	 *
-	 * This enforces the invariant that a team member's access ends no later than the team's
-	 * expiration date, regardless of subscription status, unless the member already holds a longer
-	 * finite end date from a separately purchased individual membership. Calling set_end_date()
-	 * also (re)schedules the per-membership expiry event, so the member expires on time on their
-	 * own.
+	 * This fills that specific gap: when the member's user membership has no end date at all, it
+	 * inherits the team's. We deliberately only fill a *missing* end date and never override one
+	 * that is already set -- whether by the plan's access length, a separately purchased individual
+	 * membership, or upstream Team::add_member() (which reconciles existing memberships and their
+	 * status on its own). That keeps us from fighting fixed-length plans' midnight-snapped dates,
+	 * shortening a longer independently-held membership, or duplicating upstream's membership note.
+	 *
+	 * Calling set_end_date() also (re)schedules the per-membership expiry event so the member
+	 * expires on time on their own; is_active() lazily expires the membership if the team end is
+	 * already in the past, so no status change is needed here (and we avoid the synchronous ESP
+	 * list mutations a status change would fire during a possibly-bulk member add).
 	 *
 	 * @see https://linear.app/a8c/issue/NPPM-2932
 	 *
@@ -421,6 +427,13 @@ class Teams_For_Memberships {
 			return;
 		}
 
+		// Only fill a *missing* end date. Anything already set is owned by the plan, an independent
+		// membership, or upstream Team::add_member(); overriding it would fight fixed-length plans'
+		// midnight snapping and could shorten a longer independently-held membership.
+		if ( ! empty( $user_membership->get_end_date( 'timestamp' ) ) ) {
+			return;
+		}
+
 		$team_end = $team->get_membership_end_date( 'timestamp' );
 
 		// Unlimited team (no end date): there is nothing to enforce.
@@ -428,31 +441,8 @@ class Teams_For_Memberships {
 			return;
 		}
 
-		$team_end   = (int) $team_end;
-		$member_end = (int) $user_membership->get_end_date( 'timestamp' );
-
-		// Set the member end to the team end unless the member already holds a longer finite end
-		// date (e.g. a separately purchased individual membership). A missing end date reads as 0
-		// and is corrected here.
-		if ( $member_end >= $team_end ) {
-			return;
-		}
-
 		// Pass a MySQL/UTC date string for consistency with this file's sibling set_end_date() call.
-		$user_membership->set_end_date( gmdate( 'Y-m-d H:i:s', $team_end ) );
-
-		// If the team is still current, reactivate a membership that was previously expired -- this
-		// also covers an existing, expired individual membership being absorbed into a team.
-		// is_active() does not auto-reactivate, so this has to be explicit.
-		//
-		// We intentionally do NOT force a membership added to an already-lapsed team to `expired`
-		// here. Setting the past end date is enough: is_active() lazily expires it on the next
-		// access check. Forcing the status now would synchronously fire
-		// wc_memberships_user_membership_status_changed, which removes the reader from the plan's
-		// newsletter lists at the ESP -- undesirable to trigger en masse during a (bulk) add.
-		if ( $team_end > time() && $user_membership->is_expired() ) {
-			$user_membership->update_status( 'active' );
-		}
+		$user_membership->set_end_date( gmdate( 'Y-m-d H:i:s', (int) $team_end ) );
 
 		$user_membership->add_note( __( 'Membership end date synced to the team membership expiration date.', 'newspack-plugin' ) );
 	}

--- a/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
@@ -31,6 +31,8 @@ class Teams_For_Memberships {
 		add_filter( 'newspack_my_account_disabled_pages', [ __CLASS__, 'enable_members_area_for_team_members' ] );
 		add_action( 'woocommerce_checkout_subscription_created', [ __CLASS__, 'update_team_subscription_on_resubscribe' ], 21, 2 );
 		add_filter( 'wc_memberships_for_teams_determine_order_item_action', [ __CLASS__, 'restore_team_meta_on_renewal' ], 10, 2 );
+		// Priority 20 so this runs after Teams' own subscription integration (priority 10), which is a no-op for non-subscription teams.
+		add_action( 'wc_memberships_for_teams_add_team_member', [ __CLASS__, 'sync_member_end_date_to_team' ], 20, 3 );
 	}
 
 	/**
@@ -385,6 +387,68 @@ class Teams_For_Memberships {
 		}
 
 		return $action;
+	}
+
+	/**
+	 * Stamp the team's expiration date onto a member's user membership when they are added.
+	 *
+	 * Teams only propagates the team end date to a member's user membership when the member
+	 * already had an existing membership (see Team::add_member()), or when the team is tied to a
+	 * WooCommerce subscription (see the Teams Subscriptions integration, which bails for
+	 * non-subscription teams). For manually-managed teams that have a fixed end date but no
+	 * subscription, a newly created member membership is left with the plan-relative end date,
+	 * which resolves to empty for unlimited/subscription-typed plans. The member then never
+	 * expires even after the team membership lapses.
+	 *
+	 * This enforces the invariant that a team member's access ends no later than the team's
+	 * expiration date, regardless of subscription status, while preserving a longer end date a
+	 * member may already hold from a separately purchased individual membership. Calling
+	 * set_end_date() also (re)schedules the per-membership expiry event, so the member expires on
+	 * time on their own.
+	 *
+	 * @see https://linear.app/a8c/issue/NPPM-2932
+	 *
+	 * @param \SkyVerge\WooCommerce\Memberships\Teams\Team_Member $member          The team member instance.
+	 * @param \SkyVerge\WooCommerce\Memberships\Teams\Team        $team            The team instance.
+	 * @param \WC_Memberships_User_Membership                     $user_membership The related user membership instance.
+	 */
+	public static function sync_member_end_date_to_team( $member, $team, $user_membership ) {
+		if (
+			! is_a( $team, '\SkyVerge\WooCommerce\Memberships\Teams\Team' ) ||
+			! is_a( $user_membership, '\WC_Memberships_User_Membership' )
+		) {
+			return;
+		}
+
+		$team_end = $team->get_membership_end_date( 'timestamp' );
+
+		// Unlimited team (no end date): there is nothing to enforce.
+		if ( empty( $team_end ) ) {
+			return;
+		}
+
+		$team_end   = (int) $team_end;
+		$member_end = (int) $user_membership->get_end_date( 'timestamp' );
+
+		// Only ever shorten access down to the team end date; never override a longer end date the
+		// member already holds (e.g. a separately purchased individual membership). A missing end
+		// date is read as 0 and corrected here.
+		if ( $member_end >= $team_end ) {
+			return;
+		}
+
+		$user_membership->set_end_date( $team_end );
+
+		// Mirror Team::set_membership_end_date(): reactivate if the new end date is in the future,
+		// or expire if the team has already lapsed.
+		$now = time();
+		if ( $team_end > $now && $user_membership->is_expired() ) {
+			$user_membership->update_status( 'active' );
+		} elseif ( $team_end <= $now ) {
+			$user_membership->update_status( 'expired' );
+		}
+
+		$user_membership->add_note( __( 'Membership end date synced to the team membership expiration date.', 'newspack-plugin' ) );
 	}
 }
 

--- a/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/class-teams-for-memberships.php
@@ -436,8 +436,12 @@ class Teams_For_Memberships {
 
 		$team_end = $team->get_membership_end_date( 'timestamp' );
 
-		// Unlimited team (no end date): there is nothing to enforce.
-		if ( empty( $team_end ) ) {
+		// Unlimited team (no end date): there is nothing to enforce. The is_numeric() check is
+		// belt-and-suspenders for this access-control path: get_membership_end_date( 'timestamp' )
+		// returns int|null today, but if a future upstream change returned a date string, casting it
+		// to int below would collapse it to a ~1970 timestamp and wrongly expire the member -- so we
+		// bail instead.
+		if ( empty( $team_end ) || ! is_numeric( $team_end ) ) {
 			return;
 		}
 

--- a/plugins/newspack-plugin/tests/mocks/teams-for-memberships-membership-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/teams-for-memberships-membership-mocks.php
@@ -4,9 +4,11 @@
  * Stub User Membership for sync_member_end_date_to_team() unit tests, plus the
  * namespaced Team stub it pairs with.
  *
- * These carry the real class names so the method's is_a() guards pass, and record
- * set_end_date()/update_status() calls so tests can assert on the side effects, in
- * an environment where neither WC Memberships nor SkyVerge Teams is loaded.
+ * These carry the real class names so the method's is_a() guards pass. The hook
+ * records set_end_date() calls; update_status()/status_calls are retained only as a
+ * forward regression guard -- the hook makes no status change today, so the
+ * status_calls assertions trip only if one is ever reintroduced. Runs where neither
+ * WC Memberships nor SkyVerge Teams is loaded.
  *
  * @package Newspack\Tests
  */
@@ -36,10 +38,6 @@ if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
 		public function set_end_date( $date = '' ) {
 			$this->set_end_calls[] = $date;
 			$this->end_ts          = is_numeric( $date ) ? (int) $date : strtotime( $date );
-		}
-
-		public function is_expired() {
-			return 'expired' === $this->status;
 		}
 
 		public function update_status( $status ) {

--- a/plugins/newspack-plugin/tests/mocks/teams-for-memberships-membership-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/teams-for-memberships-membership-mocks.php
@@ -1,0 +1,54 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, WordPress.NamingConventions.PrefixAllGlobals
+
+/**
+ * Stub User Membership for sync_member_end_date_to_team() unit tests, plus the
+ * namespaced Team stub it pairs with.
+ *
+ * These carry the real class names so the method's is_a() guards pass, and record
+ * set_end_date()/update_status() calls so tests can assert on the side effects, in
+ * an environment where neither WC Memberships nor SkyVerge Teams is loaded.
+ *
+ * @package Newspack\Tests
+ */
+
+require_once __DIR__ . '/teams-for-memberships-team-mock.php';
+
+if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+	class WC_Memberships_User_Membership {
+		public $end_ts;
+		public $status;
+		public $set_end_calls = [];
+		public $status_calls  = [];
+		public $notes         = [];
+
+		public function __construct( $end_ts = 0, $status = 'active' ) {
+			$this->end_ts = $end_ts;
+			$this->status = $status;
+		}
+
+		public function get_end_date( $format = 'mysql' ) {
+			if ( empty( $this->end_ts ) ) {
+				return null;
+			}
+			return 'timestamp' === $format ? (int) $this->end_ts : gmdate( 'Y-m-d H:i:s', (int) $this->end_ts );
+		}
+
+		public function set_end_date( $date = '' ) {
+			$this->set_end_calls[] = $date;
+			$this->end_ts          = is_numeric( $date ) ? (int) $date : strtotime( $date );
+		}
+
+		public function is_expired() {
+			return 'expired' === $this->status;
+		}
+
+		public function update_status( $status ) {
+			$this->status_calls[] = $status;
+			$this->status         = $status;
+		}
+
+		public function add_note( $note ) {
+			$this->notes[] = $note;
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/mocks/teams-for-memberships-team-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/teams-for-memberships-team-mock.php
@@ -1,0 +1,35 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, WordPress.NamingConventions.PrefixAllGlobals
+
+/**
+ * Stub SkyVerge Teams Team for sync_member_end_date_to_team() unit tests.
+ *
+ * Carries the real class name so the method's is_a() guard passes, and answers
+ * the get_membership_end_date() call the method makes.
+ *
+ * @package Newspack\Tests
+ */
+
+namespace SkyVerge\WooCommerce\Memberships\Teams;
+
+if ( ! class_exists( __NAMESPACE__ . '\\Team' ) ) {
+	class Team {
+		public $id;
+		public $end_ts;
+
+		public function __construct( $id, $end_ts ) {
+			$this->id     = $id;
+			$this->end_ts = $end_ts;
+		}
+
+		public function get_id() {
+			return $this->id;
+		}
+
+		public function get_membership_end_date( $format = 'mysql' ) {
+			if ( empty( $this->end_ts ) ) {
+				return null;
+			}
+			return 'timestamp' === $format ? (int) $this->end_ts : gmdate( 'Y-m-d H:i:s', (int) $this->end_ts );
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/teams-for-memberships.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/teams-for-memberships.php
@@ -8,6 +8,7 @@
 use Newspack\Teams_For_Memberships;
 
 require_once __DIR__ . '/../../mocks/teams-for-memberships-mocks.php';
+require_once __DIR__ . '/../../mocks/teams-for-memberships-membership-mocks.php';
 
 /**
  * Test Teams_For_Memberships helpers.
@@ -155,5 +156,124 @@ class Test_Teams_For_Memberships extends WP_UnitTestCase {
 
 		$this->assertSame( 'create', $result, 'Action should be unchanged for unrelated product items.' );
 		$this->assertArrayNotHasKey( $item_id, $GLOBALS['teams_mock_item_meta'], 'No meta should be written for unrelated items.' );
+	}
+
+	/**
+	 * The member end-date sync must be registered on member-add at priority 20,
+	 * after Teams' own subscription integration (priority 10).
+	 */
+	public function test_sync_member_end_date_hook_is_registered() {
+		$this->assertSame(
+			20,
+			has_action(
+				'wc_memberships_for_teams_add_team_member',
+				[ Teams_For_Memberships::class, 'sync_member_end_date_to_team' ]
+			),
+			'sync_member_end_date_to_team should be hooked at priority 20.'
+		);
+	}
+
+	/**
+	 * The core bug: a member with no end date on a team that has a future end
+	 * date should inherit the team's end date.
+	 */
+	public function test_sync_stamps_team_end_when_member_has_none() {
+		$team_end = time() + ( 30 * DAY_IN_SECONDS );
+		$team     = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 101, $team_end );
+		$um       = new \WC_Memberships_User_Membership( 0, 'active' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
+
+		$this->assertSame(
+			[ gmdate( 'Y-m-d H:i:s', $team_end ) ],
+			$um->set_end_calls,
+			'The member end date should be set to the team end date (as a UTC string).'
+		);
+		$this->assertSame( [], $um->status_calls, 'An already-active membership needs no status change.' );
+	}
+
+	/**
+	 * A finite member end date that is shorter than the team end should be
+	 * extended up to the team end.
+	 */
+	public function test_sync_extends_shorter_member_end() {
+		$team_end   = time() + ( 60 * DAY_IN_SECONDS );
+		$member_end = time() + ( 10 * DAY_IN_SECONDS );
+		$team       = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 102, $team_end );
+		$um         = new \WC_Memberships_User_Membership( $member_end, 'active' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
+
+		$this->assertSame( [ gmdate( 'Y-m-d H:i:s', $team_end ) ], $um->set_end_calls );
+	}
+
+	/**
+	 * A member who already holds a longer end date (e.g. a separately purchased
+	 * individual membership) must keep it -- the sync never shortens.
+	 */
+	public function test_sync_preserves_longer_member_end() {
+		$team_end   = time() + ( 30 * DAY_IN_SECONDS );
+		$member_end = time() + ( 365 * DAY_IN_SECONDS );
+		$team       = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 103, $team_end );
+		$um         = new \WC_Memberships_User_Membership( $member_end, 'active' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
+
+		$this->assertSame( [], $um->set_end_calls, 'A longer existing end date must not be overwritten.' );
+		$this->assertSame( [], $um->status_calls );
+	}
+
+	/**
+	 * Unlimited team (no end date): the sync must be a no-op.
+	 */
+	public function test_sync_is_noop_for_unlimited_team() {
+		$team = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 104, 0 );
+		$um   = new \WC_Memberships_User_Membership( 0, 'active' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
+
+		$this->assertSame( [], $um->set_end_calls, 'Nothing should be written for an unlimited team.' );
+	}
+
+	/**
+	 * A previously-expired membership absorbed into a still-current team should
+	 * be reactivated (is_active() does not auto-reactivate).
+	 */
+	public function test_sync_reactivates_expired_member_for_future_team() {
+		$team_end = time() + ( 30 * DAY_IN_SECONDS );
+		$team     = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 105, $team_end );
+		$um       = new \WC_Memberships_User_Membership( 0, 'expired' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
+
+		$this->assertSame( [ gmdate( 'Y-m-d H:i:s', $team_end ) ], $um->set_end_calls );
+		$this->assertSame( [ 'active' ], $um->status_calls, 'An expired member on a current team should be reactivated.' );
+	}
+
+	/**
+	 * A member added to an already-lapsed team gets the past end date but must
+	 * NOT be force-expired here -- that would synchronously fire the ESP
+	 * list-removal side effect. is_active() expires it lazily instead.
+	 */
+	public function test_sync_does_not_force_expire_for_lapsed_team() {
+		$team_end = time() - ( 30 * DAY_IN_SECONDS );
+		$team     = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 106, $team_end );
+		$um       = new \WC_Memberships_User_Membership( 0, 'active' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
+
+		$this->assertSame( [ gmdate( 'Y-m-d H:i:s', $team_end ) ], $um->set_end_calls, 'The past team end date should still be applied.' );
+		$this->assertSame( [], $um->status_calls, 'The membership must not be force-expired on add.' );
+	}
+
+	/**
+	 * Defensive guards: a non-Team object must be a no-op (safe when Teams is absent).
+	 */
+	public function test_sync_ignores_non_team_object() {
+		$um = new \WC_Memberships_User_Membership( 0, 'active' );
+
+		Teams_For_Memberships::sync_member_end_date_to_team( null, new \stdClass(), $um );
+
+		$this->assertSame( [], $um->set_end_calls, 'A non-Team object should be ignored.' );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/teams-for-memberships.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/teams-for-memberships.php
@@ -193,10 +193,11 @@ class Test_Teams_For_Memberships extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A finite member end date that is shorter than the team end should be
-	 * extended up to the team end.
+	 * A membership that already has an end date is left untouched -- whatever the
+	 * plan or upstream Team::add_member() set is owned by them. This is true even
+	 * when that date is shorter than the team end (we only fill missing dates).
 	 */
-	public function test_sync_extends_shorter_member_end() {
+	public function test_sync_skips_member_with_existing_end_date() {
 		$team_end   = time() + ( 60 * DAY_IN_SECONDS );
 		$member_end = time() + ( 10 * DAY_IN_SECONDS );
 		$team       = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 102, $team_end );
@@ -204,7 +205,8 @@ class Test_Teams_For_Memberships extends WP_UnitTestCase {
 
 		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
 
-		$this->assertSame( [ gmdate( 'Y-m-d H:i:s', $team_end ) ], $um->set_end_calls );
+		$this->assertSame( [], $um->set_end_calls, 'An existing end date must not be overwritten.' );
+		$this->assertSame( [], $um->status_calls );
 	}
 
 	/**
@@ -236,10 +238,11 @@ class Test_Teams_For_Memberships extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A previously-expired membership absorbed into a still-current team should
-	 * be reactivated (is_active() does not auto-reactivate).
+	 * The hook only fills the end date; it never changes membership status, so it
+	 * triggers no synchronous ESP list mutations. Upstream Team::add_member()
+	 * already reconciles status, and is_active() handles lazy expiry.
 	 */
-	public function test_sync_reactivates_expired_member_for_future_team() {
+	public function test_sync_does_not_change_status_when_filling_date() {
 		$team_end = time() + ( 30 * DAY_IN_SECONDS );
 		$team     = new \SkyVerge\WooCommerce\Memberships\Teams\Team( 105, $team_end );
 		$um       = new \WC_Memberships_User_Membership( 0, 'expired' );
@@ -247,7 +250,7 @@ class Test_Teams_For_Memberships extends WP_UnitTestCase {
 		Teams_For_Memberships::sync_member_end_date_to_team( null, $team, $um );
 
 		$this->assertSame( [ gmdate( 'Y-m-d H:i:s', $team_end ) ], $um->set_end_calls );
-		$this->assertSame( [ 'active' ], $um->status_calls, 'An expired member on a current team should be reactivated.' );
+		$this->assertSame( [], $um->status_calls, 'The hook must not change membership status.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Ensures a team member's access expires no later than their team membership's expiration date.**

When a member is added to a WooCommerce Memberships **team**, the member's user membership was not always given an end date. Teams only propagates the team's expiration onto a member's membership when the member already had an existing membership, or when the team is tied to a WooCommerce subscription. For **manually-managed teams** — a team with a fixed end date but no subscription behind it — a freshly created member membership was left with the plan-relative end date, which resolves to *empty* for unlimited/subscription-typed plans. The result: the member never expired, keeping access indefinitely even after the team membership lapsed.

This adds a hook on `wc_memberships_for_teams_add_team_member` that stamps the team's expiration date onto the new member's user membership:

- **Manually-managed (non-subscription) teams** — members now inherit the team's end date instead of getting none.
- **Only ever shortens down to the team end date** — a member who already holds a *longer* end date (e.g. a separately purchased individual membership) keeps it.
- **Schedules the per-membership expiry event** — calling `set_end_date()` (re)schedules `wc_memberships_user_membership_expiry`, so members expire on time on their own.
- **Subscription-tied teams are unaffected** — the hook runs at priority 20, after Teams' own subscription integration (priority 10); for those teams the member end date already matches the team end date, so nothing changes.

Closes NPPM-2932.

### How to test the changes in this Pull Request:

Regression (manually-managed team — the bug):
1. With WooCommerce Memberships + Memberships for Teams active, create a membership plan with **no** access length (unlimited) and **no** subscription product.
2. Create a team on that plan (e.g. via Memberships → Teams) and set a fixed **Team membership end date** in the future.
3. Add a member to the team.
4. Open the member's user membership and confirm its **end date now matches the team's end date** (before this PR it was empty).
5. Confirm a scheduled `wc_memberships_user_membership_expiry` action exists for that membership at the team end date (Tools → Scheduled Actions), so the member will expire when the team does.

Preserve longer access:
6. Give a user an individual membership on the same plan with an end date **further out** than the team's end date, then add them to the team. Confirm their later end date is **preserved**, not shortened.

No regression (subscription-tied team):
7. Create a subscription-product-backed team and add a member. Confirm the member's end date still tracks the subscription/team end date as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

---

## For AI

**Root cause.** Two code paths set a new team member's user-membership end date:

1. `Team::add_member()` (in `woocommerce-memberships-for-teams`) creates the membership via `wc_memberships_create_user_membership()` with **no** end date. Core then derives the end date from `MembershipPlan::get_expiration_date( $now, $args )` — plan/product length relative to *now*, which is **empty** for unlimited (and auto-renew-less subscription) plans. The team's own `_membership_end_date` is only synced in the *existing-membership* branch (`959-964`), never the *new-membership* branch (`981-994`).
2. The Teams Subscriptions integration `adjust_team_member_user_membership_data()` would set it from the subscription, but it is guarded by `if ( $subscription )` and bails entirely for non-subscription teams.

Manually-managed teams (no `_subscription_id`, fixed `_membership_end_date`) hit neither, so members get no end date.

**Fix.** `Newspack\Teams_For_Memberships::sync_member_end_date_to_team()` on `wc_memberships_for_teams_add_team_member` (priority 20, after the subscription integration's 10). It reads `$team->get_membership_end_date( 'timestamp' )`, returns early for unlimited teams, and only sets the member end date when it is shorter than the team end (`$member_end < $team_end`), preserving longer individual memberships. It mirrors `Team::set_membership_end_date()`'s status handling (reactivate if future, expire if past).

**Scope note.** This is the forward fix only. Existing members on affected sites (members already created with empty/incorrect end dates) need a separate one-off backfill that sets each member's end date to their team's end date via `set_end_date()` (so the expiry event reschedules). The fragile difference-based adjustment in `Team::set_membership_end_date()` (which produces drifting dates when an admin edits the team end date) is a vendor-side design issue left for upstream.
