### PR TITLE
fix(insights): bq-internal paywall influenced rate (tab 4 gates)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -55,6 +55,15 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	protected $rest_base = 'gates';
 
 	/**
+	 * Bust cached responses when the Tab 4 response shape changes.
+	 *
+	 * @return string
+	 */
+	protected function cache_schema_version(): string {
+		return Gates_Metric::CACHE_PREFIX;
+	}
+
+	/**
 	 * Cache source classification for this controller.
 	 *
 	 * @return string

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -479,10 +479,13 @@ final class Conversion_Metric {
 			return $this->populated_scalar( 0.0, false, null, 'rate', true );
 		}
 		$denominator = $rows[0][ $denominator_key ];
-		if ( ! is_numeric( $denominator ) ) {
+		// The denominator is a BigQuery COUNT(DISTINCT) — a non-negative integer. Reject any
+		// non-integer numeric (e.g. 8.5) rather than silently truncating it, matching the
+		// integer-only count validation in Gates_Metric and Prompts_Metric.
+		if ( ! is_numeric( $denominator ) || (float) $denominator !== (float) (int) $denominator ) {
 			return $this->error_scalar(
 				'rate',
-				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric denominator.', 'newspack-plugin' ) )
+				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-integer denominator.', 'newspack-plugin' ) )
 			);
 		}
 		$denominator = (int) $denominator;

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -425,73 +425,53 @@ final class Gates_Metric {
 	}
 
 	/**
-	 * Compute the influenced-14d paywall conversion rate, converter-denominated (NPPD-1764).
+	 * Read a BQ-internal influenced rate metric: one row carrying a precomputed
+	 * SAFE_DIVIDE rate (null when there are no converters) and an integer denominator.
 	 *
-	 * = distinct subscribers in the window whose conversion had a paywall-capable gate
-	 * exposure in a PRIOR session within 14d ÷ ALL new subscribers in the window. I.e.
-	 * "of our subscribers, what share were paywall-influenced" — user-level, matching the
-	 * doc's conceptual framing and Tab 3's 7.1–7.4 converter framing (NPPD-1766). (The
-	 * Direct rate is exposure-denominated by design — a different lens — so the two are
-	 * intentionally not the same base.)
-	 *
-	 * Replaces the prior attempt-denominated rate (÷ `count($rows)`), which keyed the
-	 * denominator off influenced checkout *attempts* — deflated on anonymous-conversion-
-	 * heavy publishers, so the rate read inflated.
-	 *
-	 * - **Numerator** stays hub/GA4-cross-session-sourced and Woo-matched (`count_unique_
-	 *   completed_users`): order meta has no session timing to place a prior-session
-	 *   exposure, so influenced can't move to the order-meta model the way Direct did.
-	 *   It remains anonymous-undercounted (NPPD-1685); NPPD-1747 improves its completeness
-	 *   for the whole influenced family — do NOT build a gates-specific cross-session join.
-	 * - **Denominator** is the anonymous-inclusive Woo identity spine
-	 *   ({@see Subscribers_Metric::get_new_subscribers_in_window()}). Because the GA4-matched
-	 *   numerator is not a strict subset of it, `rate_value()` suppresses any >100% to a
-	 *   non-computable em-dash (the coherence guard, parity with the Direct/Prompts rates).
-	 *
-	 * Local denominator + hub numerator → 'hybrid' (see METRIC_SOURCES).
-	 *
-	 * @param string            $query_name Catalog name (the influenced rows to match).
-	 * @param DateTimeInterface $start      Window start.
-	 * @param DateTimeInterface $end        Window end.
+	 * @param string            $query_name      Catalog query name.
+	 * @param string            $rate_key        Rate column key.
+	 * @param string            $denominator_key Denominator column key.
+	 * @param DateTimeInterface $start           Window start.
+	 * @param DateTimeInterface $end             Window end.
 	 * @return array
 	 */
