### PR TITLE
fix(theme): prevent Custom Fields clobber, keep box editable

### DIFF
--- a/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -80,7 +80,7 @@ final class Subtitle_Block {
 			return;
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- meta-row ids only; each row value is sanitized below and the nonce is verified above.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- only the meta-row key is read and sanitized below; the row value is never used, and the nonce is verified above.
 		foreach ( array_keys( (array) $_POST['meta'] ) as $mid ) {
 			$key = isset( $_POST['meta'][ $mid ]['key'] )
 				? sanitize_text_field( wp_unslash( $_POST['meta'][ $mid ]['key'] ) )

--- a/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/themes/newspack-block-theme/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -22,7 +22,7 @@ final class Subtitle_Block {
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'register_block_and_post_meta' ] );
 		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
-		\add_filter( 'is_protected_meta', [ __CLASS__, 'protect_post_meta' ], 10, 3 );
+		\add_action( 'admin_init', [ __CLASS__, 'prevent_classic_metabox_meta_clobber' ] );
 	}
 
 	/**
@@ -40,39 +40,55 @@ final class Subtitle_Block {
 			'post',
 			self::POST_META_NAME,
 			[
-				'show_in_rest'  => true,
-				'single'        => true,
-				'type'          => 'string',
-				// Managed by the editor subtitle UI via REST. An explicit
-				// auth_callback keeps it REST-editable while protect_post_meta()
-				// marks it protected (see that method).
-				'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
-					return current_user_can( 'edit_post', $object_id );
-				},
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
 			]
 		);
 	}
 
 	/**
-	 * Mark the subtitle meta as protected.
+	 * Stop the classic "Custom Fields" box from clobbering the subtitle meta.
 	 *
-	 * The subtitle is edited through the editor subtitle UI (saved via the REST
-	 * API), not the classic "Custom Fields" box. Leaving it unprotected lets
-	 * that box resubmit a stale value on save and silently overwrite the
-	 * REST-saved value when a classic meta box triggers the block editor's
-	 * meta-box save. Protecting it removes it from the Custom Fields box; the
-	 * explicit auth_callback on the registration keeps it REST-editable.
+	 * The subtitle is edited through the editor subtitle UI and saved via the
+	 * REST API. When the "Custom Fields" panel is enabled, the editor also fires
+	 * a separate classic meta-box save (the `meta-box-loader` request) that
+	 * resubmits the box's page-load value and writes it through edit_post(),
+	 * landing just after the REST save and silently overwriting it.
 	 *
-	 * @param bool   $protected Whether the meta key is considered protected.
-	 * @param string $meta_key  The meta key.
-	 * @param string $meta_type The type of object the meta belongs to (post, term, user, etc.).
-	 * @return bool Whether the meta key is protected.
+	 * Rather than protecting the key (which would remove it from the Custom
+	 * Fields box and block publishers who manage it there), we drop it from the
+	 * meta-box-loader payload only. Intentional edits made with the box's own
+	 * Add/Update buttons save through a separate admin-ajax request and are
+	 * unaffected.
+	 *
+	 * @return void
 	 */
