### PR TITLE
feat(insights): capability-gate prompt subscription rate on checkout_impressions (NPPD-1759)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -1459,7 +1459,8 @@ final class Prompts_Metric {
 			// Subscription is CAPABILITY-gated (NPPD-1759), symmetric with the donation
 			// column below and the gates paywall column: a prompt is subscription-capable
 			// when its per-popup `checkout_impressions` (seen events carrying a checkout-
-			// button block, NPPD-1755/1756) is non-zero. This catches an "Undefined"-intent
+			// button block, NPPD-1755 emission / NPPD-1759 hub column) is non-zero. This
+			// catches an "Undefined"-intent
 			// "50% off" promo that drives subscriptions — the order carries the popup id
 			// regardless of `action_type`, which collapses to 'undefined' for a multi-block
 			// prompt. Until the hub exposes the column, fall back to today's behavior — map

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -935,6 +935,54 @@ final class Prompts_Metric {
 	}
 
 	/**
+	 * Total subscription-capable (checkout) prompt impressions in the window, summed
+	 * from the hub's `prompts_performance_by_prompt` per-popup `checkout_impressions`
+	 * column (NPPD-1759) — seen events on prompts carrying a checkout-button block.
+	 * The subscription analog of {@see self::fetch_donation_prompt_impressions()},
+	 * anonymous-inclusive, so reusing it as the conversion-rate denominator does not
+	 * reintroduce the anonymous-at-attempt bias the order-meta numerator escapes.
+	 *
+	 * Returns `null` (not 0) when the hub hasn't shipped the column yet, so the caller
+	 * falls back to today's per-popup-keyed denominator. (The donation sibling has no
+	 * such tri-state because its fallback is an inline intent sum; subscription's
+	 * fallback is a different per-popup-keyed computation, so it's signalled here.)
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return int|null|\WP_Error Total checkout-capable impressions, null if the hub
+	 *                            column is absent, or the proxy error.
+	 */
+	private function fetch_subscription_prompt_impressions( DateTimeInterface $start, DateTimeInterface $end ) {
+		$rows = $this->fetch_performance_by_prompt_rows( $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		if ( ! is_array( $rows ) ) {
+			// Malformed hub response (not an array of rows): surface it so the rate
+			// errors instead of silently dividing by a fabricated 0 denominator
+			// (mirrors fetch_donation_prompt_impressions, NPPD-1745 #3).
+			return new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) );
+		}
+		$has_column  = false;
+		$impressions = 0;
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			if ( isset( $row['checkout_impressions'] ) ) {
+				// NPPD-1759: per-popup checkout-CAPABLE impressions — seen events where the
+				// prompt carried a checkout-button block (`prompt_has_checkout`) — summed
+				// across all popups. The population matched to the order-meta subscription
+				// numerator, and it catches a multi-block prompt whose primary intent
+				// collapsed to 'undefined'.
+				$has_column   = true;
+				$impressions += (int) $row['checkout_impressions'];
+			}
+		}
+		return $has_column ? $impressions : null;
+	}
+
+	/**
 	 * Per-popup impressions map from the hub's `prompts_performance_by_prompt` rows
 	 * (NPPD-1746), keyed by popup id (string). Used as the per-popup-keyed
 	 * denominator source for the direct subscription rate: subscription-intent
@@ -1023,14 +1071,18 @@ final class Prompts_Metric {
 	 * @return array
 	 */
 	public function get_subscription_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		// NPPD-1746: rate = popup-attributed subscription conversions (Woo order meta,
-		// anonymous-inclusive) ÷ impressions of the SAME popups (hub,
-		// `prompts_performance_by_prompt`). PER-POPUP keyed, not tab-level:
-		// subscription-intent popups share `action_type=registration` with pure
-		// registration popups, so a tab-level denominator would mix in registration-
-		// only impressions and break numerator/denominator population matching (the
-		// spike's >100% incoherence class). Restricting the denominator to the popups
-		// that actually converted keeps both sides describing the same population.
+		// NPPD-1759: rate = popup-attributed subscription conversions (Woo order meta,
+		// anonymous-inclusive) ÷ checkout-CAPABLE prompt impressions (hub
+		// `checkout_impressions` = seen events on prompts carrying a checkout-button
+		// block). This is the subscription analog of the donation rate-direct and the
+		// gates paywall rate: a tab-level capability denominator, NOT per-popup keyed.
+		// The per-popup keying was the NPPD-1746 interim workaround — without a
+		// checkout-capability signal, subscription-intent popups shared
+		// `action_type=registration` with pure registration popups, so the denominator
+		// had to be restricted to the converting popups to keep both sides describing
+		// the same population. The capability column makes that unnecessary: it already
+		// isolates the checkout-capable impression subset. Forward-compatible — prefer
+		// the column, fall back to today's per-popup keying until the hub ships it.
 		// Numerator local, denominator hub → 'hybrid' (see METRIC_SOURCES): a hub
 		// impressions failure makes the rate genuinely uncomputable and counts toward
 		// the tab-error banner. Same coherence guard as the donation rate-direct.
