### PR TITLE
fix(insights): converter-denominate prompts paid Influenced rates (NPPD-1822, plugin half)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -173,9 +173,9 @@ final class Prompts_Metric {
 		'newsletter_signup_conversion_direct'        => 'hub',
 		'newsletter_signup_conversion_influenced_7d' => 'hub',
 		'donation_conversion_direct'                 => 'hybrid', // Local order-meta numerator + hub donation-impressions denominator.
-		'donation_conversion_influenced_14d'         => 'hub',
+		'donation_conversion_influenced_14d'         => 'hybrid', // NPPD-1822: hub influenced numerator + local Woo new-donor-spine denominator (converter-denominated).
 		'subscription_conversion_direct'             => 'hybrid', // NPPD-1746: local order-meta (popup) numerator + hub per-popup-impressions denominator.
-		'subscription_conversion_influenced_14d'     => 'hub',
+		'subscription_conversion_influenced_14d'     => 'hybrid', // NPPD-1822: hub influenced numerator + local Woo new-subscriber-spine denominator (converter-denominated).
 		'donation_revenue_direct'                    => 'local',   // Pure Woo order meta; survives a hub outage.
 		'donation_revenue_influenced_14d'            => 'hub',
 		'subscription_revenue_direct'                => 'local',   // NPPD-1746: pure Woo order meta (popup surface); survives a hub outage.
@@ -1110,25 +1110,40 @@ final class Prompts_Metric {
 	}
 
 	/**
-	 * Donation conversion rate, influenced (14-day lookback).
+	 * Donation conversion rate, influenced (14-day lookback), converter-denominated (NPPD-1822).
+	 *
+	 * = distinct donors whose conversion had a prompt exposure in a PRIOR session within 14d
+	 * ÷ ALL new donors in the window. "Of our donors, what share were prompt-influenced" —
+	 * user-level, matching the doc's framing and the Gates paywall rate (NPPD-1764). Replaces
+	 * the prior attempt-denominated rate (÷ `count($joined['rows'])`), which keyed off
+	 * influenced checkout attempts and read inflated.
+	 *
+	 * Numerator stays hub/GA4-cross-session-sourced and Woo-matched (distinct converting
+	 * users); it remains anonymous-undercounted (NPPD-1685) until NPPD-1747. Denominator is
+	 * the anonymous-inclusive Woo new-donor spine. The GA4-matched numerator is not a strict
+	 * subset of it, so `rate_value()` suppresses any >100% to a non-computable em-dash. Local
+	 * denominator + hub numerator → 'hybrid' (see METRIC_SOURCES).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_donation_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no local donors to denominate against. Empty state, not a
+			// fake 0% (NPPD-1737 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'rate' );
+		}
 		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_donation_conversion_influenced_14d', $start, $end );
 		if ( is_wp_error( $joined ) ) {
 			return $this->error_scalar( 'rate', $joined );
 		}
-		$denominator = count( $joined['rows'] );
-		$numerator   = $joined['conversions'];
-		return $this->populated_scalar(
-			$denominator > 0 ? $numerator / $denominator : 0.0,
-			$denominator > 0,
-			$denominator,
-			'rate'
-		);
+		$numerator   = $this->woo_resolver->count_unique_completed_users( $joined['rows'] );
+		$denominator = $this->donors_metric()->get_new_donors_in_window( $start, $end );
+		$rate        = $this->rate_value( $numerator, $denominator );
+		return null === $rate
+			? $this->populated_scalar( 0.0, false, $denominator, 'rate' )
+			: $this->populated_scalar( $rate, true, $denominator, 'rate' );
 	}
 
 	/**
@@ -1208,25 +1223,33 @@ final class Prompts_Metric {
 	}
 
 	/**
-	 * Subscription conversion rate, influenced (14-day lookback).
+	 * Subscription conversion rate, influenced (14-day lookback), converter-denominated (NPPD-1822).
+	 *
+	 * = distinct subscribers whose conversion had a prompt exposure in a PRIOR session within
+	 * 14d ÷ ALL new subscribers in the window. Subscription sibling of
+	 * {@see self::get_donation_conversion_influenced_14d()}; same converter framing, em-dash
+	 * coherence guard, and 'hybrid' source. Numerator completeness → NPPD-1747.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_subscription_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
+		if ( ! $this->woocommerce_active() ) {
+			// Non-WC publisher: no local subscribers to denominate against. Empty state, not
+			// a fake 0% (NPPD-1737 Option A scoping).
+			return $this->populated_scalar( 0.0, false, 0, 'rate' );
+		}
 		$joined = $this->fetch_paid_attempts_woo_join( 'prompts_subscription_conversion_influenced_14d', $start, $end );
 		if ( is_wp_error( $joined ) ) {
 			return $this->error_scalar( 'rate', $joined );
 		}
-		$denominator = count( $joined['rows'] );
-		$numerator   = $joined['conversions'];
-		return $this->populated_scalar(
-			$denominator > 0 ? $numerator / $denominator : 0.0,
-			$denominator > 0,
-			$denominator,
-			'rate'
-		);
+		$numerator   = $this->woo_resolver->count_unique_completed_users( $joined['rows'] );
+		$denominator = $this->subscribers_metric()->get_new_subscribers_in_window( $start, $end );
+		$rate        = $this->rate_value( $numerator, $denominator );
+		return null === $rate
+			? $this->populated_scalar( 0.0, false, $denominator, 'rate' )
+			: $this->populated_scalar( $rate, true, $denominator, 'rate' );
 	}
 
 	// --- Section 5: Revenue from prompts --------------------------------

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -695,7 +695,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Readers who completed a donation in a later session within 14 days of seeing a donation-intent prompt ÷ readers who saw a donation-intent prompt
+                Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
               </div>
             </div>
           </div>
@@ -785,7 +785,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Readers who completed a subscription in a later session within 14 days of seeing a subscription-intent prompt ÷ readers who saw a subscription-intent prompt
+                Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
               </div>
             </div>
           </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -55,7 +55,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Donation Conversion (Influenced, 14d)', 'newspack-plugin' ),
 					description: __(
-						'Readers who completed a donation in a later session within 14 days of seeing a donation-intent prompt ÷ readers who saw a donation-intent prompt',
+						'Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors',
 						'newspack-plugin'
 					),
 					current: current.donation_conversion_influenced_14d,
@@ -84,7 +84,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Subscription Conversion (Influenced, 14d)', 'newspack-plugin' ),
 					description: __(
-						'Readers who completed a subscription in a later session within 14 days of seeing a subscription-intent prompt ÷ readers who saw a subscription-intent prompt',
+						'Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers',
 						'newspack-plugin'
 					),
 					current: current.subscription_conversion_influenced_14d,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -61,7 +61,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					current: current.donation_conversion_influenced_14d,
 					previous: previous?.donation_conversion_influenced_14d,
 					notCapableMessage: NOT_CAPABLE_COPY.donation,
-					notComputableMessage: NOT_COMPUTABLE_COPY.donation,
+					notComputableMessage: NOT_COMPUTABLE_COPY.donationInfluenced,
 				} ) }
 			/>
 			{ /* Block-name vs intent-name asymmetry: NOT_CAPABLE keys off the block that
@@ -90,7 +90,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					current: current.subscription_conversion_influenced_14d,
 					previous: previous?.subscription_conversion_influenced_14d,
 					notCapableMessage: NOT_CAPABLE_COPY.checkout,
-					notComputableMessage: NOT_COMPUTABLE_COPY.subscription,
+					notComputableMessage: NOT_COMPUTABLE_COPY.subscriptionInfluenced,
 				} ) }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
@@ -11,11 +11,14 @@
  * Insights UI, e.g. the Prompt exposure section on this same tab.
  *
  * Intent-grouped: the four conversion intents (newsletter, registration,
- * donation, subscription) each share one string across their Direct, Influenced,
- * and Revenue cards, plus the cross-intent form-submission case. Centralized here
- * (rather than inline on each card) so the cross-tab voice-and-tone audit
- * (NPPD-1698) has a single place to review them. Strings end with a period to
- * match 1720's nudges.
+ * donation, subscription) each share one string across their Direct and Revenue
+ * cards, plus the cross-intent form-submission case. The paid Influenced rates
+ * (donation, subscription) are converter-denominated (NPPD-1822) — their
+ * non-computable trigger is "no new donors/subscribers in the window", not "no
+ * in-intent prompts viewed" — so they use the dedicated `*Influenced` strings.
+ * Centralized here (rather than inline on each card) so the cross-tab
+ * voice-and-tone audit (NPPD-1698) has a single place to review them. Strings end
+ * with a period to match 1720's nudges.
  */
 
 /**
@@ -30,4 +33,8 @@ export const NOT_COMPUTABLE_COPY = {
 	registration: __( 'No prompts with a registration block viewed in this timeframe.', 'newspack-plugin' ),
 	donation: __( 'No prompts with a donation block viewed in this timeframe.', 'newspack-plugin' ),
 	subscription: __( 'No subscription-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
+	// Converter-denominated Influenced rates (NPPD-1822): non-computable means no new
+	// donors/subscribers in the window, not "no prompts viewed".
+	donationInfluenced: __( 'No new donors in this timeframe.', 'newspack-plugin' ),
+	subscriptionInfluenced: __( 'No new subscribers in this timeframe.', 'newspack-plugin' ),
 };

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -273,106 +273,114 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Wired paid-conversion RATE methods: dispatch the query, Woo-join, and
-	 * return `conversions / attempts` as a `placeholder_type: 'rate'` envelope.
+	 * Build a Prompts_Metric for the paid (donation/subscription) INFLUENCED rate cards:
+	 * injected proxy (hub influenced rows) + resolver (Woo match) + the converter-spine
+	 * collaborator(s), with a forced `woocommerce_active()` (filter removed in tear_down).
 	 *
-	 * @dataProvider provide_paid_conversion_rate_methods
-	 * @param string $method     Method on Prompts_Metric to call.
-	 * @param string $query_name Catalog name the orchestrator must dispatch.
+	 * @param BigQuery_Proxy_Client   $proxy       Hub influenced-rows proxy.
+	 * @param Woo_Order_Resolver      $resolver    Woo match resolver.
+	 * @param Donors_Metric|null      $donors      Donor converter spine (donation rate).
+	 * @param Subscribers_Metric|null $subscribers Subscriber converter spine (subscription rate).
+	 * @param bool                    $wc          What woocommerce_active() should return.
+	 * @return Prompts_Metric
 	 */
-	public function test_paid_conversion_rate_returns_populated_on_success( string $method, string $query_name ) {
-		$rows  = $this->paid_attempt_rows();
+	private function make_influenced_paid_metric( BigQuery_Proxy_Client $proxy, Woo_Order_Resolver $resolver, ?Donors_Metric $donors, ?Subscribers_Metric $subscribers, bool $wc ): Prompts_Metric {
+		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
+		return new Prompts_Metric( $proxy, $resolver, null, $donors, $subscribers );
+	}
+
+	/**
+	 * NPPD-1822: donation influenced rate = distinct prompt-influenced donors (hub rows,
+	 * Woo-matched) ÷ ALL new donors in the window — converter-denominated, not attempts.
+	 */
+	public function test_donation_conversion_influenced_converter_denominated() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->once() )
-			->method( 'query' )
-			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
-			->willReturn( $rows );
-
+		$proxy->method( 'query' )->willReturn( $this->paid_attempt_rows() );
 		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 ); // 1 of 2 attempts converted.
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+		$resolver->method( 'count_unique_completed_users' )->willReturn( 3 );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donors_in_window' )->willReturn( 12 );
 
