### PR TITLE
fix(newsletters): create account on logged-in block signup (NPPM-2936)

### DIFF
--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -496,6 +496,9 @@ function process_form() {
 
 	$registered_user      = false;
 	$verification_payload = [];
+	// Default to "did not authenticate" so the response-side registration gate below is safe
+	// even when Reader Activation is disabled/unavailable (the branch that assigns it is skipped).
+	$authenticate         = false;
 	if ( \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
 		if ( $popup_id ) {

--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -498,7 +498,7 @@ function process_form() {
 	$verification_payload = [];
 	// Default to "did not authenticate" so the response-side registration gate below is safe
 	// even when Reader Activation is disabled/unavailable (the branch that assigns it is skipped).
-	$authenticate         = false;
+	$authenticate = false;
 	if ( \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
 		if ( $popup_id ) {

--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -496,20 +496,33 @@ function process_form() {
 
 	$registered_user      = false;
 	$verification_payload = [];
-	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+	if ( \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
 		if ( $popup_id ) {
 			$metadata['registration_method'] = 'newsletters-subscription-popup';
 		}
-		$registered_user = \Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
+		// Authenticate the new reader only when the browser has no existing session. A
+		// logged-in browser (a returning reader, or a shared device still carrying a prior
+		// reader's cookie) must still get an account created for the submitted email — but
+		// without re-authenticating as that email. Skipping registration entirely when logged
+		// in is what silently orphaned these signups: the email landed in the ESP list with
+		// no WordPress account. See NPPM-2936.
+		$authenticate    = ! \is_user_logged_in();
+		$registered_user = \Newspack\Reader_Activation::register_reader( $email, $name, $authenticate, $metadata );
 		// register_reader() can return false (existing user) or a WP_Error; only proceed when
 		// we got a positive integer user ID for a freshly-created reader.
-		if ( is_int( $registered_user ) && $registered_user > 0 ) {
+		// Only signal a registration to the current browser when this signup authenticated
+		// the new reader (a clean, logged-out visitor). When a reader is already logged in we
+		// create the account for the submitted email without authenticating it, so the current
+		// session must not be told "you just registered" — otherwise the other reader's
+		// registration (its `registered` flag, verification prompt, and `reader_registered`
+		// activity) would be recorded against this browser's reader. See NPPM-2936.
+		if ( $authenticate && is_int( $registered_user ) && $registered_user > 0 ) {
 			$metadata['registered'] = '1';
 
 			// Surface verification state so the frontend can trigger the post-registration
-			// verification flow. Guarded with method_exists so we degrade gracefully when running
-			// against an older newspack-plugin that doesn't expose the helper yet.
+			// verification flow. Guarded with method_exists so we degrade gracefully when
+			// running against an older newspack-plugin that doesn't expose the helper yet.
 			if ( method_exists( '\Newspack\Reader_Activation', 'get_verification_payload' ) ) {
 				$verification_payload = \Newspack\Reader_Activation::get_verification_payload( (int) $registered_user );
 			}
@@ -564,11 +577,13 @@ function process_form() {
 	$result['metadata'] = $metadata;
 
 	// Surface registration + verification state so the frontend can trigger the
-	// post-registration verification flow when a brand-new reader account was created.
-	// `get_verification_payload()` always returns both `verified` and `verification_nonce`
-	// keys (with empty/null sentinels when not applicable); the frontend gates on the
-	// `verification_nonce` being a non-empty string.
-	if ( is_int( $registered_user ) && $registered_user > 0 ) {
+	// post-registration verification flow when a brand-new reader account was created and
+	// authenticated in this browser. `get_verification_payload()` always returns both
+	// `verified` and `verification_nonce` keys (with empty/null sentinels when not
+	// applicable); the frontend gates on the `verification_nonce` being a non-empty string.
+	// Skipped when a reader is already logged in: the new account belongs to a different
+	// email, not this session, so registration must not be surfaced to the current reader.
+	if ( $authenticate && is_int( $registered_user ) && $registered_user > 0 ) {
 		$result['email']      = $email;
 		$result['registered'] = 1;
 		$result               = array_merge( $result, $verification_payload );

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -2533,7 +2533,13 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_register_reader_disabled', __( 'Registration is disabled.', 'newspack-plugin' ) );
 		}
 
-		if ( \is_user_logged_in() ) {
+		// Registration is only blocked while logged in when it would also authenticate:
+		// a session can't be re-authenticated as a second identity. A non-authenticating
+		// registration is allowed so that a logged-in browser (e.g. a returning reader, or
+		// a shared device still carrying a prior reader's cookie) can still create an account
+		// for a different email — e.g. a Newsletter Subscription block signup — without
+		// hijacking the current session.
+		if ( \is_user_logged_in() && $authenticate ) {
 			return new \WP_Error( 'newspack_register_reader_logged_in', __( 'Cannot register while logged in.', 'newspack-plugin' ) );
 		}
 
@@ -2543,7 +2549,12 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_register_reader_empty_email', __( 'Please enter a valid email address.', 'newspack-plugin' ) );
 		}
 
-		self::set_auth_intention_cookie( $email );
+		// Only record an auth intention for a logged-out visitor. While logged in (a
+		// non-authenticating registration for a different email) the browser has no pending
+		// authentication, so the intention cookie must not be overwritten with the other email.
+		if ( ! \is_user_logged_in() ) {
+			self::set_auth_intention_cookie( $email );
+		}
 
 		$existing_user = \get_user_by( 'email', $email );
 		if ( \is_wp_error( $existing_user ) ) {
@@ -2555,7 +2566,13 @@ final class Reader_Activation {
 		if ( $existing_user ) {
 			// If the user is not a reader, send a non-reader login reminder. We don't want to expose on the front-end that the email address belongs to a non-reader account.
 			if ( ! self::is_user_reader( $existing_user ) ) {
-				self::send_non_reader_login_reminder( $existing_user );
+				// The "you already have an account, log in" reminder only makes sense for a
+				// logged-out registration attempt. While logged in (a non-authenticating
+				// registration for someone else's existing non-reader account) suppress it: the
+				// email's owner did not initiate this, and may even be the current user.
+				if ( ! \is_user_logged_in() ) {
+					self::send_non_reader_login_reminder( $existing_user );
+				}
 				return false;
 			}
 

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
@@ -49,6 +49,91 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A reader already authenticated in the browser (e.g. a returning reader, or a
+	 * shared/public device still carrying a prior reader's remember-me cookie) must
+	 * still get a WordPress account created when subscribing with a DIFFERENT email,
+	 * without hijacking the current session.
+	 *
+	 * Reproduces NPPM-2936: the Newsletter Subscription block authenticates the reader
+	 * on the first signup (register_reader -> set_current_reader -> remember-me cookie),
+	 * so a second back-to-back signup from the same browser was treated as logged-in and
+	 * silently skipped account creation — while the email was still pushed to the ESP
+	 * list, leaving a list subscription with no account.
+	 */
+	public function test_register_reader_while_logged_in_creates_account_without_hijacking_session() {
+		// First signup from a clean session creates and authenticates the reader.
+		$first_reader_id = Reader_Activation::register_reader( 'first-signup@test.com', 'First Signup', true );
+		$this->assertIsInt( $first_reader_id );
+		$this->assertSame( $first_reader_id, get_current_user_id(), 'First signup should authenticate the reader.' );
+		$this->assertTrue( is_user_logged_in() );
+
+		// A different email is then submitted from the same (now authenticated) browser,
+		// exactly as the subscription block does for a logged-in visitor: register without
+		// re-authenticating.
+		$second_reader_id = Reader_Activation::register_reader(
+			'second-signup@test.com',
+			'Second Signup',
+			false, // Do not authenticate: preserve the current session.
+			[ 'registration_method' => 'newsletters-subscription' ]
+		);
+
+		// The second email must get its own real reader account...
+		$this->assertIsInt( $second_reader_id, 'A logged-in browser submitting a different email must still create an account.' );
+		$second_reader = get_user_by( 'email', 'second-signup@test.com' );
+		$this->assertInstanceOf( 'WP_User', $second_reader );
+		$this->assertTrue( (bool) get_user_meta( $second_reader->ID, Reader_Activation::READER, true ), 'The second account must be a real reader account, not a bare WP user.' );
+
+		// ...without changing who is logged in.
+		$this->assertSame( $first_reader_id, get_current_user_id(), 'Creating the second account must not hijack the current session.' );
+
+		wp_delete_user( $first_reader_id );  // Clean up.
+		wp_delete_user( $second_reader_id ); // Clean up.
+	}
+
+	/**
+	 * The dominant real-world path: a returning reader who is still logged in re-subscribes
+	 * via the block with their OWN email. This must be a no-op — reuse the existing account,
+	 * create no duplicate, preserve the session, and send no email. The "no email" guard is
+	 * load-bearing: the magic-link/OTP for a passwordless reader is suppressed only because
+	 * the registration method contains `newsletters-subscription`; a regression there would
+	 * silently email returning readers on every signup.
+	 */
+	public function test_register_reader_while_logged_in_with_own_email_is_noop() {
+		// A returning reader is already authenticated in this browser (passwordless, as RAS
+		// readers are — so the magic-link branch is genuinely exercised).
+		$reader_id = Reader_Activation::register_reader( 'returning@test.com', 'Returning Reader', true );
+		$this->assertIsInt( $reader_id );
+		$this->assertSame( $reader_id, get_current_user_id() );
+		$this->assertTrue( Reader_Activation::is_reader_without_password( $reader_id ), 'Test precondition: the reader must be passwordless to exercise the OTP-suppression path.' );
+
+		// Capture any outgoing email to prove the re-subscribe is side-effect-free.
+		$sent_emails = 0;
+		$email_counter = function ( $args ) use ( &$sent_emails ) {
+			$sent_emails++;
+			return $args;
+		};
+		add_filter( 'wp_mail', $email_counter );
+
+		// The reader re-subscribes via the block with their OWN (current) email.
+		$result = Reader_Activation::register_reader(
+			'returning@test.com',
+			'Returning Reader',
+			false, // Logged in: do not authenticate.
+			[ 'registration_method' => 'newsletters-subscription' ]
+		);
+
+		remove_filter( 'wp_mail', $email_counter );
+
+		// Existing account reused (false), no duplicate, no email, session preserved.
+		$this->assertFalse( $result, 'Re-subscribing with the current reader\'s own email must not create a second account.' );
+		$this->assertSame( $reader_id, get_user_by( 'email', 'returning@test.com' )->ID, 'The existing reader account must be reused, not duplicated.' );
+		$this->assertSame( 0, $sent_emails, 'Re-subscribing via the block must not send a magic link or login reminder.' );
+		$this->assertSame( $reader_id, get_current_user_id(), 'Session must be preserved.' );
+
+		wp_delete_user( $reader_id ); // Clean up.
+	}
+
+	/**
 	 * Test that verifying a reader register the proper meta.
 	 */
 	public function test_verify_reader_email() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the Newspack Contributing guidelines?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

NPPM-2936

The Newsletter Subscription block did not create a WordPress user account when the visitor's browser already carried a Newspack reader auth cookie — a returning reader, or a shared/public device still holding a prior reader's remember-me cookie. The submitted email was still pushed to the ESP, producing a list subscription with no account.

**Root cause:** a successful signup calls `Reader_Activation::register_reader( …, $authenticate = true )`, which runs `set_current_reader()` and sets a persistent (remember-me) auth cookie. Every later signup from that browser was then treated as logged-in, so `process_form()` (and `register_reader()` itself) skipped account creation while the ESP subscribe ran unconditionally.

**Changes:**
- `Reader_Activation::register_reader()`: the logged-in guard now only blocks *re-authentication* (`is_user_logged_in() && $authenticate`), so a non-authenticating registration is allowed while logged in — creating an account for the submitted email without hijacking the current session. Backward-compatible: every existing caller passes `$authenticate = true`.
- Subscription block `process_form()`: always attempts registration when Audience Management is enabled, passing `$authenticate = ! is_user_logged_in()`. Front-end registration signals (verification prompt, `registered` flag, `reader_registered` activity) are surfaced only when the signup authenticated the new reader, so a different reader's registration is never recorded against the current session.
- `register_reader()` side effects scoped to the logged-out flow: the auth-intention cookie and the non-reader login reminder no longer fire while logged in.

### How to test the changes in this Pull Request:

1. On a site with Audience Management (RAS) enabled and a Newsletter Subscription block on a page, in a clean browser, sign up with email A → a reader account is created and you are logged in.
2. Without clearing cookies (same browser/session), sign up again with a different email B.
3. **Before** this PR: B is subscribed to the list but no WordPress account is created for B. **After** this PR: B gets its own reader account, and the session stays as A (you are not re-logged-in as B).
4. Sign up again with A's own email → no duplicate account, no email sent, session unchanged.
5. `cd plugins/newspack-plugin && n test-php --filter Newspack_Test_Reader_Activation`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)