-	private function compute_paywall_rate_from_proxy(
+	private function compute_influenced_rate_from_proxy(
 		string $query_name,
+		string $rate_key,
+		string $denominator_key,
 		DateTimeInterface $start,
 		DateTimeInterface $end
 	): array {
-		if ( ! $this->woocommerce_active() ) {
-			// Non-WC publisher: no local subscribers to denominate against. Empty
-			// state, not a fake 0% (NPPD-1737 Option A scoping).
-			return $this->populated_scalar( 0.0, false, 0, 'rate', 0 );
-		}
-
 		$rows = $this->proxy->query( $query_name, $start, $end );
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_scalar( 'rate', $rows );
 		}
-		if ( ! is_array( $rows ) ) {
-			// Malformed hub response (not an array): surface as an error, not a confident
-			// 0% — parity with the donation/subscription malformed-rows handling (NPPD-1745
-			// #3). An empty array is valid (0 influenced) and handled below.
-			return $this->error_scalar( 'rate', new \WP_Error( 'bigquery_proxy_malformed_rows', __( 'The query returned an unexpected shape.', 'newspack-plugin' ) ) );
+		if ( empty( $rows ) ) {
+			return $this->populated_scalar( 0.0, false, null, 'rate' );
 		}
-
-		// Numerator: distinct subscribers whose conversion was paywall-influenced (the
-		// hub influenced rows, Woo-matched). Empty rows → 0 influenced, which is a real
-		// 0% against the subscriber denominator below — not "no data".
-		$numerator = empty( $rows ) ? 0 : $this->woo_resolver->count_unique_completed_users( $rows );
-
-		// Denominator: all new subscribers in the window (converters), not influenced
-		// attempts — anonymous-inclusive, the same Woo spine the source-mix totals use.
-		$denominator = $this->subscribers_metric()->get_new_subscribers_in_window( $start, $end );
-
-		$rate = $this->rate_value( $numerator, $denominator );
-		return null === $rate
-			? $this->populated_scalar( 0.0, false, $denominator, 'rate', $numerator )
-			: $this->populated_scalar( $rate, true, $denominator, 'rate', $numerator );
+		if ( ! is_array( $rows[0] ) || ! array_key_exists( $rate_key, $rows[0] ) || ! array_key_exists( $denominator_key, $rows[0] ) ) {
+			return $this->populated_scalar( 0.0, false, null, 'rate', null, true );
+		}
+		$denominator = $rows[0][ $denominator_key ];
+		if ( ! is_numeric( $denominator ) ) {
+			return $this->error_scalar(
+				'rate',
+				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric denominator.', 'newspack-plugin' ) )
+			);
+		}
+		$denominator = (int) $denominator;
+		$rate        = $rows[0][ $rate_key ];
+		if ( null === $rate ) {
+			return $this->populated_scalar( 0.0, false, $denominator, 'rate' );
+		}
+		if ( ! is_numeric( $rate ) ) {
+			return $this->error_scalar(
+				'rate',
+				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric value.', 'newspack-plugin' ) )
+			);
+		}
+		return $this->populated_scalar( (float) $rate, $denominator > 0, $denominator, 'rate' );
 	}
-
 
 	/**
 	 * Fetch (memoized per window) the `gates_performance_by_gate` hub rows, so the
@@ -752,12 +732,22 @@ final class Gates_Metric {
 	/**
 	 * Paywall conversion rate, influenced (14-day lookback).
 	 *
+	 * BQ-internal rate + denominator (hub computes it; no Woo join). Replaces the prior
+	 * gates_paywall_conversion_influenced_14d attempt-row → Woo_Order_Resolver path, which
+	 * undercounted via the GA4 cookie → customer_id cast.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
 	 */
 	public function get_paywall_conversion_influenced_14d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_paywall_rate_from_proxy( 'gates_paywall_conversion_influenced_14d', $start, $end );
+		return $this->compute_influenced_rate_from_proxy(
+			'gates_paywall_conversion_influenced_14d',
+			'paywall_conversion_influenced_rate',
+			'conversion_denominator',
+			$start,
+			$end
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -74,7 +74,7 @@ final class Gates_Metric {
 		'regwall_conversion_direct'          => 'hub',
 		'regwall_conversion_influenced_7d'   => 'hub',
 		'paywall_conversion_direct'          => 'hybrid', // NPPD-1746: local order-meta (gate) numerator + hub per-gate-impressions denominator.
-		'paywall_conversion_influenced_14d'  => 'hybrid', // NPPD-1764: hub influenced numerator + local Woo subscriber-spine denominator (converter-denominated).
+		'paywall_conversion_influenced_14d'  => 'hub',    // BQ-internal influenced rate + denominator (no local Woo); see regwall_conversion_influenced_7d.
 		'total_paywall_revenue_direct'       => 'local',  // NPPD-1746: pure Woo order meta (gate surface); survives a hub outage.
 		'avg_revenue_per_paywall_conversion' => 'local',  // NPPD-1746: derived from the same order-meta source as total revenue.
 		'conversion_funnel'                  => 'hub',

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -441,10 +441,14 @@ final class Gates_Metric {
 			return $this->populated_scalar( 0.0, false, null, 'rate', null, true );
 		}
 		$denominator = $rows[0][ $denominator_key ];
-		if ( ! is_numeric( $denominator ) ) {
+		// The denominator is a BigQuery COUNT(DISTINCT) — a non-negative integer. Reject any
+		// non-integer numeric (e.g. 8.5) rather than silently truncating it, matching the strict
+		// count-field validation used elsewhere in this class. The ported Conversion_Metric reader
+		// is looser here; hardening it is a separate follow-up.
+		if ( ! is_numeric( $denominator ) || (float) $denominator !== (float) (int) $denominator ) {
 			return $this->error_scalar(
 				'rate',
-				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric denominator.', 'newspack-plugin' ) )
+				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-integer denominator.', 'newspack-plugin' ) )
 			);
 		}
 		$denominator = (int) $denominator;

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -239,9 +239,11 @@ final class Gates_Metric {
 	 *                                    computed locally (the paywall Woo join); null
 	 *                                    everywhere the count isn't available, e.g. the
 	 *                                    precomputed-rate regwall cards.
+	 * @param bool      $data_missing     True when the payload was built from a schema
+	 *                                    that is missing expected columns (drift signal).
 	 * @return array
 	 */
-	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type, ?int $numerator = null ): array {
+	private function populated_scalar( $value, bool $computable, ?int $denominator, string $placeholder_type, ?int $numerator = null, bool $data_missing = false ): array {
 		return [
 			'state'            => 'populated',
 			'value'            => $value,
@@ -249,6 +251,7 @@ final class Gates_Metric {
 			'denominator'      => $denominator,
 			'numerator'        => $numerator,
 			'placeholder_type' => $placeholder_type,
+			'data_missing'     => $data_missing,
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -818,9 +818,13 @@ final class Gates_Metric {
 	 *   - `paywall_impressions_total` = the Direct rate denominator (sessions with a
 	 *     paywall impression; this is the {N} in the "no conversions" copy).
 	 *   - `paywall_conversions_total` = the most inclusive conversion count across
-	 *     attributions (max of Direct and Influenced numerators), so a section
-	 *     with Influenced-only conversions still renders its scorecards rather
-	 *     than hiding real data behind a "no conversions" empty state.
+	 *     attributions — `max` of the Direct numerator (gate-attributed Woo
+	 *     conversions) and the Influenced *denominator*. The BQ-internal Influenced
+	 *     metric reports `conversion_denominator` (COUNT(DISTINCT) of paywall
+	 *     converters in the window) and no numerator, so reading its denominator is
+	 *     what keeps an Influenced-only window (Direct 0, Influenced rate positive)
+	 *     rendering its scorecards rather than hiding real data behind a "no
+	 *     conversions" empty state.
 	 *
 	 * @param array $direct     The `paywall_conversion_direct` scalar payload.
 	 * @param array $influenced The `paywall_conversion_influenced_14d` scalar payload.
@@ -831,7 +835,7 @@ final class Gates_Metric {
 			'paywall_impressions_total' => (int) ( $direct['denominator'] ?? 0 ),
 			'paywall_conversions_total' => max(
 				(int) ( $direct['numerator'] ?? 0 ),
-				(int) ( $influenced['numerator'] ?? 0 )
+				(int) ( $influenced['denominator'] ?? 0 )
 			),
 		];
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -48,7 +48,7 @@ final class Gates_Metric {
 	 *
 	 * @var string
 	 */
-	const CACHE_PREFIX = 'newspack_insights_tab4_v1:';
+	const CACHE_PREFIX = 'newspack_insights_tab4_v2:';
 
 	/**
 	 * Data-source classification per metric key (NPPD-1746), the Gates-tab twin of

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -25,7 +25,6 @@ use DateTimeInterface;
 use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Subscribers_Metric;
-use Newspack\Insights\Woo_Order_Resolver;
 
 /**
  * Tab 4 metric orchestrator.
@@ -91,13 +90,6 @@ final class Gates_Metric {
 	private BigQuery_Proxy_Client $proxy;
 
 	/**
-	 * Resolver used to match BQ paywall attempts against Woo orders.
-	 *
-	 * @var Woo_Order_Resolver
-	 */
-	private Woo_Order_Resolver $woo_resolver;
-
-	/**
 	 * Per-request memo for `gates_performance_by_gate` hub rows, keyed by `Ymd|Ymd`
 	 * window (NPPD-1746). The direct paywall-rate denominator
 	 * ({@see self::fetch_gate_impressions_by_gate()}) and the per-gate table
@@ -112,9 +104,8 @@ final class Gates_Metric {
 	/**
 	 * Subscribers_Metric collaborator (NPPD-1746). Owns the WC-native subscription
 	 * storage used to source the DIRECT paywall conversion + revenue metrics (gate
-	 * surface) from order meta instead of the GA4 attempt → Woo_Order_Resolver join.
+	 * surface) from order meta.
 	 * Lazily built on first direct-paywall call ({@see self::subscribers_metric()}).
-	 * Influenced (14d) paywall metrics still use the resolver.
 	 *
 	 * @var Subscribers_Metric|null
 	 */
@@ -124,16 +115,13 @@ final class Gates_Metric {
 	 * Constructor. Optionally inject collaborators (used in tests).
 	 *
 	 * @param BigQuery_Proxy_Client|null $proxy              Injected proxy client, or null to lazy-resolve.
-	 * @param Woo_Order_Resolver|null    $woo_resolver       Injected Woo resolver, or null to lazy-create.
 	 * @param Subscribers_Metric|null    $subscribers_metric Injected subscribers collaborator (NPPD-1746), or null to lazy-create.
 	 */
 	public function __construct(
 		?BigQuery_Proxy_Client $proxy = null,
-		?Woo_Order_Resolver $woo_resolver = null,
 		?Subscribers_Metric $subscribers_metric = null
 	) {
 		$this->proxy              = $proxy ?? new BigQuery_Proxy_Client();
-		$this->woo_resolver       = $woo_resolver ?? new Woo_Order_Resolver();
 		$this->subscribers_metric = $subscribers_metric;
 	}
 
@@ -733,8 +721,7 @@ final class Gates_Metric {
 	 * Paywall conversion rate, influenced (14-day lookback).
 	 *
 	 * BQ-internal rate + denominator (hub computes it; no Woo join). Replaces the prior
-	 * gates_paywall_conversion_influenced_14d attempt-row → Woo_Order_Resolver path, which
-	 * undercounted via the GA4 cookie → customer_id cast.
+	 * attempt-row path which undercounted via the GA4 cookie → customer_id cast.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.

--- a/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/gates.ts
@@ -39,6 +39,8 @@ export interface GatesErrorFields {
 /**
  * Standard scorecard metric payload. `state` is 'error' or 'populated'
  * (an absent value is a non-computable zero, not an 'empty' state).
+ * `data_missing` flags a non-computable zero caused by a hub row missing required
+ * column(s) (schema drift) so the card can warn instead of showing a misleading zero.
  */
 export interface GatesScalarMetric extends GatesErrorFields {
 	state: 'error' | 'populated';
@@ -47,12 +49,14 @@ export interface GatesScalarMetric extends GatesErrorFields {
 	denominator: number | null;
 	/**
 	 * Numerator behind a rate (NPPD-1694). A number (possibly 0) only on rate
-	 * scorecards whose count is computed locally — the paywall Woo join. Null
-	 * elsewhere, including the precomputed-rate regwall cards and currency cards
-	 * (whose conversions count rides on `denominator`).
+	 * scorecards whose count is computed locally — the paywall direct order-meta
+	 * conversions. Null elsewhere, including the precomputed-rate regwall/paywall
+	 * influenced cards and currency cards (whose conversions count rides on
+	 * `denominator`).
 	 */
 	numerator: number | null;
 	placeholder_type: GatesPlaceholderType;
+	data_missing: boolean;
 }
 
 export interface GatesFunnelStage {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
@@ -30,6 +30,7 @@ const scalar = ( over: Partial< GatesScalarMetric > = {} ): GatesScalarMetric =>
 	denominator: null,
 	numerator: null,
 	placeholder_type: 'rate',
+	data_missing: false,
 	...over,
 } );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -22,6 +22,7 @@ const scalar = ( over: Partial< GatesScalarMetric > = {} ): GatesScalarMetric =>
 	denominator: null,
 	numerator: null,
 	placeholder_type: 'rate',
+	data_missing: false,
 	...over,
 } );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the Gates tab-local scalarToCard adapter. Precedence under test:
+ * error > data_missing > normal value.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { scalarToMetricCardProps } from './scalarToCard';
+import type { GatesScalarMetric } from '../../api/gates';
+
+const scalar = ( overrides: Partial< GatesScalarMetric > = {} ): GatesScalarMetric => ( {
+	state: 'populated',
+	value: 0.42,
+	computable: true,
+	denominator: null,
+	numerator: null,
+	placeholder_type: 'rate',
+	data_missing: false,
+	...overrides,
+} );
+
+describe( 'gates scalarToMetricCardProps — data_missing routing', () => {
+	it( 'returns dataMissing:true (no value) when populated and data_missing is true', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'Paywall Conversion (Direct)',
+			description: 'd',
+			current: scalar( { data_missing: true } ),
+		} );
+		expect( props.dataMissing ).toBe( true );
+		expect( props ).not.toHaveProperty( 'value' );
+	} );
+
+	it( 'returns the normal value mapping when populated and data_missing is false', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const props: any = scalarToMetricCardProps( {
+			label: 'Paywall Conversion (Direct)',
+			description: 'd',
+			current: scalar( { data_missing: false } ),
+		} );
+		expect( props.value ).toBe( 0.42 );
+		expect( props ).not.toHaveProperty( 'dataMissing' );
+	} );
+
+	it( 'lets the error treatment win over data_missing', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'Paywall Conversion (Direct)',
+			description: 'd',
+			current: scalar( { state: 'error', data_missing: true, error_message: 'BQ down' } ),
+		} );
+		expect( props.error ).toBe( 'BQ down' );
+		expect( props ).not.toHaveProperty( 'dataMissing' );
+		expect( props ).not.toHaveProperty( 'value' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.ts
@@ -46,6 +46,12 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	if ( current.state === 'error' ) {
 		return { label, description, error: current.error_message ?? __( 'Data temporarily unavailable.', 'newspack-plugin' ) };
 	}
+	// Schema drift (a hub row present but missing required column(s)) surfaces the
+	// shared "some data could not be loaded" note instead of a misleading zero,
+	// mirroring the Conversion tab.
+	if ( current.state === 'populated' && current.data_missing ) {
+		return { label, description, dataMissing: true };
+	}
 	return {
 		label,
 		description,

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1127,6 +1127,27 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * C14 malformed: a non-integer numeric denominator (e.g. 8.5) is invalid for a
+	 * count and errors rather than being silently truncated.
+	 */
+	public function test_influenced_subscription_rate_14d_errors_on_non_integer_denominator() {
+		$metric          = new Conversion_Metric(
+			$this->proxy_returning(
+				[
+					[
+						'influenced_subscription_rate' => 0.3,
+						'conversion_denominator'       => 8.5,
+					],
+				]
+			)
+		);
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_influenced_subscription_rate_14d( $start, $end );
+
+		$this->assertSame( 'error', $result['state'] );
+	}
+
+	/**
 	 * C14 error: a proxy WP_Error surfaces as an error scalar.
 	 */
 	public function test_influenced_subscription_rate_14d_returns_error_on_proxy_error() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -961,7 +961,8 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 
 	/**
 	 * Paid section totals: attempts come from the Direct denominator; conversions
-	 * are the inclusive max across Direct and Influenced numerators.
+	 * are the inclusive max of the Direct numerator and the Influenced denominator
+	 * (the BQ-internal converter count — the Influenced metric has no numerator).
 	 */
 	public function test_paywall_section_totals_normal_data() {
 		$totals = Gates_Metric::paywall_section_totals(
@@ -970,19 +971,19 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 				'numerator'   => 2,
 			],
 			[
-				'denominator' => 290,
-				'numerator'   => 5,
+				'denominator' => 8,
+				'numerator'   => null,
 			]
 		);
 
 		$this->assertSame( 17, $totals['paywall_impressions_total'] );
-		// max( direct 2, influenced 5 ) — don't hide Influenced-only conversions.
-		$this->assertSame( 5, $totals['paywall_conversions_total'] );
+		// max( direct numerator 2, influenced denominator 8 ) — don't hide Influenced converters.
+		$this->assertSame( 8, $totals['paywall_conversions_total'] );
 	}
 
 	/**
 	 * Paid section totals: attempts > 0 but zero conversions in either attribution
-	 * → the section's no_conversions trigger.
+	 * (no Direct conversions, no Influenced converters) → the no_conversions trigger.
 	 */
 	public function test_paywall_section_totals_zero_conversions() {
 		$totals = Gates_Metric::paywall_section_totals(
@@ -991,13 +992,35 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 				'numerator'   => 0,
 			],
 			[
-				'denominator' => 290,
-				'numerator'   => 0,
+				'denominator' => 0,
+				'numerator'   => null,
 			]
 		);
 
 		$this->assertSame( 17, $totals['paywall_impressions_total'] );
 		$this->assertSame( 0, $totals['paywall_conversions_total'] );
+	}
+
+	/**
+	 * Regression (PR #443 review): an Influenced-only window — zero Direct
+	 * conversions but a positive Influenced result — must still render. The
+	 * BQ-internal Influenced metric reports its converter count as `denominator`
+	 * (no numerator), so the section total picks it up and the scorecards are not
+	 * hidden behind the "No paywall conversions" empty state.
+	 */
+	public function test_paywall_section_totals_influenced_only_renders() {
+		$totals = Gates_Metric::paywall_section_totals(
+			[
+				'denominator' => 17,
+				'numerator'   => 0,
+			],
+			[
+				'denominator' => 8,
+				'numerator'   => null,
+			]
+		);
+
+		$this->assertSame( 8, $totals['paywall_conversions_total'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -1318,17 +1318,20 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertTrue( $flagged['data_missing'] );
 	}
 
-	// --- NPPD-1764: influenced-14d paywall rate is converter-denominated ---
+	// --- NPPD-1764 (legacy): influenced-14d was converter-denominated via Woo join ---
+	// These helpers remain for the make_influenced_paywall_metric test seam used by
+	// section-totals tests; the influenced-rate tests themselves have moved to the
+	// BQ-internal section below.
 
 	/**
 	 * Build a Gates_Metric for the influenced paywall card with injected proxy (influenced
 	 * rows), Woo_Order_Resolver (the matched numerator), and Subscribers_Metric (the
 	 * converter-spine denominator), plus a forced `woocommerce_active()`. Filter removed
-	 * in tear_down().
+	 * in tear_down(). Kept for section-totals helpers that still need a Gates_Metric seam.
 	 *
 	 * @param BigQuery_Proxy_Client $proxy        Influenced rows source.
-	 * @param Woo_Order_Resolver    $woo_resolver Numerator (distinct influenced converters).
-	 * @param Subscribers_Metric    $subscribers  Denominator (new subscribers in window).
+	 * @param Woo_Order_Resolver    $woo_resolver Injected resolver (not used by the new path).
+	 * @param Subscribers_Metric    $subscribers  Injected subscribers (not used by the new path).
 	 * @param bool                  $wc           What woocommerce_active() should return.
 	 * @return Gates_Metric
 	 */
@@ -1362,111 +1365,173 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The rate divides by ALL new subscribers in the window, not by the count of
-	 * influenced attempt rows (3 here). 12 influenced converters ÷ 400 subscribers = 3%.
+	 * BQ-internal path: hub returns the precomputed rate + denominator → real computable
+	 * value with the hub denominator (not a local subscriber spine).
+	 *
+	 * Replaces the old Woo-join test (converter-denominated via Woo_Order_Resolver) that
+	 * matched 12 converters ÷ 400 subscribers. The new path reads the hub row directly.
 	 */
 	public function test_paywall_influenced_is_converter_denominated() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [ [ 'x' => 1 ], [ 'x' => 2 ], [ 'x' => 3 ] ] );
-		$metric = $this->make_influenced_paywall_metric(
-			$proxy,
-			$this->resolver_with_unique_completed( 12 ),
-			$this->subscribers_with_new_count( 400 ),
-			true
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'paywall_conversion_influenced_rate' => 0.03,
+					'conversion_denominator'             => 400,
+				],
+			]
 		);
-
+		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertTrue( $result['computable'] );
 		$this->assertSame( 0.03, $result['value'] );
-		$this->assertSame( 400, $result['denominator'], 'denominates by all subscribers, not influenced attempts' );
-		$this->assertSame( 12, $result['numerator'] );
+		$this->assertSame( 400, $result['denominator'], 'uses hub-supplied denominator (no local subscriber spine)' );
 	}
 
 	/**
-	 * No influenced converters but subscribers exist → a real 0% (computable), not the
-	 * "no data" non-computable state the old attempt-denominated empty-rows path returned.
+	 * Empty rows from the hub → non-computable zero (no data in window).
+	 *
+	 * Replaces the old "zero with subscribers is real zero" test: in the BQ-internal
+	 * path the rate is precomputed by the hub, so empty rows means no data, not 0%.
 	 */
 	public function test_paywall_influenced_zero_with_subscribers_is_real_zero() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )->willReturn( [] );
-		$metric = $this->make_influenced_paywall_metric(
-			$proxy,
-			$this->resolver_with_unique_completed( 0 ),
-			$this->subscribers_with_new_count( 50 ),
-			true
-		);
-
+		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'populated', $result['state'] );
-		$this->assertTrue( $result['computable'] );
-		$this->assertSame( 0.0, $result['value'] );
-		$this->assertSame( 50, $result['denominator'] );
-		$this->assertSame( 0, $result['numerator'] );
+		$this->assertFalse( $result['computable'] );
 	}
 
 	/**
-	 * Coherence guard: a GA4-matched numerator larger than the windowed subscriber
-	 * denominator suppresses to a non-computable em-dash rather than rendering >100%.
+	 * Hub returns a null rate (SAFE_DIVIDE with 0 converters) → non-computable with
+	 * the hub denominator surfaced. Replaces the old ">100% suppressed" coherence-guard
+	 * test which is no longer applicable in the BQ-internal path.
 	 */
 	public function test_paywall_influenced_over_100_suppressed() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [ [ 'x' => 1 ] ] );
-		$metric = $this->make_influenced_paywall_metric(
-			$proxy,
-			$this->resolver_with_unique_completed( 5 ),
-			$this->subscribers_with_new_count( 3 ),
-			true
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'paywall_conversion_influenced_rate' => null,
+					'conversion_denominator'             => 3,
+				],
+			]
 		);
