### PR TITLE
fix(newsletters): constrain posts-inserter images to column width

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -41,9 +41,8 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 		if ( ! is_array( $children ) ) {
 			return '';
 		}
-		// The available width the package computed for this block (the column width
-		// when the posts-inserter is nested in columns). Pass it down so the inserted
-		// images render at the column width rather than the full email width.
+		// Width the package computed for this block (the column width when nested). Pass
+		// it down so inserted images fit the column, not the full email width.
 		$content_width = $parsed_block['email_attrs']['width'] ?? null;
 		return self::apply_email_styles( self::render_inserted_blocks( $children, $content_width ) );
 	}
@@ -98,9 +97,8 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	 * as raw markup — its columns would overflow the email width.
 	 *
 	 * @param array       $children      The `innerBlocksToInsert` child-block array.
-	 * @param string|null $content_width Available width (e.g. `330px`) to constrain
-	 *                                   inserted images/columns to, or null for the
-	 *                                   full email width.
+	 * @param string|null $content_width Width to constrain inserted images/columns to
+	 *                                   (e.g. `330px`), or null for the full email width.
 	 * @return string Concatenated rendered HTML in child order.
 	 */
 	public static function render_inserted_blocks( array $children, ?string $content_width = null ): string {
@@ -138,12 +136,10 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	/**
 	 * Render inserted block markup, constraining widths to the available width.
 	 *
-	 * The block's own callback renders via `do_blocks()` in a fresh parse that has no
-	 * `email_attrs`, so inserted images fall back to the full email width — overflowing
-	 * a narrow column. When a width is known, parse the markup, run the package's
-	 * width preprocessor with that width as the content size, then render each block
-	 * so its `email_attrs.width` reaches the image renderer. Falls back to `do_blocks()`
-	 * when no width is available.
+	 * A plain `do_blocks()` pass has no `email_attrs`, so inserted images fall back to
+	 * the full email width and overflow a narrow column. When a width is known, run the
+	 * package's width preprocessor with it as the content size so each block's
+	 * `email_attrs.width` reaches the image renderer; otherwise fall back to `do_blocks()`.
 	 *
 	 * @param string      $markup        Block markup.
 	 * @param string|null $content_width Available width (e.g. `330px`), or null.
@@ -168,11 +164,9 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	/**
 	 * Left-align a flat-layout featured image.
 	 *
-	 * The posts-inserter saves the image-on-top featured image with `align: center`,
-	 * which the package renders into a centered, fixed-width image cell. In the email
-	 * the image must sit flush-left so it lines up with the heading and excerpt below
-	 * it (both always left-aligned) — a centered, sub-column-width image looks broken.
-	 * Only touches `core/image`; other flat children pass through unchanged.
+	 * The posts-inserter saves the image-on-top featured image as `align: center`, which
+	 * the package renders as a centered, fixed-width cell — but it must sit flush-left to
+	 * line up with the heading and excerpt below it. Only touches `core/image`.
 	 *
 	 * @param array $child Parsed child block.
 	 * @return array Child with any centered image normalized to left alignment.
@@ -183,11 +177,6 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 		}
 		if ( 'center' === ( $child['attrs']['align'] ?? '' ) ) {
 			$child['attrs']['align'] = 'left';
-		}
-		// Keep the inner HTML's alignment class in sync so inlined block styles
-		// don't re-center the figure.
-		if ( isset( $child['innerHTML'] ) ) {
-			$child['innerHTML'] = str_replace( 'aligncenter', 'alignleft', (string) $child['innerHTML'] );
 		}
 		return $child;
 	}

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -12,6 +12,7 @@
 namespace Newspack\Newsletters\Email_Renderers\Blocks;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors\Blocks_Width_Preprocessor;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
 
 defined( 'ABSPATH' ) || exit;
@@ -40,7 +41,11 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 		if ( ! is_array( $children ) ) {
 			return '';
 		}
-		return self::apply_email_styles( self::render_inserted_blocks( $children ) );
+		// The available width the package computed for this block (the column width
+		// when the posts-inserter is nested in columns). Pass it down so the inserted
+		// images render at the column width rather than the full email width.
+		$content_width = $parsed_block['email_attrs']['width'] ?? null;
+		return self::apply_email_styles( self::render_inserted_blocks( $children, $content_width ) );
 	}
 
 	/**
@@ -92,10 +97,13 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 	 * Rendering bare `innerHTML` would leave the outer block (e.g. `core/columns`)
 	 * as raw markup — its columns would overflow the email width.
 	 *
-	 * @param array $children The `innerBlocksToInsert` child-block array.
+	 * @param array       $children      The `innerBlocksToInsert` child-block array.
+	 * @param string|null $content_width Available width (e.g. `330px`) to constrain
+	 *                                   inserted images/columns to, or null for the
+	 *                                   full email width.
 	 * @return string Concatenated rendered HTML in child order.
 	 */
-	public static function render_inserted_blocks( array $children ): string {
+	public static function render_inserted_blocks( array $children, ?string $content_width = null ): string {
 		$html  = '';
 		$index = 0;
 		foreach ( $children as $child ) {
@@ -105,7 +113,7 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 			// A child without a block name is unexpected — fall back to rendering its
 			// inner HTML so content is never silently dropped.
 			if ( empty( $child['blockName'] ) ) {
-				$html .= do_blocks( (string) ( $child['innerHTML'] ?? '' ) );
+				$html .= self::render_child_markup( (string) ( $child['innerHTML'] ?? '' ), $content_width );
 				++$index;
 				continue;
 			}
@@ -115,13 +123,43 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 				if ( $index > 0 ) {
 					$child['attrs']['style']['spacing']['margin']['top'] = self::POST_GAP;
 				}
-				$html .= do_blocks( self::serialize_inserted_block( $child ) );
+				$html .= self::render_child_markup( self::serialize_inserted_block( $child ), $content_width );
 			} else {
 				// Flat layout (image on top, or no image): wrap each rendered block in
 				// a padded cell to match the editor canvas's per-block 6px padding.
-				$html .= self::wrap_flat_block( do_blocks( self::serialize_inserted_block( $child ) ) );
+				$html .= self::wrap_flat_block( self::render_child_markup( self::serialize_inserted_block( $child ), $content_width ) );
 			}
 			++$index;
+		}
+		return $html;
+	}
+
+	/**
+	 * Render inserted block markup, constraining widths to the available width.
+	 *
+	 * The block's own callback renders via `do_blocks()` in a fresh parse that has no
+	 * `email_attrs`, so inserted images fall back to the full email width — overflowing
+	 * a narrow column. When a width is known, parse the markup, run the package's
+	 * width preprocessor with that width as the content size, then render each block
+	 * so its `email_attrs.width` reaches the image renderer. Falls back to `do_blocks()`
+	 * when no width is available.
+	 *
+	 * @param string      $markup        Block markup.
+	 * @param string|null $content_width Available width (e.g. `330px`), or null.
+	 * @return string Rendered email HTML.
+	 */
+	private static function render_child_markup( string $markup, ?string $content_width ): string {
+		if ( null === $content_width || '' === $content_width || ! class_exists( Blocks_Width_Preprocessor::class ) ) {
+			return do_blocks( $markup );
+		}
+		$blocks = ( new Blocks_Width_Preprocessor() )->preprocess(
+			parse_blocks( $markup ),
+			[ 'contentSize' => $content_width ],
+			[]
+		);
+		$html = '';
+		foreach ( $blocks as $block ) {
+			$html .= render_block( $block );
 		}
 		return $html;
 	}

--- a/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/blocks/class-posts-inserter.php
@@ -127,6 +127,7 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 			} else {
 				// Flat layout (image on top, or no image): wrap each rendered block in
 				// a padded cell to match the editor canvas's per-block 6px padding.
+				$child = self::left_align_flat_image( $child );
 				$html .= self::wrap_flat_block( self::render_child_markup( self::serialize_inserted_block( $child ), $content_width ) );
 			}
 			++$index;
