### PR TITLE
fix(blocks): limit articles endpoint to viewable post types

### DIFF
--- a/plugins/newspack-blocks/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -129,6 +129,21 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			$exclude_ids = [];
 		}
 
+		// This endpoint is public, so restrict it to publicly viewable post types — matching
+		// what WordPress exposes on the front end. The editor endpoints are capability-gated.
+		$attributes['postType'] = self::filter_viewable_post_types( isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ] );
+		if ( empty( $attributes['postType'] ) ) {
+			// Every requested post type was non-viewable; return nothing rather than
+			// substituting a different post type.
+			return rest_ensure_response(
+				[
+					'items' => [],
+					'ids'   => [],
+					'next'  => '',
+				]
+			);
+		}
+
 		$article_query_args = Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' ) );
 
 		// If using exclude_ids, don't worry about pagination. Just get the next postsToShow number of results without the excluded posts. Otherwise, use standard WP pagination.
@@ -199,6 +214,20 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 				'next'  => $next_url,
 			]
 		);
+	}
+
+	/**
+	 * Restrict a list of post types to those that are publicly viewable.
+	 *
+	 * Used to keep the public articles endpoint from exposing post types that
+	 * WordPress would not surface on the front end. Non-viewable types are dropped;
+	 * the returned list may be empty when none qualify (the caller then returns no results).
+	 *
+	 * @param array|string $post_types Requested post type(s).
+	 * @return array Viewable post types (may be empty).
+	 */
+	private static function filter_viewable_post_types( $post_types ) {
+		return array_values( array_filter( (array) $post_types, 'is_post_type_viewable' ) );
 	}
 
 	/**

--- a/plugins/newspack-blocks/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -131,17 +131,11 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 
 		// This endpoint is public, so restrict it to publicly viewable post types — matching
 		// what WordPress exposes on the front end. The editor endpoints are capability-gated.
-		$attributes['postType'] = self::filter_viewable_post_types( isset( $attributes['postType'] ) ? $attributes['postType'] : [ 'post' ] );
+		$attributes['postType'] = self::filter_viewable_post_types( $attributes['postType'] );
 		if ( empty( $attributes['postType'] ) ) {
 			// Every requested post type was non-viewable; return nothing rather than
 			// substituting a different post type.
-			return rest_ensure_response(
-				[
-					'items' => [],
-					'ids'   => [],
-					'next'  => '',
-				]
-			);
+			return self::articles_response();
 		}
 
 		$article_query_args = Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' ) );
@@ -207,11 +201,23 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			);
 		}
 
+		return self::articles_response( $items, $ids, $next_url );
+	}
+
+	/**
+	 * Build the articles endpoint response.
+	 *
+	 * @param array  $items Rendered article items.
+	 * @param array  $ids   Post ids in the response.
+	 * @param string $next  URL for the next page, or empty string when there is none.
+	 * @return WP_REST_Response
+	 */
+	private static function articles_response( $items = [], $ids = [], $next = '' ) {
 		return rest_ensure_response(
 			[
 				'items' => $items,
 				'ids'   => $ids,
-				'next'  => $next_url,
+				'next'  => $next,
 			]
 		);
 	}

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -79,4 +79,153 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		self::assertEquals( 1, count( $query->posts ), 'There is one post returned.' );
 		self::assertEquals( $post_id, $query->posts[0]->ID, 'The post returned is the one with the CAP author assigned.' );
 	}
