### PR TITLE
feat(insights): pre-warm Insights tabs with durable cache

### DIFF
--- a/plugins/newspack-ads/includes/blocks/class-ad-slot-block.php
+++ b/plugins/newspack-ads/includes/blocks/class-ad-slot-block.php
@@ -56,7 +56,8 @@ final class Ad_Slot_Block {
 	 * Providers::render_placement_ad_code() pipeline. Returns empty string when no
 	 * placement is selected, no listener is subscribed for that placement (e.g.,
 	 * classic-theme context, or unknown key), or the hook produces no output
-	 * (no ad unit bound, suppressed, provider not active).
+	 * (no ad unit bound, suppressed, provider not active). Any captured output is
+	 * passed through apply_spacing() to merge the block's padding/margin styles.
 	 *
 	 * @param array $attrs Block attributes.
 	 *
@@ -72,7 +73,54 @@ final class Ad_Slot_Block {
 		}
 		ob_start();
 		do_action( $hook_name );
-		return ob_get_clean();
+		$content = ob_get_clean();
+
+		return self::apply_spacing( $content, $attrs );
+	}
+
+	/**
+	 * Merge the block's spacing (padding/margin) styles onto the first element of
+	 * the rendered ad markup, instead of adding a wrapper element. Styles come
+	 * from the block's `style` attribute via the style engine, which resolves
+	 * theme spacing presets and needs no global render context.
+	 *
+	 * @param string $content Rendered ad markup.
+	 * @param array  $attrs   Block attributes.
+	 *
+	 * @return string Markup with spacing applied.
+	 */
+	private static function apply_spacing( $content, $attrs ) {
+		if ( '' === trim( (string) $content ) || empty( $attrs['style']['spacing'] ) ) {
+			return $content;
+		}
+
+		$styles = wp_style_engine_get_styles( [ 'spacing' => $attrs['style']['spacing'] ] );
+		$css    = $styles['css'] ?? '';
+		if ( '' === $css ) {
+			return $content;
+		}
+
+		// Skip leading <style>/<script> tags so spacing lands on the visible
+		// container (fixed-height GAM placements emit a <style> block first).
+		$processor = new \WP_HTML_Tag_Processor( $content );
+		$found     = false;
+		while ( $processor->next_tag() ) {
+			$tag = $processor->get_tag();
+			if ( 'STYLE' === $tag || 'SCRIPT' === $tag ) {
+				continue;
+			}
+			$found = true;
+			break;
+		}
+		// No element to attach to (e.g. comment- or text-only output); leave as-is.
+		if ( ! $found ) {
+			return $content;
+		}
+		$existing = $processor->get_attribute( 'style' );
+		$merged   = $existing ? rtrim( trim( $existing ), ';' ) . ';' . $css : $css;
+		$processor->set_attribute( 'style', $merged );
+
+		return $processor->get_updated_html();
 	}
 }
 Ad_Slot_Block::init();

--- a/plugins/newspack-ads/src/blocks/ad-slot/block.json
+++ b/plugins/newspack-ads/src/blocks/ad-slot/block.json
@@ -15,6 +15,10 @@
 	},
 	"supports": {
 		"html": false,
-		"visibility": false
+		"visibility": false,
+		"spacing": {
+			"padding": true,
+			"margin": true
+		}
 	}
 }

--- a/plugins/newspack-ads/src/blocks/ad-slot/edit.js
+++ b/plugins/newspack-ads/src/blocks/ad-slot/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, Placeholder, SelectControl } from '@wordpress/components';
+import { PanelBody, Placeholder, SelectControl, Spinner } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -99,15 +99,17 @@ export default function Edit( { attributes, setAttributes } ) {
 	}
 
 	// Selected: reuse the ad-unit block's placeholder visual so styling is identical.
+	// Fill/stroke are set inline so the mock paints correctly before the editor
+	// stylesheet loads into the canvas iframe; the stylesheet still overrides.
 	return (
 		<div { ...blockProps }>
 			{ inspector }
 			<div className="newspack-ads-ad-block-placeholder">
 				<svg className="newspack-ads-ad-block-mock" width="100%" height="100%">
-					<rect width="100%" height="100%" />
-					<line x1="0" y1="0" x2="100%" y2="100%" />
+					<rect width="100%" height="100%" fill="#fff" stroke="rgba(30, 30, 30, 0.4)" />
+					<line x1="0" y1="0" x2="100%" y2="100%" stroke="rgba(30, 30, 30, 0.4)" />
 				</svg>
-				<div className="newspack-ads-ad-block-ad-label">{ selectedLabel }</div>
+				{ isLoading ? <Spinner /> : <div className="newspack-ads-ad-block-ad-label">{ selectedLabel }</div> }
 			</div>
 		</div>
 	);