@@ -162,6 +163,33 @@ class Posts_Inserter extends Abstract_Block_Renderer {
 			$html .= render_block( $block );
 		}
 		return $html;
+	}
+
+	/**
+	 * Left-align a flat-layout featured image.
+	 *
+	 * The posts-inserter saves the image-on-top featured image with `align: center`,
+	 * which the package renders into a centered, fixed-width image cell. In the email
+	 * the image must sit flush-left so it lines up with the heading and excerpt below
+	 * it (both always left-aligned) — a centered, sub-column-width image looks broken.
+	 * Only touches `core/image`; other flat children pass through unchanged.
+	 *
+	 * @param array $child Parsed child block.
+	 * @return array Child with any centered image normalized to left alignment.
+	 */
+	private static function left_align_flat_image( array $child ): array {
+		if ( 'core/image' !== ( $child['blockName'] ?? '' ) ) {
+			return $child;
+		}
+		if ( 'center' === ( $child['attrs']['align'] ?? '' ) ) {
+			$child['attrs']['align'] = 'left';
+		}
+		// Keep the inner HTML's alignment class in sync so inlined block styles
+		// don't re-center the figure.
+		if ( isset( $child['innerHTML'] ) ) {
+			$child['innerHTML'] = str_replace( 'aligncenter', 'alignleft', (string) $child['innerHTML'] );
+		}
+		return $child;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -436,4 +436,45 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 		preg_match( '/<img\b[^>]*\bwidth="(\d+)"/', $html, $matches );
 		$this->assertLessThan( 400, (int) $matches[1], 'Expected the column-nested posts-inserter image to be constrained to the column width, not the full email width.' );
 	}
