### PR TITLE
fix(popups): prevent stale prompt settings saves

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -89,6 +89,8 @@ final class Newspack_Popups {
 		add_action( 'init', [ __CLASS__, 'disable_prompts_for_protected_pages' ] );
 		add_action( 'init', [ __CLASS__, 'maybe_create_temp_reader_session' ] );
 		add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_action( 'add_meta_boxes_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'remove_custom_fields_meta_box' ], 99 );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
@@ -175,6 +177,15 @@ final class Newspack_Popups {
 			'menu_icon'    => 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDI0IDI0IiByb2xlPSJpbWciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02Ljg2MyAxMy42NDRMNSAxMy4yNWgtLjVhLjUuNSAwIDAxLS41LS41di0zYS41LjUgMCAwMS41LS41SDVMMTggNi41aDJWMTZoLTJsLTMuODU0LS44MTUuMDI2LjAwOGEzLjc1IDMuNzUgMCAwMS03LjMxLTEuNTQ5em0xLjQ3Ny4zMTNhMi4yNTEgMi4yNTEgMCAwMDQuMzU2LjkyMWwtNC4zNTYtLjkyMXptLTIuODQtMy4yOEwxOC4xNTcgOGguMzQzdjYuNWgtLjM0M0w1LjUgMTEuODIzdi0xLjE0NnoiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0id2hpdGUiPjwvcGF0aD48L3N2Zz4K',
 		];
 		\register_post_type( self::NEWSPACK_POPUPS_CPT, $cpt_args );
+	}
+
+	/**
+	 * Remove the core Custom Fields metabox from the Prompt editor.
+	 *
+	 * @param WP_Post $post The current post object.
+	 */
+	public static function remove_custom_fields_meta_box( $post ) {
+		remove_meta_box( 'postcustom', self::NEWSPACK_POPUPS_CPT, 'normal' );
 	}
 
 	/**
@@ -688,20 +699,27 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Load up common JS/CSS for the editor.
+	 * Load block assets in the editor.
 	 */
 	public static function enqueue_block_assets() {
 		if ( ! is_admin() ) {
 			return;
 		}
-		$screen = get_current_screen();
 
 		// Block assets for Custom Placement and Prompt blocks.
+		$dist_dir           = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist';
+		$blocks_asset_path  = trailingslashit( $dist_dir ) . 'blocks.asset.php';
+		$blocks_script_path = trailingslashit( $dist_dir ) . 'blocks.js';
+		if ( ! self::build_assets_exist( [ $blocks_asset_path, $blocks_script_path ] ) ) {
+			return;
+		}
+
+		$blocks_asset = require $blocks_asset_path;
 		\wp_enqueue_script(
 			'newspack-popups-blocks',
 			plugins_url( '../dist/blocks.js', __FILE__ ),
-			[],
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.js' ),
+			$blocks_asset['dependencies'] ?? [],
+			$blocks_asset['version'] ?? filemtime( $blocks_script_path ),
 			true
 		);
 
@@ -716,14 +734,60 @@ final class Newspack_Popups {
 			]
 		);
 
-		\wp_register_style(
-			'newspack-popups-blocks',
-			plugins_url( '../dist/blocks.css', __FILE__ ),
-			[],
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.css' )
+		$blocks_style_path = trailingslashit( $dist_dir ) . 'blocks.css';
+		if ( self::build_assets_exist( [ $blocks_style_path ] ) ) {
+			\wp_register_style(
+				'newspack-popups-blocks',
+				plugins_url( '../dist/blocks.css', __FILE__ ),
+				[],
+				$blocks_asset['version'] ?? filemtime( $blocks_style_path )
+			);
+			wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
+			wp_enqueue_style( 'newspack-popups-blocks' );
+		}
+	}
+
+	/**
+	 * Check that generated build assets exist.
+	 *
+	 * @param string[] $asset_paths Build asset paths.
+	 *
+	 * @return bool Whether all assets exist.
+	 */
+	private static function build_assets_exist( $asset_paths ) {
+		$missing_asset_paths = array_filter(
+			$asset_paths,
+			function ( $asset_path ) {
+				return ! file_exists( $asset_path );
+			}
 		);
-		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
-		wp_enqueue_style( 'newspack-popups-blocks' );
+
+		if ( empty( $missing_asset_paths ) ) {
+			return true;
+		}
+
+		$plugin_dir     = trailingslashit( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) );
+		$relative_paths = array_map(
+			function ( $asset_path ) use ( $plugin_dir ) {
+				return str_replace( $plugin_dir, '', $asset_path );
+			},
+			$missing_asset_paths
+		);
+
+		error_log( sprintf( 'Newspack Popups build assets missing: %s', implode( ', ', $relative_paths ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+
+		return false;
+	}
+
+	/**
+	 * Load prompt editor UI assets.
+	 */
+	public static function enqueue_block_editor_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$screen = get_current_screen();
 
 		// Don't enqueue Prompt editor files if we don't have a valid post type or ID (e.g. on the Widget Blocks screen).
 		if ( empty( $screen->post_type ) || empty( get_the_ID() ) ) {
@@ -736,11 +800,18 @@ final class Newspack_Popups {
 			$supported_post_types = Newspack_Popups_Model::get_default_popup_post_types();
 			if ( in_array( $screen->post_type, $supported_post_types, true ) ) {
 				// But it's a supported post type.
+				$document_settings_asset_path  = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/documentSettings.asset.php';
+				$document_settings_script_path = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/documentSettings.js';
+				if ( ! self::build_assets_exist( [ $document_settings_asset_path, $document_settings_script_path ] ) ) {
+					return;
+				}
+
+				$document_settings_asset = require $document_settings_asset_path;
 				\wp_enqueue_script(
 					'newspack-popups',
 					plugins_url( '../dist/documentSettings.js', __FILE__ ),
-					[],
-					filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/documentSettings.js' ),
+					$document_settings_asset['dependencies'] ?? [],
+					$document_settings_asset['version'] ?? filemtime( $document_settings_script_path ),
 					true
 				);
 			}
@@ -748,11 +819,18 @@ final class Newspack_Popups {
 			return;
 		}
 
+		$editor_asset_path  = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.asset.php';
+		$editor_script_path = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.js';
+		if ( ! self::build_assets_exist( [ $editor_asset_path, $editor_script_path ] ) ) {
+			return;
+		}
+
+		$editor_asset = require $editor_asset_path;
 		\wp_enqueue_script(
 			'newspack-popups',
 			plugins_url( '../dist/editor.js', __FILE__ ),
-			[ 'wp-components' ],
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.js' ),
+			$editor_asset['dependencies'] ?? [],
+			$editor_asset['version'] ?? filemtime( $editor_script_path ),
 			true
 		);
 
@@ -785,12 +863,15 @@ final class Newspack_Popups {
 				'segmentation_enabled'         => self::$segmentation_enabled,
 			]
 		);
-		\wp_enqueue_style(
-			'newspack-popups-editor',
-			plugins_url( '../dist/editor.css', __FILE__ ),
-			null,
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.css' )
-		);
+		$editor_style_path = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.css';
+		if ( self::build_assets_exist( [ $editor_style_path ] ) ) {
+			\wp_enqueue_style(
+				'newspack-popups-editor',
+				plugins_url( '../dist/editor.css', __FILE__ ),
+				[],
+				$editor_asset['version'] ?? filemtime( $editor_style_path )
+			);
+		}
 	}
 
 	/**

--- a/plugins/newspack-popups/src/blocks/index.js
+++ b/plugins/newspack-popups/src/blocks/index.js
@@ -3,6 +3,7 @@
  */
 import { registerCustomPlacementBlock } from './custom-placement';
 import { registerSinglePromptBlock } from './single-prompt';
+import './prompt-editor-canvas.scss';
 
 // Register the Custom Placement block.
 registerCustomPlacementBlock();

--- a/plugins/newspack-popups/src/blocks/prompt-editor-canvas.scss
+++ b/plugins/newspack-popups/src/blocks/prompt-editor-canvas.scss
@@ -1,0 +1,49 @@
+/**
+ * Prompt editor canvas styles.
+ *
+ * These rules need to load through blocks.css so WordPress does not copy
+ * editor.css into the iframe and warn. The post-type scope keeps them limited
+ * to the Prompt editor canvas.
+ *
+ * The duplicated `.editor-styles-wrapper` selector supports both the iframe
+ * body and the legacy non-iframe editor wrapper.
+ */
+
+$overlay__gap: 16px;
+$size__x-small: 380px;
+$size__small: 544px;
+$size__medium: 784px;
+$size__large: 1264px;
+
+.post-type-newspack_popups_cpt {
+	.editor-post-title__input::placeholder {
+		color: var(--newspack-popups-editor-placeholder-color, #7d7d7d) !important;
+	}
+
+	.block-editor-block-list__layout {
+		margin-left: auto;
+		margin-right: auto;
+
+		&[class*="is-size-"] {
+			max-width: $size__large;
+			padding: #{2 * $overlay__gap};
+		}
+
+		&.is-size-x-small {
+			max-width: $size__x-small;
+		}
+
+		&.is-size-small {
+			max-width: $size__small;
+		}
+
+		&.is-size-medium {
+			max-width: $size__medium;
+		}
+	}
+
+	&.editor-styles-wrapper .block-editor-block-list__layout[class*="is-size-"] .wp-block,
+	.editor-styles-wrapper .block-editor-block-list__layout[class*="is-size-"] .wp-block {
+		max-width: 100%;
+	}
+}

--- a/plugins/newspack-popups/src/editor/Duplicate.js
+++ b/plugins/newspack-popups/src/editor/Duplicate.js
@@ -146,7 +146,7 @@ const DuplicateButton = ( { autosave, campaignGroups, duplicateOf, isSavingPost,
 export default compose( [
 	withSelect( select => {
 		const { isSavingPost, getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
-		const { duplicate_of: duplicateOf } = getEditedPostAttribute( 'meta' );
+		const { duplicate_of: duplicateOf } = getEditedPostAttribute( 'meta' ) || {};
 		return {
 			postId: getCurrentPostId(),
 			isSavingPost: isSavingPost(),

--- a/plugins/newspack-popups/src/editor/EditorAdditions.js
+++ b/plugins/newspack-popups/src/editor/EditorAdditions.js
@@ -14,7 +14,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { getEditorDocument, isOverlayPlacement, updateEditorColors, whenEditorReady } from './utils';
 
 const EditorAdditions = () => {
-	const meta = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) );
+	const meta = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) ) || {};
 	const { background_color, overlay_size, placement } = meta;
 
 	// Keep a ref so the mount effect always has the current background color.

--- a/plugins/newspack-popups/src/editor/Preview.js
+++ b/plugins/newspack-popups/src/editor/Preview.js
@@ -13,6 +13,10 @@ import { addQueryArgs } from '@wordpress/url';
 import { WebPreview } from 'newspack-components';
 
 const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) => {
+	if ( ! postId || ! metaFields ) {
+		return null;
+	}
+
 	const previewQueryKeys = window.newspack_popups_data?.preview_query_keys || {};
 	const frontendUrl = window?.newspack_popups_data?.frontend_url || '/';
 	const abbreviatedKeys = {};

--- a/plugins/newspack-popups/src/editor/style.scss
+++ b/plugins/newspack-popups/src/editor/style.scss
@@ -1,18 +1,8 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
-$overlay__gap: 16px;
-$size__x-small: 380px;
-$size__small: 544px;
-$size__medium: 784px;
-$size__large: 1264px;
-
 .block-editor-post-preview__button-toggle,
 .edit-post-post-visibility {
 	display: none;
-}
-
-.editor-post-title__input::placeholder {
-	color: var(--newspack-popups-editor-placeholder-color, #7d7d7d) !important;
 }
 
 .newspack-popups {
@@ -179,32 +169,6 @@ $size__large: 1264px;
 			box-shadow: inset 0 0 0 1px wp-colors.$gray-400;
 			color: wp-colors.$gray-900;
 		}
-	}
-}
-
-.block-editor-block-list__layout {
-	margin-left: auto;
-	margin-right: auto;
-
-	&[class*="is-size-"] {
-		max-width: $size__large;
-		padding: #{2 * $overlay__gap};
-	}
-
-	&.is-size-x-small {
-		max-width: $size__x-small;
-	}
-
-	&.is-size-small {
-		max-width: $size__small;
-	}
-
-	&.is-size-medium {
-		max-width: $size__medium;
-	}
-
-	.editor-styles-wrapper &[class*="is-size-"] .wp-block {
-		max-width: 100%;
 	}
 }
 

--- a/plugins/newspack-popups/tests/test-editor-assets.php
+++ b/plugins/newspack-popups/tests/test-editor-assets.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Class Editor Assets Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Editor assets test case.
+ */
+class EditorAssetsTest extends WP_UnitTestCase {
+	/**
+	 * Asset fixture files created during a test.
+	 *
+	 * @var array
+	 */
+	private $created_asset_files = [];
+
+	/**
+	 * Asset fixture directories created during a test.
+	 *
+	 * @var array
+	 */
+	private $created_asset_dirs = [];
+
+	/**
+	 * Original Prompt metabox state.
+	 *
+	 * @var array|null
+	 */
+	private $original_prompt_meta_boxes = null;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_prompt_meta_boxes = $GLOBALS['wp_meta_boxes'][ Newspack_Popups::NEWSPACK_POPUPS_CPT ] ?? null;
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		wp_dequeue_script( 'newspack-popups' );
+		wp_deregister_script( 'newspack-popups' );
+		wp_dequeue_script( 'newspack-popups-blocks' );
+		wp_deregister_script( 'newspack-popups-blocks' );
+		wp_dequeue_style( 'newspack-popups-editor' );
+		wp_deregister_style( 'newspack-popups-editor' );
+		wp_dequeue_style( 'newspack-popups-blocks' );
+		wp_deregister_style( 'newspack-popups-blocks' );
+		foreach ( array_reverse( $this->created_asset_files ) as $file ) {
+			if ( file_exists( $file ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink -- Removes only per-test fixture assets created by this test.
+				unlink( $file );
+			}
+		}
+		foreach ( array_reverse( $this->created_asset_dirs ) as $dir ) {
+			if ( is_dir( $dir ) && 2 === count( scandir( $dir ) ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir -- Removes only the empty per-test fixture directory created by this test.
+				rmdir( $dir );
+			}
+		}
+		$this->created_asset_files = [];
+		$this->created_asset_dirs  = [];
+		wp_reset_postdata();
+		unset( $GLOBALS['post'] );
+		if ( null === $this->original_prompt_meta_boxes ) {
+			unset( $GLOBALS['wp_meta_boxes'][ Newspack_Popups::NEWSPACK_POPUPS_CPT ] );
+		} else {
+			$GLOBALS['wp_meta_boxes'][ Newspack_Popups::NEWSPACK_POPUPS_CPT ] = $this->original_prompt_meta_boxes;
+		}
+		set_current_screen( 'front' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Ensure required build asset files exist.
+	 */
+	private function ensure_dist_asset_files() {
+		$dist_dir = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist';
+		if ( ! is_dir( $dist_dir ) ) {
+			wp_mkdir_p( $dist_dir );
+			$this->created_asset_dirs[] = $dist_dir;
+		}
+
+		$asset_fixtures = [
+			'blocks.asset.php'           => "<?php return [ 'dependencies' => [ 'wp-blocks' ], 'version' => 'blocks-test' ];\n",
+			'blocks.js'                  => '',
+			'blocks.css'                 => '',
+			'editor.asset.php'           => "<?php return [ 'dependencies' => [ 'wp-components', 'wp-plugins' ], 'version' => 'editor-test' ];\n",
+			'editor.js'                  => '',
+			'editor.css'                 => '',
+			'documentSettings.asset.php' => "<?php return [ 'dependencies' => [ 'wp-components', 'wp-plugins' ], 'version' => 'document-settings-test' ];\n",
+			'documentSettings.js'        => '',
+		];
+
+		foreach ( $asset_fixtures as $filename => $contents ) {
+			$path = trailingslashit( $dist_dir ) . $filename;
+			if ( file_exists( $path ) ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Per-test fixture asset under the generated dist directory.
+			file_put_contents( $path, $contents );
+			$this->created_asset_files[] = $path;
+		}
+	}
+
+	/**
+	 * Get generated asset metadata.
+	 *
+	 * @param string $filename Asset metadata filename.
+	 *
+	 * @return array Asset metadata.
+	 */
+	private function get_asset_metadata( $filename ) {
+		return require trailingslashit( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist' ) . $filename;
+	}
+
+	/**
+	 * Set the current screen to the prompt editor.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	private function set_editor_screen( $post_type = Newspack_Popups::NEWSPACK_POPUPS_CPT ) {
+		$this->ensure_dist_asset_files();
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => $post_type,
+				'post_title'   => 'Prompt editor assets',
+				'post_content' => 'Prompt content.',
+			]
+		);
+
+		$GLOBALS['post'] = get_post( $post_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		setup_postdata( $GLOBALS['post'] );
+
+		set_current_screen( 'post' );
+		get_current_screen()->post_type = $post_type;
+	}
+
+	/**
+	 * Test editor UI assets are not enqueued with block assets.
+	 */
+	public function test_prompt_editor_ui_assets_are_not_enqueued_as_block_assets() {
+		$this->set_editor_screen();
+
+		self::assertSame( 10, has_action( 'enqueue_block_assets', [ Newspack_Popups::class, 'enqueue_block_assets' ] ) );
+
+		do_action( 'enqueue_block_assets' );
+
+		self::assertTrue( wp_script_is( 'newspack-popups-blocks', 'enqueued' ) );
+		self::assertTrue( wp_style_is( 'newspack-popups-blocks', 'enqueued' ) );
+		self::assertSame( $this->get_asset_metadata( 'blocks.asset.php' )['version'], wp_scripts()->registered['newspack-popups-blocks']->ver );
+		self::assertSame( $this->get_asset_metadata( 'blocks.asset.php' )['version'], wp_styles()->registered['newspack-popups-blocks']->ver );
+		self::assertFalse( wp_script_is( 'newspack-popups', 'enqueued' ) );
+	}
+
+	/**
+	 * Test editor UI assets are enqueued with editor assets.
+	 */
+	public function test_prompt_editor_ui_assets_are_enqueued_as_editor_assets() {
+		$this->set_editor_screen();
+
+		self::assertSame( 10, has_action( 'enqueue_block_editor_assets', [ Newspack_Popups::class, 'enqueue_block_editor_assets' ] ) );
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		self::assertTrue( wp_script_is( 'newspack-popups', 'enqueued' ) );
+		self::assertTrue( wp_style_is( 'newspack-popups-editor', 'enqueued' ) );
+		self::assertContains( 'wp-plugins', wp_scripts()->registered['newspack-popups']->deps );
+		self::assertSame( $this->get_asset_metadata( 'editor.asset.php' )['version'], wp_scripts()->registered['newspack-popups']->ver );
+		self::assertSame( $this->get_asset_metadata( 'editor.asset.php' )['version'], wp_styles()->registered['newspack-popups-editor']->ver );
+	}
+
+	/**
+	 * Test supported post type document settings are enqueued with editor assets.
+	 */
+	public function test_supported_post_type_document_settings_are_enqueued_as_editor_assets() {
+		$this->set_editor_screen( 'post' );
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		self::assertTrue( wp_script_is( 'newspack-popups', 'enqueued' ) );
+		self::assertStringContainsString( 'documentSettings.js', wp_scripts()->registered['newspack-popups']->src );
+		self::assertContains( 'wp-plugins', wp_scripts()->registered['newspack-popups']->deps );
+		self::assertSame( $this->get_asset_metadata( 'documentSettings.asset.php' )['version'], wp_scripts()->registered['newspack-popups']->ver );
+		self::assertFalse( wp_style_is( 'newspack-popups-editor', 'enqueued' ) );
+	}
+
+	/**
+	 * Test prompt meta is not editable through the stale core Custom Fields metabox.
+	 */
+	public function test_prompt_editor_removes_core_custom_fields_meta_box() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			]
+		);
+		$post    = get_post( $post_id );
+
+		self::assertTrue( post_type_supports( Newspack_Popups::NEWSPACK_POPUPS_CPT, 'custom-fields' ) );
+
+		add_meta_box(
+			'postcustom',
+			'Custom Fields',
+			'__return_empty_string',
+			Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			'normal',
+			'core'
+		);
+
+		self::assertSame( 99, has_action( 'add_meta_boxes_' . Newspack_Popups::NEWSPACK_POPUPS_CPT, [ Newspack_Popups::class, 'remove_custom_fields_meta_box' ] ) );
+		self::assertIsArray( $GLOBALS['wp_meta_boxes'][ Newspack_Popups::NEWSPACK_POPUPS_CPT ]['normal']['core']['postcustom'] );
+
+		do_action( 'add_meta_boxes_' . Newspack_Popups::NEWSPACK_POPUPS_CPT, $post );
+
+		self::assertFalse( $GLOBALS['wp_meta_boxes'][ Newspack_Popups::NEWSPACK_POPUPS_CPT ]['normal']['core']['postcustom'] );
+	}
+}


### PR DESCRIPTION
Hotfix: cherry-pick of #266 onto `release`.

Full description, review, and testing steps are in #266. Cherry-picked from `7900ad6` (squash merge of #266 into `main`).

Closes NPPM-2906.
