### PR TITLE
feat(insights): conversion registration-leg empty states (NPPD-1743)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -229,8 +229,16 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			[
 				// Section 1.
 				'reader_lifecycle_funnel'          => array_merge( $error, [ 'stages' => [] ] ),
-				// Section 2.
-				'anonymous_to_registered_funnel'   => array_merge( $error, [ 'stages' => [] ] ),
+				// Section 2. Registration leg is always visible (NPPD-1743) — carries
+				// the gated shape live code now stamps via with_leg_visibility().
+				'anonymous_to_registered_funnel'   => array_merge(
+					$error,
+					[
+						'stages'            => [],
+						'visibility'        => 'visible',
+						'visibility_reason' => null,
+					]
+				),
 				// Config-matrix legs (NPPD-1742): configured (visible); the query errored.
 				'registered_to_subscriber_funnel'  => array_merge(
 					$error,
@@ -343,8 +351,15 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			[
 				// Section 1.
 				'reader_lifecycle_funnel'          => $empty_stages,
-				// Section 2.
-				'anonymous_to_registered_funnel'   => $empty_stages,
+				// Section 2. Registration leg always visible (NPPD-1743), no rows →
+				// component renders the funnel-shaped no_opportunity treatment.
+				'anonymous_to_registered_funnel'   => array_merge(
+					$empty_stages,
+					[
+						'visibility'        => 'visible',
+						'visibility_reason' => null,
+					]
+				),
 				// Config-matrix legs (NPPD-1742): configured (visible) but no rows →
 				// the component renders the funnel-shaped no_opportunity treatment.
 				'registered_to_subscriber_funnel'  => array_merge(
@@ -664,10 +679,12 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 					'state'  => 'populated',
 					'stages' => $s1_stages,
 				],
-				// Section 2.
+				// Section 2. Registration leg always visible (NPPD-1743).
 				'anonymous_to_registered_funnel'   => [
-					'state'  => 'populated',
-					'stages' => $a2r_stages,
+					'state'             => 'populated',
+					'stages'            => $a2r_stages,
+					'visibility'        => 'visible',
+					'visibility_reason' => null,
 				],
 				// Config-matrix legs (NPPD-1742): visible in the populated fixture.
 				'registered_to_subscriber_funnel'  => [

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -562,15 +562,31 @@ final class Conversion_Metric {
 	// --- Section 2: Per-journey conversion funnels ----------------------
 
 	/**
-	 * Anonymous → Registered funnel (2.1) — three stages. Dispatches
-	 * `conversion_journey_funnel_anon_to_registered`; the hub returns one row
-	 * with step_1_anonymous, step_2_saw_conversion_surface, step_3_registered.
+	 * Anonymous → Registered funnel (2.1) — three stages. Always rendered: there
+	 * is no configuration gate for the registration journey (every site can
+	 * register readers), so the leg is stamped `visibility: 'visible'` and its
+	 * empty states are data-driven (NPPD-1743), mirroring the subscription and
+	 * donation legs' funnel-shaped empty-state treatment from NPPD-1742.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array{state: string, stages: array<int, array{label: string, count: int, pct_of_top: float}>, visibility: string, visibility_reason: string|null}
+	 */
+	public function get_anonymous_to_registered_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return $this->with_leg_visibility( $this->compute_anonymous_to_registered_funnel( $start, $end ) );
+	}
+
+	/**
+	 * Build the Anonymous → Registered funnel payload (no visibility gating).
+	 * Dispatches `conversion_journey_funnel_anon_to_registered`; the hub returns
+	 * one row with step_1_anonymous, step_2_saw_conversion_surface,
+	 * step_3_registered.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array{state: string, stages: array<int, array{label: string, count: int, pct_of_top: float}>}
 	 */
-	public function get_anonymous_to_registered_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
+	private function compute_anonymous_to_registered_funnel( DateTimeInterface $start, DateTimeInterface $end ): array {
 		$rows = $this->proxy->query( 'conversion_journey_funnel_anon_to_registered', $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_collection( 'stages', $rows );

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -210,7 +210,10 @@ export interface ConversionWindow {
 	// Section 1 — The reader lifecycle.
 	reader_lifecycle_funnel: ConversionFunnelData;
 	// Section 2 — Per-journey conversion funnels.
-	anonymous_to_registered_funnel: ConversionFunnelData;
+	// The registration leg is always visible (no config gate), but carries the
+	// same gated shape so it can use the shared empty-state cell (NPPD-1743):
+	// `visibility: 'visible'`, `visibility_reason: null`.
+	anonymous_to_registered_funnel: ConversionGatedFunnelData;
 	// Subscription / donation legs carry the config-matrix visibility gate
 	// (NPPD-1742): `visibility: 'hidden'` + reason `'not_configured'` when the
 	// publisher doesn't run that reader-revenue stream.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
@@ -147,3 +147,57 @@ describe( 'PerJourneyConversionFunnelsSection — per-leg states (NPPD-1742)', (
 		expect( screen.getByText( /250 registered readers saw a donation prompt, but none donated/ ) ).toBeInTheDocument();
 	} );
 } );
+
+describe( 'PerJourneyConversionFunnelsSection — registration leg states (NPPD-1743)', () => {
+	const registrationLeg = ( opts: Parameters< typeof conversionLeg >[ 0 ] = {} ) =>
+		conversionLeg( { labels: [ 'Anonymous', 'Saw a conversion surface', 'Registered' ], ...opts } );
+
+	it( 'no_opportunity: nobody entered the journey → swaps the funnel for the no-opportunity note', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( { anonymousToRegisteredFunnel: registrationLeg( { state: 'empty' } ) } ) }
+			/>
+		);
+		// The leg is always visible; the heading stays and the no_opportunity copy shows.
+		expect( heading( 'Anonymous → Registered' ) ).toBeInTheDocument();
+		expect( screen.getByText( /No readers entered the registration journey in this timeframe/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'no_conversions: keeps the funnel and annotates with {N} = prior-stage base', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					anonymousToRegisteredFunnel: registrationLeg( { entry: 1000, prior: 600, conversion: 0 } ),
+				} ) }
+			/>
+		);
+		expect( screen.getByText( /600 readers saw a registration prompt or gate, but none registered/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /No readers entered the registration journey/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'with registrations: renders the normal funnel with no empty-state note', () => {
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					anonymousToRegisteredFunnel: registrationLeg( { entry: 1000, prior: 600, conversion: 200 } ),
+				} ) }
+			/>
+		);
+		expect( screen.queryByText( /No readers entered the registration journey/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /but none registered/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'registrations but zero prior-stage base: normal funnel, no contradictory no_conversions note', () => {
+		// Guards the priorStage===0 edge: readers registered but nobody reached the
+		// saw-a-surface stage, so the "{0} saw a prompt or gate" note must not render.
+		render(
+			<PerJourneyConversionFunnelsSection
+				current={ makeConversionWindow( {
+					anonymousToRegisteredFunnel: registrationLeg( { entry: 1000, prior: 0, conversion: 0 } ),
+				} ) }
+			/>
+		);
+		expect( screen.queryByText( /saw a registration prompt or gate/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /No readers entered the registration journey/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -1,5 +1,5 @@
 /**
- * PerJourneyConversionFunnelsSection (NPPD-1609, Section 2; empty states NPPD-1742).
+ * PerJourneyConversionFunnelsSection (NPPD-1609, Section 2; empty states NPPD-1742, NPPD-1743).
  *
  * Funnels in a grid: anonymous → registered (2.1), registered → subscriber
  * (2.2), registered → donor (2.3), and the visibility-gated subscriber → donor
@@ -18,9 +18,10 @@
  *     note, `{N}` = the prior-stage base;
  *   - otherwise → the normal funnel.
  *
- * The registration leg (2.1) is intentionally left as-is — its empty-state
- * treatment needs hub-side registration counts and is tracked in NPPD-1743.
- * Section 2.4 keeps its own cohort-size visibility gate, unchanged.
+ * The registration leg (2.1) gets the same funnel-shaped empty states (NPPD-1743),
+ * driven by its own funnel stages (anonymous → saw a conversion surface →
+ * registered); it is always visible (no config gate). Section 2.4 keeps its own
+ * cohort-size visibility gate, unchanged.
  *
  * Body copy here is provisional, mirroring the sibling shape; final wording is
  * owned by the voice-and-tone audit (NPPD-1698).
@@ -34,7 +35,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { ConversionFunnelData, ConversionGatedFunnelData, ConversionWindow } from '../../api/conversion';
+import type { ConversionGatedFunnelData, ConversionWindow } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
 import SectionEmpty from '../components/SectionEmpty';
 import { formatNumber } from '../components/format';
@@ -57,17 +58,6 @@ const JourneyFunnel = ( { title, caption, children }: JourneyFunnelProps ) => (
 		<p className="newspack-insights__conversion-subcaption">{ caption }</p>
 		{ children }
 	</div>
-);
-
-interface StandardFunnelCellProps {
-	data: ConversionFunnelData;
-	emptyMessage: string;
-}
-
-const StandardFunnelCell = ( { data, emptyMessage }: StandardFunnelCellProps ) => (
-	<SectionState state={ data.state } emptyMessage={ emptyMessage }>
-		<Funnel stages={ data.stages } />
-	</SectionState>
 );
 
 interface GatedFunnelCellProps {
@@ -183,10 +173,18 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 						'newspack-plugin'
 					) }
 				>
-					<StandardFunnelCell
+					<ConversionLegCell
 						data={ current.anonymous_to_registered_funnel }
 						emptyMessage={ __(
 							'No registration funnel data yet. This will populate once registrations occur in this timeframe.',
+							'newspack-plugin'
+						) }
+						noOpportunityMessage={ __(
+							'No readers entered the registration journey in this timeframe. Try a wider date range.',
+							'newspack-plugin'
+						) }
+						noConversionsBody={ __(
+							'No new registrations in this timeframe. {N} readers saw a registration prompt or gate, but none registered — the funnel below shows where they dropped off.',
 							'newspack-plugin'
 						) }
 					/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
@@ -53,11 +53,13 @@ const gatedFunnel = ( visibility: ConversionVisibility, state: ConversionMetricS
 } );
 
 /**
- * A config-matrix conversion leg (NPPD-1742) — Section 2.2 / 2.3. Builds a
- * three-stage gated funnel with controllable entry/prior/conversion counts so
- * tests can drive the funnel-shaped states: entry 0 → no_opportunity; entry > 0
- * & conversion 0 → no_conversions; all > 0 → normal. `visibility: 'hidden'`
- * models an unconfigured stream (reason `'not_configured'`).
+ * A config-matrix conversion leg (NPPD-1742) — Section 2.2 / 2.3, and the
+ * always-visible registration leg (NPPD-1743). Builds a three-stage gated funnel
+ * with controllable entry/prior/conversion counts so tests can drive the
+ * funnel-shaped states: entry 0 → no_opportunity; entry > 0 & conversion 0 →
+ * no_conversions; all > 0 → normal. `visibility: 'hidden'` models an
+ * unconfigured stream (reason `'not_configured'`). `labels` overrides the stage
+ * labels for legs other than subscription/donation.
  */
 export const conversionLeg = (
 	opts: {
@@ -67,18 +69,27 @@ export const conversionLeg = (
 		prior?: number;
 		conversion?: number;
 		reason?: ConversionVisibilityReason;
+		labels?: [ string, string, string ];
 	} = {}
 ): ConversionGatedFunnelData => {
-	const { visibility = 'visible', state = 'populated', entry = 1000, prior = 400, conversion = 80, reason } = opts;
+	const {
+		visibility = 'visible',
+		state = 'populated',
+		entry = 1000,
+		prior = 400,
+		conversion = 80,
+		reason,
+		labels = [ 'Registered', 'Saw a conversion-intent surface', 'Converted' ],
+	} = opts;
 	const top = entry > 0 ? entry : 1;
 	return {
 		state,
 		stages:
 			state === 'populated'
 				? [
-						{ label: 'Registered', count: entry, pct_of_top: entry / top },
-						{ label: 'Saw a conversion-intent surface', count: prior, pct_of_top: prior / top },
-						{ label: 'Converted', count: conversion, pct_of_top: conversion / top },
+						{ label: labels[ 0 ], count: entry, pct_of_top: entry / top },
+						{ label: labels[ 1 ], count: prior, pct_of_top: prior / top },
+						{ label: labels[ 2 ], count: conversion, pct_of_top: conversion / top },
 				  ]
 				: [],
 		visibility,
@@ -138,6 +149,8 @@ export interface ConversionWindowOverrides {
 	subscriptionVisibility?: ConversionVisibility;
 	/** Config-matrix visibility for the donation leg (2.3), NPPD-1742. */
 	donationVisibility?: ConversionVisibility;
+	/** Full override of the registration leg (for the funnel-shaped states), NPPD-1743. */
+	anonymousToRegisteredFunnel?: ConversionGatedFunnelData;
 	/** Full override of the subscription leg (for the funnel-shaped states). */
 	registeredToSubscriberFunnel?: ConversionGatedFunnelData;
 	/** Full override of the donation leg (for the funnel-shaped states). */
@@ -168,8 +181,11 @@ export const makeConversionWindow = ( overrides: ConversionWindowOverrides = {} 
 		'Newsletter subscriber',
 		'Subscriber or donor'
 	),
-	// Section 2 — Phase A, wired.
-	anonymous_to_registered_funnel: funnel( 'populated', 'Anonymous', 'Saw a conversion surface', 'Registered' ),
+	// Section 2 — Phase A, wired. Registration leg is always visible (NPPD-1743)
+	// and carries the gated shape so it can use the shared empty-state cell.
+	anonymous_to_registered_funnel:
+		overrides.anonymousToRegisteredFunnel ??
+		conversionLeg( { entry: 5000, prior: 1800, conversion: 600, labels: [ 'Anonymous', 'Saw a conversion surface', 'Registered' ] } ),
 	registered_to_subscriber_funnel:
 		overrides.registeredToSubscriberFunnel ?? conversionLeg( { visibility: overrides.subscriptionVisibility ?? 'visible' } ),
 	registered_to_donor_funnel: overrides.registeredToDonorFunnel ?? conversionLeg( { visibility: overrides.donationVisibility ?? 'visible' } ),

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -323,6 +323,11 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'pending', $result );
 		$this->assertCount( 3, $result['stages'] );
 
+		// NPPD-1743: registration leg is always visible (no config gate) so it
+		// carries the same gated shape the subscription/donation legs do.
+		$this->assertSame( 'visible', $result['visibility'] );
+		$this->assertNull( $result['visibility_reason'] );
+
 		// Stage 1: top → pct_of_top must be 1.0.
 		$this->assertSame( 500, $result['stages'][0]['count'] );
 		$this->assertSame( 1.0, $result['stages'][0]['pct_of_top'] );
@@ -366,6 +371,10 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['stages'] );
+		// Always visible even with no rows — drives the data-driven no_opportunity
+		// empty state rather than hiding the leg (NPPD-1743).
+		$this->assertSame( 'visible', $result['visibility'] );
+		$this->assertNull( $result['visibility_reason'] );
 	}
 
 	/**
@@ -381,6 +390,10 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
 		$this->assertSame( 'HTTP 503', $result['error_message'] );
 		$this->assertSame( [], $result['stages'] );
+		// The visibility stamp is unconditional — even an errored leg renders
+		// (the cell shows the shared error treatment), never hidden (NPPD-1743).
+		$this->assertSame( 'visible', $result['visibility'] );
+		$this->assertNull( $result['visibility_reason'] );
 	}
 
 	// --- C4: get_source_mix_registrations ----------------------------------

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1807,6 +1807,10 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		// Section 2 — per-journey funnels.
 		$this->assertSame( 'populated', $current['anonymous_to_registered_funnel']['state'] );
 		$this->assertCount( 3, $current['anonymous_to_registered_funnel']['stages'] );
+		// Registration leg fixture must carry the same always-visible shape as
+		// live (NPPD-1743), so fixture mode matches production.
+		$this->assertSame( 'visible', $current['anonymous_to_registered_funnel']['visibility'] );
+		$this->assertNull( $current['anonymous_to_registered_funnel']['visibility_reason'] );
 		$this->assertSame( 'populated', $current['registered_to_subscriber_funnel']['state'] );
 		$this->assertSame( 'populated', $current['registered_to_donor_funnel']['state'] );
 


### PR DESCRIPTION
## Why

[NPPD-1743](https://linear.app/a8c/issue/NPPD-1743) — sub-issue of NPPD-1739. Gives the **Anonymous → Registered** leg of the Conversion Journeys tab the same `EmptyMetricSection`-style empty states the subscription and donation legs got in NPPD-1742 (PR #371). Until now it was the one leg left on the plain `StandardFunnelCell`.

## Recon correction

The ticket framed this as blocked on hub-side registration counts (`registration_impressions_total` / `registrations_total`, the NPPD-1744 / NPPD-1702 dependency). On inspection that premise doesn't hold: the registration leg is driven by its **own** funnel query `conversion_journey_funnel_anon_to_registered`, which already returns always-present live counts (`step_1_anonymous` → `step_2_saw_conversion_surface` → `step_3_registered`). Those Gates-regwall columns are a different surface and aren't consumed here. So — same as NPPD-1742's recon correction — the real work is just to mirror the sub/donation funnel-stage empty-state treatment. No new hub work, no consumption of #467.

## Changes

- **PHP** (`class-conversion-metric.php`): split `get_anonymous_to_registered_funnel()` into a `compute_*` body + a wrapper that stamps `visibility: 'visible'` / `visibility_reason: null` via the existing `with_leg_visibility()`. The leg is always rendered (no config gate); empty states are data-driven.
- **TS** (`conversion.ts`): `anonymous_to_registered_funnel` retyped `ConversionFunnelData` → `ConversionGatedFunnelData`.
- **React** (`PerJourneyConversionFunnelsSection.tsx`): registration leg swapped `StandardFunnelCell` → the shared, tested `ConversionLegCell` (entry 0 → `no_opportunity`; entry > 0 & conversion 0 & prior > 0 → `no_conversions` with `{N}` = prior-stage base; else the funnel). Removed the now-dead `StandardFunnelCell`.
- **Fixtures/tests**: generalized `conversionLeg` with an optional `labels` param so the registration leg reuses it honestly; added 4 React tests + PHP visibility assertions.

## Copy

Placeholder, mirroring the sub/donation wording and using "timeframe" — e.g. *"No new registrations in this timeframe. {N} readers saw a registration prompt or gate, but none registered…"*. **Final wording owned by the voice-and-tone audit (NPPD-1698).**

## Tests

- PHP: `php -l` + workspace-root PHPCS clean; behavior verified (populated/empty/error all carry `visibility: 'visible'`).
- JS: conversion-tab Jest suite **16/16** (4 new registration-leg cases + the 12 existing config-matrix / sub-donation cases — no regression).
- `tsc --noEmit` + ESLint clean.