### PR TITLE
feat(newsletters): full-bleed alignfull background sections (WC)

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
@@ -43,6 +43,12 @@ class Full_Bleed_Sections {
 	const DEFAULT_VERTICAL_PADDING = '12px';
 
 	/**
+	 * Email content width in pixels — the package `contentSize` the band content is
+	 * re-centered to so it lines up with normal blocks.
+	 */
+	const CONTENT_WIDTH = 660;
+
+	/**
 	 * Restructure top-level alignfull background groups into body-level full-width rows.
 	 *
 	 * @param string $html Rendered (CSS-inlined) email HTML from the WC renderer.
@@ -82,19 +88,42 @@ class Full_Bleed_Sections {
 			. "contains(concat(' ', normalize-space(@class), ' '), ' has-background ')]";
 
 		$root_padding = self::detect_root_padding( $xpath, $container );
+		$nodes        = iterator_to_array( $container->childNodes ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
+		$node_count   = count( $nodes );
 		$segments     = [];
 		$band_count   = 0;
-		foreach ( $container->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
-			if ( ! ( $child instanceof \DOMElement ) ) {
+		$run          = '';
+		for ( $i = 0; $i < $node_count; $i++ ) {
+			$node = $nodes[ $i ];
+
+			// Drop a band's own per-block MSO ghost-table wrapper: build_band emits a fresh
+			// one, so skip the opening comment that immediately precedes a band element.
+			if ( self::is_mso_open( $node ) && isset( $nodes[ $i + 1 ] ) && self::is_band( $nodes[ $i + 1 ], $xpath, $band_query ) ) {
 				continue;
 			}
-			$group = $xpath->query( $band_query, $child )->item( 0 );
-			if ( $group instanceof \DOMElement ) {
+
+			if ( self::is_band( $node, $xpath, $band_query ) ) {
+				if ( '' !== $run ) {
+					$segments[] = [ 'normal', $run ];
+					$run        = '';
+				}
+				$group      = $xpath->query( $band_query, $node )->item( 0 );
 				$segments[] = [ 'band', self::build_band( $group, $dom, $xpath, $root_padding ) ];
 				++$band_count;
-			} else {
-				$segments[] = [ 'normal', $dom->saveHTML( $child ) ];
+				// Skip the band's closing ghost-table comment too.
+				if ( isset( $nodes[ $i + 1 ] ) && self::is_mso_close( $nodes[ $i + 1 ] ) ) {
+					++$i;
+				}
+				continue;
 			}
+
+			// Normal node — an element block, its surrounding MSO ghost-table comments, or
+			// whitespace. Keep it verbatim so Outlook's per-block gutter and spacing (which
+			// live in those conditional comments, not the CSS) survive into the rebuilt body.
+			$run .= $dom->saveHTML( $node );
+		}
+		if ( '' !== $run ) {
+			$segments[] = [ 'normal', $run ];
 		}
 
 		// No qualifying band — leave the render untouched.
@@ -107,27 +136,13 @@ class Full_Bleed_Sections {
 			return $html;
 		}
 
-		// Assemble: a vertical stack of content-width runs and full-width band rows.
-		$out         = $shell['head'];
-		$run         = '';
-		$first_run   = true;
-		$flush_run   = static function () use ( &$run, &$out, &$first_run, $shell ) {
-			if ( '' === $run ) {
-				return;
-			}
-			$out      .= ( $first_run ? $shell['open'] : $shell['open_no_preheader'] ) . $run . $shell['close'];
-			$run       = '';
-			$first_run = false;
-		};
+		// Assemble: the preheader once at the top (so it wins the inbox preview slot even
+		// when the first block is a band), then a vertical stack of content-width runs and
+		// full-width band rows. A run is any string segment; a band is already full markup.
+		$out = $shell['head'] . $shell['preheader'];
 		foreach ( $segments as $segment ) {
-			if ( 'band' === $segment[0] ) {
-				$flush_run();
-				$out .= $segment[1];
-			} else {
-				$run .= $segment[1];
-			}
+			$out .= 'band' === $segment[0] ? $segment[1] : $shell['open'] . $segment[1] . $shell['close'];
 		}
-		$flush_run();
 		$out .= $shell['tail'];
 
 		return $out;
@@ -139,7 +154,7 @@ class Full_Bleed_Sections {
 	 * @param string $html Email HTML.
 	 * @return \DOMDocument|null Document, or null on failure.
 	 */
-	private static function load_dom( string $html ) {
+	private static function load_dom( string $html ): ?\DOMDocument {
 		$dom = new \DOMDocument();
 		$use = libxml_use_internal_errors( true );
 		$ok  = $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING );
@@ -204,14 +219,15 @@ class Full_Bleed_Sections {
 		// border-box so the content width matches normal blocks: the content-size cap
 		// includes the horizontal gutter, leaving the same inner content width.
 		$inner_style = sprintf(
-			'box-sizing:border-box;max-width:660px;margin:0 auto;padding-left:%1$s;padding-right:%1$s;%2$s',
+			'box-sizing:border-box;max-width:%1$dpx;margin:0 auto;padding-left:%2$s;padding-right:%2$s;%3$s',
+			self::CONTENT_WIDTH,
 			$root_padding,
 			$color ? 'color:' . $color . ';' : ''
 		);
 
 		return '<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" bgcolor="' . esc_attr( $bg ) . '" style="' . esc_attr( 'width:100%;background-color:' . $bg . ';' ) . '">'
 			. '<tbody><tr><td align="center" style="' . esc_attr( $cell_padding ) . '">'
-			. '<!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="660" style="width:660px"><tr><td><![endif]-->'
+			. '<!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="' . self::CONTENT_WIDTH . '" style="width:' . self::CONTENT_WIDTH . 'px"><tr><td><![endif]-->'
 			. '<div style="' . esc_attr( $inner_style ) . '">' . $inner . '</div>'
 			. '<!--[if mso | IE]></td></tr></table><![endif]-->'
 			. '</td></tr></tbody></table>';
@@ -221,10 +237,16 @@ class Full_Bleed_Sections {
 	 * Extract the email shell fragments (from the package template canvas) used to wrap
 	 * each content-width run. Returns null when the expected markers are absent.
 	 *
+	 * Assumes the canvas places nothing of substance between the layout wrapper and
+	 * `</body>` (verified against the current `template-canvas.php`: only the MSO close
+	 * comment and whitespace; styles are parked in `<head>`). `tail` is therefore a
+	 * literal close; if a future package version emits a footer there it would be dropped
+	 * in banded emails — revisit this on package bumps.
+	 *
 	 * @param string $html Email HTML.
-	 * @return array{head:string,open:string,open_no_preheader:string,close:string,tail:string}|null
+	 * @return array{head:string,preheader:string,open:string,close:string,tail:string}|null
 	 */
-	private static function shell_fragments( string $html ) {
+	private static function shell_fragments( string $html ): ?array {
 		$body_pos = strpos( $html, '<body' );
 		$mso_pos  = strpos( $html, '<!--[if mso | IE]><table align="center"' );
 		$cw_pos   = strpos( $html, '<td class="email_content_wrapper"' );
@@ -239,17 +261,68 @@ class Full_Bleed_Sections {
 
 		$open = substr( $html, $mso_pos, $cw_open_end + 1 - $mso_pos );
 
-		// A run after the first repeats the wrapper; drop the (hidden) preheader row so
-		// it appears only once at the top.
-		$open_no_preheader = preg_replace( '#<tr>\s*<td class="email_preheader".*?</td>\s*</tr>#is', '', $open );
+		// Lift the (hidden) preheader row out of the wrapper so it is emitted once at the
+		// top of the body — before any band — and the per-run wrapper carries no preheader.
+		$preheader = '';
+		if ( preg_match( '#<tr>\s*<td class="email_preheader".*?</td>\s*</tr>#is', $open, $match ) ) {
+			$preheader = '<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tbody>' . $match[0] . '</tbody></table>';
+			$stripped  = preg_replace( '#<tr>\s*<td class="email_preheader".*?</td>\s*</tr>#is', '', $open );
+			$open      = is_string( $stripped ) ? $stripped : $open;
+		}
 
 		return [
-			'head'              => substr( $html, 0, $body_open_end + 1 ),
-			'open'              => $open,
-			'open_no_preheader' => is_string( $open_no_preheader ) ? $open_no_preheader : $open,
-			'close'             => '</td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]-->',
-			'tail'              => "\n</body></html>",
+			'head'      => substr( $html, 0, $body_open_end + 1 ),
+			'preheader' => $preheader,
+			'open'      => $open,
+			'close'     => '</td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]-->',
+			'tail'      => "\n</body></html>",
 		];
+	}
+
+	/**
+	 * Whether a node is a top-level band: an element directly wrapping an alignfull
+	 * background group table.
+	 *
+	 * @param \DOMNode  $node       Node to test.
+	 * @param \DOMXPath $xpath      XPath over the document.
+	 * @param string    $band_query Relative XPath matching the band group table.
+	 * @return bool
+	 */
+	private static function is_band( \DOMNode $node, \DOMXPath $xpath, string $band_query ): bool {
+		return $node instanceof \DOMElement && $xpath->query( $band_query, $node )->item( 0 ) instanceof \DOMElement;
+	}
+
+	/**
+	 * Whether a node is an MSO ghost-table OPENING conditional comment (contains a
+	 * `<table` open tag).
+	 *
+	 * @param \DOMNode $node Node to test.
+	 * @return bool
+	 */
+	private static function is_mso_open( \DOMNode $node ): bool {
+		return $node instanceof \DOMComment && false !== strpos( self::comment_value( $node ), '><table' );
+	}
+
+	/**
+	 * Whether a node is an MSO ghost-table CLOSING conditional comment (closes a table
+	 * but opens none).
+	 *
+	 * @param \DOMNode $node Node to test.
+	 * @return bool
+	 */
+	private static function is_mso_close( \DOMNode $node ): bool {
+		$value = self::comment_value( $node );
+		return $node instanceof \DOMComment && false !== strpos( $value, '</table>' ) && false === strpos( $value, '><table' );
+	}
+
+	/**
+	 * Read a comment node's text.
+	 *
+	 * @param \DOMNode $node Comment node.
+	 * @return string
+	 */
+	private static function comment_value( \DOMNode $node ): string {
+		return (string) $node->nodeValue; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Full-bleed restructuring for top-level alignfull background sections.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters\Email_Renderers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Re-threads the rendered WC email so top-level `align:full` groups that carry a
+ * background color bleed to the full email width, while their content — and every
+ * other block — stays constrained to the content width.
+ *
+ * The WC email-editor renders the whole email inside one content-width container (a
+ * `max-width` div for modern clients, an MSO fixed-width table for Outlook), so an
+ * alignfull group's background can only reach the content edge, never beyond. This
+ * post-processor splits the email at each top-level alignfull-background group and
+ * re-emits that group as a body-level full-width row — the cross-client full-bleed
+ * structure (`<table width="100%" bgcolor>` with a re-centered content-width inner) —
+ * matching how the legacy MJML renderer treated `full-width` sections. Normal blocks
+ * stay in the original content-width wrapper.
+ *
+ * It is a strict no-op when there are no qualifying groups or the expected package
+ * structure is absent, so non-alignfull emails — and any future package output
+ * change — fall back to the unmodified render.
+ */
+class Full_Bleed_Sections {
+
+	/**
+	 * Default horizontal root padding (content gutter) to inset band content by so it
+	 * lines up with normal blocks, when it can't be read from the rendered email.
+	 */
+	const DEFAULT_ROOT_PADDING = '24px';
+
+	/**
+	 * Default vertical padding for a background group that sets none. The email editor
+	 * canvas gives background groups this default padding, but the package render emits
+	 * zero — so a no-padding band would otherwise be tighter in the email than the editor.
+	 */
+	const DEFAULT_VERTICAL_PADDING = '12px';
+
+	/**
+	 * Restructure top-level alignfull background groups into body-level full-width rows.
+	 *
+	 * @param string $html Rendered (CSS-inlined) email HTML from the WC renderer.
+	 * @return string Transformed HTML, or the input unchanged when not applicable.
+	 */
+	public static function transform( string $html ): string {
+		// Fast bail: nothing to bleed without an alignfull background group.
+		if ( false === strpos( $html, 'alignfull' ) || false === strpos( $html, 'has-background' ) ) {
+			return $html;
+		}
+
+		$dom = self::load_dom( $html );
+		if ( ! $dom ) {
+			return $html;
+		}
+		$xpath = new \DOMXPath( $dom );
+
+		// The template wraps post-content in one constrained group; its content cell is
+		// the first `email-block-group-content`, and the flat list of top-level blocks
+		// lives in the single `<td>` of that group's layout table.
+		$cell = $xpath->query( "//td[contains(concat(' ', normalize-space(@class), ' '), ' email-block-group-content ')]" )->item( 0 );
+		if ( ! $cell ) {
+			return $html;
+		}
+		$container = $xpath->query( "./div[contains(concat(' ', normalize-space(@class), ' '), ' email-block-layout ')]/table/tbody/tr/td", $cell )->item( 0 );
+		if ( ! $container ) {
+			return $html;
+		}
+
+		// Enumerate top-level blocks in order, classifying each as a full-bleed band or
+		// normal content. The band group must be the block's OWN immediate table (child
+		// axis) — a normal Columns/Group block that merely contains a nested alignfull
+		// background group deeper down must not be hoisted wholesale.
+		$band_query = './table['
+			. "contains(concat(' ', normalize-space(@class), ' '), ' email-block-group ') and "
+			. "contains(concat(' ', normalize-space(@class), ' '), ' alignfull ') and "
+			. "contains(concat(' ', normalize-space(@class), ' '), ' has-background ')]";
+
+		$root_padding = self::detect_root_padding( $xpath, $container );
+		$segments     = [];
+		$band_count   = 0;
+		foreach ( $container->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
+			if ( ! ( $child instanceof \DOMElement ) ) {
+				continue;
+			}
+			$group = $xpath->query( $band_query, $child )->item( 0 );
+			if ( $group instanceof \DOMElement ) {
+				$segments[] = [ 'band', self::build_band( $group, $dom, $xpath, $root_padding ) ];
+				++$band_count;
+			} else {
+				$segments[] = [ 'normal', $dom->saveHTML( $child ) ];
+			}
+		}
+
+		// No qualifying band — leave the render untouched.
+		if ( 0 === $band_count ) {
+			return $html;
+		}
+
+		$shell = self::shell_fragments( $html );
+		if ( ! $shell ) {
+			return $html;
+		}
+
+		// Assemble: a vertical stack of content-width runs and full-width band rows.
+		$out         = $shell['head'];
+		$run         = '';
+		$first_run   = true;
+		$flush_run   = static function () use ( &$run, &$out, &$first_run, $shell ) {
+			if ( '' === $run ) {
+				return;
+			}
+			$out      .= ( $first_run ? $shell['open'] : $shell['open_no_preheader'] ) . $run . $shell['close'];
+			$run       = '';
+			$first_run = false;
+		};
+		foreach ( $segments as $segment ) {
+			if ( 'band' === $segment[0] ) {
+				$flush_run();
+				$out .= $segment[1];
+			} else {
+				$run .= $segment[1];
+			}
+		}
+		$flush_run();
+		$out .= $shell['tail'];
+
+		return $out;
+	}
+
+	/**
+	 * Parse the email HTML into a DOMDocument, preserving MSO conditional comments.
+	 *
+	 * @param string $html Email HTML.
+	 * @return \DOMDocument|null Document, or null on failure.
+	 */
+	private static function load_dom( string $html ) {
+		$dom = new \DOMDocument();
+		$use = libxml_use_internal_errors( true );
+		$ok  = $dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $use );
+		return $ok ? $dom : null;
+	}
+
+	/**
+	 * Read the horizontal content gutter (root padding) from a normal block so band
+	 * content can be inset to match. Falls back to the default when none is found.
+	 *
+	 * @param \DOMXPath   $xpath     XPath over the document.
+	 * @param \DOMElement $container The top-level block container cell.
+	 * @return string Padding value (e.g. `24px`).
+	 */
+	private static function detect_root_padding( \DOMXPath $xpath, \DOMElement $container ): string {
+		$node = $xpath->query( ".//div[contains(concat(' ', normalize-space(@class), ' '), ' email-root-padding ')]", $container )->item( 0 );
+		if ( $node instanceof \DOMElement ) {
+			$left = self::style_value( $node->getAttribute( 'style' ), 'padding-left' );
+			if ( '' !== $left ) {
+				return $left;
+			}
+		}
+		return self::DEFAULT_ROOT_PADDING;
+	}
+
+	/**
+	 * Build a body-level full-width band row from an alignfull background group.
+	 *
+	 * @param \DOMElement  $group        The alignfull background group table.
+	 * @param \DOMDocument $dom          Owner document (for serializing inner content).
+	 * @param \DOMXPath    $xpath        XPath over the document.
+	 * @param string       $root_padding Horizontal inset to align band content with normal blocks.
+	 * @return string Full-width band HTML.
+	 */
+	private static function build_band( \DOMElement $group, \DOMDocument $dom, \DOMXPath $xpath, string $root_padding ): string {
+		$group_style = $group->getAttribute( 'style' );
+		$bg          = self::style_value( $group_style, 'background-color' );
+		if ( '' === $bg ) {
+			$bg = self::style_value( $group_style, 'background' );
+		}
+		$color = self::style_value( $group_style, 'color' );
+
+		$content_cell = $xpath->query( "./tbody/tr/td[contains(concat(' ', normalize-space(@class), ' '), ' email-block-group-content ')]", $group )->item( 0 );
+		$cell_style   = $content_cell instanceof \DOMElement ? $content_cell->getAttribute( 'style' ) : '';
+		$pad_top      = self::style_value( $cell_style, 'padding-top' );
+		$pad_bottom   = self::style_value( $cell_style, 'padding-bottom' );
+
+		$inner = '';
+		if ( $content_cell instanceof \DOMElement ) {
+			foreach ( $content_cell->childNodes as $node ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
+				$inner .= $dom->saveHTML( $node );
+			}
+		}
+
+		$cell_padding = sprintf(
+			'padding-top:%s;padding-bottom:%s;',
+			'' !== $pad_top ? $pad_top : self::DEFAULT_VERTICAL_PADDING,
+			'' !== $pad_bottom ? $pad_bottom : self::DEFAULT_VERTICAL_PADDING
+		);
+		// border-box so the content width matches normal blocks: the content-size cap
+		// includes the horizontal gutter, leaving the same inner content width.
+		$inner_style = sprintf(
+			'box-sizing:border-box;max-width:660px;margin:0 auto;padding-left:%1$s;padding-right:%1$s;%2$s',
+			$root_padding,
+			$color ? 'color:' . $color . ';' : ''
+		);
+
+		return '<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" bgcolor="' . esc_attr( $bg ) . '" style="' . esc_attr( 'width:100%;background-color:' . $bg . ';' ) . '">'
+			. '<tbody><tr><td align="center" style="' . esc_attr( $cell_padding ) . '">'
+			. '<!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="660" style="width:660px"><tr><td><![endif]-->'
+			. '<div style="' . esc_attr( $inner_style ) . '">' . $inner . '</div>'
+			. '<!--[if mso | IE]></td></tr></table><![endif]-->'
+			. '</td></tr></tbody></table>';
+	}
+
+	/**
+	 * Extract the email shell fragments (from the package template canvas) used to wrap
+	 * each content-width run. Returns null when the expected markers are absent.
+	 *
+	 * @param string $html Email HTML.
+	 * @return array{head:string,open:string,open_no_preheader:string,close:string,tail:string}|null
+	 */
+	private static function shell_fragments( string $html ) {
+		$body_pos = strpos( $html, '<body' );
+		$mso_pos  = strpos( $html, '<!--[if mso | IE]><table align="center"' );
+		$cw_pos   = strpos( $html, '<td class="email_content_wrapper"' );
+		if ( false === $body_pos || false === $mso_pos || false === $cw_pos ) {
+			return null;
+		}
+		$body_open_end = strpos( $html, '>', $body_pos );
+		$cw_open_end   = strpos( $html, '>', $cw_pos );
+		if ( false === $body_open_end || false === $cw_open_end ) {
+			return null;
+		}
+
+		$open = substr( $html, $mso_pos, $cw_open_end + 1 - $mso_pos );
+
+		// A run after the first repeats the wrapper; drop the (hidden) preheader row so
+		// it appears only once at the top.
+		$open_no_preheader = preg_replace( '#<tr>\s*<td class="email_preheader".*?</td>\s*</tr>#is', '', $open );
+
+		return [
+			'head'              => substr( $html, 0, $body_open_end + 1 ),
+			'open'              => $open,
+			'open_no_preheader' => is_string( $open_no_preheader ) ? $open_no_preheader : $open,
+			'close'             => '</td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]-->',
+			'tail'              => "\n</body></html>",
+		];
+	}
+
+	/**
+	 * Read a single declaration value out of an inline style string.
+	 *
+	 * @param string $style Inline style attribute value.
+	 * @param string $prop  CSS property name.
+	 * @return string Trimmed value, or empty string when absent.
+	 */
+	private static function style_value( string $style, string $prop ): string {
+		if ( preg_match( '/(?:^|;)\s*' . preg_quote( $prop, '/' ) . '\s*:\s*([^;]+)/i', $style, $matches ) ) {
+			return trim( $matches[1] );
+		}
+		return '';
+	}
+}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-renderer-controller.php
@@ -123,7 +123,7 @@ class Renderer_Controller {
 				'',
 				Editor_Bootstrap::TEMPLATE_SLUG
 			);
-			return isset( $result['html'] ) ? (string) $result['html'] : '';
+			return isset( $result['html'] ) ? Full_Bleed_Sections::transform( (string) $result['html'] ) : '';
 		} catch ( \Throwable $e ) {
 			\Newspack_Newsletters_Logger::log( 'Email editor: WC render failed — ' . $e->getMessage() );
 			return '';

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -57,6 +57,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-feature-flag.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-fonts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-email-defaults.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-full-bleed-sections.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-renderer-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/email-renderers/class-editor-bootstrap.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -259,6 +259,49 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Normal blocks in a banded email keep their per-block MSO ghost-table scaffolding —
+	 * the Outlook side gutter / spacing lives in those conditional comments, not CSS, so
+	 * the rebuild must carry the comment siblings across, not just the block elements.
+	 */
+	public function test_render_wc_banded_email_preserves_normal_block_mso_scaffolding() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:paragraph --><p>Intro</p><!-- /wp:paragraph -->'
+			. '<!-- wp:group {"align":"full","style":{"color":{"background":"#ffcc00"}}} -->'
+			. '<div class="wp-block-group alignfull has-background" style="background-color:#ffcc00">'
+			. '<!-- wp:paragraph --><p>Banded</p><!-- /wp:paragraph --></div><!-- /wp:group -->'
+			. '<!-- wp:paragraph --><p>Outro</p><!-- /wp:paragraph -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 1, $this->count_body_level_bands( $html ), 'Sanity: the band should still bleed.' );
+		$this->assertMatchesRegularExpression(
+			'/<!--\[if mso \| IE\]>(?:(?!<!\[endif\]).)*?padding-left:\s*24px/is',
+			$html,
+			'Normal blocks must retain their MSO ghost-table side gutter in a banded email.'
+		);
+	}
+
+	/**
+	 * When the first top-level block is a band (e.g. a full-bleed site-title header), the
+	 * hidden preheader is still emitted before it so it wins the inbox preview slot.
+	 */
+	public function test_render_wc_preheader_precedes_a_leading_band() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:group {"align":"full","style":{"color":{"background":"#ffcc00"}}} -->'
+			. '<div class="wp-block-group alignfull has-background" style="background-color:#ffcc00">'
+			. '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph --></div><!-- /wp:group -->'
+			. '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->';
+
+		$html      = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+		$preheader = strpos( $html, 'email_preheader' );
+		$band      = strpos( $html, 'bgcolor=' );
+
+		$this->assertNotFalse( $preheader );
+		$this->assertNotFalse( $band );
+		$this->assertLessThan( $band, $preheader, 'The preheader must appear before a leading full-bleed band.' );
+	}
+
+	/**
 	 * The transform fast-bails (returns input untouched) when the markup has no
 	 * alignfull background section.
 	 */

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -146,4 +146,127 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 		$this->assertSame( '', $html );
 		$this->assertNull( Renderer_Controller::get_rendering_post(), 'render post is cleared even when rendering throws' );
 	}
+
+	/**
+	 * Create a newsletter CPT post with arbitrary block markup.
+	 *
+	 * @param string $content Serialized block markup.
+	 * @return int Created post ID.
+	 */
+	private function create_newsletter( $content ) {
+		return self::factory()->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status'  => 'draft',
+				'post_title'   => 'Full bleed newsletter',
+				'post_content' => wp_slash( $content ),
+			]
+		);
+	}
+
+	/**
+	 * Count full-width band tables (bgcolor + width:100%) that sit at body level —
+	 * i.e. outside the content-width `email_layout_wrapper`.
+	 *
+	 * @param string $html Email HTML.
+	 * @return int Number of body-level full-width band tables.
+	 */
+	private function count_body_level_bands( $html ) {
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING );
+		libxml_clear_errors();
+		$xpath = new DOMXPath( $dom );
+		$bands = $xpath->query( "//table[@bgcolor and contains(@style, 'width:100%')]" );
+		$count = 0;
+		foreach ( $bands as $band ) {
+			if ( 0 === $xpath->query( "ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' email_layout_wrapper ')]", $band )->length ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	/**
+	 * A top-level alignfull group with a background bleeds to a body-level full-width
+	 * band, while its content survives (NEWS-1901 default-layout full-bleed).
+	 */
+	public function test_render_wc_bleeds_alignfull_background_section() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:paragraph --><p>Intro</p><!-- /wp:paragraph -->'
+			. '<!-- wp:group {"align":"full","style":{"color":{"background":"#ffcc00","text":"#000000"}}} -->'
+			. '<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#ffcc00;color:#000000">'
+			. '<!-- wp:paragraph --><p>Banded content</p><!-- /wp:paragraph --></div>'
+			. '<!-- /wp:group -->'
+			. '<!-- wp:paragraph --><p>Outro</p><!-- /wp:paragraph -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 1, $this->count_body_level_bands( $html ), 'Expected one body-level full-width band for the alignfull background group.' );
+		$this->assertStringContainsString( 'Banded content', $html, 'Expected the band content to survive the transform.' );
+		$this->assertStringContainsString( 'Intro', $html, 'Expected surrounding content to survive.' );
+		$this->assertStringContainsString( 'Outro', $html );
+	}
+
+	/**
+	 * An alignfull group with NO background is left in the content-width wrapper — only
+	 * background sections bleed.
+	 */
+	public function test_render_wc_does_not_bleed_alignfull_without_background() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:group {"align":"full"} -->'
+			. '<div class="wp-block-group alignfull"><!-- wp:paragraph --><p>No background here</p><!-- /wp:paragraph --></div>'
+			. '<!-- /wp:group -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 0, $this->count_body_level_bands( $html ), 'A backgroundless alignfull group must not be hoisted to a full-width band.' );
+		$this->assertStringContainsString( 'No background here', $html );
+	}
+
+	/**
+	 * A newsletter without any alignfull background section renders unchanged: no
+	 * body-level band, and the single content-width wrapper is preserved.
+	 */
+	public function test_render_wc_normal_newsletter_has_no_bands() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter_with_paragraph( 'Just a paragraph' ) ) );
+
+		$this->assertSame( 0, $this->count_body_level_bands( $html ) );
+		$this->assertStringContainsString( 'Just a paragraph', $html );
+	}
+
+	/**
+	 * An alignfull background group nested inside a Columns block is NOT hoisted
+	 * wholesale — only a top-level group's own background bleeds.
+	 */
+	public function test_render_wc_does_not_hoist_alignfull_nested_in_columns() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column --><div class="wp-block-column">'
+			. '<!-- wp:group {"align":"full","style":{"color":{"background":"#ffcc00"}}} -->'
+			. '<div class="wp-block-group alignfull has-background" style="background-color:#ffcc00">'
+			. '<!-- wp:paragraph --><p>Nested banded</p><!-- /wp:paragraph --></div><!-- /wp:group -->'
+			. '</div><!-- /wp:column -->'
+			. '<!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Side</p><!-- /wp:paragraph --></div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 0, $this->count_body_level_bands( $html ), 'A nested alignfull group must not hoist its containing columns block.' );
+		$this->assertStringContainsString( 'Nested banded', $html );
+		$this->assertStringContainsString( 'Side', $html );
+	}
+
+	/**
+	 * The transform fast-bails (returns input untouched) when the markup has no
+	 * alignfull background section.
+	 */
+	public function test_full_bleed_transform_is_noop_without_markers() {
+		$html = '<html><body><table><tr><td><p>nothing to bleed</p></td></tr></table></body></html>';
+		$this->assertSame(
+			$html,
+			\Newspack\Newsletters\Email_Renderers\Full_Bleed_Sections::transform( $html )
+		);
+	}
 }


