### PR TITLE
fix(insights): cohort retention demo graphs + clearer cold-snapshot copy

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -40,8 +40,8 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 	];
 
 	// Phase-B sections — 4.2/4.3/4.4 are 'populated' (implemented; all-history
-	// snapshots, so identical across variants); 5.1/5.2 remain 'coming_soon'.
-	// Each preserves the extra keys React reads unconditionally.
+	// snapshots, so identical across variants); 5.1/5.2 are 'populated' snapshots
+	// (mock curves). Each preserves the extra keys React reads unconditionally.
 	$deferred = static function () {
 		return [
 			// 4.2 — time-to-subscribe (multi-series, per-source cumulative).
@@ -189,16 +189,170 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'visibility'        => 'hidden',
 				'visibility_reason' => 'insufficient_data',
 			],
-			// 5.1 — registration-to-conversion cohort (reference_line off; autoscaled).
+			// 5.1 — registration-to-conversion cohort (snapshot; autoscaled, no reference line).
 			'registration_to_conversion_cohort'    => [
-				'state'          => 'coming_soon',
-				'cohorts'        => [],
+				'state'          => 'populated',
+				'cohorts'        => [
+					[
+						'label'  => '2025-07',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 0.0,
+							],
+							[
+								'period' => 3,
+								'value'  => 0.008,
+							],
+							[
+								'period' => 6,
+								'value'  => 0.015,
+							],
+							[
+								'period' => 9,
+								'value'  => 0.019,
+							],
+							[
+								'period' => 12,
+								'value'  => 0.022,
+							],
+						],
+					],
+					[
+						'label'  => '2025-10',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 0.0,
+							],
+							[
+								'period' => 3,
+								'value'  => 0.010,
+							],
+							[
+								'period' => 6,
+								'value'  => 0.017,
+							],
+							[
+								'period' => 9,
+								'value'  => 0.021,
+							],
+						],
+					],
+					[
+						'label'  => '2026-01',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 0.0,
+							],
+							[
+								'period' => 3,
+								'value'  => 0.012,
+							],
+							[
+								'period' => 6,
+								'value'  => 0.018,
+							],
+						],
+					],
+					[
+						'label'  => '2026-04',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 0.0,
+							],
+							[
+								'period' => 2,
+								'value'  => 0.009,
+							],
+						],
+					],
+				],
 				'reference_line' => null,
 			],
