### PR TITLE
fix(newsletters): keep email-only blocks in the WC email render

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -85,7 +85,7 @@ final class Newspack_Newsletters {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'branding_scripts' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		add_filter( 'gform_force_hooks_js_output', [ __CLASS__, 'suppress_gravityforms_js_on_newsletters' ] );
-		add_filter( 'render_block', [ __CLASS__, 'remove_email_only_block' ], 10, 2 );
+		add_filter( 'render_block', [ __CLASS__, 'remove_visibility_hidden_block' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'display_newsletters_in_archives' ] );
 		add_action( 'the_post', [ __CLASS__, 'fix_public_status' ] );
 	}
@@ -1391,22 +1391,26 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Do not display blocks that are configured to be email-only.
+	 * Hide blocks whose `newsletterVisibility` doesn't match the current render.
+	 *
+	 * On the web front-end, `email`-only blocks are hidden. During an email render
+	 * (`render_wc`, detected via the rendering-post accessor) it's the opposite:
+	 * `web`-only blocks are hidden and `email`-only blocks are kept. Without the
+	 * email branch, `render_wc` followed the web path and wrongly dropped email-only
+	 * blocks — e.g. the prebuilt layouts' "Support our newsroom" section.
 	 *
 	 * @param string $block_content The block content about to be appended.
 	 * @param array  $block         The full block, including name and attributes.
-	 *
-	 * @return string Transformed block content to be apppended.
+	 * @return string The block content, or '' when the block is hidden in this context.
 	 */
-	public static function remove_email_only_block( $block_content, $block ) {
-		if (
-			self::NEWSPACK_NEWSLETTERS_CPT === get_post_type() &&
-			isset( $block['attrs']['newsletterVisibility'] ) &&
-			'email' === $block['attrs']['newsletterVisibility']
-		) {
-			return '';
+	public static function remove_visibility_hidden_block( $block_content, $block ) {
+		if ( self::NEWSPACK_NEWSLETTERS_CPT !== get_post_type() || empty( $block['attrs']['newsletterVisibility'] ) ) {
+			return $block_content;
 		}
-		return $block_content;
+		$is_email_render   = class_exists( '\Newspack\Newsletters\Email_Renderers\Renderer_Controller' )
+			&& \Newspack\Newsletters\Email_Renderers\Renderer_Controller::get_rendering_post() instanceof \WP_Post;
+		$hidden_visibility = $is_email_render ? 'web' : 'email';
+		return $hidden_visibility === $block['attrs']['newsletterVisibility'] ? '' : $block_content;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -81,6 +81,32 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The email render keeps `email`-only blocks and hides `web`-only blocks. The
+	 * prebuilt layouts' "Support our newsroom" section is email-only and was being
+	 * dropped because render_wc followed the web visibility path (NEWS-1901).
+	 */
+	public function test_render_wc_respects_newsletter_visibility() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:paragraph --><p>ALWAYS VISIBLE</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph {"newsletterVisibility":"email"} --><p>EMAIL ONLY BLOCK</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph {"newsletterVisibility":"web"} --><p>WEB ONLY BLOCK</p><!-- /wp:paragraph -->';
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Visibility newsletter',
+				'post_content' => $content,
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $post_id ) );
+
+		$this->assertStringContainsString( 'ALWAYS VISIBLE', $html, 'Expected an unmarked block to render in the email.' );
+		$this->assertStringContainsString( 'EMAIL ONLY BLOCK', $html, 'Expected an email-only block to render in the email.' );
+		$this->assertStringNotContainsString( 'WEB ONLY BLOCK', $html, 'Expected a web-only block to be hidden in the email.' );
+	}
+
+	/**
 	 * The active engine follows the WC renderer feature flag.
 	 */
 	public function test_active_engine_follows_flag() {


### PR DESCRIPTION
## Summary

**Email-only blocks were being dropped from the WC email render, so the prebuilt layouts' "Support our newsroom" section disappeared from the preview/email.**

The `render_block` visibility filter only handled the web front-end: it stripped `newsletterVisibility:"email"` blocks whenever a newsletter's blocks rendered. The legacy MJML renderer walks blocks itself and never hit this, but `render_wc()` renders via `do_blocks()`, which fires `render_block` — so the email render followed the **web** path and **dropped every email-only block** (the support CTA section, email-only spacers, social links) while **keeping web-only ones**. Exactly inverted for an email.

- **What changed:** the filter (`remove_email_only_block` → `remove_visibility_hidden_block`) is now context-aware. During an email render — detected via `Renderer_Controller::get_rendering_post()`, which is set only inside `render_wc()` — it hides `web`-only blocks and keeps `email`-only blocks. On the web front-end the behavior is unchanged.

**Behavior & regression notes:** the web front-end and the MJML path are untouched (MJML doesn't go through this `render_block` filter for its body). Only the WC email render gains the correct email-context behavior.

Closes NEWS-1901.

### How to test

1. With the WC renderer flag on, start a newsletter from a prebuilt layout that has the **"Support our newsroom"** section (e.g. Topper / Editor's letter / Daily-Weekly).
2. **Preview email** — the support section (and the email-only social links) now render, where they were previously missing.
3. Add a block, set its visibility to **Web** in the sidebar — confirm it does **not** appear in the email preview.
4. Confirm the public newsletter URL (web) still hides email-only blocks (unchanged).

## For AI

- `includes/class-newspack-newsletters.php` — `remove_visibility_hidden_block()` (hooked on `render_block`, line ~88) now computes the hidden visibility from context: `web` during an email render (`Renderer_Controller::get_rendering_post() instanceof WP_Post`), else `email`. Returns `''` for a block whose `newsletterVisibility` equals the hidden value.
- Test: `tests/email-renderers/test-renderer-controller.php::test_render_wc_respects_newsletter_visibility` renders a newsletter with always/email-only/web-only paragraphs through `render_wc()` and asserts email-only + always are kept and web-only is hidden. Full suite green (571 tests / 2585 assertions); PHPCS clean.

### Submission checklist
- [x] Follows coding standards (PHPCS clean)
- [x] Test added and passing
- [ ] Changelog (auto-generated by CI)