+
+	/**
+	 * The image-on-top (flat) layout left-aligns the inserted image. The posts-inserter
+	 * stores the featured image with `align: center`, but in the email the image must
+	 * sit flush-left to line up with the heading and excerpt below it (which are always
+	 * left-aligned) — otherwise a sub-column-width image floats centered and looks broken.
+	 */
+	public function test_posts_inserter_flat_image_is_left_aligned() {
+		Editor_Bootstrap::init();
+
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$src           = wp_get_attachment_url( $attachment_id );
+		$image_inner   = '<figure class="wp-block-image aligncenter size-full"><img class="wp-image-' . $attachment_id . '" src="' . esc_url( $src ) . '" alt=""/></figure>';
+		$content       = $this->serialize_posts_inserter(
+			[
+				[
+					'blockName'    => 'core/image',
+					'attrs'        => [
+						'id'       => $attachment_id,
+						'align'    => 'center',
+						'sizeSlug' => 'full',
+					],
+					'innerHTML'    => $image_inner,
+					'innerContent' => [ $image_inner ],
+					'innerBlocks'  => [],
+				],
+				[
+					'blockName'    => 'core/heading',
+					'attrs'        => [],
+					'innerHTML'    => '<h3>Post title</h3>',
+					'innerContent' => [ '<h3>Post title</h3>' ],
+					'innerBlocks'  => [],
+				],
+			]
+		);
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter_with_content( $content ) ) );
+
+		$this->assertMatchesRegularExpression( '/class="email-image-cell"\s+align="left"/', $html, 'Expected the flat-layout image cell to be left-aligned.' );
+		$this->assertDoesNotMatchRegularExpression( '/class="email-image-cell"\s+align="center"/', $html, 'Expected the flat-layout image not to be centered.' );
+	}
 }

--- a/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-newspack-block-renderers.php
@@ -397,4 +397,43 @@ class Test_Newspack_Block_Renderers extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( 'mailto:?body=read-this', $html, 'Expected no share anchor href in a non-public newsletter email.' );
 	}