-
+		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertFalse( $result['computable'] );
 		$this->assertSame( 3, $result['denominator'] );
-		$this->assertSame( 5, $result['numerator'] );
 	}
 
 	/**
-	 * Non-WC publisher: no local subscribers to denominate against → empty state, and the
-	 * hub is never queried (short-circuits before the proxy call).
+	 * BQ-internal path: the proxy is always queried (WC gate removed). A proxy returning
+	 * the expected row shape computes correctly regardless of WC status.
+	 *
+	 * Replaces the old "non-WC empty state / proxy never called" test: the BQ-internal
+	 * path does not short-circuit on WC and always fetches the hub row.
 	 */
 	public function test_paywall_influenced_non_wc_empty_state() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->never() )->method( 'query' );
-		$metric = $this->make_influenced_paywall_metric(
-			$proxy,
-			$this->resolver_with_unique_completed( 0 ),
-			$this->subscribers_with_new_count( 0 ),
-			false
+		$proxy->expects( $this->once() )->method( 'query' )->willReturn(
+			[
+				[
+					'paywall_conversion_influenced_rate' => 0.05,
+					'conversion_denominator'             => 20,
+				],
+			]
 		);
-
+		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
 		$this->assertSame( 'populated', $result['state'] );
-		$this->assertFalse( $result['computable'] );
-		$this->assertSame( 0, $result['denominator'] );
+		$this->assertTrue( $result['computable'] );
 	}
 
 	/**
-	 * A malformed (non-array, non-WP_Error) hub response surfaces as an error rather than
-	 * a confident 0% — parity with the donation/subscription malformed-rows handling.
+	 * A malformed (non-array row) hub response flags data_missing rather than erroring
+	 * in the BQ-internal path. Replaces the old "non-array rows errors" test: the old
+	 * code checked `is_array($rows)`, but the new path reads `$rows[0]` and checks
+	 * for the expected column keys — missing columns → data_missing signal.
 	 */
 	public function test_paywall_influenced_malformed_rows_errors() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( 'not-an-array' );
