### PR TITLE
fix(content-gate): keep commenting per Discussion Settings on metered posts (NPPD-1829)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -37,11 +37,19 @@ class Content_Gate {
 	private static $is_gated = false;
 
 	/**
-	 * Whether the post is being shown via metering.
+	 * Whether the queried post's content is locked for the current reader, i.e.
+	 * fully gated with no access (the content has been replaced by a gate).
+	 *
+	 * Distinct from $is_gated, which only signals that gate markup is being
+	 * rendered: that flag is also raised while building the metering excerpt
+	 * and while rendering an overlay gate for a *metered* (still-readable) post.
+	 * Comment gating must key off the access decision instead so it stays
+	 * correct regardless of when gate markup happens to render. Set once, on the
+	 * `the_post` action, before any content or comments are rendered.
 	 *
 	 * @var boolean
 	 */
-	private static $is_metered = false;
+	private static $is_content_locked = false;
 
 	/**
 	 * Valid gate post statuses.
@@ -217,13 +225,13 @@ class Content_Gate {
 			 */
 			! apply_filters( 'newspack_content_gate_restrict_post', true, $post->ID )
 		) {
-			// Content is accessible via metering — show comments but prevent commenting.
-			self::$is_metered        = true;
-			$post->comment_status    = 'closed';
+			// Content is accessible (e.g. via metering); leave commenting governed
+			// by the site's Discussion Settings rather than gating it.
 			return;
 		}
 
-		self::$is_gated = true;
+		self::$is_gated          = true;
+		self::$is_content_locked = true;
 
 		$content = self::get_restricted_post_excerpt( $post );
 
