### PR TITLE
fix(newsletters): add ad status control (active/inactive) to editor

### DIFF
--- a/plugins/newspack-newsletters/src/ads/editor/index.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.js
@@ -7,7 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Fragment, useState } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel, store as editPostStore } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { ToggleControl, TextControl, DatePicker, Notice, RangeControl, Button, Modal } from '@wordpress/components';
+import { ToggleControl, TextControl, DatePicker, Notice, RadioControl, RangeControl, Button, Modal } from '@wordpress/components';
 import { date as wpDate, format, isInTheFuture } from '@wordpress/date';
 import { SelectControl } from 'newspack-components';
 import AdPlacements from '../../components/ad-placements';
@@ -28,10 +28,11 @@ apiFetch.use( ( options, next ) => {
 } );
 
 function AdEdit() {
-	const { price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
+	const { status, price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
+			status: getEditedPostAttribute( 'status' ),
 			price: meta.price,
 			// Normalize to Y-m-d on read so all client-side date comparisons are
 			// plain string compares regardless of any legacy ISO-datetime value.
@@ -104,12 +105,35 @@ function AdEdit() {
 		};
 	}
 
-	// Remove the "post-status" (Summary) panel.
+	// Ads only need an on/off state: whether they run (`publish`) or not
+	// (`draft`). Scheduling is driven by the start/expiry date meta, and
+	// private/pending/password statuses never serve. Remove the native
+	// "Summary" panel (which offers all of those) and expose a single
+	// Active/Inactive control instead, matching the ads list Quick Edit.
 	removeEditorPanel( 'post-status' );
+
+	// `future`/`private`/etc. are edge statuses a publisher can't set from
+	// this control; map any publish-equivalent to Active and everything else
+	// to Inactive, and only write `publish`/`draft` back on an actual change.
+	const statusControl = [ 'publish', 'future' ].includes( status ) ? 'active' : 'inactive';
 
 	return (
 		<Fragment>
 			<PluginDocumentSettingPanel name="newsletters-ads-settings-panel" title={ __( 'Ad settings', 'newspack-newsletters' ) }>
+				<RadioControl
+					label={ __( 'Status', 'newspack-newsletters' ) }
+					selected={ statusControl }
+					options={ [
+						{ label: __( 'Active', 'newspack-newsletters' ), value: 'active' },
+						{ label: __( 'Inactive', 'newspack-newsletters' ), value: 'inactive' },
+					] }
+					onChange={ value => editPost( { status: value === 'active' ? 'publish' : 'draft' } ) }
+					help={ __(
+						'Active ads run according to their start and expiration dates. Inactive ads are never shown.',
+						'newspack-newsletters'
+					) }
+				/>
+				<hr />
 				<TextControl
 					type="number"
 					label={ __( 'Price', 'newspack-newsletters' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Newsletter Ad editor exposed no usable post-status control: the editor stripped the native "Summary" panel, and the ads list Quick Edit deferred status "to the full editor" — so publishers had no way to pause a running ad or bring a draft live from the editor. (See the ads-list Quick Edit companion in #478.)

This adds a single **Status: Active / Inactive** control to the editor's Ad settings panel:

- **Active** → `post_status = publish`, **Inactive** → `post_status = draft`. `publish` is what gates ad insertion (`Ads::get_newsletter_ads()` serves publish-only), so Active/Inactive maps directly to "runs" / "never runs".
- The status is only written back on an actual change, so pre-existing edge statuses (`future`/`private`/`pending`) are preserved when a publisher edits other fields without touching the control.
- The native "Summary" panel stays removed on purpose. Ads have no use for its Scheduled / Private / Pending / Password options — scheduling is driven by the start/expiration date meta, and non-`publish` statuses never serve. Exposing only Active/Inactive avoids publishers setting a status that silently prevents an ad from running.

Labels match the ads list Quick Edit control (#478) so the two surfaces read consistently.

### Regression origin

The editor stopped showing any status UI when `removeEditorPanel( 'post-status' )` was introduced in the legacy `newspack-newsletters` repo by commit [`265642f9`](https://github.com/Automattic/newspack-newsletters/commit/265642f944d0d308580347d062eba7b00935f561) ("feat: ads taxonomies and fields", #1262, part of the #1272 revenue-optimizations epic; Sep 2023). That commit created `src/ads/editor/index.js`, superseding `src/ads-admin/editor/index.js`, which did not remove the panel — and [#1262](https://github.com/Automattic/newspack-newsletters/pull/1262)'s description never mentioned the removal. It rode along silently in the editor rewrite that also introduced date-driven activation, so the panel was most likely stripped on the assumption dates would govern display, without accounting for `post_status` still gating insertion. This PR keeps the native panel off (correct, given the unwanted statuses) but adds back a purpose-built control.

### How to test the changes in this Pull Request:

1. Open a Newsletter Ad in the block editor.
2. Confirm the Document sidebar shows **no** native Status/Visibility/Publish-date panel (no Scheduled/Private/Password options anywhere).
3. In the **Ad settings** panel, confirm a **Status** control (Active / Inactive) at the top, reflecting the ad's current state (published ad → Active).
4. Switch to **Inactive**, save, and confirm the ad's `post_status` becomes `draft` (unpublished; the ads list shows Inactive) and it is no longer served.
5. Switch back to **Active**, save, and confirm it publishes (Active in the list, eligible for insertion).

### Other information:

* [x] Have you successfully run tests with your changes locally? (ESLint clean; JS suite green; verified end-to-end in an isolated env — Active↔Inactive round-trips to publish/draft and persists server-side.)