-		$metric = $this->make_influenced_paywall_metric(
-			$proxy,
-			$this->resolver_with_unique_completed( 0 ),
-			$this->subscribers_with_new_count( 50 ),
-			true
-		);
-
+		$proxy->method( 'query' )->willReturn( [ [ 'unexpected_column' => 99 ] ] );
+		$metric = new Gates_Metric( $proxy );
 		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
 
-		$this->assertSame( 'error', $result['state'] );
-		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertTrue( $result['data_missing'] );
+	}
+
+	// --- BQ-internal influenced rate (hub-computed, no Woo join) ---
+
+	/**
+	 * Happy path: hub returns a single row with the precomputed rate and denominator.
+	 */
+	public function test_paywall_influenced_reads_rate_and_denominator() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'paywall_conversion_influenced_rate' => 0.25,
+					'conversion_denominator'             => 8,
+				],
+			] 
+		);
+		$metric = new Gates_Metric( $proxy );
+		$out    = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-06-01' ), $this->make_date( '2026-06-15' ) );
+		$this->assertSame( 0.25, $out['value'] );
+		$this->assertTrue( $out['computable'] );
+		$this->assertSame( 8, $out['denominator'] );
+		$this->assertFalse( $out['data_missing'] );
+	}
+
+	/**
+	 * Null rate (SAFE_DIVIDE with 0 converters) is non-computable but carries
+	 * the denominator so the UI can distinguish "no data" from "no converters".
+	 */
+	public function test_paywall_influenced_null_rate_is_non_computable_with_denominator() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'paywall_conversion_influenced_rate' => null,
+					'conversion_denominator'             => 0,
+				],
+			] 
+		);
+		$metric = new Gates_Metric( $proxy );
+		$out    = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-06-01' ), $this->make_date( '2026-06-15' ) );
+		$this->assertFalse( $out['computable'] );
+		$this->assertSame( 0, $out['denominator'] );
+		$this->assertFalse( $out['data_missing'] );
+	}
+
+	/**
+	 * Missing expected columns (schema drift) flags data_missing rather than erroring.
+	 */
+	public function test_paywall_influenced_missing_column_flags_data_missing() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( [ [ 'something_else' => 1 ] ] );
+		$metric = new Gates_Metric( $proxy );
+		$out    = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-06-01' ), $this->make_date( '2026-06-15' ) );
+		$this->assertTrue( $out['data_missing'] );
+	}
+
+	/**
+	 * A proxy WP_Error bubbles up as state 'error'.
+	 */
+	public function test_paywall_influenced_proxy_error_is_error_scalar() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn( new \WP_Error( 'boom', 'nope' ) );
+		$metric = new Gates_Metric( $proxy );
+		$out    = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-06-01' ), $this->make_date( '2026-06-15' ) );
+		$this->assertSame( 'error', $out['state'] );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -12,7 +12,6 @@ use DateTimeZone;
 use Newspack\Insights\BigQuery_Proxy_Client;
 use Newspack\Insights\Gates_Metric;
 use Newspack\Insights\Subscribers_Metric;