### PR DESCRIPTION
## Summary

**Top-level `align:full` groups with a background now bleed to the full email width under the WC renderer**, while their content — and every other block — stays constrained. This restores the full-bleed behavior the legacy MJML renderer gave `full-width` sections.

The WC email-editor renders the whole email inside one content-width container (a `max-width` div for modern clients, an MSO fixed-width table for Outlook), so an alignfull group's background could only reach the content edge, never beyond. Several default layouts (site-title headers, "Support our newsroom" sections) use full-bleed colored bands, so under the WC flag they rendered as centered content-width boxes instead.

- **New `Full_Bleed_Sections` post-processor** (`includes/email-renderers/class-full-bleed-sections.php`), invoked at the end of `render_wc()`. It splits the rendered email at each top-level alignfull-background group and re-emits that group as a body-level full-width row — `<table width="100%" bgcolor>` with a re-centered content-width inner — the proven cross-client full-bleed structure. Because the band table sits *outside* the 660 MSO cap, it bleeds in Outlook too.
- **Content stays aligned** with normal blocks (`box-sizing:border-box` + 24px root-padding inset), and a no-padding band gets the editor's **12px** vertical default so the email matches the editor canvas.
- **Strict no-op** when there are no qualifying groups or the expected structure is absent — non-alignfull emails (and any future package output change) fall back to the unmodified render.

