### PR TITLE
feat(newsletters): add status control to ads quick edit

### DIFF
--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -1,12 +1,13 @@
 /**
- * Quick Edit panel for the ads list — advertiser, placement,
+ * Quick Edit panel for the ads list — status, advertiser, placement,
  * category, start/expiry dates, price.
  *
- * Status / insertion strategy / position stay in the full editor.
+ * Insertion strategy / position stay in the full editor; status is
+ * editable here.
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { FormTokenField, TextControl } from '@wordpress/components';
+import { FormTokenField, RadioControl, TextControl } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { emailAd } from 'newspack-icons';
@@ -47,7 +48,9 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 		const value = item?.meta?.price;
 		return value ? String( value ) : '';
 	} )();
+	const initialStatus = [ 'publish', 'private', 'future' ].includes( item?.status ) ? 'active' : 'draft';
 
+	const [ status, setStatus ] = useState( initialStatus );
 	const [ advertiserSelections, setAdvertiserSelections ] = useState( initialAdvertiserSelections );
 	const [ placementSelections, setPlacementSelections ] = useState( initialPlacementSelections );
 	const [ categorySelections, setCategorySelections ] = useState( initialCategorySelections );
@@ -57,6 +60,7 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 	const [ isBusy, setIsBusy ] = useState( false );
 
 	const isDirty =
+		status !== initialStatus ||
 		startDate !== initialStartDate ||
 		expiryDate !== initialExpiryDate ||
 		price !== initialPrice ||
@@ -97,6 +101,9 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 			categories: categorySelections.map( s => s.id ),
 			meta,
 		};
+		if ( status !== initialStatus ) {
+			data.status = status === 'active' ? 'publish' : 'draft';
+		}
 		try {
 			await apiFetch( { path: `${ POSTS_PATH }/${ item.id }`, method: 'POST', data } );
 			notifySuccess( __( 'Ad updated.', 'newspack-newsletters' ) );
@@ -121,6 +128,16 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 			canSave={ canSave }
 			saveLabel={ __( 'Save', 'newspack-newsletters' ) }
 		>
+			<RadioControl
+				label={ __( 'Status', 'newspack-newsletters' ) }
+				selected={ status }
+				options={ [
+					{ label: __( 'Draft', 'newspack-newsletters' ), value: 'draft' },
+					{ label: __( 'Active', 'newspack-newsletters' ), value: 'active' },
+				] }
+				onChange={ setStatus }
+				help={ __( 'Active ads run according to their start and expiration dates. Draft ads are never shown.', 'newspack-newsletters' ) }
+			/>
 			<FormTokenField
 				label={ __( 'Advertiser', 'newspack-newsletters' ) }
 				value={ advertiserTokens }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
@@ -1,0 +1,113 @@
+// Spy on the network layer; the real `@wordpress/components` render the
+// RadioControl so we exercise the actual radio markup. `QuickEditPanel`
+// is a thin modal shell (portal + exit animation), so it's mocked down to
+// a plain wrapper that exposes `isDirty` and a Save trigger — the panel's
+// own status/save logic is what's under test here.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../components/quick-edit-panel', () => ( {
+	__esModule: true,
+	default: ( { children, isDirty, canSave, isBusy, onSave } ) => (
+		<div>
+			<div data-testid="panel-dirty">{ String( isDirty ) }</div>
+			{ children }
+			<button type="button" data-testid="panel-save" onClick={ onSave } disabled={ isBusy || ! canSave }>
+				Save
+			</button>
+		</div>
+	),
+} ) );
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import AdsQuickEditPanel from './quick-edit-panel';
+
+const ADVERTISERS = [ { id: 10, name: 'Acme' } ];
+const PLACEMENTS = [ { id: 20, name: 'Header' } ];
+
+const renderPanel = ( item, extra = {} ) =>
+	render(
+		<AdsQuickEditPanel
+			item={ item }
+			advertisers={ ADVERTISERS }
+			placements={ PLACEMENTS }
+			onClose={ jest.fn() }
+			onSaved={ jest.fn() }
+			{ ...extra }
+		/>
+	);
+
+const makeItem = status => ( { id: 42, status, title: { raw: 'Summer sale' }, meta: {} } );
+
+const postCall = () => apiFetch.mock.calls.find( call => call[ 0 ]?.method === 'POST' )?.[ 0 ];
+
+describe( 'AdsQuickEditPanel status control', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		// Categories fetch (`fetchAllTerms`) and the save POST both go
+		// through this mock; an empty object resolves both harmlessly.
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	it( 'selects Active when the raw post_status is publish', async () => {
+		renderPanel( makeItem( 'publish' ) );
+		expect( await screen.findByRole( 'radio', { name: 'Active' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Draft' } ) ).not.toBeChecked();
+	} );
+
+	it( 'selects Draft when the raw post_status is draft', async () => {
+		renderPanel( makeItem( 'draft' ) );
+		expect( await screen.findByRole( 'radio', { name: 'Draft' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Active' } ) ).not.toBeChecked();
+	} );
+
+	it( 'POSTs status: publish when toggled Draft → Active', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'draft' ), { onSaved } );
+		fireEvent.click( await screen.findByRole( 'radio', { name: 'Active' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().path ).toBe( '/wp/v2/newspack_nl_ads_cpt/42' );
+		expect( postCall().method ).toBe( 'POST' );
+		expect( postCall().data.status ).toBe( 'publish' );
+	} );
+
+	it( 'POSTs status: draft when toggled Active → Draft', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'publish' ), { onSaved } );
+		fireEvent.click( await screen.findByRole( 'radio', { name: 'Draft' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data.status ).toBe( 'draft' );
+	} );
+
+	it( 'omits status from the payload when it is unchanged', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'publish' ), { onSaved } );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data ).not.toHaveProperty( 'status' );
+	} );
+
+	it( 'preserves an edge status (future) by omitting status when unchanged', async () => {
+		const onSaved = jest.fn();
+		renderPanel( makeItem( 'future' ), { onSaved } );
+		// `future` maps to the Active radio but must not be rewritten to publish on save.
+		expect( await screen.findByRole( 'radio', { name: 'Active' } ) ).toBeChecked();
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+		await waitFor( () => expect( onSaved ).toHaveBeenCalled() );
+		expect( postCall().data ).not.toHaveProperty( 'status' );
+	} );
+
+	it( 'marks the panel dirty after a status-only change', async () => {
+		renderPanel( makeItem( 'publish' ) );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'false' );
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Draft' } ) );
+		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'true' );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a Status control (Draft / Active) to the top of the Quick Edit panel on the Newsletter Ads list. Until now an ad's status could not be changed from the list, and the full ad editor hides the status panel, so publishers had no way to pause a running ad or bring a draft live without workarounds.

The control maps to the ad's post status: Active publishes the ad, Draft unpublishes it. Because a published ad's list label is derived from its start and expiration dates, an Active ad still reads as Scheduled or Expired according to those dates, and help text in the panel explains this. Setting an ad to Draft is a manual override that immediately pulls a currently running ad out of rotation without touching its dates. The status is only sent when it actually changes, so edge statuses like private or future are preserved when the publisher edits other fields.

<img width="3520" height="2460" alt="Screenshot 2026-07-01 at 09 46 32@2x" src="https://github.com/user-attachments/assets/748808d5-469a-4c4e-be5d-80e369463d7e" />

### How to test the changes in this Pull Request:

1. Go to Newsletters > Advertising (`edit.php?post_type=newspack_nl_ads_cpt&page=newspack-newsletters-ads-list`).
2. Create or pick a published ad that is within its date window and confirm its Status column reads Active.
3. Open Quick Edit and confirm a Status control (Draft / Active) appears at the top with Active selected.
4. Switch it to Draft and Save, then confirm the row's Status becomes Draft (the ad is now unpublished and will not be served).
5. Open Quick Edit on that draft, switch to Active and Save, then confirm the row returns to Active.
6. On an ad with a future start date, set it to Active and Save, then confirm it reads Scheduled (the dates govern the published label).
7. On an ad with a past expiration date, set it to Active, then confirm it reads Expired.
8. Confirm that changing only the Status enables the Save button, and that saving without changing Status does not alter the post status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