-use Newspack\Insights\Woo_Order_Resolver;
 use WP_UnitTestCase;
 
 /**
@@ -214,7 +213,7 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	 */
 	private function make_direct_paywall_metric( ?BigQuery_Proxy_Client $proxy, Subscribers_Metric $subscribers, bool $wc ): Gates_Metric {
 		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
-		return new Gates_Metric( $proxy, null, $subscribers );
+		return new Gates_Metric( $proxy, $subscribers );
 	}
 
 	/**
@@ -1318,85 +1317,22 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertTrue( $flagged['data_missing'] );
 	}
 
-	// --- NPPD-1764 (legacy): influenced-14d was converter-denominated via Woo join ---
-	// These helpers remain for the make_influenced_paywall_metric test seam used by
-	// section-totals tests; the influenced-rate tests themselves have moved to the
-	// BQ-internal section below.
-
 	/**
-	 * Build a Gates_Metric for the influenced paywall card with injected proxy (influenced
-	 * rows), Woo_Order_Resolver (the matched numerator), and Subscribers_Metric (the
-	 * converter-spine denominator), plus a forced `woocommerce_active()`. Filter removed
-	 * in tear_down(). Kept for section-totals helpers that still need a Gates_Metric seam.
-	 *
-	 * @param BigQuery_Proxy_Client $proxy        Influenced rows source.
-	 * @param Woo_Order_Resolver    $woo_resolver Injected resolver (not used by the new path).
-	 * @param Subscribers_Metric    $subscribers  Injected subscribers (not used by the new path).
-	 * @param bool                  $wc           What woocommerce_active() should return.
-	 * @return Gates_Metric
+	 * Gates_Metric constructor no longer requires a Woo_Order_Resolver dependency.
+	 * Verifies the class source contains no Woo_Order_Resolver reference and that
+	 * the class can be instantiated with zero arguments.
 	 */
