### PR TITLE
fix(insights): capability-restrict Direct conversion-rate numerators (NPPD-1817)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/gates-fixture.php
@@ -69,7 +69,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		// (NPPD-1694).
 		$current['registration_impressions_total'] = null;
 		$current['registrations_total']            = null;
-		$current['paywall_attempts_total']         = 0;
+		$current['paywall_impressions_total']         = 0;
 		$current['paywall_conversions_total']      = 0;
 		$collections = [
 			'conversion_funnel'      => 'stages',
@@ -109,7 +109,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		// these fields exist in the response, they're just empty for this window.
 		$current['registration_impressions_total'] = 0;
 		$current['registrations_total']            = 0;
-		$current['paywall_attempts_total']         = 0;
+		$current['paywall_impressions_total']         = 0;
 		$current['paywall_conversions_total']      = 0;
 		$current['conversion_funnel']      = [
 			'state'  => 'empty',
@@ -166,7 +166,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			'registration_impressions_total'     => (int) round( 14000 * $f ),
 			'registrations_total'                => (int) round( 1476 * $f ),
 			// Section 3 empty-state totals (NPPD-1694).
-			'paywall_attempts_total'             => (int) round( 320 * $f ),
+			'paywall_impressions_total'          => (int) round( 320 * $f ),
 			'paywall_conversions_total'          => (int) round( 11 * $f ),
 			// Section 4 — How readers convert. Funnel uses a mid-size publisher's
 			// shape so both drop-off deltas exceed 20% and render in the error color.
@@ -290,7 +290,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 		// 17 paywall attempts, zero conversions → the section's `no_conversions`
 		// empty state with {N} = 17 (a mid-size publisher's live scenario).
 		$current                              = $build( 1.0 );
-		$current['paywall_attempts_total']    = 17;
+		$current['paywall_impressions_total']    = 17;
 		$current['paywall_conversions_total'] = 0;
 		return [
 			'tab_error' => false,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -524,6 +524,52 @@ final class Gates_Metric {
 		return $map;
 	}
 
+	/**
+	 * Per-gate `checkout_impressions` map (NPPD-1817) from the hub's
+	 * `gates_performance_by_gate` rows, keyed by gate post id (string). Used to
+	 * capability-RESTRICT the direct paywall rate: a gate is paywall-capable when its
+	 * `checkout_impressions` (seen events on the gate carrying a checkout button) is
+	 * > 0, so the rate's numerator (conversions) shares its capable-impressions
+	 * denominator's population and reconciles with the per-gate table, which credits a
+	 * paywall conversion only to a capable gate. Without this, a converting-but-not-
+	 * capable gate inflates the numerator over a denominator that excludes its
+	 * impressions (the NPPD-1746 scalar/table divergence class).
+	 *
+	 * Distinct from {@see self::fetch_gate_impressions_by_gate()}, which conflates a
+	 * present-but-zero `checkout_impressions` with the pre-column total-impressions
+	 * fallback; this map exposes only rows that actually carry the column, returning
+	 * `null` when none do (hub hasn't shipped NPPD-1749) so the caller keeps the
+	 * pre-column per-gate-keyed denominator.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string, int>|null|\WP_Error Map, null if the column is absent, or the proxy error.
+	 */
+	private function fetch_checkout_impressions_by_gate( DateTimeInterface $start, DateTimeInterface $end ) {
+		$rows = $this->fetch_performance_by_gate_rows( $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		if ( ! is_array( $rows ) ) {
+			return new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) );
+		}
+		$map = null;
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) || ! isset( $row['checkout_impressions'] ) ) {
+				continue;
+			}
+			$gate_id = (string) ( $row['gate_post_id'] ?? '' );
+			if ( '' === $gate_id || '0' === $gate_id ) {
+				continue;
+			}
+			if ( null === $map ) {
+				$map = [];
+			}
+			$map[ $gate_id ] = (int) $row['checkout_impressions'];
+		}
+		return $map;
+	}
+
 	// --- Section 1: Gate exposure ---------------------------------------
 
 	/**
@@ -604,33 +650,56 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_paywall_conversion_direct( DateTimeInterface $start, DateTimeInterface $end ): array {
-		// NPPD-1746: rate = gate-attributed subscription conversions (Woo order meta,
-		// anonymous-inclusive) ÷ impressions of the SAME gates (hub,
-		// `gates_performance_by_gate`). PER-GATE keyed: the denominator is restricted
-		// to the gates that actually converted, keeping numerator and denominator on
-		// the same population. Numerator local, denominator hub → 'hybrid' (see the
+		// NPPD-1746/1817: rate = gate-attributed subscription conversions (Woo order
+		// meta, anonymous-inclusive) ÷ paywall-capable gate impressions (hub,
+		// `gates_performance_by_gate`). When the hub exposes per-gate `checkout_impressions`
+		// (NPPD-1749), numerator and denominator are both restricted to paywall-CAPABLE
+		// gates so they share a population and reconcile with the per-gate table; until
+		// then it falls back to the per-gate-keyed total-impressions denominator over the
+		// gates that converted. Numerator local, denominator hub → 'hybrid' (see the
 		// Gates controller METRIC_SOURCES): a hub impressions failure makes the rate
-		// genuinely uncomputable and counts toward the tab-error banner. Same
-		// coherence guard as the prompts subscription/donation rate-direct. Replaces
-		// the prior attempt-row denominator (`gates_paywall_conversion_direct`), which
-		// undercounted via the GA4 cookie → customer_id join.
+		// genuinely uncomputable and counts toward the tab-error banner. Same coherence
+		// guard as the prompts subscription/donation rate-direct. Replaces the prior
+		// attempt-row denominator (`gates_paywall_conversion_direct`), which undercounted
+		// via the GA4 cookie → customer_id join.
 		if ( ! $this->woocommerce_active() ) {
 			// Non-WC publisher: no local conversions to count. Empty state, not a fake
 			// 0% (NPPD-1737 Option A scoping).
 			return $this->populated_scalar( 0.0, false, 0, 'rate', 0 );
 		}
 
-		$impressions_by_gate = $this->fetch_gate_impressions_by_gate( $start, $end );
-		if ( is_wp_error( $impressions_by_gate ) ) {
-			return $this->error_scalar( 'rate', $impressions_by_gate );
+		$by_gate                = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_gate'];
+		$capability_impressions = $this->fetch_checkout_impressions_by_gate( $start, $end );
+		if ( is_wp_error( $capability_impressions ) ) {
+			return $this->error_scalar( 'rate', $capability_impressions );
 		}
 
-		$by_gate     = $this->subscribers_metric()->get_attributed_subscription_conversions( $start, $end )['by_gate'];
 		$conversions = 0;
 		$impressions = 0;
-		foreach ( $by_gate as $gate_id => $row ) {
-			$conversions += (int) $row['conversions'];
-			$impressions += (int) ( $impressions_by_gate[ (string) $gate_id ] ?? 0 );
+		if ( is_array( $capability_impressions ) ) {
+			// NPPD-1817: the hub exposes per-gate `checkout_impressions` (NPPD-1749), so
+			// restrict BOTH sides to paywall-CAPABLE gates (checkout_impressions > 0) — a
+			// tab-level capable denominator that reconciles with the per-gate table (which
+			// credits a paywall conversion only to a capable gate). A converting-but-not-
+			// capable gate is excluded from both the numerator and the denominator.
+			foreach ( $capability_impressions as $gate_id => $gate_impressions ) {
+				if ( $gate_impressions <= 0 ) {
+					continue;
+				}
+				$impressions += $gate_impressions;
+				$conversions += (int) ( $by_gate[ $gate_id ]['conversions'] ?? 0 );
+			}
+		} else {
+			// Forward-compat fallback (hub hasn't shipped `checkout_impressions` yet):
+			// per-gate-keyed total impressions, restricted to the gates that converted.
+			$impressions_by_gate = $this->fetch_gate_impressions_by_gate( $start, $end );
+			if ( is_wp_error( $impressions_by_gate ) ) {
+				return $this->error_scalar( 'rate', $impressions_by_gate );
+			}
+			foreach ( $by_gate as $gate_id => $row ) {
+				$conversions += (int) $row['conversions'];
+				$impressions += (int) ( $impressions_by_gate[ (string) $gate_id ] ?? 0 );
+			}
 		}
 
 		$rate = $this->rate_value( $conversions, $impressions );

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -793,7 +793,7 @@ final class Gates_Metric {
 	 * Pure derivation from already-computed scalars — no extra query. The
 	 * section component reads these to choose between the normal scorecard
 	 * render and an `<EmptyMetricSection>`:
-	 *   - `paywall_attempts_total` = the Direct rate denominator (sessions with a
+	 *   - `paywall_impressions_total` = the Direct rate denominator (sessions with a
 	 *     paywall impression; this is the {N} in the "no conversions" copy).
 	 *   - `paywall_conversions_total` = the most inclusive conversion count across
 	 *     attributions (max of Direct and Influenced numerators), so a section
@@ -802,11 +802,11 @@ final class Gates_Metric {
 	 *
 	 * @param array $direct     The `paywall_conversion_direct` scalar payload.
 	 * @param array $influenced The `paywall_conversion_influenced_14d` scalar payload.
-	 * @return array{paywall_attempts_total:int, paywall_conversions_total:int}
+	 * @return array{paywall_impressions_total:int, paywall_conversions_total:int}
 	 */
 	public static function paywall_section_totals( array $direct, array $influenced ): array {
 		return [
-			'paywall_attempts_total'    => (int) ( $direct['denominator'] ?? 0 ),
+			'paywall_impressions_total' => (int) ( $direct['denominator'] ?? 0 ),
 			'paywall_conversions_total' => max(
 				(int) ( $direct['numerator'] ?? 0 ),
 				(int) ( $influenced['numerator'] ?? 0 )

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -844,8 +844,14 @@ final class Prompts_Metric {
 		// hasn't shipped `donation_impressions`, the map is null and we keep counting all
 		// attributed conversions, pairing with the intent-sum fallback denominator.
 		$capability_impressions = $this->fetch_capability_impressions_by_popup( 'donation_impressions', $start, $end );
-		$by_popup               = $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end );
-		$conversions            = 0;
+		if ( is_wp_error( $capability_impressions ) ) {
+			return $this->error_scalar( 'rate', $capability_impressions );
+		}
+		// `null` (column absent) → count all attributed conversions (pre-column behavior,
+		// paired with the intent-sum fallback denominator); an array → restrict to donation-
+		// capable popups.
+		$by_popup    = $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end );
+		$conversions = 0;
 		foreach ( $by_popup as $popup_id => $row ) {
 			if ( ! is_array( $capability_impressions ) || (int) ( $capability_impressions[ (string) $popup_id ] ?? 0 ) > 0 ) {
 				$conversions += (int) $row['conversions'];
@@ -1169,7 +1175,10 @@ final class Prompts_Metric {
 			// not-capable popup is excluded here; its conversion still counts in the
 			// count + revenue cards (those sum all attributed conversions).
 			$capability_impressions = $this->fetch_capability_impressions_by_popup( 'checkout_impressions', $start, $end );
-			$conversions            = 0;
+			if ( is_wp_error( $capability_impressions ) ) {
+				return $this->error_scalar( 'rate', $capability_impressions );
+			}
+			$conversions = 0;
 			foreach ( $by_popup as $popup_id => $row ) {
 				if ( ! is_array( $capability_impressions ) || (int) ( $capability_impressions[ (string) $popup_id ] ?? 0 ) > 0 ) {
 					$conversions += (int) $row['conversions'];

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -836,10 +836,20 @@ final class Prompts_Metric {
 			return $this->error_scalar( 'rate', $impressions );
 		}
 
-		$by_popup    = $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end );
-		$conversions = 0;
-		foreach ( $by_popup as $row ) {
-			$conversions += (int) $row['conversions'];
+		// NPPD-1817: restrict the numerator to donation-CAPABLE popups (per-popup
+		// `donation_impressions` > 0) so it shares the capable-impressions denominator's
+		// population and reconciles with the per-prompt table, which credits a donation
+		// conversion only to a capable row. A converting-but-not-capable popup is excluded
+		// here; its conversion still counts in the count + revenue cards. When the hub
+		// hasn't shipped `donation_impressions`, the map is null and we keep counting all
+		// attributed conversions, pairing with the intent-sum fallback denominator.
+		$capability_impressions = $this->fetch_capability_impressions_by_popup( 'donation_impressions', $start, $end );
+		$by_popup               = $this->donors_metric()->get_prompt_attributed_donation_conversions( $start, $end );
+		$conversions            = 0;
+		foreach ( $by_popup as $popup_id => $row ) {
+			if ( ! is_array( $capability_impressions ) || (int) ( $capability_impressions[ (string) $popup_id ] ?? 0 ) > 0 ) {
+				$conversions += (int) $row['conversions'];
+			}
 		}
 
 		// Shared coherence guard + em-dash semantics (also drives the per-prompt
@@ -988,6 +998,53 @@ final class Prompts_Metric {
 	}
 
 	/**
+	 * Per-popup capability-impressions map for a capability column
+	 * (`donation_impressions` / `checkout_impressions`) on the hub's
+	 * `prompts_performance_by_prompt` rows, keyed by popup id (string).
+	 *
+	 * Used to capability-RESTRICT the Direct conversion-rate numerators (NPPD-1817):
+	 * a popup is capability-capable when its column value is > 0, so the rate's
+	 * numerator (conversions) describes the same population as its capable-impressions
+	 * denominator — and reconciles with the per-prompt table, which already credits a
+	 * conversion only to a capable row. Without this, a converting-but-not-capable
+	 * popup inflates the scalar numerator over a denominator that excludes its
+	 * impressions (the NPPD-1746 scalar/table divergence class).
+	 *
+	 * Returns `null` when NO row carries the column (the hub hasn't shipped it yet), so
+	 * the caller keeps its pre-column numerator behavior. The map includes every row
+	 * that carries the column; the capable subset is the entries with value > 0.
+	 *
+	 * @param string            $column Capability column name.
+	 * @param DateTimeInterface $start  Window start.
+	 * @param DateTimeInterface $end    Window end.
+	 * @return array<string, int>|null|\WP_Error Map, null if the column is absent, or the proxy error.
+	 */
+	private function fetch_capability_impressions_by_popup( string $column, DateTimeInterface $start, DateTimeInterface $end ) {
+		$rows = $this->fetch_performance_by_prompt_rows( $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return $rows;
+		}
+		if ( ! is_array( $rows ) ) {
+			return new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) );
+		}
+		$map = null;
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) || ! isset( $row[ $column ] ) ) {
+				continue;
+			}
+			if ( null === $map ) {
+				$map = [];
+			}
+			$popup_id = (string) ( $row['popup_id'] ?? '' );
+			if ( '' === $popup_id ) {
+				continue;
+			}
+			$map[ $popup_id ] = (int) $row[ $column ];
+		}
+		return $map;
+	}
+
+	/**
 	 * Per-popup impressions map from the hub's `prompts_performance_by_prompt` rows
 	 * (NPPD-1746), keyed by popup id (string). Used as the per-popup-keyed
 	 * denominator source for the direct subscription rate: subscription-intent
@@ -1104,12 +1161,19 @@ final class Prompts_Metric {
 		}
 
 		if ( null !== $checkout_impressions ) {
-			// Capability denominator (preferred): conversions across ALL converting
-			// popups ÷ total checkout-capable impressions, population-matched the same
-			// way the donation rate-direct is.
-			$conversions = 0;
-			foreach ( $by_popup as $row ) {
-				$conversions += (int) $row['conversions'];
+			// Capability denominator (preferred): checkout-capable conversions ÷ total
+			// checkout-capable impressions. NPPD-1817: the numerator is restricted to
+			// checkout-CAPABLE popups (per-popup `checkout_impressions` > 0) so it shares
+			// the denominator's population and reconciles with the per-prompt table, which
+			// credits a subscription conversion only to a capable row. A converting-but-
+			// not-capable popup is excluded here; its conversion still counts in the
+			// count + revenue cards (those sum all attributed conversions).
+			$capability_impressions = $this->fetch_capability_impressions_by_popup( 'checkout_impressions', $start, $end );
+			$conversions            = 0;
+			foreach ( $by_popup as $popup_id => $row ) {
+				if ( ! is_array( $capability_impressions ) || (int) ( $capability_impressions[ (string) $popup_id ] ?? 0 ) > 0 ) {
+					$conversions += (int) $row['conversions'];
+				}
 			}
 			$impressions = $checkout_impressions;
 		} else {

--- a/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
@@ -126,7 +126,7 @@ export interface GatesWindow {
 	// Section 3 empty-state totals (NPPD-1694): drive the Paid section's
 	// no_opportunity / no_conversions / normal decision. Derived server-side from
 	// the scalars above — no extra query.
-	paywall_attempts_total: number;
+	paywall_impressions_total: number;
 	paywall_conversions_total: number;
 	// Section 4 — How readers convert.
 	conversion_funnel: GatesFunnelData;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -45,11 +45,11 @@ export interface MetricCardOverlay {
  * `0 conversions`, or the `—` null glyph with an explanatory secondary line).
  *
  * Keyed on two counts, regardless of card `format`:
- *   - `denominator` — the "opportunity" count (paywall attempts / regwall impressions)
+ *   - `denominator` — the "opportunity" count (paywall / regwall impressions)
  *   - `numerator`   — the conversions count (for currency cards, the conversions companion)
  *
  * The decision is driven by these counts, NOT by `value`: a real $0 alongside N
- * conversions still reads as data, while 0 conversions out of N attempts reads
+ * conversions still reads as data, while 0 conversions out of N impressions reads
  * as an honest zero. `currencyRole` distinguishes the two currency behaviors
  * (ticket: a total card shows `0 conversions`; an average card shows `—` with a
  * "No conversions…" secondary). It is ignored for `format='percent'`.
@@ -58,7 +58,7 @@ export interface MetricCardZeroFallback {
 	numerator?: number;
 	denominator?: number;
 	currencyRole?: 'total' | 'average';
-	/** Plural noun for the "No … in this timeframe" line, e.g. "paywall attempts". */
+	/** Plural noun for the "No … in this timeframe" line, e.g. "paywall impressions". */
 	attemptsLabel: string;
 	/** Plural noun for the conversions line, e.g. "conversions". */
 	conversionsLabel?: string;
@@ -198,12 +198,12 @@ const MetricCard = ( props: MetricCardProps ) => {
 		const conversionsNoun = conversionsLabel ?? __( 'conversions', 'newspack-plugin' );
 		const noneInWindow = ( pluralNoun: string ) =>
 			sprintf(
-				/* translators: %s is a plural noun, e.g. "paywall attempts". */
+				/* translators: %s is a plural noun, e.g. "paywall impressions". */
 				__( 'No %s in this timeframe', 'newspack-plugin' ),
 				pluralNoun
 			);
 		if ( denominator === 0 ) {
-			// Nothing happened at all → em-dash + "No <attempts> in this timeframe".
+			// Nothing happened at all → em-dash + "No <impressions> in this timeframe".
 			fallbackHero = EM_DASH;
 			fallbackSecondary = noneInWindow( attemptsLabel );
 		} else if ( numerator === 0 && typeof denominator === 'number' && denominator > 0 ) {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
@@ -45,7 +45,7 @@ const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
 	paywall_conversion_influenced_14d: scalar(),
 	total_paywall_revenue_direct: scalar( { placeholder_type: 'currency' } ),
 	avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency' } ),
-	paywall_attempts_total: 0,
+	paywall_impressions_total: 0,
 	paywall_conversions_total: 0,
 	// Default: hub count fields ABSENT (null) — the pre-deploy production state.
 	registration_impressions_total: null,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -37,7 +37,7 @@ const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
 	paywall_conversion_influenced_14d: scalar(),
 	total_paywall_revenue_direct: scalar( { placeholder_type: 'currency' } ),
 	avg_revenue_per_paywall_conversion: scalar( { placeholder_type: 'currency' } ),
-	paywall_attempts_total: 0,
+	paywall_impressions_total: 0,
 	paywall_conversions_total: 0,
 	// NPPD-1702 Free-section totals — required by the type; null (absent) here
 	// since these tests exercise the Paid section, which never reads them.
@@ -50,19 +50,19 @@ const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
 } );
 
 describe( 'PaidReaderConversionSection empty states', () => {
-	it( 'renders no_opportunity when there are no paywall attempts', () => {
-		const current = makeWindow( { paywall_attempts_total: 0, paywall_conversions_total: 0 } );
+	it( 'renders no_opportunity when there are no paywall impressions', () => {
+		const current = makeWindow( { paywall_impressions_total: 0, paywall_conversions_total: 0 } );
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Body is asserted on the container — the Notice's speak() duplicates it into a
 		// global live-region, so a screen-level text query would match twice.
-		expect( container ).toHaveTextContent( 'No paywall attempts in this timeframe' );
+		expect( container ).toHaveTextContent( 'No paywall impressions in this timeframe' );
 		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders no_conversions with the attempt count interpolated when attempts > 0 and conversions = 0', () => {
-		const current = makeWindow( { paywall_attempts_total: 17, paywall_conversions_total: 0 } );
+	it( 'renders no_conversions with the impression count interpolated when impressions > 0 and conversions = 0', () => {
+		const current = makeWindow( { paywall_impressions_total: 17, paywall_conversions_total: 0 } );
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_conversions"]' ) ).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 
 	it( 'renders the four scorecards (no empty state) when the section has data', () => {
 		const current = makeWindow( {
-			paywall_attempts_total: 320,
+			paywall_impressions_total: 320,
 			paywall_conversions_total: 11,
 			paywall_conversion_direct: scalar( { value: 0.021, numerator: 7, denominator: 320 } ),
 			paywall_conversion_influenced_14d: scalar( { value: 0.038, numerator: 11, denominator: 290 } ),
@@ -87,18 +87,18 @@ describe( 'PaidReaderConversionSection empty states', () => {
 	} );
 
 	it( 'does NOT show an empty state when the Direct scalar errored — renders the scorecards instead', () => {
-		// An errored Direct query leaves paywall_attempts_total at 0 (null denominator).
-		// That must not be mistaken for a genuine "no paywall attempts" empty state — the
+		// An errored Direct query leaves paywall_impressions_total at 0 (null denominator).
+		// That must not be mistaken for a genuine "no paywall impressions" empty state — the
 		// cards should render so the errored one surfaces its own error treatment.
 		const current = makeWindow( {
-			paywall_attempts_total: 0,
+			paywall_impressions_total: 0,
 			paywall_conversions_total: 0,
 			paywall_conversion_direct: scalar( { state: 'error', computable: false, error_message: 'BQ down' } ),
 		} );
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( container ).not.toHaveTextContent( 'No paywall attempts in this timeframe' );
+		expect( container ).not.toHaveTextContent( 'No paywall impressions in this timeframe' );
 		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
 	} );
 
@@ -107,7 +107,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		// (its null numerator coerces to 0 in paywall_section_totals). The section must
 		// not render the no_conversions empty state and hide the errored Influenced card.
 		const current = makeWindow( {
-			paywall_attempts_total: 17,
+			paywall_impressions_total: 17,
 			paywall_conversions_total: 0,
 			paywall_conversion_direct: scalar( { value: 0, numerator: 0, denominator: 17 } ),
 			paywall_conversion_influenced_14d: scalar( { state: 'error', computable: false, error_message: 'BQ down' } ),
@@ -126,7 +126,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		// Section has data (Influenced converted) so it renders scorecards, but the
 		// Direct rate card has 0 of 320 and the Direct revenue card has 0 conversions.
 		const current = makeWindow( {
-			paywall_attempts_total: 320,
+			paywall_impressions_total: 320,
 			paywall_conversions_total: 11,
 			paywall_conversion_direct: scalar( { value: 0, computable: true, numerator: 0, denominator: 320 } ),
 			paywall_conversion_influenced_14d: scalar( { value: 0.038, numerator: 11, denominator: 290 } ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -66,7 +66,7 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_conversions"]' ) ).toBeInTheDocument();
-		expect( container ).toHaveTextContent( 'Your paywall reached 17 readers' );
+		expect( container ).toHaveTextContent( 'Your paywall was shown 17 times' );
 		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -7,8 +7,8 @@
  *
  * When the section would render as a row of zeros it swaps the grid for a
  * single `<EmptyMetricSection>` (detection stays here, not in the orchestrator):
- *   - no paywall attempts in the window → `no_opportunity`
- *   - attempts but no conversions       → `no_conversions` (with the attempt count)
+ *   - no paywall impressions in the window → `no_opportunity`
+ *   - impressions but no conversions       → `no_conversions` (with the impression count)
  *   - otherwise the four scorecards, each carrying its count fallback so an
  *     individual zero card reads as "0 of N" / "0 conversions" rather than 0%/$0.
  */
@@ -40,10 +40,10 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 		'How effectively paywall gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paywall impression. Influenced counts subscriptions that happened in a later session within 14 days of a paywall impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
 		'newspack-plugin'
 	);
-	const attemptsLabel = __( 'paywall attempts', 'newspack-plugin' );
+	const impressionsLabel = __( 'paywall impressions', 'newspack-plugin' );
 	const conversionsLabel = __( 'conversions', 'newspack-plugin' );
 
-	const attempts = current.paywall_attempts_total;
+	const impressions = current.paywall_impressions_total;
 	const conversions = current.paywall_conversions_total;
 
 	// The section totals are derived from the Direct denominator and the Direct/
@@ -51,19 +51,19 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 	// coercing the totals to 0. A zero total is only a *genuine* empty state when
 	// both source metrics actually computed; if either errored we fall through to
 	// the scorecards so each card surfaces its own error treatment rather than a
-	// misleading "no paywall attempts" / "no conversions" empty state. (Direct and
+	// misleading "no paywall impressions" / "no conversions" empty state. (Direct and
 	// Influenced are separate queries and can fail independently.)
 	const dataKnown = current.paywall_conversion_direct.state !== 'error' && current.paywall_conversion_influenced_14d.state !== 'error';
 
 	// Empty states (NPPD-1694). Order matters: no opportunity before no conversions.
-	if ( dataKnown && attempts === 0 ) {
+	if ( dataKnown && impressions === 0 ) {
 		return (
 			<EmptyMetricSection
 				title={ title }
 				caption={ caption }
 				state="no_opportunity"
 				body={ __(
-					'No paywall attempts in this timeframe. Your paywall gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
+					'No paywall impressions in this timeframe. Your paywall gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
 					'newspack-plugin'
 				) }
 			/>
@@ -75,7 +75,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				title={ title }
 				caption={ caption }
 				state="no_conversions"
-				signalCount={ attempts }
+				signalCount={ impressions }
 				body={ __(
 					'No paywall conversions in this timeframe. Your paywall reached {N} readers, but none completed a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
 					'newspack-plugin'
@@ -100,7 +100,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						zeroFallback: {
 							numerator: current.paywall_conversion_direct.numerator ?? undefined,
 							denominator: current.paywall_conversion_direct.denominator ?? undefined,
-							attemptsLabel,
+							attemptsLabel: impressionsLabel,
 						},
 					} ) }
 				/>
@@ -116,7 +116,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						zeroFallback: {
 							numerator: current.paywall_conversion_influenced_14d.numerator ?? undefined,
 							denominator: current.paywall_conversion_influenced_14d.denominator ?? undefined,
-							attemptsLabel,
+							attemptsLabel: impressionsLabel,
 						},
 					} ) }
 				/>
@@ -130,15 +130,15 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						current: current.total_paywall_revenue_direct,
 						previous: previous?.total_paywall_revenue_direct,
 						// Currency total: conversions ride on the scalar's `denominator`;
-						// attempts come from the section total — but only when the Direct
-						// scalar computed. Otherwise `attempts` is an unreliable 0, so pass
+						// impressions come from the section total — but only when the Direct
+						// scalar computed. Otherwise `impressions` is an unreliable 0, so pass
 						// undefined and let the card render its own value/error treatment
-						// instead of a misleading "No paywall attempts".
+						// instead of a misleading "No paywall impressions".
 						zeroFallback: {
 							numerator: current.total_paywall_revenue_direct.denominator ?? undefined,
-							denominator: dataKnown ? attempts : undefined,
+							denominator: dataKnown ? impressions : undefined,
 							currencyRole: 'total',
-							attemptsLabel,
+							attemptsLabel: impressionsLabel,
 							conversionsLabel,
 						},
 					} ) }
@@ -151,9 +151,9 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						previous: previous?.avg_revenue_per_paywall_conversion,
 						zeroFallback: {
 							numerator: current.avg_revenue_per_paywall_conversion.denominator ?? undefined,
-							denominator: dataKnown ? attempts : undefined,
+							denominator: dataKnown ? impressions : undefined,
 							currencyRole: 'average',
-							attemptsLabel,
+							attemptsLabel: impressionsLabel,
 							conversionsLabel,
 						},
 					} ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -77,7 +77,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				state="no_conversions"
 				signalCount={ impressions }
 				body={ __(
-					'No paywall conversions in this timeframe. Your paywall reached {N} readers, but none completed a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
+					'No paywall conversions in this timeframe. Your paywall was shown {N} times, but none led to a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
 					'newspack-plugin'
 				) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
@@ -32,8 +32,8 @@ export interface ScalarCardProps {
 	previous?: GatesScalarMetric | null;
 	/**
 	 * Count-fallback for a zero card (NPPD-1694). The section builds it because
-	 * it owns the attempt/conversion copy and (for currency cards) the
-	 * section-level attempts count. Forwarded as-is; ignored in the error branch.
+	 * it owns the impressions/conversion copy and (for currency cards) the
+	 * section-level impressions count. Forwarded as-is; ignored in the error branch.
 	 */
 	zeroFallback?: MetricCardZeroFallback;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -975,7 +975,7 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 17, $totals['paywall_attempts_total'] );
+		$this->assertSame( 17, $totals['paywall_impressions_total'] );
 		// max( direct 2, influenced 5 ) — don't hide Influenced-only conversions.
 		$this->assertSame( 5, $totals['paywall_conversions_total'] );
 	}
@@ -996,7 +996,7 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( 17, $totals['paywall_attempts_total'] );
+		$this->assertSame( 17, $totals['paywall_impressions_total'] );
 		$this->assertSame( 0, $totals['paywall_conversions_total'] );
 	}
 
@@ -1015,11 +1015,11 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 				'numerator'   => 0,
 			]
 		);
-		$this->assertSame( 0, $zero['paywall_attempts_total'] );
+		$this->assertSame( 0, $zero['paywall_impressions_total'] );
 		$this->assertSame( 0, $zero['paywall_conversions_total'] );
 
 		$missing = Gates_Metric::paywall_section_totals( [], [] );
-		$this->assertSame( 0, $missing['paywall_attempts_total'] );
+		$this->assertSame( 0, $missing['paywall_impressions_total'] );
 		$this->assertSame( 0, $missing['paywall_conversions_total'] );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -317,6 +317,64 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1817: with the capability column present, the numerator and denominator are
+	 * both restricted to paywall-CAPABLE gates (checkout_impressions > 0). A capable
+	 * gate that did NOT convert still enters the (tab-level) denominator; a converting-
+	 * but-not-capable gate is excluded from BOTH sides — keeping the rate on one
+	 * population and reconciling with the per-gate table. The excluded conversion still
+	 * belongs to the inclusive count surfaces.
+	 */
+	public function test_paywall_conversion_direct_restricts_numerator_to_capable_gates() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				// Capable + converting.
+				[
+					'gate_post_id'         => 77,
+					'impressions'          => 5000,
+					'checkout_impressions' => 300,
+				],
+				// Capable but did NOT convert — still in the capable denominator.
+				[
+					'gate_post_id'         => 88,
+					'impressions'          => 2000,
+					'checkout_impressions' => 100,
+				],
+				// Converting but NOT paywall-capable (no checkout button) → excluded from both sides.
+				[
+					'gate_post_id'         => 99,
+					'impressions'          => 1500,
+					'checkout_impressions' => 0,
+				],
+			]
+		);
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [
+					'77' => [
+						'conversions' => 30,
+						'revenue'     => 0.0,
+					],
+					'99' => [
+						'conversions' => 20,
+						'revenue'     => 0.0,
+					],
+				],
+				'by_popup' => [],
+			]
+		);
+
+		$metric = $this->make_direct_paywall_metric( $proxy, $subscribers, true );
+		$result = $metric->get_paywall_conversion_direct( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertSame( 400, $result['denominator'], 'tab-level capable impressions (300 + 100); non-capable gate 99 excluded' );
+		$this->assertSame( 30, $result['numerator'], 'gate 99\'s 20 conversions are excluded — not paywall-capable' );
+		$this->assertSame( 0.075, $result['value'], '30 / 400' );
+	}
+
+	/**
 	 * No impressions for the converting gate → no denominator → not computable.
 	 */
 	public function test_paywall_conversion_direct_not_computable_without_impressions() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -662,6 +662,56 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPD-1817: the numerator is restricted to donation-CAPABLE popups, so a
+	 * converting-but-not-capable popup (donation_impressions = 0) is excluded from the
+	 * rate — keeping the numerator on the same population as the capable-impressions
+	 * denominator and reconciling with the per-prompt table (which zeroes its row). The
+	 * excluded conversion still belongs to the count/revenue cards, which sum all.
+	 */
+	public function test_donation_conversion_direct_excludes_non_capable_converting_popup() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				// Donation-capable + converting.
+				[
+					'popup_id'             => 1,
+					'intent'               => 'donation',
+					'impressions'          => 1000,
+					'donation_impressions' => 300,
+				],
+				// Converting but NOT donation-capable (no donate block) → excluded from the rate.
+				[
+					'popup_id'             => 2,
+					'intent'               => 'undefined',
+					'impressions'          => 800,
+					'donation_impressions' => 0,
+				],
+			]
+		);
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_prompt_attributed_donation_conversions' )->willReturn(
+			[
+				'1' => [
+					'conversions' => 30,
+					'revenue'     => 0.0,
+				],
+				'2' => [
+					'conversions' => 20,
+					'revenue'     => 0.0,
+				],
+			]
+		);
+
+		$metric = $this->make_direct_donation_metric( $proxy, $donors, true );
+		$rate   = $metric->get_donation_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertSame( 300, $rate['denominator'], 'only the capable popup contributes impressions' );
+		$this->assertSame( 0.1, $rate['value'], '30 capable conversions / 300 (popup 2\'s 20 conversions excluded)' );
+		$this->assertTrue( $rate['computable'] );
+	}
+
+	/**
 	 * No donation impressions → no denominator → not computable (em-dash),
 	 * distinct from the real 0% below.
 	 */
@@ -942,6 +992,59 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'populated', $rate['state'] );
 		$this->assertSame( 300, $rate['denominator'], 'tab-level checkout_impressions sum (200 + 100), not the per-popup-keyed 200' );
 		$this->assertEqualsWithDelta( 0.16667, $rate['value'], 0.0001, '50 conversions / 300 checkout-capable impressions' );
+		$this->assertTrue( $rate['computable'] );
+	}
+
+	/**
+	 * NPPD-1817: the numerator is restricted to checkout-CAPABLE popups, so a
+	 * converting-but-not-capable popup (checkout_impressions = 0) is excluded from the
+	 * rate — keeping the numerator on the same population as the capable-impressions
+	 * denominator and reconciling with the per-prompt table (which zeroes its row). The
+	 * excluded conversion still belongs to the count/revenue cards, which sum all.
+	 */
+	public function test_subscription_conversion_direct_excludes_non_capable_converting_popup() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				// Checkout-capable + converting.
+				[
+					'popup_id'             => 1,
+					'intent'               => 'undefined',
+					'impressions'          => 1000,
+					'checkout_impressions' => 300,
+				],
+				// Converting but NOT checkout-capable (no checkout block) → excluded from the rate.
+				[
+					'popup_id'             => 2,
+					'intent'               => 'registration',
+					'impressions'          => 800,
+					'checkout_impressions' => 0,
+				],
+			]
+		);
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_attributed_subscription_conversions' )->willReturn(
+			[
+				'by_gate'  => [],
+				'by_popup' => [
+					'1' => [
+						'conversions' => 30,
+						'revenue'     => 0.0,
+					],
+					'2' => [
+						'conversions' => 20,
+						'revenue'     => 0.0,
+					],
+				],
+			]
+		);
+
+		$metric = $this->make_direct_subscription_metric( $proxy, $subscribers, true );
+		$rate   = $metric->get_subscription_conversion_direct( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $rate['state'] );
+		$this->assertSame( 300, $rate['denominator'], 'only the capable popup contributes impressions' );
+		$this->assertSame( 0.1, $rate['value'], '30 capable conversions / 300 (popup 2\'s 20 conversions excluded)' );
 		$this->assertTrue( $rate['computable'] );
 	}
 


