### PR TITLE
fix(popups): harmonize overlay prompt preview with inline

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -290,6 +290,14 @@ final class Newspack_Popups_Model {
 	 * @return array|null Popup object array, or null if the post id does not resolve to a post.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
+		// Previews render unsaved prompt content, so restrict them to users who can manage
+		// prompts and to the prompts CPT, mirroring the plugin's other preview entry points.
+		if ( ! Newspack_Popups::is_user_admin() ) {
+			return null;
+		}
+		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT !== get_post_type( $post_id ) ) {
+			return null;
+		}
 		// Up-to-date post data is stored in an autosave.
 		$autosave    = wp_get_post_autosave( $post_id );
 		$post_object = $autosave ? $autosave : get_post( $post_id );

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -284,10 +284,14 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Retrieve popup preview CPT post.
+	 * Retrieve popup preview CPT post, for users who can manage prompts.
+	 *
+	 * Previews render unsaved prompt content, so access is restricted to users who can
+	 * manage prompts and to the prompts CPT.
 	 *
 	 * @param int|string $post_id Post id. Often a query-parameter string.
-	 * @return array|null Popup object array, or null if the post id does not resolve to a post.
+	 * @return array|null Popup object array, or null if the current user cannot manage prompts,
+	 *                    the post is not a prompt, or the id does not resolve to a post.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
 		// Previews render unsaved prompt content, so restrict them to users who can manage

--- a/plugins/newspack-popups/tests/test-model.php
+++ b/plugins/newspack-popups/tests/test-model.php
@@ -256,6 +256,102 @@ class ModelTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A preview should only load content for users who can manage prompts.
+	 */
+	public function test_retrieve_preview_popup_denies_logged_out_user() {
+		wp_set_current_user( 0 );
+		$draft_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_content' => 'Unpublished draft body.',
+			]
+		);
+		self::assertNull(
+			Newspack_Popups_Model::retrieve_preview_popup( $draft_id ),
+			'A logged-out visitor must not be able to load a post as a preview.'
+		);
+	}
+
+	/**
+	 * A preview should only load the prompts CPT, not arbitrary post types.
+	 */
+	public function test_retrieve_preview_popup_denies_non_prompt_post_type() {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$draft_id = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_content' => 'Unpublished draft body.',
+			]
+		);
+		self::assertNull(
+			Newspack_Popups_Model::retrieve_preview_popup( $draft_id ),
+			'A preview must not load a non-prompt post, even for an admin.'
+		);
+	}
+
+	/**
+	 * A user who can manage prompts can still preview a prompt draft.
+	 */
+	public function test_retrieve_preview_popup_allows_admin_for_prompt() {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status'  => 'draft',
+				'post_content' => 'Prompt draft body.',
+			]
+		);
+		self::assertNotNull(
+			Newspack_Popups_Model::retrieve_preview_popup( $popup_id ),
+			'A user who can manage prompts must be able to preview a prompt draft.'
+		);
+	}
+
+	/**
+	 * A logged-out visitor must not preview an unpublished prompt.
+	 *
+	 * Isolates the capability gate: the post is the prompts CPT, so only the
+	 * capability check (not the post-type check) can deny it.
+	 */
+	public function test_retrieve_preview_popup_denies_logged_out_user_for_prompt() {
+		wp_set_current_user( 0 );
+		$prompt_id = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status'  => 'draft',
+				'post_content' => 'Unpublished prompt body.',
+			]
+		);
+		self::assertNull(
+			Newspack_Popups_Model::retrieve_preview_popup( $prompt_id ),
+			'A logged-out visitor must not be able to preview an unpublished prompt.'
+		);
+	}
+
+	/**
+	 * A non-admin-role user who can manage prompts can still preview a prompt draft.
+	 */
+	public function test_retrieve_preview_popup_allows_non_admin_prompt_manager() {
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+		$prompt_id = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status'  => 'draft',
+				'post_content' => 'Prompt draft body.',
+			]
+		);
+		self::assertNotNull(
+			Newspack_Popups_Model::retrieve_preview_popup( $prompt_id ),
+			'A non-admin user who can manage prompts must be able to preview a prompt draft.'
+		);
+	}
+
+	/**
 	 * Tests that an invalid `pp` query param does not produce a popup list with null entries,
 	 * which would cascade to "Trying to access array offset on null" warnings downstream.
 	 */

--- a/plugins/newspack-popups/tests/test-model.php
+++ b/plugins/newspack-popups/tests/test-model.php
@@ -256,24 +256,6 @@ class ModelTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A preview should only load content for users who can manage prompts.
-	 */
-	public function test_retrieve_preview_popup_denies_logged_out_user() {
-		wp_set_current_user( 0 );
-		$draft_id = self::factory()->post->create(
-			[
-				'post_type'    => 'post',
-				'post_status'  => 'draft',
-				'post_content' => 'Unpublished draft body.',
-			]
-		);
-		self::assertNull(
-			Newspack_Popups_Model::retrieve_preview_popup( $draft_id ),
-			'A logged-out visitor must not be able to load a post as a preview.'
-		);
-	}
-
-	/**
 	 * A preview should only load the prompts CPT, not arbitrary post types.
 	 */
 	public function test_retrieve_preview_popup_denies_non_prompt_post_type() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Overlay prompt previews now apply the same capability and post-type checks the
inline placement already uses, so both placements behave consistently: preview
content is loaded only for users who can manage prompts, and only for the
prompts CPT.

Part of NPPM-2962.

### How to test the changes in this Pull Request:

1. Run the model tests: `n test-php --filter ModelTest` (11 pass).
2. As an admin, preview a prompt from the editor (overlay and inline) — both render as before.
3. As a logged-out visitor, the overlay preview now shows nothing, matching the inline placement.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