@@ -1040,17 +1092,35 @@ final class Prompts_Metric {
 			return $this->populated_scalar( 0.0, false, 0, 'rate' );
 		}
 
-		$impressions_by_popup = $this->fetch_prompt_impressions_by_popup( $start, $end );
-		if ( is_wp_error( $impressions_by_popup ) ) {
-			return $this->error_scalar( 'rate', $impressions_by_popup );
+		$by_popup             = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_popup'];
+		$checkout_impressions = $this->fetch_subscription_prompt_impressions( $start, $end );
+		if ( is_wp_error( $checkout_impressions ) ) {
+			return $this->error_scalar( 'rate', $checkout_impressions );
 		}
 
-		$by_popup    = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_popup'];
-		$conversions = 0;
-		$impressions = 0;
-		foreach ( $by_popup as $popup_id => $row ) {
-			$conversions += (int) $row['conversions'];
-			$impressions += (int) ( $impressions_by_popup[ (string) $popup_id ] ?? 0 );
+		if ( null !== $checkout_impressions ) {
+			// Capability denominator (preferred): conversions across ALL converting
+			// popups ÷ total checkout-capable impressions, population-matched the same
+			// way the donation rate-direct is.
+			$conversions = 0;
+			foreach ( $by_popup as $row ) {
+				$conversions += (int) $row['conversions'];
+			}
+			$impressions = $checkout_impressions;
+		} else {
+			// Forward-compat fallback (hub hasn't shipped `checkout_impressions` yet):
+			// today's per-popup-keyed denominator — restrict to the impressions of the
+			// popups that actually converted (NPPD-1746 interim).
+			$impressions_by_popup = $this->fetch_prompt_impressions_by_popup( $start, $end );
+			if ( is_wp_error( $impressions_by_popup ) ) {
+				return $this->error_scalar( 'rate', $impressions_by_popup );
+			}
+			$conversions = 0;
+			$impressions = 0;
+			foreach ( $by_popup as $popup_id => $row ) {
+				$conversions += (int) $row['conversions'];
+				$impressions += (int) ( $impressions_by_popup[ (string) $popup_id ] ?? 0 );
+			}
 		}
 
 		$rate = $this->rate_value( $conversions, $impressions );
@@ -1386,13 +1456,20 @@ final class Prompts_Metric {
 			$intent      = (string) ( $row['intent'] ?? '' );
 			$impressions = (int) ( $row['impressions'] ?? 0 );
 
-			// Subscription conversions are sourced per-popup from order meta (NPPD-1746),
-			// keyed by popup id, anonymous-inclusive — NOT gated on the popup's declared
-			// intent (the order carries the popup id regardless of `action_type`, so an
-			// "Undefined"-intent "50% off" promo can still drive a subscription). Until a
-			// checkout-capability signal exists (NPPD-1755/1756), the rate below is gated on
-			// map membership (a converting popup) as the interim.
-			$subscription_conversions = (int) ( $subscription_map[ $popup_id ]['conversions'] ?? 0 );
+			// Subscription is CAPABILITY-gated (NPPD-1759), symmetric with the donation
+			// column below and the gates paywall column: a prompt is subscription-capable
+			// when its per-popup `checkout_impressions` (seen events carrying a checkout-
+			// button block, NPPD-1755/1756) is non-zero. This catches an "Undefined"-intent
+			// "50% off" promo that drives subscriptions — the order carries the popup id
+			// regardless of `action_type`, which collapses to 'undefined' for a multi-block
+			// prompt. Until the hub exposes the column, fall back to today's behavior — map
+			// membership (a popup that actually converted). The rate denominator is those
+			// checkout-capable impressions, else total impressions.
+			$checkout_impressions     = (int) ( $row['checkout_impressions'] ?? $impressions );
+			$subscription_capable     = isset( $row['checkout_impressions'] )
+				? $checkout_impressions > 0
+				: isset( $subscription_map[ $popup_id ] );
+			$subscription_conversions = $subscription_capable ? (int) ( $subscription_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
 
 			// Donation is CAPABILITY-gated: a prompt is donation-capable when its per-popup
 			// `donation_impressions` (seen events carrying a donate block) is non-zero — or,
@@ -1425,7 +1502,7 @@ final class Prompts_Metric {
 				'donation_conversions'         => $donation_conversions,
 				'donation_conversion_rate'     => ( $wc && $donation_capable ) ? $this->rate_value( $donation_conversions, $donation_impressions ) : null,
 				'subscription_conversions'     => $subscription_conversions,
-				'subscription_conversion_rate' => ( $wc && isset( $subscription_map[ $popup_id ] ) ) ? $this->rate_value( $subscription_conversions, $impressions ) : null,
+				'subscription_conversion_rate' => ( $wc && $subscription_capable ) ? $this->rate_value( $subscription_conversions, $checkout_impressions ) : null,
 			];
 		}
 

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -886,10 +886,11 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Direct subscription rate = popup-attributed conversions ÷ impressions of the
-	 * SAME popups. Popup 9's 500 impressions are excluded because popup 9 had no
-	 * subscription conversions — proving the per-popup keying (denominator 200, not
-	 * 700).
+	 * Forward-compat fallback (NPPD-1759): until the hub ships `checkout_impressions`,
+	 * the direct subscription rate keeps today's per-popup keying — popup-attributed
+	 * conversions ÷ impressions of the SAME popups. Popup 9's 500 impressions are
+	 * excluded because popup 9 had no subscription conversions (denominator 200, not
+	 * 700). These rows carry no `checkout_impressions` key, so the fallback runs.
 	 */
 	public function test_subscription_conversion_direct_rate_per_popup_over_impressions() {
 		$metric = $this->make_direct_subscription_metric(
@@ -904,6 +905,44 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 0.25, $rate['value'] );
 		$this->assertTrue( $rate['computable'] );
 		$this->assertSame( 200, $rate['denominator'], 'denominator is popup 1 only, not the unrelated popup 9' );
+	}
+
+	/**
+	 * NPPD-1759: once the hub exposes `checkout_impressions`, the direct subscription
+	 * rate prefers it — a TAB-LEVEL capability denominator (summed across ALL
+	 * checkout-capable popups), dropping the per-popup keying. Conversions are summed
+	 * across the whole popup surface. Here popup 9 is checkout-capable but did NOT
+	 * convert, yet its 100 capable impressions still enter the denominator (300 total),
+	 * which the old per-popup keying would have excluded — proving the keying is gone.
+	 */
+	public function test_subscription_conversion_direct_prefers_checkout_impressions_column() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				// Checkout-CAPABLE and converting (Undefined intent — a "50% off" promo).
+				[
+					'popup_id'             => 1,
+					'intent'               => 'undefined',
+					'impressions'          => 1000,
+					'checkout_impressions' => 200,
+				],
+				// Checkout-capable but did NOT convert — still in the capability denominator.
+				[
+					'popup_id'             => 9,
+					'intent'               => 'registration',
+					'impressions'          => 500,
+					'checkout_impressions' => 100,
+				],
+			]
+		);
+
+		$metric = $this->make_direct_subscription_metric( $proxy, $this->subscribers_with_popup( 50, 0.0 ), true );
+		$rate   = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertSame( 300, $rate['denominator'], 'tab-level checkout_impressions sum (200 + 100), not the per-popup-keyed 200' );
+		$this->assertEqualsWithDelta( 0.16667, $rate['value'], 0.0001, '50 conversions / 300 checkout-capable impressions' );
+		$this->assertTrue( $rate['computable'] );
 	}
 
 	/**
@@ -1506,6 +1545,81 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $result['rows'][0]['donation_conversions'] );
 		$this->assertSame( 0.0, $result['rows'][0]['donation_conversion_rate'], 'capable-but-no-conversion is a real 0% over donation_impressions, not an em-dash' );
+	}
+
+	/**
+	 * NPPD-1759 (capability path): a subscription-CAPABLE prompt (non-zero hub
+	 * `checkout_impressions`) surfaces its subscriptions + a rate over the checkout-
+	 * capable impressions, not total — symmetric with the donation capability column
+	 * and the gates paywall column. Here an Undefined-intent "50% off" promo carries a
+	 * checkout block: 3 / 500 capable impressions, not / 1000 total.
+	 */
+	public function test_performance_by_prompt_subscription_rate_prefers_checkout_impressions() {
+		$row = array_merge(
+			$this->performance_row( 77, '50% off promo', 'undefined', 1000 ),
+			[ 'checkout_impressions' => 500 ] // Checkout-capable despite non-registration intent.
+		);
+		$proxy = $this->make_performance_proxy( [ $row ], [], [] );
+
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tear_down.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn( [] );
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [
+					'77' => [
+						'conversions' => 3,
+						'revenue'     => 150.0,
+					],
+				],
+			]
+		);
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $subscribers );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 3, $result['rows'][0]['subscription_conversions'] );
+		$this->assertEqualsWithDelta( 0.006, $result['rows'][0]['subscription_conversion_rate'], 0.0001, '3 / 500 checkout-capable impressions, not / 1000 total' );
+	}
+
+	/**
+	 * NPPD-1759 (capability gate): the subscription column is now CAPABILITY-gated, not
+	 * map-gated. A prompt that converted (is in the subscription map) but is NOT
+	 * checkout-capable (`checkout_impressions` = 0) gets null subscription columns —
+	 * the capability gate overrides map membership. This is the behavior change from
+	 * the interim map-membership gate; a checkout block is what makes the rate apply.
+	 */
+	public function test_performance_by_prompt_subscription_not_capable_when_checkout_impressions_zero() {
+		$row = array_merge(
+			$this->performance_row( 77, 'Registration only', 'registration', 1000 ),
+			[ 'checkout_impressions' => 0 ] // No checkout block → not subscription-capable.
+		);
+		$proxy = $this->make_performance_proxy( [ $row ], [], [] );
+
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' ); // Removed in tear_down.
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn( [] );
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [
+					// Popup converted, but the capability column (0) gates it out anyway.
+					'77' => [
+						'conversions' => 4,
+						'revenue'     => 0.0,
+					],
+				],
+			]
+		);
+
+		$metric = new Prompts_Metric( $proxy, null, null, $donors, $subscribers );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 0, $result['rows'][0]['subscription_conversions'], 'capability gate (checkout_impressions 0) overrides map membership' );
+		$this->assertNull( $result['rows'][0]['subscription_conversion_rate'], 'a non-checkout-capable prompt gets an em-dash, not a rate' );
 	}
 
 	/**


### PR DESCRIPTION
## What

Switches the prompt subscription conversion rate denominator from the per-popup-keying workaround to the hub `checkout_impressions` capability column, in `Prompts_Metric`:

1. **Direct rate** (`get_subscription_conversion_direct`): now uses a tab-level `checkout_impressions` sum (seen events on checkout-capable prompts) as the denominator, **dropping the per-popup keying**. New `fetch_subscription_prompt_impressions` returns `null` when the hub hasn't shipped the column yet → falls back to today's per-popup-keyed behavior (forward-compatible, no flag day).
2. **Per-prompt table**: subscription column moved from **map-gated** to **capability-gated** (`checkout_impressions > 0`), with `checkout_impressions` as the denominator — symmetric with the donation column and the gates paywall column.

Mirrors the merged donation work (NPPD-1757) and the gates paywall pattern (NPPD-1749).

Linear: [NPPD-1759](https://linear.app/a8c/issue/NPPD-1759)

## Depends on

- Hub column: [newspack-manager-admin#468](https://github.com/Automattic/newspack-manager-admin/pull/468) (the `checkout_impressions` source). The fallback path means this PR is safe to merge before the column lands.

## Verification

- 3 new unit tests: preferred-path direct rate (tab-level capability denominator), per-prompt capability rate (over `checkout_impressions`, not total), and capability-gate-overrides-map-membership (a converting-but-not-checkout-capable prompt gets null columns).
- Existing subscription-direct + per-prompt tests now exercise the forward-compat fallback (rows without `checkout_impressions`) and stay green.
- **Full Prompts + Gates suite green: 275 tests, 1182 assertions.**

## Carry-over decisions

- Link-out to landing pages (no checkout block → not capability-flagged) are excluded from the rate; conversions still count in the count + revenue cards. Same Phase-1 decision as donation.