### PR TITLE
feat(insights): converter-denominate free Influenced rates — plugin (NPPD-1821 + NPPD-1824)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -343,17 +343,21 @@ final class Gates_Metric {
 	 * response (one present, one absent/non-numeric) is treated as absent so a
 	 * malformed envelope degrades rather than half-renders a count fallback.
 	 *
-	 * @param string            $query_name Catalog name (`gates_regwall_conversion_*`).
-	 * @param string            $rate_key   Column holding the precomputed rate.
-	 * @param DateTimeInterface $start      Window start.
-	 * @param DateTimeInterface $end        Window end.
+	 * @param string            $query_name      Catalog name (`gates_regwall_conversion_*`).
+	 * @param string            $rate_key        Column holding the precomputed rate.
+	 * @param DateTimeInterface $start           Window start.
+	 * @param DateTimeInterface $end             Window end.
+	 * @param string            $denominator_col Column holding the denominator count ({N}).
+	 * @param string            $numerator_col   Column holding the numerator count.
 	 * @return array
 	 */
 	private function compute_regwall_rate_from_proxy(
 		string $query_name,
 		string $rate_key,
 		DateTimeInterface $start,
-		DateTimeInterface $end
+		DateTimeInterface $end,
+		string $denominator_col = 'registration_impressions_total',
+		string $numerator_col = 'registrations_total'
 	): array {
 		$rows = $this->proxy->query( $query_name, $start, $end );
 		if ( is_wp_error( $rows ) ) {
@@ -379,10 +383,13 @@ final class Gates_Metric {
 				new \WP_Error( 'bigquery_proxy_malformed_value', __( 'The query returned a non-numeric value.', 'newspack-plugin' ) )
 			);
 		}
-		// Read the new count columns iff BOTH are present and integer-valued.
-		// Absent (pre-hub-deploy) → null counts → today's envelope, today's render.
-		$impressions = $this->read_optional_count( $row, 'registration_impressions_total' );
-		$registrations = $this->read_optional_count( $row, 'registrations_total' );
+		// Read the denominator + numerator count columns iff BOTH are present and
+		// integer-valued. Column names vary by rate: the Direct query exposes
+		// `registration_impressions_total` / `registrations_total`; the converter-
+		// denominated Influenced query (NPPD-1821) exposes `new_registrations_total` /
+		// `influenced_registrations_total`. Absent → null counts → today's envelope.
+		$impressions = $this->read_optional_count( $row, $denominator_col );
+		$registrations = $this->read_optional_count( $row, $numerator_col );
 		if ( null === $impressions || null === $registrations ) {
 			return $this->populated_scalar( (float) $value, true, null, 'rate' );
 		}
@@ -650,7 +657,10 @@ final class Gates_Metric {
 	 * @return array
 	 */
 	public function get_regwall_conversion_influenced_7d( DateTimeInterface $start, DateTimeInterface $end ): array {
-		return $this->compute_regwall_rate_from_proxy( 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced', $start, $end );
+		// NPPD-1821: the influenced query is converter-denominated, so its count columns
+		// are `new_registrations_total` (denominator) / `influenced_registrations_total`
+		// (numerator), not the Direct query's `registration_impressions_total` / `registrations_total`.
+		return $this->compute_regwall_rate_from_proxy( 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced', $start, $end, 'new_registrations_total', 'influenced_registrations_total' );
 	}
 
 	// --- Section 3: Paid reader conversion ------------------------------

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -328,10 +328,11 @@ final class Gates_Metric {
 	 *
 	 * Unlike the paywall rate (computed locally from a Woo join), the regwall rate
 	 * is precomputed server-side by the hub. This method reads that rate exactly as
-	 * `compute_metric_from_proxy` would, then *additionally* reads two integer
-	 * columns the hub query will start returning once Derrick's Newspack Manager
-	 * change ships: `registration_impressions_total` (the denominator / {N}) and
-	 * `registrations_total` (the numerator).
+	 * `compute_metric_from_proxy` would, then *additionally* reads two integer count
+	 * columns whose names vary by rate (passed via `$denominator_col` / `$numerator_col`):
+	 * the Direct query exposes `registration_impressions_total` (denominator / {N}) and
+	 * `registrations_total` (numerator); the converter-denominated Influenced query
+	 * (NPPD-1821) exposes `new_registrations_total` and `influenced_registrations_total`.
 	 *
 	 * The production-safety crux: those columns do not exist in the hub response
 	 * yet. When they are absent, this returns numerator + denominator as `null` —

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -487,7 +487,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Readers who registered in a later session within 7 days of seeing a prompt with a registration block ÷ readers who saw a prompt with a registration block
+                Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
               </div>
             </div>
           </div>
@@ -577,7 +577,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Readers who signed up for a newsletter in a later session within 7 days of seeing a prompt with a newsletter block ÷ readers who saw a prompt with a newsletter block
+                New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
               </div>
             </div>
           </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
@@ -50,6 +50,10 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 		'newspack-plugin'
 	);
 	const impressionsLabel = __( 'registration gate impressions', 'newspack-plugin' );
+	// NPPD-1821: the Influenced rate is converter-denominated, so its count fallback
+	// reads "0 of N new registrations" (the denominator is all new registrations),
+	// not gate impressions like the Direct card.
+	const newRegistrationsLabel = __( 'new registrations', 'newspack-plugin' );
 
 	const impressions = current.registration_impressions_total;
 	const registrations = current.registrations_total;
@@ -127,7 +131,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					{ ...scalarToMetricCardProps( {
 						label: __( 'Regwall Conversion (Influenced, 7d)', 'newspack-plugin' ),
 						description: __(
-							'Readers who registered in a later session within 7 days of seeing a registration gate ÷ readers who saw a registration gate',
+							'Registrants whose registration followed a registration-gate view in a prior session within 7 days ÷ all new registrations',
 							'newspack-plugin'
 						),
 						current: current.regwall_conversion_influenced_7d,
@@ -135,7 +139,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 						zeroFallback: {
 							numerator: current.regwall_conversion_influenced_7d.numerator ?? undefined,
 							denominator: current.regwall_conversion_influenced_7d.denominator ?? undefined,
-							attemptsLabel: impressionsLabel,
+							attemptsLabel: newRegistrationsLabel,
 						},
 					} ) }
 				/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -54,13 +54,13 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Registration Conversion (Influenced, 7d)', 'newspack-plugin' ),
 					description: __(
-						'Readers who registered in a later session within 7 days of seeing a prompt with a registration block ÷ readers who saw a prompt with a registration block',
+						'Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations',
 						'newspack-plugin'
 					),
 					current: current.registration_conversion_influenced_7d,
 					previous: previous?.registration_conversion_influenced_7d,
 					notCapableMessage: NOT_CAPABLE_COPY.registration,
-					notComputableMessage: NOT_COMPUTABLE_COPY.registration,
+					notComputableMessage: NOT_COMPUTABLE_COPY.registrationInfluenced,
 				} ) }
 			/>
 			<MetricCard
@@ -80,13 +80,13 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Newsletter Signup Conversion (Influenced, 7d)', 'newspack-plugin' ),
 					description: __(
-						'Readers who signed up for a newsletter in a later session within 7 days of seeing a prompt with a newsletter block ÷ readers who saw a prompt with a newsletter block',
+						'New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups',
 						'newspack-plugin'
 					),
 					current: current.newsletter_signup_conversion_influenced_7d,
 					previous: previous?.newsletter_signup_conversion_influenced_7d,
 					notCapableMessage: NOT_CAPABLE_COPY.newsletter,
-					notComputableMessage: NOT_COMPUTABLE_COPY.newsletter,
+					notComputableMessage: NOT_COMPUTABLE_COPY.newsletterInfluenced,
 				} ) }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/notComputableCopy.ts