-			// 5.2 — subscriber retention cohort (reference_line preserved).
+			// 5.2 — subscriber retention cohort (snapshot; 70% reference line).
 			'subscriber_retention_cohort'          => [
-				'state'          => 'coming_soon',
-				'cohorts'        => [],
+				'state'          => 'populated',
+				'cohorts'        => [
+					[
+						'label'  => '2025-07',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 1.0,
+							],
+							[
+								'period' => 3,
+								'value'  => 0.88,
+							],
+							[
+								'period' => 6,
+								'value'  => 0.79,
+							],
+							[
+								'period' => 9,
+								'value'  => 0.73,
+							],
+							[
+								'period' => 12,
+								'value'  => 0.69,
+							],
+						],
+					],
+					[
+						'label'  => '2025-10',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 1.0,
+							],
+							[
+								'period' => 3,
+								'value'  => 0.90,
+							],
+							[
+								'period' => 6,
+								'value'  => 0.82,
+							],
+							[
+								'period' => 9,
+								'value'  => 0.76,
+							],
+						],
+					],
+					[
+						'label'  => '2026-01',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 1.0,
+							],
+							[
+								'period' => 3,
+								'value'  => 0.91,
+							],
+							[
+								'period' => 6,
+								'value'  => 0.84,
+							],
+						],
+					],
+					[
+						'label'  => '2026-04',
+						'points' => [
+							[
+								'period' => 0,
+								'value'  => 1.0,
+							],
+							[
+								'period' => 2,
+								'value'  => 0.94,
+							],
+						],
+					],
+				],
 				'reference_line' => [
 					'value' => 0.70,
 					'label' => __( '70% at 12 months', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for CohortRetentionSection (Section 5).
  *
- * Both 5.1 and 5.2 are Phase-B coming_soon metrics. Covers:
+ * Covers:
  *   - Section structure (heading, both cohort titles)
  *   - coming_soon treatment (default fixture)
  *   - empty treatment
@@ -42,15 +42,16 @@ describe( 'CohortRetentionSection', () => {
 		expect( screen.getByText( 'Subscriber retention' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the coming_soon treatment for both cohort charts (Phase B)', () => {
+	it( 'renders the cohort coming_soon message for both charts', () => {
 		render( <CohortRetentionSection current={ makeConversionWindow( { cohortState: 'coming_soon' } ) } /> );
-		// Both charts should show coming_soon
-		expect( screen.getAllByText( /Coming soon/ ) ).toHaveLength( 2 );
+		expect(
+			screen.getAllByText( 'Cohort data is being prepared. Check back in a few minutes, then click Refresh now to load it.' )
+		).toHaveLength( 2 );
 	} );
 
 	it( 'renders the empty treatment when state is empty', () => {
 		render( <CohortRetentionSection current={ makeConversionWindow( { cohortState: 'empty' } ) } /> );
-		expect( screen.getAllByText( 'Cohort data will appear after the first weekly refresh.' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( 'No cohort data available yet.' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'renders the error treatment when state is error', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -7,8 +7,7 @@
  * 15% benchmark was removed — a self-relative baseline is planned).
  * Snapshot — refreshed weekly, independent of the date picker.
  *
- * Phase 2: both metrics (5.1, 5.2) are `coming_soon` (Phase B). Each
- * chart's rendering is gated on the metric's `state` envelope.
+ * Each chart's rendering is gated on the metric's `state` envelope.
  */
 
 /**
@@ -48,12 +47,19 @@ interface CohortChartProps {
 const CohortChart = ( { title, data, yMax, referenceLine }: CohortChartProps ) => (
 	<div className="newspack-insights__conversion-cohort-cell">
 		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
-		<SectionState state={ data.state } emptyMessage={ __( 'Cohort data will appear after the first weekly refresh.', 'newspack-plugin' ) }>
+		<SectionState
+			state={ data.state }
+			comingSoonMessage={ __(
+				'Cohort data is being prepared. Check back in a few minutes, then click Refresh now to load it.',
+				'newspack-plugin'
+			) }
+			emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
+		>
 			<LineChart
 				series={ toCohortSeries( data ) }
 				referenceLine={ referenceLine }
 				yMax={ yMax }
-				emptyMessage={ __( 'Cohort data will appear after the first weekly refresh.', 'newspack-plugin' ) }
+				emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
 			/>
 		</SectionState>
 	</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/SectionState.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/SectionState.tsx
@@ -8,7 +8,7 @@
  *   - 'populated'   → the section's content (children)
  *
  * Mirrors the tab-local Prompts `SectionState` and adds the
- * `coming_soon` arm for Phase-B deferred metrics.
+ * `coming_soon` arm for deferred metrics.
  */
 
 /**
@@ -30,10 +30,12 @@ export interface SectionStateProps {
 	state: ConversionMetricState;
 	/** Copy shown when the query succeeded with no rows. */
 	emptyMessage: string;
+	/** Optional override for the `coming_soon` copy (defaults to the generic message). */
+	comingSoonMessage?: string;
 	children: React.ReactNode;
 }
 
-const SectionState = ( { state, emptyMessage, children }: SectionStateProps ) => {
+const SectionState = ( { state, emptyMessage, comingSoonMessage, children }: SectionStateProps ) => {
 	if ( state === 'error' ) {
 		return (
 			<p className="newspack-insights__section-error" role="alert">
@@ -49,7 +51,10 @@ const SectionState = ( { state, emptyMessage, children }: SectionStateProps ) =>
 		return (
 			<p className="newspack-insights__section-coming-soon" role="note">
 				<Icon icon={ scheduled } size={ 20 } />
-				<span>{ __( 'Coming soon. This metric is being built and will be available in a future update.', 'newspack-plugin' ) }</span>
+				<span>
+					{ comingSoonMessage ??
+						__( 'Coming soon. This metric is being built and will be available in a future update.', 'newspack-plugin' ) }
+				</span>
 			</p>
 		);
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1901,14 +1901,15 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'hidden', $current['subscriber_to_donor_lag_distribution']['visibility'] );
 		$this->assertSame( 'insufficient_data', $current['subscriber_to_donor_lag_distribution']['visibility_reason'] );
 
-		// 5.1 — registration cohort (reference_line off; autoscaled).
-		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
-		$this->assertSame( [], $current['registration_to_conversion_cohort']['cohorts'] );
+		// 5.1 — registration cohort (snapshot → populated; autoscaled, no reference line).
+		$this->assertSame( 'populated', $current['registration_to_conversion_cohort']['state'] );
+		$this->assertNotEmpty( $current['registration_to_conversion_cohort']['cohorts'] );
+		$this->assertSame( '2025-07', $current['registration_to_conversion_cohort']['cohorts'][0]['label'] );
 		$this->assertNull( $current['registration_to_conversion_cohort']['reference_line'] );
 
-		// 5.2 — subscriber retention cohort (reference_line).
-		$this->assertSame( 'coming_soon', $current['subscriber_retention_cohort']['state'] );
-		$this->assertSame( [], $current['subscriber_retention_cohort']['cohorts'] );
+		// 5.2 — subscriber retention cohort (snapshot → populated; 70% reference line).
+		$this->assertSame( 'populated', $current['subscriber_retention_cohort']['state'] );
+		$this->assertNotEmpty( $current['subscriber_retention_cohort']['cohorts'] );
 		$this->assertSame( 0.70, $current['subscriber_retention_cohort']['reference_line']['value'] );
 	}
 
@@ -1948,9 +1949,9 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'empty', $current['top_pages_no_conversion']['state'] );
 		$this->assertSame( [], $current['top_pages_no_conversion']['rows'] );
 
-		// 4.2 is an all-history snapshot → populated; the 5.1 cohort stays coming_soon.
+		// 4.2 + the 5.1 cohort are all-history snapshots → populated regardless of variant.
 		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
-		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
+		$this->assertSame( 'populated', $current['registration_to_conversion_cohort']['state'] );
 	}
 
 	/**
@@ -1985,9 +1986,9 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $current['at_risk_subscriber_count']['state'] );
 		$this->assertSame( 'populated', $current['lapsed_donor_count']['state'] );
 
-		// 4.2 is an all-history snapshot → populated; the 5.1 cohort stays coming_soon.
+		// 4.2 + the 5.1 cohort are all-history snapshots → populated regardless of variant.
 		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
-		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
+		$this->assertSame( 'populated', $current['registration_to_conversion_cohort']['state'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1916,7 +1916,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	/**
 	 * Empty fixture: BQ-backed collections carry state:'empty' with empty
 	 * collections; scalars carry non-computable zeros; tab_error is false;
-	 * deferred sections stay 'coming_soon'.
+	 * the 5.1/5.2 cohort snapshots are populated regardless of variant.
 	 */
 	public function test_fixture_empty_variant() {
 		$payload = Conversion_Metric::get_fixture( 'empty', false );
@@ -1958,8 +1958,8 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * Error fixture: BQ-backed metrics carry state:'error'; local-only metrics
 	 * (subscriber-to-donor funnel, opportunity counts) stay 'populated'; tab_error
 	 * is NOW true (NPPD-1745) because all hub-backed metrics are 'error' — the
-	 * scoped banner fires regardless of the local/coming_soon cards; deferred
-	 * sections stay 'coming_soon'.
+	 * scoped banner fires regardless of the local cards; the 5.1/5.2 cohort
+	 * snapshots are populated regardless of variant.
 	 */
 	public function test_fixture_error_variant() {
 		$payload = Conversion_Metric::get_fixture( 'error', false );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -329,11 +329,10 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $current['influenced_registration_rate_7d']['state'] );
 		$this->assertSame( 'populated', $current['top_pages_no_conversion']['state'] );
 
-		// 4.2 is implemented (all-history snapshot → populated in the fixture);
-		// 5.1/5.2 cohorts are still coming_soon stubs.
+		// 4.2 + 5.1/5.2 cohorts are all-history snapshots → populated in the fixture.
 		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
-		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
-		$this->assertSame( 'coming_soon', $current['subscriber_retention_cohort']['state'] );
+		$this->assertSame( 'populated', $current['registration_to_conversion_cohort']['state'] );
+		$this->assertSame( 'populated', $current['subscriber_retention_cohort']['state'] );
 	}
 
 	/**
@@ -375,15 +374,14 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $current['influenced_registration_rate_7d']['state'] );
 		$this->assertFalse( $current['influenced_registration_rate_7d']['computable'] );
 
-		// 4.2 is an all-history snapshot → populated in the fixture regardless of
-		// the window variant (5.1/5.2 cohorts remain coming_soon).
+		// 4.2 + 5.1/5.2 cohorts are all-history snapshots → populated regardless of variant.
 		$this->assertSame( 'populated', $current['time_to_subscribe_distribution']['state'] );
 	}
 
 	/**
 	 * Fixture-mode error variant: BQ (hub) metrics are 'error', local-only
-	 * metrics stay 'populated', deferred stay 'coming_soon'. NPPD-1745: with the
-	 * scoped banner, all-hub-error → tab_error true (fixture updated to match).
+	 * metrics stay 'populated', snapshot sections stay 'populated'. NPPD-1745:
+	 * with the scoped banner, all-hub-error → tab_error true (fixture updated).
 	 */
 	public function test_fixture_error_variant_via_metric() {
 		$payload = Conversion_Metric::get_fixture( 'error', false );
@@ -395,7 +393,7 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'error', $current['reader_lifecycle_funnel']['state'] );
 		$this->assertSame( 'bigquery_proxy_http_error', $current['reader_lifecycle_funnel']['error_code'] );
 		$this->assertSame( 'populated', $current['stale_registered_count']['state'] );
-		$this->assertSame( 'coming_soon', $current['registration_to_conversion_cohort']['state'] );
+		$this->assertSame( 'populated', $current['registration_to_conversion_cohort']['state'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

> Base branch: **`feat/insights-rsm`** (Insights epic), not `main`.

Two small UX fixes for the Insights → Conversion Journey **Cohort retention** section (5.1 Registration → conversion, 5.2 Subscriber retention). These metrics are fully implemented, but they render a confusing placeholder in two cases:

1. **Demo / fixture mode showed no graphs.** The demo fixture hardcoded 5.1/5.2 to `coming_soon`, so a fixture-mode site never showed cohort charts. They now render **populated mock cohort curves** (consistent with the other snapshot sections, which are already populated in demo mode).
2. **The cold-snapshot message was misleading.** Cohort charts are pre-warmed *snapshots* (a 365-day computation done in the background). On a cold snapshot the section showed *"Coming soon. This metric is being built and will be available in a future update."* — which reads as "not implemented." It now shows an accurate message: **"Cohort data is being prepared. Check back in a few minutes, then click Refresh now to load it."** (a new opt-in `comingSoonMessage` prop on the section's state renderer; every other section is unchanged). The empty-state copy also drops the misleading "…after the first weekly refresh" → **"No cohort data available yet."**

**Why "Refresh now":** the first view of a cold tab schedules the background pre-warm, but the cohort placeholder is cached in the 24h conversion payload — so a plain reload won't surface the warmed graphs; the in-app **Refresh now** control does. (Auto-refreshing the view was considered and deliberately left out — it would force a full-tab BigQuery recompute, which is too heavy to warm two charts.)

No backend / cache behavior change: a real cold snapshot still returns `coming_soon` and warms in the background exactly as before.

### How to test the changes in this Pull Request:

1. With fixture mode on (`NEWSPACK_INSIGHTS_FIXTURE_MODE`), open **Insights → Conversion Journey** → **Cohort retention** — both charts now render mock curves (5.1 small cumulative conversion lines, autoscaled; 5.2 retention lines decaying from 100% with the 70% reference line).
2. Run the PHP insights suite: `cd plugins/newspack-plugin && n test-php --group insights` — all green (464). The fixture variants now assert `populated` cohorts; the real cold-cache getter tests (which still return `coming_soon`) and the snapshot test are unchanged.
3. Run the JS suite: `cd plugins/newspack-plugin && npm test` — all green (667), including the updated cohort coming-soon / empty message assertions.
4. `npm run tsc` and `npm run lint:js` — clean for the changed files.
5. On a live site with a cold cohort snapshot, the section shows the new "being prepared … Refresh now" message; clicking **Refresh now** surfaces the graphs once the background pre-warm has completed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