-		$metric = new Prompts_Metric( $proxy, $resolver );
-		$result = $metric->$method( $this->start(), $this->end() );
+		$metric = $this->make_influenced_paid_metric( $proxy, $resolver, $donors, null, true );
+		$result = $metric->get_donation_conversion_influenced_14d( $this->start(), $this->end() );
 
 		$this->assertSame( 'populated', $result['state'] );
-		$this->assertSame( 0.5, $result['value'] );
 		$this->assertTrue( $result['computable'] );
-		$this->assertSame( 2, $result['denominator'] );
+		$this->assertSame( 12, $result['denominator'] );
+		$this->assertEqualsWithDelta( 0.25, $result['value'], 0.0001 );
 		$this->assertSame( 'rate', $result['placeholder_type'] );
 	}
 
 	/**
-	 * Wired paid-conversion RATE methods: proxy WP_Error → state 'error'.
-	 *
-	 * @dataProvider provide_paid_conversion_rate_methods
-	 * @param string $method     Method on Prompts_Metric to call.
-	 * @param string $query_name Catalog name the orchestrator must dispatch.
+	 * NPPD-1822: subscription influenced rate = distinct prompt-influenced subscribers ÷
+	 * ALL new subscribers in the window.
 	 */
-	public function test_paid_conversion_rate_returns_error_state_on_proxy_error( string $method, string $query_name ) {
+	public function test_subscription_conversion_influenced_converter_denominated() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->once() )
-			->method( 'query' )
-			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
-			->willReturn( new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' ) );
-
-		$metric = new Prompts_Metric( $proxy, $this->createMock( Woo_Order_Resolver::class ) );
-		$result = $metric->$method( $this->start(), $this->end() );
-
-		$this->assertSame( 'error', $result['state'] );
-		$this->assertFalse( $result['computable'] );
-		$this->assertSame( 'rate', $result['placeholder_type'] );
-		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
-		$this->assertSame( 'HTTP 500', $result['error_message'] );
-		$this->assertSame( 0, $result['value'] );
-	}
-
-	/**
-	 * Wired paid-conversion RATE methods: empty BQ response → non-computable
-	 * 0.0 with denominator 0 (a real "no attempts in window", not an error).
-	 *
-	 * @dataProvider provide_paid_conversion_rate_methods
-	 * @param string $method     Method on Prompts_Metric to call.
-	 * @param string $query_name Catalog name the orchestrator must dispatch.
-	 */
-	public function test_paid_conversion_rate_returns_noncomputable_zero_on_empty( string $method, string $query_name ) {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->once() )
-			->method( 'query' )
-			->with( $query_name, $this->isInstanceOf( DateTimeImmutable::class ), $this->isInstanceOf( DateTimeImmutable::class ) )
-			->willReturn( [] );
-
+		$proxy->method( 'query' )->willReturn( $this->paid_attempt_rows() );
 		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 0 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 0.0 );