@@ -12,13 +12,13 @@
  *
  * Intent-grouped: the four conversion intents (newsletter, registration,
  * donation, subscription) each share one string across their Direct and Revenue
- * cards, plus the cross-intent form-submission case. The paid Influenced rates
- * (donation, subscription) are converter-denominated (NPPD-1822) — their
- * non-computable trigger is "no new donors/subscribers in the window", not "no
- * in-intent prompts viewed" — so they use the dedicated `*Influenced` strings.
- * Centralized here (rather than inline on each card) so the cross-tab
- * voice-and-tone audit (NPPD-1698) has a single place to review them. Strings end
- * with a period to match 1720's nudges.
+ * cards, plus the cross-intent form-submission case. All four **Influenced** rates
+ * are converter-denominated (paid: NPPD-1822; free registration/newsletter:
+ * NPPD-1824) — their non-computable trigger is "no new converters of that type in
+ * the window", not "no in-intent prompts viewed" — so they use the dedicated
+ * `*Influenced` strings. Centralized here (rather than inline on each card) so the
+ * cross-tab voice-and-tone audit (NPPD-1698) has a single place to review them.
+ * Strings end with a period to match 1720's nudges.
  */
 
 /**
@@ -33,8 +33,10 @@ export const NOT_COMPUTABLE_COPY = {
 	registration: __( 'No prompts with a registration block viewed in this timeframe.', 'newspack-plugin' ),
 	donation: __( 'No prompts with a donation block viewed in this timeframe.', 'newspack-plugin' ),
 	subscription: __( 'No subscription-intent prompts viewed in this timeframe.', 'newspack-plugin' ),
-	// Converter-denominated Influenced rates (NPPD-1822): non-computable means no new
-	// donors/subscribers in the window, not "no prompts viewed".
+	// Converter-denominated Influenced rates (paid NPPD-1822, free NPPD-1824): non-
+	// computable means no new converters of that type in the window, not "no prompts viewed".
 	donationInfluenced: __( 'No new donors in this timeframe.', 'newspack-plugin' ),
 	subscriptionInfluenced: __( 'No new subscribers in this timeframe.', 'newspack-plugin' ),
+	registrationInfluenced: __( 'No new registrations in this timeframe.', 'newspack-plugin' ),
+	newsletterInfluenced: __( 'No new newsletter signups in this timeframe.', 'newspack-plugin' ),
 };

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-metric.php
@@ -1054,11 +1054,13 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	 * the Paid rate scalars — so the card can render "0 of N".
 	 *
 	 * @dataProvider provide_regwall_methods
-	 * @param string $method     Method on Gates_Metric to call.
-	 * @param string $query_name Catalog query name.
-	 * @param string $rate_key   Precomputed-rate column.
+	 * @param string $method          Method on Gates_Metric to call.
+	 * @param string $query_name      Catalog query name.
+	 * @param string $rate_key        Precomputed-rate column.
+	 * @param string $denominator_col Column holding the denominator count.
+	 * @param string $numerator_col   Column holding the numerator count.
 	 */