--- a/plugins/newspack-ads/tests/test-ad-slot-block.php
+++ b/plugins/newspack-ads/tests/test-ad-slot-block.php
@@ -41,15 +41,7 @@ class AdSlotBlockTest extends WP_UnitTestCase {
 	 * A registered placement with no ad unit bound renders nothing.
 	 */
 	public function test_render_with_registered_placement_no_assignment() {
-		// Force the block-theme branch so block placements are registered.
-		add_filter( 'newspack_ads_is_block_theme', '__return_true' );
-
-		// Reset and re-register placements.
-		$ref      = new \ReflectionClass( \Newspack_Ads\Placements::class );
-		$prop     = $ref->getProperty( 'placements' );
-		$prop->setAccessible( true );
-		$prop->setValue( null, [] );
-		\Newspack_Ads\Placements::register_default_placements();
+		$this->register_block_placements();
 
 		$html = \Newspack_Ads\Ad_Slot_Block::render_block( [ 'placement' => 'global_above_header' ] );
 		self::assertSame( '', $html );
@@ -58,33 +50,187 @@ class AdSlotBlockTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When a registered placement's hook is fired, the block's render callback
-	 * captures the hook's output.
+	 * Force the block-theme branch and re-register the default placements so the
+	 * synthetic block-placement hooks exist for the duration of a test. Callers
+	 * are responsible for removing the filter afterwards.
 	 */
-	public function test_render_captures_hook_output() {
-		// Force the block-theme branch so block placements are registered.
+	private function register_block_placements() {
 		add_filter( 'newspack_ads_is_block_theme', '__return_true' );
 
-		// Reset placement registry and re-register so we hold the hook subscription.
 		$ref  = new \ReflectionClass( \Newspack_Ads\Placements::class );
 		$prop = $ref->getProperty( 'placements' );
 		$prop->setAccessible( true );
 		$prop->setValue( null, [] );
 		\Newspack_Ads\Placements::register_default_placements();
+	}
 
-		// Plant a known-output hook listener on the synthetic hook for `global_above_header`.
-		// This stands in for whatever inject_placement_ad would normally emit when
-		// an ad unit is bound and a provider is active.
-		$marker   = 'PLACEMENT_RENDERED_MARKER';
-		$listener = function () use ( $marker ) {
-			echo esc_html( $marker );
+	/**
+	 * Render the block with a placement whose synthetic hook echoes the given
+	 * markup, standing in for whatever a bound ad unit/provider would emit.
+	 *
+	 * @param array  $attrs       Block attributes.
+	 * @param string $output_html Markup the planted listener should echo.
+	 *
+	 * @return string Rendered block HTML.
+	 */
+	private function render_with_output( $attrs, $output_html ) {
+		$this->register_block_placements();
+
+		$listener = function () use ( $output_html ) {
+			echo $output_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		};
 		add_action( 'newspack_ads_block_placement_global_above_header', $listener, 999 );
 
-		$html = \Newspack_Ads\Ad_Slot_Block::render_block( [ 'placement' => 'global_above_header' ] );
-		self::assertStringContainsString( $marker, $html );
+		$html = \Newspack_Ads\Ad_Slot_Block::render_block( array_merge( [ 'placement' => 'global_above_header' ], $attrs ) );
 
 		remove_action( 'newspack_ads_block_placement_global_above_header', $listener, 999 );
 		remove_filter( 'newspack_ads_is_block_theme', '__return_true' );
+
+		return $html;
+	}
+
+	/**
+	 * Spacing padding/margin values merge onto the first element of the output.
+	 */
+	public function test_render_merges_spacing_onto_first_element() {
+		$attrs = [
+			'style' => [
+				'spacing' => [
+					'padding' => [
+						'top'    => '10px',
+						'bottom' => '20px',
+					],
+					'margin'  => [
+						'top' => '30px',
+					],
+				],
+			],
+		];
+
+		$html = $this->render_with_output( $attrs, "<div id='div-gpt-ad-test-0'></div>" );
+
+		self::assertStringContainsString( 'padding-top:10px', $html );
+		self::assertStringContainsString( 'padding-bottom:20px', $html );
+		self::assertStringContainsString( 'margin-top:30px', $html );
+		self::assertStringContainsString( 'div-gpt-ad-test-0', $html );
+	}
+
+	/**
+	 * An existing inline style on the output element is preserved, not overwritten.
+	 */
+	public function test_render_preserves_existing_style() {
+		$attrs = [
+			'style' => [
+				'spacing' => [
+					'padding' => [ 'top' => '10px' ],
+				],
+			],
+		];
+
+		$html = $this->render_with_output( $attrs, '<div class="newspack-broadstreet-ad" style="width: 300px;"></div>' );
+
+		self::assertStringContainsString( 'width: 300px', $html );
+		self::assertStringContainsString( 'padding-top:10px', $html );
+	}
+
+	/**
+	 * Output with a leading HTML comment still has spacing applied to the element.
+	 */
+	public function test_render_applies_spacing_past_leading_comment() {
+		$attrs = [
+			'style' => [
+				'spacing' => [
+					'margin' => [ 'bottom' => '15px' ],
+				],
+			],
+		];
+
+		$html = $this->render_with_output( $attrs, "<!-- /network/code --><div id='div-gpt-ad-test-0'></div>" );
+
+		self::assertStringContainsString( '<!-- /network/code -->', $html );
+		self::assertStringContainsString( 'margin-bottom:15px', $html );
+	}
+
+	/**
+	 * Spacing is applied to the first rendered element, skipping a leading
+	 * <style> block (e.g. the fixed-height CSS emitted on
+	 * newspack_ads_before_placement_ad) so it lands on the visible ad container.
+	 */
+	public function test_render_skips_leading_style_block() {
+		$attrs = [
+			'style' => [
+				'spacing' => [
+					'margin' => [ 'top' => '30px' ],
+				],
+			],
+		];
+
+		$output = '<style>@media ( min-width: 320px ) { .newspack_global_ad.x { min-height: 100px; } }</style><div class="newspack_global_ad"><div id="div-gpt-ad-test-0"></div></div>';
+
+		$html = $this->render_with_output( $attrs, $output );
+
+		// Margin must land on the visible container, not the <style> tag.
+		self::assertMatchesRegularExpression( '/<div\b(?=[^>]*\bclass="newspack_global_ad")(?=[^>]*margin-top:30px)[^>]*>/', $html );
+		self::assertDoesNotMatchRegularExpression( '/<style[^>]*margin-top/', $html );
+	}
+
+	/**
+	 * When no spacing is set, the output is returned unchanged.
+	 */
+	public function test_render_without_spacing_is_unchanged() {
+		$output = "<div id='div-gpt-ad-test-0'></div>";
+		$html   = $this->render_with_output( [], $output );
+		self::assertSame( $output, $html );
+	}
+
+	/**
+	 * Non-empty output with no element to attach to (e.g. a comment) is returned
+	 * unchanged even when spacing is set.
+	 */
+	public function test_render_with_no_matchable_element_is_unchanged() {
+		$attrs = [
+			'style' => [
+				'spacing' => [
+					'margin' => [ 'top' => '30px' ],
+				],
+			],
+		];
+
+		$output = '<!-- ad failed to render -->';
+		$html   = $this->render_with_output( $attrs, $output );
+
+		self::assertSame( $output, $html );
+		self::assertStringNotContainsString( 'style=', $html );
+	}
+
+	/**
+	 * An existing inline style without a trailing semicolon still merges cleanly
+	 * (the separator is added between the existing declarations and the spacing).
+	 */
+	public function test_render_merges_onto_style_without_trailing_semicolon() {
+		$attrs = [
+			'style' => [
+				'spacing' => [
+					'margin' => [ 'top' => '30px' ],
+				],
+			],
+		];
+
+		$html = $this->render_with_output( $attrs, '<div style="width:300px"></div>' );
+
+		self::assertStringContainsString( 'width:300px;margin-top:30px', $html );
+	}
+
+	/**
+	 * When a registered placement's hook is fired, the block's render callback
+	 * captures the hook's output.
+	 */
+	public function test_render_captures_hook_output() {
+		// This stands in for whatever inject_placement_ad would normally emit when
+		// an ad unit is bound and a provider is active.
+		$marker = 'PLACEMENT_RENDERED_MARKER';
+
+		$html = $this->render_with_output( [], esc_html( $marker ) );
+		self::assertStringContainsString( $marker, $html );
 	}
 }

--- a/plugins/newspack-newsletters/CHANGELOG.md
+++ b/plugins/newspack-newsletters/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-newsletters [3.35.1](https://github.com/Automattic/newspack-workspace/compare/newspack-newsletters@3.35.0...newspack-newsletters@3.35.1) (2026-07-01)
+
+
+### Bug Fixes
+
+* **newsletters:** limit ad editor status to active/inactive ([d7c741c](https://github.com/Automattic/newspack-workspace/commit/d7c741cd0d56abfc2e962f5d0f0df22dc840bf2d))
+
 # newspack-newsletters [3.35.0](https://github.com/Automattic/newspack-workspace/compare/newspack-newsletters@3.34.4...newspack-newsletters@3.35.0) (2026-06-29)
 
 

--- a/plugins/newspack-newsletters/CHANGELOG.md
+++ b/plugins/newspack-newsletters/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-newsletters [3.35.2](https://github.com/Automattic/newspack-workspace/compare/newspack-newsletters@3.35.1...newspack-newsletters@3.35.2) (2026-07-01)
+
+
+### Bug Fixes
+
+* **newsletters:** add status control to ads quick edit ([#478](https://github.com/Automattic/newspack-workspace/issues/478)) ([4a3fab1](https://github.com/Automattic/newspack-workspace/commit/4a3fab13eb016a436e26f0759625c23f59cc9cab))
+
 ## newspack-newsletters [3.35.1](https://github.com/Automattic/newspack-workspace/compare/newspack-newsletters@3.35.0...newspack-newsletters@3.35.1) (2026-07-01)
 
 

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
- * Version:         3.35.0
+ * Version:         3.35.1
  *
  * @package         Newspack_Newsletters
  */

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
- * Version:         3.35.1
+ * Version:         3.35.2
  *
  * @package         Newspack_Newsletters
  */

--- a/plugins/newspack-newsletters/package.json
+++ b/plugins/newspack-newsletters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-newsletters",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"description": "",
 	"repository": {
 		"type": "git",

--- a/plugins/newspack-newsletters/package.json
+++ b/plugins/newspack-newsletters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-newsletters",
-	"version": "3.35.1",
+	"version": "3.35.2",
 	"description": "",
 	"repository": {
 		"type": "git",

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
@@ -136,6 +136,7 @@ export default function AdsListScreen() {
 			/>
 			{ quickEditItem && (
 				<AdsQuickEditPanel
+					key={ quickEditItem.id }
 					item={ quickEditItem }
 					advertisers={ filterTerms.advertisers }
 					placements={ filterTerms.placements }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -1,12 +1,13 @@
 /**
- * Quick Edit panel for the ads list — advertiser, placement,
+ * Quick Edit panel for the ads list — status, advertiser, placement,
  * category, start/expiry dates, price.
  *
- * Status / insertion strategy / position stay in the full editor.
+ * Insertion strategy / position stay in the full editor; status is
+ * editable here.
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { FormTokenField, TextControl } from '@wordpress/components';
+import { FormTokenField, RadioControl, TextControl } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { emailAd } from 'newspack-icons';
@@ -47,7 +48,10 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 		const value = item?.meta?.price;
 		return value ? String( value ) : '';
 	} )();
+	// `private` ads are never served (the serving queries are publish-only), so they are Inactive alongside drafts.
+	const initialStatus = [ 'publish', 'future' ].includes( item?.status ) ? 'active' : 'inactive';
 
+	const [ status, setStatus ] = useState( initialStatus );
 	const [ advertiserSelections, setAdvertiserSelections ] = useState( initialAdvertiserSelections );
 	const [ placementSelections, setPlacementSelections ] = useState( initialPlacementSelections );
 	const [ categorySelections, setCategorySelections ] = useState( initialCategorySelections );
@@ -57,6 +61,7 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 	const [ isBusy, setIsBusy ] = useState( false );
 
 	const isDirty =
+		status !== initialStatus ||
 		startDate !== initialStartDate ||
 		expiryDate !== initialExpiryDate ||
 		price !== initialPrice ||
@@ -97,6 +102,9 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 			categories: categorySelections.map( s => s.id ),
 			meta,
 		};
+		if ( status !== initialStatus ) {
+			data.status = status === 'active' ? 'publish' : 'draft';
+		}
 		try {
 			await apiFetch( { path: `${ POSTS_PATH }/${ item.id }`, method: 'POST', data } );
 			notifySuccess( __( 'Ad updated.', 'newspack-newsletters' ) );
@@ -121,6 +129,16 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 			canSave={ canSave }
 			saveLabel={ __( 'Save', 'newspack-newsletters' ) }
 		>
+			<RadioControl
+				label={ __( 'Status', 'newspack-newsletters' ) }
+				selected={ status }
+				options={ [
+					{ label: __( 'Active', 'newspack-newsletters' ), value: 'active' },
+					{ label: __( 'Inactive', 'newspack-newsletters' ), value: 'inactive' },
+				] }
+				onChange={ setStatus }
+				help={ __( 'Active ads run according to their start and expiration dates. Inactive ads are never shown.', 'newspack-newsletters' ) }
+			/>
 			<FormTokenField
 				label={ __( 'Advertiser', 'newspack-newsletters' ) }
 				value={ advertiserTokens }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
@@ -1,0 +1,134 @@
+// Spy on the network layer; the real `@wordpress/components` render the
+// RadioControl so we exercise the actual radio markup. `QuickEditPanel`
+// is a thin modal shell (portal + exit animation), so it's mocked down to
+// a plain wrapper that exposes `isDirty` and a Save trigger — the panel's
+// own status/save logic is what's under test here.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../components/quick-edit-panel', () => ( {
+	__esModule: true,
+	default: ( { children, isDirty, canSave, isBusy, onSave } ) => (
+		<div>
+			<div data-testid="panel-dirty">{ String( isDirty ) }</div>
+			{ children }
+			<button type="button" data-testid="panel-save" onClick={ onSave } disabled={ isBusy || ! canSave }>
+				Save
+			</button>
+		</div>
+	),
+} ) );
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import AdsQuickEditPanel from './quick-edit-panel';
+
+const ADVERTISERS = [ { id: 10, name: 'Acme' } ];
+const PLACEMENTS = [ { id: 20, name: 'Header' } ];
+
+const renderPanel = ( item, extra = {} ) =>
+	render(
+		<AdsQuickEditPanel
+			item={ item }
+			advertisers={ ADVERTISERS }
+			placements={ PLACEMENTS }
+			onClose={ jest.fn() }
+			onSaved={ jest.fn() }
+			{ ...extra }
+		/>
+	);
+
+const makeItem = status => ( { id: 42, status, title: { raw: 'Summer sale' }, meta: {} } );
+
+const postCall = () => apiFetch.mock.calls.find( call => call[ 0 ]?.method === 'POST' )?.[ 0 ];
+
+describe( 'AdsQuickEditPanel status control', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		// Categories fetch (`fetchAllTerms`) and the save POST both go
+		// through this mock; an empty object resolves both harmlessly.
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	it( 'selects Active when the raw post_status is publish', async () => {
+		renderPanel( makeItem( 'publish' ) );
+		expect( await screen.findByRole( 'radio', { name: 'Active' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Inactive' } ) ).not.toBeChecked();
+	} );
+
+	it( 'selects Inactive when the raw post_status is draft', async () => {
+		renderPanel( makeItem( 'draft' ) );
+		expect( await screen.findByRole( 'radio', { name: 'Inactive' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Active' } ) ).not.toBeChecked();
+	} );
+
+	it( 'POSTs status: publish when toggled Inactive → Active', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'draft' ), { onSaved } );
+		fireEvent.click( await screen.findByRole( 'radio', { name: 'Active' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().path ).toBe( '/wp/v2/newspack_nl_ads_cpt/42' );
+		expect( postCall().method ).toBe( 'POST' );
+		expect( postCall().data.status ).toBe( 'publish' );
+	} );
+
+	it( 'POSTs status: draft when toggled Active → Inactive', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'publish' ), { onSaved } );
+		fireEvent.click( await screen.findByRole( 'radio', { name: 'Inactive' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data.status ).toBe( 'draft' );
+	} );
+
+	it( 'omits status from the payload when it is unchanged', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'publish' ), { onSaved } );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data ).not.toHaveProperty( 'status' );
+	} );
+
+	it( 'preserves an edge status (future) by omitting status when unchanged', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'future' ), { onSaved } );
+		// `future` maps to the Active radio but must not be rewritten to publish on save.
+		expect( await screen.findByRole( 'radio', { name: 'Active' } ) ).toBeChecked();
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data ).not.toHaveProperty( 'status' );
+	} );
+
+	it( 'flattens a scheduled (future) ad to draft when toggled to Inactive', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'future' ), { onSaved } );
+		// Toggling a scheduled ad off is a manual override: it POSTs `draft`, discarding the scheduled post_date.
+		fireEvent.click( await screen.findByRole( 'radio', { name: 'Inactive' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data.status ).toBe( 'draft' );
+	} );
+
+	it( 'selects Inactive for a private ad and preserves it by omitting status when unchanged', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'private' ), { onSaved } );
+		// `private` ads are never served, so the control reflects Inactive; leaving it untouched must not rewrite the status.
+		expect( await screen.findByRole( 'radio', { name: 'Inactive' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Active' } ) ).not.toBeChecked();
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data ).not.toHaveProperty( 'status' );
+	} );
+
+	it( 'marks the panel dirty after a status-only change', async () => {
+		renderPanel( makeItem( 'publish' ) );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'false' );
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Inactive' } ) );
+		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'true' );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/status-label.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/status-label.js
@@ -14,7 +14,8 @@ export const { STATUS_KIND_LABELS, statusKindLabel } = createStatusLabelModule( 
 	active: __( 'Active', 'newspack-newsletters' ),
 	scheduled: __( 'Scheduled', 'newspack-newsletters' ),
 	expired: __( 'Expired', 'newspack-newsletters' ),
-	draft: __( 'Draft', 'newspack-newsletters' ),
+	// The `draft` kind (draft / pending ads) is the list's non-serving state; label it "Inactive" to match the Quick Edit control.
+	draft: __( 'Inactive', 'newspack-newsletters' ),
 	trash: __( 'Trash', 'newspack-newsletters' ),
 } ) );
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/status-label.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/status-label.test.js
@@ -10,14 +10,14 @@ describe( 'ads status-label', () => {
 		expect( labels.active ).toBe( 'Active' );
 		expect( labels.scheduled ).toBe( 'Scheduled' );
 		expect( labels.expired ).toBe( 'Expired' );
-		expect( labels.draft ).toBe( 'Draft' );
+		expect( labels.draft ).toBe( 'Inactive' );
 		expect( labels.trash ).toBe( 'Trash' );
 	} );
 
-	it( 'statusKindLabel returns the matching label or falls back to draft', () => {
+	it( 'statusKindLabel returns the matching label or falls back to the draft (Inactive) kind', () => {
 		expect( statusKindLabel( 'active' ) ).toBe( 'Active' );
 		expect( statusKindLabel( 'expired' ) ).toBe( 'Expired' );
-		expect( statusKindLabel( 'unknown' ) ).toBe( 'Draft' );
-		expect( statusKindLabel( '' ) ).toBe( 'Draft' );
+		expect( statusKindLabel( 'unknown' ) ).toBe( 'Inactive' );
+		expect( statusKindLabel( '' ) ).toBe( 'Inactive' );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/ads/editor/index.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.js
@@ -7,7 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Fragment, useState } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel, store as editPostStore } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { ToggleControl, TextControl, DatePicker, Notice, RangeControl, Button, Modal } from '@wordpress/components';
+import { ToggleControl, TextControl, DatePicker, Notice, RadioControl, RangeControl, Button, Modal } from '@wordpress/components';
 import { date as wpDate, format, isInTheFuture } from '@wordpress/date';
 import { SelectControl } from 'newspack-components';
 import AdPlacements from '../../components/ad-placements';
@@ -28,10 +28,11 @@ apiFetch.use( ( options, next ) => {
 } );
 
 function AdEdit() {
-	const { price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
+	const { status, price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
+			status: getEditedPostAttribute( 'status' ),
 			price: meta.price,
 			// Normalize to Y-m-d on read so all client-side date comparisons are
 			// plain string compares regardless of any legacy ISO-datetime value.
@@ -104,12 +105,35 @@ function AdEdit() {
 		};
 	}
 
-	// Remove the "post-status" (Summary) panel.
+	// Ads only need an on/off state: whether they run (`publish`) or not
+	// (`draft`). Scheduling is driven by the start/expiry date meta, and
+	// private/pending/password statuses never serve. Remove the native
+	// "Summary" panel (which offers all of those) and expose a single
+	// Active/Inactive control instead, matching the ads list Quick Edit.
 	removeEditorPanel( 'post-status' );
+
+	// `future`/`private`/etc. are edge statuses a publisher can't set from
+	// this control; map any publish-equivalent to Active and everything else
+	// to Inactive, and only write `publish`/`draft` back on an actual change.
+	const statusControl = [ 'publish', 'future' ].includes( status ) ? 'active' : 'inactive';
 
 	return (
 		<Fragment>
 			<PluginDocumentSettingPanel name="newsletters-ads-settings-panel" title={ __( 'Ad settings', 'newspack-newsletters' ) }>
+				<RadioControl
+					label={ __( 'Status', 'newspack-newsletters' ) }
+					selected={ statusControl }
+					options={ [
+						{ label: __( 'Active', 'newspack-newsletters' ), value: 'active' },
+						{ label: __( 'Inactive', 'newspack-newsletters' ), value: 'inactive' },
+					] }
+					onChange={ value => editPost( { status: value === 'active' ? 'publish' : 'draft' } ) }
+					help={ __(
+						'Active ads run according to their start and expiration dates. Inactive ads are never shown.',
+						'newspack-newsletters'
+					) }
+				/>
+				<hr />
 				<TextControl
 					type="number"
 					label={ __( 'Price', 'newspack-newsletters' ) }

--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -496,20 +496,36 @@ function process_form() {
 
 	$registered_user      = false;
 	$verification_payload = [];
-	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+	// Default to "did not authenticate" so the response-side registration gate below is safe
+	// even when Reader Activation is disabled/unavailable (the branch that assigns it is skipped).
+	$authenticate = false;
+	if ( \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
 		if ( $popup_id ) {
 			$metadata['registration_method'] = 'newsletters-subscription-popup';
 		}
-		$registered_user = \Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
+		// Authenticate the new reader only when the browser has no existing session. A
+		// logged-in browser (a returning reader, or a shared device still carrying a prior
+		// reader's cookie) must still get an account created for the submitted email — but
+		// without re-authenticating as that email. Skipping registration entirely when logged
+		// in is what silently orphaned these signups: the email landed in the ESP list with
+		// no WordPress account. See NPPM-2936.
+		$authenticate    = ! \is_user_logged_in();
+		$registered_user = \Newspack\Reader_Activation::register_reader( $email, $name, $authenticate, $metadata );
 		// register_reader() can return false (existing user) or a WP_Error; only proceed when
 		// we got a positive integer user ID for a freshly-created reader.
-		if ( is_int( $registered_user ) && $registered_user > 0 ) {
+		// Only signal a registration to the current browser when this signup authenticated
+		// the new reader (a clean, logged-out visitor). When a reader is already logged in we
+		// create the account for the submitted email without authenticating it, so the current
+		// session must not be told "you just registered" — otherwise the other reader's
+		// registration (its `registered` flag, verification prompt, and `reader_registered`
+		// activity) would be recorded against this browser's reader. See NPPM-2936.
+		if ( $authenticate && is_int( $registered_user ) && $registered_user > 0 ) {
 			$metadata['registered'] = '1';
 
 			// Surface verification state so the frontend can trigger the post-registration
-			// verification flow. Guarded with method_exists so we degrade gracefully when running
-			// against an older newspack-plugin that doesn't expose the helper yet.
+			// verification flow. Guarded with method_exists so we degrade gracefully when
+			// running against an older newspack-plugin that doesn't expose the helper yet.
 			if ( method_exists( '\Newspack\Reader_Activation', 'get_verification_payload' ) ) {
 				$verification_payload = \Newspack\Reader_Activation::get_verification_payload( (int) $registered_user );
 			}
@@ -564,11 +580,13 @@ function process_form() {
 	$result['metadata'] = $metadata;
 
 	// Surface registration + verification state so the frontend can trigger the
-	// post-registration verification flow when a brand-new reader account was created.
-	// `get_verification_payload()` always returns both `verified` and `verification_nonce`
-	// keys (with empty/null sentinels when not applicable); the frontend gates on the
-	// `verification_nonce` being a non-empty string.
-	if ( is_int( $registered_user ) && $registered_user > 0 ) {
+	// post-registration verification flow when a brand-new reader account was created and
+	// authenticated in this browser. `get_verification_payload()` always returns both
+	// `verified` and `verification_nonce` keys (with empty/null sentinels when not
+	// applicable); the frontend gates on the `verification_nonce` being a non-empty string.
+	// Skipped when a reader is already logged in: the new account belongs to a different
+	// email, not this session, so registration must not be surfaced to the current reader.
+	if ( $authenticate && is_int( $registered_user ) && $registered_user > 0 ) {
 		$result['email']      = $email;
 		$result['registered'] = 1;
 		$result               = array_merge( $result, $verification_payload );

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -170,6 +170,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-cache.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-preset-windows.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/api/trait-cached-controller.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/api/trait-insights-rest.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-audience.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-engagement.php';

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -168,6 +168,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-dashboard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-cache.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-preset-windows.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/api/trait-cached-controller.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-audience.php';

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -169,6 +169,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-cache.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-preset-windows.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-prewarm.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/api/trait-cached-controller.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/api/trait-insights-rest.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-wizard.php';

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -2533,7 +2533,13 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_register_reader_disabled', __( 'Registration is disabled.', 'newspack-plugin' ) );
 		}
 
-		if ( \is_user_logged_in() ) {
+		// Registration is only blocked while logged in when it would also authenticate:
+		// a session can't be re-authenticated as a second identity. A non-authenticating
+		// registration is allowed so that a logged-in browser (e.g. a returning reader, or
+		// a shared device still carrying a prior reader's cookie) can still create an account
+		// for a different email — e.g. a Newsletter Subscription block signup — without
+		// hijacking the current session.
+		if ( \is_user_logged_in() && $authenticate ) {
 			return new \WP_Error( 'newspack_register_reader_logged_in', __( 'Cannot register while logged in.', 'newspack-plugin' ) );
 		}
 
@@ -2543,7 +2549,12 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_register_reader_empty_email', __( 'Please enter a valid email address.', 'newspack-plugin' ) );
 		}
 
-		self::set_auth_intention_cookie( $email );
+		// Only record an auth intention for a logged-out visitor. While logged in (a
+		// non-authenticating registration for a different email) the browser has no pending
+		// authentication, so the intention cookie must not be overwritten with the other email.
+		if ( ! \is_user_logged_in() ) {
+			self::set_auth_intention_cookie( $email );
+		}
 
 		$existing_user = \get_user_by( 'email', $email );
 		if ( \is_wp_error( $existing_user ) ) {
@@ -2555,7 +2566,13 @@ final class Reader_Activation {
 		if ( $existing_user ) {
 			// If the user is not a reader, send a non-reader login reminder. We don't want to expose on the front-end that the email address belongs to a non-reader account.
 			if ( ! self::is_user_reader( $existing_user ) ) {
-				self::send_non_reader_login_reminder( $existing_user );
+				// The "you already have an account, log in" reminder only makes sense for a
+				// logged-out registration attempt. While logged in (a non-authenticating
+				// registration for someone else's existing non-reader account) suppress it: the
+				// email's owner did not initiate this, and may even be the current user.
+				if ( ! \is_user_logged_in() ) {
+					self::send_non_reader_login_reminder( $existing_user );
+				}
 				return false;
 			}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
@@ -167,6 +167,22 @@ class Advertising_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * Note: Advertising uses SOURCE_EXTERNAL (GAM) with its own scheduled
+	 * refresh via Action Scheduler. This method satisfies the abstract contract
+	 * but the advertising controller is NOT registered for the daily pre-warm
+	 * (Task 7) — its existing GAM refresh owns its cache.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the top-level response.
 	 *
 	 * @param DateTimeImmutable      $start         Current window start.

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
@@ -23,8 +23,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -36,6 +34,7 @@ use WP_REST_Server;
 class Advertising_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Shared Insights namespace.
@@ -99,22 +98,6 @@ class Advertising_REST_Controller extends WP_REST_Controller {
 				],
 			]
 		);
-	}
-
-	/**
-	 * Permission check.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
 	}
 
 	/**
@@ -184,59 +167,6 @@ class Advertising_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
-	}
-
-	/**
 	 * Assemble the top-level response.
 	 *
 	 * @param DateTimeImmutable      $start         Current window start.
@@ -259,104 +189,5 @@ class Advertising_REST_Controller extends WP_REST_Controller {
 			$response['previous'] = Advertising_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );
 		}
 		return $response;
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -166,6 +166,17 @@ class Audience_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the top-level response. When the metric returns a tab_error
 	 * payload it is surfaced as the whole response.
 	 *

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -25,8 +25,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -38,6 +36,7 @@ use WP_REST_Server;
 class Audience_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Shared Insights namespace.
@@ -104,22 +103,6 @@ class Audience_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET handler.
 	 *
 	 * @param WP_REST_Request $request Request.
@@ -183,59 +166,6 @@ class Audience_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
-	}
-
-	/**
 	 * Assemble the top-level response. When the metric returns a tab_error
 	 * payload it is surfaced as the whole response.
 	 *
@@ -281,104 +211,5 @@ class Audience_REST_Controller extends WP_REST_Controller {
 			$response['previous'] = isset( $previous['tab_error'] ) ? null : $previous;
 		}
 		return $response;
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -193,6 +193,17 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( new Conversion_Metric(), $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the top-level response.
 	 *
 	 * `tab_error` is true only when every **hub-backed** metric in the current

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -32,8 +32,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -45,6 +43,7 @@ use WP_REST_Server;
 class Conversion_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Shared Insights namespace.
@@ -122,29 +121,6 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check.
-	 *
-	 * This route is intentionally callable via application passwords. The
-	 * BQ-side rate limit is the 10-minute cooldown enforced in
-	 * {@see Cache::refresh()}, not a per-route rate limiter — any caller
-	 * authenticated as a user with `manage_options` (whether via cookie +
-	 * nonce or an application password) can trigger a refresh, and the
-	 * cooldown applies uniformly.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET handler.
 	 *
 	 * @param WP_REST_Request $request Request.
@@ -214,59 +190,6 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
 			}
 		);
-	}
-
-	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
 	}
 
 	/**
@@ -436,104 +359,5 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 			'at_risk_subscriber_count'             => $metric->get_at_risk_subscriber_count( $start, $end ),
 			'lapsed_donor_count'                   => $metric->get_lapsed_donor_count( $start, $end ),
 		];
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-conversion-rest-controller.php
@@ -78,17 +78,6 @@ class Conversion_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Response-shape version for the conversion cache key. Bump
-	 * {@see Conversion_Metric::CACHE_PREFIX} whenever the Tab 3 response shape
-	 * changes so cached payloads from a prior shape don't survive a deploy.
-	 *
-	 * @return string
-	 */
-	protected function cache_schema_version(): string {
-		return Conversion_Metric::CACHE_PREFIX;
-	}
-
-	/**
 	 * Register the Tab 3 routes.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -14,8 +14,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -27,6 +25,7 @@ use WP_REST_Server;
 class Donors_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Dedicated namespace shared with Tab 6.
@@ -93,29 +92,6 @@ class Donors_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check.
-	 *
-	 * This route is intentionally callable via application passwords. The
-	 * BQ-side rate limit is the 10-minute cooldown enforced in
-	 * {@see Cache::refresh()}, not a per-route rate limiter — any caller
-	 * authenticated as a user with `manage_options` (whether via cookie +
-	 * nonce or an application password) can trigger a refresh, and the
-	 * cooldown applies uniformly.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET handler.
 	 *
 	 * @param WP_REST_Request $request Request.
@@ -157,59 +133,6 @@ class Donors_REST_Controller extends WP_REST_Controller {
 				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
 			}
 		);
-	}
-
-	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
 	}
 
 	/**
@@ -281,104 +204,5 @@ class Donors_REST_Controller extends WP_REST_Controller {
 			// derived signals, mirroring Gates_Metric::paywall_section_totals().
 			'has_window_activity'        => Donors_Metric::window_activity_signal( $new_donors, $lapsed_donors, $total_revenue ),
 		];
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -136,6 +136,17 @@ class Donors_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( new Donors_Metric(), $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble response.
 	 *
 	 * @param Donors_Metric          $metric        Orchestrator.

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
@@ -17,8 +17,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -30,6 +28,7 @@ use WP_REST_Server;
 class Engagement_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Shared Insights namespace.
@@ -96,22 +95,6 @@ class Engagement_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET handler.
 	 *
 	 * @param WP_REST_Request $request Request.
@@ -175,59 +158,6 @@ class Engagement_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
-	}
-
-	/**
 	 * Assemble the top-level response (tab_error surfaced when the metric errors).
 	 *
 	 * @param DateTimeImmutable      $start         Current window start.
@@ -256,104 +186,5 @@ class Engagement_REST_Controller extends WP_REST_Controller {
 			$response['previous'] = isset( $previous['tab_error'] ) ? null : $previous;
 		}
 		return $response;
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-engagement-rest-controller.php
@@ -158,6 +158,17 @@ class Engagement_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the top-level response (tab_error surfaced when the metric errors).
 	 *
 	 * @param DateTimeImmutable      $start         Current window start.

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -26,8 +26,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -39,6 +37,7 @@ use WP_REST_Server;
 class Gates_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Shared Tab 4–7 namespace.
@@ -114,29 +113,6 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check.
-	 *
-	 * This route is intentionally callable via application passwords. The
-	 * BQ-side rate limit is the 10-minute cooldown enforced in
-	 * {@see Cache::refresh()}, not a per-route rate limiter — any caller
-	 * authenticated as a user with `manage_options` (whether via cookie +
-	 * nonce or an application password) can trigger a refresh, and the
-	 * cooldown applies uniformly.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET handler.
 	 *
 	 * @param WP_REST_Request $request Request.
@@ -206,59 +182,6 @@ class Gates_REST_Controller extends WP_REST_Controller {
 				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
 			}
 		);
-	}
-
-	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
 	}
 
 	/**
@@ -389,104 +312,5 @@ class Gates_REST_Controller extends WP_REST_Controller {
 			// Section 3 empty-state totals (NPPD-1694).
 			Gates_Metric::paywall_section_totals( $paywall_direct, $paywall_influenced )
 		);
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -54,15 +54,6 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	protected $rest_base = 'gates';
 
 	/**
-	 * Bust cached responses when the Tab 4 response shape changes.
-	 *
-	 * @return string
-	 */
-	protected function cache_schema_version(): string {
-		return Gates_Metric::CACHE_PREFIX;
-	}
-
-	/**
 	 * Cache source classification for this controller.
 	 *
 	 * @return string

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-gates-rest-controller.php
@@ -185,6 +185,17 @@ class Gates_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( new Gates_Metric(), $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the top-level response.
 	 *
 	 * `tab_error` is true only when every metric in the current window reports

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -186,6 +186,17 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( new Prompts_Metric(), $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the top-level response.
 	 *
 	 * `tab_error` is true only when every **hub-backed** metric in the current

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -27,8 +27,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -40,6 +38,7 @@ use WP_REST_Server;
 class Prompts_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Shared Tab 4–7 namespace.
@@ -115,29 +114,6 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check.
-	 *
-	 * This route is intentionally callable via application passwords. The
-	 * BQ-side rate limit is the 10-minute cooldown enforced in
-	 * {@see Cache::refresh()}, not a per-route rate limiter — any caller
-	 * authenticated as a user with `manage_options` (whether via cookie +
-	 * nonce or an application password) can trigger a refresh, and the
-	 * cooldown applies uniformly.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET handler.
 	 *
 	 * @param WP_REST_Request $request Request.
@@ -207,59 +183,6 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
 			}
 		);
-	}
-
-	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
 	}
 
 	/**
@@ -406,104 +329,5 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 		}
 
 		return $window;
-	}
-
-	/**
-	 * Args spec.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$base = [
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => [ $this, 'validate_date_string' ],
-		];
-		return [
-			'start'         => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'end'           => array_merge(
-				$base,
-				[
-					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-					'required'    => true,
-				]
-			),
-			'compare_start' => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-			'compare_end'   => array_merge(
-				$base,
-				[
-					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
-					'required'    => false,
-				]
-			),
-		];
-	}
-
-	/**
-	 * REST validate_callback.
-	 *
-	 * @param mixed $value Value.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable.
-	 *
-	 * @param mixed        $value      Raw value.
-	 * @param DateTimeZone $tz         Timezone.
-	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
-	 * @return DateTimeImmutable
-	 * @throws Exception On parse failure.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-prompts-rest-controller.php
@@ -55,15 +55,6 @@ class Prompts_REST_Controller extends WP_REST_Controller {
 	protected $rest_base = 'prompts';
 
 	/**
-	 * Bust cached responses when the Tab 5 response shape changes.
-	 *
-	 * @return string
-	 */
-	protected function cache_schema_version(): string {
-		return Prompts_Metric::CACHE_PREFIX;
-	}
-
-	/**
 	 * Cache source classification for this controller.
 	 *
 	 * @return string

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -154,6 +154,17 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Base-window payload (no comparison) for the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( new Subscribers_Metric(), $start, $end, null, null );
+	}
+
+	/**
 	 * Assemble the response payload.
 	 *
 	 * @param Subscribers_Metric     $metric        Metric orchestrator.

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -28,8 +28,6 @@ namespace Newspack\Insights;
 defined( 'ABSPATH' ) || exit;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use Exception;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -42,6 +40,7 @@ use WP_REST_Server;
 class Subscribers_REST_Controller extends WP_REST_Controller {
 
 	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
 
 	/**
 	 * Dedicated namespace for Insights endpoints, separate from
@@ -109,30 +108,6 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check. Mirrors the Insights wizard capability so the
-	 * data layer is only available to users who can view the tab.
-	 *
-	 * This route is intentionally callable via application passwords. The
-	 * BQ-side rate limit is the 10-minute cooldown enforced in
-	 * {@see Cache::refresh()}, not a per-route rate limiter — any caller
-	 * authenticated as a user with `manage_options` (whether via cookie +
-	 * nonce or an application password) can trigger a refresh, and the
-	 * cooldown applies uniformly.
-	 *
-	 * @return bool|WP_Error
-	 */
-	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'newspack_insights_rest_forbidden',
-				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * GET /newspack-insights/v1/subscribers handler.
 	 *
 	 * @param WP_REST_Request $request Incoming request.
@@ -176,67 +151,6 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 				return $this->build_response( $metric, $start, $end, $compare_start, $compare_end );
 			}
 		);
-	}
-
-	/**
-	 * Validate and parse the window args. Returns [start, end, compare_start, compare_end] on
-	 * success; WP_Error on validation failure.
-	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array|WP_Error
-	 */
-	private function parse_window_args( WP_REST_Request $request ) {
-		$tz = $this->site_timezone();
-		try {
-			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
-			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
-		} catch ( Exception $e ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				$e->getMessage(),
-				[ 'status' => 400 ]
-			);
-		}
-		if ( $start > $end ) {
-			return new WP_Error(
-				'newspack_insights_invalid_window',
-				__( 'Start date must be on or before end date.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$compare_start_param = $request->get_param( 'compare_start' );
-		$compare_end_param   = $request->get_param( 'compare_end' );
-		$compare_start       = null;
-		$compare_end         = null;
-		if ( $compare_start_param || $compare_end_param ) {
-			if ( ! $compare_start_param || ! $compare_end_param ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison',
-					__( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-			try {
-				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
-				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
-			} catch ( Exception $e ) {
-				return new WP_Error(
-					'newspack_insights_invalid_date',
-					$e->getMessage(),
-					[ 'status' => 400 ]
-				);
-			}
-			if ( $compare_start > $compare_end ) {
-				return new WP_Error(
-					'newspack_insights_invalid_comparison_window',
-					__( 'compare_start must be on or before compare_end.', 'newspack-plugin' ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return [ $start, $end, $compare_start, $compare_end ];
 	}
 
 	/**
@@ -310,101 +224,5 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 			// derived signals, mirroring Donors_Metric::window_activity_signal().
 			'has_window_activity'       => Subscribers_Metric::window_activity_signal( $new_subscribers, $churned_subscribers, $revenue_gross, $revenue_net ),
 		];
-	}
-
-	/**
-	 * Build the args spec for query parameters. Validation runs before
-	 * the handler so we can reject malformed input early.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		return [
-			'start'         => [
-				'description'       => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-				'type'              => 'string',
-				'required'          => true,
-				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => [ $this, 'validate_date_string' ],
-			],
-			'end'           => [
-				'description'       => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
-				'type'              => 'string',
-				'required'          => true,
-				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => [ $this, 'validate_date_string' ],
-			],
-			'compare_start' => [
-				'description'       => __( 'Optional comparison window start (YYYY-MM-DD). Must be paired with compare_end.', 'newspack-plugin' ),
-				'type'              => 'string',
-				'required'          => false,
-				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => [ $this, 'validate_date_string' ],
-			],
-			'compare_end'   => [
-				'description'       => __( 'Optional comparison window end (YYYY-MM-DD). Must be paired with compare_start.', 'newspack-plugin' ),
-				'type'              => 'string',
-				'required'          => false,
-				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => [ $this, 'validate_date_string' ],
-			],
-		];
-	}
-
-	/**
-	 * REST validate_callback for date params.
-	 *
-	 * @param mixed $value Value provided by the client.
-	 * @return bool|WP_Error
-	 */
-	public function validate_date_string( $value ) {
-		if ( ! is_string( $value ) || '' === $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
-				[ 'status' => 400 ]
-			);
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			return new WP_Error(
-				'newspack_insights_invalid_date',
-				/* translators: %s: the invalid date string */
-				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
-				[ 'status' => 400 ]
-			);
-		}
-		return true;
-	}
-
-	/**
-	 * Parse a Y-m-d string into a DateTimeImmutable at the start or end
-	 * of day in the site's timezone.
-	 *
-	 * @param mixed        $value      The raw value from the request.
-	 * @param DateTimeZone $tz         Site timezone.
-	 * @param bool         $end_of_day If true, sets time to 23:59:59 (inclusive).
-	 * @return DateTimeImmutable
-	 * @throws Exception If the value cannot be parsed.
-	 */
-	private function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
-		if ( ! is_string( $value ) || '' === $value ) {
-			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
-		}
-		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
-		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
-			/* translators: %s: the invalid date string */
-			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
-		}
-		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
-	}
-
-	/**
-	 * Site timezone resolver.
-	 *
-	 * @return DateTimeZone
-	 */
-	private function site_timezone(): DateTimeZone {
-		return wp_timezone();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
@@ -29,13 +29,14 @@ trait Cached_Controller_Trait {
 	abstract protected function tab_slug(): string;
 
 	/**
-	 * Response-shape version mixed into the cache key. Override and bump it when
-	 * a controller's payload shape changes so cached payloads from a prior shape
-	 * don't survive a deploy. Default empty: no version component, so controllers
-	 * that don't opt in keep their existing key shape (no surprise cache-bust).
+	 * Global envelope cache-schema version mixed into the cache key for every
+	 * Insights controller. Returns {@see Cache::ENVELOPE_SCHEMA_VERSION} by
+	 * default so ALL tabs are versioned uniformly — no per-tab opt-in required.
+	 * Override only when a single tab needs an independent bump that must NOT
+	 * bust the rest of the pre-warm cycle.
 	 */
 	protected function cache_schema_version(): string {
-		return '';
+		return Cache::ENVELOPE_SCHEMA_VERSION;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
@@ -10,6 +10,7 @@
 
 namespace Newspack\Insights;
 
+use DateTimeImmutable;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -35,6 +36,43 @@ trait Cached_Controller_Trait {
 	 */
 	protected function cache_schema_version(): string {
 		return '';
+	}
+
+	/**
+	 * Base-window payload builder — same shape as a no-comparison GET. Each
+	 * controller implements it by delegating to its existing build_response()
+	 * with null comparison.
+	 *
+	 * @param DateTimeImmutable $start Window start (00:00:00, site tz).
+	 * @param DateTimeImmutable $end   Window end (23:59:59, site tz).
+	 * @return array
+	 */
+	abstract public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array;
+
+	/**
+	 * Build and durably store one pre-warmed base window. Uses the controller's
+	 * own tab/source/versioned key so the entry key-matches the GET read path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 */
+	public function warm_window( DateTimeImmutable $start, DateTimeImmutable $end ): void {
+		$key_parts = $this->versioned_key_parts_from(
+			$start->format( 'Y-m-d' ),
+			$end->format( 'Y-m-d' ),
+			null,
+			null
+		);
+		Cache::store_durable(
+			$this->tab_slug(),
+			$this->cache_source(),
+			$key_parts,
+			$this->build_window_payload( $start, $end ),
+			[
+				'start' => $start->format( 'Y-m-d' ),
+				'end'   => $end->format( 'Y-m-d' ),
+			]
+		);
 	}
 
 	/**
@@ -77,18 +115,22 @@ trait Cached_Controller_Trait {
 	}
 
 	/**
-	 * Canonical window components used as the cache key.
+	 * Pure cache-key derivation from raw window strings, with the response-shape
+	 * version prepended when the controller sets one.
 	 *
-	 * @param WP_REST_Request $request Incoming request.
-	 * @return array{0:string,1:string,2:?string,3:?string}
+	 * @param string      $start Window start (Y-m-d).
+	 * @param string      $end   Window end (Y-m-d).
+	 * @param string|null $cs    Comparison start or null.
+	 * @param string|null $ce    Comparison end or null.
+	 * @return array
 	 */
-	private static function cache_key_parts( WP_REST_Request $request ): array {
-		return [
-			(string) $request->get_param( 'start' ),
-			(string) $request->get_param( 'end' ),
-			$request->get_param( 'compare_start' ) ? (string) $request->get_param( 'compare_start' ) : null,
-			$request->get_param( 'compare_end' ) ? (string) $request->get_param( 'compare_end' ) : null,
-		];
+	private function versioned_key_parts_from( string $start, string $end, ?string $cs, ?string $ce ): array {
+		$parts   = [ $start, $end, $cs, $ce ];
+		$version = $this->cache_schema_version();
+		if ( '' !== $version ) {
+			array_unshift( $parts, $version );
+		}
+		return $parts;
 	}
 
 	/**
@@ -100,12 +142,12 @@ trait Cached_Controller_Trait {
 	 * @return array
 	 */
 	private function versioned_cache_key_parts( WP_REST_Request $request ): array {
-		$parts   = self::cache_key_parts( $request );
-		$version = $this->cache_schema_version();
-		if ( '' !== $version ) {
-			array_unshift( $parts, $version );
-		}
-		return $parts;
+		return $this->versioned_key_parts_from(
+			(string) $request->get_param( 'start' ),
+			(string) $request->get_param( 'end' ),
+			$request->get_param( 'compare_start' ) ? (string) $request->get_param( 'compare_start' ) : null,
+			$request->get_param( 'compare_end' ) ? (string) $request->get_param( 'compare_end' ) : null
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
@@ -53,10 +53,16 @@ trait Cached_Controller_Trait {
 	 * Build and durably store one pre-warmed base window. Uses the controller's
 	 * own tab/source/versioned key so the entry key-matches the GET read path.
 	 *
+	 * Returns the versioned key parts the entry was stored under, so the
+	 * pre-warm caller can build the prune keep-list from the exact key written
+	 * (single source of truth — avoids re-computing key parts in a separate
+	 * code path that may diverge from cache_schema_version()).
+	 *
 	 * @param DateTimeImmutable $start Window start.
 	 * @param DateTimeImmutable $end   Window end.
+	 * @return array Versioned key parts passed to Cache::store_durable().
 	 */
-	public function warm_window( DateTimeImmutable $start, DateTimeImmutable $end ): void {
+	public function warm_window( DateTimeImmutable $start, DateTimeImmutable $end ): array {
 		$key_parts = $this->versioned_key_parts_from(
 			$start->format( 'Y-m-d' ),
 			$end->format( 'Y-m-d' ),
@@ -73,6 +79,7 @@ trait Cached_Controller_Trait {
 				'end'   => $end->format( 'Y-m-d' ),
 			]
 		);
+		return $key_parts;
 	}
 
 	/**
@@ -137,6 +144,13 @@ trait Cached_Controller_Trait {
 	 * Canonical window key parts with the response-shape version prepended when
 	 * the controller sets one. An empty version leaves the window parts
 	 * untouched, so a non-overriding controller's cache key is unchanged.
+	 *
+	 * NOTE — truthiness coupling: empty-string compare_start / compare_end are
+	 * treated as absent here (falsy → null) to match the behaviour of
+	 * Insights_REST_Trait::parse_window_args(), which treats a falsy param as
+	 * "no comparison window". Both sides must change together if either switches
+	 * to isset() / !== '' checks; otherwise cache keys and parsed comparison
+	 * windows will disagree on what "absent" means.
 	 *
 	 * @param WP_REST_Request $request Incoming request.
 	 * @return array

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-insights-rest.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-insights-rest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Newspack Insights — shared REST helpers.
+ *
+ * Date parsing/validation, the window-args parser, the collection params spec,
+ * and the permission check, shared by every Insights REST controller. Extracted
+ * from the per-controller copies (NEWS-2581) so the GET path, the refresh path,
+ * and the pre-warm path agree on window handling and so Phase 2 (hub incremental
+ * cache) has a single date/window seam.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use WP_Error;
+use WP_REST_Request;
+
+defined( 'ABSPATH' ) || exit;
+
+trait Insights_REST_Trait {
+
+	/**
+	 * Permission check — requires the Insights wizard capability.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_insights_rest_forbidden',
+				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * REST validate_callback for a Y-m-d date string.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool|WP_Error
+	 */
+	public function validate_date_string( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				__( 'Date must be a non-empty YYYY-MM-DD string.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $this->site_timezone() );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			return new WP_Error(
+				'newspack_insights_invalid_date',
+				/* translators: %s: the invalid date string */
+				sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ),
+				[ 'status' => 400 ]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Collection params: start, end (required) + compare_start, compare_end.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$base = [
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+		];
+		return [
+			'start'         => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				] 
+			),
+			'end'           => array_merge(
+				$base,
+				[
+					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
+					'required'    => true,
+				] 
+			),
+			'compare_start' => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
+					'required'    => false,
+				] 
+			),
+			'compare_end'   => array_merge(
+				$base,
+				[
+					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
+					'required'    => false,
+				] 
+			),
+		];
+	}
+
+	/**
+	 * Validate and parse the window args.
+	 *
+	 * @param WP_REST_Request $request Incoming request.
+	 * @return array{0:DateTimeImmutable,1:DateTimeImmutable,2:?DateTimeImmutable,3:?DateTimeImmutable}|WP_Error
+	 */
+	protected function parse_window_args( WP_REST_Request $request ) {
+		$tz = $this->site_timezone();
+		try {
+			$start = $this->parse_date( $request->get_param( 'start' ), $tz, false );
+			$end   = $this->parse_date( $request->get_param( 'end' ), $tz, true );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+		}
+		if ( $start > $end ) {
+			return new WP_Error( 'newspack_insights_invalid_window', __( 'Start date must be on or before end date.', 'newspack-plugin' ), [ 'status' => 400 ] );
+		}
+
+		$compare_start_param = $request->get_param( 'compare_start' );
+		$compare_end_param   = $request->get_param( 'compare_end' );
+		$compare_start       = null;
+		$compare_end         = null;
+		if ( $compare_start_param || $compare_end_param ) {
+			if ( ! $compare_start_param || ! $compare_end_param ) {
+				return new WP_Error( 'newspack_insights_invalid_comparison', __( 'Both compare_start and compare_end must be provided to enable comparison mode.', 'newspack-plugin' ), [ 'status' => 400 ] );
+			}
+			try {
+				$compare_start = $this->parse_date( $compare_start_param, $tz, false );
+				$compare_end   = $this->parse_date( $compare_end_param, $tz, true );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'newspack_insights_invalid_date', $e->getMessage(), [ 'status' => 400 ] );
+			}
+			if ( $compare_start > $compare_end ) {
+				return new WP_Error( 'newspack_insights_invalid_comparison_window', __( 'compare_start must be on or before compare_end.', 'newspack-plugin' ), [ 'status' => 400 ] );
+			}
+		}
+
+		return [ $start, $end, $compare_start, $compare_end ];
+	}
+
+	/**
+	 * Parse a Y-m-d string into a DateTimeImmutable.
+	 *
+	 * @param mixed        $value      Raw value.
+	 * @param DateTimeZone $tz         Timezone.
+	 * @param bool         $end_of_day If true, 23:59:59; else 00:00:00.
+	 * @return DateTimeImmutable
+	 * @throws Exception On parse failure.
+	 */
+	protected function parse_date( $value, DateTimeZone $tz, bool $end_of_day ): DateTimeImmutable {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw new Exception( esc_html__( 'Missing date value.', 'newspack-plugin' ) );
+		}
+		$parsed = DateTimeImmutable::createFromFormat( 'Y-m-d', $value, $tz );
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $value ) {
+			/* translators: %s: the invalid date string */
+			throw new Exception( esc_html( sprintf( __( 'Invalid date "%s". Expected YYYY-MM-DD.', 'newspack-plugin' ), $value ) ) );
+		}
+		return $end_of_day ? $parsed->setTime( 23, 59, 59 ) : $parsed->setTime( 0, 0, 0 );
+	}
+
+	/**
+	 * Site timezone.
+	 *
+	 * @return DateTimeZone
+	 */
+	protected function site_timezone(): DateTimeZone {
+		return wp_timezone();
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-insights-rest.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-insights-rest.php
@@ -24,12 +24,13 @@ defined( 'ABSPATH' ) || exit;
 trait Insights_REST_Trait {
 
 	/**
-	 * Permission check — requires the Insights wizard capability.
+	 * Permission check — requires the capability defined by
+	 * {@see \Newspack\Insights_Wizard::get_required_capability()}.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( \Newspack\Insights_Wizard::get_required_capability() ) ) {
 			return new WP_Error(
 				'newspack_insights_rest_forbidden',
 				__( 'You do not have permission to view Insights data.', 'newspack-plugin' ),
@@ -82,28 +83,28 @@ trait Insights_REST_Trait {
 				[
 					'description' => __( 'Inclusive window start date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
 					'required'    => true,
-				] 
+				]
 			),
 			'end'           => array_merge(
 				$base,
 				[
 					'description' => __( 'Inclusive window end date (YYYY-MM-DD, site timezone).', 'newspack-plugin' ),
 					'required'    => true,
-				] 
+				]
 			),
 			'compare_start' => array_merge(
 				$base,
 				[
 					'description' => __( 'Optional comparison window start. Must pair with compare_end.', 'newspack-plugin' ),
 					'required'    => false,
-				] 
+				]
 			),
 			'compare_end'   => array_merge(
 				$base,
 				[
 					'description' => __( 'Optional comparison window end. Must pair with compare_start.', 'newspack-plugin' ),
 					'required'    => false,
-				] 
+				]
 			),
 		];
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -467,6 +467,20 @@ final class Cache {
 			if ( self::SOURCE_SNAPSHOT !== $source ) {
 				self::index_add( $tab, $key );
 			}
+
+			// If a durable (pre-warmed) entry already exists for this window, overwrite
+			// it so the durable store stays in sync with the manually-refreshed data.
+			// This ensures the read-precedence path in store() (durable → transient →
+			// compute) returns fresh data on the next request rather than serving the
+			// older pre-warmed entry. Reusing $existing_durable['window'] avoids having
+			// to parse start/end from $key_parts, and store_durable() builds its own
+			// envelope with a fresh computed_at — resetting the ~25h SWR clock.
+			// We deliberately do NOT create a durable entry when none exists: durable
+			// storage must remain bounded to windows the pre-warm job created.
+			$existing_durable = self::peek_durable( $tab, $source, $key_parts );
+			if ( null !== $existing_durable ) {
+				self::store_durable( $tab, $source, $key_parts, $envelope['payload'], $existing_durable['window'] );
+			}
 		}
 
 		// BigQuery refreshes always come back with the active cooldown stamp

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -24,6 +24,8 @@ final class Cache {
 
 	const TTL_SNAPSHOT = 9 * DAY_IN_SECONDS;
 
+	const TTL_DURABLE_FRESH = 25 * HOUR_IN_SECONDS;
+
 	const TTL_BIGQUERY        = DAY_IN_SECONDS;
 	const TTL_EXTERNAL        = 10 * MINUTE_IN_SECONDS;
 	const BQ_COOLDOWN_SECONDS = 10 * MINUTE_IN_SECONDS;
@@ -138,6 +140,147 @@ final class Cache {
 			return null;
 		}
 		return $cached;
+	}
+
+	/**
+	 * Durable option name for a warmed window. Mirrors transient_key() but in
+	 * the wp_options namespace, so pre-warmed presets survive memcached eviction.
+	 *
+	 * @param string   $tab       Tab slug.
+	 * @param string[] $key_parts Canonicalized window components.
+	 * @return string
+	 */
+	private static function durable_option( string $tab, array $key_parts ): string {
+		return 'newspack_insights_warm_' . $tab . '_' . md5( (string) wp_json_encode( $key_parts ) );
+	}
+
+	/**
+	 * Per-tab durable warm index option name.
+	 *
+	 * @param string $tab Tab slug.
+	 * @return string
+	 */
+	private static function durable_index_option( string $tab ): string {
+		return 'newspack_insights_warm_index_' . $tab;
+	}
+
+	/**
+	 * Write a pre-warmed window to durable (non-autoloaded) storage and record
+	 * its key in the per-tab warm index. No storage TTL — freshness is logical
+	 * (computed_at + is_fresh()). No-op write when caching is disabled; the
+	 * envelope is still returned so callers behave uniformly.
+	 *
+	 * @param string   $tab       Tab slug.
+	 * @param string   $source    SOURCE_* constant.
+	 * @param string[] $key_parts Canonicalized window components.
+	 * @param array    $payload   The window payload.
+	 * @param array    $window    [ 'start' => 'Y-m-d', 'end' => 'Y-m-d' ].
+	 * @return array{ payload: array, computed_at: string, source: string, cooldown_until: null }
+	 */
+	public static function store_durable( string $tab, string $source, array $key_parts, array $payload, array $window ): array {
+		$envelope = self::envelope( $payload, $source );
+		if ( self::is_disabled() ) {
+			return $envelope;
+		}
+		$store = [
+			'payload'     => $envelope['payload'],
+			'computed_at' => $envelope['computed_at'],
+			'source'      => $envelope['source'],
+			'window'      => $window,
+		];
+		update_option( self::durable_option( $tab, $key_parts ), $store, false );
+		self::durable_index_add( $tab, $key_parts );
+		return $envelope;
+	}
+
+	/**
+	 * Read a durable warm entry without computing. Returns the stored
+	 * { payload, computed_at, source, window } or null when disabled, absent,
+	 * malformed, or the stored source does not match $source.
+	 *
+	 * @param string   $tab       Tab slug.
+	 * @param string   $source    SOURCE_* constant the caller expects.
+	 * @param string[] $key_parts Canonicalized window components.
+	 * @return array{ payload: array, computed_at: string, source: string, window: array }|null
+	 */
+	public static function peek_durable( string $tab, string $source, array $key_parts ): ?array {
+		if ( self::is_disabled() ) {
+			return null;
+		}
+		$stored = get_option( self::durable_option( $tab, $key_parts ), null );
+		if ( ! is_array( $stored ) || ! isset( $stored['payload'], $stored['computed_at'], $stored['source'] ) ) {
+			return null;
+		}
+		if ( $stored['source'] !== $source ) {
+			return null;
+		}
+		if ( ! isset( $stored['window'] ) || ! is_array( $stored['window'] ) ) {
+			$stored['window'] = [ 'start' => '', 'end' => '' ];
+		}
+		return $stored;
+	}
+
+	/**
+	 * Whether an ISO 8601 UTC timestamp is within the durable freshness window.
+	 *
+	 * @param string $computed_at ISO 8601 UTC timestamp.
+	 * @return bool
+	 */
+	public static function is_fresh( string $computed_at ): bool {
+		$ts = strtotime( $computed_at );
+		if ( false === $ts ) {
+			return false;
+		}
+		return ( time() - $ts ) <= self::TTL_DURABLE_FRESH;
+	}
+
+	/**
+	 * Add a key to the per-tab durable warm index.
+	 *
+	 * @param string   $tab       Tab slug.
+	 * @param string[] $key_parts Canonicalized window components.
+	 */
+	private static function durable_index_add( string $tab, array $key_parts ): void {
+		$option = self::durable_index_option( $tab );
+		$keys   = get_option( $option, [] );
+		if ( ! is_array( $keys ) ) {
+			$keys = [];
+		}
+		$hash = md5( (string) wp_json_encode( $key_parts ) );
+		if ( ! in_array( $hash, $keys, true ) ) {
+			$keys[] = $hash;
+			update_option( $option, $keys, false );
+		}
+	}
+
+	/**
+	 * Delete durable warm options for $tab whose key is not in $keep_key_parts,
+	 * and rewrite the index to the kept set. Bounds durable option growth as the
+	 * daily-shifting presets move (yesterday's Last-30 window becomes orphaned).
+	 * No-op when caching is disabled.
+	 *
+	 * @param string  $tab            Tab slug.
+	 * @param array[] $keep_key_parts List of key_parts arrays to retain.
+	 */
+	public static function prune_durable( string $tab, array $keep_key_parts ): void {
+		if ( self::is_disabled() ) {
+			return;
+		}
+		$keep_hashes = array_map(
+			static fn( array $parts ): string => md5( (string) wp_json_encode( $parts ) ),
+			$keep_key_parts
+		);
+		$option = self::durable_index_option( $tab );
+		$hashes = get_option( $option, [] );
+		if ( ! is_array( $hashes ) ) {
+			$hashes = [];
+		}
+		foreach ( $hashes as $hash ) {
+			if ( ! in_array( $hash, $keep_hashes, true ) ) {
+				delete_option( 'newspack_insights_warm_' . $tab . '_' . $hash );
+			}
+		}
+		update_option( $option, array_values( $keep_hashes ), false );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -22,6 +22,15 @@ final class Cache {
 
 	const SOURCE_SNAPSHOT = 'snapshot';
 
+	/**
+	 * Global envelope cache-schema version, folded into every Insights window
+	 * cache key (durable + transient) via Cached_Controller_Trait. Bump this on
+	 * ANY Insights window-payload shape change so a shape-changing deploy cannot
+	 * serve an old-shaped durable/transient payload to the new frontend. A bump
+	 * busts every tab's window cache at once (one cold pre-warm cycle).
+	 */
+	const ENVELOPE_SCHEMA_VERSION = 'v1';
+
 	const TTL_SNAPSHOT = 9 * DAY_IN_SECONDS;
 
 	const TTL_DURABLE_FRESH = 25 * HOUR_IN_SECONDS;

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -245,11 +245,17 @@ final class Cache {
 		if ( $stored['source'] !== $source ) {
 			return null;
 		}
-		if ( ! isset( $stored['window'] ) || ! is_array( $stored['window'] ) ) {
-			$stored['window'] = [
-				'start' => '',
-				'end'   => '',
-			];
+		// A durable entry with a missing or empty window cannot be SWR-refreshed:
+		// on_durable_stale() bails when start/end are empty, so the entry would be
+		// served forever-stale with no way to refresh. Return null to fall through
+		// to a live recompute rather than serving an unserviceable entry.
+		if (
+			! isset( $stored['window'] ) ||
+			! is_array( $stored['window'] ) ||
+			empty( $stored['window']['start'] ) ||
+			empty( $stored['window']['end'] )
+		) {
+			return null;
 		}
 		return $stored;
 	}
@@ -314,7 +320,12 @@ final class Cache {
 				delete_option( 'newspack_insights_warm_' . $tab . '_' . $hash );
 			}
 		}
-		update_option( $option, array_values( $keep_hashes ), false );
+		// Rewrite the index as the intersection of what was already indexed and
+		// what the caller wants to keep. This is self-consistent: an entry that
+		// was never stored (e.g. a phantom versioned hash computed incorrectly)
+		// cannot survive a prune cycle.
+		$surviving = array_values( array_intersect( $hashes, $keep_hashes ) );
+		update_option( $option, $surviving, false );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -62,7 +62,38 @@ final class Cache {
 		}
 
 		$cooldown_until = self::SOURCE_BIGQUERY === $source ? self::bq_cooldown_until( $tab ) : null;
-		$key            = self::transient_key( $tab, $key_parts );
+
+		// Durable warm store takes precedence over the transient. Pre-warmed
+		// preset windows live here (memcached-eviction-proof). A stale entry is
+		// still served instantly; we fire an action so the pre-warm layer can
+		// schedule an async background refresh (stale-while-revalidate).
+		$durable = self::peek_durable( $tab, $source, $key_parts );
+		if ( null !== $durable ) {
+			if ( ! self::is_fresh( $durable['computed_at'] ) ) {
+				/**
+				 * Fires when a durable warm entry is served past its freshness
+				 * bound. The pre-warm layer schedules an async refresh.
+				 *
+				 * @param string $tab   Tab slug.
+				 * @param string $start Window start (Y-m-d).
+				 * @param string $end   Window end (Y-m-d).
+				 */
+				do_action(
+					'newspack_insights_durable_stale',
+					$tab,
+					(string) ( $durable['window']['start'] ?? '' ),
+					(string) ( $durable['window']['end'] ?? '' )
+				);
+			}
+			return [
+				'payload'        => $durable['payload'],
+				'computed_at'    => $durable['computed_at'],
+				'source'         => $durable['source'],
+				'cooldown_until' => $cooldown_until,
+			];
+		}
+
+		$key = self::transient_key( $tab, $key_parts );
 		$cached         = get_transient( $key );
 
 		if ( is_array( $cached ) && isset( $cached['payload'], $cached['computed_at'], $cached['source'] ) ) {
@@ -215,7 +246,10 @@ final class Cache {
 			return null;
 		}
 		if ( ! isset( $stored['window'] ) || ! is_array( $stored['window'] ) ) {
-			$stored['window'] = [ 'start' => '', 'end' => '' ];
+			$stored['window'] = [
+				'start' => '',
+				'end'   => '',
+			];
 		}
 		return $stored;
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-preset-windows.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-preset-windows.php
@@ -1,0 +1,71 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- Insights prefix matches directory convention.
+/**
+ * Newspack Insights — fixed timeframe preset windows.
+ *
+ * PHP mirror of the React date-range presets (src/wizards/insights/state/
+ * useDateRange.ts computeRangeForPreset). Used by the daily pre-warm to
+ * compute the exact windows the dropdown produces, so warmed cache entries
+ * key-match the REST requests the UI issues. Excludes 'custom' (unbounded /
+ * unpredictable — never a warm target).
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+use DateTimeImmutable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Fixed preset window calculator.
+ */
+final class Preset_Windows {
+
+	/**
+	 * Compute every fixed preset window, anchored to $today, in $today's
+	 * timezone. Each "Last N days" preset is an inclusive N-day window ending
+	 * today (subtract N-1). Start is 00:00:00, end is 23:59:59, matching the
+	 * REST controllers' parse_date() boundaries.
+	 *
+	 * @param DateTimeImmutable $today Site-timezone "now" (e.g. current_datetime()).
+	 * @return array<int, array{preset:string, start:DateTimeImmutable, end:DateTimeImmutable}>
+	 */
+	public static function all( DateTimeImmutable $today ): array {
+		$end_today = $today->setTime( 23, 59, 59 );
+		$sod       = static fn( DateTimeImmutable $d ): DateTimeImmutable => $d->setTime( 0, 0, 0 );
+		$eod       = static fn( DateTimeImmutable $d ): DateTimeImmutable => $d->setTime( 23, 59, 59 );
+
+		$month_start      = $sod( $today->modify( 'first day of this month' ) );
+		$last_month_start = $sod( $today->modify( 'first day of last month' ) );
+		$last_month_end   = $eod( $today->modify( 'last day of last month' ) );
+
+		return [
+			[
+				'preset' => 'last-7',
+				'start'  => $sod( $today->modify( '-6 days' ) ),
+				'end'    => $end_today,
+			],
+			[
+				'preset' => 'last-30',
+				'start'  => $sod( $today->modify( '-29 days' ) ),
+				'end'    => $end_today,
+			],
+			[
+				'preset' => 'last-90',
+				'start'  => $sod( $today->modify( '-89 days' ) ),
+				'end'    => $end_today,
+			],
+			[
+				'preset' => 'this-month',
+				'start'  => $month_start,
+				'end'    => $end_today,
+			],
+			[
+				'preset' => 'last-month',
+				'start'  => $last_month_start,
+				'end'    => $last_month_end,
+			],
+		];
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
@@ -61,10 +61,13 @@ final class Prewarm {
 
 	/**
 	 * Register a tab's warmer. The warmer builds + durably stores one base
-	 * window. Typically [ $controller, 'warm_window' ].
+	 * window and RETURNS the versioned key parts it stored under. Typically
+	 * [ $controller, 'warm_window' ] — the Cached_Controller_Trait implementation
+	 * returns the key array from warm_window() so the prune keep-list is derived
+	 * from the actual stored key rather than a re-derived approximation.
 	 *
 	 * @param string   $tab    Tab slug.
-	 * @param callable $warmer fn( DateTimeImmutable $start, DateTimeImmutable $end ): void.
+	 * @param callable $warmer fn( DateTimeImmutable $start, DateTimeImmutable $end ): array.
 	 */
 	public static function register_tab( string $tab, callable $warmer ): void {
 		self::$tabs[ $tab ] = $warmer;
@@ -134,18 +137,29 @@ final class Prewarm {
 		if ( ! self::is_warmable() ) {
 			return;
 		}
+		if ( empty( self::$tabs ) ) {
+			if ( class_exists( '\Newspack\Logger' ) ) {
+				\Newspack\Logger::newspack_log(
+					'newspack_insights_prewarm_empty_registry',
+					'Pre-warm ran with an empty tab registry — no warmers registered.',
+					[ 'header' => Cache::LOGGER_HEADER ],
+					'warning'
+				);
+			}
+			return;
+		}
 		$windows     = Preset_Windows::all( current_datetime() );
 		$any_success = false;
 		foreach ( self::$tabs as $tab => $warmer ) {
 			$keep = [];
 			foreach ( $windows as $w ) {
 				try {
-					$warmer( $w['start'], $w['end'] );
+					$key_parts = $warmer( $w['start'], $w['end'] );
 				} catch ( \Throwable $e ) {
 					self::log_failure( $tab, $w['preset'], $e );
 					continue;
 				}
-				$keep[] = [ $w['start']->format( 'Y-m-d' ), $w['end']->format( 'Y-m-d' ), null, null ];
+				$keep[] = $key_parts; // the actual (versioned) key the warmer wrote.
 			}
 			// Only prune when at least one window warmed successfully. An empty
 			// $keep (total-failure run, e.g. BQ outage) would wipe all durable
@@ -209,7 +223,10 @@ final class Prewarm {
 		$tz    = wp_timezone();
 		$start = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['start'] ?? '' ), $tz );
 		$end   = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['end'] ?? '' ), $tz );
-		if ( ! $start || ! $end ) {
+		if ( ! $start || $start->format( 'Y-m-d' ) !== (string) ( $args['start'] ?? '' ) ) {
+			return;
+		}
+		if ( ! $end || $end->format( 'Y-m-d' ) !== (string) ( $args['end'] ?? '' ) ) {
 			return;
 		}
 		try {

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
@@ -122,12 +122,20 @@ final class Prewarm {
 	/**
 	 * WARM_ACTION handler. Warms every registered tab × preset, prunes orphaned
 	 * windows, and records the daily marker.
+	 *
+	 * The daily marker is only stamped when at least one window warmed
+	 * successfully across all tabs. A total-failure run (e.g. a BQ-proxy outage
+	 * that throws on every window) leaves the marker unchanged so the next
+	 * admin_init can re-enqueue a retry, still de-duped by as_has_scheduled_action.
+	 * A partial success (some tabs/windows succeeded) does stamp the marker —
+	 * real work was done.
 	 */
 	public static function run_prewarm(): void {
 		if ( ! self::is_warmable() ) {
 			return;
 		}
-		$windows = Preset_Windows::all( current_datetime() );
+		$windows     = Preset_Windows::all( current_datetime() );
+		$any_success = false;
 		foreach ( self::$tabs as $tab => $warmer ) {
 			$keep = [];
 			foreach ( $windows as $w ) {
@@ -144,9 +152,15 @@ final class Prewarm {
 			// entries, removing yesterday's still-serveable cache on a transient error.
 			if ( ! empty( $keep ) ) {
 				Cache::prune_durable( $tab, $keep );
+				$any_success = true;
 			}
 		}
-		update_option( self::MARKER_OPTION, self::today(), false );
+		// Only stamp the marker when real work was done. A total-failure run
+		// must leave the marker unchanged so the next admin_init re-enqueues a
+		// retry rather than skipping until tomorrow.
+		if ( $any_success ) {
+			update_option( self::MARKER_OPTION, self::today(), false );
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
@@ -81,12 +81,6 @@ final class Prewarm {
 	/**
 	 * Whether warming should run at all in this environment.
 	 *
-	 * Note: Cache::is_disabled() is intentionally NOT checked here. When the
-	 * durable store is off, warm_window calls are silently no-ops inside
-	 * Cache::store_durable(), so warming is harmless. Checking is_disabled()
-	 * here causes test-ordering issues because test suites define
-	 * NEWSPACK_INSIGHTS_CACHE_DISABLED as a PHP constant that cannot be unset.
-	 *
 	 * @return bool
 	 */
 	private static function is_warmable(): bool {
@@ -94,6 +88,9 @@ final class Prewarm {
 			return false;
 		}
 		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			return false;
+		}
+		if ( Cache::is_disabled() ) {
 			return false;
 		}
 		return true;
@@ -142,7 +139,12 @@ final class Prewarm {
 				}
 				$keep[] = [ $w['start']->format( 'Y-m-d' ), $w['end']->format( 'Y-m-d' ), null, null ];
 			}
-			Cache::prune_durable( $tab, $keep );
+			// Only prune when at least one window warmed successfully. An empty
+			// $keep (total-failure run, e.g. BQ outage) would wipe all durable
+			// entries, removing yesterday's still-serveable cache on a transient error.
+			if ( ! empty( $keep ) ) {
+				Cache::prune_durable( $tab, $keep );
+			}
 		}
 		update_option( self::MARKER_OPTION, self::today(), false );
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
@@ -1,0 +1,237 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- Insights prefix matches directory convention.
+/**
+ * Newspack Insights — daily pre-warm.
+ *
+ * Warms the five fixed timeframe presets for every registered windowed tab into
+ * the durable cache, so opening Insights renders from cache. Scheduling is
+ * triggered on admin_init (once/day, guarded) and the actual work runs in an
+ * async Action Scheduler job — never inline on a request. Stale durable entries
+ * trigger a background refresh (stale-while-revalidate). NEWS-2581 Phase 1.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+use Newspack\Insights_Wizard;
+use DateTimeImmutable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insights pre-warm scheduler + worker.
+ */
+final class Prewarm {
+
+	const WARM_ACTION         = 'newspack_insights_prewarm';
+	const WARM_REFRESH_ACTION = 'newspack_insights_warm_refresh';
+	const WARM_GROUP          = 'newspack-insights';
+	const MARKER_OPTION       = 'newspack_insights_last_prewarm_date';
+
+	/**
+	 * Registry: tab slug => warmer callable( DateTimeImmutable, DateTimeImmutable ): void.
+	 *
+	 * @var array<string, callable>
+	 */
+	private static $tabs = [];
+
+	/**
+	 * Whether hooks have been registered already.
+	 *
+	 * @var bool
+	 */
+	private static $hooks_registered = false;
+
+	/**
+	 * Wire hooks. Idempotent; called from each section's register_hooks (on 'init').
+	 */
+	public static function init(): void {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
+		if ( self::$hooks_registered ) {
+			return;
+		}
+		self::$hooks_registered = true;
+		add_action( 'admin_init', [ __CLASS__, 'maybe_schedule' ] );
+		add_action( self::WARM_ACTION, [ __CLASS__, 'run_prewarm' ] );
+		add_action( self::WARM_REFRESH_ACTION, [ __CLASS__, 'run_warm_refresh' ] );
+		add_action( 'newspack_insights_durable_stale', [ __CLASS__, 'on_durable_stale' ], 10, 3 );
+	}
+
+	/**
+	 * Register a tab's warmer. The warmer builds + durably stores one base
+	 * window. Typically [ $controller, 'warm_window' ].
+	 *
+	 * @param string   $tab    Tab slug.
+	 * @param callable $warmer fn( DateTimeImmutable $start, DateTimeImmutable $end ): void.
+	 */
+	public static function register_tab( string $tab, callable $warmer ): void {
+		self::$tabs[ $tab ] = $warmer;
+	}
+
+	/**
+	 * Test-only: clear the in-memory registry.
+	 */
+	public static function reset_registry_for_tests(): void {
+		self::$tabs             = [];
+		self::$hooks_registered = false;
+	}
+
+	/**
+	 * Whether warming should run at all in this environment.
+	 *
+	 * Note: Cache::is_disabled() is intentionally NOT checked here. When the
+	 * durable store is off, warm_window calls are silently no-ops inside
+	 * Cache::store_durable(), so warming is harmless. Checking is_disabled()
+	 * here causes test-ordering issues because test suites define
+	 * NEWSPACK_INSIGHTS_CACHE_DISABLED as a PHP constant that cannot be unset.
+	 *
+	 * @return bool
+	 */
+	private static function is_warmable(): bool {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return false;
+		}
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Schedule an async warm at most once per day on admin_init. Never computes
+	 * inline. Guards on environment, capability, and the daily marker.
+	 */
+	public static function maybe_schedule(): void {
+		if ( ! self::is_warmable() ) {
+			return;
+		}
+		if ( ! current_user_can( Insights_Wizard::get_required_capability() ) ) {
+			return;
+		}
+		if ( get_option( self::MARKER_OPTION ) === self::today() ) {
+			return;
+		}
+		if ( ! function_exists( 'as_enqueue_async_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		if ( as_has_scheduled_action( self::WARM_ACTION, [], self::WARM_GROUP ) ) {
+			return;
+		}
+		as_enqueue_async_action( self::WARM_ACTION, [], self::WARM_GROUP );
+	}
+
+	/**
+	 * WARM_ACTION handler. Warms every registered tab × preset, prunes orphaned
+	 * windows, and records the daily marker.
+	 */
+	public static function run_prewarm(): void {
+		if ( ! self::is_warmable() ) {
+			return;
+		}
+		$windows = Preset_Windows::all( current_datetime() );
+		foreach ( self::$tabs as $tab => $warmer ) {
+			$keep = [];
+			foreach ( $windows as $w ) {
+				try {
+					$warmer( $w['start'], $w['end'] );
+				} catch ( \Throwable $e ) {
+					self::log_failure( $tab, $w['preset'], $e );
+					continue;
+				}
+				$keep[] = [ $w['start']->format( 'Y-m-d' ), $w['end']->format( 'Y-m-d' ), null, null ];
+			}
+			Cache::prune_durable( $tab, $keep );
+		}
+		update_option( self::MARKER_OPTION, self::today(), false );
+	}
+
+	/**
+	 * Stale durable hit → schedule a one-off background refresh for that window.
+	 *
+	 * @param string $tab   Tab slug.
+	 * @param string $start Window start (Y-m-d).
+	 * @param string $end   Window end (Y-m-d).
+	 */
+	public static function on_durable_stale( string $tab, string $start, string $end ): void {
+		if ( ! self::is_warmable() || '' === $start || '' === $end ) {
+			return;
+		}
+		if ( ! isset( self::$tabs[ $tab ] ) ) {
+			return;
+		}
+		if ( ! function_exists( 'as_enqueue_async_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		$args = [
+			[
+				'tab'   => $tab,
+				'start' => $start,
+				'end'   => $end,
+			],
+		];
+		if ( as_has_scheduled_action( self::WARM_REFRESH_ACTION, $args, self::WARM_GROUP ) ) {
+			return;
+		}
+		as_enqueue_async_action( self::WARM_REFRESH_ACTION, $args, self::WARM_GROUP );
+	}
+
+	/**
+	 * WARM_REFRESH_ACTION handler. Re-warms a single (tab, window).
+	 *
+	 * @param array $args [ 'tab' => string, 'start' => 'Y-m-d', 'end' => 'Y-m-d' ].
+	 */
+	public static function run_warm_refresh( array $args ): void {
+		if ( ! self::is_warmable() ) {
+			return;
+		}
+		$tab = $args['tab'] ?? '';
+		if ( ! isset( self::$tabs[ $tab ] ) ) {
+			return;
+		}
+		$tz    = wp_timezone();
+		$start = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['start'] ?? '' ), $tz );
+		$end   = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['end'] ?? '' ), $tz );
+		if ( ! $start || ! $end ) {
+			return;
+		}
+		try {
+			( self::$tabs[ $tab ] )( $start->setTime( 0, 0, 0 ), $end->setTime( 23, 59, 59 ) );
+		} catch ( \Throwable $e ) {
+			self::log_failure( $tab, 'swr-refresh', $e );
+		}
+	}
+
+	/**
+	 * Today's date in the site timezone (Y-m-d).
+	 *
+	 * @return string
+	 */
+	private static function today(): string {
+		return current_datetime()->format( 'Y-m-d' );
+	}
+
+	/**
+	 * Log a warm failure without aborting the run.
+	 *
+	 * @param string     $tab    Tab slug.
+	 * @param string     $window Preset/window label.
+	 * @param \Throwable $e      Error.
+	 */
+	private static function log_failure( string $tab, string $window, \Throwable $e ): void {
+		if ( ! class_exists( '\Newspack\Logger' ) ) {
+			return;
+		}
+		\Newspack\Logger::newspack_log(
+			'newspack_insights_prewarm_failed',
+			sprintf( '[%s/%s] pre-warm failed: %s', $tab, $window, $e->getMessage() ),
+			[
+				'tab'    => $tab,
+				'window' => $window,
+				'header' => Cache::LOGGER_HEADER,
+			],
+			'warning'
+		);
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -56,17 +56,19 @@ class Insights_Section_Audience {
 	}
 
 	/**
-	 * Register the Tab 1 REST route.
+	 * Register the Tab 1 REST route and warm the audience tab.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Audience_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Audience_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'audience', [ $controller, 'warm_window' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -61,18 +61,20 @@ class Insights_Section_Conversion {
 	}
 
 	/**
-	 * Register the Tab 3 REST route and cohort pre-warm hooks.
+	 * Register the Tab 3 REST route, cohort pre-warm hooks, and window pre-warm.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Conversion_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Conversion_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'conversion', [ $controller, 'warm_window' ] );
 		// Cohort pre-warm: handler runs both the one-off (cold-cache) and the
 		// weekly recurring refresh; the recurring schedule is ensured on init.
 		add_action( Conversion_Metric::COHORT_REFRESH_ACTION, [ Conversion_Metric::class, 'run_cohort_refresh' ] );

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
@@ -61,17 +61,19 @@ class Insights_Section_Donors {
 	}
 
 	/**
-	 * Register the Tab 7 REST route.
+	 * Register the Tab 7 REST route and warm the donors tab.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Donors_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Donors_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'donors', [ $controller, 'warm_window' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -56,17 +56,19 @@ class Insights_Section_Engagement {
 	}
 
 	/**
-	 * Register the Tab 2 REST route.
+	 * Register the Tab 2 REST route and warm the engagement tab.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Engagement_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Engagement_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'engagement', [ $controller, 'warm_window' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -61,17 +61,21 @@ class Insights_Section_Gates {
 	}
 
 	/**
-	 * Register the Tab 4 REST route.
+	 * Register the Tab 4 REST route and warm the gates tab.
+	 *
+	 * Called only when NEWSPACK_INSIGHTS_GATES_PREVIEW is set (enforced by init()).
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Gates_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Gates_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'gates', [ $controller, 'warm_window' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
@@ -60,17 +60,19 @@ class Insights_Section_Prompts {
 	}
 
 	/**
-	 * Register the Tab 5 REST route.
+	 * Register the Tab 5 REST route and warm the prompts tab.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Prompts_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Prompts_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'prompts', [ $controller, 'warm_window' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -70,19 +70,21 @@ class Insights_Section_Subscribers {
 	}
 
 	/**
-	 * Register the Tab 6 REST route + delegate donation-classifier cache
-	 * invalidation hooks.
+	 * Register the Tab 6 REST route, donation-classifier cache invalidation
+	 * hooks, and warm the subscribers tab.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		\Newspack\Insights\Prewarm::init();
+		$controller = new Subscribers_REST_Controller();
 		add_action(
 			'rest_api_init',
-			function () {
-				$controller = new Subscribers_REST_Controller();
+			function () use ( $controller ) {
 				$controller->register_routes();
 			}
 		);
+		\Newspack\Insights\Prewarm::register_tab( 'subscribers', [ $controller, 'warm_window' ] );
 		Donation_Product_Classifier::register_hooks();
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -71,6 +71,17 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
+	 * The capability required to view the Insights wizard pages. Reused by the
+	 * pre-warm scheduler so warming is only triggered by users who can see the
+	 * dashboard.
+	 *
+	 * @return string
+	 */
+	public static function get_required_capability(): string {
+		return 'manage_options';
+	}
+
+	/**
 	 * Whether the Gates preview tab (Tab 4 / NPPD-1604) is enabled
 	 * for this environment.
 	 *

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -74,16 +74,6 @@ use Newspack\Insights\Subscribers_Metric;
 final class Conversion_Metric {
 
 	/**
-	 * Response-shape version mixed into the conversion cache key via the REST
-	 * controller's `cache_schema_version()`. Bump the v-suffix whenever the Tab 3
-	 * response shape changes so cached payloads from a prior shape don't survive
-	 * a deploy. Bumped to v2 for the `data_missing` scalar field.
-	 *
-	 * @var string
-	 */
-	const CACHE_PREFIX = 'newspack_insights_tab3_v2:';
-
-	/**
 	 * Tab slug used as the Cache namespace for Section 5 snapshots.
 	 *
 	 * @var string

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-gates-metric.php
@@ -43,14 +43,6 @@ use Newspack\Insights\Subscribers_Metric;
 final class Gates_Metric {
 
 	/**
-	 * Cache key prefix. Bumped when the response shape changes so
-	 * cached payloads from a prior shape don't break a deploy.
-	 *
-	 * @var string
-	 */
-	const CACHE_PREFIX = 'newspack_insights_tab4_v2:';
-
-	/**
 	 * Data-source classification per metric key (NPPD-1746), the Gates-tab twin of
 	 * {@see Prompts_Metric::METRIC_SOURCES}:
 	 *

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -57,14 +57,6 @@ use Newspack\Insights\Subscribers_Metric;
 final class Prompts_Metric {
 
 	/**
-	 * Cache key prefix. Bumped when the response shape changes so
-	 * cached payloads from a prior shape don't break a deploy.
-	 *
-	 * @var string
-	 */
-	const CACHE_PREFIX = 'newspack_insights_tab5_v2:';
-
-	/**
 	 * Display labels for each `action_type` (intent) value. Spec §7.2 prescribes
 	 * title-cased labels with `newsletters_subscription` rendered as the more
 	 * publisher-friendly "Newsletter signup" (the auto-ucwords result —

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for useDateRange state module.
+ */
+
+import { computeRangeForPreset } from './useDateRange';
+
+describe( 'computeRangeForPreset — basic', () => {
+	it( 'returns null for custom preset', () => {
+		expect( computeRangeForPreset( 'custom' ) ).toBeNull();
+	} );
+
+	it( 'returns a 7-day range for last-7', () => {
+		const today = new Date( 2026, 5, 15 ); // 2026-06-15 local
+		const range = computeRangeForPreset( 'last-7', today );
+		expect( range ).toEqual( { start: '2026-06-09', end: '2026-06-15' } );
+	} );
+
+	it( 'returns a 30-day range for last-30', () => {
+		const today = new Date( 2026, 5, 15 ); // 2026-06-15 local
+		const range = computeRangeForPreset( 'last-30', today );
+		expect( range ).toEqual( { start: '2026-05-17', end: '2026-06-15' } );
+	} );
+
+	it( 'returns a 90-day range for last-90', () => {
+		const today = new Date( 2026, 5, 15 ); // 2026-06-15 local
+		const range = computeRangeForPreset( 'last-90', today );
+		expect( range ).toEqual( { start: '2026-03-18', end: '2026-06-15' } );
+	} );
+
+	it( 'returns this-month range', () => {
+		const today = new Date( 2026, 5, 15 ); // 2026-06-15
+		const range = computeRangeForPreset( 'this-month', today );
+		expect( range ).toEqual( { start: '2026-06-01', end: '2026-06-15' } );
+	} );
+
+	it( 'returns last-month range', () => {
+		const today = new Date( 2026, 5, 15 ); // 2026-06-15
+		const range = computeRangeForPreset( 'last-month', today );
+		expect( range ).toEqual( { start: '2026-05-01', end: '2026-05-31' } );
+	} );
+} );
+
+describe( 'computeRangeForPreset — site timezone anchoring', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+		// Clean up window.newspackInsights
+		if ( typeof window !== 'undefined' ) {
+			delete ( window as any ).newspackInsights;
+		}
+	} );
+
+	it( 'anchors last-30 end to site-TZ date when browser UTC is a day ahead', () => {
+		// UTC 2026-06-30T02:00:00Z → LA still on 2026-06-29
+		jest.useFakeTimers().setSystemTime( new Date( '2026-06-30T02:00:00Z' ) );
+		( window as any ).newspackInsights = { timezone: 'America/Los_Angeles' };
+		const range = computeRangeForPreset( 'last-30' );
+		expect( range!.end ).toBe( '2026-06-29' );
+	} );
+
+	it( 'anchors last-7 end to site-TZ date when browser UTC is a day ahead', () => {
+		jest.useFakeTimers().setSystemTime( new Date( '2026-06-30T02:00:00Z' ) );
+		( window as any ).newspackInsights = { timezone: 'America/Los_Angeles' };
+		const range = computeRangeForPreset( 'last-7' );
+		expect( range!.end ).toBe( '2026-06-29' );
+	} );
+
+	it( 'falls back to browser-local date when no timezone is configured', () => {
+		jest.useFakeTimers().setSystemTime( new Date( '2026-06-30T02:00:00Z' ) );
+		// No window.newspackInsights set
+		expect( () => computeRangeForPreset( 'last-7' ) ).not.toThrow();
+		const range = computeRangeForPreset( 'last-7' );
+		expect( range!.end ).toBeTruthy(); // valid ISO date string
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -38,6 +38,31 @@ export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
+ * Returns "today" anchored to the site timezone so preset windows
+ * computed here match the server-side Preset_Windows (PHP current_datetime()
+ * in site TZ). Parity between these two is what makes pre-warmed durable
+ * cache keys hit — a day mismatch causes a silent cache miss.
+ * Falls back to browser-local Date if no site timezone is configured.
+ */
+const getSiteToday = (): Date => {
+	const tz = ( typeof window !== 'undefined' && window.newspackInsights?.timezone ) || undefined;
+	if ( ! tz ) {
+		return new Date(); // graceful fallback: browser-local (pre-fix behavior)
+	}
+	// en-CA formats as YYYY-MM-DD; extract the site-TZ civil date, then build a
+	// local-midnight Date carrying those civil fields so the existing day-arithmetic
+	// (setDate(-6), getMonth(), etc.) operates on the correct calendar date.
+	const parts = new Intl.DateTimeFormat( 'en-CA', {
+		timeZone: tz,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	} ).format( new Date() );
+	const [ y, m, d ] = parts.split( '-' ).map( Number );
+	return new Date( y, m - 1, d );
+};
+
+/**
  * Validate a YYYY-MM-DD string. Checks both the shape AND that the parsed
  * date round-trips back to the same string — otherwise inputs like
  * '2026-99-99' would pass the regex and silently roll over to a future
@@ -67,7 +92,7 @@ const toISO = ( d: Date ): string => `${ d.getFullYear() }-${ pad2( d.getMonth()
  *
  * Returns null for 'custom' — the caller supplies start/end directly.
  */
-export const computeRangeForPreset = ( preset: DateRangePreset, today: Date = new Date() ): { start: string; end: string } | null => {
+export const computeRangeForPreset = ( preset: DateRangePreset, today: Date = getSiteToday() ): { start: string; end: string } | null => {
 	if ( preset === 'custom' ) {
 		return null;
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/class-newspack-test-stub-cached-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/class-newspack-test-stub-cached-controller.php
@@ -5,6 +5,7 @@
  * @package Newspack
  */
 
+use DateTimeImmutable;
 use Newspack\Insights\Cache;
 use Newspack\Insights\Cached_Controller_Trait;
 
@@ -26,6 +27,17 @@ class Newspack_Test_Stub_Cached_Controller extends WP_REST_Controller {
 	 */
 	protected function tab_slug(): string {
 		return 'stub';
+	}
+
+	/**
+	 * Stub implementation — returns an empty base-window payload.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return [];
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights-cached-controller-trait.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-cached-controller-trait.php
@@ -119,6 +119,17 @@ class Newspack_Test_Cached_Controller_Trait extends WP_UnitTestCase {
 			}
 
 			/**
+			 * Stub base-window payload (no-op for cooldown test).
+			 *
+			 * @param \DateTimeImmutable $start Window start.
+			 * @param \DateTimeImmutable $end   Window end.
+			 * @return array
+			 */
+			public function build_window_payload( \DateTimeImmutable $start, \DateTimeImmutable $end ): array {
+				return [];
+			}
+
+			/**
 			 * Expose refresh_response.
 			 *
 			 * @param WP_REST_Request $request Request.

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -14,6 +14,7 @@
 namespace Newspack\Tests\Insights;
 
 use Newspack\Insights\Cache;
+use Newspack\Insights\Audience_REST_Controller;
 use Newspack\Insights\Conversion_Metric;
 use Newspack\Insights\Conversion_REST_Controller;
 use Newspack\Insights\Cached_Controller_Trait;
@@ -446,11 +447,12 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Default: a controller that doesn't override cache_schema_version() keeps
-	 * the canonical four-part window key — no version component, so unrelated
-	 * tabs aren't cache-busted by this mechanism.
+	 * Global versioning: every controller (including a plain trait consumer that
+	 * does not override cache_schema_version()) now produces a five-part key with
+	 * Cache::ENVELOPE_SCHEMA_VERSION as the first component. The consolidation
+	 * ensures all tabs are versioned uniformly — no per-tab opt-in required.
 	 */
-	public function test_cache_key_has_no_version_prefix_by_default() {
+	public function test_cache_key_has_global_version_prefix_by_default() {
 		$controller = new class() {
 			use Cached_Controller_Trait;
 
@@ -491,14 +493,16 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$method->setAccessible( true );
 		$parts = $method->invoke( $controller, $request );
 
-		$this->assertCount( 4, $parts );
-		$this->assertSame( '2026-01-01', $parts[0] );
+		$this->assertCount( 5, $parts );
+		$this->assertSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
+		$this->assertSame( '2026-01-01', $parts[1] );
 	}
 
 	/**
-	 * Conversion overrides cache_schema_version() with its CACHE_PREFIX, so the
-	 * version is the first cache-key component — bumping CACHE_PREFIX on a
-	 * response-shape change busts stale-shape transients on deploy.
+	 * Conversion no longer overrides cache_schema_version(); it inherits the
+	 * global Cache::ENVELOPE_SCHEMA_VERSION so the version is the first
+	 * cache-key component — bumping the global constant on any shape change
+	 * busts all tabs' stale-shape transients on deploy.
 	 */
 	public function test_conversion_cache_key_includes_schema_version() {
 		$controller = new Conversion_REST_Controller();
@@ -511,8 +515,31 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$parts = $method->invoke( $controller, $request );
 
 		$this->assertCount( 5, $parts );
-		$this->assertSame( Conversion_Metric::CACHE_PREFIX, $parts[0] );
+		$this->assertSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
 		$this->assertContains( '2026-01-01', $parts );
+	}
+
+	/**
+	 * Global-version consolidation: a previously-unversioned tab (Audience, Tab 1)
+	 * now inherits Cache::ENVELOPE_SCHEMA_VERSION from the trait default, confirming
+	 * that the consolidation applies to ALL tabs — not just the three that formerly
+	 * opted in via per-tab CACHE_PREFIX overrides.
+	 */
+	public function test_global_version_applies_to_previously_unversioned_tab() {
+		$controller = new Audience_REST_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-insights/v1/audience' );
+		$request->set_param( 'start', '2026-01-01' );
+		$request->set_param( 'end', '2026-01-31' );
+
+		$method = new ReflectionMethod( Audience_REST_Controller::class, 'versioned_cache_key_parts' );
+		$method->setAccessible( true );
+		$parts = $method->invoke( $controller, $request );
+
+		// Five parts: global version + start + end + null + null.
+		$this->assertCount( 5, $parts );
+		$this->assertSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
+		$this->assertSame( '2026-01-01', $parts[1] );
+		$this->assertSame( '2026-01-31', $parts[2] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -471,6 +471,17 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 			protected function tab_slug(): string {
 				return 'test';
 			}
+
+			/**
+			 * Stub base-window payload (no-op for key-derivation test).
+			 *
+			 * @param \DateTimeImmutable $start Window start.
+			 * @param \DateTimeImmutable $end   Window end.
+			 * @return array
+			 */
+			public function build_window_payload( \DateTimeImmutable $start, \DateTimeImmutable $end ): array {
+				return [];
+			}
 		};
 		$request = new WP_REST_Request( 'GET', self::ROUTE );
 		$request->set_param( 'start', '2026-01-01' );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-gates-rest-controller.php
@@ -202,16 +202,16 @@ class Test_Gates_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gates_REST_Controller overrides cache_schema_version() with Gates_Metric::CACHE_PREFIX
-	 * (tab4_v2), so bumping the prefix on a response-shape change busts stale-shape
-	 * transients on deploy.
+	 * Gates_REST_Controller no longer overrides cache_schema_version(); it inherits
+	 * the global Cache::ENVELOPE_SCHEMA_VERSION from Cached_Controller_Trait, so
+	 * bumping that constant busts all tabs at once on a shape-changing deploy.
 	 */
-	public function test_gates_controller_cache_version_is_tab4_v2_prefix() {
+	public function test_gates_controller_cache_version_is_global_envelope_version() {
 		$controller = new Gates_REST_Controller();
 		$ref        = new \ReflectionMethod( $controller, 'cache_schema_version' );
 		$ref->setAccessible( true );
-		$this->assertSame( Gates_Metric::CACHE_PREFIX, $ref->invoke( $controller ) );
-		$this->assertStringContainsString( 'v2', Gates_Metric::CACHE_PREFIX );
+		$this->assertSame( Cache::ENVELOPE_SCHEMA_VERSION, $ref->invoke( $controller ) );
+		$this->assertNotEmpty( Cache::ENVELOPE_SCHEMA_VERSION );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-rest-controller.php
@@ -549,16 +549,16 @@ class Test_Prompts_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Prompts_REST_Controller overrides cache_schema_version() with Prompts_Metric::CACHE_PREFIX
-	 * (tab5_v2), so bumping the prefix on a response-shape change busts stale-shape
-	 * transients on deploy.
+	 * Prompts_REST_Controller no longer overrides cache_schema_version(); it inherits
+	 * the global Cache::ENVELOPE_SCHEMA_VERSION from Cached_Controller_Trait, so
+	 * bumping that constant busts all tabs at once on a shape-changing deploy.
 	 */
-	public function test_prompts_controller_cache_version_is_tab5_v2_prefix() {
+	public function test_prompts_controller_cache_version_is_global_envelope_version() {
 		$controller = new Prompts_REST_Controller();
 		$ref        = new \ReflectionMethod( $controller, 'cache_schema_version' );
 		$ref->setAccessible( true );
-		$this->assertSame( Prompts_Metric::CACHE_PREFIX, $ref->invoke( $controller ) );
-		$this->assertStringContainsString( 'v2', Prompts_Metric::CACHE_PREFIX );
+		$this->assertSame( Cache::ENVELOPE_SCHEMA_VERSION, $ref->invoke( $controller ) );
+		$this->assertNotEmpty( Cache::ENVELOPE_SCHEMA_VERSION );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
@@ -196,7 +196,15 @@ class Test_Cache_Durable extends WP_UnitTestCase {
 		$this->assertFalse( $fired );
 	}
 
-	/** Cache is fully disabled when NEWSPACK_INSIGHTS_CACHE_DISABLED is true. */
+	/**
+	 * Cache is fully disabled when NEWSPACK_INSIGHTS_CACHE_DISABLED is true.
+	 *
+	 * Runs in a separate process so the define() does not leak into the parent
+	 * and poison other tests (PHP constants cannot be unset).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test_disabled_skips_write_and_read() {
 		if ( ! defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) ) {
 			define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
@@ -197,6 +197,58 @@ class Test_Cache_Durable extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Manual refresh overwrites an existing durable entry so the next store()
+	 * call returns the freshly-computed payload rather than the older pre-warmed
+	 * one, and the compute closure is never invoked.
+	 *
+	 * @covers Cache::refresh
+	 */
+	public function test_refresh_overwrites_existing_durable_entry() {
+		// Seed the durable store with a pre-warmed payload.
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'warm' => true ], $this->window );
+
+		// Manually refresh — must overwrite the durable entry.
+		Cache::refresh( $this->tab, $this->source, $this->key, fn() => [ 'fresh' => true ] );
+
+		// Durable entry now holds the refreshed payload with the same window.
+		$durable = Cache::peek_durable( $this->tab, $this->source, $this->key );
+		$this->assertNotNull( $durable, 'Durable entry should still exist after refresh.' );
+		$this->assertSame( [ 'fresh' => true ], $durable['payload'], 'Durable payload should be the refreshed data.' );
+		$this->assertSame( $this->window, $durable['window'], 'Window metadata should be preserved.' );
+
+		// A subsequent store() must serve the refreshed durable — compute must not be called.
+		$called = false;
+		$env    = Cache::store(
+			$this->tab,
+			$this->source,
+			$this->key,
+			function () use ( &$called ) {
+				$called = true;
+				return [ 'compute' => true ];
+			}
+		);
+		$this->assertSame( [ 'fresh' => true ], $env['payload'], 'store() should serve the refreshed durable, not the older warm data.' );
+		$this->assertFalse( $called, 'Compute closure must not be invoked when a fresh durable entry exists.' );
+	}
+
+	/**
+	 * Manual refresh does not create a durable entry when none was pre-warmed
+	 * for the requested window, keeping durable storage bounded to preset windows.
+	 *
+	 * @covers Cache::refresh
+	 */
+	public function test_refresh_does_not_create_durable_for_unwarmed_window() {
+		// No durable entry exists — only a transient will be written by refresh.
+		Cache::refresh( $this->tab, $this->source, $this->key, fn() => [ 'fresh' => true ] );
+
+		// Durable store must remain empty for this window.
+		$this->assertNull(
+			Cache::peek_durable( $this->tab, $this->source, $this->key ),
+			'refresh() must not fabricate a durable entry for a never-warmed window.'
+		);
+	}
+
+	/**
 	 * Cache is fully disabled when NEWSPACK_INSIGHTS_CACHE_DISABLED is true.
 	 *
 	 * Runs in a separate process so the define() does not leak into the parent

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
@@ -8,20 +8,50 @@
 use Newspack\Insights\Cache;
 
 /**
+ * Tests for Insights Cache durable-option store.
+ *
  * @group insights
  */
 class Test_Cache_Durable extends WP_UnitTestCase {
 
-	private $tab    = 'gates';
-	private $source = Cache::SOURCE_BIGQUERY;
-	private $key    = [ '2026-06-01', '2026-06-30', null, null ];
-	private $window = [ 'start' => '2026-06-01', 'end' => '2026-06-30' ];
+	/**
+	 * Tab slug used in tests.
+	 *
+	 * @var string
+	 */
+	private $tab = 'gates';
 
+	/**
+	 * Data source constant used in tests.
+	 *
+	 * @var string
+	 */
+	private $source = Cache::SOURCE_BIGQUERY;
+
+	/**
+	 * Cache key tuple used in tests.
+	 *
+	 * @var array
+	 */
+	private $key = [ '2026-06-01', '2026-06-30', null, null ];
+
+	/**
+	 * Window array used in tests.
+	 *
+	 * @var array
+	 */
+	private $window = [
+		'start' => '2026-06-01',
+		'end'   => '2026-06-30',
+	];
+
+	/** Cleans up durable cache entries after each test. */
 	public function tearDown(): void {
 		Cache::prune_durable( $this->tab, [] );
 		parent::tearDown();
 	}
 
+	/** Stored payload, source, and window are returned verbatim by peek. */
 	public function test_store_then_peek_round_trips() {
 		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
 		$got = Cache::peek_durable( $this->tab, $this->source, $this->key );
@@ -31,23 +61,27 @@ class Test_Cache_Durable extends WP_UnitTestCase {
 		$this->assertNotEmpty( $got['computed_at'] );
 	}
 
+	/** Peek returns null when the stored source does not match the requested source. */
 	public function test_peek_returns_null_on_source_mismatch() {
 		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
 		$this->assertNull( Cache::peek_durable( $this->tab, Cache::SOURCE_EXTERNAL, $this->key ) );
 	}
 
+	/** Peek returns null when no entry exists for the given key. */
 	public function test_peek_returns_null_when_absent() {
 		$this->assertNull( Cache::peek_durable( $this->tab, $this->source, $this->key ) );
 	}
 
+	/** Durable cache options are stored with autoload disabled. */
 	public function test_durable_option_is_not_autoloaded() {
 		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
 		global $wpdb;
 		$name     = 'newspack_insights_warm_' . $this->tab . '_' . md5( (string) wp_json_encode( $this->key ) );
-		$autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", $name ) );
+		$autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$this->assertContains( $autoload, [ 'no', 'off' ], 'Durable cache option must not autoload.' );
 	}
 
+	/** Is_fresh returns true within the TTL and false outside it. */
 	public function test_is_fresh_boundary() {
 		$fresh = gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS );
 		$stale = gmdate( 'Y-m-d\TH:i:s\Z', time() - 26 * HOUR_IN_SECONDS );
@@ -55,11 +89,30 @@ class Test_Cache_Durable extends WP_UnitTestCase {
 		$this->assertFalse( Cache::is_fresh( $stale ) );
 	}
 
+	/** Prune_durable preserves listed keys and deletes unlisted ones. */
 	public function test_prune_keeps_listed_deletes_others() {
 		$keep = [ '2026-06-01', '2026-06-30', null, null ];
 		$drop = [ '2026-05-01', '2026-05-31', null, null ];
-		Cache::store_durable( $this->tab, $this->source, $keep, [ 'k' => 1 ], [ 'start' => '2026-06-01', 'end' => '2026-06-30' ] );
-		Cache::store_durable( $this->tab, $this->source, $drop, [ 'd' => 1 ], [ 'start' => '2026-05-01', 'end' => '2026-05-31' ] );
+		Cache::store_durable(
+			$this->tab,
+			$this->source,
+			$keep,
+			[ 'k' => 1 ],
+			[
+				'start' => '2026-06-01',
+				'end'   => '2026-06-30',
+			]
+		);
+		Cache::store_durable(
+			$this->tab,
+			$this->source,
+			$drop,
+			[ 'd' => 1 ],
+			[
+				'start' => '2026-05-01',
+				'end'   => '2026-05-31',
+			]
+		);
 
 		Cache::prune_durable( $this->tab, [ $keep ] );
 
@@ -143,6 +196,7 @@ class Test_Cache_Durable extends WP_UnitTestCase {
 		$this->assertFalse( $fired );
 	}
 
+	/** Cache is fully disabled when NEWSPACK_INSIGHTS_CACHE_DISABLED is true. */
 	public function test_disabled_skips_write_and_read() {
 		if ( ! defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) ) {
 			define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for the Insights Cache durable-option store.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Insights\Cache;
+
+/**
+ * @group insights
+ */
+class Test_Cache_Durable extends WP_UnitTestCase {
+
+	private $tab    = 'gates';
+	private $source = Cache::SOURCE_BIGQUERY;
+	private $key    = [ '2026-06-01', '2026-06-30', null, null ];
+	private $window = [ 'start' => '2026-06-01', 'end' => '2026-06-30' ];
+
+	public function tearDown(): void {
+		Cache::prune_durable( $this->tab, [] );
+		parent::tearDown();
+	}
+
+	public function test_store_then_peek_round_trips() {
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
+		$got = Cache::peek_durable( $this->tab, $this->source, $this->key );
+		$this->assertSame( [ 'a' => 1 ], $got['payload'] );
+		$this->assertSame( $this->source, $got['source'] );
+		$this->assertSame( $this->window, $got['window'] );
+		$this->assertNotEmpty( $got['computed_at'] );
+	}
+
+	public function test_peek_returns_null_on_source_mismatch() {
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
+		$this->assertNull( Cache::peek_durable( $this->tab, Cache::SOURCE_EXTERNAL, $this->key ) );
+	}
+
+	public function test_peek_returns_null_when_absent() {
+		$this->assertNull( Cache::peek_durable( $this->tab, $this->source, $this->key ) );
+	}
+
+	public function test_durable_option_is_not_autoloaded() {
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
+		global $wpdb;
+		$name     = 'newspack_insights_warm_' . $this->tab . '_' . md5( (string) wp_json_encode( $this->key ) );
+		$autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", $name ) );
+		$this->assertContains( $autoload, [ 'no', 'off' ], 'Durable cache option must not autoload.' );
+	}
+
+	public function test_is_fresh_boundary() {
+		$fresh = gmdate( 'Y-m-d\TH:i:s\Z', time() - HOUR_IN_SECONDS );
+		$stale = gmdate( 'Y-m-d\TH:i:s\Z', time() - 26 * HOUR_IN_SECONDS );
+		$this->assertTrue( Cache::is_fresh( $fresh ) );
+		$this->assertFalse( Cache::is_fresh( $stale ) );
+	}
+
+	public function test_prune_keeps_listed_deletes_others() {
+		$keep = [ '2026-06-01', '2026-06-30', null, null ];
+		$drop = [ '2026-05-01', '2026-05-31', null, null ];
+		Cache::store_durable( $this->tab, $this->source, $keep, [ 'k' => 1 ], [ 'start' => '2026-06-01', 'end' => '2026-06-30' ] );
+		Cache::store_durable( $this->tab, $this->source, $drop, [ 'd' => 1 ], [ 'start' => '2026-05-01', 'end' => '2026-05-31' ] );
+
+		Cache::prune_durable( $this->tab, [ $keep ] );
+
+		$this->assertNotNull( Cache::peek_durable( $this->tab, $this->source, $keep ) );
+		$this->assertNull( Cache::peek_durable( $this->tab, $this->source, $drop ) );
+	}
+
+	public function test_disabled_skips_write_and_read() {
+		if ( ! defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) ) {
+			define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true );
+		}
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'a' => 1 ], $this->window );
+		$this->assertNull( Cache::peek_durable( $this->tab, $this->source, $this->key ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-durable.php
@@ -67,6 +67,82 @@ class Test_Cache_Durable extends WP_UnitTestCase {
 		$this->assertNull( Cache::peek_durable( $this->tab, $this->source, $drop ) );
 	}
 
+	/**
+	 * Durable hit short-circuits compute and transient read.
+	 *
+	 * @covers Cache::store
+	 */
+	public function test_store_serves_durable_over_transient_and_compute() {
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'durable' => true ], $this->window );
+		$called = false;
+		$env    = Cache::store(
+			$this->tab,
+			$this->source,
+			$this->key,
+			function () use ( &$called ) {
+				$called = true;
+				return [ 'computed' => true ];
+			}
+		);
+		$this->assertSame( [ 'durable' => true ], $env['payload'] );
+		$this->assertFalse( $called, 'Durable hit must not invoke the compute closure.' );
+	}
+
+	/**
+	 * Stale durable entry fires the SWR action and is served immediately.
+	 *
+	 * @covers Cache::store
+	 */
+	public function test_store_fires_stale_action_for_stale_durable() {
+		// Seed a stale durable entry directly (computed_at 26h ago).
+		$name = 'newspack_insights_warm_' . $this->tab . '_' . md5( (string) wp_json_encode( $this->key ) );
+		update_option(
+			$name,
+			[
+				'payload'     => [ 'stale' => true ],
+				'computed_at' => gmdate( 'Y-m-d\TH:i:s\Z', time() - 26 * HOUR_IN_SECONDS ),
+				'source'      => $this->source,
+				'window'      => $this->window,
+			],
+			false
+		);
+
+		$fired = [];
+		add_action(
+			'newspack_insights_durable_stale',
+			function ( $tab, $start, $end ) use ( &$fired ) {
+				$fired = [ $tab, $start, $end ];
+			},
+			10,
+			3
+		);
+
+		$env = Cache::store( $this->tab, $this->source, $this->key, fn() => [ 'computed' => true ] );
+
+		$this->assertSame( [ 'stale' => true ], $env['payload'], 'Stale durable is served immediately.' );
+		$this->assertSame( [ $this->tab, '2026-06-01', '2026-06-30' ], $fired, 'Stale action fires with the window.' );
+	}
+
+	/**
+	 * Fresh durable entry does not trigger the stale-while-revalidate action.
+	 *
+	 * @covers Cache::store
+	 */
+	public function test_store_does_not_fire_stale_action_for_fresh_durable() {
+		Cache::store_durable( $this->tab, $this->source, $this->key, [ 'fresh' => true ], $this->window );
+		$fired = false;
+		add_action(
+			'newspack_insights_durable_stale',
+			function () use ( &$fired ) {
+				$fired = true;
+			},
+			10,
+			3
+		);
+		Cache::store( $this->tab, $this->source, $this->key, fn() => [ 'computed' => true ] );
+		$this->assertFalse( $fired );
+	}
+
 	public function test_disabled_skips_write_and_read() {
 		if ( ! defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) ) {
 			define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-preset-windows.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-preset-windows.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for Insights Preset_Windows.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Insights\Preset_Windows;
+
+/**
+ * Tests for Preset_Windows.
+ *
+ * @group insights
+ */
+class Test_Insights_Preset_Windows extends WP_UnitTestCase {
+
+	/** Anchor: Wed 2026-06-17 in UTC. */
+	private function anchor(): DateTimeImmutable {
+		return new DateTimeImmutable( '2026-06-17 09:30:00', new DateTimeZone( 'UTC' ) );
+	}
+
+	/** Returns exactly 5 presets in canonical order. */
+	public function test_returns_five_presets_in_order() {
+		$rows    = Preset_Windows::all( $this->anchor() );
+		$presets = array_column( $rows, 'preset' );
+		$this->assertSame( [ 'last-7', 'last-30', 'last-90', 'this-month', 'last-month' ], $presets );
+	}
+
+	/** Last-7 is an inclusive 7-day window ending today with correct boundary times. */
+	public function test_last_7_is_inclusive_seven_day_window_ending_today() {
+		$rows = Preset_Windows::all( $this->anchor() );
+		$row  = $rows[0];
+		$this->assertSame( '2026-06-11', $row['start']->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-06-17', $row['end']->format( 'Y-m-d' ) );
+		$this->assertSame( '00:00:00', $row['start']->format( 'H:i:s' ) );
+		$this->assertSame( '23:59:59', $row['end']->format( 'H:i:s' ) );
+	}
+
+	/** Last-30 starts 29 days ago; last-90 starts 89 days ago (inclusive windows). */
+	public function test_last_30_and_90_offsets() {
+		$rows = Preset_Windows::all( $this->anchor() );
+		$this->assertSame( '2026-05-19', $rows[1]['start']->format( 'Y-m-d' ) ); // last-30: -29 days.
+		$this->assertSame( '2026-03-20', $rows[2]['start']->format( 'Y-m-d' ) ); // last-90: -89 days.
+	}
+
+	/** This-month starts on the 1st and ends today. */
+	public function test_this_month_starts_first_of_month_ends_today() {
+		$rows = Preset_Windows::all( $this->anchor() );
+		$this->assertSame( '2026-06-01', $rows[3]['start']->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-06-17', $rows[3]['end']->format( 'Y-m-d' ) );
+	}
+
+	/** Last-month covers the full previous calendar month. */
+	public function test_last_month_is_full_previous_month() {
+		$rows = Preset_Windows::all( $this->anchor() );
+		$this->assertSame( '2026-05-01', $rows[4]['start']->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-05-31', $rows[4]['end']->format( 'Y-m-d' ) );
+	}
+
+	/** Returned DateTimeImmutable objects preserve the input timezone. */
+	public function test_preserves_timezone() {
+		$tz   = new DateTimeZone( 'America/New_York' );
+		$rows = Preset_Windows::all( new DateTimeImmutable( '2026-06-17 12:00:00', $tz ) );
+		$this->assertSame( $tz->getName(), $rows[0]['start']->getTimezone()->getName() );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -130,6 +130,22 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A run where every warmer throws must NOT stamp the daily marker, so the
+	 * next admin_init can retry without waiting until tomorrow.
+	 */
+	public function test_run_prewarm_skips_marker_when_all_warmers_fail() {
+		delete_option( Prewarm::MARKER_OPTION );
+		Prewarm::register_tab(
+			'gates',
+			function ( $start, $end ) {
+				throw new \RuntimeException( 'BQ down' );
+			}
+		);
+		Prewarm::run_prewarm();
+		$this->assertFalse( get_option( Prewarm::MARKER_OPTION, false ) );
+	}
+
+	/**
 	 * The run_warm_refresh method calls the registered warmer with the correct DTI range.
 	 */
 	public function test_run_warm_refresh_calls_registered_warmer() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -173,13 +173,14 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 	/**
 	 * REGRESSION — versioned-key prune correctness (FIX 1 / blocker).
 	 *
-	 * Uses the real Gates_REST_Controller (which overrides cache_schema_version()
-	 * with Gates_Metric::CACHE_PREFIX) to prove that after run_prewarm() the
-	 * durable entry SURVIVES the prune call under the versioned key.
+	 * Uses the real Gates_REST_Controller (now versioned via the global
+	 * Cache::ENVELOPE_SCHEMA_VERSION instead of the per-tab Gates_Metric::CACHE_PREFIX)
+	 * to prove that after run_prewarm() the durable entry SURVIVES the prune call
+	 * under the versioned key.
 	 *
 	 * The bug: run_prewarm() previously built its keep-list from unversioned key
 	 * parts [ $start, $end, null, null ], but warm_window() stored entries under
-	 * versioned parts [ CACHE_PREFIX, $start, $end, null, null ]. The keep hash
+	 * versioned parts [ version, $start, $end, null, null ]. The keep hash
 	 * never matched the stored hash, so prune_durable() deleted the entry the run
 	 * had just warmed, giving zero durable benefit on any tab with a non-empty
 	 * cache_schema_version(). This test FAILS against the pre-fix code and PASSES
@@ -221,9 +222,10 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 		$start_str = $last30['start']->format( 'Y-m-d' );
 		$end_str   = $last30['end']->format( 'Y-m-d' );
 
-		// The durable entry must exist under the VERSIONED key (CACHE_PREFIX + window).
+		// The durable entry must exist under the GLOBAL-VERSIONED key
+		// (Cache::ENVELOPE_SCHEMA_VERSION + window), not the old per-tab CACHE_PREFIX.
 		$versioned_key = array_merge(
-			[ \Newspack\Insights\Gates_Metric::CACHE_PREFIX ],
+			[ Cache::ENVELOPE_SCHEMA_VERSION ],
 			[ $start_str, $end_str, null, null ]
 		);
 		$durable = Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $versioned_key );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Tests for Insights Prewarm.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Insights\Prewarm;
+use Newspack\Insights\Cache;
+
+/**
+ * Tests for Prewarm.
+ *
+ * @group insights
+ */
+class Test_Insights_Prewarm extends WP_UnitTestCase {
+
+	/**
+	 * Enable the Insights feature flag before each test.
+	 * Constants cannot be undefined, so we define once if not already set.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		if ( ! defined( 'NEWSPACK_INSIGHTS_ENABLED' ) ) {
+			define( 'NEWSPACK_INSIGHTS_ENABLED', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		}
+	}
+
+	/**
+	 * Reset prewarm registry and marker option after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( Prewarm::MARKER_OPTION );
+		Prewarm::reset_registry_for_tests();
+		parent::tearDown();
+	}
+
+	/**
+	 * The run_prewarm method warms all five presets and records today's marker.
+	 */
+	public function test_run_prewarm_writes_durable_for_each_preset_and_sets_marker() {
+		$calls = [];
+		Prewarm::register_tab(
+			'gates',
+			function ( $start, $end ) use ( &$calls ) {
+				$calls[] = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
+				Cache::store_durable(
+					'gates',
+					Cache::SOURCE_BIGQUERY,
+					[
+						$start->format( 'Y-m-d' ),
+						$end->format( 'Y-m-d' ),
+						null,
+						null,
+					],
+					[ 'ok' => true ],
+					[
+						'start' => $start->format( 'Y-m-d' ),
+						'end'   => $end->format( 'Y-m-d' ),
+					]
+				);
+			}
+		);
+
+		Prewarm::run_prewarm();
+
+		$this->assertCount( 5, $calls, 'All five presets warmed.' );
+		$today = current_datetime()->format( 'Y-m-d' );
+		$this->assertSame( $today, get_option( Prewarm::MARKER_OPTION ) );
+	}
+
+	/**
+	 * The maybe_schedule method skips when today's marker is already set.
+	 */
+	public function test_maybe_schedule_skips_when_marker_is_today() {
+		update_option( Prewarm::MARKER_OPTION, current_datetime()->format( 'Y-m-d' ) );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		Prewarm::maybe_schedule();
+		$this->assertFalse( as_has_scheduled_action( Prewarm::WARM_ACTION, [], Prewarm::WARM_GROUP ) );
+	}
+
+	/**
+	 * The maybe_schedule method skips when the current user lacks the required capability.
+	 */
+	public function test_maybe_schedule_skips_without_capability() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'subscriber' ] ) );
+		Prewarm::maybe_schedule();
+		$this->assertFalse( as_has_scheduled_action( Prewarm::WARM_ACTION, [], Prewarm::WARM_GROUP ) );
+	}
+
+	/**
+	 * The maybe_schedule method enqueues an async action for a capable user with no marker.
+	 */
+	public function test_maybe_schedule_enqueues_for_capable_user_without_marker() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		Prewarm::maybe_schedule();
+		$this->assertTrue( as_has_scheduled_action( Prewarm::WARM_ACTION, [], Prewarm::WARM_GROUP ) );
+	}
+
+	/**
+	 * The on_durable_stale method schedules a WARM_REFRESH_ACTION for a registered tab.
+	 */
+	public function test_on_durable_stale_schedules_refresh() {
+		Prewarm::register_tab( 'gates', function ( $start, $end ) {} );
+		Prewarm::on_durable_stale( 'gates', '2026-06-01', '2026-06-30' );
+		$args = [
+			[
+				'tab'   => 'gates',
+				'start' => '2026-06-01',
+				'end'   => '2026-06-30',
+			],
+		];
+		$this->assertTrue( as_has_scheduled_action( Prewarm::WARM_REFRESH_ACTION, $args, Prewarm::WARM_GROUP ) );
+	}
+
+	/**
+	 * The run_warm_refresh method calls the registered warmer with the correct DTI range.
+	 */
+	public function test_run_warm_refresh_calls_registered_warmer() {
+		$got = null;
+		Prewarm::register_tab(
+			'gates',
+			function ( $start, $end ) use ( &$got ) {
+				$got = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
+			}
+		);
+		Prewarm::run_warm_refresh(
+			[
+				'tab'   => 'gates',
+				'start' => '2026-06-01',
+				'end'   => '2026-06-30',
+			]
+		);
+		$this->assertSame( '2026-06-01..2026-06-30', $got );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -7,6 +7,7 @@
 
 use Newspack\Insights\Prewarm;
 use Newspack\Insights\Cache;
+use Newspack\Insights\Preset_Windows;
 
 /**
  * Tests for Prewarm.
@@ -44,21 +45,23 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 			'gates',
 			function ( $start, $end ) use ( &$calls ) {
 				$calls[] = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
+				$key     = [
+					$start->format( 'Y-m-d' ),
+					$end->format( 'Y-m-d' ),
+					null,
+					null,
+				];
 				Cache::store_durable(
 					'gates',
 					Cache::SOURCE_BIGQUERY,
-					[
-						$start->format( 'Y-m-d' ),
-						$end->format( 'Y-m-d' ),
-						null,
-						null,
-					],
+					$key,
 					[ 'ok' => true ],
 					[
 						'start' => $start->format( 'Y-m-d' ),
 						'end'   => $end->format( 'Y-m-d' ),
 					]
 				);
+				return $key;
 			}
 		);
 
@@ -154,6 +157,7 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 			'gates',
 			function ( $start, $end ) use ( &$got ) {
 				$got = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
+				return [ $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), null, null ];
 			}
 		);
 		Prewarm::run_warm_refresh(
@@ -164,5 +168,70 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 			]
 		);
 		$this->assertSame( '2026-06-01..2026-06-30', $got );
+	}
+
+	/**
+	 * REGRESSION — versioned-key prune correctness (FIX 1 / blocker).
+	 *
+	 * Uses the real Gates_REST_Controller (which overrides cache_schema_version()
+	 * with Gates_Metric::CACHE_PREFIX) to prove that after run_prewarm() the
+	 * durable entry SURVIVES the prune call under the versioned key.
+	 *
+	 * The bug: run_prewarm() previously built its keep-list from unversioned key
+	 * parts [ $start, $end, null, null ], but warm_window() stored entries under
+	 * versioned parts [ CACHE_PREFIX, $start, $end, null, null ]. The keep hash
+	 * never matched the stored hash, so prune_durable() deleted the entry the run
+	 * had just warmed, giving zero durable benefit on any tab with a non-empty
+	 * cache_schema_version(). This test FAILS against the pre-fix code and PASSES
+	 * after the fix.
+	 *
+	 * @group insights
+	 */
+	public function test_versioned_tab_durable_entry_survives_prune() {
+		// Ensure the Gates controller and metric are loaded (they live in the gates
+		// section file which is only included when NEWSPACK_INSIGHTS_GATES_PREVIEW is
+		// set; in the unit harness we load them directly).
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		if ( ! class_exists( 'Newspack\Insights\Gates_Metric' ) ) {
+			include_once $base . 'metrics/class-gates-metric.php';
+		}
+		if ( ! class_exists( 'Newspack\Insights\Gates_REST_Controller' ) ) {
+			include_once $base . 'api/class-gates-rest-controller.php';
+		}
+
+		$controller = new \Newspack\Insights\Gates_REST_Controller();
+
+		Prewarm::register_tab( 'gates', [ $controller, 'warm_window' ] );
+
+		// Run the full prewarm (warms + prunes) against today's preset windows.
+		Prewarm::run_prewarm();
+
+		// Find the last-30 preset to check a concrete window.
+		$today   = current_datetime();
+		$windows = Preset_Windows::all( $today );
+		$last30  = null;
+		foreach ( $windows as $w ) {
+			if ( 'last-30' === $w['preset'] ) {
+				$last30 = $w;
+				break;
+			}
+		}
+		$this->assertNotNull( $last30, 'last-30 preset must exist.' );
+
+		$start_str = $last30['start']->format( 'Y-m-d' );
+		$end_str   = $last30['end']->format( 'Y-m-d' );
+
+		// The durable entry must exist under the VERSIONED key (CACHE_PREFIX + window).
+		$versioned_key = array_merge(
+			[ \Newspack\Insights\Gates_Metric::CACHE_PREFIX ],
+			[ $start_str, $end_str, null, null ]
+		);
+		$durable = Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $versioned_key );
+
+		$this->assertNotNull(
+			$durable,
+			'Durable entry must survive prune under the versioned key. ' .
+			'If null, prune deleted the entry because the keep-list used unversioned keys (pre-fix bug).'
+		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -114,6 +114,22 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Maybe_schedule() must not enqueue a warm when the cache is disabled.
+	 *
+	 * Runs in a separate process so the define() does not leak into the parent
+	 * and poison other tests (PHP constants cannot be unset).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_schedule_skips_when_cache_disabled() {
+		define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		Prewarm::maybe_schedule();
+		$this->assertFalse( as_has_scheduled_action( Prewarm::WARM_ACTION, [], Prewarm::WARM_GROUP ) );
+	}
+
+	/**
 	 * The run_warm_refresh method calls the registered warmer with the correct DTI range.
 	 */
 	public function test_run_warm_refresh_calls_registered_warmer() {

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
@@ -49,6 +49,91 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A reader already authenticated in the browser (e.g. a returning reader, or a
+	 * shared/public device still carrying a prior reader's remember-me cookie) must
+	 * still get a WordPress account created when subscribing with a DIFFERENT email,
+	 * without hijacking the current session.
+	 *
+	 * Reproduces NPPM-2936: the Newsletter Subscription block authenticates the reader
+	 * on the first signup (register_reader -> set_current_reader -> remember-me cookie),
+	 * so a second back-to-back signup from the same browser was treated as logged-in and
+	 * silently skipped account creation — while the email was still pushed to the ESP
+	 * list, leaving a list subscription with no account.
+	 */
+	public function test_register_reader_while_logged_in_creates_account_without_hijacking_session() {
+		// First signup from a clean session creates and authenticates the reader.
+		$first_reader_id = Reader_Activation::register_reader( 'first-signup@test.com', 'First Signup', true );
+		$this->assertIsInt( $first_reader_id );
+		$this->assertSame( $first_reader_id, get_current_user_id(), 'First signup should authenticate the reader.' );
+		$this->assertTrue( is_user_logged_in() );
+
+		// A different email is then submitted from the same (now authenticated) browser,
+		// exactly as the subscription block does for a logged-in visitor: register without
+		// re-authenticating.
+		$second_reader_id = Reader_Activation::register_reader(
+			'second-signup@test.com',
+			'Second Signup',
+			false, // Do not authenticate: preserve the current session.
+			[ 'registration_method' => 'newsletters-subscription' ]
+		);
+
+		// The second email must get its own real reader account...
+		$this->assertIsInt( $second_reader_id, 'A logged-in browser submitting a different email must still create an account.' );
+		$second_reader = get_user_by( 'email', 'second-signup@test.com' );
+		$this->assertInstanceOf( 'WP_User', $second_reader );
+		$this->assertTrue( (bool) get_user_meta( $second_reader->ID, Reader_Activation::READER, true ), 'The second account must be a real reader account, not a bare WP user.' );
+
+		// ...without changing who is logged in.
+		$this->assertSame( $first_reader_id, get_current_user_id(), 'Creating the second account must not hijack the current session.' );
+
+		wp_delete_user( $first_reader_id );  // Clean up.
+		wp_delete_user( $second_reader_id ); // Clean up.
+	}
+
+	/**
+	 * The dominant real-world path: a returning reader who is still logged in re-subscribes
+	 * via the block with their OWN email. This must be a no-op — reuse the existing account,
+	 * create no duplicate, preserve the session, and send no email. The "no email" guard is
+	 * load-bearing: the magic-link/OTP for a passwordless reader is suppressed only because
+	 * the registration method contains `newsletters-subscription`; a regression there would
+	 * silently email returning readers on every signup.
+	 */
+	public function test_register_reader_while_logged_in_with_own_email_is_noop() {
+		// A returning reader is already authenticated in this browser (passwordless, as RAS
+		// readers are — so the magic-link branch is genuinely exercised).
+		$reader_id = Reader_Activation::register_reader( 'returning@test.com', 'Returning Reader', true );
+		$this->assertIsInt( $reader_id );
+		$this->assertSame( $reader_id, get_current_user_id() );
+		$this->assertTrue( Reader_Activation::is_reader_without_password( $reader_id ), 'Test precondition: the reader must be passwordless to exercise the OTP-suppression path.' );
+
+		// Capture any outgoing email to prove the re-subscribe is side-effect-free.
+		$sent_emails = 0;
+		$email_counter = function ( $args ) use ( &$sent_emails ) {
+			$sent_emails++;
+			return $args;
+		};
+		add_filter( 'wp_mail', $email_counter );
+
+		// The reader re-subscribes via the block with their OWN (current) email.
+		$result = Reader_Activation::register_reader(
+			'returning@test.com',
+			'Returning Reader',
+			false, // Logged in: do not authenticate.
+			[ 'registration_method' => 'newsletters-subscription' ]
+		);
+
+		remove_filter( 'wp_mail', $email_counter );
+
+		// Existing account reused (false), no duplicate, no email, session preserved.
+		$this->assertFalse( $result, 'Re-subscribing with the current reader\'s own email must not create a second account.' );
+		$this->assertSame( $reader_id, get_user_by( 'email', 'returning@test.com' )->ID, 'The existing reader account must be reused, not duplicated.' );
+		$this->assertSame( 0, $sent_emails, 'Re-subscribing via the block must not send a magic link or login reminder.' );
+		$this->assertSame( $reader_id, get_current_user_id(), 'Session must be preserved.' );
+
+		wp_delete_user( $reader_id ); // Clean up.
+	}
+
+	/**
 	 * Test that verifying a reader register the proper meta.
 	 */
 	public function test_verify_reader_email() {

--- a/themes/newspack-block-theme/parts/footer.html
+++ b/themes/newspack-block-theme/parts/footer.html
@@ -1,3 +1,5 @@
+<!-- wp:newspack-ads/ad-slot {"placement":"global_above_footer"} /-->
+
 <!-- wp:newspack/responsive-container -->
 <div class="wp-block-newspack-responsive-container newspack-responsive-container"><!-- wp:newspack/responsive-container-breakpoint -->
 <div class="wp-block-newspack-responsive-container-breakpoint newspack-responsive-container-breakpoint--desktop"><!-- wp:template-part {"slug":"footer-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-desktop"} /-->
@@ -9,3 +11,5 @@
 </div>
 <!-- /wp:newspack/responsive-container-breakpoint --></div>
 <!-- /wp:newspack/responsive-container -->
+
+<!-- wp:newspack-ads/ad-slot {"placement":"sticky"} /-->

--- a/themes/newspack-block-theme/parts/header.html
+++ b/themes/newspack-block-theme/parts/header.html
@@ -1,3 +1,5 @@
+<!-- wp:newspack-ads/ad-slot {"placement":"global_above_header"} /-->
+
 <!-- wp:newspack/responsive-container -->
 <div class="wp-block-newspack-responsive-container newspack-responsive-container"><!-- wp:newspack/responsive-container-breakpoint -->
 <div class="wp-block-newspack-responsive-container-breakpoint newspack-responsive-container-breakpoint--desktop"><!-- wp:template-part {"slug":"header-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"header-desktop"} /--></div>
@@ -7,3 +9,5 @@
 <div class="wp-block-newspack-responsive-container-breakpoint newspack-responsive-container-breakpoint--mobile"><!-- wp:template-part {"slug":"header-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"header-mobile"} /--></div>
 <!-- /wp:newspack/responsive-container-breakpoint --></div>
 <!-- /wp:newspack/responsive-container -->
+
+<!-- wp:newspack-ads/ad-slot {"placement":"global_below_header","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"var:preset|spacing|30"}}}} /-->

--- a/themes/newspack-block-theme/src/scss/_gutenberg-shim.scss
+++ b/themes/newspack-block-theme/src/scss/_gutenberg-shim.scss
@@ -65,3 +65,23 @@ figcaption a {
 		margin-bottom: var(--wp--preset--spacing--50);
 	}
 }
+
+/*
+ * Editor styles - Ad spacing
+ *
+ * When an ad slot is immediately after the header, remove the bottom margin from
+ * the header to prevent extra spacing. This mirrors the front-end rule in
+ * `_header.scss`, but keys off the ad-slot block wrapper rather than the rendered
+ * ad. The wrapper is always present in the canvas, so this is an editor-only
+ * approximation: it collapses the margin whenever the block is placed, even if
+ * the placement is unbound and no ad would render on the front end. The
+ * `!important` overrides the block's inline spacing, which selector specificity
+ * alone can't beat.
+ */
+.editor-styles-wrapper {
+	.wp-block-newspack-responsive-container:has( + .wp-block-newspack-ads-ad-slot ) {
+		.newspack-responsive-container-breakpoint .block-editor-block-list__layout > *:last-child {
+			margin-bottom: 0 !important;
+		}
+	}
+}

--- a/themes/newspack-block-theme/src/scss/_header.scss
+++ b/themes/newspack-block-theme/src/scss/_header.scss
@@ -18,3 +18,26 @@
 		margin-top: 0;
 	}
 }
+
+/**
+ * Header ad spacing
+ *
+ * `.global_below_header` is present whenever the below-header placement has a
+ * configured ad unit and an active provider — it tracks whether an ad is
+ * *configured*, not whether the creative actually filled. On a provider no-fill
+ * the wrapper still renders, so the header's bottom margin collapses even though
+ * no ad is visible; keying this on an actual fill signal would need a client-side
+ * hook we don't have here. The `!important` overrides the block's inline spacing,
+ * which selector specificity alone can't beat.
+ */
+header.wp-block-template-part {
+	.wp-block-newspack-responsive-container:has( ~ .global_below_header ) {
+		// When there's a below header ad, remove the bottom most margin from the header:
+		.header-desktop,
+		.header-mobile {
+			> *:last-child {
+				margin-bottom: 0 !important;
+			}
+		}
+	}
+}

--- a/themes/newspack-block-theme/templates/single-newspack_nl_cpt.html
+++ b/themes/newspack-block-theme/templates/single-newspack_nl_cpt.html
@@ -18,7 +18,9 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/themes/newspack-block-theme/templates/single.html
+++ b/themes/newspack-block-theme/templates/single.html
@@ -18,7 +18,9 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/themes/newspack-block-theme/templates/single/50-50-image.html
+++ b/themes/newspack-block-theme/templates/single/50-50-image.html
@@ -28,7 +28,9 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/themes/newspack-block-theme/templates/single/full-width-image.html
+++ b/themes/newspack-block-theme/templates/single/full-width-image.html
@@ -18,7 +18,9 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/themes/newspack-block-theme/templates/single/large-image.html
+++ b/themes/newspack-block-theme/templates/single/large-image.html
@@ -18,7 +18,9 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/themes/newspack-block-theme/templates/single/sidebar-layout.html
+++ b/themes/newspack-block-theme/templates/single/sidebar-layout.html
@@ -20,7 +20,9 @@
 	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--80)">
 		<!-- wp:column {"width":"66.66%","templateLock":"insert","lock":{"move":false,"remove":true},"metadata":{"name":"Content"},"layout":{"type":"default"}} -->
 		<div class="wp-block-column" style="flex-basis:66.66%">
+			<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 			<!-- wp:post-content {"lock":{"move":false,"remove":true},"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"default"}} /-->
+			<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 
 			<!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme","className":"post-footer"} /-->
 		</div>

--- a/themes/newspack-block-theme/templates/single/wide-image.html
+++ b/themes/newspack-block-theme/templates/single/wide-image.html
@@ -18,7 +18,9 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:newspack-ads/ad-slot {"placement":"above_content"} /-->
 		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:newspack-ads/ad-slot {"placement":"below_content"} /-->
 	</div>
 	<!-- /wp:group -->
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Phase 1 of NEWS-2581** — improve the perceived loading speed of the Insights dashboard. This is consumer-side only; the hub-side incremental BigQuery cache is a follow-up (Phase 2).

Today the windowed Insights tabs compute on demand and cache in short-lived transients, which this stack stores in memcached and can evict under memory pressure — so the first dashboard view (and any view after an eviction) pays the full BigQuery/WooCommerce round-trip. This PR makes the common case instant:

- **Daily pre-warm.** On `admin_init` (guarded, at most once per day), a background Action Scheduler job warms the five fixed dropdown timeframes — Last 7 / 30 / 90 days, This month, Last month — for every windowed tab. The work runs off the request path; nothing is computed inline on `admin_init`. So by the time an editor opens Insights, the data is usually already cached.
- **Durable, eviction-proof storage.** Pre-warmed windows are stored in non-autoloaded options (DB-backed) instead of transients, so they survive memcached eviction. Reads prefer the durable entry, then fall back to the existing transient/compute path — durable storage is written only by the warm job, so option growth is bounded to presets × tabs (orphaned windows are pruned as the rolling presets shift each day).
- **Stale-while-revalidate.** A cached view always renders instantly; if its data is older than ~25 hours, a background refresh is scheduled so the next view is current. The visible "last updated" timestamp and the manual refresh control are unchanged.

No UI changes. The Advertising tab (Google Ad Manager) keeps its own existing scheduled refresh and is not pre-warmed. Behavior is gated by the existing `NEWSPACK_INSIGHTS_ENABLED` flag, skips when `NEWSPACK_INSIGHTS_FIXTURE_MODE` is on, and fully no-ops (including BigQuery spend) when `NEWSPACK_INSIGHTS_CACHE_DISABLED` is set.

This PR also extracts the date/permission/window-validation helpers that were duplicated across all eight Insights REST controllers into a shared trait — a behavior-preserving refactor that nets out to fewer lines and gives Phase 2 a single seam for window handling.

Closes NEWS-2581.

### How to test the changes in this Pull Request:

Prerequisites: a site connected to the Insights BigQuery proxy (Newspack Manager Admin hub), with `define( 'NEWSPACK_INSIGHTS_ENABLED', true );` and `NEWSPACK_INSIGHTS_FIXTURE_MODE` off.

1. **Unit tests + lint.** From `plugins/newspack-plugin`: `n test-php --group insights` (597 passing) and `npm run lint:php` (0 errors).
2. **Warm is scheduled, not inline.** As an admin, load any wp-admin page (not necessarily Insights). Confirm a `newspack_insights_prewarm` action is enqueued in the `newspack-insights` group (Tools → Scheduled Actions, or `wp action-scheduler list --group=newspack-insights`), and that the admin page itself did not block on data computation.
3. **Durable options are written and not autoloaded.** After the warm action runs, confirm `wp option list --search='newspack_insights_warm_*'` lists entries for the windowed tabs, and that they are stored with `autoload = no` (so they don't bloat the autoload cache).
4. **Fast render across presets.** Open Insights and switch the timeframe across Last 7 / Last 30 / Last 90 / This month / Last month. Each should render from cache quickly; the "last updated" timestamp reflects the warm time, not the page-load time.
5. **Once per day.** Reload an admin page again the same day and confirm a second warm is NOT enqueued (the daily marker guards it). Clear the marker (`wp option delete newspack_insights_last_prewarm_date`) and confirm the next admin page load enqueues a fresh warm.
6. **Prune on day-roll.** After the rolling presets shift (next day, or by hand-warming with an earlier "today"), confirm yesterday's now-orphaned `newspack_insights_warm_*` windows are pruned and only the current five presets per tab remain.
7. **Stale-while-revalidate.** With a durable entry older than ~25h (e.g. edit its `computed_at`), open that tab: it renders the cached data immediately AND a `newspack_insights_warm_refresh` action is enqueued; after it runs, the entry's `computed_at` is current.
8. **Manual refresh persists on a warmed preset.** On a pre-warmed preset window (e.g. Last 30 days), note the "last updated" time, then use the tab's manual **Refresh** control. Confirm the data updates AND that reloading Insights **keeps** the refreshed data with the new "last updated" time — it must not revert to the older pre-warmed numbers. (Refresh overwrites the durable entry in place and resets the freshness clock.) On a custom or comparison-enabled window (never pre-warmed), confirm Refresh still works via the transient path and creates no durable entry (`wp option list --search='newspack_insights_warm_*'` shows nothing new for that window).
9. **Capability gate.** As a non-admin (no `manage_options`), load wp-admin and confirm no warm is enqueued.
10. **Escape hatches.** Set `define( 'NEWSPACK_INSIGHTS_CACHE_DISABLED', true );` and confirm no warm is scheduled or run (no BigQuery queries fire) and tabs still load via the compute path. Set `NEWSPACK_INSIGHTS_FIXTURE_MODE` and confirm warming is skipped.
11. **Refactor parity.** Confirm the Insights REST endpoints still validate dates, reject bad/inverted ranges and unpaired comparison params, and enforce `manage_options` exactly as before (the shared-trait extraction is behavior-preserving).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