+		$resolver->method( 'count_unique_completed_users' )->willReturn( 4 );
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_new_subscribers_in_window' )->willReturn( 16 );
 
-		$metric = new Prompts_Metric( $proxy, $resolver );
-		$result = $metric->$method( $this->start(), $this->end() );
+		$metric = $this->make_influenced_paid_metric( $proxy, $resolver, null, $subscribers, true );
+		$result = $metric->get_subscription_conversion_influenced_14d( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 16, $result['denominator'] );
+		$this->assertEqualsWithDelta( 0.25, $result['value'], 0.0001 );
+		$this->assertSame( 'rate', $result['placeholder_type'] );
+	}
+
+	/**
+	 * NPPD-1822: a non-WC publisher gets the empty state (no local converter denominator),
+	 * and the hub influenced query is never dispatched.
+	 */
+	public function test_paid_influenced_rate_empty_state_when_not_woocommerce() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->expects( $this->never() )->method( 'query' );
+
+		$metric = $this->make_influenced_paid_metric( $proxy, $this->createMock( Woo_Order_Resolver::class ), null, null, false );
+		$result = $metric->get_subscription_conversion_influenced_14d( $this->start(), $this->end() );
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertFalse( $result['computable'] );
 		$this->assertSame( 0, $result['denominator'] );