### PR DESCRIPTION
## What

Two related fixes on the Insights Gates + Prompts Direct-rate metrics.

Linear: [NPPD-1817](https://linear.app/a8c/issue/NPPD-1817)

### 1. Capability-restrict the Direct-rate numerators (the ticket)

The three "Direct" conversion-rate scalars summed their numerator over **all** attributed-converting popups/gates, while the denominator was the **capability-capable** impression subset (`donation_impressions` / `checkout_impressions`). A converting-but-not-capable popup/gate therefore inflated the scalar numerator over a denominator that excluded its impressions, and diverged from the per-row table (which already zeroes a non-capable row's conversions) — the same scalar/table incoherence class as [NPPD-1746](https://linear.app/a8c/issue/NPPD-1746).

This restricts each Direct-rate numerator to capability-capable entities (`*_impressions > 0`) so numerator and denominator share one population and reconcile with the table.

- **Prompts** (`Prompts_Metric`): new shared `fetch_capability_impressions_by_popup( $column, … )`; `get_donation_conversion_direct` + `get_subscription_conversion_direct` restrict the numerator to capable popups. Column absent → null map → pre-column behavior (count all), pairing with the fallback denominator. (Includes a review follow-up: explicit `is_wp_error` guards on the capability-map result, matching the gates pattern.)
- **Gates** (`Gates_Metric`): new `fetch_checkout_impressions_by_gate(…)`; `get_paywall_conversion_direct` restricts numerator + denominator to paywall-capable gates (tab-level capable denominator) when `checkout_impressions` is present, else falls back to the per-gate-keyed total.

**Decision (confirmed):** rate numerator = capability-restricted (matches denominator + table). **Count + revenue cards keep counting ALL** attributed conversions — those are separate metrics and were not touched.

### 2. "attempts" → "impressions" on the Gates Paid section

Surfaced by #1: the Gates Paid section labeled its denominator "paywall attempts" / "No paywall attempts", but that value is impressions (and after #1, capability-restricted checkout impressions) — and the Free section already says "impressions". Renamed the user-facing copy and the `paywall_attempts_total` field → `paywall_impressions_total` (symmetric with `registration_impressions_total`) across PHP (metric + fixtures), the TS type, the consumer, and tests. Genuine attempt metrics ("Subscription attempt rate", payment "retry attempts") are intentionally left unchanged.

**Empty-state behavior change worth a look:** because the gates Direct denominator now counts all capable gates (not just converting ones), a publisher with paywall impressions but zero conversions now correctly hits the `no_conversions` state (*"Your paywall was shown {N} times, but none led to a paid subscription…"*) instead of mis-hitting `no_opportunity` (*"No paywall impressions…"*), which the old converting-gates-only denominator caused. The `no_conversions` copy was also reworded from "{N} readers" to "shown {N} times" since {N} is impression events, not unique readers.

## Verification

- **169 PHP tests green** (`Test_Prompts_Metric` + `Test_Gates_Metric`), incl. 3 new exclusion tests (converting-but-not-capable popup/gate excluded; capable non-converting gate still in the denominator).
- **tsc + wp-prettier + PHPCS** (workspace-root standard) all clean.