### PR TITLE
feat(subscribers): group seat-increase requests and admin design

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -416,7 +416,7 @@ class Group_Subscription_Invite {
 		$subscription_settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 		if ( $subscription_settings['limit'] > 0 ) {
 			if ( $pending_invites_count + count( Group_Subscription::get_members( $subscription ) ) >= $subscription_settings['limit'] ) {
-				return new \WP_Error( 'newspack_group_subscription_invite_limit_reached', __( 'You have reached the group member limit for this subscription. Please remove some members or cancel pending invitations before inviting more group members.', 'newspack-plugin' ) );
+				return new \WP_Error( 'newspack_group_subscription_invite_limit_reached', __( 'You have reached the seat limit for this subscription. Please remove some members or cancel pending invitations before inviting more group members.', 'newspack-plugin' ) );
 			}
 		}
 
@@ -827,7 +827,7 @@ class Group_Subscription_Invite {
 				'type'    => 'error',
 			],
 			'link_full'                 => [
-				'message' => __( 'This group already has the maximum number of members. Please contact the group manager.', 'newspack-plugin' ),
+				'message' => __( 'This group has reached its seat limit. Please contact the group manager.', 'newspack-plugin' ),
 				'type'    => 'error',
 			],
 			'link_failed'               => [

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -44,6 +44,11 @@ class Group_Subscription_MyAccount {
 	const LEAVE_GROUP_NONCE_ACTION = 'newspack_group_subscription_leave_group';
 
 	/**
+	 * Nonce action for the request-more-seats form.
+	 */
+	const REQUEST_SEATS_NONCE_ACTION = 'newspack_group_subscription_request_seats';
+
+	/**
 	 * Register hooks for the My Account group subscription UI.
 	 */
 	public static function init() {
@@ -59,6 +64,7 @@ class Group_Subscription_MyAccount {
 		add_action( 'admin_post_' . self::CANCEL_INVITE_NONCE_ACTION, [ __CLASS__, 'handle_cancel_invite' ] );
 		add_action( 'admin_post_' . self::REMOVE_MEMBER_NONCE_ACTION, [ __CLASS__, 'handle_remove_member' ] );
 		add_action( 'admin_post_' . self::LEAVE_GROUP_NONCE_ACTION, [ __CLASS__, 'handle_leave_group' ] );
+		add_action( 'admin_post_' . self::REQUEST_SEATS_NONCE_ACTION, [ __CLASS__, 'handle_request_seats' ] );
 	}
 
 	/**
@@ -585,6 +591,109 @@ class Group_Subscription_MyAccount {
 				Group_Subscription::get_label_lower( 'singular' )
 			)
 		);
+	}
+
+	/**
+	 * Handle the request-more-seats form submission.
+	 *
+	 * The owner asks the publisher to raise the member limit. We record the
+	 * requested limit on the subscription and email the publisher; the publisher
+	 * fulfils it by raising the limit through the existing seat-limit setting,
+	 * which clears the pending request automatically.
+	 */
+	public static function handle_request_seats() {
+		check_admin_referer( self::REQUEST_SEATS_NONCE_ACTION );
+		[ $subscription_id, $redirect_url ] = self::get_subscription_context();
+		self::verify_permission( $subscription_id, $redirect_url, 'members' );
+		self::verify_active( $subscription_id, $redirect_url, 'members' );
+
+		$requested     = (int) filter_input( INPUT_POST, 'newspack-group-subscription-requested-limit', FILTER_VALIDATE_INT );
+		$subscription  = WooCommerce_Subscriptions::sanitize_subscription( $subscription_id );
+		$current_limit = $subscription ? (int) Group_Subscription_Settings::get_subscription_settings( $subscription )['limit'] : 0;
+
+		// A request only makes sense as a finite increase beyond the current limit
+		// (an unlimited group — limit 0 — has no ceiling to raise).
+		if ( ! $subscription || $current_limit <= 0 || $requested <= $current_limit ) {
+			$invalid_message = sprintf(
+				/* translators: %s: lowercase singular group label. */
+				__( 'Enter a member limit higher than your %s\'s current limit.', 'newspack-plugin' ),
+				Group_Subscription::get_label_lower( 'singular' )
+			);
+			self::redirect(
+				new \WP_Error( 'newspack_group_subscription_invalid_seat_request', $invalid_message ),
+				$redirect_url,
+				'members',
+				$invalid_message
+			);
+		}
+
+		Group_Subscription_Settings::set_requested_limit( $subscription, $requested );
+		self::notify_publisher_of_seat_request( $subscription, $current_limit, $requested );
+
+		self::redirect(
+			true,
+			$redirect_url,
+			'members',
+			sprintf(
+				/* translators: %d: requested number of seats. */
+				__( 'Your request to increase the number of seats to %d has been received.', 'newspack-plugin' ),
+				$requested
+			)
+		);
+	}
+
+	/**
+	 * Email the publisher that a group owner has requested more seats.
+	 *
+	 * @param \WC_Subscription $subscription    The group subscription.
+	 * @param int              $current_limit   The current member limit.
+	 * @param int              $requested_limit The requested member limit.
+	 */
+	private static function notify_publisher_of_seat_request( $subscription, $current_limit, $requested_limit ): void {
+		$settings  = Group_Subscription_Settings::get_subscription_settings( $subscription );
+		$requester = get_user_by( 'id', $subscription->get_user_id() );
+		$requester_label = $requester ? newspack_get_user_display_label( $requester ) : __( 'A group owner', 'newspack-plugin' );
+
+		$recipient = apply_filters(
+			'newspack_group_subscription_seat_request_recipient',
+			get_option( 'admin_email' ),
+			$subscription
+		);
+
+		$subject = sprintf(
+			/* translators: %s: group name. */
+			__( 'Seat increase requested for %s', 'newspack-plugin' ),
+			$settings['name']
+		);
+
+		$lines   = [
+			sprintf(
+				/* translators: 1: requester name, 2: group name. */
+				__( '%1$s has requested more seats for the group subscription "%2$s".', 'newspack-plugin' ),
+				$requester_label,
+				$settings['name']
+			),
+			'',
+			sprintf(
+				/* translators: %d: current member limit. */
+				__( 'Current member limit: %d', 'newspack-plugin' ),
+				$current_limit
+			),
+			sprintf(
+				/* translators: %d: requested member limit. */
+				__( 'Requested member limit: %d', 'newspack-plugin' ),
+				$requested_limit
+			),
+			'',
+			sprintf(
+				/* translators: %s: subscription admin URL. */
+				__( 'Review and raise the limit here: %s', 'newspack-plugin' ),
+				$subscription->get_edit_order_url()
+			),
+		];
+		$message = implode( "\n", $lines );
+
+		wp_mail( $recipient, $subject, $message ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
 	}
 }
 Group_Subscription_MyAccount::init();

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -616,7 +616,7 @@ class Group_Subscription_MyAccount {
 		if ( ! $subscription || $current_limit <= 0 || $requested <= $current_limit ) {
 			$invalid_message = sprintf(
 				/* translators: %s: lowercase singular group label. */
-				__( 'Enter a member limit higher than your %s\'s current limit.', 'newspack-plugin' ),
+				__( 'Enter a seat limit higher than your %s\'s current limit.', 'newspack-plugin' ),
 				Group_Subscription::get_label_lower( 'singular' )
 			);
 			self::redirect(
@@ -675,13 +675,13 @@ class Group_Subscription_MyAccount {
 			),
 			'',
 			sprintf(
-				/* translators: %d: current member limit. */
-				__( 'Current member limit: %d', 'newspack-plugin' ),
+				/* translators: %d: current seat limit. */
+				__( 'Current seat limit: %d', 'newspack-plugin' ),
 				$current_limit
 			),
 			sprintf(
-				/* translators: %d: requested member limit. */
-				__( 'Requested member limit: %d', 'newspack-plugin' ),
+				/* translators: %d: requested seat limit. */
+				__( 'Requested seat limit: %d', 'newspack-plugin' ),
 				$requested_limit
 			),
 			'',

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -322,7 +322,56 @@ class Group_Subscription_Settings {
 			if ( in_array( 'enabled', $changed_keys, true ) ) {
 				self::clear_group_subscription_ids_cache();
 			}
+
+			// Raising the limit (or making it unlimited) fulfils any pending owner seat request.
+			if ( in_array( 'limit', $changed_keys, true ) ) {
+				$requested = (int) $subscription->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'requested_limit', true );
+				$new_limit = (int) $subscription->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', true );
+				if ( $requested > 0 && ( 0 === $new_limit || $new_limit >= $requested ) ) {
+					$subscription->update_meta_data( self::GROUP_SUBSCRIPTION_META_PREFIX . 'requested_limit', 0 );
+					$subscription->save();
+				}
+			}
 		}
+	}
+
+	/**
+	 * Get the member limit a group owner has requested, or 0 when none is pending.
+	 *
+	 * @param WC_Subscription|int $subscription The subscription object or ID.
+	 *
+	 * @return int The requested member limit, or 0.
+	 */
+	public static function get_requested_limit( $subscription ) {
+		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		if ( ! $subscription ) {
+			return 0;
+		}
+		return (int) $subscription->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'requested_limit', true );
+	}
+
+	/**
+	 * Store an owner-requested member limit on the subscription.
+	 *
+	 * @param WC_Subscription|int $subscription The subscription object or ID.
+	 * @param int                 $limit        The requested member limit.
+	 */
+	public static function set_requested_limit( $subscription, $limit ) {
+		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		if ( ! $subscription ) {
+			return;
+		}
+		$subscription->update_meta_data( self::GROUP_SUBSCRIPTION_META_PREFIX . 'requested_limit', absint( $limit ) );
+		$subscription->save();
+	}
+
+	/**
+	 * Clear any pending owner-requested member limit.
+	 *
+	 * @param WC_Subscription|int $subscription The subscription object or ID.
+	 */
+	public static function clear_requested_limit( $subscription ) {
+		self::set_requested_limit( $subscription, 0 );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -157,9 +157,9 @@ class Group_Subscription_Settings {
 		$custom_product_pricing_options['newspack_group_subscription_limit'] = [
 			'id'                => self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit',
 			'wrapper_class'     => 'show_if_newspack_group_subscription_enabled',
-			'label'             => __( 'Group subscription member limit', 'newspack-plugin' ),
+			'label'             => __( 'Group subscription seat limit', 'newspack-plugin' ),
 			'desc_tip'          => true,
-			'description'       => __( 'Set the maximum number of members for group subscriptions. Set to 0 to allow an unlimited number of group members.', 'newspack-plugin' ),
+			'description'       => __( 'Set the maximum number of seats for group subscriptions. Set to 0 to allow an unlimited number of seats.', 'newspack-plugin' ),
 			'default'           => self::DEFAULT_SETTINGS['limit'],
 			'product_types'     => [ 'subscription', 'subscription_variation' ],
 			'type'              => 'number',
@@ -201,8 +201,8 @@ class Group_Subscription_Settings {
 			\esc_html( $settings['name'] ),
 			\esc_html(
 				sprintf(
-					/* translators: 1: member count, 2: member limit or "unlimited" */
-					__( '%1$s of %2$s members', 'newspack-plugin' ),
+					/* translators: 1: seats used, 2: seat limit or "unlimited" */
+					__( '%1$s of %2$s seats', 'newspack-plugin' ),
 					$member_count,
 					$limit
 				)

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -316,7 +316,7 @@ class Group_Subscription {
 		// move this check ahead of the removal loop and compute the projected count there.
 		$existing_members = self::get_members( $subscription );
 		if ( $subscription_settings['limit'] > 0 && count( $existing_members ) + count( $members_to_add ) > $subscription_settings['limit'] ) {
-			return new \WP_Error( 'newspack_group_subscription_update_members', __( 'Member limit reached. Please remove some members or increase the limit.', 'newspack-plugin' ), [ 'status' => 409 ] );
+			return new \WP_Error( 'newspack_group_subscription_update_members', __( 'Seat limit reached. Please remove some members or increase the limit.', 'newspack-plugin' ), [ 'status' => 409 ] );
 		}
 
 		// Add new members.

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -326,6 +326,50 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 			</div><!-- .newspack-ui__modal__small -->
 	</div> <!-- .newspack-ui__modal-container -->
 
+	<?php if ( $is_active && $member_limit > 0 ) : ?>
+	<!-- .newspack-ui__modal: request more seats -->
+	<div id="newspack-my-account__group_subscription--request-seats" class="newspack-ui__modal-container">
+		<div class="newspack-ui__modal-container__overlay"></div>
+		<div class="newspack-ui__modal newspack-ui__modal--small">
+				<header class="newspack-ui__modal__header">
+					<h2><?php esc_html_e( 'Request more seats', 'newspack-plugin' ); ?></h2>
+
+					<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
+						<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
+						<?php Newspack_UI_Icons::print_svg( 'close' ); ?>
+					</button>
+				</header>
+
+				<section class="newspack-ui__modal__content">
+					<p>
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: 1: lowercase singular group label, 2: current member limit. */
+								__( 'Your %1$s currently allows %2$d members. Tell the publication the new limit you need and they\'ll be in touch.', 'newspack-plugin' ),
+								$group_label_lower,
+								$member_limit
+							)
+						);
+						?>
+					</p>
+					<form name="newspack-group-subscription-request-seats" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+						<input type="hidden" name="action" value="newspack_group_subscription_request_seats">
+						<input type="hidden" name="subscription_id" value="<?php echo esc_attr( $subscription->get_id() ); ?>">
+						<?php wp_nonce_field( Group_Subscription_MyAccount::REQUEST_SEATS_NONCE_ACTION ); ?>
+						<p>
+							<label for="newspack-group-subscription-requested-limit"><?php esc_html_e( 'New member limit', 'newspack-plugin' ); ?></label>
+							<input type="number" id="newspack-group-subscription-requested-limit" name="newspack-group-subscription-requested-limit" min="<?php echo esc_attr( $member_limit + 1 ); ?>" value="<?php echo esc_attr( $member_limit + 1 ); ?>" required>
+						</p>
+
+						<button type="submit" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide"><span><?php esc_html_e( 'Send request', 'newspack-plugin' ); ?></span></button>
+						<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__close"><?php esc_html_e( 'Cancel', 'newspack-plugin' ); ?></button>
+					</form>
+				</section>
+			</div><!-- .newspack-ui__modal__small -->
+	</div> <!-- .newspack-ui__modal-container -->
+	<?php endif; ?>
+
 	<!-- .newspack-ui__modal: regenerate invite link -->
 	<div id="newspack-my-account__group_subscription--confirm-regenerate-link" class="newspack-ui__modal-container">
 		<div class="newspack-ui__modal-container__overlay"></div>

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -290,7 +290,7 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 							echo esc_html(
 								sprintf(
 									/* translators: 1: lowercase singular group label, 2: lowercase singular group label (again). */
-									__( 'You have reached the member limit for this %1$s. Please remove some members or cancel pending invitations before inviting more %2$s members.', 'newspack-plugin' ),
+									__( 'You have reached the seat limit for this %1$s. Please remove some members or cancel pending invitations before inviting more %2$s members.', 'newspack-plugin' ),
 									$group_label_lower,
 									$group_label_lower
 								)
@@ -345,8 +345,8 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 						<?php
 						echo esc_html(
 							sprintf(
-								/* translators: 1: lowercase singular group label, 2: current member limit. */
-								__( 'Your %1$s currently allows %2$d members. Tell the publication the new limit you need and they\'ll be in touch.', 'newspack-plugin' ),
+								/* translators: 1: lowercase singular group label, 2: current seat count. */
+								__( 'Your %1$s currently has %2$d seats. Tell the publication the new limit you need and they\'ll be in touch.', 'newspack-plugin' ),
 								$group_label_lower,
 								$member_limit
 							)
@@ -358,7 +358,7 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 						<input type="hidden" name="subscription_id" value="<?php echo esc_attr( $subscription->get_id() ); ?>">
 						<?php wp_nonce_field( Group_Subscription_MyAccount::REQUEST_SEATS_NONCE_ACTION ); ?>
 						<p>
-							<label for="newspack-group-subscription-requested-limit"><?php esc_html_e( 'New member limit', 'newspack-plugin' ); ?></label>
+							<label for="newspack-group-subscription-requested-limit"><?php esc_html_e( 'New seat limit', 'newspack-plugin' ); ?></label>
 							<input type="number" id="newspack-group-subscription-requested-limit" name="newspack-group-subscription-requested-limit" min="<?php echo esc_attr( $member_limit + 1 ); ?>" value="<?php echo esc_attr( $member_limit + 1 ); ?>" required>
 						</p>
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
@@ -35,7 +35,10 @@ $has_pending_request = $requested_limit > $member_limit;
 $current_user_id     = $user_id;
 $invite_link         = \Newspack\Group_Subscription_Invite::get_link_invite( $subscription, $current_user_id );
 $members             = Group_Subscription::get_members( $subscription );
+$managers            = Group_Subscription::get_managers( $subscription );
 $all_invites         = \Newspack\Group_Subscription_Invite::get_invites( $subscription );
+// A seat is held by the owner and each accepted member; a pending invite doesn't take a seat until it's accepted.
+$seats_used          = count( array_unique( array_map( 'intval', array_merge( (array) $managers, (array) $members ) ) ) );
 $is_completely_empty = empty( $members ) && empty( $all_invites );
 
 $status_badge_classes = [ 'newspack-ui__badge' ];
@@ -69,25 +72,6 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 				<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--secondary">
 					<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
 				</a>
-				<?php if ( $can_request_seats ) : ?>
-					<?php if ( $has_pending_request ) : ?>
-						<span class="newspack-ui__badge newspack-ui__badge--outline newspack-my-account__group_subscription__seat-request-pending">
-							<?php
-							echo esc_html(
-								sprintf(
-									/* translators: %d: the requested member limit. */
-									__( 'Increase to %d requested', 'newspack-plugin' ),
-									$requested_limit
-								)
-							);
-							?>
-						</span>
-					<?php else : ?>
-						<button type="button" class="newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__request-seats">
-							<?php esc_html_e( 'Request more seats', 'newspack-plugin' ); ?>
-						</button>
-					<?php endif; ?>
-				<?php endif; ?>
 				<?php if ( $is_active && ! $is_completely_empty ) : ?>
 					<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
 						<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__dropdown__toggle">
@@ -115,6 +99,44 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 			</div>
 		</div>
 	</header>
+	<div class="newspack-my-account__subscription--meta">
+		<span class="newspack-my-account__subscription--seat-count">
+			<?php
+			if ( $member_limit > 0 ) {
+				printf(
+					/* translators: 1: seats used, 2: total seat limit. */
+					esc_html__( '%1$d of %2$d seats', 'newspack-plugin' ),
+					(int) $seats_used,
+					(int) $member_limit
+				);
+			} else {
+				printf(
+					/* translators: %d: number of seats used. */
+					esc_html( _n( '%d seat', '%d seats', (int) $seats_used, 'newspack-plugin' ) ),
+					(int) $seats_used
+				);
+			}
+			?>
+		</span>
+		<?php if ( $can_request_seats ) : ?>
+			<span class="newspack-my-account__subscription--meta-sep" aria-hidden="true">&middot;</span>
+			<?php if ( $has_pending_request ) : ?>
+				<span class="newspack-my-account__group_subscription__seat-request-pending">
+					<?php
+					printf(
+						/* translators: %d: the requested member limit. */
+						esc_html__( 'Increase to %d requested', 'newspack-plugin' ),
+						(int) $requested_limit
+					);
+					?>
+				</span>
+			<?php else : ?>
+				<button type="button" class="newspack-my-account__subscription--meta-link newspack-my-account__group_subscription__request-seats">
+					<?php esc_html_e( 'Request more seats', 'newspack-plugin' ); ?>
+				</button>
+			<?php endif; ?>
+		<?php endif; ?>
+	</div>
 
 	<div class="newspack-my-account__group__content">
 		<?php

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
@@ -27,6 +27,11 @@ $managed             = Group_Subscription::get_managed_subscriptions_for_user( $
 $multi_group         = count( $managed ) > 1;
 $subscription_status = $subscription->get_status();
 $is_active           = Group_Subscription_MyAccount::is_subscription_active( $subscription );
+$member_limit        = (int) $settings['limit'];
+$requested_limit     = Group_Subscription_Settings::get_requested_limit( $subscription );
+// A finite limit can be raised; an unlimited group (limit 0) has no ceiling to request beyond.
+$can_request_seats   = $is_active && $member_limit > 0;
+$has_pending_request = $requested_limit > $member_limit;
 $current_user_id     = $user_id;
 $invite_link         = \Newspack\Group_Subscription_Invite::get_link_invite( $subscription, $current_user_id );
 $members             = Group_Subscription::get_members( $subscription );
@@ -64,6 +69,25 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 				<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--secondary">
 					<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
 				</a>
+				<?php if ( $can_request_seats ) : ?>
+					<?php if ( $has_pending_request ) : ?>
+						<span class="newspack-ui__badge newspack-ui__badge--outline newspack-my-account__group_subscription__seat-request-pending">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %d: the requested member limit. */
+									__( 'Increase to %d requested', 'newspack-plugin' ),
+									$requested_limit
+								)
+							);
+							?>
+						</span>
+					<?php else : ?>
+						<button type="button" class="newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__request-seats">
+							<?php esc_html_e( 'Request more seats', 'newspack-plugin' ); ?>
+						</button>
+					<?php endif; ?>
+				<?php endif; ?>
 				<?php if ( $is_active && ! $is_completely_empty ) : ?>
 					<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
 						<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__dropdown__toggle">

--- a/plugins/newspack-plugin/src/my-account/v1/_group.scss
+++ b/plugins/newspack-plugin/src/my-account/v1/_group.scss
@@ -9,6 +9,25 @@
 	}
 }
 
+// The seat-count row sits directly beneath the whole header (title, badge and
+// actions), so collapse the header's own bottom margin and carry the gap to the
+// content on the seat-count row instead. Matches the shared --header selector
+// depth (.woocommerce-account.newspack-my-account.newspack-ui) so it wins.
+.woocommerce-account.newspack-my-account.newspack-ui .newspack-my-account__group {
+	.newspack-my-account__subscription--header {
+		gap: var(--newspack-ui-spacer-1);
+		margin-bottom: var(--newspack-ui-spacer-1);
+	}
+
+	.newspack-my-account__subscription--meta {
+		margin-bottom: var(--newspack-ui-spacer-6);
+
+		@media ( min-width: 768px ) {
+			margin-bottom: var(--newspack-ui-spacer-8);
+		}
+	}
+}
+
 .newspack-my-account__group-picker {
 	> header {
 		margin-bottom: var(--newspack-ui-spacer-5);

--- a/plugins/newspack-plugin/src/my-account/v1/_subscriptions.scss
+++ b/plugins/newspack-plugin/src/my-account/v1/_subscriptions.scss
@@ -100,6 +100,32 @@
 				white-space: nowrap;
 			}
 		}
+		&--meta {
+			align-items: center;
+			color: var(--newspack-ui-color-neutral-60);
+			display: flex;
+			flex-wrap: wrap;
+			font-size: var(--newspack-ui-font-size-s);
+			gap: var(--newspack-ui-spacer-1);
+			line-height: var(--newspack-ui-line-height-s);
+		}
+		&--meta-sep {
+			color: var(--newspack-ui-color-neutral-40);
+		}
+		&--meta-link {
+			background: none;
+			border: 0;
+			color: inherit;
+			cursor: pointer;
+			font: inherit;
+			padding: 0;
+			text-decoration: underline;
+
+			&:hover,
+			&:focus {
+				color: var(--newspack-ui-color-neutral-90);
+			}
+		}
 		&--back-link {
 			margin: 0;
 

--- a/plugins/newspack-plugin/src/my-account/v1/group-subscriptions.js
+++ b/plugins/newspack-plugin/src/my-account/v1/group-subscriptions.js
@@ -33,6 +33,18 @@ domReady( function () {
 		} );
 	}
 
+	// Handle request-more-seats modal.
+	const requestSeatsModal = document.getElementById( 'newspack-my-account__group_subscription--request-seats' );
+	const openRequestSeatsModal = [ ...document.querySelectorAll( '.newspack-my-account__group_subscription__request-seats' ) ];
+	if ( requestSeatsModal ) {
+		openRequestSeatsModal.forEach( open => {
+			open.addEventListener( 'click', event => {
+				event.preventDefault();
+				requestSeatsModal.setAttribute( 'data-state', 'open' );
+			} );
+		} );
+	}
+
 	// Handle remove-member confirm modal via event delegation.
 	const removeMemberModal = document.getElementById( 'newspack-my-account__group_subscription--confirm-remove-member' );
 	if ( removeMemberModal ) {

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/README.md
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/README.md
@@ -180,7 +180,14 @@ source of truth; this is a map of it.
   menu (Add directly / Invite by email / Copy invite link, plus Regenerate /
   Disable invite link once a link exists). The Invitations DataViews
   (Pending/Expired badges, "Accept on behalf" as a per-row and bulk action) only
-  appears when there are pending invites.
+  appears when there are pending invites. When a `seatRequest` is outstanding, a
+  full-width notice shows the requested seat count and status, with admin CTAs
+  Decline (removes the request) and Mark as paid (applies the limit immediately,
+  logs a manual "Seat upgrade payment" order); when `awaiting-payment` the notice
+  also shows the amount. The owner originates such a request from the front-end My
+  Account group page (a real feature, not part of this prototype). The **GroupList**
+  shows a badge on groups with a pending or awaiting-payment request so admins can
+  spot them at a glance.
 
 **Admin superpower (divergence from owner parity).** Beyond the owner-facing My
 Account flow (#148), an admin can add members directly (Add members → Add directly) and
@@ -209,7 +216,7 @@ All mutate through the `onComplete({ message, mutate })` convention above.
 | `InviteMemberFlow` | "Add members → Invite by email" | `FormTokenField` multi-email, capacity-aware (warns at zero seats, trims over capacity, de-dupes vs. pending). | Pending email invites added. |
 | `AddMembersFlow` | "Add members → Add directly" | `FormTokenField` multi-email, capacity-aware (trims over capacity with a warning), "Send a welcome email" checkbox. Existing accounts resolve by email; unknown emails create a stub account. | Members added immediately; a matching pending invite is consumed. |
 | `AcceptInviteFlow` | Invitations "Accept on behalf" (row or bulk) | Confirms the count with a "Send a welcome email" checkbox. | Pending invite(s) converted to members; seat count unchanged. |
-| `AdjustSeatsFlow` | "Adjust seats" | Number input floored at reserved seats, raise only while active; two-step input → confirm summary. | Seat limit updated. |
+| `AdjustSeatsFlow` | "Adjust seats" | Number input floored at reserved seats, raise only while active; two-step input → confirm summary. When raising the limit, offers Increase for free or Increase & send a payment link (admin-entered amount); can be opened pre-filled from an owner seat request. | Seat limit updated (free path: immediate; payment-link path: sends link and sets `awaiting-payment` on the request). |
 | `MakeOwnerFlow` | Member kebab "Make owner" | `ConfirmFlow`. | Ownership transferred; previous owner demoted. |
 | `RemoveMemberFlow` | Member kebab / bulk "Remove member" (row or bulk) | `ConfirmFlow` (destructive); pluralizes the copy for multiple members. The owner is never eligible. | Member(s) removed; seats freed. |
 | `RegenerateLinkFlow` / `DisableLinkFlow` | "Add members" menu (when a link exists) | `ConfirmFlow` (disable is destructive). Copy invite link itself is no modal: it copies and creates the link if none exists. | Link regenerated / disabled. |
@@ -217,6 +224,14 @@ All mutate through the `onComplete({ message, mutate })` convention above.
 
 `ConfirmFlow` is the shared scaffold (title, body, Cancel + primary/destructive
 Confirm) behind the six simple confirmations above.
+
+The owner's "Request more seats" / seat-upgrade payment is **not** part of this
+prototype: it ships as a real front-end feature on the My Account group page
+(`includes/plugins/woocommerce/.../templates/v1/group.php`). The prototype only
+covers the admin-side response to such a request (the seat-request notice with
+its Decline / Mark as paid actions, and the request badge on `GroupList`). The
+real owner template lives at
+`includes/plugins/woocommerce/my-account/templates/v1/group.php`.
 
 ## Data model
 
@@ -261,6 +276,13 @@ Confirm) behind the six simple confirmations above.
     { id, type: 'email', email, status, sentAt },  // status 'pending'; expiry derived from sentAt
     { id, type: 'link', status, createdAt },        // one persistent reusable link
   ],
+  seatRequest: {            // null when no outstanding request
+    target,                 // requested total seat count (> seatLimit)
+    requestedAt,            // YYYY-MM-DD
+    status,                 // 'pending' | 'awaiting-payment'
+    amount,                 // set when admin sends a payment link
+    linkSentAt,             // set when admin sends a payment link
+  } | null,
 }
 ```
 

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/data/mock-groups.js
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/data/mock-groups.js
@@ -172,6 +172,7 @@ const FIXTURES = [
 				createdAt: iso( 12 ),
 			},
 		],
+		seatRequest: { target: 25, requestedAt: '2026-06-20', status: 'pending' },
 	},
 	{
 		id: 'grp_riverside',
@@ -497,6 +498,58 @@ export function isGroupActive( group ) {
 
 export function isGroupManageable( group ) {
 	return group.status !== 'cancelled';
+}
+
+// PROTOTYPE: a single outstanding seat-increase request lives on the group as
+// `seatRequest` (null when none). These are pure transformers — callers persist
+// via setStoredGroup or the GroupDetail setGroup→useEffect seam, matching how the
+// rest of the data layer mutates groups.
+const todayStr = () => new Date().toISOString().slice( 0, 10 );
+
+export function hasSeatRequest( group ) {
+	return !! group.seatRequest;
+}
+
+// A request can only be opened on an active group with no outstanding request.
+export function canRequestSeats( group ) {
+	return isGroupActive( group ) && ! hasSeatRequest( group );
+}
+
+// Owner asks the publication for a higher seat count. Records the target only;
+// the admin decides free vs. paid.
+export function requestSeatIncrease( group, target ) {
+	return { ...group, seatRequest: { target, requestedAt: todayStr(), status: 'pending' } };
+}
+
+// Free fulfilment (or any admin-applied increase): raise the limit, clear the request.
+export function applySeatIncrease( group, target ) {
+	return { ...group, seatLimit: target, seatRequest: null };
+}
+
+// Paid path: a link is emailed to the owner. The limit holds at the current value
+// until payment; the requested target and amount ride on the request.
+export function sendSeatUpgradeLink( group, target, amount ) {
+	return {
+		...group,
+		seatRequest: {
+			...( group.seatRequest || {} ),
+			target,
+			amount,
+			status: 'awaiting-payment',
+			requestedAt: group.seatRequest?.requestedAt || todayStr(),
+			linkSentAt: todayStr(),
+		},
+	};
+}
+
+// Owner pays (or admin marks paid): apply the awaiting-payment target, clear request.
+export function paySeatUpgrade( group ) {
+	return { ...group, seatLimit: group.seatRequest.target, seatRequest: null };
+}
+
+// Decline / dismiss: drop the request, no seat change.
+export function clearSeatRequest( group ) {
+	return { ...group, seatRequest: null };
 }
 
 // PROTOTYPE ONLY: group mutations are persisted to the current admin's

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/data/mock-groups.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/data/mock-groups.test.js
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies.
+ */
+import {
+	requestSeatIncrease,
+	applySeatIncrease,
+	sendSeatUpgradeLink,
+	paySeatUpgrade,
+	clearSeatRequest,
+	hasSeatRequest,
+	canRequestSeats,
+} from './mock-groups';
+
+const baseGroup = () => ( {
+	id: 'grp_test',
+	status: 'active',
+	seatLimit: 10,
+	members: [ { subscriberId: 's1', role: 'owner', joinedAt: '2026-01-01' } ],
+	invites: [],
+	seatRequest: null,
+} );
+
+describe( 'seat request helpers', () => {
+	it( 'requestSeatIncrease records a pending request without changing the limit', () => {
+		const next = requestSeatIncrease( baseGroup(), 15 );
+		expect( next.seatLimit ).toBe( 10 );
+		expect( next.seatRequest.target ).toBe( 15 );
+		expect( next.seatRequest.status ).toBe( 'pending' );
+		expect( next.seatRequest.requestedAt ).toMatch( /^\d{4}-\d{2}-\d{2}$/ );
+	} );
+
+	it( 'applySeatIncrease raises the limit and clears the request', () => {
+		const next = applySeatIncrease( requestSeatIncrease( baseGroup(), 15 ), 15 );
+		expect( next.seatLimit ).toBe( 15 );
+		expect( next.seatRequest ).toBeNull();
+	} );
+
+	it( 'sendSeatUpgradeLink stores amount and awaiting-payment without changing the limit', () => {
+		const next = sendSeatUpgradeLink( requestSeatIncrease( baseGroup(), 15 ), 15, 50 );
+		expect( next.seatLimit ).toBe( 10 );
+		expect( next.seatRequest.status ).toBe( 'awaiting-payment' );
+		expect( next.seatRequest.amount ).toBe( 50 );
+		expect( next.seatRequest.target ).toBe( 15 );
+		expect( next.seatRequest.linkSentAt ).toMatch( /^\d{4}-\d{2}-\d{2}$/ );
+	} );
+
+	it( 'paySeatUpgrade applies the awaiting-payment target and clears the request', () => {
+		const awaiting = sendSeatUpgradeLink( requestSeatIncrease( baseGroup(), 15 ), 15, 50 );
+		const next = paySeatUpgrade( awaiting );
+		expect( next.seatLimit ).toBe( 15 );
+		expect( next.seatRequest ).toBeNull();
+	} );
+
+	it( 'clearSeatRequest drops the request with no seat change', () => {
+		const next = clearSeatRequest( requestSeatIncrease( baseGroup(), 15 ) );
+		expect( next.seatLimit ).toBe( 10 );
+		expect( next.seatRequest ).toBeNull();
+	} );
+
+	it( 'canRequestSeats is false when a request already exists or the group is inactive', () => {
+		expect( canRequestSeats( baseGroup() ) ).toBe( true );
+		expect( canRequestSeats( requestSeatIncrease( baseGroup(), 15 ) ) ).toBe( false );
+		expect( hasSeatRequest( requestSeatIncrease( baseGroup(), 15 ) ) ).toBe( true );
+		expect( canRequestSeats( { ...baseGroup(), status: 'on-hold' } ) ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/flows/AdjustSeatsFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/flows/AdjustSeatsFlow.jsx
@@ -8,17 +8,22 @@
 
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { TextControl, __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { RadioControl, TextControl, __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Button, Modal } from '../../../../packages/components/src';
-import { reservedSeats, isGroupActive } from '../data/mock-groups';
+import { reservedSeats, isGroupActive, applySeatIncrease, sendSeatUpgradeLink } from '../data/mock-groups';
+import { buildSeatIncreaseOrder, buildPaymentLinkOrder } from './subscription-actions';
+import { fmtCurrency } from '../format';
 import { GROUP_LABEL_LOWER } from '../labels';
 
 export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 	// Floor for the new limit: members plus pending invites and active link uses,
 	// so a reduction can never strand obligations the group already made.
 	const reserved = reservedSeats( group );
-	const [ value, setValue ] = useState( String( group.seatLimit ) );
+	const initial = group.seatRequest?.target && group.seatRequest.target > group.seatLimit ? group.seatRequest.target : group.seatLimit;
+	const [ value, setValue ] = useState( String( initial ) );
 	const [ confirming, setConfirming ] = useState( false );
+	const [ mode, setMode ] = useState( 'free' ); // 'free' | 'link'
+	const [ amountValue, setAmountValue ] = useState( '' );
 
 	// Seat increases require an active group; paused (on-hold) groups may only
 	// hold or reduce the limit, never raise it.
@@ -26,13 +31,28 @@ export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 	const limit = parseInt( value, 10 );
 	const invalid = isNaN( limit ) || limit < reserved || ( limit > group.seatLimit && ! canIncrease );
 	const unchanged = limit === group.seatLimit;
+	const isIncrease = ! isNaN( limit ) && limit > group.seatLimit;
+	const amount = parseFloat( amountValue );
+	const amountInvalid = mode === 'link' && ( isNaN( amount ) || amount <= 0 );
+	const cannotConfirm = invalid || unchanged || ( isIncrease && amountInvalid );
 
 	const save = () => {
+		if ( isIncrease && mode === 'link' ) {
+			onComplete( {
+				type: 'success',
+				transient: true,
+				message: sprintf( __( 'Payment link sent for %d seats.', 'newspack-plugin' ), limit ),
+				mutate: g => sendSeatUpgradeLink( g, limit, amount ),
+				ownerOrder: buildPaymentLinkOrder( group ),
+			} );
+			return;
+		}
 		onComplete( {
 			type: 'success',
 			transient: true,
 			message: sprintf( __( 'Seat limit updated to %d.', 'newspack-plugin' ), limit ),
-			mutate: g => ( { ...g, seatLimit: limit } ),
+			mutate: g => applySeatIncrease( g, limit ),
+			ownerOrder: isIncrease ? buildSeatIncreaseOrder( group ) : undefined,
 		} );
 	};
 
@@ -47,6 +67,15 @@ export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 								strong: <strong />,
 							} ) }
 						</span>
+						{ isIncrease && mode === 'link' && (
+							<span>
+								{ sprintf(
+									__( 'A payment link for %s will be emailed to the owner. Seats apply once paid.', 'newspack-plugin' ),
+									fmtCurrency( amount )
+								) }
+							</span>
+						) }
+						{ isIncrease && mode === 'free' && <span>{ __( 'Seats are granted now at no charge.', 'newspack-plugin' ) }</span> }
 					</VStack>
 					<HStack spacing={ 2 } justify="flex-end">
 						<Button variant="tertiary" size="compact" onClick={ onClose }>
@@ -92,11 +121,34 @@ export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
+				{ isIncrease && (
+					<RadioControl
+						label={ __( 'How to apply this increase', 'newspack-plugin' ) }
+						selected={ mode }
+						options={ [
+							{ label: __( 'Increase for free', 'newspack-plugin' ), value: 'free' },
+							{ label: __( 'Increase & send a payment link', 'newspack-plugin' ), value: 'link' },
+						] }
+						onChange={ setMode }
+					/>
+				) }
+				{ isIncrease && mode === 'link' && (
+					<TextControl
+						type="number"
+						label={ __( 'Upgrade charge amount', 'newspack-plugin' ) }
+						value={ amountValue }
+						min={ 0 }
+						onChange={ setAmountValue }
+						help={ __( 'The owner is emailed a payment link. Seats apply automatically once they pay.', 'newspack-plugin' ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				) }
 				<HStack spacing={ 2 } justify="flex-end">
 					<Button variant="tertiary" size="compact" onClick={ onClose }>
 						{ __( 'Cancel', 'newspack-plugin' ) }
 					</Button>
-					<Button variant="primary" size="compact" onClick={ () => setConfirming( true ) } disabled={ invalid || unchanged }>
+					<Button variant="primary" size="compact" onClick={ () => setConfirming( true ) } disabled={ cannotConfirm }>
 						{ __( 'Adjust seats', 'newspack-plugin' ) }
 					</Button>
 				</HStack>

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/flows/AdjustSeatsFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/flows/AdjustSeatsFlow.jsx
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { RadioControl, TextControl, __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Button, Modal } from '../../../../packages/components/src';
 import { reservedSeats, isGroupActive, applySeatIncrease, sendSeatUpgradeLink } from '../data/mock-groups';
+import { getSubscriberById } from '../data/mock-subscribers';
 import { buildSeatIncreaseOrder, buildPaymentLinkOrder } from './subscription-actions';
 import { fmtCurrency } from '../format';
 import { GROUP_LABEL_LOWER } from '../labels';
@@ -19,6 +20,7 @@ export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 	// Floor for the new limit: members plus pending invites and active link uses,
 	// so a reduction can never strand obligations the group already made.
 	const reserved = reservedSeats( group );
+	const ownerEmail = getSubscriberById( group.ownerId )?.email;
 	const initial = group.seatRequest?.target && group.seatRequest.target > group.seatLimit ? group.seatRequest.target : group.seatLimit;
 	const [ value, setValue ] = useState( String( initial ) );
 	const [ confirming, setConfirming ] = useState( false );
@@ -70,8 +72,9 @@ export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 						{ isIncrease && mode === 'link' && (
 							<span>
 								{ sprintf(
-									__( 'A payment link for %s will be emailed to the owner. Seats apply once paid.', 'newspack-plugin' ),
-									fmtCurrency( amount )
+									__( 'A payment link for %1$s will be emailed to %2$s. Seats apply once paid.', 'newspack-plugin' ),
+									fmtCurrency( amount ),
+									ownerEmail
 								) }
 							</span>
 						) }
@@ -139,7 +142,6 @@ export default function AdjustSeatsFlow( { group, onClose, onComplete } ) {
 						value={ amountValue }
 						min={ 0 }
 						onChange={ setAmountValue }
-						help={ __( 'The owner is emailed a payment link. Seats apply automatically once they pay.', 'newspack-plugin' ) }
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 					/>

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/flows/subscription-actions.js
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/flows/subscription-actions.js
@@ -76,3 +76,22 @@ export const buildPaymentLinkOrder = target => ( {
 	type: __( 'Payment link sent', 'newspack-plugin' ),
 	subscriptionId: target.id,
 } );
+
+// A "Seat increase" billing-history order (free grant, no amount) for the group.
+export const buildSeatIncreaseOrder = group => ( {
+	id: `ord_seat_${ Date.now() }`,
+	date: todayIso(),
+	amount: null,
+	type: __( 'Seat increase', 'newspack-plugin' ),
+	subscriptionId: group.id,
+} );
+
+// A "Seat upgrade payment" order for a paid seat increase. `manual` marks an
+// offline settlement (cheque, bank transfer) the admin recorded by hand.
+export const buildSeatUpgradePaymentOrder = ( group, amount, { manual = false } = {} ) => ( {
+	id: `ord_seatpay_${ Date.now() }`,
+	date: todayIso(),
+	amount,
+	type: manual ? __( 'Seat upgrade payment (offline)', 'newspack-plugin' ) : __( 'Seat upgrade payment', 'newspack-plugin' ),
+	subscriptionId: group.id,
+} );

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/GroupDetail.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/GroupDetail.jsx
@@ -15,7 +15,18 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { Dropdown, MenuGroup, MenuItem, __experimentalHStack as HStack, Notice, Snackbar } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	Dropdown,
+	MenuGroup,
+	MenuItem,
+	Modal,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	Notice,
+	Snackbar,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -33,14 +44,16 @@ import {
 	isGroupManageable,
 	isInviteExpired,
 	hasActiveInviteLink,
+	clearSeatRequest,
+	paySeatUpgrade,
 	GROUP_STATUS_LABELS,
 	GROUP_STATUS_BADGE_LEVEL,
 } from '../data/mock-groups';
 import { GROUP_LABEL, GROUP_LABEL_PLURAL } from '../labels';
-import { fmtDate } from '../format';
+import { fmtCurrency, fmtDate } from '../format';
 import { useNoticesPortal } from '../use-portals';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
-import { NoticesPanel, groupOnHoldNotice } from './SubscriberNotices';
+import { NoticesPanel, groupOnHoldNotice, seatRequestNotice } from './SubscriberNotices';
 
 import AcceptInviteFlow from '../flows/AcceptInviteFlow';
 import AddMembersFlow from '../flows/AddMembersFlow';
@@ -57,7 +70,13 @@ import RefundFlow from '../flows/RefundFlow';
 import PlanChangeFlow from '../flows/PlanChangeFlow';
 import GuidedFixFlow from '../flows/GuidedFixFlow';
 import { hasUsableCard } from '../flows/free-access';
-import { buildReactivation, buildFreeReactivation, buildPaymentLinkOrder, reactivatedMessage } from '../flows/subscription-actions';
+import {
+	buildReactivation,
+	buildFreeReactivation,
+	buildPaymentLinkOrder,
+	buildSeatUpgradePaymentOrder,
+	reactivatedMessage,
+} from '../flows/subscription-actions';
 import { latestOrderDate } from '../data/orders';
 
 const { useParams, useHistory } = Router;
@@ -179,7 +198,7 @@ function GroupDetailView() {
 	// Subscription flows (refund/cancel, plan change) return the same group
 	// descriptors the person profile handles; here the group on screen is the
 	// target, so they fold straight into setGroup.
-	const completeFlow = ( { message, mutate, groupCancel, groupChange } ) => {
+	const completeFlow = ( { message, mutate, ownerOrder, groupCancel, groupChange } ) => {
 		if ( groupCancel ) {
 			setGroup( prev => ( { ...prev, status: 'cancelled', nextBillingDate: null } ) );
 		}
@@ -191,6 +210,9 @@ function GroupDetailView() {
 				amount: groupChange.amount,
 				seatLimit: groupChange.seatLimit,
 			} ) );
+		}
+		if ( ownerOrder ) {
+			addOwnerOrder( ownerOrder );
 		}
 		applyMutation( { message, mutate } );
 		setModal( null );
@@ -226,6 +248,22 @@ function GroupDetailView() {
 	const sendGroupPaymentLink = () => {
 		addOwnerOrder( buildPaymentLinkOrder( group ) );
 		setSnackbar( { message: sprintf( __( 'Payment link sent to %s.', 'newspack-plugin' ), owner?.email ) } );
+		setModal( null );
+	};
+
+	// Decline a pending seat-increase request: drop it, no seat change.
+	const declineSeatRequest = () => {
+		setGroup( prev => clearSeatRequest( prev ) );
+		setSnackbar( { message: __( 'Seat request declined.', 'newspack-plugin' ) } );
+	};
+
+	// Mark an awaiting-payment upgrade as paid offline (cheque, bank transfer):
+	// apply the increase now and log the payment with the manual flag.
+	const markSeatUpgradePaid = () => {
+		const { target, amount } = group.seatRequest;
+		addOwnerOrder( buildSeatUpgradePaymentOrder( group, amount, { manual: true } ) );
+		setGroup( prev => paySeatUpgrade( prev ) );
+		setSnackbar( { message: sprintf( __( 'Marked as paid. Seat limit raised to %d.', 'newspack-plugin' ), target ) } );
 		setModal( null );
 	};
 
@@ -460,9 +498,28 @@ function GroupDetailView() {
 	const goToOwner = () => history.push( `/profile/${ group.ownerId }?from=${ encodeURIComponent( `#/group/${ group.id }` ) }` );
 	// On-hold defers to the owner's profile, where Reactivate lives. A cancelled
 	// group shows no notice: the header badge and disabled actions already say so.
-	const groupNotices = [ group.status === 'on-hold' && groupOnHoldNotice( { plan: group.plan, lastCharged: fmtDate( ownerLastCharge ) } ) ]
+	const groupNotices = [
+		group.status === 'on-hold' && groupOnHoldNotice( { plan: group.plan, lastCharged: fmtDate( ownerLastCharge ) } ),
+		group.seatRequest &&
+			( () => {
+				const notice = seatRequestNotice( { target: group.seatRequest.target, status: group.seatRequest.status } );
+				if ( group.seatRequest.status === 'awaiting-payment' ) {
+					return {
+						...notice,
+						action: { label: __( 'Mark as paid', 'newspack-plugin' ), onClick: () => setModal( { kind: 'mark-seat-paid' } ) },
+					};
+				}
+				return {
+					...notice,
+					actions: [
+						{ label: __( 'Decline request', 'newspack-plugin' ), onClick: declineSeatRequest, variant: 'tertiary' },
+						{ label: __( 'Adjust seats', 'newspack-plugin' ), onClick: () => setModal( { kind: 'seats' } ), variant: 'secondary' },
+					],
+				};
+			} )(),
+	]
 		.filter( Boolean )
-		.map( notice => ( { ...notice, action: { label: notice.actionLabel, onClick: goToOwner } } ) );
+		.map( notice => ( notice.actions ? notice : { ...notice, action: notice.action ?? { label: notice.actionLabel, onClick: goToOwner } } ) );
 
 	return (
 		<div className="newspack-subscribers-demo__profile">
@@ -589,6 +646,27 @@ function GroupDetailView() {
 				<RemoveMemberFlow group={ group } members={ modal.members } onClose={ closeModal } onComplete={ completeFlow } />
 			) }
 			{ modal?.kind === 'seats' && <AdjustSeatsFlow group={ group } onClose={ closeModal } onComplete={ completeFlow } /> }
+			{ modal?.kind === 'mark-seat-paid' && group.seatRequest && (
+				<Modal title={ __( 'Mark seat upgrade as paid', 'newspack-plugin' ) } onRequestClose={ closeModal } size="small">
+					<VStack spacing={ 4 }>
+						<p>
+							{ sprintf(
+								__( 'Record an offline payment of %1$s and raise the seat limit to %2$d now?', 'newspack-plugin' ),
+								fmtCurrency( group.seatRequest.amount ),
+								group.seatRequest.target
+							) }
+						</p>
+						<HStack spacing={ 2 } justify="flex-end">
+							<Button variant="tertiary" size="compact" onClick={ closeModal }>
+								{ __( 'Cancel', 'newspack-plugin' ) }
+							</Button>
+							<Button variant="primary" size="compact" onClick={ markSeatUpgradePaid }>
+								{ __( 'Mark as paid', 'newspack-plugin' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</Modal>
+			) }
 			{ modal?.kind === 'make-owner' && (
 				<MakeOwnerFlow
 					group={ group }

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/GroupList.jsx
@@ -25,7 +25,7 @@ import './style.scss';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { getSubscriberById } from '../data/mock-subscribers';
-import { getAllGroups, seatsUsed, ALL_GROUP_PLAN_NAMES, GROUP_STATUS_LABELS, GROUP_STATUS_BADGE_LEVEL } from '../data/mock-groups';
+import { getAllGroups, seatsUsed, hasSeatRequest, ALL_GROUP_PLAN_NAMES, GROUP_STATUS_LABELS, GROUP_STATUS_BADGE_LEVEL } from '../data/mock-groups';
 import { GROUP_LABEL_PLURAL, GROUP_LABEL_PLURAL_LOWER } from '../labels';
 
 const { useHistory } = Router;
@@ -78,7 +78,19 @@ export default function GroupList() {
 					const owner = getSubscriberById( item.ownerId );
 					const details = (
 						<div>
-							{ owner ? <div>{ owner.name }</div> : <span>—</span> }
+							<HStack spacing={ 2 } justify="flex-start" alignment="center" expanded={ false }>
+								{ owner ? <span>{ owner.name }</span> : <span>—</span> }
+								{ hasSeatRequest( item ) && (
+									<Badge
+										level="warning"
+										text={
+											item.seatRequest.status === 'awaiting-payment'
+												? __( 'Awaiting payment', 'newspack-plugin' )
+												: __( 'Seat increase requested', 'newspack-plugin' )
+										}
+									/>
+								) }
+							</HStack>
 							<div className="newspack-subscribers-demo__email">{ item.plan }</div>
 						</div>
 					);

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberNotices.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberNotices.jsx
@@ -86,6 +86,25 @@ export const groupOnHoldNotice = ( { plan, lastCharged } ) => ( {
 	actionLabel: __( 'View owner', 'newspack-plugin' ),
 } );
 
+// The group's own page: the owner has requested more seats. `awaiting` switches
+// the copy to the payment-pending state (admin has already sent a link).
+export const seatRequestNotice = ( { target, status } ) => ( {
+	id: 'group_seat_request',
+	status: 'warning',
+	body:
+		status === 'awaiting-payment'
+			? sprintf(
+					// translators: %d is the requested seat count (wrapped in bold tags).
+					__( "Awaiting the owner's payment to increase to <b>%d seats</b>.", 'newspack-plugin' ),
+					target
+			  )
+			: sprintf(
+					// translators: %d is the requested seat count (wrapped in bold tags).
+					__( 'The owner requested an increase to <b>%d seats</b>.', 'newspack-plugin' ),
+					target
+			  ),
+} );
+
 /**
  * Portal + render for the notices strip. `notices` are normalized notice
  * objects with an optional `action: { label, onClick }`; when `plan` is set it
@@ -109,14 +128,18 @@ export const NoticesPanel = ( { noticesNode, notices } ) => {
 											notice.plan,
 											notice.body
 										),
-										{ name: <strong /> }
+										{ name: <strong />, b: <strong /> }
 								  )
-								: notice.body }
+								: createInterpolateElement( notice.body, { b: <strong /> } ) }
 						</span>
-						{ notice.action && (
-							<Button variant="secondary" size="compact" onClick={ notice.action.onClick }>
-								{ notice.action.label }
-							</Button>
+						{ ( notice.actions || ( notice.action ? [ notice.action ] : [] ) ).length > 0 && (
+							<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+								{ ( notice.actions || [ notice.action ] ).map( ( action, index ) => (
+									<Button key={ index } variant={ action.variant || 'secondary' } size="compact" onClick={ action.onClick }>
+										{ action.label }
+									</Button>
+								) ) }
+							</HStack>
 						) }
 					</HStack>
 				</Notice>

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberNotices.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberNotices.jsx
@@ -117,7 +117,16 @@ export const NoticesPanel = ( { noticesNode, notices } ) => {
 	return createPortal(
 		<div className="newspack-subscribers-demo__notices-inner">
 			{ notices.map( notice => (
-				<Notice key={ notice.id } status={ notice.status } isDismissible={ false }>
+				// `spokenMessage` is given an explicit plain-text string: without it, WP
+				// Notice defaults it to the JSX children and calls renderToString() on
+				// them during render, which walks our Button subtree and corrupts React's
+				// hook dispatcher (crashes on the next re-render).
+				<Notice
+					key={ notice.id }
+					status={ notice.status }
+					isDismissible={ false }
+					spokenMessage={ ( notice.plan ? `${ notice.plan } ` : '' ) + notice.body.replace( /<[^>]+>/g, '' ) }
+				>
 					<HStack justify="space-between" alignment="center" spacing={ 4 }>
 						<span>
 							{ notice.plan

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberNotices.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberNotices.test.js
@@ -1,0 +1,36 @@
+/**
+ * Reproduction: the seat-request notice crashes on the pending -> awaiting-payment
+ * transition (single `action` vs `actions` array).
+ */
+import { render } from '@testing-library/react';
+import { NoticesPanel } from './SubscriberNotices';
+
+const pendingNotice = {
+	id: 'group_seat_request',
+	status: 'warning',
+	body: 'The owner requested an increase to <b>25 seats</b>.',
+	actions: [
+		{ label: 'Decline request', onClick: () => {}, variant: 'tertiary' },
+		{ label: 'Adjust seats', onClick: () => {}, variant: 'secondary' },
+	],
+};
+
+const awaitingNotice = {
+	id: 'group_seat_request',
+	status: 'warning',
+	body: "Awaiting the owner's payment to increase to <b>25 seats</b>.",
+	action: { label: 'Mark as paid', onClick: () => {} },
+};
+
+describe( 'NoticesPanel seat-request rendering', () => {
+	it( 'renders the awaiting-payment notice (single action) without crashing', () => {
+		const node = document.createElement( 'div' );
+		expect( () => render( <NoticesPanel noticesNode={ node } notices={ [ awaitingNotice ] } /> ) ).not.toThrow();
+	} );
+
+	it( 'survives the pending -> awaiting-payment transition', () => {
+		const node = document.createElement( 'div' );
+		const { rerender } = render( <NoticesPanel noticesNode={ node } notices={ [ pendingNotice ] } /> );
+		expect( () => rerender( <NoticesPanel noticesNode={ node } notices={ [ awaitingNotice ] } /> ) ).not.toThrow();
+	} );
+} );

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -242,4 +242,89 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 
 		$this->assertSame( Group_Subscription::get_label( 'singular' ), $settings['name'], 'When neither name meta nor a product name is set, the group name should fall back to the publisher singular group label.' );
 	}
+
+	/*
+	 * --- requested member limit (owner seat requests) ---
+	 */
+
+	/**
+	 * With no request stored, the requested limit reads as 0.
+	 */
+	public function test_requested_limit_defaults_to_zero() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '5',
+			]
+		);
+
+		$this->assertSame( 0, Group_Subscription_Settings::get_requested_limit( $subscription ), 'A subscription with no pending request should report a requested limit of 0.' );
+	}
+
+	/**
+	 * A requested limit can be stored and read back.
+	 */
+	public function test_set_and_get_requested_limit() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '5',
+			]
+		);
+
+		Group_Subscription_Settings::set_requested_limit( $subscription, 10 );
+
+		$this->assertSame( 10, Group_Subscription_Settings::get_requested_limit( $subscription ), 'The stored requested limit should be returned.' );
+	}
+
+	/**
+	 * Clearing a requested limit resets it to 0.
+	 */
+	public function test_clear_requested_limit() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '5',
+			]
+		);
+
+		Group_Subscription_Settings::set_requested_limit( $subscription, 10 );
+		Group_Subscription_Settings::clear_requested_limit( $subscription );
+
+		$this->assertSame( 0, Group_Subscription_Settings::get_requested_limit( $subscription ), 'A cleared requested limit should read as 0.' );
+	}
+
+	/**
+	 * Raising the limit to meet or exceed the request clears the pending request.
+	 */
+	public function test_raising_limit_fulfils_pending_request() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '5',
+			]
+		);
+		Group_Subscription_Settings::set_requested_limit( $subscription, 10 );
+
+		Group_Subscription_Settings::update_subscription_settings( $subscription, [ 'limit' => 10 ] );
+
+		$this->assertSame( 0, Group_Subscription_Settings::get_requested_limit( $subscription ), 'Raising the limit to the requested value should clear the pending request.' );
+	}
+
+	/**
+	 * A limit bump that still falls short of the request leaves it pending.
+	 */
+	public function test_partial_limit_increase_keeps_request_pending() {
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '5',
+			]
+		);
+		Group_Subscription_Settings::set_requested_limit( $subscription, 10 );
+
+		Group_Subscription_Settings::update_subscription_settings( $subscription, [ 'limit' => 8 ] );
+
+		$this->assertSame( 10, Group_Subscription_Settings::get_requested_limit( $subscription ), 'A limit increase below the requested value should leave the request pending.' );
+	}
 }


### PR DESCRIPTION
## Summary

Group owners can request more seats for their group subscription, and publishers fulfil the request by raising the existing seat-limit setting. This is split into two connected pieces, both tied to **DSGNEWS-179**:

1. **Real, wired feature** (production WooCommerce / group-subscription code) — a group owner requests more seats from the front-end **My Account** group page. The request is stored on the subscription, the publisher is emailed, and raising the seat-limit setting to meet/exceed the request auto-clears it.
2. **Prototype admin design** (subscribers-demo wizard, mock data) — how the publisher *sees and handles* a request: a warning notice on the group view (Decline + Adjust seats) and a warning badge in the groups list. The real admin side currently just receives the email and raises the limit; this design can feed a real admin UI later.

## Real feature

- `class-group-subscription-settings.php` — `get_/set_/clear_requested_limit()` helpers (meta `_newspack_group_subscription_requested_limit`); `update_subscription_settings()` auto-clears the request when the limit is raised to meet it.
- `class-group-subscription-myaccount.php` — `admin_post` handler `handle_request_seats()` (mirrors the invite flow: permission + active checks, validate target > current, store, redirect-with-notice) and `notify_publisher_of_seat_request()` (emails `admin_email`, filter `newspack_group_subscription_seat_request_recipient`).
- `templates/v1/group.php` — owner-only "Request more seats" button + pending badge in the header.
- `templates/v1/group-subscription-members.php` + `group-subscriptions.js` — the request modal (mirrors the invite modal; posts via admin-post + nonce).
- 5 new unit tests covering get/set/clear and fulfilment auto-clear.

**Scope boundary:** "notify + existing controls" — no new admin screen in WooCommerce; the publisher raises the limit via the existing seat-limit setting.

## Prototype admin design

- `screens/GroupDetail.jsx` — seat-request **warning** notice with two actions (Decline request + Adjust seats, reusing `AdjustSeatsFlow`).
- `screens/GroupList.jsx` — "Seat increase requested" warning badge next to the group title.
- `screens/SubscriberNotices.jsx` — `NoticesPanel` extended to render a `notice.actions` array and interpolate a `<b>` count in the body.

## Terminology: seats vs members

Aligned the user-facing copy on a single rule: **seats = capacity** (the slots, which can be empty), **members = the people** in them. Anything about the limit now reads "seats", and anything about the actual people stays "members".

- Capacity → "seats": the WooCommerce product setting (now **"Group subscription seat limit"**), the admin Subscriptions list summary (**"X of Y seats"**), the publisher email (**"Current/Requested seat limit"**), the owner request modal (**"New seat limit"**, "Your group currently has N seats"), and the limit-reached errors across `class-group-subscription-invite.php`, `class-group-subscription.php`, and the members template ("You have reached the seat limit…", "Seat limit reached…").
- People → "members" (unchanged): the Members list/tab, the Member role, Invite/Add/Remove member, "manage members", "not a member". The groups-list **Members** column also stays "members" even though it shows `used / limit` — in a table that reads clearer than "seats".

This swept a few pre-existing strings outside the seat-request feature (the general settings label and invite errors), which is why `invite.php` and `class-group-subscription.php` show up in the diff.

## Verification

- PHPCS clean (changed files), JS lint 0 errors.
- 44 PHP tests pass (`WooCommerce_Subscriptions_Integration`), 258 JS tests pass.

## Notes

- Stacked on #295 (the subscribers prototype) since the admin design builds on the demo wizard. GitHub will retarget this to `main` once #295 merges.
- Local mail is down in dev, so the publisher email can't be delivered here, but the path is correct.
- When per-seat licensing lands, the upgrade amount should derive from seat count rather than being admin-entered (out of scope here).

## Walkthrough

**Group owner (My account)**

https://github.com/user-attachments/assets/fdad0033-3aba-449c-bf5c-f4910225cdfc

**Publisher (wp-admin)**

https://github.com/user-attachments/assets/536b9eb0-877b-424b-af6e-f535f4f4b9d3