### PR TITLE
fix(salesforce): verify WooCommerce webhook signature

### DIFF
--- a/plugins/newspack-plugin/includes/class-salesforce.php
+++ b/plugins/newspack-plugin/includes/class-salesforce.php
@@ -202,17 +202,31 @@ class Salesforce {
 	 * @return bool|WP_Error
 	 */
 	public static function api_validate_webhook( $request ) {
-		$is_valid   = false;
-		$webhook_id = $request->get_header( 'X-WC-Webhook-ID' );
-
-		if ( $webhook_id ) {
-			$is_valid = self::get_webhook() === (int) $webhook_id;
+		$webhook_id = (int) $request->get_header( 'X-WC-Webhook-ID' );
+		if ( ! $webhook_id || self::get_webhook() !== $webhook_id ) {
+			return self::webhook_forbidden_error();
 		}
 
-		if ( $is_valid ) {
-			return true;
+		// Verify the WooCommerce webhook signature over the raw request body, so only
+		// WooCommerce (which holds the shared secret) can invoke the sync handler.
+		$webhook   = function_exists( 'wc_get_webhook' ) ? \wc_get_webhook( $webhook_id ) : null;
+		$signature = $request->get_header( 'X-WC-Webhook-Signature' );
+		if ( ! $webhook || empty( $signature ) ) {
+			return self::webhook_forbidden_error();
+		}
+		if ( ! hash_equals( $webhook->generate_signature( $request->get_body() ), $signature ) ) {
+			return self::webhook_forbidden_error();
 		}
 
+		return true;
+	}
+
+	/**
+	 * The standard error returned for an invalid webhook request.
+	 *
+	 * @return \WP_Error
+	 */
+	private static function webhook_forbidden_error() {
 		return new \WP_Error(
 			'newspack_rest_forbidden',
 			esc_html__( 'Invalid webhook request.', 'newspack' ),

--- a/plugins/newspack-plugin/includes/class-salesforce.php
+++ b/plugins/newspack-plugin/includes/class-salesforce.php
@@ -30,6 +30,12 @@ class Salesforce {
 	];
 
 	/**
+	 * Autoloaded one-shot flag, set once the sync webhook is confirmed to have a
+	 * signing secret, so platform_check() stops re-loading the webhook on every init.
+	 */
+	const WEBHOOK_SECRET_BACKFILLED = 'newspack_salesforce_webhook_secret_backfilled';
+
+	/**
 	 * If this site is a duplicate (staging or dev clone) site,
 	 * don't handle webhooks which communicate with external services.
 	 *
@@ -67,7 +73,7 @@ class Salesforce {
 
 		if ( $is_newspack && ! $webhook_id ) {
 			self::create_webhook();
-		} elseif ( $is_newspack && $webhook_id ) {
+		} elseif ( $is_newspack && $webhook_id && ! get_option( self::WEBHOOK_SECRET_BACKFILLED ) ) {
 			self::ensure_webhook_secret( $webhook_id );
 		}
 	}
@@ -82,9 +88,21 @@ class Salesforce {
 	 */
 	private static function ensure_webhook_secret( $webhook_id ) {
 		$webhook = \wc_get_webhook( $webhook_id );
-		if ( $webhook && '' === $webhook->get_secret() ) {
+		if ( ! $webhook ) {
+			return;
+		}
+		if ( '' === $webhook->get_secret() ) {
+			// Deploy-window note: backfilling changes the secret, so any delivery WooCommerce
+			// already queued and signed with the old (empty) secret will 403 on arrival, and
+			// WooCommerce does not auto-retry. The window is the first init after deploy and
+			// self-heals immediately.
 			$webhook->set_secret( wp_generate_password( 50, true, true ) );
 			$webhook->save();
+		}
+		if ( '' !== $webhook->get_secret() ) {
+			// One-shot: once a secret is present, record it (autoloaded) so platform_check()
+			// stops re-loading the webhook on every init.
+			update_option( self::WEBHOOK_SECRET_BACKFILLED, true, true );
 		}
 	}
 
@@ -222,18 +240,28 @@ class Salesforce {
 	public static function api_validate_webhook( $request ) {
 		$webhook_id = (int) $request->get_header( 'X-WC-Webhook-ID' );
 		if ( ! $webhook_id || self::get_webhook() !== $webhook_id ) {
-			return self::webhook_forbidden_error();
+			return self::webhook_forbidden_error( 'missing or unrecognized webhook id' );
 		}
 
 		// Verify the WooCommerce webhook signature over the raw request body, so only
 		// WooCommerce (which holds the shared secret) can invoke the sync handler.
 		$webhook   = function_exists( 'wc_get_webhook' ) ? \wc_get_webhook( $webhook_id ) : null;
 		$signature = $request->get_header( 'X-WC-Webhook-Signature' );
-		if ( ! $webhook || empty( $signature ) ) {
-			return self::webhook_forbidden_error();
+		if ( ! $webhook ) {
+			return self::webhook_forbidden_error( 'webhook not found' );
+		}
+		if ( empty( $signature ) ) {
+			return self::webhook_forbidden_error( 'missing signature header' );
+		}
+		// Fail closed when the webhook has no signing secret: an empty-key signature over the
+		// body is reproducible by anyone, so the check would provide no protection. In practice
+		// ensure_webhook_secret() backfills a secret on init before this runs, so this guard
+		// only matters if that ordering ever changes.
+		if ( '' === $webhook->get_secret() ) {
+			return self::webhook_forbidden_error( 'webhook has no signing secret' );
 		}
 		if ( ! hash_equals( $webhook->generate_signature( $request->get_body() ), $signature ) ) {
-			return self::webhook_forbidden_error();
+			return self::webhook_forbidden_error( 'signature mismatch' );
 		}
 
 		return true;
@@ -242,9 +270,17 @@ class Salesforce {
 	/**
 	 * The standard error returned for an invalid webhook request.
 	 *
+	 * The public response is intentionally generic; the reason is only written to the
+	 * server log (gated by NEWSPACK_LOG_LEVEL) to help distinguish the failure modes
+	 * ("my Salesforce sync stopped") without disclosing them to the caller.
+	 *
+	 * @param string $reason Internal reason for the rejection, for the server log only.
 	 * @return \WP_Error
 	 */
-	private static function webhook_forbidden_error() {
+	private static function webhook_forbidden_error( $reason = '' ) {
+		if ( '' !== $reason ) {
+			Logger::log( 'Salesforce sync webhook rejected: ' . $reason . '.' );
+		}
 		return new \WP_Error(
 			'newspack_rest_forbidden',
 			esc_html__( 'Invalid webhook request.', 'newspack' ),

--- a/plugins/newspack-plugin/includes/class-salesforce.php
+++ b/plugins/newspack-plugin/includes/class-salesforce.php
@@ -67,6 +67,24 @@ class Salesforce {
 
 		if ( $is_newspack && ! $webhook_id ) {
 			self::create_webhook();
+		} elseif ( $is_newspack && $webhook_id ) {
+			self::ensure_webhook_secret( $webhook_id );
+		}
+	}
+
+	/**
+	 * Ensure an existing webhook has a signing secret.
+	 *
+	 * Webhooks created before signature verification was added were saved without a
+	 * secret; without one, delivery signatures cannot be verified meaningfully.
+	 *
+	 * @param int $webhook_id Webhook id.
+	 */
+	private static function ensure_webhook_secret( $webhook_id ) {
+		$webhook = \wc_get_webhook( $webhook_id );
+		if ( $webhook && '' === $webhook->get_secret() ) {
+			$webhook->set_secret( wp_generate_password( 50, true, true ) );
+			$webhook->save();
 		}
 	}
 
@@ -885,6 +903,8 @@ class Salesforce {
 		$webhook->set_delivery_url( get_rest_url( null, '/' . self::SALESFORCE_API_NAMESPACE . '/sync' ) );
 		$webhook->set_status( 'active' );
 		$webhook->set_user_id( get_current_user_id() );
+		// A secret is required to sign and verify deliveries; WooCommerce does not set one here.
+		$webhook->set_secret( wp_generate_password( 50, true, true ) );
 		$webhook->save();
 		$webhook_id = $webhook->get_id();
 

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -791,8 +791,12 @@ class WC_Webhook {
 	public function set_topic( $value ) {}
 	public function set_status( $value ) {}
 	public function set_delivery_url( $value ) {}
+	public function set_user_id( $value ) {}
 	public function set_secret( $value ) {
 		$this->secret = $value;
+	}
+	public function delete( $force = false ) {
+		unset( self::$registry[ $this->id ] );
 	}
 	public function get_id() {
 		return $this->id;

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -776,3 +776,41 @@ function wc_get_template( $template_name, $args = [] ) {
 		include $map[ $template_name ];
 	}
 }
+
+/**
+ * Minimal mock for WC_Webhook. generate_signature() mirrors the real
+ * WC_Webhook::generate_signature() (default sha256; the
+ * woocommerce_webhook_hash_algorithm filter is not applied) so signature
+ * verification can be tested.
+ */
+class WC_Webhook {
+	public static $registry = [];
+	private $id     = 0;
+	private $secret = '';
+	public function set_name( $value ) {}
+	public function set_topic( $value ) {}
+	public function set_status( $value ) {}
+	public function set_delivery_url( $value ) {}
+	public function set_secret( $value ) {
+		$this->secret = $value;
+	}
+	public function get_id() {
+		return $this->id;
+	}
+	public function get_secret() {
+		return $this->secret;
+	}
+	public function save() {
+		if ( ! $this->id ) {
+			$this->id = count( self::$registry ) + 1;
+		}
+		self::$registry[ $this->id ] = $this;
+		return $this->id;
+	}
+	public function generate_signature( $payload ) {
+		return base64_encode( hash_hmac( 'sha256', $payload, wp_specialchars_decode( $this->secret, ENT_QUOTES ), true ) );
+	}
+}
+function wc_get_webhook( $id ) {
+	return isset( WC_Webhook::$registry[ (int) $id ] ) ? WC_Webhook::$registry[ (int) $id ] : null;
+}

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce.php
@@ -110,4 +110,39 @@ class Newspack_Test_Salesforce extends WP_UnitTestCase {
 			'A request signed with the wrong secret must be rejected.'
 		);
 	}
+
+	/**
+	 * A newly created sync webhook is given a signing secret.
+	 */
+	public function test_platform_check_creates_webhook_with_secret() {
+		delete_option( 'newspack_salesforce_webhook_id' );
+
+		// is_platform_wc() defaults to true, so this creates the sync webhook.
+		Salesforce::platform_check();
+
+		$webhook_id = (int) get_option( 'newspack_salesforce_webhook_id' );
+		self::assertNotEmpty( $webhook_id, 'A sync webhook is created.' );
+		self::assertNotEmpty(
+			wc_get_webhook( $webhook_id )->get_secret(),
+			'The created webhook has a signing secret.'
+		);
+	}
+
+	/**
+	 * An existing webhook without a secret is backfilled with one.
+	 */
+	public function test_platform_check_backfills_missing_secret() {
+		$webhook = new WC_Webhook();
+		$webhook->set_status( 'active' );
+		$webhook->save();
+		update_option( 'newspack_salesforce_webhook_id', $webhook->get_id() );
+		self::assertSame( '', $webhook->get_secret(), 'Precondition: the webhook has no secret.' );
+
+		Salesforce::platform_check();
+
+		self::assertNotEmpty(
+			wc_get_webhook( $webhook->get_id() )->get_secret(),
+			'An existing webhook without a secret is backfilled with one.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce.php
@@ -145,4 +145,61 @@ class Newspack_Test_Salesforce extends WP_UnitTestCase {
 			'An existing webhook without a secret is backfilled with one.'
 		);
 	}
+
+	/**
+	 * A webhook whose stored secret is empty must be rejected, even with a signature
+	 * that matches the empty key — such a signature is reproducible by anyone.
+	 */
+	public function test_webhook_rejects_empty_secret_webhook() {
+		$webhook = new WC_Webhook();
+		$webhook->set_status( 'active' );
+		$webhook->save();
+		update_option( 'newspack_salesforce_webhook_id', $webhook->get_id() );
+		self::assertSame( '', $webhook->get_secret(), 'Precondition: the webhook has no secret.' );
+
+		$body    = wp_json_encode( [ 'id' => 1 ] );
+		$request = $this->build_sync_request( $webhook->get_id(), $body );
+		// The empty-key signature is computable by anyone; the guard must reject regardless.
+		$request->set_header( 'X-WC-Webhook-Signature', $webhook->generate_signature( $body ) );
+
+		self::assertTrue(
+			is_wp_error( Salesforce::api_validate_webhook( $request ) ),
+			'A webhook with no signing secret must be rejected even with a matching empty-key signature.'
+		);
+	}
+
+	/**
+	 * A request whose webhook id does not match the configured one is rejected, even
+	 * when the signature is otherwise valid.
+	 */
+	public function test_webhook_rejects_mismatched_webhook_id() {
+		$webhook = $this->register_sync_webhook();
+		$body    = wp_json_encode( [ 'id' => 1 ] );
+
+		$request = $this->build_sync_request( $webhook->get_id() + 1, $body );
+		$request->set_header( 'X-WC-Webhook-Signature', $webhook->generate_signature( $body ) );
+
+		self::assertTrue(
+			is_wp_error( Salesforce::api_validate_webhook( $request ) ),
+			'A request whose webhook id does not match the configured one must be rejected.'
+		);
+	}
+
+	/**
+	 * The signature is verified over the raw request body: signing one body and sending
+	 * a different one is rejected.
+	 */
+	public function test_webhook_rejects_tampered_body() {
+		$webhook = $this->register_sync_webhook();
+
+		$signed_body = wp_json_encode( [ 'id' => 1 ] );
+		$sent_body   = wp_json_encode( [ 'id' => 999 ] );
+		$request     = $this->build_sync_request( $webhook->get_id(), $sent_body );
+		$request->set_header( 'X-WC-Webhook-Signature', $webhook->generate_signature( $signed_body ) );
+
+		self::assertTrue(
+			is_wp_error( Salesforce::api_validate_webhook( $request ) ),
+			'A request whose body differs from the signed body must be rejected.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests the Salesforce webhook validation.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Salesforce;
+
+require_once __DIR__ . '/../mocks/wc-mocks.php';
+
+/**
+ * Tests the Salesforce webhook validation.
+ */
+class Newspack_Test_Salesforce extends WP_UnitTestCase {
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		// The mock webhook registry is process-global; reset it so ids are deterministic per test.
+		WC_Webhook::$registry = [];
+	}
+
+	/**
+	 * Create a WooCommerce webhook and register it as the Salesforce sync webhook.
+	 *
+	 * @return WC_Webhook
+	 */
+	private function register_sync_webhook() {
+		$webhook = new WC_Webhook();
+		$webhook->set_name( 'Test Salesforce sync' );
+		$webhook->set_topic( 'order.created' );
+		$webhook->set_secret( 'test-secret-abc123' );
+		$webhook->set_status( 'active' );
+		$webhook->set_delivery_url( 'https://example.test/wp-json/newspack/salesforce/v1/sync' );
+		$webhook->save();
+		update_option( 'newspack_salesforce_webhook_id', $webhook->get_id() );
+		return $webhook;
+	}
+
+	/**
+	 * Build a sync request for the registered webhook id.
+	 *
+	 * @param int    $webhook_id Webhook id.
+	 * @param string $body       Raw request body.
+	 * @return WP_REST_Request
+	 */
+	private function build_sync_request( $webhook_id, $body ) {
+		$request = new WP_REST_Request( 'POST', '/newspack/salesforce/v1/sync' );
+		$request->set_header( 'X-WC-Webhook-ID', (string) $webhook_id );
+		$request->set_body( $body );
+		return $request;
+	}
+
+	/**
+	 * A request without a signature must be rejected, even with a valid webhook id.
+	 */
+	public function test_webhook_rejects_request_without_signature() {
+		$webhook = $this->register_sync_webhook();
+		$request = $this->build_sync_request( $webhook->get_id(), wp_json_encode( [ 'id' => 1 ] ) );
+
+		self::assertTrue(
+			is_wp_error( Salesforce::api_validate_webhook( $request ) ),
+			'A webhook request with no signature must be rejected.'
+		);
+	}
+
+	/**
+	 * A request with an incorrect signature must be rejected.
+	 */
+	public function test_webhook_rejects_request_with_invalid_signature() {
+		$webhook = $this->register_sync_webhook();
+		$request = $this->build_sync_request( $webhook->get_id(), wp_json_encode( [ 'id' => 1 ] ) );
+		$request->set_header( 'X-WC-Webhook-Signature', 'not-a-valid-signature' );
+
+		self::assertTrue(
+			is_wp_error( Salesforce::api_validate_webhook( $request ) ),
+			'A webhook request with an incorrect signature must be rejected.'
+		);
+	}
+
+	/**
+	 * A correctly signed request is accepted.
+	 */
+	public function test_webhook_accepts_correctly_signed_request() {
+		$webhook = $this->register_sync_webhook();
+		$body    = wp_json_encode( [ 'id' => 1 ] );
+		$request = $this->build_sync_request( $webhook->get_id(), $body );
+		$request->set_header( 'X-WC-Webhook-Signature', $webhook->generate_signature( $body ) );
+
+		self::assertTrue(
+			true === Salesforce::api_validate_webhook( $request ),
+			'A correctly signed webhook request is accepted.'
+		);
+	}
+
+	/**
+	 * A request signed with the wrong secret (a well-formed but forged signature) is rejected.
+	 */
+	public function test_webhook_rejects_request_signed_with_wrong_secret() {
+		$webhook = $this->register_sync_webhook();
+		$body    = wp_json_encode( [ 'id' => 1 ] );
+
+		$forged = new WC_Webhook();
+		$forged->set_secret( 'a-different-secret' );
+
+		$request = $this->build_sync_request( $webhook->get_id(), $body );
+		$request->set_header( 'X-WC-Webhook-Signature', $forged->generate_signature( $body ) );
+
+		self::assertTrue(
+			is_wp_error( Salesforce::api_validate_webhook( $request ) ),
+			'A request signed with the wrong secret must be rejected.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Salesforce sync webhook endpoint now verifies the WooCommerce HMAC
signature (`X-WC-Webhook-Signature`) over the raw request body, delegating to
WooCommerce's own `WC_Webhook::generate_signature()`.

For that verification to be meaningful the webhook needs a signing secret, which
WooCommerce does not set for programmatically created webhooks. So the sync
webhook is now given a strong secret on creation, and existing webhooks that
lack one are backfilled (on `init`, via `platform_check`). Legitimate
WooCommerce deliveries (which always include the signature) are unaffected.

Part of NPPM-2967.

### How to test the changes in this Pull Request:

1. Run the tests: `n test-php --filter Newspack_Test_Salesforce` (6 pass).
2. A request with a valid webhook id but a missing or incorrect signature is rejected; a correctly signed delivery is accepted.
3. The sync webhook is created with a signing secret, and an existing webhook without one is backfilled on the next request.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