-	public static function protect_post_meta( $protected, $meta_key, $meta_type ) {
-		if ( 'post' !== $meta_type ) {
-			return $protected;
+	public static function prevent_classic_metabox_meta_clobber() {
+		// Only the block editor's auxiliary meta-box save carries this flag; a
+		// genuine classic-editor save does not, and must keep writing normally.
+		if ( ! isset( $_REQUEST['meta-box-loader'], $_POST['post_ID'], $_POST['_wpnonce'], $_POST['meta'] ) ) {
+			return;
 		}
-		return self::POST_META_NAME === $meta_key ? true : $protected;
+
+		// edit_post() processes $_POST['meta'] only after core verifies this nonce
+		// for the 'editpost' action (wp-admin/post.php). This runs earlier (on
+		// admin_init), so verify the same nonce before touching the payload.
+		$post_id = (int) $_POST['post_ID'];
+		$nonce   = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) );
+		if ( ! $post_id || ! wp_verify_nonce( $nonce, 'update-post_' . $post_id ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- meta-row ids only; each row value is sanitized below and the nonce is verified above.
+		foreach ( array_keys( (array) $_POST['meta'] ) as $mid ) {
+			$key = isset( $_POST['meta'][ $mid ]['key'] )
+				? sanitize_text_field( wp_unslash( $_POST['meta'][ $mid ]['key'] ) )
+				: '';
+			if ( self::POST_META_NAME === $key ) {
+				unset( $_POST['meta'][ $mid ] );
+			}
+		}
 	}
 
 	/**

--- a/themes/newspack-theme/newspack-theme/functions.php
+++ b/themes/newspack-theme/newspack-theme/functions.php
@@ -906,13 +906,6 @@ add_filter( 'jetpack_photon_override_image_downsize', 'newspack_override_avatar_
  * - Show share buttons (pages)
  */
 function newspack_register_meta() {
-	// These fields are edited through dedicated editor panels via the REST API.
-	// An explicit auth_callback keeps them REST-editable even though
-	// newspack_protect_editor_meta() marks them protected (see that function).
-	$auth_callback = function ( $allowed, $meta_key, $object_id ) {
-		return current_user_can( 'edit_post', $object_id );
-	};
-
 	$featured_image_post_types = newspack_get_featured_image_post_types();
 
 	foreach ( $featured_image_post_types as $post_type ) {
@@ -920,10 +913,9 @@ function newspack_register_meta() {
 			$post_type,
 			'newspack_featured_image_position',
 			array(
-				'show_in_rest'  => true,
-				'single'        => true,
-				'type'          => 'string',
-				'auth_callback' => $auth_callback,
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
 			)
 		);
 	}
@@ -932,10 +924,9 @@ function newspack_register_meta() {
 		'post',
 		'newspack_post_subtitle',
 		array(
-			'show_in_rest'  => true,
-			'single'        => true,
-			'type'          => 'string',
-			'auth_callback' => $auth_callback,
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
 		)
 	);
 
@@ -943,11 +934,10 @@ function newspack_register_meta() {
 		'post',
 		'newspack_article_summary_title',
 		array(
-			'default'       => esc_html__( 'Overview:', 'newspack-theme' ),
-			'show_in_rest'  => true,
-			'single'        => true,
-			'type'          => 'string',
-			'auth_callback' => $auth_callback,
+			'default'      => esc_html__( 'Overview:', 'newspack-theme' ),
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
 		)
 	);
 
@@ -955,10 +945,9 @@ function newspack_register_meta() {
 		'post',
 		'newspack_article_summary',
 		array(
-			'show_in_rest'  => true,
-			'single'        => true,
-			'type'          => 'string',
-			'auth_callback' => $auth_callback,
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
 		)
 	);
 
@@ -966,10 +955,9 @@ function newspack_register_meta() {
 		'page',
 		'newspack_hide_page_title',
 		array(
-			'show_in_rest'  => true,
-			'single'        => true,
-			'type'          => 'boolean',
-			'auth_callback' => $auth_callback,
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'boolean',
 		)
 	);
 
@@ -977,38 +965,25 @@ function newspack_register_meta() {
 		'page',
 		'newspack_show_share_buttons',
 		array(
-			'show_in_rest'  => true,
-			'single'        => true,
-			'type'          => 'boolean',
-			'default'       => false,
-			'auth_callback' => $auth_callback,
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'boolean',
+			'default'      => false,
 		)
 	);
 }
 add_action( 'init', 'newspack_register_meta' );
 
 /**
- * Mark the theme's editor-managed post meta as protected.
+ * Editor-managed post meta keys the classic "Custom Fields" box must not write.
  *
- * These fields are managed by dedicated block-editor panels (saved via the REST
- * API), not by the classic "Custom Fields" box. When that box is enabled, it
- * renders a row for each non-protected meta key and resubmits its page-load
- * value on save; if a classic meta box triggers the block editor's separate
- * meta-box save, that stale value silently overwrites the value the REST save
- * just wrote. Marking these keys protected removes them from the Custom Fields
- * box so they can't be clobbered. REST editing is preserved by the explicit
- * auth_callback set on each registration in newspack_register_meta().
+ * These keys are edited through dedicated block-editor panels and saved via the
+ * REST API. See newspack_prevent_classic_metabox_meta_clobber().
  *
- * @param bool   $protected Whether the meta key is considered protected.
- * @param string $meta_key  The meta key.
- * @param string $meta_type The type of object the meta belongs to (post, term, user, etc.).
- * @return bool Whether the meta key is protected.
+ * @return string[] Meta keys.
  */
-function newspack_protect_editor_meta( $protected, $meta_key, $meta_type ) {
-	if ( 'post' !== $meta_type ) {
-		return $protected;
-	}
-	$editor_meta = array(
+function newspack_get_editor_managed_meta_keys() {
+	return array(
 		'newspack_featured_image_position',
 		'newspack_post_subtitle',
 		'newspack_article_summary_title',
@@ -1016,9 +991,54 @@ function newspack_protect_editor_meta( $protected, $meta_key, $meta_type ) {
 		'newspack_hide_page_title',
 		'newspack_show_share_buttons',
 	);
-	return in_array( $meta_key, $editor_meta, true ) ? true : $protected;
 }
-add_filter( 'is_protected_meta', 'newspack_protect_editor_meta', 10, 3 );
+
+/**
+ * Stop the classic "Custom Fields" box from clobbering editor-managed meta.
+ *
+ * The block editor saves these keys via the REST API. When the "Custom Fields"
+ * panel is enabled, the editor also fires a separate classic meta-box save (the
+ * `meta-box-loader` request) that resubmits the box's page-load value for every
+ * existing meta row and writes it through edit_post(). That stale write lands a
+ * moment after the REST save and silently overwrites it.
+ *
+ * Rather than protecting these keys (which would remove them from the Custom
+ * Fields box entirely and block publishers who manage subtitles there, e.g. on
+ * custom post types that have no dedicated panel), we drop our managed keys from
+ * the meta-box-loader payload only. Intentional edits made with the box's own
+ * Add/Update buttons save through a separate admin-ajax request and are
+ * unaffected.
+ *
+ * @return void
+ */
+function newspack_prevent_classic_metabox_meta_clobber() {
+	// Only the block editor's auxiliary meta-box save carries this flag; a genuine
+	// classic-editor save does not, and must keep writing Custom Fields normally.
+	if ( ! isset( $_REQUEST['meta-box-loader'], $_POST['post_ID'], $_POST['_wpnonce'], $_POST['meta'] ) ) {
+		return;
+	}
+
+	// edit_post() processes $_POST['meta'] only after core verifies this nonce for
+	// the 'editpost' action (wp-admin/post.php). This runs earlier (admin_init), so
+	// verify the same nonce here before touching the payload.
+	$post_id = (int) $_POST['post_ID'];
+	$nonce   = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) );
+	if ( ! $post_id || ! wp_verify_nonce( $nonce, 'update-post_' . $post_id ) ) {
+		return;
+	}
+
+	$managed = newspack_get_editor_managed_meta_keys();
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- meta-row ids only; each row value is sanitized below and the nonce is verified above.
+	foreach ( array_keys( (array) $_POST['meta'] ) as $mid ) {
+		$key = isset( $_POST['meta'][ $mid ]['key'] )
+			? sanitize_text_field( wp_unslash( $_POST['meta'][ $mid ]['key'] ) )
+			: '';
+		if ( in_array( $key, $managed, true ) ) {
+			unset( $_POST['meta'][ $mid ] );
+		}
+	}
+}
+add_action( 'admin_init', 'newspack_prevent_classic_metabox_meta_clobber' );
 
 
 /**

--- a/themes/newspack-theme/newspack-theme/functions.php
+++ b/themes/newspack-theme/newspack-theme/functions.php
@@ -1028,7 +1028,7 @@ function newspack_prevent_classic_metabox_meta_clobber() {
 	}
 
 	$managed = newspack_get_editor_managed_meta_keys();
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- meta-row ids only; each row value is sanitized below and the nonce is verified above.
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- only the meta-row key is read and sanitized below; the row value is never used, and the nonce is verified above.
 	foreach ( array_keys( (array) $_POST['meta'] ) as $mid ) {
 		$key = isset( $_POST['meta'][ $mid ]['key'] )
 			? sanitize_text_field( wp_unslash( $_POST['meta'][ $mid ]['key'] ) )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR keeps editor-managed post meta (subtitle, featured image position, and similar) from being overwritten on save, while keeping those fields editable in the Custom Fields box.

The hotfix in `newspack-theme` 2.23.4 / `newspack-block-theme` 1.28.5 (#375) fixed the overwrite by marking those keys as protected, which also removed them from the Custom Fields box entirely. That blocked some publishers who add subtitles through the box, for example on custom post types without a dedicated Subtitle panel: they could no longer add or edit the subtitle there. This change keeps the overwrite fixed and restores the box for those keys.

**What this changes:**

- Reverts the protection and the explicit `auth_callback` added in #375, so the keys are ordinary editable meta again and reappear in the Custom Fields box.
- Adds a guard (`newspack_prevent_classic_metabox_meta_clobber`, on `admin_init`) that drops only these managed keys from the classic meta-box save payload, so the box can no longer overwrite the REST-saved value. The guard runs only on the `meta-box-loader` save, verifies the same nonce core verifies for that request, and leaves a genuine classic-editor save and the box's own Add/Update buttons untouched.

**How the overwrite happens:** when the Custom Fields panel is enabled, saving in the block editor also fires a classic meta-box save (the `meta-box-loader` request) that resubmits the box's page-load value just after the REST save, overwriting the newer value.

**Known trade-off:** on the server, the classic meta-box save can't tell the page-load value apart from a value typed directly into a Custom Fields row and committed with the main editor Save button, so that one action won't persist these keys. The supported ways to edit them remain the editor's own panels (Subtitle, Featured Image Position, and so on) and the box's own Add/Update buttons, which save immediately. Compared with the current release, this restores Custom Fields access for these keys while keeping the overwrite guard.

Reference: NPPM-2931

### How to test the changes in this Pull Request:

Enable the editor Custom Fields panel first: Options ⋮ → Preferences → Advanced → Custom fields.

Reproduce the problem (on the current release):

1. Open a published post that already has a subtitle.
2. Change the subtitle in the Article Subtitle panel and save.
3. Reload, and confirm the subtitle reverts to its previous value.
4. Confirm the Custom Fields box won't let you add `newspack_post_subtitle`.

Verify the fix:

5. Change the subtitle in the Article Subtitle panel, save, reload, and confirm the new subtitle persists.
6. In the Custom Fields box, confirm the `newspack_post_subtitle` row is present and editable; change its value, click that row's Update button, and confirm the new value persists.
7. Confirm an editor with Custom Fields off still saves subtitle and Featured Image Position normally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (The affected themes have no PHPUnit harness; verified end-to-end on an isolated environment instead.)
* [x] Have you successfully run tests with your changes locally?

**Verification:** Verified end-to-end on an isolated environment: the two-save flow (REST save plus `meta-box-loader` save) was captured on the wire, the `meta-box-loader` request carried the page-load subtitle value, and the database kept the new value. The original overwrite was reproduced as a control and the guard prevented it; the Custom Fields box add and edit paths were confirmed working. `phpcs` is clean.

### Release risk: High

| Signal | Score | Why |
|--------|-------|-----|
| Contract surface | Low | Themes only. The six meta keys are read across repos, but only through `get_post_meta` / REST reads, which this change doesn't touch. No contract signature change. |
| Surface type | Medium | Reverts the protection + `auth_callback` on the six `register_post_meta` calls, and adds an `admin_init` guard that verifies the save nonce and edits `$_POST['meta']`. |
| Publisher exposure | High | Parent `newspack-theme` (inherited by all child themes) + `newspack-block-theme`; the guard runs for every publisher. The behavior change is gated by the per-user Custom Fields setting, but that's a deliberate workflow, so it isn't treated as narrowing the exposure. |
| Change shape | Medium | ~36 net LOC across 2 files (small), bumped one step because this exact area shipped in #375 and this partially reverts it. |

**Tier: High**, driven by parent-theme reach. This is intentionally one tier above #375's Medium: #375 narrowed its exposure score on a single-site Custom-Fields count, which is the case that turned out to under-weight the risk, so this keeps exposure at High. Conservative by design: the behavior change is restorative, and the broad failure mode (REST editing breaking) is verified safe. The High-tier bar (verify the named failure modes on live data) is met by the verification above, including a live capture of the real two-save flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
