### PR TITLE
fix(cli): match duplicate teams by normalized title (NPPM-2741)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
@@ -186,21 +186,10 @@ class Teams_For_Memberships_Diagnostics {
 			$teams = self::get_all_teams();
 		}
 
-		$buckets = [];
-		foreach ( $teams as $team ) {
-			$key = $team->post_author . '|' . self::normalize_team_title( $team->post_title );
-			if ( ! isset( $buckets[ $key ] ) ) {
-				$buckets[ $key ] = [];
-			}
-			$buckets[ $key ][] = $team;
-		}
-
 		// When scoped with `--team-id`, only the requested team's bucket is relevant –
-		// widening by author can pull in the owner's other, unrelated teams, so drop them.
-		if ( self::$team_id ) {
-			$target_key = $target->post_author . '|' . self::normalize_team_title( $target->post_title );
-			$buckets    = isset( $buckets[ $target_key ] ) ? [ $target_key => $buckets[ $target_key ] ] : [];
-		}
+		// widening by author can pull in the owner's other, unrelated teams, so restrict to it.
+		$only_key       = self::$team_id ? self::team_bucket_key( $target ) : null;
+		$buckets        = self::bucket_teams_by_owner( $teams, $only_key );
 
 		$duplicate_sets = array_filter(
 			$buckets,
@@ -372,14 +361,54 @@ class Teams_For_Memberships_Diagnostics {
 	}
 
 	/**
+	 * Build the owner+title bucketing key for a team.
+	 *
+	 * The `|` separator keeps the author/title boundary unambiguous so two distinct
+	 * (author, title) pairs can never collide on a shared prefix.
+	 *
+	 * @param \WP_Post|object $team Team post (or any object exposing post_author + post_title).
+	 * @return string
+	 */
+	public static function team_bucket_key( $team ) {
+		return $team->post_author . '|' . self::normalize_team_title( $team->post_title );
+	}
+
+	/**
+	 * Group teams into duplicate buckets keyed by owner + normalized title.
+	 *
+	 * Extracted so the (otherwise hard-to-reach) `--team-id` scoping can be unit-tested:
+	 * widening the lookup to the owner can surface the owner's *other*, unrelated teams,
+	 * and `$only_key` is what guarantees a scoped run acts on the requested team's bucket
+	 * alone.
+	 *
+	 * @param array       $teams    Team posts/objects exposing post_author + post_title.
+	 * @param string|null $only_key When set, restrict the result to this bucket key (others dropped).
+	 * @return array<string,object[]> Map of bucket key => teams in that bucket.
+	 */
+	public static function bucket_teams_by_owner( array $teams, $only_key = null ) {
+		$buckets = [];
+		foreach ( $teams as $team ) {
+			$buckets[ self::team_bucket_key( $team ) ][] = $team;
+		}
+		if ( null !== $only_key ) {
+			$buckets = isset( $buckets[ $only_key ] ) ? [ $only_key => $buckets[ $only_key ] ] : [];
+		}
+		return $buckets;
+	}
+
+	/**
 	 * Normalize a team title into a duplicate-bucketing key.
 	 *
 	 * The renewal bug can regenerate a replacement team whose title differs from the
 	 * original only cosmetically – a possessive apostrophe ("Smith' Team" vs
-	 * "Smith's Team"), letter case, or surrounding whitespace. Bucketing on the raw
-	 * title files those as separate teams and the duplicate goes undetected, so collapse
-	 * those differences to a single comparison key. The result is only ever used as a
-	 * grouping key, never displayed.
+	 * "Smith's Team"), letter case, or surrounding whitespace – so collapse those
+	 * differences to a single comparison key. The collapse is intentionally aggressive:
+	 * it strips every straight or curly apostrophe plus an optional trailing 's', so even
+	 * unrelated titles that differ only by a possessive map together. That's safe because
+	 * Check 1 only ever merges subscription-less orphans of the *same owner*
+	 * (see classify_team_bucket()) – independently subscribed teams are never merged.
+	 * Case folding of non-ASCII letters depends on mbstring; without it only ASCII case is
+	 * collapsed. The result is only ever a grouping key, never displayed.
 	 *
 	 * @param string $title Raw team post_title.
 	 * @return string
@@ -387,10 +416,11 @@ class Teams_For_Memberships_Diagnostics {
 	public static function normalize_team_title( $title ) {
 		$title = function_exists( 'mb_strtolower' ) ? mb_strtolower( (string) $title ) : strtolower( (string) $title );
 		// Drop possessive markers: a straight or curly apostrophe with an optional trailing
-		// 's', so "collyns'" and "collyns's" collapse to the same stem.
-		$title = preg_replace( '/[\'\x{2019}]s?/u', '', $title );
+		// 's', so "collyns'" and "collyns's" collapse to the same stem. The `/u` modifier can
+		// return null on malformed UTF-8 – coalesce to '' so the value stays a string.
+		$title = preg_replace( '/[\'\x{2019}]s?/u', '', $title ) ?? '';
 		// Collapse internal whitespace runs and trim.
-		$title = trim( (string) preg_replace( '/\s+/u', ' ', (string) $title ) );
+		$title = trim( (string) preg_replace( '/\s+/u', ' ', $title ) );
 		return $title;
 	}
 

--- a/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
@@ -148,20 +148,26 @@ class Teams_For_Memberships_Diagnostics {
 	}
 
 	/**
-	 * Check 1: duplicate teams with the same title + post_author.
+	 * Check 1: duplicate teams owned by the same author (title-insensitive).
 	 *
 	 * These appear when SkyVerge Teams creates a replacement team on renewal
-	 * because the subscription's line item lost its dispatch meta.
+	 * because the subscription's line item lost its dispatch meta. The replacement's
+	 * title can differ from the original only cosmetically (a possessive apostrophe,
+	 * case, or whitespace), so teams are bucketed by owner + a normalized title rather
+	 * than an exact title match – otherwise such an orphan escapes detection and leaves
+	 * a membership stranded. See normalize_team_title().
 	 *
 	 * @return void
 	 */
 	private static function check_duplicate_teams() {
-		WP_CLI::line( 'Check 1: duplicate teams (same title + same post_author)' );
+		WP_CLI::line( 'Check 1: duplicate teams (same owner, title-insensitive)' );
 
 		if ( self::$team_id ) {
 			// A naive `get_all_teams()` here returns the single requested row and Check 1
-			// becomes a no-op. Widen the search to every team sharing the target team's
-			// title + author so `--team-id` can still surface a known-duplicated team.
+			// becomes a no-op. Widen the search to every team owned by the same author so
+			// `--team-id` can still surface a known-duplicated team. Titles are bucketed
+			// insensitively below, so an orphan whose title differs only cosmetically still
+			// groups in.
 			$target = get_post( self::$team_id );
 			if ( ! $target || 'wc_memberships_team' !== $target->post_type ) {
 				WP_CLI::warning( '  SKIP: --team-id does not point to a wc_memberships_team post.' );
@@ -174,7 +180,6 @@ class Teams_For_Memberships_Diagnostics {
 					'post_status'    => 'any',
 					'posts_per_page' => -1,
 					'author'         => $target->post_author,
-					'title'          => $target->post_title,
 				]
 			);
 		} else {
@@ -183,11 +188,18 @@ class Teams_For_Memberships_Diagnostics {
 
 		$buckets = [];
 		foreach ( $teams as $team ) {
-			$key = $team->post_author . '|' . $team->post_title;
+			$key = $team->post_author . '|' . self::normalize_team_title( $team->post_title );
 			if ( ! isset( $buckets[ $key ] ) ) {
 				$buckets[ $key ] = [];
 			}
 			$buckets[ $key ][] = $team;
+		}
+
+		// When scoped with `--team-id`, only the requested team's bucket is relevant –
+		// widening by author can pull in the owner's other, unrelated teams, so drop them.
+		if ( self::$team_id ) {
+			$target_key = $target->post_author . '|' . self::normalize_team_title( $target->post_title );
+			$buckets    = isset( $buckets[ $target_key ] ) ? [ $target_key => $buckets[ $target_key ] ] : [];
 		}
 
 		$duplicate_sets = array_filter(
@@ -357,6 +369,29 @@ class Teams_For_Memberships_Diagnostics {
 			'separate_purchases'   => [],
 			'unattributed_orphans' => [],
 		];
+	}
+
+	/**
+	 * Normalize a team title into a duplicate-bucketing key.
+	 *
+	 * The renewal bug can regenerate a replacement team whose title differs from the
+	 * original only cosmetically – a possessive apostrophe ("Smith' Team" vs
+	 * "Smith's Team"), letter case, or surrounding whitespace. Bucketing on the raw
+	 * title files those as separate teams and the duplicate goes undetected, so collapse
+	 * those differences to a single comparison key. The result is only ever used as a
+	 * grouping key, never displayed.
+	 *
+	 * @param string $title Raw team post_title.
+	 * @return string
+	 */
+	public static function normalize_team_title( $title ) {
+		$title = function_exists( 'mb_strtolower' ) ? mb_strtolower( (string) $title ) : strtolower( (string) $title );
+		// Drop possessive markers: a straight or curly apostrophe with an optional trailing
+		// 's', so "collyns'" and "collyns's" collapse to the same stem.
+		$title = preg_replace( '/[\'\x{2019}]s?/u', '', $title );
+		// Collapse internal whitespace runs and trim.
+		$title = trim( (string) preg_replace( '/\s+/u', ' ', (string) $title ) );
+		return $title;
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/teams-for-memberships-diagnostics.php
+++ b/plugins/newspack-plugin/tests/unit-tests/teams-for-memberships-diagnostics.php
@@ -118,4 +118,31 @@ class Test_Teams_For_Memberships_Diagnostics extends WP_UnitTestCase {
 		$this->assertEqualSets( [ 200 ], wp_list_pluck( $result['duplicates'], 'ID' ), 'The newer unlinked team is the duplicate.' );
 		$this->assertEmpty( $result['separate_purchases'] );
 	}
+
+	/**
+	 * The renewal bug can regenerate the replacement team with a cosmetically different
+	 * title – a different possessive apostrophe, letter case, or stray whitespace. Those
+	 * variants must normalize to one bucket key, or Check 1 never groups the duplicate and
+	 * the orphan escapes repair (the gap that left a paying reader's membership stranded:
+	 * "John Collyns' Team" vs "John Collyns's Team").
+	 */
+	public function test_cosmetic_title_variants_share_one_bucket_key() {
+		$apostrophe_only = Teams_For_Memberships_Diagnostics::normalize_team_title( "John Collyns' Team" );
+		$apostrophe_s    = Teams_For_Memberships_Diagnostics::normalize_team_title( "John Collyns's Team" );
+		$case_and_space  = Teams_For_Memberships_Diagnostics::normalize_team_title( "  JOHN   Collyns's   TEAM  " );
+
+		$this->assertSame( $apostrophe_only, $apostrophe_s, "Collyns' and Collyns's must bucket together." );
+		$this->assertSame( $apostrophe_only, $case_and_space, 'Case and whitespace must not split the bucket.' );
+	}
+
+	/**
+	 * Normalization must not over-collapse: genuinely different team names keep distinct
+	 * keys, so separate memberships are never grouped (and merged) into each other.
+	 */
+	public function test_distinct_titles_keep_distinct_bucket_keys() {
+		$acme = Teams_For_Memberships_Diagnostics::normalize_team_title( "Acme Co's Team" );
+		$beta = Teams_For_Memberships_Diagnostics::normalize_team_title( "Beta LLC's Team" );
+
+		$this->assertNotSame( $acme, $beta, 'Different team names must not collapse into one bucket.' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/teams-for-memberships-diagnostics.php
+++ b/plugins/newspack-plugin/tests/unit-tests/teams-for-memberships-diagnostics.php
@@ -145,4 +145,76 @@ class Test_Teams_For_Memberships_Diagnostics extends WP_UnitTestCase {
 
 		$this->assertNotSame( $acme, $beta, 'Different team names must not collapse into one bucket.' );
 	}
+
+	/**
+	 * WordPress runs stored titles through wptexturize, which rewrites a straight apostrophe
+	 * to a curly one (U+2019). That curly variant is the load-bearing case the real stranded
+	 * membership hit, so the regex's curly branch and the `/u` modifier must collapse it to
+	 * the same key as the straight form – an ASCII-only assertion would miss the actual fix.
+	 */
+	public function test_curly_apostrophe_normalizes_like_straight() {
+		$straight        = Teams_For_Memberships_Diagnostics::normalize_team_title( "John Collyns' Team" );
+		$curly           = Teams_For_Memberships_Diagnostics::normalize_team_title( 'John Collyns’ Team' );
+		$curly_possessive = Teams_For_Memberships_Diagnostics::normalize_team_title( 'John Collyns’s Team' );
+
+		$this->assertSame( $straight, $curly, 'A curly apostrophe must bucket with the straight form.' );
+		$this->assertSame( $straight, $curly_possessive, 'A curly possessive-s must bucket with it too.' );
+	}
+
+	/**
+	 * The `--team-id` path widens the lookup to every team owned by the same author, then
+	 * restricts to the target team's bucket. An owner who has the duplicated team *and* a
+	 * genuinely distinct second team must see only the duplicate's bucket – the unrelated
+	 * team is never pulled into the merge set.
+	 */
+	public function test_team_id_scope_returns_only_the_targets_bucket() {
+		$original  = (object) [
+			'ID'          => 10,
+			'post_author' => 7,
+			'post_title'  => "Smith's Team",
+		];
+		$orphan    = (object) [
+			'ID'          => 11,
+			'post_author' => 7,
+			'post_title'  => "Smith' Team",
+		];
+		$unrelated = (object) [
+			'ID'          => 12,
+			'post_author' => 7,
+			'post_title'  => 'Garden Club',
+		];
+
+		$only_key = Teams_For_Memberships_Diagnostics::team_bucket_key( $original );
+		$buckets  = Teams_For_Memberships_Diagnostics::bucket_teams_by_owner( [ $original, $orphan, $unrelated ], $only_key );
+
+		$this->assertCount( 1, $buckets, "Only the target team's bucket is returned." );
+		$bucketed_ids = wp_list_pluck( array_values( $buckets )[0], 'ID' );
+		$this->assertEqualSets( [ 10, 11 ], $bucketed_ids, 'The apostrophe-variant orphan buckets with the original; the unrelated team is excluded.' );
+	}
+
+	/**
+	 * Without a scope key, every owner+title bucket is returned (the site-wide pass), so
+	 * the unrelated team forms its own single-team bucket rather than vanishing.
+	 */
+	public function test_unscoped_bucketing_keeps_every_owner_title_group() {
+		$original  = (object) [
+			'ID'          => 10,
+			'post_author' => 7,
+			'post_title'  => "Smith's Team",
+		];
+		$orphan    = (object) [
+			'ID'          => 11,
+			'post_author' => 7,
+			'post_title'  => "Smith' Team",
+		];
+		$unrelated = (object) [
+			'ID'          => 12,
+			'post_author' => 7,
+			'post_title'  => 'Garden Club',
+		];
+
+		$buckets = Teams_For_Memberships_Diagnostics::bucket_teams_by_owner( [ $original, $orphan, $unrelated ] );
+
+		$this->assertCount( 2, $buckets, 'The duplicated pair and the unrelated team are separate buckets.' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`teams-for-memberships diagnostics` Check 1 detects renewal-bug duplicate teams by bucketing on exact `post_author` + `post_title`. The SkyVerge Teams renewal bug can regenerate the replacement (orphan) team with a title that differs from the original only cosmetically – a possessive apostrophe (`John Collyns' Team` vs `John Collyns's Team`), letter case, or whitespace. Such an orphan lands in its own bucket, is never flagged as a duplicate, and both `--fix` and `--team-id` silently skip it – leaving a paying member's membership stranded on the orphan with no detection.

This change buckets teams by **owner + a normalized title** (case-, possessive-apostrophe-, and whitespace-insensitive) instead of an exact title match, and widens the `--team-id` path to the team's owner so a scoped run catches the variant too. The existing separate-purchase guard still applies per bucket, so an owner who legitimately holds multiple subscribed teams is never merged.

Prior work in this area:
- https://github.com/Automattic/newspack-plugin/pull/4661 – prevents the duplicate teams on stripped-meta renewals
- https://github.com/Automattic/newspack-plugin/pull/4662 – the original diagnostics command
- https://github.com/Automattic/newspack-workspace/pull/380 – separate-purchase (≥2 subscribed) guard

Refs https://linear.app/a8c/issue/NPPM-2741 – a real reader was found stranded exactly this way (orphan titled `X's Team` vs original `X' Team`); fixed manually, this closes the detection gap so the tool would catch it.

### How to test the changes in this Pull Request:

1. Create two `wc_memberships_team` posts owned by the same user with titles differing only by a possessive apostrophe, e.g. `Smith' Team` and `Smith's Team`; give one a `_subscription_id` (the original) and leave the other without (the orphan).
2. Run `wp newspack teams-for-memberships diagnostics`. On `main` Check 1 reports `OK: no duplicates`; with this branch it reports the orphan as a duplicate of the subscribed original, and `--team-id=<original> --fix` merges + relinks it.
3. `cd plugins/newspack-plugin && n test-php --filter Test_Teams_For_Memberships_Diagnostics` → green (includes the new normalization spec).

### Other information:

- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?