### PR TITLE
fix(insights): converter-denominate the gates influenced-14d paywall rate (NPPD-1764)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -467,13 +467,17 @@ final class Gates_Metric {
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_scalar( 'rate', $rows );
 		}
+		if ( ! is_array( $rows ) ) {
+			// Malformed hub response (not an array): surface as an error, not a confident
+			// 0% — parity with the donation/subscription malformed-rows handling (NPPD-1745
+			// #3). An empty array is valid (0 influenced) and handled below.
+			return $this->error_scalar( 'rate', new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) ) );
+		}
 
 		// Numerator: distinct subscribers whose conversion was paywall-influenced (the
-		// hub influenced rows, Woo-matched). Empty/malformed rows → 0 influenced, which
-		// is a real 0% against the subscriber denominator below — not "no data".
-		$numerator = is_array( $rows ) && ! empty( $rows )
-			? $this->woo_resolver->count_unique_completed_users( $rows )
-			: 0;
+		// hub influenced rows, Woo-matched). Empty rows → 0 influenced, which is a real
+		// 0% against the subscriber denominator below — not "no data".
+		$numerator = empty( $rows ) ? 0 : $this->woo_resolver->count_unique_completed_users( $rows );
 
 		// Denominator: all new subscribers in the window (converters), not influenced
 		// attempts — anonymous-inclusive, the same Woo spine the source-mix totals use.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -75,7 +75,7 @@ final class Gates_Metric {
 		'regwall_conversion_direct'          => 'hub',
 		'regwall_conversion_influenced_7d'   => 'hub',
 		'paywall_conversion_direct'          => 'hybrid', // NPPD-1746: local order-meta (gate) numerator + hub per-gate-impressions denominator.
-		'paywall_conversion_influenced_14d'  => 'hub',
+		'paywall_conversion_influenced_14d'  => 'hybrid', // NPPD-1764: hub influenced numerator + local Woo subscriber-spine denominator (converter-denominated).
 		'total_paywall_revenue_direct'       => 'local',  // NPPD-1746: pure Woo order meta (gate surface); survives a hub outage.
 		'avg_revenue_per_paywall_conversion' => 'local',  // NPPD-1746: derived from the same order-meta source as total revenue.
 		'conversion_funnel'                  => 'hub',