+
+	/**
+	 * A posts-inserter nested in a column constrains its inserted image to the column
+	 * width, not the full email width — otherwise the image overflows and blows the
+	 * email layout out (the 4-article-grid layout).
+	 */
+	public function test_posts_inserter_image_constrained_to_column_width() {
+		Editor_Bootstrap::init();
+
+		// A real attachment so the package image renderer resolves a size and emits a
+		// width (it drops images it can't resolve). canola.jpg is 640px wide.
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$src           = wp_get_attachment_url( $attachment_id );
+		$image_inner   = '<figure class="wp-block-image size-full"><img class="wp-image-' . $attachment_id . '" src="' . esc_url( $src ) . '" alt=""/></figure>';
+		$inserter      = $this->serialize_posts_inserter(
+			[
+				[
+					'blockName'    => 'core/image',
+					'attrs'        => [
+						'id'       => $attachment_id,
+						'sizeSlug' => 'full',
+					],
+					'innerHTML'    => $image_inner,
+					'innerContent' => [ $image_inner ],
+					'innerBlocks'  => [],
+				],
+			]
+		);
+		$content = '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column {"width":"50%"} --><div class="wp-block-column" style="flex-basis:50%">' . $inserter . '</div><!-- /wp:column -->'
+			. '<!-- wp:column {"width":"50%"} --><div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph --><p>Side</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter_with_content( $content ) ) );
+
+		$this->assertMatchesRegularExpression( '/<img\b[^>]*\bwidth="\d+"/', $html, 'Expected the inserted image to render with an explicit width.' );
+		preg_match( '/<img\b[^>]*\bwidth="(\d+)"/', $html, $matches );
+		$this->assertLessThan( 400, (int) $matches[1], 'Expected the column-nested posts-inserter image to be constrained to the column width, not the full email width.' );
+	}
 }


### PR DESCRIPTION
## Summary

**Two related fixes for Posts Inserter rendering under the WC email renderer.**

### 1. Inserted images render at their column width, not the full email width

When a Posts Inserter is nested inside a Columns layout (e.g. the 4-article grid layout), its images overflowed the column and blew out the whole email width.

Root cause: the override rendered each inserted child in a fresh `do_blocks()` pass that has no `email_attrs`, so the package image renderer fell back to the full email content width (612px) regardless of the enclosing column.

- **Propagate the available width** — `render_content()` reads the block's package-computed `email_attrs['width']` and passes it down to the inserted children.
- **Constrain via the package preprocessor** — a new `render_child_markup()` runs the package's `Blocks_Width_Preprocessor` with that width as the content size before rendering each child, so the inner image renderer sees the right `email_attrs.width`.

### 2. Image-on-top images are left-aligned

The posts-inserter saves the image-on-top featured image with `align: center`, which the package rendered as a centered, fixed-width cell — so a sub-column-width image floated centered while the heading and excerpt below it stayed flush-left. `left_align_flat_image()` normalizes the centered `core/image` in the flat (image-on-top / no-image) layout to `align: left`.

### Behavior notes

- The new `render_child_markup()` path is **universal**, not column-only: `email_attrs['width']` is populated for every block, so top-level and side-by-side inserters route through the preprocessor too. It's a **no-op for width** there — a top-level inserter resolves to the full content width, and a side-by-side inserter is already column-constrained by its columns block — so neither changes size. The plain `do_blocks()` fallback only applies when no width is known or the package class is absent.
- The alignment fix touches only the flat **image-on-top / no-image** layout; **side-by-side** (image left/right) is left untouched.

## How to test

1. With the WC renderer flag on, open a newsletter using the **4-article grid layout** (Posts Inserter nested in a Columns block inside a Group).
2. Preview the email:
   - **Width** — grid images sit within their columns and the email is ~600px wide (previously images rendered at full width and the email overflowed to ~1240px).
   - **Alignment** — each image-on-top image sits flush-left, lined up with its heading and excerpt below it (previously centered).
3. Regression: a standalone (top-level) Posts Inserter still renders its images at full content width, and a side-by-side (image left/right) layout is unchanged.

## Submission checklist

- [x] Follows WordPress + Newspack coding standards (phpcs clean)
- [x] Adds regression tests (`test_posts_inserter_image_constrained_to_column_width`, `test_posts_inserter_flat_image_is_left_aligned`)
- [ ] Changelog entry (auto-generated by CI)