-		$this->assertSame( 'rate', $result['placeholder_type'] );
-		$this->assertSame( 0.0, $result['value'] );
 	}
 
 	/**
-	 * Data provider for the proxy-backed paid-conversion rate methods.
-	 *
-	 * NPPD-1745/1746: `get_donation_conversion_direct` AND
-	 * `get_subscription_conversion_direct` are intentionally absent — neither
-	 * dispatches a paid-attempt proxy query any more. Both are hybrid order-meta
-	 * conversions ÷ hub impressions (see test_donation_conversion_direct_* and
-	 * test_subscription_conversion_direct_*). Only the influenced pair is still
-	 * proxy-backed.
-	 *
-	 * @return array
+	 * Proxy WP_Error → state 'error' (WC active, so it reaches the hub).
 	 */
-	public function provide_paid_conversion_rate_methods(): array {
-		return [
-			'donation_influenced'     => [ 'get_donation_conversion_influenced_14d', 'prompts_donation_conversion_influenced_14d' ],
-			'subscription_influenced' => [ 'get_subscription_conversion_influenced_14d', 'prompts_subscription_conversion_influenced_14d' ],
-		];
+	public function test_paid_influenced_rate_errors_on_proxy_error() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' ) );
+
+		$metric = $this->make_influenced_paid_metric( $proxy, $this->createMock( Woo_Order_Resolver::class ), $this->createMock( Donors_Metric::class ), null, true );
+		$result = $metric->get_donation_conversion_influenced_14d( $this->start(), $this->end() );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
+	}
+
+	/**
+	 * Coherence guard: a GA4-matched numerator exceeding the converter denominator
+	 * suppresses to a non-computable em-dash rather than rendering >100% (NPPD-1822).
+	 */
+	public function test_paid_influenced_rate_coherence_guard_suppresses_over_100() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( $this->paid_attempt_rows() );
+		$resolver = $this->createMock( Woo_Order_Resolver::class );
+		$resolver->method( 'count_unique_completed_users' )->willReturn( 5 );
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_new_subscribers_in_window' )->willReturn( 2 );
+
+		$metric = $this->make_influenced_paid_metric( $proxy, $resolver, null, $subscribers, true );
+		$result = $metric->get_subscription_conversion_influenced_14d( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 2, $result['denominator'] );
 	}
 
 	// --- Section 5: Revenue from prompts --------------------------------