-	public function test_regwall_surfaces_counts_when_fields_present( string $method, string $query_name, string $rate_key ) {
+	public function test_regwall_surfaces_counts_when_fields_present( string $method, string $query_name, string $rate_key, string $denominator_col, string $numerator_col ) {
 		$proxy = $this->createMock( BigQuery_Proxy_Client::class );
 		$proxy->expects( $this->once() )
 			->method( 'query' )
@@ -1066,9 +1068,9 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 			->willReturn(
 				[
 					[
-						$rate_key                        => 0.05,
-						'registration_impressions_total' => 200,
-						'registrations_total'            => 10,
+						$rate_key        => 0.05,
+						$denominator_col => 200,
+						$numerator_col   => 10,
 					],
 				]
 			);
@@ -1190,8 +1192,11 @@ class Test_Gates_Metric extends WP_UnitTestCase {
 	 */
 	public function provide_regwall_methods(): array {
 		return [
-			'direct'     => [ 'get_regwall_conversion_direct', 'gates_regwall_conversion_direct', 'regwall_conversion_rate_direct' ],
-			'influenced' => [ 'get_regwall_conversion_influenced_7d', 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced' ],
+			// method, query, rate_key, denominator_col, numerator_col. NPPD-1821: the
+			// influenced query is converter-denominated, so it exposes different count
+			// columns than Direct.
+			'direct'     => [ 'get_regwall_conversion_direct', 'gates_regwall_conversion_direct', 'regwall_conversion_rate_direct', 'registration_impressions_total', 'registrations_total' ],
+			'influenced' => [ 'get_regwall_conversion_influenced_7d', 'gates_regwall_conversion_influenced_7d', 'regwall_conversion_influenced', 'new_registrations_total', 'influenced_registrations_total' ],
 		];
 	}
 


### PR DESCRIPTION
## What

Plugin/frontend consumer side of the converter-denominated free **Influenced** rates (parent **NPPD-1823**). The hub PR Automattic/newspack-manager-admin#471 renames the gates regwall influenced count columns and converter-denominates the prompts free influenced rates; this PR updates the plugin to match and corrects the user-facing copy/labels.

### Gates regwall (NPPD-1821)
- `Gates_Metric::compute_regwall_rate_from_proxy` now takes the denominator/numerator **column names** as parameters. The Direct caller keeps `registration_impressions_total` / `registrations_total`; the Influenced caller reads the converter-denominated `new_registrations_total` / `influenced_registrations_total`. (The two queries legitimately differ now: Direct is impression-denominated, Influenced is converter-denominated.)
- Frontend: the Influenced card description is rewritten to converter framing, and its `zeroFallback` label changes from "registration gate impressions" to "new registrations" (its denominator is now all new registrations). Section-level empty states are untouched — they remain Direct/impressions-based via the unchanged `regwall_section_totals` window keys.

### Prompts free (NPPD-1824)
- The free registration + newsletter Influenced rates are converter-denominated in the hub (rate-only, no count columns), so the plugin is pure passthrough. Only the copy changes:
  - Card descriptions rewritten to converter framing (`÷ all new registrations` / `÷ all new newsletter signups`).
  - Not-computable copy now uses dedicated `registrationInfluenced` / `newsletterInfluenced` strings ("No new registrations / newsletter signups in this timeframe"), mirroring the paid fix in #442. Direct cards keep their existing strings.

## Why

The Influenced rate answers "of everyone who converted, what share were influenced by a gate/prompt?" — a converter denominator. The previous viewer/exposure denominator made the rate incomparable to Direct and inflated/deflated it by traffic volume. This aligns the free rates with the paid Influenced rates (NPPD-1822) and the conversion-journey reference.

## Testing

- `Test_Gates_Metric`: 69 tests / 246 assertions green (provider updated so the influenced case feeds the new column names).
- PHPCS (workspace root standard): clean.
- Prettier (wp-prettier): clean.
- `PromptsTab.test.tsx.snap` updated for the new descriptions.

## Graceful degradation

The renamed hub columns are read defensively (`read_optional_count` → null when absent), so this PR and #471 can land in either order.

