### PR TITLE
feat(insights): add New subs column to Subscriptions by product

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -42,7 +42,7 @@ class Subscribers_Metric {
 	 *
 	 * @var string
 	 */
-	const CACHE_PREFIX = 'newspack_insights_tab6_v4:';
+	const CACHE_PREFIX = 'newspack_insights_tab6_v5:';
 
 	/**
 	 * Cache TTL for windowed and snapshot metrics (30 min).
@@ -367,7 +367,7 @@ class Subscribers_Metric {
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
-	 * @return array<int, array{product_id: int, product_name: string, active_subs: int, churned_subs: int, active_value: float, lifetime_revenue: float}>
+	 * @return array<int, array{product_id: int, product_name: string, active_subs: int, new_subs: int, churned_subs: int, active_value: float, lifetime_revenue: float}>
 	 */
 	public function get_subscriptions_by_product( DateTimeInterface $start, DateTimeInterface $end ): array {
 		return (array) $this->cached(

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -698,6 +698,8 @@ class HPOS_Storage implements Storage_Interface {
 		// lifetime_revenue  — lifetime sum of subscription-record totals
 		// attributed per product; not windowed by
 		// design (true LTV waits on the v1.1 BQ wrapper)
+		// new_subs          — WINDOWED to {start, end} via the
+		// `_schedule_start` meta join below
 		// churned_subs      — WINDOWED to {start, end} via the
 		// `_schedule_cancelled` meta join below
 		//
@@ -708,11 +710,12 @@ class HPOS_Storage implements Storage_Interface {
 		// per-product active_value beyond the subscription's actual total
 		// (instead it's attributed once per product — a simplification).
 		//
-		// The LEFT JOIN to `_schedule_cancelled` is required for window
-		// scoping. Active subscriptions don't have this meta set, so the
-		// left-joined row is NULL and the churned CASE naturally rejects
-		// them. Subscription Woo writes one `_schedule_cancelled` row per
-		// subscription at most, so no row multiplication.
+		// The LEFT JOINs to `_schedule_start` and `_schedule_cancelled`
+		// are required for window scoping. Subscriptions missing the meta
+		// (e.g. an active sub has no `_schedule_cancelled`) left-join to
+		// NULL and the corresponding CASE naturally rejects them. Woo
+		// writes at most one row per subscription for each of these keys,
+		// so no row multiplication.
 
 		/*
 		 * Query at the effective-product level. Woo's convention for
@@ -737,6 +740,10 @@ class HPOS_Storage implements Storage_Interface {
 				COALESCE(period_meta.meta_value, '') AS sub_period,
 				COUNT(DISTINCT CASE WHEN o.status = 'wc-active' THEN o.id END) AS active_subs,
 				COUNT(DISTINCT CASE
+					WHEN st.meta_value BETWEEN %s AND %s
+					THEN o.id
+				END) AS new_subs,
+				COUNT(DISTINCT CASE
 					WHEN o.status IN ('wc-cancelled', 'wc-expired')
 					 AND sch.meta_value BETWEEN %s AND %s
 					THEN o.id
@@ -755,12 +762,16 @@ class HPOS_Storage implements Storage_Interface {
 			LEFT JOIN {$prefix}posts pp ON pp.ID = pv.post_parent
 			LEFT JOIN {$prefix}postmeta period_meta
 				ON period_meta.post_id = pv.ID AND period_meta.meta_key = '_subscription_period'
+			LEFT JOIN {$prefix}wc_orders_meta st
+				ON st.order_id = o.id AND st.meta_key = '_schedule_start'
 			LEFT JOIN {$prefix}wc_orders_meta sch
 				ON sch.order_id = o.id AND sch.meta_key = '_schedule_cancelled'
 			WHERE o.type = 'shop_subscription'
 			  AND pid_meta.meta_value NOT IN ($donations)
 			GROUP BY pv.ID, pv.post_title, pv.post_parent, parent_name, sub_period
 			ORDER BY active_subs DESC",
+			$this->fmt( $start ),
+			$this->fmt( $end ),
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);
@@ -805,6 +816,7 @@ class HPOS_Storage implements Storage_Interface {
 			$parent_name      = (string) $row['parent_name'];
 			$period           = (string) $row['sub_period'];
 			$active_subs      = (int) $row['active_subs'];
+			$new_subs         = (int) $row['new_subs'];
 			$churned_subs     = (int) $row['churned_subs'];
 			$active_value     = (float) $row['active_value'];
 			$lifetime_revenue = (float) $row['lifetime_revenue'];
@@ -817,6 +829,7 @@ class HPOS_Storage implements Storage_Interface {
 						'name'             => '' !== $parent_name ? $parent_name : __( '(unnamed product)', 'newspack-plugin' ),
 						'is_parent'        => true,
 						'active_subs'      => 0,
+						'new_subs'         => 0,
 						'churned_subs'     => 0,
 						'active_value'     => 0.0,
 						'lifetime_revenue' => 0.0,
@@ -824,6 +837,7 @@ class HPOS_Storage implements Storage_Interface {
 					];
 				}
 				$parents[ $parent_id ]['active_subs']      += $active_subs;
+				$parents[ $parent_id ]['new_subs']         += $new_subs;
 				$parents[ $parent_id ]['churned_subs']     += $churned_subs;
 				$parents[ $parent_id ]['active_value']     += $active_value;
 				$parents[ $parent_id ]['lifetime_revenue'] += $lifetime_revenue;
@@ -831,6 +845,7 @@ class HPOS_Storage implements Storage_Interface {
 					'variation_id'     => $variation_id,
 					'label'            => $this->variation_label( $period, $variation_name, $parent_name ),
 					'active_subs'      => $active_subs,
+					'new_subs'         => $new_subs,
 					'churned_subs'     => $churned_subs,
 					'active_value'     => $active_value,
 					'lifetime_revenue' => $lifetime_revenue,
@@ -842,6 +857,7 @@ class HPOS_Storage implements Storage_Interface {
 					'name'             => '' !== $variation_name ? $variation_name : __( '(unnamed product)', 'newspack-plugin' ),
 					'is_parent'        => false,
 					'active_subs'      => $active_subs,
+					'new_subs'         => $new_subs,
 					'churned_subs'     => $churned_subs,
 					'active_value'     => $active_value,
 					'lifetime_revenue' => $lifetime_revenue,

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -699,7 +699,11 @@ class HPOS_Storage implements Storage_Interface {
 		// attributed per product; not windowed by
 		// design (true LTV waits on the v1.1 BQ wrapper)
 		// new_subs          — WINDOWED to {start, end} via the
-		// `_schedule_start` meta join below
+		// `_schedule_start` meta join below. Gross starts:
+		// counts every sub that STARTED in-window regardless of
+		// current status, so a sub that started AND churned in the
+		// same timeframe is counted in both new_subs and
+		// churned_subs (independent events, by design)
 		// churned_subs      — WINDOWED to {start, end} via the
 		// `_schedule_cancelled` meta join below
 		//
@@ -740,7 +744,7 @@ class HPOS_Storage implements Storage_Interface {
 				COALESCE(period_meta.meta_value, '') AS sub_period,
 				COUNT(DISTINCT CASE WHEN o.status = 'wc-active' THEN o.id END) AS active_subs,
 				COUNT(DISTINCT CASE
-					WHEN st.meta_value BETWEEN %s AND %s
+					WHEN st.meta_value != '' AND st.meta_value BETWEEN %s AND %s
 					THEN o.id
 				END) AS new_subs,
 				COUNT(DISTINCT CASE

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -671,6 +671,7 @@ class Legacy_Storage implements Storage_Interface {
 		// active_subs       — current state
 		// active_value      — current state
 		// lifetime_revenue  — lifetime sum (intentionally not windowed)
+		// new_subs          — WINDOWED via _schedule_start postmeta
 		// churned_subs      — WINDOWED via _schedule_cancelled postmeta
 		//
 		// Each subscription line item is counted toward the product it
@@ -689,6 +690,10 @@ class Legacy_Storage implements Storage_Interface {
 				COALESCE(pp.post_title, '') AS parent_name,
 				COALESCE(period_meta.meta_value, '') AS sub_period,
 				COUNT(DISTINCT CASE WHEN p.post_status = 'wc-active' THEN p.ID END) AS active_subs,
+				COUNT(DISTINCT CASE
+					WHEN st.meta_value BETWEEN %s AND %s
+					THEN p.ID
+				END) AS new_subs,
 				COUNT(DISTINCT CASE
 					WHEN p.post_status IN ('wc-cancelled', 'wc-expired')
 					 AND sch.meta_value BETWEEN %s AND %s
@@ -710,12 +715,16 @@ class Legacy_Storage implements Storage_Interface {
 			LEFT JOIN {$prefix}posts pp ON pp.ID = pv.post_parent
 			LEFT JOIN {$prefix}postmeta period_meta
 				ON period_meta.post_id = pv.ID AND period_meta.meta_key = '_subscription_period'
+			LEFT JOIN {$prefix}postmeta st
+				ON st.post_id = p.ID AND st.meta_key = '_schedule_start'
 			LEFT JOIN {$prefix}postmeta sch
 				ON sch.post_id = p.ID AND sch.meta_key = '_schedule_cancelled'
 			WHERE p.post_type = 'shop_subscription'
 			  AND pid_meta.meta_value NOT IN ($donations)
 			GROUP BY pv.ID, pv.post_title, pv.post_parent, parent_name, sub_period
 			ORDER BY active_subs DESC",
+			$this->fmt( $start ),
+			$this->fmt( $end ),
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);
@@ -746,6 +755,7 @@ class Legacy_Storage implements Storage_Interface {
 			$parent_name      = (string) $row['parent_name'];
 			$period           = (string) $row['sub_period'];
 			$active_subs      = (int) $row['active_subs'];
+			$new_subs         = (int) $row['new_subs'];
 			$churned_subs     = (int) $row['churned_subs'];
 			$active_value     = (float) $row['active_value'];
 			$lifetime_revenue = (float) $row['lifetime_revenue'];
@@ -757,6 +767,7 @@ class Legacy_Storage implements Storage_Interface {
 						'name'             => '' !== $parent_name ? $parent_name : __( '(unnamed product)', 'newspack-plugin' ),
 						'is_parent'        => true,
 						'active_subs'      => 0,
+						'new_subs'         => 0,
 						'churned_subs'     => 0,
 						'active_value'     => 0.0,
 						'lifetime_revenue' => 0.0,
@@ -764,6 +775,7 @@ class Legacy_Storage implements Storage_Interface {
 					];
 				}
 				$parents[ $parent_id ]['active_subs']      += $active_subs;
+				$parents[ $parent_id ]['new_subs']         += $new_subs;
 				$parents[ $parent_id ]['churned_subs']     += $churned_subs;
 				$parents[ $parent_id ]['active_value']     += $active_value;
 				$parents[ $parent_id ]['lifetime_revenue'] += $lifetime_revenue;
@@ -771,6 +783,7 @@ class Legacy_Storage implements Storage_Interface {
 					'variation_id'     => $variation_id,
 					'label'            => $this->variation_label( $period, $variation_name, $parent_name ),
 					'active_subs'      => $active_subs,
+					'new_subs'         => $new_subs,
 					'churned_subs'     => $churned_subs,
 					'active_value'     => $active_value,
 					'lifetime_revenue' => $lifetime_revenue,
@@ -781,6 +794,7 @@ class Legacy_Storage implements Storage_Interface {
 					'name'             => '' !== $variation_name ? $variation_name : __( '(unnamed product)', 'newspack-plugin' ),
 					'is_parent'        => false,
 					'active_subs'      => $active_subs,
+					'new_subs'         => $new_subs,
 					'churned_subs'     => $churned_subs,
 					'active_value'     => $active_value,
 					'lifetime_revenue' => $lifetime_revenue,

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -671,7 +671,11 @@ class Legacy_Storage implements Storage_Interface {
 		// active_subs       — current state
 		// active_value      — current state
 		// lifetime_revenue  — lifetime sum (intentionally not windowed)
-		// new_subs          — WINDOWED via _schedule_start postmeta
+		// new_subs          — WINDOWED via _schedule_start postmeta.
+		// Gross starts: counts every sub that started in-window
+		// regardless of current status, so a sub that started AND
+		// churned in the same timeframe is counted in both new_subs
+		// and churned_subs (independent events, by design)
 		// churned_subs      — WINDOWED via _schedule_cancelled postmeta
 		//
 		// Each subscription line item is counted toward the product it
@@ -691,7 +695,7 @@ class Legacy_Storage implements Storage_Interface {
 				COALESCE(period_meta.meta_value, '') AS sub_period,
 				COUNT(DISTINCT CASE WHEN p.post_status = 'wc-active' THEN p.ID END) AS active_subs,
 				COUNT(DISTINCT CASE
-					WHEN st.meta_value BETWEEN %s AND %s
+					WHEN st.meta_value != '' AND st.meta_value BETWEEN %s AND %s
 					THEN p.ID
 				END) AS new_subs,
 				COUNT(DISTINCT CASE

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -199,6 +199,7 @@ interface Storage_Interface {
 	 *     'name'             => string,
 	 *     'is_parent'        => bool,    // true when this entry has variations
 	 *     'active_subs'      => int,     // parent: SUM of variation active_subs
+	 *     'new_subs'         => int,     // parent: SUM (windowed)
 	 *     'churned_subs'     => int,     // parent: SUM (windowed)
 	 *     'active_value'     => float,   // parent: SUM
 	 *     'lifetime_revenue' => float,   // parent: SUM (approximate; see Tab 6 doc)
@@ -207,6 +208,7 @@ interface Storage_Interface {
 	 *         'variation_id'     => int,
 	 *         'label'            => string,  // 'Monthly' / 'Annual' / etc
 	 *         'active_subs'      => int,
+	 *         'new_subs'         => int,     // windowed
 	 *         'churned_subs'     => int,     // windowed
 	 *         'active_value'     => float,
 	 *         'lifetime_revenue' => float,
@@ -215,8 +217,9 @@ interface Storage_Interface {
 	 *     ],
 	 *   ]
 	 *
-	 * `churned_subs` is windowed to `[$start, $end]`. The other three
-	 * aggregates are current-state / lifetime (see HPOS_Storage's
+	 * `new_subs` (by `_schedule_start`) and `churned_subs` (by
+	 * `_schedule_cancelled`) are windowed to `[$start, $end]`. The other
+	 * three aggregates are current-state / lifetime (see HPOS_Storage's
 	 * column-scope comment).
 	 *
 	 * @param DateTimeInterface $start Inclusive window start.

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -65,6 +65,8 @@ export interface PerformanceVariationRow {
 	variation_id: number;
 	label: string;
 	active_subs: number;
+	/** Subscriptions that started within the selected timeframe. */
+	new_subs: number;
 	churned_subs: number;
 	active_value: number;
 	lifetime_revenue: number;
@@ -75,6 +77,8 @@ export interface PerformanceRow {
 	name: string;
 	is_parent: boolean;
 	active_subs: number;
+	/** Subscriptions that started within the selected timeframe. */
+	new_subs: number;
 	churned_subs: number;
 	active_value: number;
 	lifetime_revenue: number;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -336,6 +336,19 @@
 			font-variant-numeric: tabular-nums;
 		}
 
+		// Top header band: group labels ("Current", "Selected timeframe",
+		// "All time") sitting above the per-column headers. Centered over
+		// the columns each spans, with a divider between adjacent groups so
+		// they read as distinct bands.
+		th#{&}-group {
+			text-align: center;
+			border-bottom: 1px solid wp-colors.$gray-200;
+		}
+
+		th#{&}-group + th#{&}-group {
+			border-left: 1px solid wp-colors.$gray-300;
+		}
+
 		// Em-dash for cells where the column doesn't apply to the row (e.g. a
 		// regwall has no paywall attempts). Muted (gray-600) so it reads as "not
 		// applicable" and is distinct from a real, default-colored zero — a zero

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
@@ -53,7 +53,7 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 				id="newspack-insights-performance-heading"
 				title={ __( 'Subscriptions by product', 'newspack-plugin' ) }
 				description={ __(
-					'Active subscriptions per product (subscriptions, not unique customers). Lifetime revenue is the all-time total per product.',
+					'Active subscriptions per product (subscriptions, not unique customers). New and churned subs reflect the selected timeframe; active counts and value are current, and lifetime revenue is the all-time total per product.',
 					'newspack-plugin'
 				) }
 			/>
@@ -61,15 +61,31 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 				<table className="newspack-insights__table">
 					<thead>
 						<tr>
-							<th scope="col">{ __( 'Product', 'newspack-plugin' ) }</th>
+							<th scope="col" rowSpan={ 2 }>
+								{ __( 'Product', 'newspack-plugin' ) }
+							</th>
+							<th scope="colgroup" colSpan={ 2 } className="newspack-insights__table-group">
+								{ __( 'Current', 'newspack-plugin' ) }
+							</th>
+							<th scope="colgroup" colSpan={ 2 } className="newspack-insights__table-group">
+								{ __( 'Selected timeframe', 'newspack-plugin' ) }
+							</th>
+							<th scope="colgroup" className="newspack-insights__table-group">
+								{ __( 'All time', 'newspack-plugin' ) }
+							</th>
+						</tr>
+						<tr>
 							<th scope="col" className="newspack-insights__table-num">
 								{ __( 'Active subs', 'newspack-plugin' ) }
 							</th>
 							<th scope="col" className="newspack-insights__table-num">
-								{ __( 'Churned subs', 'newspack-plugin' ) }
+								{ __( 'Active value', 'newspack-plugin' ) }
 							</th>
 							<th scope="col" className="newspack-insights__table-num">
-								{ __( 'Active value', 'newspack-plugin' ) }
+								{ __( 'New subs', 'newspack-plugin' ) }
+							</th>
+							<th scope="col" className="newspack-insights__table-num">
+								{ __( 'Churned subs', 'newspack-plugin' ) }
 							</th>
 							<th scope="col" className="newspack-insights__table-num">
 								{ __( 'Lifetime revenue', 'newspack-plugin' ) }
@@ -84,8 +100,9 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 										<a href={ getPostEditUrl( row.product_id ) }>{ row.name }</a>
 									</td>
 									<td className="newspack-insights__table-num">{ formatNumber( row.active_subs ) }</td>
-									<td className="newspack-insights__table-num">{ formatNumber( row.churned_subs ) }</td>
 									<td className="newspack-insights__table-num">{ formatCurrency( row.active_value ).display }</td>
+									<td className="newspack-insights__table-num">{ formatNumber( row.new_subs ) }</td>
+									<td className="newspack-insights__table-num">{ formatNumber( row.churned_subs ) }</td>
 									<td className="newspack-insights__table-num">{ formatCurrency( row.lifetime_revenue ).display }</td>
 								</tr>
 								{ row.is_parent &&
@@ -93,8 +110,9 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 										<tr key={ `${ row.product_id }-${ v.variation_id }` } className="newspack-insights__table-row--variation">
 											<td>{ v.label }</td>
 											<td className="newspack-insights__table-num">{ formatNumber( v.active_subs ) }</td>
-											<td className="newspack-insights__table-num">{ formatNumber( v.churned_subs ) }</td>
 											<td className="newspack-insights__table-num">{ formatCurrency( v.active_value ).display }</td>
+											<td className="newspack-insights__table-num">{ formatNumber( v.new_subs ) }</td>
+											<td className="newspack-insights__table-num">{ formatNumber( v.churned_subs ) }</td>
 											<td className="newspack-insights__table-num">{ formatCurrency( v.lifetime_revenue ).display }</td>
 										</tr>
 									) ) }


### PR DESCRIPTION
## Why

On the Subscribers tab, the **Subscriptions by product** table mixed three time bases without saying so: `Active subs` / `Active value` are current snapshots, `Lifetime revenue` is all-time, and only `Churned subs` reacted to the timeframe selector. Changing the timeframe moved exactly one column, which read as broken.

## What

Reworked the table so the timeframe selector visibly drives it (**"Option A": balance the flow story rather than drop churn**):

- Added a windowed **New subs** column, paired with **Churned subs**, so within the selected timeframe you see started-vs-lost per product.
- Grouped the header into three bands so each column's time basis is explicit:

| Product | **Current** | **Selected timeframe** | **All time** |
|---|---|---|---|
| | Active subs · Active value | New subs · Churned subs | Lifetime revenue |

### Implementation notes

- `new_subs` counts subscriptions whose `_schedule_start` falls in `[start, end]` (LEFT JOIN, mirroring the existing `_schedule_cancelled` churn join). Counts subs that *started* in the timeframe regardless of current status. Implemented symmetrically in HPOS and legacy storage; rolled up into parent rows + variations alongside `churned_subs`.
- Cache prefix bumped `tab6_v4 → tab6_v5` (cached row shape changed).
- Storage-interface + metric docblocks updated to document the new windowed field.

### Date-key note (no action needed)

While here I checked whether windowing churn on `_schedule_cancelled` undercounts naturally-expired subs. It doesn't — the tab README (NPPD-1724) verified `_schedule_cancelled` is populated on 100% of expired subs because the dominant flow is `active → pending-cancel → expired`. `new_subs` uses `_schedule_start`, consistent with the rest of the tab.