### PR TITLE
fix(insights): guard donation product lookup when WooCommerce inactive

### DIFF
--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -231,6 +231,13 @@ class Donations {
 	 * Get the parent donation product.
 	 */
 	private static function get_parent_donation_product() {
+		// Bail when WooCommerce core is inactive: wc_get_product() is undefined
+		// and there can be no donation product. Treating this as "no parent
+		// product" lets callers (e.g. the Insights donation-activity gate)
+		// degrade gracefully instead of fataling on every admin page load.
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return false;
+		}
 		$product = \wc_get_product( get_option( self::DONATION_PRODUCT_ID_OPTION, 0 ) );
 		if ( ! $product || 'grouped' !== $product->get_type() ) {
 			return false;

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
@@ -24,6 +24,7 @@ use Newspack\Insights_Wizard;
  * Boot-config degradation with WooCommerce inactive.
  *
  * @group insights
+ * @group donations
  */
 class Test_Donation_Activity_WC_Inactive extends WP_UnitTestCase {
 

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
@@ -28,6 +28,9 @@ use Newspack\Insights_Wizard;
  */
 class Test_Donation_Activity_WC_Inactive extends WP_UnitTestCase {
 
+	/**
+	 * Clean up the test option on teardown.
+	 */
 	public function tear_down() {
 		delete_option( Donations::DONATION_PRODUCT_ID_OPTION );
 		parent::tear_down();

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
@@ -28,6 +28,12 @@ use Newspack\Insights_Wizard;
  */
 class Test_Donation_Activity_WC_Inactive extends WP_UnitTestCase {
 
+	public function tear_down() {
+		delete_option( Donations::DONATION_PRODUCT_ID_OPTION );
+		parent::tear_down();
+	}
+
+
 	/**
 	 * The donation-product child lookup degrades to the safe all-false
 	 * default — rather than fataling — when WooCommerce is inactive.

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-activity-wc-inactive.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Regression: the Insights wizard boot-config path must not fatal when
+ * WooCommerce core is inactive.
+ *
+ * With NEWSPACK_INSIGHTS_ENABLED true but WooCommerce inactive, loading
+ * wp-admin used to fatal with "Call to undefined function wc_get_product()"
+ * because the donation-activity gate runs the Donation_Product_Classifier,
+ * which threads through Donations::get_donation_product_child_products_ids()
+ * -> get_parent_donation_product() -> wc_get_product().
+ *
+ * These tests run in a separate process that intentionally does NOT load the
+ * wc-mocks shim, so wc_get_product() is genuinely undefined — exactly the
+ * WooCommerce-core-inactive condition. The fix guards the WooCommerce path
+ * and treats "no donation activity" as the safe default.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Donations;
+use Newspack\Insights_Wizard;
+
+/**
+ * Boot-config degradation with WooCommerce inactive.
+ *
+ * @group insights
+ */
+class Test_Donation_Activity_WC_Inactive extends WP_UnitTestCase {
+
+	/**
+	 * The donation-product child lookup degrades to the safe all-false
+	 * default — rather than fataling — when WooCommerce is inactive.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_child_products_lookup_without_woocommerce() {
+		if ( function_exists( 'wc_get_product' ) ) {
+			self::markTestSkipped( 'wc_get_product() is defined; cannot exercise the WooCommerce-inactive path.' );
+		}
+
+		// Configure a donation parent ID so the unguarded code path would
+		// have reached wc_get_product() and fataled.
+		update_option( Donations::DONATION_PRODUCT_ID_OPTION, 123 );
+
+		$children = Donations::get_donation_product_child_products_ids();
+
+		self::assertSame(
+			[
+				'once'  => false,
+				'month' => false,
+				'year'  => false,
+			],
+			$children,
+			'With WooCommerce inactive, the donation child-product lookup must return the safe all-false default.'
+		);
+	}
+
+	/**
+	 * The Insights donation-activity gate (the boot-config path that
+	 * enqueue_scripts_and_styles() runs on every admin page load) computes
+	 * "no donation activity" without fataling when WooCommerce is inactive.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_donation_activity_gate_without_woocommerce() {
+		if ( function_exists( 'wc_get_product' ) ) {
+			self::markTestSkipped( 'wc_get_product() is defined; cannot exercise the WooCommerce-inactive path.' );
+		}
+
+		// No donation product is configured — the realistic state when
+		// WooCommerce core is inactive. The unguarded code fataled here
+		// regardless, because get_parent_donation_product() called
+		// wc_get_product( 0 ) before this method could short-circuit.
+		//
+		// force_refresh_donation_activity() runs the same classifier ->
+		// compute_donation_activity() chain that get_boot_config() relies on.
+		// Reaching the assertion at all proves the path did not fatal.
+		$has_activity = Insights_Wizard::force_refresh_donation_activity();
+
+		self::assertFalse(
+			$has_activity,
+			'With WooCommerce inactive there are no donation products, so the activity gate must report no activity.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With `NEWSPACK_INSIGHTS_ENABLED` true but WooCommerce core inactive, visiting any admin page (e.g. `wp-admin/admin.php?page=newspack-insights`) fataled the entire screen with `Call to undefined function wc_get_product()`.

The Insights wizard runs a donation-activity gate on every admin page load to decide whether to show the Donors tab. That gate threads through `Donations::get_parent_donation_product()`, which called `wc_get_product()` without checking that WooCommerce is active.

This guards that single chokepoint so the Insights wizard — and every other consumer that routes through it (`is_donation_product()`, `is_ready_to_render()`, the donation child-product lookup) — degrades gracefully when WooCommerce is inactive. "No donation product / no donation activity" becomes the safe default, so the Donors tab is simply hidden instead of taking down the admin page. The guard matches the WooCommerce-inactive pattern already used elsewhere in the same class.

Base branch is `feat/insights-rsm` per the Insights workflow. Independent of NEWS-2586 (funnel graphics).

### How to test the changes in this Pull Request:

1. On a site with WooCommerce core **deactivated**, ensure the Insights feature is on (`NEWSPACK_INSIGHTS_ENABLED` truthy).
2. Visit `wp-admin/` and `wp-admin/admin.php?page=newspack-insights`. Before this change the page fatals with `Call to undefined function wc_get_product()`; after it, the admin loads normally and the Insights Donors tab is hidden.
3. Activate WooCommerce and configure the Newspack donation product. Confirm the Donors tab reappears and donation activity is detected as before (no regression to the WC-active path).
4. Run the PHP tests: `n test-php --group insights` and `n test-php --group donations`. The new `Test_Donation_Activity_WC_Inactive` cases reproduce the fatal on the old code (process-isolated, WooCommerce-inactive) and pass with the fix.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
