### PR TITLE
fix: handle sync case where metadata key not present

### DIFF
--- a/plugins/newspack-plugin/includes/data-events/connectors/class-contact-sync-connector.php
+++ b/plugins/newspack-plugin/includes/data-events/connectors/class-contact-sync-connector.php
@@ -289,7 +289,7 @@ class Contact_Sync_Connector {
 		}
 
 		$contact['metadata'] = array_merge(
-			$contact['metadata'],
+			$contact['metadata'] ?? [],
 			[
 				'account'              => $data['user_id'],
 				'newsletter_selection' => implode( ', ', $lists_names ),

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/connectors/class-contact-sync-connector.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/connectors/class-contact-sync-connector.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Tests for the Contact_Sync_Connector data events handler.
+ *
+ * @package Newspack\Tests\Data_Events\Connectors
+ * @group data-events-connectors
+ */
+
+namespace Newspack\Tests\Data_Events\Connectors;
+
+use Newspack\Data_Events\Connectors\Contact_Sync_Connector;
+
+/**
+ * @group data-events-connectors
+ */
+class Newspack_Test_Contact_Sync_Connector extends \WP_UnitTestCase {
+
+	/**
+	 * Load newsletter mocks once per class so the static helpers used by
+	 * Contact_Sync_Connector::newsletter_updated() are available.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 3 ) . '/mocks/newsletters-mocks.php';
+	}
+
+	/**
+	 * Reset mock state between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		\Newspack_Newsletters_Subscription::reset_calls();
+	}
+
+	/**
+	 * Regression test: when a `newsletter_subscribed` event arrives with a
+	 * `$contact` array that has no `metadata` key (which is allowed by the
+	 * contact contract — see Newspack_Newsletters_Contacts::subscribe()),
+	 * the handler must not throw `array_merge(): Argument #1 must be of type
+	 * array, null given` under PHP 8+. See class-contact-sync-connector.php:292.
+	 */
+	public function test_newsletter_updated_tolerates_missing_metadata() {
+		$data = [
+			'user_id'  => 1,
+			'email'    => 'reader@example.com',
+			'provider' => 'mailchimp',
+			// Contact intentionally omits the 'metadata' key — this is the
+			// shape dispatched by Newspack_Newsletters_Contacts::subscribe()
+			// when no extra metadata is provided by the caller.
+			'contact'  => [
+				'email' => 'reader@example.com',
+				'name'  => 'Test Reader',
+			],
+			'lists'    => [ '123' ],
+		];
+
+		Contact_Sync_Connector::newsletter_updated( time(), $data );
+
+		$this->assertTrue( true, 'Handler returned without throwing a TypeError.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/connectors/class-contact-sync-connector.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/connectors/class-contact-sync-connector.php
@@ -11,6 +11,8 @@ namespace Newspack\Tests\Data_Events\Connectors;
 use Newspack\Data_Events\Connectors\Contact_Sync_Connector;
 
 /**
+ * Test the Contact_Sync_Connector class.
+ *
  * @group data-events-connectors
  */
 class Newspack_Test_Contact_Sync_Connector extends \WP_UnitTestCase {

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/connectors/class-contact-sync-connector.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/connectors/class-contact-sync-connector.php
@@ -39,7 +39,8 @@ class Newspack_Test_Contact_Sync_Connector extends \WP_UnitTestCase {
 	 * `$contact` array that has no `metadata` key (which is allowed by the
 	 * contact contract — see Newspack_Newsletters_Contacts::subscribe()),
 	 * the handler must not throw `array_merge(): Argument #1 must be of type
-	 * array, null given` under PHP 8+. See class-contact-sync-connector.php:292.
+	 * array, null given` under PHP 8+. This guards the metadata merge in
+	 * Contact_Sync_Connector::newsletter_updated().
 	 */
 	public function test_newsletter_updated_tolerates_missing_metadata() {
 		$data = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: this is a hotfix**

Related to NPPD-1818. There are some errors in our logging like the following:

```
Max retries (5) reached for handler Newspack\Data_Events\Connectors\Contact_Sync_Connector::newsletter_updated on "newsletter_subscribed". Last error: array_merge(): Argument #1 must be of type array, null given.
```

This appears to be because:


> 1. The handler runs on the newsletter_subscribed event (class-contact-sync-connector.php:48). The listener for that event puts the raw $contact array onto the payload (includes/data-events/listeners.php:140).
>  2. That $contact comes verbatim from the newspack_newsletters_contact_subscribed action fired in plugins/newspack-newsletters/includes/class-newspack-newsletters-contacts.php:100.
>  3. The contact shape documents metadata as optional (class-newspack-newsletters-contacts.php:36, :93). In the plain subscribe() path (someone hitting a newsletter form with no extra  metadata), the array is dispatched without a metadata key at all.
>  4. The handler's guard only checks empty( $data['contact'] ) — it doesn't check $contact['metadata']. On PHP 8+, array_merge( null, [...] ) is a fatal TypeError.
>  5. The retry queue tries 5 times — each time the contact still has no metadata, so each retry fails identically, leading to data_event_retry_exhausted.
>
> Note: the same handler is also registered for newsletter_updated, but that listener's payload doesn't include a contact key at all (listeners.php:160-166), so the empty( $data['contact'] ) guard short-circuits it. The bug only fires on newsletter_subscribed, which matches the log.


Long explanation, but simple fix. This PR adjusts the logic to make the metadata field actually optional.

### How to test the changes in this Pull Request:

Run the unit tests really. The manual test is just re-creating what the unit tests do:

```
wp shell
Newspack_Newsletters_Contacts::subscribe( ["email" => "qa-reader@example.com", "name" => "QA Reader" ], false, "Manual test" );
exit
wp action-scheduler run
```
This will throw/log an error before the patch and succeed after the patch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
