### PR TITLE
fix(oauth): verify Google access token audience and email

### DIFF
--- a/plugins/newspack-plugin/includes/oauth/class-google-oauth.php
+++ b/plugins/newspack-plugin/includes/oauth/class-google-oauth.php
@@ -366,9 +366,21 @@ class Google_OAuth {
 				// Confirm the token was issued to this site's own OAuth client, when that is known.
 				$expected_client_id = self::get_expected_client_id();
 				if ( '' !== $expected_client_id ) {
-					$token_client_id = $token_info->audience ?? $token_info->issued_to ?? '';
+					// Prefer a non-empty audience, falling back to issued_to; treat an empty
+					// audience as unset so a valid issued_to is not ignored.
+					$token_client_id = '' !== ( $token_info->audience ?? '' )
+						? $token_info->audience
+						: ( $token_info->issued_to ?? '' );
 					if ( (string) $expected_client_id !== (string) $token_client_id ) {
 						Logger::error( 'OAuth token was issued to a different client id than expected.' );
+						// Surface via the always-on log so a rejection (an attack attempt, or a
+						// legitimate login broken by a client-id skew) is auditable fleet-wide.
+						Logger::newspack_log(
+							'newspack_google_oauth',
+							'Google sign-in rejected: token was issued to a different OAuth client id than expected.',
+							[ 'file' => 'newspack_google_oauth' ],
+							'error'
+						);
 						return new \WP_Error( 'newspack_google_oauth', __( 'Invalid Google credentials. Please reconnect.', 'newspack' ) );
 					}
 				} else {
@@ -377,7 +389,7 @@ class Google_OAuth {
 					Logger::newspack_log(
 						'newspack_google_oauth',
 						'Google sign-in proceeded without OAuth client id verification: no expected client id is known yet.',
-						[ 'file' => 'newspack_google_login' ],
+						[ 'file' => 'newspack_google_oauth' ],
 						'warning'
 					);
 				}
@@ -386,6 +398,12 @@ class Google_OAuth {
 				// as either a boolean or a string, so normalize before checking.
 				if ( ! filter_var( $token_info->verified_email ?? false, FILTER_VALIDATE_BOOLEAN ) ) {
 					Logger::error( 'Google account email address is not verified.' );
+					Logger::newspack_log(
+						'newspack_google_oauth',
+						'Google sign-in rejected: account email address is not verified.',
+						[ 'file' => 'newspack_google_oauth' ],
+						'error'
+					);
 					return new \WP_Error( 'newspack_google_oauth', __( 'Invalid Google credentials. Please reconnect.', 'newspack' ) );
 				}
 

--- a/plugins/newspack-plugin/includes/oauth/class-google-oauth.php
+++ b/plugins/newspack-plugin/includes/oauth/class-google-oauth.php
@@ -21,6 +21,11 @@ class Google_OAuth {
 	const AUTH_CALLBACK        = 'newspack_google_oauth_callback';
 	const CSRF_TOKEN_NAMESPACE = 'google';
 
+	/**
+	 * Option storing the Google OAuth client id the proxy issues tokens for.
+	 */
+	const CLIENT_ID_OPTION_NAME = 'newspack_google_oauth_client_id';
+
 	const REQUIRED_SCOPES = [
 		'https://www.googleapis.com/auth/userinfo.email', // User's email address.
 		'https://www.googleapis.com/auth/admanager',
@@ -180,6 +185,11 @@ class Google_OAuth {
 				);
 			}
 			$response_body = json_decode( $result['body'] );
+			// Remember the client id the proxy issues tokens for, so received tokens can be
+			// confirmed to have been issued to this app.
+			if ( isset( $response_body->client_id ) ) {
+				update_option( self::CLIENT_ID_OPTION_NAME, sanitize_text_field( $response_body->client_id ), false );
+			}
 			return $response_body->url;
 		} catch ( \Exception $e ) {
 			return new WP_Error(
@@ -353,6 +363,32 @@ class Google_OAuth {
 			// We always request the email scope. Otherwise, the https://www.googleapis.com/oauth2/v2/userinfo endpoint can be used
 			// to retrieve the user email.
 			if ( isset( $token_info->email ) ) {
+				// Confirm the token was issued to this site's own OAuth client, when that is known.
+				$expected_client_id = self::get_expected_client_id();
+				if ( '' !== $expected_client_id ) {
+					$token_client_id = $token_info->audience ?? $token_info->issued_to ?? '';
+					if ( (string) $expected_client_id !== (string) $token_client_id ) {
+						Logger::error( 'OAuth token was issued to a different client id than expected.' );
+						return new \WP_Error( 'newspack_google_oauth', __( 'Invalid Google credentials. Please reconnect.', 'newspack' ) );
+					}
+				} else {
+					// Surface via newspack_log (not just the level-gated logger) so sites still
+					// running without a known client id can be audited across the fleet.
+					Logger::newspack_log(
+						'newspack_google_oauth',
+						'Google sign-in proceeded without OAuth client id verification: no expected client id is known yet.',
+						[ 'file' => 'newspack_google_login' ],
+						'warning'
+					);
+				}
+
+				// Only trust a verified email address. The tokeninfo endpoint has returned this
+				// as either a boolean or a string, so normalize before checking.
+				if ( ! filter_var( $token_info->verified_email ?? false, FILTER_VALIDATE_BOOLEAN ) ) {
+					Logger::error( 'Google account email address is not verified.' );
+					return new \WP_Error( 'newspack_google_oauth', __( 'Invalid Google credentials. Please reconnect.', 'newspack' ) );
+				}
+
 				return $token_info->email;
 			} else {
 				Logger::error( 'User email missing in the response.' );
@@ -365,6 +401,23 @@ class Google_OAuth {
 			Logger::error( 'Failed retrieving user info – invalid credentials.' );
 			return new \WP_Error( 'newspack_google_oauth', __( 'Invalid Google credentials. Please reconnect.', 'newspack' ) );
 		}
+	}
+
+	/**
+	 * The Google OAuth client id that access tokens are expected to be issued to.
+	 *
+	 * Defaults to the value most recently reported by the OAuth proxy and stored
+	 * locally. Returns an empty string when none is known yet.
+	 *
+	 * @return string
+	 */
+	public static function get_expected_client_id() {
+		/**
+		 * Filters the Google OAuth client id that access tokens are expected to be issued to.
+		 *
+		 * @param string $client_id The stored client id, or empty string if none is known.
+		 */
+		return (string) apply_filters( 'newspack_google_oauth_expected_client_id', (string) get_option( self::CLIENT_ID_OPTION_NAME, '' ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/oauth.php
+++ b/plugins/newspack-plugin/tests/unit-tests/oauth.php
@@ -404,4 +404,50 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 			'The client id from the /start response should be stored.'
 		);
 	}
+
+	/**
+	 * When a client id is expected but the token carries neither audience nor
+	 * issued_to, the token is rejected (closed by default).
+	 */
+	public function test_rejects_token_without_audience_or_issued_to() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertTrue(
+			is_wp_error( $result ),
+			'A token carrying neither audience nor issued_to must be rejected when a client id is expected.'
+		);
+	}
+
+	/**
+	 * Admin-scoped tokens (Ad Manager / Analytics) with a mismatched audience are
+	 * rejected too — the shared validator protects the admin connection flow.
+	 */
+	public function test_rejects_admin_scoped_token_with_mismatched_audience() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'other-client-id.apps.googleusercontent.com',
+				'audience'       => 'other-client-id.apps.googleusercontent.com',
+				'scope'          => implode( ' ', Google_OAuth::REQUIRED_SCOPES ),
+				'email'          => 'admin@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_OAuth::REQUIRED_SCOPES );
+
+		self::assertTrue(
+			is_wp_error( $result ),
+			'An admin-scoped token with a mismatched audience must be rejected.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/oauth.php
+++ b/plugins/newspack-plugin/tests/unit-tests/oauth.php
@@ -7,6 +7,7 @@
 
 use Newspack\OAuth;
 use Newspack\Google_OAuth;
+use Newspack\Google_Login;
 use Newspack\Google_Services_Connection;
 
 /**
@@ -127,6 +128,280 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 			Google_Services_Connection::get_oauth2_credentials(),
 			false,
 			'OAuth2 object getter return false after credentials are removed.'
+		);
+	}
+
+	/**
+	 * Stub Google's oauth2/v1/tokeninfo endpoint with a canned response body.
+	 *
+	 * @param array $token_info Fields to return as the tokeninfo JSON body.
+	 */
+	private function stub_tokeninfo( array $token_info ) {
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( $token_info ) {
+				if ( false !== strpos( $url, 'oauth2/v1/tokeninfo' ) ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode( $token_info ),
+					];
+				}
+				return $pre;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * The site's own Google OAuth client id that the sign-in flow validates tokens against.
+	 *
+	 * Configured via a filter so the test is independent of how the value is sourced.
+	 *
+	 * @param string $client_id Expected client id.
+	 */
+	private function set_expected_client_id( $client_id ) {
+		add_filter( 'newspack_google_oauth_expected_client_id', fn() => $client_id );
+	}
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		delete_option( Google_OAuth::CLIENT_ID_OPTION_NAME );
+		parent::tear_down();
+	}
+
+	/**
+	 * Google's tokeninfo returns the owner's email for any email-scoped access token,
+	 * regardless of which OAuth client requested it. The sign-in flow should therefore
+	 * confirm the token was issued to this site's own client id before using its email:
+	 * validate_token_and_get_email_address() compares the token's audience / issued_to
+	 * against the configured client id and rejects a token issued to a different client.
+	 */
+	public function test_rejects_access_token_issued_to_a_different_client() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'other-client-id.apps.googleusercontent.com',
+				'audience'       => 'other-client-id.apps.googleusercontent.com',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertTrue(
+			is_wp_error( $result ),
+			'A token whose audience is a different client id must be rejected.'
+		);
+	}
+
+	/**
+	 * A token issued to the site's own client id is accepted and resolves to its email.
+	 *
+	 * Guards against the audience check over-rejecting valid sign-ins.
+	 */
+	public function test_accepts_access_token_issued_to_configured_client() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'site-client-id.apps.googleusercontent.com',
+				'audience'       => 'site-client-id.apps.googleusercontent.com',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertEquals(
+			'reader@example.com',
+			$result,
+			'A token issued to the configured client id must be accepted.'
+		);
+	}
+
+	/**
+	 * A Google account whose email address is not verified should not be used to sign in.
+	 */
+	public function test_rejects_access_token_with_unverified_email() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'site-client-id.apps.googleusercontent.com',
+				'audience'       => 'site-client-id.apps.googleusercontent.com',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => false,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertTrue(
+			is_wp_error( $result ),
+			'A token whose email is not verified must be rejected.'
+		);
+	}
+
+	/**
+	 * When no expected client id is known yet (e.g. before the proxy has reported one),
+	 * the audience check is skipped so existing sign-ins keep working; the email is returned.
+	 */
+	public function test_accepts_token_when_no_expected_client_id_is_configured() {
+		// No expected client id configured (filter not set, option empty).
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'any-client-id.apps.googleusercontent.com',
+				'audience'       => 'any-client-id.apps.googleusercontent.com',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertEquals(
+			'reader@example.com',
+			$result,
+			'With no expected client id configured, a verified token should still be accepted.'
+		);
+	}
+
+	/**
+	 * A Google account email flagged verified as the string "false" must not be trusted.
+	 *
+	 * Google's tokeninfo has historically returned this field as a boolean or a string.
+	 */
+	public function test_rejects_access_token_with_string_false_verified_email() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'site-client-id.apps.googleusercontent.com',
+				'audience'       => 'site-client-id.apps.googleusercontent.com',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => 'false',
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertTrue(
+			is_wp_error( $result ),
+			'A token whose verified_email is the string "false" must be rejected.'
+		);
+	}
+
+	/**
+	 * A token with no verified_email field at all must be rejected.
+	 */
+	public function test_rejects_access_token_with_missing_verified_email() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to' => 'site-client-id.apps.googleusercontent.com',
+				'audience'  => 'site-client-id.apps.googleusercontent.com',
+				'scope'     => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'     => 'reader@example.com',
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertTrue(
+			is_wp_error( $result ),
+			'A token with no verified_email field must be rejected.'
+		);
+	}
+
+	/**
+	 * The client id is matched against issued_to when the audience field is absent.
+	 */
+	public function test_accepts_token_matched_by_issued_to_when_audience_absent() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'site-client-id.apps.googleusercontent.com',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'email'          => 'reader@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_Login::REQUIRED_SCOPES );
+
+		self::assertEquals( 'reader@example.com', $result, 'A token matched by issued_to should be accepted.' );
+	}
+
+	/**
+	 * Admin-scoped tokens (Ad Manager / Analytics) with a matching audience still pass.
+	 *
+	 * The check lives in the validator shared by the admin connection flow, so this
+	 * guards against a regression there.
+	 */
+	public function test_accepts_admin_scoped_token_with_matching_audience() {
+		$this->set_expected_client_id( 'site-client-id.apps.googleusercontent.com' );
+		$this->stub_tokeninfo(
+			[
+				'issued_to'      => 'site-client-id.apps.googleusercontent.com',
+				'audience'       => 'site-client-id.apps.googleusercontent.com',
+				'scope'          => implode( ' ', Google_OAuth::REQUIRED_SCOPES ),
+				'email'          => 'admin@example.com',
+				'verified_email' => true,
+			]
+		);
+
+		$result = Google_OAuth::validate_token_and_get_email_address( 'some-access-token', Google_OAuth::REQUIRED_SCOPES );
+
+		self::assertEquals( 'admin@example.com', $result, 'An admin-scoped token with a matching audience should be accepted.' );
+	}
+
+	/**
+	 * The client id reported by the proxy /start response is stored for later checks.
+	 */
+	public function test_start_response_client_id_is_persisted() {
+		self::set_api_key();
+		if ( ! defined( 'NEWSPACK_GOOGLE_OAUTH_PROXY' ) ) {
+			define( 'NEWSPACK_GOOGLE_OAUTH_PROXY', 'http://dummy.proxy' );
+		}
+		delete_option( Google_OAuth::CLIENT_ID_OPTION_NAME );
+
+		// Stub the proxy /start response with a url and a client id.
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) {
+				if ( false !== strpos( $url, 'newspack-oauth-proxy/v1/start' ) ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'url'       => 'https://accounts.google.com/o/oauth2/v2/auth?stub',
+								'client_id' => 'site-client-id.apps.googleusercontent.com',
+							]
+						),
+					];
+				}
+				return $pre;
+			},
+			10,
+			3
+		);
+
+		Google_OAuth::google_auth_get_url(
+			[
+				'csrf_token'     => 'csrf-token-123',
+				'scope'          => 'https://www.googleapis.com/auth/userinfo.email',
+				'redirect_after' => 'https://example.org/',
+			]
+		);
+
+		self::assertEquals(
+			'site-client-id.apps.googleusercontent.com',
+			get_option( Google_OAuth::CLIENT_ID_OPTION_NAME ),
+			'The client id from the /start response should be stored.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Newspack's OAuth proxy now announces its client ID to downstream consumers. This consumes that ID to match access tokens and their included email addresses to the appropriate audience.

Part of NPPM-2963.

### How to test the changes in this Pull Request:

1. Run the OAuth unit tests: `n test-php --filter Newspack_Test_OAuth` (11 pass).
2. With Google reader login configured, sign in with Google — sign-in succeeds and the expected client id is stored from the proxy `/start` response.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### Scope note (from review)

The audience / `verified_email` checks live in `validate_token_and_get_email_address()`, which is shared by the admin Ad Manager / Analytics connection-status flow (`authenticated_user_basic_information()`) as well as reader login. Both flows route through `google_auth_get_url()`, which persists the single stored expected client id (`CLIENT_ID_OPTION_NAME`) the validator reads — so both resolve the **same** expected client id, and a token issued to that client passes in both. The admin rejection path is covered by `test_rejects_admin_scoped_token_with_mismatched_audience`.

Rejections now also emit via the always-on `Logger::newspack_log()` so a client-id skew during rollout (or a replay attempt) is auditable fleet-wide, not just at `NEWSPACK_LOG_LEVEL >= 1`.