@@ -422,9 +422,32 @@ final class Gates_Metric {
 	}
 
 	/**
-	 * Compute a paywall conversion rate from BQ rows + Woo completion join.
+	 * Compute the influenced-14d paywall conversion rate, converter-denominated (NPPD-1764).
 	 *
-	 * @param string            $query_name Catalog name (`gates_paywall_conversion_*`).
+	 * = distinct subscribers in the window whose conversion had a paywall-capable gate
+	 * exposure in a PRIOR session within 14d ÷ ALL new subscribers in the window. I.e.
+	 * "of our subscribers, what share were paywall-influenced" — user-level, matching the
+	 * doc's conceptual framing and Tab 3's 7.1–7.4 converter framing (NPPD-1766). (The
+	 * Direct rate is exposure-denominated by design — a different lens — so the two are
+	 * intentionally not the same base.)
+	 *
+	 * Replaces the prior attempt-denominated rate (÷ `count($rows)`), which keyed the
+	 * denominator off influenced checkout *attempts* — deflated on anonymous-conversion-
+	 * heavy publishers, so the rate read inflated.
+	 *
+	 * - **Numerator** stays hub/GA4-cross-session-sourced and Woo-matched (`count_unique_
+	 *   completed_users`): order meta has no session timing to place a prior-session
+	 *   exposure, so influenced can't move to the order-meta model the way Direct did.
+	 *   It remains anonymous-undercounted (NPPD-1685); NPPD-1747 improves its completeness
+	 *   for the whole influenced family — do NOT build a gates-specific cross-session join.
+	 * - **Denominator** is the anonymous-inclusive Woo identity spine
+	 *   ({@see Subscribers_Metric::get_new_subscribers_in_window()}). Because the GA4-matched
+	 *   numerator is not a strict subset of it, `rate_value()` suppresses any >100% to a
+	 *   non-computable em-dash (the coherence guard, parity with the Direct/Prompts rates).
+	 *
+	 * Local denominator + hub numerator → 'hybrid' (see METRIC_SOURCES).
+	 *
+	 * @param string            $query_name Catalog name (the influenced rows to match).
 	 * @param DateTimeInterface $start      Window start.
 	 * @param DateTimeInterface $end        Window end.
 	 * @return array
@@ -434,21 +457,32 @@ final class Gates_Metric {
 		DateTimeInterface $start,
 		DateTimeInterface $end
 	): array {
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no local subscribers to denominate against. Empty
+			// state, not a fake 0% (NPPD-1737 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'rate', 0 );
+		}
+
 		$rows = $this->proxy->query( $query_name, $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_scalar( 'rate', $rows );
 		}
-		if ( ! is_array( $rows ) || empty( $rows ) ) {
-			// No paywall attempts in the window → a real 0% rate. Numerator and
-			// denominator are both an explicit 0 so the card's count fallback can
-			// tell "no attempts" (denominator 0) from "0 of N" (NPPD-1694).
-			return $this->populated_scalar( 0.0, false, 0, 'rate', 0 );
-		}
-		$denominator = count( $rows );
-		$numerator   = $this->woo_resolver->count_completed_orders( $rows );
-		// Surface the numerator (matched Woo orders) alongside the denominator so
-		// the card can render "0 of {denominator}" when no attempt converted.
-		return $this->populated_scalar( $denominator > 0 ? $numerator / $denominator : 0.0, true, $denominator, 'rate', $numerator );
+
+		// Numerator: distinct subscribers whose conversion was paywall-influenced (the
+		// hub influenced rows, Woo-matched). Empty/malformed rows → 0 influenced, which
+		// is a real 0% against the subscriber denominator below — not "no data".
+		$numerator = is_array( $rows ) && ! empty( $rows )
+			? $this->woo_resolver->count_unique_completed_users( $rows )
+			: 0;
+
+		// Denominator: all new subscribers in the window (converters), not influenced
+		// attempts — anonymous-inclusive, the same Woo spine the source-mix totals use.
+		$denominator = $this->subscribers_metric()->get_new_subscribers_in_window( $start, $end );
+
+		$rate = $this->rate_value( $numerator, $denominator );
+		return null === $rate
+			? $this->populated_scalar( 0.0, false, $denominator, 'rate', $numerator )
+			: $this->populated_scalar( $rate, true, $denominator, 'rate', $numerator );
 	}
 
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -41,6 +41,9 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 		'newspack-plugin'
 	);
 	const impressionsLabel = __( 'paywall impressions', 'newspack-plugin' );
+	// The Influenced rate is converter-denominated (NPPD-1764): its denominator is all
+	// new subscribers in the window, not paywall impressions.
+	const subscribersLabel = __( 'subscribers', 'newspack-plugin' );
 	const conversionsLabel = __( 'conversions', 'newspack-plugin' );
 
 	const impressions = current.paywall_impressions_total;
@@ -108,7 +111,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					{ ...scalarToMetricCardProps( {
 						label: __( 'Paywall Conversion (Influenced, 14d)', 'newspack-plugin' ),
 						description: __(
-							'Readers who subscribed in a later session within 14 days of seeing a paywall ÷ readers who saw a paywall',
+							'Subscribers whose conversion followed a paywall exposure in a prior session within 14 days ÷ all new subscribers',
 							'newspack-plugin'
 						),
 						current: current.paywall_conversion_influenced_14d,
@@ -116,7 +119,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						zeroFallback: {
 							numerator: current.paywall_conversion_influenced_14d.numerator ?? undefined,
 							denominator: current.paywall_conversion_influenced_14d.denominator ?? undefined,
-							attemptsLabel: impressionsLabel,
+							attemptsLabel: subscribersLabel,
 						},
 					} ) }
 				/>

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -1432,4 +1432,24 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertFalse( $result['computable'] );
 		$this->assertSame( 0, $result['denominator'] );
 	}
+
+	/**
+	 * A malformed (non-array, non-WP_Error) hub response surfaces as an error rather than
+	 * a confident 0% — parity with the donation/subscription malformed-rows handling.
+	 */
+	public function test_paywall_influenced_malformed_rows_errors() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( 'not-an-array' );
+		$metric = $this->make_influenced_paywall_metric(
+			$proxy,
+			$this->resolver_with_unique_completed( 0 ),
+			$this->subscribers_with_new_count( 50 ),
+			true
+		);
+
+		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -12,6 +12,7 @@ use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Gates_Metric;
 use Newspack\Insights\Subscribers_Metric;