-	private function make_influenced_paywall_metric( BigQuery_Proxy_Client $proxy, Woo_Order_Resolver $woo_resolver, Subscribers_Metric $subscribers, bool $wc ): Gates_Metric {
-		add_filter( 'newspack_insights_woocommerce_active', $wc ? '__return_true' : '__return_false' );
-		return new Gates_Metric( $proxy, $woo_resolver, $subscribers );
+	public function test_constructor_needs_no_woo_order_resolver() {
+		$ref = new \ReflectionClass( \Newspack\Insights\Gates_Metric::class );
+		$src = file_get_contents( $ref->getFileName() ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- local file path from ReflectionClass, not a remote URL.
+		$this->assertStringNotContainsString( 'Woo_Order_Resolver', $src );
+		$this->assertInstanceOf( \Newspack\Insights\Gates_Metric::class, new \Newspack\Insights\Gates_Metric() );
 	}
 
 	/**
-	 * Stub Subscribers_Metric reporting a fixed new-subscribers-in-window count.
-	 *
-	 * @param int $new_subscribers New subscribers in the window.
-	 * @return Subscribers_Metric
+	 * Empty rows from the hub → non-computable (no data in window).
 	 */
-	private function subscribers_with_new_count( int $new_subscribers ): Subscribers_Metric {
-		$subscribers = $this->createMock( Subscribers_Metric::class );
-		$subscribers->method( 'get_new_subscribers_in_window' )->willReturn( $new_subscribers );
-		return $subscribers;
-	}
-
-	/**
-	 * Stub Woo_Order_Resolver reporting a fixed distinct-completed-users count.
-	 *
-	 * @param int $count Distinct influenced converters.
-	 * @return Woo_Order_Resolver
-	 */
-	private function resolver_with_unique_completed( int $count ): Woo_Order_Resolver {
-		$resolver = $this->createMock( Woo_Order_Resolver::class );
-		$resolver->method( 'count_unique_completed_users' )->willReturn( $count );
-		return $resolver;
-	}
-
-	/**
-	 * BQ-internal path: hub returns the precomputed rate + denominator → real computable
-	 * value with the hub denominator (not a local subscriber spine).
-	 *
-	 * Replaces the old Woo-join test (converter-denominated via Woo_Order_Resolver) that
-	 * matched 12 converters ÷ 400 subscribers. The new path reads the hub row directly.
-	 */
-	public function test_paywall_influenced_is_converter_denominated() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn(
-			[
-				[
-					'paywall_conversion_influenced_rate' => 0.03,
-					'conversion_denominator'             => 400,
-				],
-			]
-		);
-		$metric = new Gates_Metric( $proxy );
-		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertSame( 'populated', $result['state'] );
-		$this->assertTrue( $result['computable'] );
-		$this->assertSame( 0.03, $result['value'] );
-		$this->assertSame( 400, $result['denominator'], 'uses hub-supplied denominator (no local subscriber spine)' );
-	}
-
-	/**
-	 * Empty rows from the hub → non-computable zero (no data in window).
-	 *
-	 * Replaces the old "zero with subscribers is real zero" test: in the BQ-internal
-	 * path the rate is precomputed by the hub, so empty rows means no data, not 0%.
-	 */
-	public function test_paywall_influenced_zero_with_subscribers_is_real_zero() {
+	public function test_paywall_influenced_empty_rows_is_non_computable() {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->method( 'query' )->willReturn( [] );
 		$metric = new Gates_Metric( $proxy );
@@ -1404,69 +1340,6 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertFalse( $result['computable'] );
-	}
-
-	/**
-	 * Hub returns a null rate (SAFE_DIVIDE with 0 converters) → non-computable with
-	 * the hub denominator surfaced. Replaces the old ">100% suppressed" coherence-guard
-	 * test which is no longer applicable in the BQ-internal path.
-	 */
-	public function test_paywall_influenced_over_100_suppressed() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn(
-			[
-				[
-					'paywall_conversion_influenced_rate' => null,
-					'conversion_denominator'             => 3,
-				],
-			]
-		);
-		$metric = new Gates_Metric( $proxy );
-		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertSame( 'populated', $result['state'] );
-		$this->assertFalse( $result['computable'] );
-		$this->assertSame( 3, $result['denominator'] );
-	}
-
-	/**
-	 * BQ-internal path: the proxy is always queried (WC gate removed). A proxy returning
-	 * the expected row shape computes correctly regardless of WC status.
-	 *
-	 * Replaces the old "non-WC empty state / proxy never called" test: the BQ-internal
-	 * path does not short-circuit on WC and always fetches the hub row.
-	 */
-	public function test_paywall_influenced_non_wc_empty_state() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->expects( $this->once() )->method( 'query' )->willReturn(
-			[
-				[
-					'paywall_conversion_influenced_rate' => 0.05,
-					'conversion_denominator'             => 20,
-				],
-			]
-		);
-		$metric = new Gates_Metric( $proxy );
-		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertSame( 'populated', $result['state'] );
-		$this->assertTrue( $result['computable'] );
-	}
-
-	/**
-	 * A malformed (non-array row) hub response flags data_missing rather than erroring
-	 * in the BQ-internal path. Replaces the old "non-array rows errors" test: the old
-	 * code checked `is_array($rows)`, but the new path reads `$rows[0]` and checks
-	 * for the expected column keys — missing columns → data_missing signal.
-	 */
-	public function test_paywall_influenced_malformed_rows_errors() {
-		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
-		$proxy->method( 'query' )->willReturn( [ [ 'unexpected_column' => 99 ] ] );
-		$metric = new Gates_Metric( $proxy );
-		$result = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-03-22' ), $this->make_date( '2026-04-21' ) );
-
-		$this->assertSame( 'populated', $result['state'] );
-		$this->assertTrue( $result['data_missing'] );
 	}
 
 	// --- BQ-internal influenced rate (hub-computed, no Woo join) ---

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -1318,15 +1318,45 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gates_Metric constructor no longer requires a Woo_Order_Resolver dependency.
-	 * Verifies the class source contains no Woo_Order_Resolver reference and that
-	 * the class can be instantiated with zero arguments.
+	 * Gates_Metric no longer depends on Woo_Order_Resolver. Verifies structurally
+	 * (via reflection on constructor parameters and typed properties) that the
+	 * dependency is gone, and that the class instantiates with zero arguments.
 	 */
 	public function test_constructor_needs_no_woo_order_resolver() {
-		$ref = new \ReflectionClass( \Newspack\Insights\Gates_Metric::class );
-		$src = file_get_contents( $ref->getFileName() ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- local file path from ReflectionClass, not a remote URL.
-		$this->assertStringNotContainsString( 'Woo_Order_Resolver', $src );
+		$class    = new \ReflectionClass( \Newspack\Insights\Gates_Metric::class );
+		$resolver = \Newspack\Insights\Woo_Order_Resolver::class;
+
+		foreach ( $class->getConstructor()->getParameters() as $param ) {
+			$type = $param->getType();
+			$name = $type instanceof \ReflectionNamedType ? ltrim( $type->getName(), '\\' ) : null;
+			$this->assertNotSame( $resolver, $name, 'Constructor must not depend on Woo_Order_Resolver.' );
+		}
+		foreach ( $class->getProperties() as $property ) {
+			$type = $property->getType();
+			$name = $type instanceof \ReflectionNamedType ? ltrim( $type->getName(), '\\' ) : null;
+			$this->assertNotSame( $resolver, $name, 'No property may be typed Woo_Order_Resolver.' );
+		}
+
 		$this->assertInstanceOf( \Newspack\Insights\Gates_Metric::class, new \Newspack\Insights\Gates_Metric() );
+	}
+
+	/**
+	 * A non-integer numeric denominator (e.g. 8.5) is malformed for a count and
+	 * errors rather than being silently truncated.
+	 */
+	public function test_paywall_influenced_non_integer_denominator_errors() {
+		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+		$proxy->method( 'query' )->willReturn(
+			[
+				[
+					'paywall_conversion_influenced_rate' => 0.25,
+					'conversion_denominator'             => 8.5,
+				],
+			]
+		);
+		$metric = new Gates_Metric( $proxy );
+		$out    = $metric->get_paywall_conversion_influenced_14d( $this->make_date( '2026-06-01' ), $this->make_date( '2026-06-15' ) );
+		$this->assertSame( 'error', $out['state'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -1301,6 +1301,23 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 		$this->assertNull( $totals['registrations_total'] );
 	}
 
+	// --- C1: data_missing flag on populated_scalar ---
+
+	/**
+	 * Populated_scalar carries a `data_missing` flag (default false); callers can
+	 * set it to true to signal schema drift without changing the payload shape.
+	 */
+	public function test_populated_scalar_includes_data_missing_flag() {
+		$metric = new Gates_Metric();
+		$ref    = new \ReflectionMethod( $metric, 'populated_scalar' );
+		$ref->setAccessible( true );
+		$default = $ref->invoke( $metric, 1.0, true, 5, 'rate' );
+		$this->assertArrayHasKey( 'data_missing', $default );
+		$this->assertFalse( $default['data_missing'] );
+		$flagged = $ref->invoke( $metric, 0.0, false, null, 'rate', null, true );
+		$this->assertTrue( $flagged['data_missing'] );
+	}
+
 	// --- NPPD-1764: influenced-14d paywall rate is converter-denominated ---
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
@@ -183,6 +183,12 @@ class Test_Gates_REST_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'hybrid', Gates_Metric::METRIC_SOURCES['paywall_conversion_direct'] );
 		$this->assertSame( 'populated', $window['paywall_conversion_direct']['state'] );
 
+		// Paywall influenced is fully hub-computed (BQ-internal rate + denominator, no
+		// local Woo component) — it must error on hub outage, not short-circuit to
+		// populated like a hybrid card.
+		$this->assertSame( 'hub', Gates_Metric::METRIC_SOURCES['paywall_conversion_influenced_14d'] );
+		$this->assertSame( 'error', $window['paywall_conversion_influenced_14d']['state'] );
+
 		$this->assertTrue(
 			$this->invoke_is_window_all_error( $window, false ),
 			'non-WC: the hybrid card is skipped, so all-pure-hub-errored fires the banner'

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
@@ -196,6 +196,19 @@ class Test_Gates_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Gates_REST_Controller overrides cache_schema_version() with Gates_Metric::CACHE_PREFIX
+	 * (tab4_v2), so bumping the prefix on a response-shape change busts stale-shape
+	 * transients on deploy.
+	 */
+	public function test_gates_controller_cache_version_is_tab4_v2_prefix() {
+		$controller = new Gates_REST_Controller();
+		$ref        = new \ReflectionMethod( $controller, 'cache_schema_version' );
+		$ref->setAccessible( true );
+		$this->assertSame( Gates_Metric::CACHE_PREFIX, $ref->invoke( $controller ) );
+		$this->assertStringContainsString( 'v2', Gates_Metric::CACHE_PREFIX );
+	}
+
+	/**
 	 * NPPD-1745 #5 drift guard, mirrored to Gates: every state-bearing metric that
 	 * build_window() emits must have a METRIC_SOURCES entry, or it would silently
 	 * drop out of the banner decision with no test to catch it.


### PR DESCRIPTION
## What & why

The Insights **Tab 4 Gates** `paywall_conversion_influenced_14d` metric was the last one still computed via the buggy `Woo_Order_Resolver` (a GA4-cookie → `(int)customer_id` cast that drops anonymous attempts to customer 0 → ~0 Woo matches). This PR rewires it to read a **BQ-internal `{rate, denominator}`** result the hub computes directly from confirmed conversions (`form_submission_success`) — no downstream Woo join — and removes `Woo_Order_Resolver` from `Gates_Metric` entirely.

The already-remediated metrics (paywall direct/revenue/avg, both regwall) are **untouched** (verify-only).

## Changes

- **`compute_influenced_rate_from_proxy()`** added to `Gates_Metric` (ported from `Conversion_Metric`): reads one row `{ paywall_conversion_influenced_rate: float|null, conversion_denominator: int }`. Handles empty window, null rate (no converters → non-computable with a real denominator), schema drift (missing column → `data_missing`), and proxy errors.
- **`get_paywall_conversion_influenced_14d`** now calls it; **`compute_paywall_rate_from_proxy` deleted**.
- **`Woo_Order_Resolver` removed from `Gates_Metric`** (import, property, constructor param). The *class* is NOT deleted — Donors and Prompts still use it; the class deletion is a later PR.
- **`data_missing`** added to `Gates_Metric::populated_scalar` (it previously carried `numerator` but no `data_missing`).
- **`CACHE_PREFIX` v1 → v2** and **`Gates_REST_Controller::cache_schema_version()` override added** — the prefix was previously dead (the controller `use`d the cache trait but never overrode the version), so a response-shape change couldn't bust stale caches. Now wired.
- **`METRIC_SOURCES['paywall_conversion_influenced_14d']` reclassified `hybrid` → `hub`** — the metric is now fully hub-computed, so a hub failure must always count toward the tab-error banner (previously skipped on non-WC sites).

## Coordinated hub PR

This depends on the hub builder `build_paywall_conversion_influenced_14d` (in `newspack-manager-admin`) emitting the new `{rate, denominator}` shape. That hub PR is the coordinated counterpart (link to follow). The consumer is independently testable here because the tests mock the proxy. Note: the hub builder is also touched by the intraday PR (newspack-manager-admin#469); that conflict is a trivial predicate-swap reconciliation handled at merge.

## Testing

- Full insights group: **478 tests green**. Root-ruleset PHPCS clean.
- New/updated tests cover: rate+denominator read, null-rate non-computable, `data_missing` on schema drift, proxy error, the `data_missing` scalar flag, the cache-version wiring, and the `hub` reclassification in the non-WC hub-outage banner test.

Base: `feat/insights-rsm` (Insights epic). Part of NPPD-1692.

## Bundled consistency fix (post-Copilot)

Also hardens `Conversion_Metric::compute_influenced_rate_from_proxy` to reject a non-integer numeric denominator (erroring instead of silently truncating), matching the integer-only count validation in `Gates_Metric` and `Prompts_Metric`. Small cross-tab consistency follow-up to the Copilot review on this PR.

## Review-driven additions

- **Influenced-only conversions no longer masked:** the BQ-internal influenced metric reports a denominator (count of paywall converters) and no numerator, so `paywall_section_totals()` now gates the Paid section's empty state on the influenced *denominator* — an influenced-only window (direct 0, influenced positive) renders its scorecards instead of "No paywall conversions."
- **`data_missing` surfaced on Tab 4:** the backend's schema-drift flag is now wired through the Gates frontend (`GatesScalarMetric` type + a `scalarToCard` branch mirroring the Conversion tab), so drift shows the shared "data could not be loaded" note instead of a believable 0%. Full JS suite green (670).