@@ -263,7 +271,9 @@ class Content_Gate {
 	/**
 	 * Filter whether comments are open.
 	 *
-	 * Close comments on gated and metered posts.
+	 * Close comments only on fully locked posts, where the reader cannot access
+	 * the content. Metered (currently-accessible) posts are left untouched so
+	 * the site's Discussion Settings continue to govern commenting.
 	 *
 	 * @param bool $open    Whether comments are open.
 	 * @param int  $post_id Post ID.
@@ -271,7 +281,7 @@ class Content_Gate {
 	 * @return bool
 	 */
 	public static function filter_comments_open( $open, $post_id ) {
-		if ( ( self::$is_gated || self::$is_metered ) && (int) $post_id === (int) get_queried_object_id() ) {
+		if ( self::$is_content_locked && (int) $post_id === (int) get_queried_object_id() ) {
 			return false;
 		}
 		return $open;
@@ -280,7 +290,7 @@ class Content_Gate {
 	/**
 	 * Filter comments array.
 	 *
-	 * Hide all comments on fully gated posts.
+	 * Hide all comments on fully locked posts.
 	 *
 	 * @param array $comments Array of comments.
 	 * @param int   $post_id  Post ID.
@@ -288,7 +298,7 @@ class Content_Gate {
 	 * @return array
 	 */
 	public static function filter_comments_array( $comments, $post_id ) {
-		if ( self::$is_gated && (int) $post_id === (int) get_queried_object_id() ) {
+		if ( self::$is_content_locked && (int) $post_id === (int) get_queried_object_id() ) {
 			return [];
 		}
 		return $comments;
@@ -297,7 +307,7 @@ class Content_Gate {
 	/**
 	 * Filter the comment count.
 	 *
-	 * Return 0 on fully gated posts.
+	 * Return 0 on fully locked posts.
 	 *
 	 * @param int $count   Comment count.
 	 * @param int $post_id Post ID.
@@ -305,7 +315,7 @@ class Content_Gate {
 	 * @return int
 	 */
 	public static function filter_comments_number( $count, $post_id ) {
-		if ( self::$is_gated && (int) $post_id === (int) get_queried_object_id() ) {
+		if ( self::$is_content_locked && (int) $post_id === (int) get_queried_object_id() ) {
 			return 0;
 		}
 		return $count;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -1158,6 +1158,10 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		remove_filter( 'newspack_content_gate_restrict_post', '__return_false' );
 
 		$this->assertSame( 'open', $post->comment_status, 'Metered post must not have its comment status force-closed' );
+		// Assert the gate filter directly (not only via comments_open()) so the
+		// pass/fail hinge is explicit and does not depend on the filter being
+		// registered through init() at runtime.
+		$this->assertTrue( Content_Gate::filter_comments_open( true, $post_id ), 'Gate filter must not close comments on a metered post' );
 		$this->assertTrue( comments_open( $post_id ), 'Logged-out reader must be able to comment on a metered post when Discussion Settings allow it' );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -185,6 +185,9 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			wp_delete_post( $post_id, true );
 		}
 		$this->reset_restriction_cache();
+		// Statics persist across tests (they are not rolled back with the DB), so
+		// reset them here — including after an assertion failure leaves them dirty.
+		$this->reset_gate_render_state();
 		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		if ( null === $this->original_remote_addr ) {
 			unset( $_SERVER['REMOTE_ADDR'] );
@@ -1044,45 +1047,55 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test comment filters on fully gated posts.
+	 * Reset the render-time static flags on Content_Gate so a test driving
+	 * restrict_post() starts from a clean slate, independent of test ordering
+	 * (restrict_post() short-circuits on has_rendered()).
 	 */
-	public function test_comments_closed_on_gated_post() {
-		$post_id = $this->post_ids[0];
-
-		$this->set_content_gate_property( 'is_gated', true );
-		$this->set_content_gate_property( 'is_metered', false );
-
-		// Simulate queried object.
-		$this->go_to( get_permalink( $post_id ) );
-
-		$this->assertFalse( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should be closed on gated post' );
-		$this->assertEmpty( Content_Gate::filter_comments_array( [ 'comment1', 'comment2' ], $post_id ), 'Comments array should be empty on gated post' );
-		$this->assertSame( 0, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be 0 on gated post' );
-
-		// Reset.
+	private function reset_gate_render_state() {
+		$this->set_content_gate_property( 'gate_rendered', false );
 		$this->set_content_gate_property( 'is_gated', false );
+		$this->set_content_gate_property( 'is_content_locked', false );
 	}
 
 	/**
-	 * Test comment filters on metered posts.
+	 * Test comment filters gate a fully locked post (reader has no access).
 	 */
-	public function test_comments_closed_but_visible_on_metered_post() {
+	public function test_comments_closed_on_locked_post() {
 		$post_id = $this->post_ids[0];
 
-		$this->set_content_gate_property( 'is_gated', false );
-		$this->set_content_gate_property( 'is_metered', true );
+		$this->set_content_gate_property( 'is_content_locked', true );
 
 		// Simulate queried object.
 		$this->go_to( get_permalink( $post_id ) );
 
-		$this->assertFalse( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should be closed on metered post' );
+		$this->assertFalse( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should be closed on a locked post' );
+		$this->assertEmpty( Content_Gate::filter_comments_array( [ 'comment1', 'comment2' ], $post_id ), 'Comments array should be empty on a locked post' );
+		$this->assertSame( 0, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be 0 on a locked post' );
+	}
 
+	/**
+	 * Test comment filters pass through when the content is not locked.
+	 *
+	 * This covers metered (still-readable) and unrestricted posts alike: neither
+	 * locks the content, so commenting is left to the site's Discussion Settings.
+	 * Critically, the filters key off the access decision ($is_content_locked),
+	 * not the render-time $is_gated flag, which is also raised while rendering an
+	 * overlay gate for a metered post (NPPD-1829).
+	 */
+	public function test_comments_pass_through_when_not_locked() {
+		$post_id = $this->post_ids[0];
+
+		$this->set_content_gate_property( 'is_content_locked', false );
+		// $is_gated may be raised by overlay/excerpt rendering on a readable post;
+		// it must not gate comments on its own.
+		$this->set_content_gate_property( 'is_gated', true );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertTrue( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should remain open when the content is not locked' );
 		$comments = [ 'comment1', 'comment2' ];
-		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $post_id ), 'Existing comments should remain visible on metered post' );
-		$this->assertSame( 5, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be unchanged on metered post' );
-
-		// Reset.
-		$this->set_content_gate_property( 'is_metered', false );
+		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $post_id ), 'Existing comments should remain visible when the content is not locked' );
+		$this->assertSame( 5, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be unchanged when the content is not locked' );
 	}
 
 	/**
@@ -1093,37 +1106,91 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$other_post_id = $this->factory->post->create();
 		$this->post_ids[] = $other_post_id;
 
-		$this->set_content_gate_property( 'is_gated', true );
-		$this->set_content_gate_property( 'is_metered', false );
+		$this->set_content_gate_property( 'is_content_locked', true );
 
-		// Simulate queried object as the gated post.
+		// Simulate queried object as the locked post.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Filters should not affect the other post.
-		$this->assertTrue( Content_Gate::filter_comments_open( true, $other_post_id ), 'Comments should remain open on non-gated post' );
+		$this->assertTrue( Content_Gate::filter_comments_open( true, $other_post_id ), 'Comments should remain open on the non-locked post' );
 		$comments = [ 'comment1' ];
-		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $other_post_id ), 'Comments array should be unchanged on non-gated post' );
-		$this->assertSame( 3, Content_Gate::filter_comments_number( 3, $other_post_id ), 'Comment count should be unchanged on non-gated post' );
-
-		// Reset.
-		$this->set_content_gate_property( 'is_gated', false );
+		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $other_post_id ), 'Comments array should be unchanged on the non-locked post' );
+		$this->assertSame( 3, Content_Gate::filter_comments_number( 3, $other_post_id ), 'Comment count should be unchanged on the non-locked post' );
 	}
 
 	/**
-	 * Test comment filters pass through on unrestricted posts.
+	 * Metered (currently-accessible) content must leave commenting governed by
+	 * the site's Discussion Settings, not force it closed.
+	 *
+	 * Regression test for NPPD-1829: a Paid Access gate left logged-out readers
+	 * unable to comment on posts they could still read via metering, even on a
+	 * site that allows unauthenticated commenting.
 	 */
-	public function test_comments_unaffected_on_unrestricted_post() {
+	public function test_metered_post_keeps_commenting_per_discussion_settings() {
 		$post_id = $this->post_ids[0];
 
-		$this->set_content_gate_property( 'is_gated', false );
-		$this->set_content_gate_property( 'is_metered', false );
+		$this->reset_gate_render_state();
 
+		// Site allows logged-out commenting (name + email), per Discussion Settings.
+		update_option( 'comment_registration', 0 );
+		wp_update_post(
+			[
+				'ID'             => $post_id,
+				'comment_status' => 'open',
+			]
+		);
+
+		// Logged-out reader.
+		wp_set_current_user( 0 );
+
+		// The published gate restricts this post for the anonymous reader...
+		$this->assertNotFalse( Content_Gate::is_post_restricted( $post_id ), 'Post should be restricted for the logged-out reader' );
+
+		// ...but metering grants read access for this view. The Metering class
+		// signals that by returning false from this filter.
+		add_filter( 'newspack_content_gate_restrict_post', '__return_false' );
+
+		// Render the post through the gate's restriction logic.
 		$this->go_to( get_permalink( $post_id ) );
+		$post = get_post( $post_id );
+		Content_Gate::restrict_post( $post, $GLOBALS['wp_query'] );
 
-		$this->assertTrue( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should remain open on unrestricted post' );
-		$comments = [ 'comment1', 'comment2' ];
-		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $post_id ), 'Comments array should be unchanged on unrestricted post' );
-		$this->assertSame( 5, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be unchanged on unrestricted post' );
+		remove_filter( 'newspack_content_gate_restrict_post', '__return_false' );
+
+		$this->assertSame( 'open', $post->comment_status, 'Metered post must not have its comment status force-closed' );
+		$this->assertTrue( comments_open( $post_id ), 'Logged-out reader must be able to comment on a metered post when Discussion Settings allow it' );
+	}
+
+	/**
+	 * The companion invariant to NPPD-1829: a fully gated post (reader has no
+	 * access, no metering grace) must still lock commenting end-to-end.
+	 */
+	public function test_gated_post_locks_commenting() {
+		$post_id = $this->post_ids[0];
+
+		$this->reset_gate_render_state();
+
+		update_option( 'comment_registration', 0 );
+		wp_update_post(
+			[
+				'ID'             => $post_id,
+				'comment_status' => 'open',
+			]
+		);
+
+		// Logged-out reader with no access and no metering grace (default filter).
+		wp_set_current_user( 0 );
+		$this->assertNotFalse( Content_Gate::is_post_restricted( $post_id ), 'Post should be restricted for the logged-out reader' );
+
+		// Render the post through the gate's restriction logic (gated branch).
+		$this->go_to( get_permalink( $post_id ) );
+		$post = get_post( $post_id );
+		Content_Gate::restrict_post( $post, $GLOBALS['wp_query'] );
+
+		$this->assertSame( 'closed', $post->comment_status, 'Gated post should have its comment status closed' );
+		$this->assertFalse( comments_open( $post_id ), 'Gated post must not accept comments' );
+		$this->assertFalse( Content_Gate::filter_comments_open( true, $post_id ), 'Comment filter should report closed on a gated post' );
+		$this->assertSame( 0, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be 0 on a gated post' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

> **Hotfix** — branched from and targeting `release` (v6.44.0).

### Changes proposed in this Pull Request:

A Paid Access content gate was force-closing comments for logged-out readers who could still read a post **via metering**, overriding the site's WordPress Discussion Settings. On a site that allows unauthenticated name+email commenting, logged-out readers saw "comments closed" / no comment form, while logged-in readers could comment — because comments were never actually closed at the data layer.

Root cause: comment gating keyed on the render-time `Content_Gate::$is_gated` static. That flag is raised not only when a reader is genuinely blocked, but also while building the metering excerpt and while rendering an **overlay** gate for a *metered* (still-readable) post. In **block themes**, the overlay renders during the `core/post-content` block — before `core/comments` — so commenting was closed even though the reader could access the content.

Fix:

- Introduce a dedicated `Content_Gate::$is_content_locked` flag that means "the reader cannot access this content." It is set **only** in `restrict_post()`'s gated branch, which runs on the `the_post` action (before any content or comments render), so the decision is order-independent.
- The three comment filters (`filter_comments_open` / `filter_comments_array` / `filter_comments_number`) now key off `$is_content_locked` instead of `$is_gated`.
- `$is_gated` is preserved unchanged as the render flag (still consumed by `is_gated()` → the metering countdown blocks).
- The metered early-return in `restrict_post()` no longer touches `comment_status`.

Net behavior: metered/accessible posts leave commenting to the site's Discussion Settings; **fully gated** posts still close and hide comments.

Closes NPPD-1829.

### How to test the changes in this Pull Request:

Automated (covers the fix end-to-end against the real `restrict_post` flow):

1. `cd plugins/newspack-plugin && n test-php --filter Test_Content_Gates` — 63 tests pass.
   - `test_metered_post_keeps_commenting_per_discussion_settings` — drives the metered branch; asserts `comment_status` stays `open` and `comments_open()` is true.
   - `test_gated_post_locks_commenting` — drives the gated branch; asserts comments are closed.
   - `test_comments_pass_through_when_not_locked` — proves `$is_gated` alone no longer gates comments.

Manual:

1. Enable Access Control (`NEWSPACK_CONTENT_GATES`); set Discussion Settings so users do **not** need to be registered to comment (name + email).
2. Create a **Paid Access** gate (not a registration gate) with metering, matching a post.
3. In an incognito window, open a metered (still-readable) post: the comment form should appear and a comment can be left, per Discussion Settings.
4. Confirm a **fully gated** post (no metering grace) still shows the gate and no comment form.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

#### Verified against the reported configuration (read-only)

The reporting site runs the classic `newspack-theme`, has comment registration off with name+email required, and its published content gate has metering enabled. So logged-out readers are metered/readable and hit the exact `restrict_post()` branch fixed here.

#### Out of scope / noted during review

- Block-theme comment **list**: the `core/comment-template` block builds its list via `WP_Comment_Query` directly and does not run the `comments_array` filter (only classic `comments_template()` does). On a *fully gated* post in a block theme, the comment form and count are suppressed but previously-approved comments may still render in the list. Pre-existing and unrelated to this fix; the reported site (classic theme) is fully covered.
- When WooCommerce Memberships is active, `restrict_post()` bails before setting `$is_content_locked`, so these filters don't fire — Memberships controls the front-end (including comments) while active, per the project model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AVd3DyqVbPN8Tbcirpj6H