+
+	/**
+	 * The public /articles endpoint must not return posts from non-viewable post types.
+	 */
+	public function test_articles_endpoint_excludes_non_viewable_post_types() {
+		register_post_type(
+			'newspack_secret_cpt',
+			[
+				'public'       => false,
+				'show_in_rest' => false,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$secret_id = self::factory()->post->create(
+			[
+				'post_type'    => 'newspack_secret_cpt',
+				'post_status'  => 'publish',
+				'post_title'   => 'Secret CPT title',
+				'post_content' => 'Secret CPT body.',
+			]
+		);
+		// A regular published post exists, to prove the endpoint returns nothing here
+		// rather than silently substituting a different post type.
+		self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'newspack_secret_cpt' ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertNotContains(
+			$secret_id,
+			$ids,
+			'A non-viewable post type must not be returned by the public articles endpoint.'
+		);
+		self::assertEmpty(
+			$ids,
+			'A request for only non-viewable post types returns no results, not substituted posts.'
+		);
+
+		unregister_post_type( 'newspack_secret_cpt' );
+	}
+
+	/**
+	 * Mixed input keeps the viewable post types and drops the non-viewable ones.
+	 */
+	public function test_articles_endpoint_filters_mixed_post_types() {
+		register_post_type(
+			'newspack_secret_cpt',
+			[
+				'public'       => false,
+				'show_in_rest' => false,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$secret_id  = self::factory()->post->create(
+			[
+				'post_type'   => 'newspack_secret_cpt',
+				'post_status' => 'publish',
+			]
+		);
+		$regular_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'post', 'newspack_secret_cpt' ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertContains( $regular_id, $ids, 'The viewable post type is kept.' );
+		self::assertNotContains( $secret_id, $ids, 'The non-viewable post type is dropped.' );
+
+		unregister_post_type( 'newspack_secret_cpt' );
+	}
+
+	/**
+	 * A publicly viewable custom post type is still returned by the endpoint.
+	 */
+	public function test_articles_endpoint_allows_viewable_post_types() {
+		register_post_type(
+			'newspack_public_cpt',
+			[
+				'public'       => true,
+				'show_in_rest' => true,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$public_id = self::factory()->post->create(
+			[
+				'post_type'   => 'newspack_public_cpt',
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'newspack_public_cpt' ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertContains(
+			$public_id,
+			$ids,
+			'A publicly viewable post type must still be returned by the public articles endpoint.'
+		);
+
+		unregister_post_type( 'newspack_public_cpt' );
+	}
+
+	/**
+	 * The specific-posts selection mode must not surface a non-viewable post by ID.
+	 */
+	public function test_articles_endpoint_excludes_non_viewable_in_specific_posts_mode() {
+		register_post_type(
+			'newspack_secret_cpt',
+			[
+				'public'       => false,
+				'show_in_rest' => false,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$secret_id = self::factory()->post->create(
+			[
+				'post_type'   => 'newspack_secret_cpt',
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'newspack_secret_cpt' ] );
+		$request->set_param( 'specificMode', 1 );
+		$request->set_param( 'specificPosts', [ $secret_id ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertNotContains(
+			$secret_id,
+			$ids,
+			'Specific-posts mode must not surface a non-viewable post by ID.'
+		);
+
+		unregister_post_type( 'newspack_secret_cpt' );
+	}
 }

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -9,6 +9,63 @@
  * Homepage Posts Block test case.
  */
 class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+
+	/**
+	 * Post types registered during a test, unregistered in tear_down() so the
+	 * suite stays order-independent even if a test fails mid-way.
+	 *
+	 * @var string[]
+	 */
+	private $registered_post_types = [];
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		foreach ( $this->registered_post_types as $post_type ) {
+			if ( post_type_exists( $post_type ) ) {
+				unregister_post_type( $post_type );
+			}
+		}
+		$this->registered_post_types = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a non-viewable (private, not in REST) CPT for the duration of a test.
+	 *
+	 * @param string $name Post type name.
+	 * @return string The registered post type name.
+	 */
+	private function register_non_viewable_cpt( $name = 'newspack_secret_cpt' ) {
+		register_post_type(
+			$name,
+			[
+				'public'       => false,
+				'show_in_rest' => false,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$this->registered_post_types[] = $name;
+		return $name;
+	}
+
+	/**
+	 * Register a publicly viewable CPT for the duration of a test.
+	 *
+	 * @param string $name Post type name.
+	 * @return string The registered post type name.
+	 */
+	private function register_viewable_cpt( $name = 'newspack_public_cpt' ) {
+		register_post_type(
+			$name,
+			[
+				'public'       => true,
+				'show_in_rest' => true,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$this->registered_post_types[] = $name;
+		return $name;
+	}
+
 	/**
 	 * HPB query from attributes.
 	 */
@@ -84,17 +141,10 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * The public /articles endpoint must not return posts from non-viewable post types.
 	 */
 	public function test_articles_endpoint_excludes_non_viewable_post_types() {
-		register_post_type(
-			'newspack_secret_cpt',
-			[
-				'public'       => false,
-				'show_in_rest' => false,
-				'supports'     => [ 'title', 'editor' ],
-			]
-		);
+		$secret    = $this->register_non_viewable_cpt();
 		$secret_id = self::factory()->post->create(
 			[
-				'post_type'    => 'newspack_secret_cpt',
+				'post_type'    => $secret,
 				'post_status'  => 'publish',
 				'post_title'   => 'Secret CPT title',
 				'post_content' => 'Secret CPT body.',
@@ -107,7 +157,7 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		$controller = new WP_REST_Newspack_Articles_Controller();
 		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
-		$request->set_param( 'postType', [ 'newspack_secret_cpt' ] );
+		$request->set_param( 'postType', [ $secret ] );
 		$request->set_param( 'postsToShow', 10 );
 		$ids = $controller->get_items( $request )->get_data()['ids'];
 
@@ -120,25 +170,16 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$ids,
 			'A request for only non-viewable post types returns no results, not substituted posts.'
 		);
-
-		unregister_post_type( 'newspack_secret_cpt' );
 	}
 
 	/**
 	 * Mixed input keeps the viewable post types and drops the non-viewable ones.
 	 */
 	public function test_articles_endpoint_filters_mixed_post_types() {
-		register_post_type(
-			'newspack_secret_cpt',
-			[
-				'public'       => false,
-				'show_in_rest' => false,
-				'supports'     => [ 'title', 'editor' ],
-			]
-		);
+		$secret     = $this->register_non_viewable_cpt();
 		$secret_id  = self::factory()->post->create(
 			[
-				'post_type'   => 'newspack_secret_cpt',
+				'post_type'   => $secret,
 				'post_status' => 'publish',
 			]
 		);
@@ -147,31 +188,22 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		$controller = new WP_REST_Newspack_Articles_Controller();
 		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
-		$request->set_param( 'postType', [ 'post', 'newspack_secret_cpt' ] );
+		$request->set_param( 'postType', [ 'post', $secret ] );
 		$request->set_param( 'postsToShow', 10 );
 		$ids = $controller->get_items( $request )->get_data()['ids'];
 
 		self::assertContains( $regular_id, $ids, 'The viewable post type is kept.' );
 		self::assertNotContains( $secret_id, $ids, 'The non-viewable post type is dropped.' );
-
-		unregister_post_type( 'newspack_secret_cpt' );
 	}
 
 	/**
 	 * A publicly viewable custom post type is still returned by the endpoint.
 	 */
 	public function test_articles_endpoint_allows_viewable_post_types() {
-		register_post_type(
-			'newspack_public_cpt',
-			[
-				'public'       => true,
-				'show_in_rest' => true,
-				'supports'     => [ 'title', 'editor' ],
-			]
-		);
+		$public    = $this->register_viewable_cpt();
 		$public_id = self::factory()->post->create(
 			[
-				'post_type'   => 'newspack_public_cpt',
+				'post_type'   => $public,
 				'post_status' => 'publish',
 			]
 		);
@@ -179,7 +211,7 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		$controller = new WP_REST_Newspack_Articles_Controller();
 		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
-		$request->set_param( 'postType', [ 'newspack_public_cpt' ] );
+		$request->set_param( 'postType', [ $public ] );
 		$request->set_param( 'postsToShow', 10 );
 		$ids = $controller->get_items( $request )->get_data()['ids'];
 
@@ -188,25 +220,17 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$ids,
 			'A publicly viewable post type must still be returned by the public articles endpoint.'
 		);
-
-		unregister_post_type( 'newspack_public_cpt' );
 	}
 
 	/**
-	 * The specific-posts selection mode must not surface a non-viewable post by ID.
+	 * The specific-posts selection mode must not surface a non-viewable post by ID
+	 * (requested post type is itself non-viewable — the empty-guard path).
 	 */
 	public function test_articles_endpoint_excludes_non_viewable_in_specific_posts_mode() {
-		register_post_type(
-			'newspack_secret_cpt',
-			[
-				'public'       => false,
-				'show_in_rest' => false,
-				'supports'     => [ 'title', 'editor' ],
-			]
-		);
+		$secret    = $this->register_non_viewable_cpt();
 		$secret_id = self::factory()->post->create(
 			[
-				'post_type'   => 'newspack_secret_cpt',
+				'post_type'   => $secret,
 				'post_status' => 'publish',
 			]
 		);
@@ -214,7 +238,7 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		$controller = new WP_REST_Newspack_Articles_Controller();
 		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
-		$request->set_param( 'postType', [ 'newspack_secret_cpt' ] );
+		$request->set_param( 'postType', [ $secret ] );
 		$request->set_param( 'specificMode', 1 );
 		$request->set_param( 'specificPosts', [ $secret_id ] );
 		$request->set_param( 'postsToShow', 10 );
@@ -225,7 +249,35 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$ids,
 			'Specific-posts mode must not surface a non-viewable post by ID.'
 		);
+	}
 
-		unregister_post_type( 'newspack_secret_cpt' );
+	/**
+	 * Specific-posts mode must not surface a non-viewable post by ID even when the
+	 * requested postType is viewable. This reaches the WP_Query post_type + post__in
+	 * intersection (the realistic attack), not the empty-guard short-circuit.
+	 */
+	public function test_articles_endpoint_excludes_non_viewable_specific_post_under_viewable_type() {
+		$secret    = $this->register_non_viewable_cpt();
+		$secret_id = self::factory()->post->create(
+			[
+				'post_type'   => $secret,
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'post' ] ); // Viewable — survives the filter.
+		$request->set_param( 'specificMode', 1 );
+		$request->set_param( 'specificPosts', [ $secret_id ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertNotContains(
+			$secret_id,
+			$ids,
+			'A non-viewable post requested by ID must not surface even under a viewable postType.'
+		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The public `/articles` REST endpoint now restricts the requested `postType` to
publicly viewable post types, matching what WordPress exposes on the front end.
Non-viewable post types are dropped; a request for only non-viewable types
returns no results. The shared query builder is unchanged, so the editor
endpoints and block rendering are unaffected.

Part of NPPM-2964.

### How to test the changes in this Pull Request:

1. Run the block tests: `n test-php --filter HomepagePostsBlockTest` (6 pass).
2. As a logged-out visitor, call `/wp-json/newspack-blocks/v1/articles` with a non-public post type — no results are returned.
3. Posts and publicly viewable custom post types are returned as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### Accepted trade-off (from review)

Because `/articles` now filters requested post types through `is_post_type_viewable()`, the Sponsors CPT (`public=false`, deliberately listable in Homepage Posts / Carousel per [newspack-sponsors#52](https://github.com/Automattic/newspack-sponsors/pull/52)) is dropped from the endpoint. A Sponsors-only block still renders **page 1 via SSR**, but **load-more / infinite-scroll returns empty** — graceful, and only for a Sponsors-only block with more sponsors than the page size.

This is intentional: the predicate must **not** be loosened to `show_in_rest`, since `public=false` + `show_in_rest=true` CPTs (`np_content_gate`, `newspack_popups_cpt`, …) would then be re-exposed. Restoring Sponsors load-more behind a dedicated allow-list filter is tracked as a follow-up in **NPPM-2972**.
