### PR TITLE
fix(insights): supporter-type pie detects donations via the shared classifier (NPPD-1767)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -758,8 +758,9 @@ final class Audience_Metric {
 	}
 
 	/**
-	 * Detect which supporter products the publisher sells. Side-effect free.
-	 * Used to shape (or hide) the Supporter Type pie.
+	 * Detect which supporter products the publisher sells, to shape (or hide) the
+	 * Supporter Type pie. Read-only apart from the shared donation classifier's own
+	 * 1-hour cache priming on a miss.
 	 *
 	 * Donations resolve through the single shared {@see Donation_Product_Classifier}
 	 * (NPPD-1767) — the same source Subscribers (Tab 6), Donors (Tab 7), and the Tab 3

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -758,27 +758,41 @@ final class Audience_Metric {
 	}
 
 	/**
-	 * Detect which supporter products the publisher sells. Side-effect free:
-	 * donations are inferred from the saved donation-product option, and
-	 * subscriptions from the presence of a published WooCommerce Subscriptions
-	 * product. Used to shape (or hide) the Supporter Type pie.
+	 * Detect which supporter products the publisher sells. Side-effect free.
+	 * Used to shape (or hide) the Supporter Type pie.
+	 *
+	 * Donations resolve through the single shared {@see Donation_Product_Classifier}
+	 * (NPPD-1767) — the same source Subscribers (Tab 6), Donors (Tab 7), and the Tab 3
+	 * funnels use: the union of the canonical donation family, products a publisher
+	 * checkbox-flags via `_newspack_is_donation`, and their variations. The previous
+	 * raw `newspack_donation_product_id` option alone missed checkbox-only donations
+	 * and let a donation-flagged subscription product double-count as a subscription,
+	 * so this one pie could contradict the Donors/Subscribers numbers beside it.
+	 *
+	 * Subscriptions detect off product type but exclude the donation set, so the two
+	 * categories stay complementary: a membership product flagged as a donation counts
+	 * as a donation here (matching Tabs 6/7), not a subscription.
 	 *
 	 * @return array{subscriptions:bool,donations:bool}
 	 */
 	private static function detect_supporter_products(): array {
-		$has_donations = (int) get_option( 'newspack_donation_product_id', 0 ) > 0;
+		$donation_ids  = Donation_Product_Classifier::get_donation_product_ids();
+		$has_donations = ! empty( $donation_ids );
 
 		$has_subscriptions = false;
 		if ( class_exists( 'WC_Subscriptions' ) && function_exists( 'wc_get_products' ) ) {
-			$subs = wc_get_products(
+			$sub_ids = wc_get_products(
 				[
 					'type'   => [ 'subscription', 'variable-subscription' ],
 					'status' => 'publish',
-					'limit'  => 1,
+					'limit'  => -1,
 					'return' => 'ids',
 				]
 			);
-			$has_subscriptions = ! empty( $subs );
+			// Drop products the publisher designated as donations so a flagged
+			// subscription-type product doesn't count as both categories.
+			$sub_ids           = array_diff( array_map( 'intval', $sub_ids ), $donation_ids );
+			$has_subscriptions = ! empty( $sub_ids );
 		}
 
 		return [

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -751,6 +751,12 @@ function wc_get_product( $product_id ) {
 	global $products_database;
 	return $products_database[ $product_id ] ?? false;
 }
+function wc_get_products( $args = [] ) {
+	// Test-controlled product query. Returns the IDs a test stages in
+	// $GLOBALS['newspack_test_wc_products'] (default empty), enough for callers that
+	// only need an existence / id-set check (e.g. the Audience supporter-type pie).
+	return $GLOBALS['newspack_test_wc_products'] ?? [];
+}
 function wcs_get_subscription_status_name( $status ) {
 	return ucfirst( $status );
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-metric.php
@@ -13,7 +13,12 @@
 namespace Newspack\Tests\Insights;
 
 use Newspack\Insights\Audience_Metric;
+use Newspack\Insights\Donation_Product_Classifier;
 use WP_UnitTestCase;
+
+// Supporter-type detection (NPPD-1767) reads `WC_Subscriptions` + `wc_get_products`;
+// the unit bootstrap loads neither, so pull in the shared WC stubs for those tests.
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
 
 /**
  * Audience_Metric registered-readers test class.
@@ -108,5 +113,88 @@ class Test_Audience_Metric extends WP_UnitTestCase {
 
 		$this->assertFalse( $payload['computable'] );
 		$this->assertNull( $payload['value'] );
+	}
+
+	/**
+	 * Reset the supporter-detection seams between tests: the staged subscription
+	 * product IDs, the classifier cache, and the canonical donation option.
+	 */
+	public function tear_down(): void {
+		unset( $GLOBALS['newspack_test_wc_products'] );
+		delete_transient( Donation_Product_Classifier::TRANSIENT_KEY );
+		delete_option( 'newspack_donation_product_id' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Invoke the private `detect_supporter_products()` directly.
+	 *
+	 * @return array{subscriptions:bool,donations:bool}
+	 */
+	private function detect_supporter_products(): array {
+		$method = new \ReflectionMethod( Audience_Metric::class, 'detect_supporter_products' );
+		$method->setAccessible( true );
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Seed the donation classifier's cache so `get_donation_product_ids()` returns
+	 * the given set without touching real products/options.
+	 *
+	 * @param int[] $ids Donation product IDs.
+	 */
+	private function set_donation_product_ids( array $ids ): void {
+		set_transient( Donation_Product_Classifier::TRANSIENT_KEY, $ids, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * NPPD-1767: donations are detected via the shared classifier, so a product
+	 * designated a donation ONLY via the `_newspack_is_donation` checkbox (no
+	 * canonical `newspack_donation_product_id` option) still registers — matching
+	 * Donors/Tab 7. The raw-option check this replaced would have read false.
+	 */
+	public function test_supporter_products_detects_checkbox_only_donations() {
+		delete_option( 'newspack_donation_product_id' );
+		$this->set_donation_product_ids( [ 555 ] );
+
+		$result = $this->detect_supporter_products();
+
+		$this->assertTrue( $result['donations'], 'checkbox-flagged donation (no canonical option) registers as a donation' );
+	}
+
+	/**
+	 * No products in the classifier set → no donation slice, even if some unrelated
+	 * option exists. (The classifier is the single source of truth.)
+	 */
+	public function test_supporter_products_no_donations_when_classifier_empty() {
+		$this->set_donation_product_ids( [] );
+
+		$result = $this->detect_supporter_products();
+
+		$this->assertFalse( $result['donations'] );
+	}
+
+	/**
+	 * NPPD-1767: a subscription-type product the publisher flagged as a donation is
+	 * counted as a donation here, NOT a subscription — keeping the pie's categories
+	 * complementary and consistent with Tabs 6/7. A genuine (non-donation)
+	 * subscription product still counts as a subscription.
+	 */
+	public function test_supporter_products_flagged_subscription_is_donation_not_subscription() {
+		// The only published subscription-type product (700) is flagged as a donation.
+		$this->set_donation_product_ids( [ 700 ] );
+		$GLOBALS['newspack_test_wc_products'] = [ 700 ];
+
+		$result = $this->detect_supporter_products();
+
+		$this->assertTrue( $result['donations'], 'the flagged product is a donation' );
+		$this->assertFalse( $result['subscriptions'], 'a donation-flagged subscription product is not double-counted as a subscription' );
+
+		// Add a genuine, non-donation subscription product (800): now subscriptions exist.
+		$GLOBALS['newspack_test_wc_products'] = [ 700, 800 ];
+
+		$result = $this->detect_supporter_products();
+
+		$this->assertTrue( $result['subscriptions'], 'a non-donation subscription product counts as a subscription' );
 	}
 }


### PR DESCRIPTION
## What

`Audience_Metric::detect_supporter_products()` shapes the **Supporter Type** pie. It detected donations from the **raw canonical option only** (`newspack_donation_product_id`), so it disagreed with every other Insights surface (Subscribers/Tab 6, Donors/Tab 7, Tab 3 funnels), which all resolve donations through the single shared `Donation_Product_Classifier`.

Two consequences this fixes:
1. **Checkbox-only donations were invisible.** A publisher who flags products as donations via `_newspack_is_donation` (a supported feature) but never set the canonical option read as `has_donations = false`, hiding the donation slice — even though Donors/Tab 7 counted those donations.
2. **A donation-flagged subscription product double-counted.** `$has_subscriptions` keyed purely off product *type*, so a membership product flagged as a donation registered as a subscription here while the classifier (Tabs 6/7) treated it as a donation — the pie could contradict the Donors/Subscribers numbers beside it.

Linear: [NPPD-1767](https://linear.app/a8c/issue/NPPD-1767) (surfaced during the [NPPD-1692](https://linear.app/a8c/issue/NPPD-1692) audit, alongside [NPPD-1766](https://linear.app/a8c/issue/NPPD-1766)).

## Fix

In `detect_supporter_products()`:
- **Donations** → `! empty( Donation_Product_Classifier::get_donation_product_ids() )` instead of the raw option (the single source of truth, already registered on this tab).
- **Subscriptions** → exclude the classifier's donation product IDs from the subscription set (`array_diff`), so a product flagged as a donation isn't also counted as a subscription — mirroring how Subscribers vs Donors split the same set.

Consumer-only (no hub, no conversion-rate impact) — a visibility/shape gate on one pie.

## Acceptance

- [x] Pie reflects donations designated *only* via the `_newspack_is_donation` checkbox (no canonical option).
- [x] A subscription-type product flagged as a donation counts as a donation, not a subscription — consistent with Tabs 6/7.
- [x] Shares the same donation set as Subscribers/Donors/Tab 3 — no second definition.
- [x] Unit tests for the checkbox-only-donations and flagged-subscription cases.

## Verification

- 8 `Test_Audience_Metric` tests green (3 new, via reflection on the private method with the classifier primed through its transient + a staged subscription set). The unit bootstrap loads neither WooCommerce nor WC Subscriptions, so the tests pull in the existing `wc-mocks.php` (with a small `wc_get_products` stub added) — the same pattern as the WCS integration test.
- **Full `--group insights` suite green (470 tests)** — confirms the added mock require doesn't disturb other insights tests; WCS integration test still coexists.
- PHPCS clean against the workspace-root standard.