+use Newspack\Insights\Woo_Order_Resolver;
 use WP_UnitTestCase;
 
 /**
@@ -1298,5 +1299,137 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		// Section totals degrade to null (never `?? 0`), the production-safety crux.
 		$this->assertNull( $totals['registration_impressions_total'] );
 		$this->assertNull( $totals['registrations_total'] );
+	}
+
+	// --- NPPD-1764: influenced-14d paywall rate is converter-denominated ---
+
+	/**
+	 * Build a Gates_Metric for the influenced paywall card with injected proxy (influenced
+	 * rows), Woo_Order_Resolver (the matched numerator), and Subscribers_Metric (the
+	 * converter-spine denominator), plus a forced `woocommerce_active()`. Filter removed
+	 * in tear_down().
+	 *
+	 * @param BigQuery_Proxy_Client $proxy        Influenced rows source.
+	 * @param Woo_Order_Resolver    $woo_resolver Numerator (distinct influenced converters).
+	 * @param Subscribers_Metric    $subscribers  Denominator (new subscribers in window).
+	 * @param bool                  $wc           What woocommerce_active() should return.
+	 * @return Gates_Metric
+	 */
+	private function make_influenced_paywall_metric( BigQuery_Proxy_Client $proxy, Woo_Order_Resolver $woo_resolver, Subscribers_Metric $subscribers, bool $wc ): Gates_Metric {
+		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
+		return new Gates_Metric( $proxy, $woo_resolver, $subscribers );
+	}
+
+	/**
+	 * Stub Subscribers_Metric reporting a fixed new-subscribers-in-window count.
+	 *
+	 * @param int $new_subscribers New subscribers in the window.
+	 * @return Subscribers_Metric
+	 */
+	private function subscribers_with_new_count( int $new_subscribers ): Subscribers_Metric {
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_new_subscribers_in_window' )->willReturn( $new_subscribers );
+		return $subscribers;
+	}
+
+	/**
+	 * Stub Woo_Order_Resolver reporting a fixed distinct-completed-users count.
+	 *
+	 * @param int $count Distinct influenced converters.
+	 * @return Woo_Order_Resolver
+	 */
+	private function resolver_with_unique_completed( int $count ): Woo_Order_Resolver {
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_unique_completed_users' )->willReturn( $count );
+		return $resolver;
+	}
+
+	/**
+	 * The rate divides by ALL new subscribers in the window, not by the count of
+	 * influenced attempt rows (3 here). 12 influenced converters ÷ 400 subscribers = 3%.
+	 */
+	public function test_paywall_influenced_is_converter_denominated() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [ [ 'x' => 1 ], [ 'x' => 2 ], [ 'x' => 3 ] ] );
+		$metric = $this->make_influenced_paywall_metric(
+			$proxy,
+			$this->resolver_with_unique_completed( 12 ),
+			$this->subscribers_with_new_count( 400 ),
+			true
+		);
+
+		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 0.03, $result['value'] );
+		$this->assertSame( 400, $result['denominator'], 'denominates by all subscribers, not influenced attempts' );
+		$this->assertSame( 12, $result['numerator'] );
+	}
+
+	/**
+	 * No influenced converters but subscribers exist → a real 0% (computable), not the
+	 * "no data" non-computable state the old attempt-denominated empty-rows path returned.
+	 */
+	public function test_paywall_influenced_zero_with_subscribers_is_real_zero() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [] );
+		$metric = $this->make_influenced_paywall_metric(
+			$proxy,
+			$this->resolver_with_unique_completed( 0 ),
+			$this->subscribers_with_new_count( 50 ),
+			true
+		);
+
+		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 0.0, $result['value'] );
+		$this->assertSame( 50, $result['denominator'] );
+		$this->assertSame( 0, $result['numerator'] );
+	}
+
+	/**
+	 * Coherence guard: a GA4-matched numerator larger than the windowed subscriber
+	 * denominator suppresses to a non-computable em-dash rather than rendering >100%.
+	 */
+	public function test_paywall_influenced_over_100_suppressed() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [ [ 'x' => 1 ] ] );
+		$metric = $this->make_influenced_paywall_metric(
+			$proxy,
+			$this->resolver_with_unique_completed( 5 ),
+			$this->subscribers_with_new_count( 3 ),
+			true
+		);
+
+		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 3, $result['denominator'] );
+		$this->assertSame( 5, $result['numerator'] );
+	}
+
+	/**
+	 * Non-WC publisher: no local subscribers to denominate against → empty state, and the
+	 * hub is never queried (short-circuits before the proxy call).
+	 */
+	public function test_paywall_influenced_non_wc_empty_state() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+		$metric = $this->make_influenced_paywall_metric(
+			$proxy,
+			$this->resolver_with_unique_completed( 0 ),
+			$this->subscribers_with_new_count( 0 ),
+			false
+		);
+
+		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 0, $result['denominator'] );
 	}
 }


