### PR TITLE
fix(checkout): sync repeat trial pricing in modal checkout

### DIFF
--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -205,6 +205,8 @@ final class Modal_Checkout {
 		// Make the current cart price available to the JavaScript.
 		add_action( 'wp_ajax_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
 		add_action( 'wp_ajax_nopriv_get_cart_total', [ __CLASS__, 'get_cart_total_js' ] );
+		add_action( 'wp_ajax_get_cart_product_summary', [ __CLASS__, 'get_cart_product_summary_js' ] );
+		add_action( 'wp_ajax_nopriv_get_cart_product_summary', [ __CLASS__, 'get_cart_product_summary_js' ] );
 
 		// Wrap required checkbox text in a span so it works nicely with the Newspack UI grid layout.
 		add_filter( 'woocommerce_form_field_checkbox', [ __CLASS__, 'wrap_required_checkbox_text' ], 10, 4 );
@@ -1767,6 +1769,112 @@ final class Modal_Checkout {
 	}
 
 	/**
+	 * Get validated cart item context for the modal checkout product summary.
+	 *
+	 * @param \WC_Cart $cart Cart object.
+	 *
+	 * @return array|null
+	 */
+	private static function get_cart_product_summary_context( $cart ) {
+		if ( ! $cart || 1 !== $cart->get_cart_contents_count() ) {
+			return null;
+		}
+		$cart_item_key = array_key_first( $cart->get_cart() );
+		$cart_item     = $cart->get_cart_item( $cart_item_key );
+
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
+		$product    = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+		$is_visible = $product && $product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key );
+		// phpcs:enable
+
+		return [
+			'cart_item_key' => $cart_item_key,
+			'cart_item'     => $cart_item,
+			'product'       => $product,
+			'is_visible'    => $is_visible,
+		];
+	}
+
+	/**
+	 * Get the cart product summary shown at the top of modal checkout.
+	 *
+	 * @param \WC_Cart|null $cart    Cart object.
+	 * @param array|null    $context Validated cart item context.
+	 */
+	private static function get_cart_product_summary( $cart = null, $context = null ) {
+		if ( ! $cart ) {
+			if ( ! function_exists( 'WC' ) ) {
+				return '';
+			}
+			$cart = \WC()->cart;
+		}
+		$context = $context ? $context : self::get_cart_product_summary_context( $cart );
+		if ( ! $context || ! $context['is_visible'] ) {
+			return '';
+		}
+
+		$cart_item_key    = $context['cart_item_key'];
+		$cart_item        = $context['cart_item'];
+		$product          = $context['product'];
+		$allowed_html     = self::get_cart_product_summary_allowed_html();
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
+		$product_name     = apply_filters(
+			'woocommerce_cart_item_name',
+			$product->get_name(),
+			$cart_item,
+			$cart_item_key
+		);
+		$product_subtotal = apply_filters(
+			'woocommerce_cart_item_subtotal',
+			$cart->get_product_subtotal( $product, $cart_item['quantity'] ),
+			$cart_item,
+			$cart_item_key
+		);
+		// phpcs:enable
+
+		$summary = $product_name . ': ';
+		if ( function_exists( 'wc_get_formatted_cart_item_data' ) ) {
+			$summary .= wc_get_formatted_cart_item_data( $cart_item );
+		}
+		$summary .= $product_subtotal;
+		return wp_kses( $summary, $allowed_html );
+	}
+
+	/**
+	 * Get allowed HTML for the modal checkout product summary.
+	 *
+	 * @return array Allowed HTML tags and attributes.
+	 */
+	private static function get_cart_product_summary_allowed_html() {
+		$allowed_html = wp_kses_allowed_html( 'post' );
+
+		$allowed_html['bdi'] = [
+			'class' => true,
+			'dir'   => true,
+		];
+
+		if ( ! isset( $allowed_html['span'] ) ) {
+			$allowed_html['span'] = [];
+		}
+		$allowed_html['span']['class'] = true;
+
+		if ( ! isset( $allowed_html['small'] ) ) {
+			$allowed_html['small'] = [];
+		}
+		$allowed_html['small']['class'] = true;
+
+		return $allowed_html;
+	}
+
+	/**
+	 * Get the updated cart product summary for JavaScript.
+	 */
+	public static function get_cart_product_summary_js() {
+		echo self::get_cart_product_summary(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		wp_die();
+	}
+
+	/**
 	 * Get the updated price for updating the "Place order" button.
 	 */
 	public static function get_cart_total_js() {
@@ -1792,29 +1900,20 @@ final class Modal_Checkout {
 		if ( 1 !== $cart->get_cart_contents_count() ) {
 			return;
 		}
-		$cart_item_key = array_key_first( $cart->get_cart() );
-		$cart_item = $cart->get_cart_item( $cart_item_key );
-		$product_id = $cart_item['variation_id'] ? $cart_item['variation_id'] : $cart_item['product_id'];
-		$class_prefix = self::get_class_prefix();
+		$summary_context = self::get_cart_product_summary_context( $cart );
+		$class_prefix    = self::get_class_prefix();
 		?>
 			<div class="<?php echo esc_attr( "order-details-summary {$class_prefix}__box {$class_prefix}__box--text-center" ); ?>">
 			<?php
-			// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WooCommerce hooks.
-			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
-			if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) :
+			if ( $summary_context && $summary_context['is_visible'] ) :
 				?>
 				<p id="modal-checkout-product-details" data-checkout='<?php echo wp_json_encode( Checkout_Data::get_checkout_data( $cart ) ); ?>'>
 					<strong>
-						<?php
-						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . ': '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						?>
-						<?php echo apply_filters( 'woocommerce_cart_item_subtotal', $cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo self::get_cart_product_summary( $cart, $summary_context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</strong>
 				</p>
 				<?php
 			endif;
-			// phpcs:enable
 			?>
 			</div>
 		<?php
@@ -1965,7 +2064,25 @@ final class Modal_Checkout {
 	 * @return false|int User ID if found by email address, false otherwise.
 	 */
 	public static function get_user_id_from_email() {
-		$billing_email = filter_input( INPUT_POST, 'billing_email', FILTER_SANITIZE_EMAIL );
+		$billing_email = '';
+		if ( isset( $_POST['billing_email'] ) && is_string( $_POST['billing_email'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$billing_email = sanitize_email( wp_unslash( $_POST['billing_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+
+		if ( ! $billing_email ) {
+			$post_data = '';
+			if ( isset( $_POST['post_data'] ) && is_string( $_POST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				$post_data = wp_unslash( $_POST['post_data'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Parsed and sanitized below.
+			}
+
+			// WooCommerce order-review requests send checkout fields serialized in post_data.
+			if ( $post_data ) {
+				wp_parse_str( $post_data, $parsed_post_data );
+				if ( isset( $parsed_post_data['billing_email'] ) && is_string( $parsed_post_data['billing_email'] ) ) {
+					$billing_email = sanitize_email( $parsed_post_data['billing_email'] );
+				}
+			}
+		}
 		if ( $billing_email ) {
 			$customer = \get_user_by( 'email', $billing_email );
 			if ( $customer ) {
@@ -2251,6 +2368,7 @@ final class Modal_Checkout {
 		if ( $user_id !== 0 ) {
 			return $is_limited_for_user;
 		}
+		// Standard and modal checkout refreshes can both carry guest emails in serialized post_data.
 		$id_from_email = self::get_user_id_from_email();
 		if ( $id_from_email ) {
 			$is_limited_for_user = wcs_is_product_limited_for_user( $product, $id_from_email );

--- a/plugins/newspack-blocks/src/modal-checkout/index.js
+++ b/plugins/newspack-blocks/src/modal-checkout/index.js
@@ -209,6 +209,80 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 				} );
 
 				/**
+				 * Keep the static product summary aligned with recalculated order-review totals.
+				 */
+				function setProductSummary( productDetails, allowHtml = true ) {
+					const $productDetails = $( '#modal-checkout-product-details strong' );
+					if ( ! $productDetails.length || ! productDetails ) {
+						return false;
+					}
+					if ( allowHtml && $productDetails.html() !== productDetails ) {
+						$productDetails.html( productDetails );
+					} else if ( ! allowHtml && $productDetails.text() !== productDetails ) {
+						$productDetails.text( productDetails );
+					}
+					return true;
+				}
+				let productSummaryRequest = false;
+				function getCheckoutPostData() {
+					const $checkoutForm = $( 'form.checkout' );
+					// Repeat-trial checks can only resolve once the checkout form includes a billing email.
+					return $checkoutForm.length ? $checkoutForm.serialize() : '';
+				}
+				function requestUpdatedProductSummary() {
+					if ( productSummaryRequest ) {
+						productSummaryRequest.abort();
+					}
+					const request = $.ajax( {
+						url: newspackBlocksModalCheckout.ajax_url,
+						method: 'POST',
+						data: {
+							action: 'get_cart_product_summary',
+							modal_checkout: 1,
+							post_data: getCheckoutPostData(),
+						},
+						success: response => {
+							if ( productSummaryRequest === request ) {
+								setProductSummary( response );
+							}
+						},
+						complete: () => {
+							if ( productSummaryRequest === request ) {
+								productSummaryRequest = false;
+							}
+						},
+					} );
+					productSummaryRequest = request;
+				}
+				function updateProductSummaryFromOrderReview() {
+					const $cartItem = $( '.order-review-wrapper .woocommerce-checkout-review-order-table tr.cart_item' ).first();
+					if ( ! $cartItem.length ) {
+						return false;
+					}
+
+					const $productName = $cartItem.find( '.product-name' ).clone();
+					$productName.find( '.product-quantity' ).remove();
+					// Keep the DOM path text-only; the AJAX fallback is the HTML path because PHP runs it through wp_kses.
+					const productName = $productName.text().replace( /\s+/g, ' ' ).trim();
+					const productTotal = $cartItem.find( '.product-total' ).text().replace( /\s+/g, ' ' ).trim();
+					if ( productName && productTotal ) {
+						return setProductSummary( `${ productName }: ${ productTotal }`, false );
+					}
+					return false;
+				}
+				function syncProductSummary() {
+					if ( updateProductSummaryFromOrderReview() ) {
+						if ( productSummaryRequest ) {
+							productSummaryRequest.abort();
+							productSummaryRequest = false;
+						}
+						return;
+					}
+					requestUpdatedProductSummary();
+				}
+				$( document ).on( 'updated_checkout', syncProductSummary );
+
+				/**
 				 * Toggle Transaction Details
 				 */
 				$( document ).on( 'click', '#order_review_heading', function () {
@@ -223,44 +297,60 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 				/**
 				 * Get updated cart total to update the "Place Order" button.
 				 */
-				function getUpdatedCartTotal() {
-					let cartTotal;
-					$.ajax( {
+				function getOrderReviewCartTotal() {
+					return $( '.order-review-wrapper tr.order-total:not(.recurring-total) .amount' ).first().text().replace( /\s+/g, ' ' ).trim();
+				}
+				let cartTotalRequest = false;
+				function requestUpdatedCartTotal( cb ) {
+					if ( cartTotalRequest ) {
+						cartTotalRequest.abort();
+					}
+					const request = $.ajax( {
 						url: newspackBlocksModalCheckout.ajax_url,
 						method: 'POST',
-						async: false,
 						data: {
 							action: 'get_cart_total',
+							modal_checkout: 1,
+							post_data: getCheckoutPostData(),
 						},
 						success: response => {
-							cartTotal = response;
+							if ( response && cartTotalRequest === request ) {
+								cb( response );
+							}
+						},
+						complete: () => {
+							if ( cartTotalRequest === request ) {
+								cartTotalRequest = false;
+							}
 						},
 					} );
-					if ( cartTotal ) {
-						return cartTotal;
-					}
+					cartTotalRequest = request;
 				}
 
 				/**
 				 * Update Place Order button text.
 				 */
-				$( document ).on( 'updated_checkout', function () {
+				function syncPlaceOrderButton( cartTotal = getOrderReviewCartTotal() ) {
 					// Update "Place Order" button to include current price.
 					let processOrderText = newspackBlocksModalCheckout.labels.complete_button;
 					if ( ! processOrderText ) {
 						return;
 					}
-					if ( $( '#place_order' ).has( $( 'span.cart-price' ) ) ) {
+					if ( cartTotal && $( '#place_order' ).has( $( 'span.cart-price' ) ) ) {
 						// Modify button text to include updated price.
 						const tree = $( '<div>' + processOrderText + '</div>' );
 						// Update the HTML in the .cart-price span with the new price, and return.
-						tree.find( '.cart-price' ).html( getUpdatedCartTotal, function () {
-							return this.childNodes;
-						} );
+						tree.find( '.cart-price' ).html( cartTotal );
 						processOrderText = tree.html();
 					}
 					$( '#place_order' ).html( processOrderText );
 					$( '#place_order_clone' ).html( processOrderText );
+					if ( ! cartTotal ) {
+						requestUpdatedCartTotal( syncPlaceOrderButton );
+					}
+				}
+				$( document ).on( 'updated_checkout', function () {
+					syncPlaceOrderButton();
 				} );
 
 				/**
@@ -558,6 +648,7 @@ import { domReady, onCheckoutPlaceOrderProcessing } from './utils';
 
 						// Disable 'Place Order' button if Subscription Confirmation is required.
 						handleSubscriptionConfirmation();
+						$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
 					}
 					$form.triggerHandler( 'editing_details', [ isEditingDetails ] );
 					// Scroll to top.

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -1,0 +1,419 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class ModalCheckoutTest
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Modal checkout.
+ */
+if ( ! function_exists( 'wcs_is_product_limited_for_user' ) ) {
+	/**
+	 * Mock WooCommerce Subscriptions product limiting.
+	 *
+	 * @param object $product Product.
+	 * @param int    $user_id User ID.
+	 *
+	 * @return bool
+	 */
+	function wcs_is_product_limited_for_user( $product, $user_id ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce Subscriptions global.
+		global $newspack_blocks_test_limited_product_id, $newspack_blocks_test_limited_user_id;
+
+		return (
+			$product &&
+			method_exists( $product, 'get_id' ) &&
+			(int) $product->get_id() === (int) $newspack_blocks_test_limited_product_id &&
+			(int) $user_id === (int) $newspack_blocks_test_limited_user_id
+		);
+	}
+}
+
+if ( ! function_exists( 'wcs_get_product_limitation' ) ) {
+	/**
+	 * Mock WooCommerce Subscriptions product limitation type.
+	 *
+	 * @param int $product_id Product ID.
+	 *
+	 * @return string
+	 */
+	function wcs_get_product_limitation( $product_id ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce Subscriptions global.
+		unset( $product_id );
+		return 'any';
+	}
+}
+
+class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+	/**
+	 * Clean up request data.
+	 */
+	public function tear_down() {
+		global $newspack_blocks_test_limited_product_id, $newspack_blocks_test_limited_user_id;
+		$newspack_blocks_test_limited_product_id = null;
+		$newspack_blocks_test_limited_user_id    = null;
+		remove_all_filters( 'woocommerce_cart_item_removed_message' );
+		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Set serialized checkout data in the request.
+	 *
+	 * @param string $post_data Serialized checkout data.
+	 */
+	private function set_serialized_post_data( $post_data ) {
+		$_POST['post_data']    = $post_data;
+		$_REQUEST['post_data'] = $post_data;
+	}
+
+	/**
+	 * Invoke the private cart product summary helper.
+	 *
+	 * @param object $cart Cart-like object.
+	 *
+	 * @return string
+	 */
+	private function get_cart_product_summary( $cart ) {
+		$method = new ReflectionMethod( \Newspack_Blocks\Modal_Checkout::class, 'get_cart_product_summary' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $cart );
+	}
+
+	/**
+	 * Create a cart-like object for product summary tests.
+	 *
+	 * @param array  $items Cart items.
+	 * @param string $subtotal Product subtotal HTML.
+	 *
+	 * @return object
+	 */
+	private function get_mock_cart( $items, $subtotal = '<span class="amount"><bdi>$29.00</bdi></span>' ) {
+		return new class( $items, $subtotal ) {
+			/**
+			 * Cart items.
+			 *
+			 * @var array
+			 */
+			private $items;
+
+			/**
+			 * Product subtotal HTML.
+			 *
+			 * @var string
+			 */
+			private $subtotal;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array  $items Cart items.
+			 * @param string $subtotal Product subtotal HTML.
+			 */
+			public function __construct( $items, $subtotal ) {
+				$this->items    = $items;
+				$this->subtotal = $subtotal;
+			}
+
+			/**
+			 * Get the cart contents count.
+			 *
+			 * @return int
+			 */
+			public function get_cart_contents_count() {
+				return array_sum( array_column( $this->items, 'quantity' ) );
+			}
+
+			/**
+			 * Get cart items.
+			 *
+			 * @return array
+			 */
+			public function get_cart() {
+				return $this->items;
+			}
+
+			/**
+			 * Get a cart item.
+			 *
+			 * @param string $key Cart item key.
+			 *
+			 * @return array
+			 */
+			public function get_cart_item( $key ) {
+				return $this->items[ $key ];
+			}
+
+			/**
+			 * Get the product subtotal.
+			 *
+			 * @param object $product Product.
+			 * @param int    $quantity Quantity.
+			 *
+			 * @return string
+			 */
+			public function get_product_subtotal( $product = null, $quantity = 1 ) {
+				unset( $product, $quantity );
+				return $this->subtotal;
+			}
+		};
+	}
+
+	/**
+	 * Create a product-like object for product summary tests.
+	 *
+	 * @param string $name Product name.
+	 *
+	 * @return object
+	 */
+	private function get_mock_product( $name = 'Newsroom Pro' ) {
+		return new class( $name ) {
+			/**
+			 * Product name.
+			 *
+			 * @var string
+			 */
+			private $name;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string $name Product name.
+			 */
+			public function __construct( $name ) {
+				$this->name = $name;
+			}
+
+			/**
+			 * Whether the product exists.
+			 *
+			 * @return bool
+			 */
+			public function exists() {
+				return true;
+			}
+
+			/**
+			 * Get the product name.
+			 *
+			 * @return string
+			 */
+			public function get_name() {
+				return $this->name;
+			}
+		};
+	}
+
+	/**
+	 * It finds users from a top-level billing email field.
+	 */
+	public function test_get_user_id_from_email_reads_top_level_billing_email() {
+		$user_id = self::factory()->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+
+		$_POST['billing_email'] = 'repeat@example.com';
+
+		$this->assertSame( $user_id, \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It finds users from WooCommerce's serialized order review post_data.
+	 */
+	public function test_get_user_id_from_email_reads_serialized_post_data() {
+		$user_id = self::factory()->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=repeat%40example.com&modal_checkout=1' );
+
+		$this->assertSame( $user_id, \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It preserves plus-addresses in WooCommerce's serialized order review post_data.
+	 */
+	public function test_get_user_id_from_email_reads_plus_address_from_serialized_post_data() {
+		$user_id = self::factory()->user->create(
+			[
+				'user_email' => 'admin+donationsrecaptcha@example.com',
+			]
+		);
+
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=admin%2Bdonationsrecaptcha%40example.com&modal_checkout=1' );
+
+		$this->assertSame( $user_id, \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It prefers a top-level billing email over serialized post_data.
+	 */
+	public function test_get_user_id_from_email_prefers_top_level_billing_email() {
+		$top_level_user_id = self::factory()->user->create(
+			[
+				'user_email' => 'top-level@example.com',
+			]
+		);
+		self::factory()->user->create(
+			[
+				'user_email' => 'serialized@example.com',
+			]
+		);
+
+		$_POST['billing_email'] = 'top-level@example.com';
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=serialized%40example.com&modal_checkout=1' );
+
+		$this->assertSame( $top_level_user_id, \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It returns false when no billing email is present.
+	 */
+	public function test_get_user_id_from_email_returns_false_without_email() {
+		$this->assertFalse( \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It returns false when serialized post_data has no billing email.
+	 */
+	public function test_get_user_id_from_email_returns_false_for_post_data_without_billing_email() {
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&modal_checkout=1' );
+
+		$this->assertFalse( \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It ignores non-string request data.
+	 */
+	public function test_get_user_id_from_email_ignores_non_string_request_data() {
+		$_POST['billing_email'] = [ 'repeat@example.com' ];
+		$_POST['post_data']     = [ 'billing_email=repeat%40example.com&modal_checkout=1' ];
+
+		$this->assertFalse( \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * Unknown emails should not resolve to a user.
+	 */
+	public function test_get_user_id_from_email_returns_false_for_unknown_email() {
+		$this->set_serialized_post_data( 'billing_first_name=New&billing_email=fresh%40example.com&modal_checkout=1' );
+
+		$this->assertFalse( \Newspack_Blocks\Modal_Checkout::get_user_id_from_email() );
+	}
+
+	/**
+	 * It associates modal checkout with an existing user found in serialized post_data.
+	 */
+	public function test_associate_existing_user_reads_serialized_post_data() {
+		$user_id = self::factory()->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=repeat%40example.com&modal_checkout=1' );
+
+		$this->assertSame( $user_id, \Newspack_Blocks\Modal_Checkout::associate_existing_user( 0 ) );
+	}
+
+	/**
+	 * It does not associate standard checkout requests with users from serialized post_data.
+	 */
+	public function test_associate_existing_user_ignores_serialized_post_data_outside_modal_checkout() {
+		self::factory()->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=repeat%40example.com' );
+
+		$this->assertSame( 123, \Newspack_Blocks\Modal_Checkout::associate_existing_user( 123 ) );
+	}
+
+	/**
+	 * It keeps the current customer ID when serialized post_data has a fresh email.
+	 */
+	public function test_associate_existing_user_keeps_customer_id_for_fresh_email() {
+		$this->set_serialized_post_data( 'billing_first_name=New&billing_email=fresh%40example.com&modal_checkout=1' );
+
+		$this->assertSame( 123, \Newspack_Blocks\Modal_Checkout::associate_existing_user( 123 ) );
+	}
+
+	/**
+	 * It resolves subscription limits from serialized post_data outside modal checkout.
+	 */
+	public function test_subscriptions_product_limited_for_user_resolves_serialized_post_data_outside_modal_checkout() {
+		global $newspack_blocks_test_limited_product_id, $newspack_blocks_test_limited_user_id;
+
+		$user_id = self::factory()->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+		$product = new class() {
+			/**
+			 * Get product ID.
+			 *
+			 * @return int
+			 */
+			public function get_id() {
+				return 123;
+			}
+		};
+
+		$newspack_blocks_test_limited_product_id = 123;
+		$newspack_blocks_test_limited_user_id    = $user_id;
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=repeat%40example.com' );
+
+		$this->assertTrue( \Newspack_Blocks\Modal_Checkout::subscriptions_product_limited_for_user( false, $product, 0 ) );
+	}
+
+	/**
+	 * It returns a sanitized product summary for a single-item cart.
+	 */
+	public function test_get_cart_product_summary_returns_sanitized_single_item_summary() {
+		$cart = $this->get_mock_cart(
+			[
+				'abc123' => [
+					'data'     => $this->get_mock_product( 'Newsroom Pro <script>alert(1)</script>' ),
+					'quantity' => 1,
+				],
+			],
+			'<span class="amount"><bdi>$29.00</bdi></span><script>alert(1)</script>'
+		);
+
+		$summary = $this->get_cart_product_summary( $cart );
+
+		$this->assertStringContainsString( 'Newsroom Pro', $summary );
+		$this->assertStringContainsString( '<span class="amount"><bdi>$29.00</bdi></span>', $summary );
+		$this->assertStringNotContainsString( '<script', $summary );
+	}
+
+	/**
+	 * It returns an empty summary for empty and multi-item carts.
+	 */
+	public function test_get_cart_product_summary_returns_empty_for_unsupported_cart_counts() {
+		$this->assertSame( '', $this->get_cart_product_summary( $this->get_mock_cart( [] ) ) );
+		$this->assertSame(
+			'',
+			$this->get_cart_product_summary(
+				$this->get_mock_cart(
+					[
+						'abc123' => [
+							'data'     => $this->get_mock_product( 'Monthly' ),
+							'quantity' => 1,
+						],
+						'def456' => [
+							'data'     => $this->get_mock_product( 'Annual' ),
+							'quantity' => 1,
+						],
+					]
+				)
+			)
+		);
+	}
+}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -636,8 +636,11 @@ class WooCommerce_Subscriptions {
 
 		$user_id = get_current_user_id();
 
-		// If not logged in, try to get the user ID from the billing email.
-		if ( ! $user_id && method_exists( 'Newspack_Blocks\Modal_Checkout', 'get_user_id_from_email' ) ) {
+		// Standard and modal checkout refreshes can both carry guest emails in serialized post_data.
+		if (
+			! $user_id &&
+			method_exists( 'Newspack_Blocks\Modal_Checkout', 'get_user_id_from_email' )
+		) {
 			$user_id = \Newspack_Blocks\Modal_Checkout::get_user_id_from_email();
 		}
 		if ( $trial_length && $user_id && $product && $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] ) ) {

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -457,6 +457,11 @@ if ( ! class_exists( 'WC_Subscriptions_Switcher' ) ) {
 	 * caller passed the expected sign-up-fee mode and orders_to_include list.
 	 */
 	class WC_Subscriptions_Switcher {
+		public static function cart_contains_switches( $item_action = 'any' ) {
+			unset( $item_action );
+			return false;
+		}
+
 		public static function calculate_total_paid_since_last_order( $subscription, $subscription_item, $include_sign_up_fees = 'include_sign_up_fees', $orders_to_include = [] ) {
 			global $wcs_mock_total_paid_including_signup_fee, $wcs_mock_last_calculate_total_paid_args;
 			$wcs_mock_last_calculate_total_paid_args = [

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-newspack-test-modal-checkout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-newspack-test-modal-checkout.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Test double for the modal checkout class.
+ *
+ * @package Newspack\Tests
+ */
+
+/**
+ * Test double for the modal checkout class when newspack-blocks is not loaded.
+ */
+class Newspack_Test_Modal_Checkout {
+	/**
+	 * Whether the current request is modal checkout.
+	 *
+	 * @return bool
+	 */
+	public static function is_modal_checkout() {
+		if ( isset( $_REQUEST['modal_checkout'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return isset( $_REQUEST['post_data'] ) && is_string( $_REQUEST['post_data'] ) && false !== strpos( $_REQUEST['post_data'], 'modal_checkout=1' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	}
+
+	/**
+	 * Get user from email.
+	 *
+	 * Keep this fallback aligned with Newspack_Blocks\Modal_Checkout::get_user_id_from_email().
+	 *
+	 * @return false|int User ID if found by email address, false otherwise.
+	 */
+	public static function get_user_id_from_email() {
+		$billing_email = '';
+		if ( isset( $_POST['billing_email'] ) && is_string( $_POST['billing_email'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$billing_email = sanitize_email( wp_unslash( $_POST['billing_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+
+		if ( ! $billing_email && isset( $_POST['post_data'] ) && is_string( $_POST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			wp_parse_str( wp_unslash( $_POST['post_data'] ), $parsed_post_data ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( isset( $parsed_post_data['billing_email'] ) && is_string( $parsed_post_data['billing_email'] ) ) {
+				$billing_email = sanitize_email( $parsed_post_data['billing_email'] );
+			}
+		}
+
+		if ( $billing_email ) {
+			$customer = get_user_by( 'email', $billing_email );
+			if ( $customer ) {
+				return $customer->ID;
+			}
+		}
+
+		return false;
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -9,6 +9,7 @@ use Newspack\WooCommerce_Subscriptions;
 use Newspack\Reader_Activation;
 
 require_once __DIR__ . '/../../../mocks/wc-mocks.php';
+require_once __DIR__ . '/class-newspack-test-modal-checkout.php';
 
 /**
  * Test WooCommerce Subscriptions integration functionality.
@@ -30,6 +31,8 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 		$wcs_mock_items_sign_up_fee               = 0;
 		$wcs_mock_prices_include_tax              = false;
 		$wcs_mock_last_items_sign_up_fee_tax      = null;
+		wp_set_current_user( 0 );
+		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
 	}
 
 	/**
@@ -45,7 +48,28 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 		$wcs_mock_prices_include_tax              = false;
 		$wcs_mock_last_items_sign_up_fee_tax      = null;
 		remove_all_filters( 'newspack_wc_subs_switch_include_signup_fee' );
+		wp_set_current_user( 0 );
+		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
 		parent::tear_down();
+	}
+
+	/**
+	 * Set serialized checkout data in the request.
+	 *
+	 * @param string $post_data Serialized checkout data.
+	 */
+	private function set_serialized_post_data( $post_data ) {
+		$_POST['post_data']    = $post_data;
+		$_REQUEST['post_data'] = $post_data;
+	}
+
+	/**
+	 * Ensure a modal checkout implementation is available to the integration under test.
+	 */
+	private function ensure_modal_checkout_available() {
+		if ( ! class_exists( 'Newspack_Blocks\Modal_Checkout' ) ) {
+			class_alias( 'Newspack_Test_Modal_Checkout', 'Newspack_Blocks\Modal_Checkout' );
+		}
 	}
 
 	/**
@@ -62,6 +86,64 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 	public function test_is_enabled() {
 		$is_enabled = WooCommerce_Subscriptions::is_enabled();
 		$this->assertFalse( $is_enabled, 'WooCommerce Subscriptions integration should not be active if the main WooCommerce plugin is not available.' );
+	}
+
+	/**
+	 * Trial limiting resolves serialized checkout emails outside modal checkout.
+	 */
+	public function test_limit_free_trials_resolves_serialized_email_outside_modal_checkout() {
+		$this->ensure_modal_checkout_available();
+
+		$user_id = $this->factory->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+		$product = wc_create_mock_product(
+			[
+				'id'   => 900,
+				'type' => 'subscription',
+			]
+		);
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'cancelled',
+				'products'    => [ 900 ],
+			]
+		);
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=repeat%40example.com' );
+
+		$this->assertSame( 0, WooCommerce_Subscriptions::limit_free_trials_to_one_per_user( 14, $product ) );
+	}
+
+	/**
+	 * Trial limiting still resolves serialized checkout emails in modal checkout.
+	 */
+	public function test_limit_free_trials_resolves_serialized_email_in_modal_checkout() {
+		$this->ensure_modal_checkout_available();
+
+		$user_id = $this->factory->user->create(
+			[
+				'user_email' => 'repeat@example.com',
+			]
+		);
+		$product = wc_create_mock_product(
+			[
+				'id'   => 901,
+				'type' => 'subscription',
+			]
+		);
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'cancelled',
+				'products'    => [ 901 ],
+			]
+		);
+		$this->set_serialized_post_data( 'billing_first_name=Repeat&billing_email=repeat%40example.com&modal_checkout=1' );
+
+		$this->assertSame( 0, WooCommerce_Subscriptions::limit_free_trials_to_one_per_user( 14, $product ) );
 	}
 
 	/**


### PR DESCRIPTION
Hotfix: cherry-pick of #264 onto `release`.

Full description, review, and testing steps are in #264. Cherry-picked from `ce943c6` (squash merge of #264 into `main`). One file (`class-woocommerce-subscriptions.php`) auto-merged against `release`'s baseline; the added/removed lines are identical to #264, only surrounding context shifted.

Closes NPPM-2838.