@@ -1174,11 +1182,18 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 			->willReturn( $rows );
 
 		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_completed_orders' )->willReturn( 1 );
-		$resolver->method( 'sum_completed_revenue' )->willReturn( 25.0 );
+		$resolver->method( 'count_unique_completed_users' )->willReturn( 1 );
 
-		$metric = new Prompts_Metric( $proxy, $resolver );
-		// NPPD-1745/1746: the direct donation AND subscription rates no longer dispatch
+		// NPPD-1822: the influenced rates are now WC-gated + converter-denominated, so
+		// force WC active (filter removed in tear_down) and inject converter spines.
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		$donors = $this->createMock( Donors_Metric::class );
+		$donors->method( 'get_new_donors_in_window' )->willReturn( 10 );
+		$subscribers = $this->createMock( Subscribers_Metric::class );
+		$subscribers->method( 'get_new_subscribers_in_window' )->willReturn( 10 );
+
+		$metric = new Prompts_Metric( $proxy, $resolver, null, $donors, $subscribers );
+		// NPPD-1745/1746/1822: the direct donation AND subscription rates no longer dispatch
 		// a paid-attempt query (both are hybrid order-meta ÷ impressions). Use two
 		// still-proxy-backed influenced intents with distinct query_names to exercise
 		// per-query_name cache keying.


### PR DESCRIPTION
## What

The **plugin half** of [NPPD-1822](https://linear.app/a8c/issue/NPPD-1822): converter-denominate the Prompts tab's **paid** Influenced rates, mirroring the merged gates paywall fix ([NPPD-1764](https://linear.app/a8c/issue/NPPD-1764), #438). Part of the [NPPD-1823](https://linear.app/a8c/issue/NPPD-1823) influenced-denominator unification.

`Prompts_Metric::get_donation_conversion_influenced_14d` + `get_subscription_conversion_influenced_14d` divided by **checkout attempts** (`count($joined['rows'])`) — deflated on anonymous-conversion-heavy publishers, so the rate read inflated, and inconsistent with the converter framing used by Tab 3 7.1–7.4.

## Change

- **Denominator** → all new donors / subscribers in the window (the anonymous-inclusive Woo identity spine: `Donors_Metric::get_new_donors_in_window` / `Subscribers_Metric::get_new_subscribers_in_window`), not attempts.
- **Numerator** → distinct prompt-influenced converting users (`count_unique_completed_users`), so it's user-level and shares the denominator's population.
- `rate_value()` **>100% em-dash guard** (the GA4-matched numerator isn't a strict subset of the Woo spine).
- **WC-gated** to an empty state on non-WC publishers (NPPD-1737 Option A); reclassified both metrics `hub` → `hybrid` in `METRIC_SOURCES` (hub numerator + local denominator, matching the direct rates).
- Frontend: updated both Influenced card descriptions from "÷ readers who saw a … prompt" to the converter framing ("÷ all new donors / subscribers").

## Out of scope

- **Numerator completeness** (the GA4 cross-session anonymous undercount) stays with [NPPD-1747](https://linear.app/a8c/issue/NPPD-1747) — no prompts-specific cross-session join here.
- **Revenue** Influenced siblings are sums, not rates — untouched.
- The **hub free half** (registration/newsletter Influenced, viewer-denominated) is the other part of NPPD-1822, a `newspack-manager-admin` change (batches with the gates regwall hub change, [NPPD-1821](https://linear.app/a8c/issue/NPPD-1821)).