### PR DESCRIPTION
## What

The Tab 4 **influenced-14d paywall conversion rate** divided by influenced checkout **attempts** (`count($rows)`), which deflated the denominator on anonymous-conversion-heavy publishers (the NPPD-1685 gap) and read **inflated** — and was inconsistent with both the Direct rate and Tab 3's converter-framed influenced rates.

This converter-denominates it (the framing the doc's §"Gate conversion (Influenced)" already prescribes — *"what fraction of converters were influenced is inherently a user-count question"*):

> **influenced-14d = (distinct subscribers in the window whose conversion had a paywall-capable gate exposure in a prior session within 14d) ÷ (ALL new subscribers in the window)**

Linear: [NPPD-1764](https://linear.app/a8c/issue/NPPD-1764) — discovery resolved to this framing (see the ticket comment). Sibling of [NPPD-1766](https://linear.app/a8c/issue/NPPD-1766) (Tab 3 7.2/7.3).

## How

`Gates_Metric::compute_paywall_rate_from_proxy`:
- **Numerator** = distinct Woo-matched influenced converters (`Woo_Order_Resolver::count_unique_completed_users`) from the hub `gates_paywall_conversion_influenced_14d` rows. Stays GA4-cross-session-sourced — order meta has no session timing to place a *prior*-session exposure, so influenced can't move to the order-meta model the way Direct did. Remains anonymous-undercounted; **NPPD-1747** improves its completeness for the whole influenced family (no gates-specific join built here).
- **Denominator** = all new subscribers in the window (`Subscribers_Metric::get_new_subscribers_in_window`, anonymous-inclusive Woo identity spine) — the converter population, not attempts.
- `rate_value()` suppresses any >100% to a non-computable em-dash (the GA4-matched numerator isn't a strict subset of the anonymous-inclusive denominator). Non-WC → empty state. Reclassified `paywall_conversion_influenced_14d` → `hybrid` (local denominator + hub numerator).

## Not included (deliberate)

- **Regwall influenced-7d** is hub-precomputed (`compute_regwall_rate_from_proxy` passes the hub rate through), so converter-denominating it is a separate `newspack-manager-admin` change to the `gates_regwall_conversion_influenced_7d` query — flagged in the ticket, not in this plugin PR.
- Numerator *completeness* (the cross-session anonymous gap) → NPPD-1747.

## Verification

- 64 `Test_Gates_Metric` tests green (4 new: converter-denominated happy path asserting it divides by all subscribers not attempts; real-0% when subscribers exist but none influenced; >100% coherence-guard em-dash; non-WC empty state + hub never queried).
- PHPCS clean (workspace-root standard).
- Docs: `formulas/tab-4-gates.md` updated on `insights-docs` trunk (resolved the §formula vs §framing contradiction + replaced the "denominator drift" note).