Behavior: only **top-level** alignfull background groups are hoisted; a backgroundless alignfull group, or an alignfull group nested inside Columns, is left untouched. With the WC flag off (MJML engine), nothing changes.

Part of the editor-refactor default-layout work (NEWS-1901).

### How to test

1. With the WC renderer flag on, open a newsletter using a default layout with a full-bleed section (site-title header or a `align:full` + background "Support" group). Test posts: **130/131** (isolation variants), **102** (default 4-grid).
2. Preview the email (view wide so there's space around the 660 card):
   - The colored band spans the full width, beyond the email card.
   - Its content stays aligned with the rest of the newsletter.
   - A no-padding band has ~12px vertical padding (matching the editor), not a razor-thin strip.
3. Regression: a normal newsletter (no alignfull background) renders unchanged — single content-width wrapper, no full-width band. An alignfull group **without** a background, or one **nested in Columns**, is not hoisted.
4. **Cross-client:** verify in Litmus / a real Outlook client — the full-width-row structure is the proven pattern but can't be verified locally.

## For AI

**Seam.** The package `Renderer::render()` wraps content in `template-canvas.php` — a vendored, `const`-included shell with no final-HTML filter — so the only Newspack-controlled seam is the HTML string returned by `Renderer_Controller::render_wc()`. The transform runs there, on the already-CSS-inlined HTML.

**Structure leveraged.** Our template (`templates/newspack-newsletter.html`) wraps post-content in one `constrained` `core/group`. The rendered top-level blocks are flat siblings inside the single `<td>` of that group's layout table — normal blocks wrapped in `email-root-padding`, bands as bare `email-block-layout` divs directly wrapping the `email-block-group alignfull has-background` table (alignfull skips root padding via the package `Spacing_Preprocessor`).

**`transform()`** fast-bails without `alignfull`+`has-background`; locates the template group content cell and the flat block container `<td>`; classifies each child via **child-axis** `./table[... alignfull has-background]` (so a Columns/Group block with a nested band is not hoisted wholesale); rebuilds the body as a stack of 660-shell-wrapped normal runs and full-width band rows (preheader emitted once). Every structural lookup guards and returns the input unchanged on miss; a DOMDocument parse failure also returns the input.

**`build_band()`** reads the group's background/text color and the content cell's vertical padding (default `DEFAULT_VERTICAL_PADDING = 12px` to match the editor canvas), then serializes the cell's inner content into a centered `max-width:660px; box-sizing:border-box` div with `DEFAULT_ROOT_PADDING = 24px` horizontal inset so band content lines up with normal blocks.

**Scope / follow-ups.** Only top-level alignfull-bg groups are handled. The same editor-vs-render 0-vs-12px padding gap exists for non-full-bleed background groups (content-width) — out of scope here.

### Submission checklist

- [x] Follows WordPress + Newspack coding standards (phpcs clean)
- [x] Adds regression tests (`Test_Renderer_Controller`: bleed, no-background, normal, nested-in-columns, fast-bail)
- [ ] Cross-client (Litmus/Outlook) verification
- [ ] Changelog entry (auto-generated by CI)
