### PR TITLE
feat(insights): self-labeling in-band funnel (NEWS-2586)

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/_print.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/_print.scss
@@ -181,18 +181,13 @@
 		break-inside: avoid;
 	}
 
-	// --- Watch item: Funnel (JS-driven layout) -------------------------------
-	// Funnel's side/compact layout is chosen in JS from the on-screen container
-	// width (ResizeObserver), so whatever the screen showed is what prints. Pin
-	// a deterministic max width and let the viewBox'd SVG scale within it, so
-	// the chosen layout lays out predictably on the narrower print page rather
-	// than overflowing.
+	// --- Watch item: Funnel (in-band HTML layout) ----------------------------
+	// The funnel renders as stacked HTML bands (clip-path trapezoid fills behind
+	// flowing label/count/descriptor text), sized by CSS. Pin a deterministic max
+	// width so it lays out predictably on the narrower print page rather than
+	// overflowing.
 	.newspack-insights__funnel {
 		max-width: 17cm;
-	}
-
-	.newspack-insights__funnel-svg {
-		max-height: 11cm;
 	}
 
 	// --- Watch item: BarChart (percentage-height flexbox) --------------------

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -54,14 +54,14 @@ describe( 'Funnel helpers', () => {
 			expect( halves[ 2 ] ).toBeCloseTo( 160 - ( 2 * 160 ) / 3, 5 );
 		} );
 		it( 'floors a tiny level at the minimum segment width', () => {
-			// 5-step funnel → taper 160/5 = 32. Steep tail walks 160 → 128 → 96 → 64 → 32,
-			// bottoming out at MIN_HALF_WIDTH 32 rather than the ~0 raw widths.
+			// 5-step funnel → taper 160/5 = 32. Steep tail walks 160 → 128 → 96 → 64 → 44.8,
+			// bottoming out at MIN_HALF_WIDTH 44.8 rather than the ~0 raw widths.
 			const halves = computeDisplayHalfWidths(
 				[ stage( 'a', 1000, 1 ), stage( 'b', 100, 0.1 ), stage( 'c', 10, 0.01 ), stage( 'd', 1, 0.001 ), stage( 'e', 1, 0.001 ) ],
 				1000
 			);
-			expect( halves[ 4 ] ).toBe( 32 );
-			expect( halves.every( h => h >= 32 ) ).toBe( true );
+			expect( halves[ 4 ] ).toBeCloseTo( 44.8 );
+			expect( halves.every( h => h >= 44.8 - 0.0001 ) ).toBe( true );
 		} );
 		it( 'never flares: each level is at most the level above', () => {
 			// A later stage exceeding an earlier one (data drift) must not widen.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -18,7 +18,7 @@ const stage = ( label: string, count: number, pctOfTop: number ) => ( { label, c
 
 describe( 'Funnel helpers', () => {
 	describe( 'computeDisplayHalfWidths', () => {
-		// Chart half-width 160; MIN_HALF_WIDTH 32 (20%). Max taper is per-funnel:
+		// Chart half-width 160; MIN_HALF_WIDTH 44.8 (28%). Max taper is per-funnel:
 		// HALF_WIDTH / stepCount (80 for 2 steps, ~53 for 3, 32 for 5).
 		it( 'keeps the top level at full half-width', () => {
 			const halves = computeDisplayHalfWidths( [ stage( 'a', 1000, 1 ), stage( 'b', 500, 0.5 ) ], 1000 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -12,24 +12,11 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import Funnel, { isCompactMode, stepOpacity, dropFromPrevious, computeDisplayHalfWidths } from './Funnel';
+import Funnel, { stepOpacity, dropFromPrevious, computeDisplayHalfWidths, type FunnelStage } from './Funnel';
 
 const stage = ( label: string, count: number, pctOfTop: number ) => ( { label, count, pct_of_top: pctOfTop } );
 
 describe( 'Funnel helpers', () => {
-	describe( 'isCompactMode', () => {
-		it( 'is side-label (false) for a small step count on a wide container', () => {
-			expect( isCompactMode( 3, 800 ) ).toBe( false );
-			expect( isCompactMode( 4, 480 ) ).toBe( false );
-		} );
-		it( 'is compact when there are 5+ steps regardless of width', () => {
-			expect( isCompactMode( 5, 1200 ) ).toBe( true );
-		} );
-		it( 'is compact when the container is narrower than 480px', () => {
-			expect( isCompactMode( 3, 479 ) ).toBe( true );
-		} );
-	} );
-
 	describe( 'computeDisplayHalfWidths', () => {
 		// Chart half-width 160; MIN_HALF_WIDTH 32 (20%). Max taper is per-funnel:
 		// HALF_WIDTH / stepCount (80 for 2 steps, ~53 for 3, 32 for 5).
@@ -105,27 +92,46 @@ describe( 'Funnel helpers', () => {
 } );
 
 describe( 'Funnel render', () => {
-	it( 'renders step labels and the descriptive % / drop-off lines naming the top stage', () => {
-		render( <Funnel stages={ [ stage( 'Impression', 1000, 1 ), stage( 'Engagement', 200, 0.2 ), stage( 'Conversion', 50, 0.05 ) ] } /> );
-		expect( screen.getByText( 'Impression' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Engagement' ) ).toBeInTheDocument();
-		// "% of top" names the actual first stage.
-		expect( screen.getByText( '20% of Impression' ) ).toBeInTheDocument();
-		// Drop-off uses the word "drop-off" (the ↓ glyph is a sibling node).
-		expect( screen.getByText( /80% drop-off/ ) ).toBeInTheDocument();
-		expect( screen.getByText( /75% drop-off/ ) ).toBeInTheDocument();
-		// Drop-off labels are descriptive gray, never the error-red treatment.
-		expect( document.querySelector( '.is-high-drop' ) ).toBeNull();
+	const stages = ( ...defs: Array< [ string, number ] > ): FunnelStage[] => {
+		const top = defs[ 0 ]?.[ 1 ] ?? 0;
+		return defs.map( ( [ label, count ] ) => ( { label, count, pct_of_top: top > 0 ? count / top : 0 } ) );
+	};
+
+	it( 'shows the label and count inside every stage', () => {
+		render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ], [ 'Converted', 400 ] ) } /> );
+		expect( screen.getByText( 'Impressions' ) ).toBeInTheDocument();
+		expect( screen.getByText( '25,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Converted' ) ).toBeInTheDocument();
+		expect( screen.getByText( '400' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the empty state when the first step is 0', () => {
-		render( <Funnel stages={ [ stage( 'Impression', 0, 0 ), stage( 'Conversion', 0, 0 ) ] } /> );
+	it( 'shows drop-off descriptors for stages after the first only', () => {
+		render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
+		expect( screen.getByText( /of Impressions/ ) ).toBeInTheDocument();
+		// Exactly one drop-off line: the first stage has none.
+		expect( screen.getAllByText( /drop-off/ ) ).toHaveLength( 1 );
+	} );
+
+	it( 'renders a single-stage funnel without descriptors', () => {
+		render( <Funnel stages={ stages( [ 'Only', 100 ] ) } /> );
+		expect( screen.getByText( 'Only' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /drop-off/ ) ).toBeNull();
+	} );
+
+	it( 'shows the empty message with no stages', () => {
+		render( <Funnel stages={ [] } /> );
 		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders a single stage with no drop-off lines', () => {
-		render( <Funnel stages={ [ stage( 'Impression', 1000, 1 ) ] } /> );
-		expect( screen.getByText( 'Impression' ) ).toBeInTheDocument();
-		expect( screen.queryByText( /drop-off/ ) ).not.toBeInTheDocument();
+	it( 'shows the empty message when the top count is zero', () => {
+		render( <Funnel stages={ stages( [ 'Impressions', 0 ], [ 'Engaged', 0 ] ) } /> );
+		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'no longer renders a separate legend or side-label column', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 100 ], [ 'B', 50 ] ) } /> );
+		expect( container.querySelector( '.newspack-insights__funnel-legend' ) ).toBeNull();
+		expect( container.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
+		expect( container.querySelector( '.newspack-insights__funnel-svg' ) ).toBeNull();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -1,50 +1,48 @@
 /**
  * Funnel viz — shared across Insights tabs (Gates, Prompts, Conversion Journey).
  *
- * Multi-step conversion funnel rendered as stacked SVG trapezoids. Each level's
- * width tracks its share of the top count so the silhouette narrows with
- * drop-off, but widths are clamped (min segment width + max per-segment taper)
- * so it reads as a rough relative-size viz, never a razor-thin sliver or a
- * cliff — see computeDisplayHalfWidths. The counts/percentages in the labels
- * are always exact. A single anchor color (primary-500) fades from full opacity at
- * the top to 0.6 at the bottom, so each stage carries its own weight.
+ * Self-labeling stacked funnel (NEWS-2586). Each section carries its own label,
+ * count, and — for every step after the first — the drop-off descriptors
+ * ("X% of {top}" share + "Y% drop-off") INSIDE the section. One uniform layout at
+ * every viewport and step count: no side-label/compact split, no separate legend.
  *
- * Two layouts, auto-selected from container width + step count:
- *   - Side-label (default): step name / count / labels in a fixed column to the
- *     right of each trapezoid. Used when stepCount < 5 AND width >= 480px.
- *   - Compact: the count renders inside each trapezoid and the full
- *     names/counts/labels move to a legend below. Used when stepCount >= 5 OR
- *     width < 480px.
+ * Each band is an <li> with two layers:
+ *   - a clipped trapezoid FILL (CSS clip-path, insets from computeDisplayHalfWidths)
+ *     behind the text, forming a continuous silhouette because adjacent band edges
+ *     share width; and
+ *   - a flowing TEXT layer on top that is NOT clipped, so it wraps, grows the band
+ *     height, and is never cut off — when a band's fill is narrower than its text
+ *     the text spills over the card (dark text on the faded lower bands keeps it
+ *     legible there).
+ *
+ * Width is CSS-driven (width:100%, max-width cap); the clip-path percentages scale
+ * intrinsically, so no JS measurement is needed. The single anchor color
+ * (primary-500) fades 1.0 → 0.6 down the funnel; bands above
+ * DARK_TEXT_OPACITY_THRESHOLD take white text, below it dark text.
  */
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { formatNumber, formatPercent } from './format';
 
-const COMPACT_MIN_STEPS = 5;
-const COMPACT_MAX_WIDTH = 480; // Below this container width, force compact mode.
-const MIN_STEP_HEIGHT = 32;
-const MAX_CHART_HEIGHT = 480;
+// Coordinate basis for the half-width math and the clip-path percentages.
 const VIEWBOX_WIDTH = 320;
 const FULL_OPACITY = 1;
 const TAIL_OPACITY = 0.6;
-// Above this band opacity the fill is dark enough for white text; below it, the
-// faded band needs dark text. Only affects compact mode (count rendered inside).
+// Above this band opacity the fill is dark enough for white text; below it the
+// faded band (and any text spilling onto the white card) needs dark text.
 const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
 const HALF_WIDTH = VIEWBOX_WIDTH / 2;
-// Width clamping: the funnel is a rough relative-size viz, not an exact one. No
-// segment is narrower than MIN_SEGMENT_WIDTH_RATIO of the chart width (avoids
-// razor-thin bands). The max per-segment taper is not fixed — it's computed
-// per-funnel from the step count (see computeDisplayHalfWidths) so funnels of
-// any length descend evenly across all their segments rather than cliff-diving
-// to the floor in one step.
+// The funnel is a rough relative-size viz: no segment is narrower than this share
+// of the chart width (avoids razor-thin bands and keeps the lowest band's fill
+// under its own text). The max per-segment taper is computed per-funnel from the
+// step count so funnels of any length descend evenly (see computeDisplayHalfWidths).
 const MIN_SEGMENT_WIDTH_RATIO = 0.28; // NEWS-2586: wider floor keeps the narrowest band's fill under its text.
 const MIN_HALF_WIDTH = ( MIN_SEGMENT_WIDTH_RATIO * VIEWBOX_WIDTH ) / 2;
 
@@ -58,10 +56,6 @@ export interface FunnelProps {
 	stages: FunnelStage[];
 }
 
-/** Compact when there are many steps OR the container is narrow. */
-export const isCompactMode = ( stepCount: number, containerWidth: number ): boolean =>
-	stepCount >= COMPACT_MIN_STEPS || containerWidth < COMPACT_MAX_WIDTH;
-
 /** Linear opacity from 1.0 at the first step to 0.6 at the last. */
 export const stepOpacity = ( index: number, stepCount: number ): number => {
 	if ( stepCount <= 1 ) {
@@ -72,28 +66,17 @@ export const stepOpacity = ( index: number, stepCount: number ): number => {
 
 /**
  * Drop-off from the previous step as a fraction in [0, 1]. Clamped at 0: funnel
- * stages are independent aggregates, so a later stage can occasionally exceed
- * the prior one (data drift) — a negative "drop-off" is meaningless, so show 0%.
+ * stages are independent aggregates, so a later stage can occasionally exceed the
+ * prior one (data drift) — a negative "drop-off" is meaningless, so show 0%.
  */
 export const dropFromPrevious = ( count: number, prevCount: number ): number => ( prevCount > 0 ? Math.max( 0, 1 - count / prevCount ) : 0 );
-
-/** Equal band height per step, capped so the whole chart fits ~480px. */
-const stepHeightFor = ( stepCount: number ): number => Math.max( MIN_STEP_HEIGHT, Math.floor( MAX_CHART_HEIGHT / stepCount ) );
 
 /**
  * Per-level display half-width for every stage. Raw width is proportional to the
  * stage's share of the top count, but clamped so the silhouette stays a readable
- * rough viz rather than a mathematically exact one. Walking top→bottom, each
- * level is:
- *   - at most the level above it (the funnel only ever narrows, never flares —
- *     even on anomalous data where a later stage exceeds an earlier one),
- *   - at least MIN_HALF_WIDTH (no razor-thin band), and
- *   - no more than the per-funnel max taper (HALF_WIDTH / stepCount) narrower
- *     than the level above it — so an N-step funnel descends across all N
- *     segments (≈ HALF_WIDTH / N at the bottom) instead of cliff-diving to the
- *     floor in one step. A 2-step funnel may narrow up to half the chart per
- *     step, a 3-step a third, a 5-step a fifth, etc.
- * Counts/percentages shown in the labels are unaffected — only widths are clamped.
+ * rough viz: never wider than the level above, never below MIN_HALF_WIDTH, and no
+ * more than the per-funnel max taper (HALF_WIDTH / stepCount) narrower than the
+ * level above. Counts/percentages in the labels are unaffected — only widths clamp.
  */
 export const computeDisplayHalfWidths = ( stages: FunnelStage[], topCount: number ): number[] => {
 	if ( topCount <= 0 ) {
@@ -109,189 +92,95 @@ export const computeDisplayHalfWidths = ( stages: FunnelStage[], topCount: numbe
 		}
 		const prev = halves[ index - 1 ];
 		const lower = Math.max( MIN_HALF_WIDTH, prev - maxTaperHalfWidth );
-		// Clamp raw into [lower, prev]: never wider than the level above, never
-		// below the min floor or beyond the max taper from the level above.
 		halves.push( Math.min( prev, Math.max( lower, raw ) ) );
 	} );
 	return halves;
 };
 
-/** SVG path for one trapezoid from a top half-width to a bottom half-width, centered. */
-const trapezoidPath = ( halfTop: number, halfBottom: number, yTop: number, yBottom: number ): string => {
-	const cx = VIEWBOX_WIDTH / 2;
-	return [
-		`M ${ cx - halfTop } ${ yTop }`,
-		`L ${ cx + halfTop } ${ yTop }`,
-		`L ${ cx + halfBottom } ${ yBottom }`,
-		`L ${ cx - halfBottom } ${ yBottom }`,
-		'Z',
-	].join( ' ' );
+/** Left inset (% of chart width) for a half-width; the right edge is 100 minus it. */
+const edgePercent = ( half: number ): number => ( ( HALF_WIDTH - half ) / VIEWBOX_WIDTH ) * 100;
+
+/** CSS clip-path polygon for a trapezoid from a top half-width to a bottom half-width. */
+const trapezoidClip = ( halfTop: number, halfBottom: number ): string => {
+	const lt = edgePercent( halfTop );
+	const lb = edgePercent( halfBottom );
+	return `polygon(${ lt }% 0, ${ 100 - lt }% 0, ${ 100 - lb }% 100%, ${ lb }% 100%)`;
 };
-
-interface StepView {
-	stage: FunnelStage;
-	index: number;
-	opacity: number;
-	pctOfTop: number;
-	drop: number | null;
-}
-
-/** Build the per-step view model shared by both layouts. */
-const buildSteps = ( stages: FunnelStage[], topCount: number ): StepView[] =>
-	stages.map( ( stage, index ) => {
-		const prevCount = index > 0 ? stages[ index - 1 ].count : 0;
-		return {
-			stage,
-			index,
-			opacity: stepOpacity( index, stages.length ),
-			pctOfTop: topCount > 0 ? stage.count / topCount : 0,
-			drop: index > 0 ? dropFromPrevious( stage.count, prevCount ) : null,
-		};
-	} );
 
 /**
- * The two descriptive labels shown for every step beyond the first: what share
- * of the top stage reached here, and the stage-to-stage drop-off. Both are muted
- * (not red/green) — they describe funnel progression, not a period comparison.
+ * The two descriptive lines for every step beyond the first: what share of the top
+ * stage reached here, and the stage-to-stage drop-off. Color is inherited from the
+ * band (white on dark bands, dark on faded ones) — these describe funnel
+ * progression, not a period comparison, so never red/green.
  */
-const StepLabels = ( { step, topLabel }: { step: StepView; topLabel: string } ) => {
-	if ( step.drop === null ) {
-		return null;
-	}
-	return (
-		<>
-			<span className="newspack-insights__funnel-label-pct">
-				{ sprintf(
-					/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
-					__( '%1$s of %2$s', 'newspack-plugin' ),
-					formatPercent( step.pctOfTop ),
-					topLabel
-				) }
-			</span>
-			<span className="newspack-insights__funnel-label-drop">
-				<span aria-hidden="true" className="newspack-insights__funnel-label-drop-arrow">
-					↓
-				</span>{ ' ' }
-				{ sprintf(
-					/* translators: %s: percentage drop-off from the previous stage. */
-					__( '%s drop-off', 'newspack-plugin' ),
-					formatPercent( step.drop )
-				) }
-			</span>
-		</>
-	);
-};
+const StepLabels = ( { pctOfTop, drop, topLabel }: { pctOfTop: number; drop: number; topLabel: string } ) => (
+	<>
+		<span className="newspack-insights__funnel-label-pct">
+			{ sprintf(
+				/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
+				__( '%1$s of %2$s', 'newspack-plugin' ),
+				formatPercent( pctOfTop ),
+				topLabel
+			) }
+		</span>
+		<span className="newspack-insights__funnel-label-drop">
+			<span aria-hidden="true" className="newspack-insights__funnel-label-drop-arrow">
+				↓
+			</span>{ ' ' }
+			{ sprintf(
+				/* translators: %s: percentage drop-off from the previous stage. */
+				__( '%s drop-off', 'newspack-plugin' ),
+				formatPercent( drop )
+			) }
+		</span>
+	</>
+);
 
 const Funnel = ( { stages }: FunnelProps ) => {
-	const containerRef = useRef< HTMLDivElement >( null );
-	// Default to a desktop width so the common 3-step funnel renders in
-	// side-label mode on first paint (the observer corrects narrow containers).
-	const [ width, setWidth ] = useState( COMPACT_MAX_WIDTH );
-
-	useEffect( () => {
-		const el = containerRef.current;
-		if ( ! el || typeof ResizeObserver === 'undefined' ) {
-			return;
-		}
-		setWidth( el.getBoundingClientRect().width );
-		const observer = new ResizeObserver( entries => {
-			for ( const entry of entries ) {
-				setWidth( entry.contentRect.width );
-			}
-		} );
-		observer.observe( el );
-		return () => observer.disconnect();
-	}, [] );
-
 	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
 	const topLabel = stages.length > 0 ? stages[ 0 ].label : '';
-	const steps = useMemo( () => buildSteps( stages, topCount ), [ stages, topCount ] );
-	const displayHalves = useMemo( () => computeDisplayHalfWidths( stages, topCount ), [ stages, topCount ] );
 
 	// Proportions can't be computed without a non-zero first step.
 	if ( stages.length === 0 || topCount <= 0 ) {
 		return (
-			<div ref={ containerRef } className="newspack-insights__funnel">
+			<div className="newspack-insights__funnel">
 				<p className="newspack-insights__funnel-empty">{ __( 'Not enough data to chart the funnel.', 'newspack-plugin' ) }</p>
 			</div>
 		);
 	}
 
 	const stepCount = stages.length;
-	const compact = isCompactMode( stepCount, width );
-	const stepHeight = stepHeightFor( stepCount );
-	const chartHeight = stepHeight * stepCount;
-
-	const svg = (
-		<svg
-			className="newspack-insights__funnel-svg"
-			viewBox={ `0 0 ${ VIEWBOX_WIDTH } ${ chartHeight }` }
-			preserveAspectRatio="xMidYMid meet"
-			role="img"
-			aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }
-		>
-			{ steps.map( step => {
-				const halfTop = displayHalves[ step.index ];
-				const halfBottom = step.index < stepCount - 1 ? displayHalves[ step.index + 1 ] : halfTop;
-				const yTop = step.index * stepHeight;
-				return (
-					<path
-						key={ step.index }
-						className="newspack-insights__funnel-trapezoid"
-						d={ trapezoidPath( halfTop, halfBottom, yTop, yTop + stepHeight ) }
-						fillOpacity={ step.opacity }
-					/>
-				);
-			} ) }
-			{ compact &&
-				steps.map( step => (
-					<text
-						key={ step.index }
-						className={
-							'newspack-insights__funnel-count-text ' + ( step.opacity > DARK_TEXT_OPACITY_THRESHOLD ? 'is-on-dark' : 'is-on-light' )
-						}
-						x={ VIEWBOX_WIDTH / 2 }
-						y={ step.index * stepHeight + stepHeight / 2 }
-						textAnchor="middle"
-						dominantBaseline="central"
-						style={ { '--band-opacity': step.opacity } as React.CSSProperties }
-					>
-						{ formatNumber( step.stage.count ) }
-					</text>
-				) ) }
-		</svg>
-	);
-
-	if ( compact ) {
-		return (
-			<div ref={ containerRef } className="newspack-insights__funnel newspack-insights__funnel--compact" role="figure">
-				{ svg }
-				<ol className="newspack-insights__funnel-legend">
-					{ steps.map( step => (
-						<li key={ step.index } className="newspack-insights__funnel-legend-item">
-							<span className="newspack-insights__funnel-label-name">{ step.stage.label }</span>
-							<span className="newspack-insights__funnel-label-count">{ formatNumber( step.stage.count ) }</span>
-							<StepLabels step={ step } topLabel={ topLabel } />
-						</li>
-					) ) }
-				</ol>
-			</div>
-		);
-	}
+	const halves = computeDisplayHalfWidths( stages, topCount );
 
 	return (
-		<div ref={ containerRef } className="newspack-insights__funnel newspack-insights__funnel--side" role="figure">
-			{ svg }
-			<div className="newspack-insights__funnel-labels">
-				{ steps.map( step => (
-					<div key={ step.index } className="newspack-insights__funnel-label">
-						<span className="newspack-insights__funnel-label-name">{ step.stage.label }</span>
-						<span className="newspack-insights__funnel-label-count">{ formatNumber( step.stage.count ) }</span>
-						<StepLabels step={ step } topLabel={ topLabel } />
-					</div>
-				) ) }
-			</div>
-		</div>
+		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
+			{ stages.map( ( stage, index ) => {
+				const opacity = stepOpacity( index, stepCount );
+				const halfTop = halves[ index ];
+				const halfBottom = index < stepCount - 1 ? halves[ index + 1 ] : halfTop;
+				const isDark = opacity > DARK_TEXT_OPACITY_THRESHOLD;
+				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
+				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
+				return (
+					<li
+						key={ index }
+						className={ 'newspack-insights__funnel-step ' + ( isDark ? 'is-on-dark' : 'is-on-light' ) }
+						style={ { '--band-opacity': opacity } as React.CSSProperties }
+					>
+						<span
+							className="newspack-insights__funnel-fill"
+							style={ { clipPath: trapezoidClip( halfTop, halfBottom ) } }
+							aria-hidden="true"
+						/>
+						<span className="newspack-insights__funnel-content">
+							<span className="newspack-insights__funnel-label-name">{ stage.label }</span>
+							<span className="newspack-insights__funnel-label-count">{ formatNumber( stage.count ) }</span>
+							{ drop !== null && <StepLabels pctOfTop={ pctOfTop } drop={ drop } topLabel={ topLabel } /> }
+						</span>
+					</li>
+				);
+			} ) }
+		</ol>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -45,7 +45,7 @@ const HALF_WIDTH = VIEWBOX_WIDTH / 2;
 // per-funnel from the step count (see computeDisplayHalfWidths) so funnels of
 // any length descend evenly across all their segments rather than cliff-diving
 // to the floor in one step.
-const MIN_SEGMENT_WIDTH_RATIO = 0.2;
+const MIN_SEGMENT_WIDTH_RATIO = 0.28; // NEWS-2586: wider floor keeps the narrowest band's fill under its text.
 const MIN_HALF_WIDTH = ( MIN_SEGMENT_WIDTH_RATIO * VIEWBOX_WIDTH ) / 2;
 
 export interface FunnelStage {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -481,143 +481,78 @@
 	}
 
 	// Funnel viz — shared across Gates, Prompts, and Conversion Journey tabs.
-	// Stacked SVG trapezoids in a single anchor color (primary-500) fading to
-	// 0.6 opacity at the tail. Side-label mode puts the step name/count/deltas
-	// in a fixed column beside the equal-height bands; compact mode renders the
-	// count inside each band and moves labels to a legend below.
+	// Self-labeling stacked trapezoids (NEWS-2586): each band carries its label,
+	// count, and (for every step after the first) the drop-off descriptors INSIDE
+	// it. One uniform layout at every width/step-count — no side column, no legend.
+	// Each band is an <li> with a clipped trapezoid FILL behind a flowing TEXT
+	// layer that wraps, grows the band, and overflows a narrow fill without clipping.
 	&__funnel {
+		width: 100%;
+		max-width: 500px; // NEWS-2586 container cap; grid cells render narrower (fluid).
+		margin: 0 auto;
 		padding: 20px;
+		box-sizing: border-box;
+		list-style: none;
 		background-color: #fff;
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 4px;
 
-		&--side {
-			display: flex;
-			align-items: stretch;
-			gap: 16px;
-		}
-
-		&--compact {
+		&-step {
+			position: relative;
 			display: flex;
 			flex-direction: column;
-			gap: 16px;
-		}
-
-		&-svg {
-			min-width: 0;
-			width: 100%;
-			height: auto;
-			display: block;
-		}
-
-		// Side mode: cap the SVG WIDTH (not height) so it keeps its exact viewBox
-		// aspect ratio — no letterboxing — and the equal-height trapezoid bands
-		// stay aligned with the equal-flex label column beside them.
-		&--side &-svg {
-			flex: 0 1 auto;
-			max-width: 320px;
-		}
-
-		// Compact mode: fill the width; the count sits inside each band, so there's
-		// no side column to align against and a height cap is fine.
-		&--compact &-svg {
-			max-height: 480px;
-		}
-
-		// Single anchor color; the 1.0 → 0.6 opacity interpolation gives each band
-		// its own weight while staying within one hue.
-		&-trapezoid {
-			fill: colors.$primary-500;
-		}
-
-		// In-band count (compact mode): white on the darker top bands, dark on the
-		// faded tail bands — see DARK_TEXT_OPACITY_THRESHOLD in Funnel.tsx. The
-		// stroke "halo" (painted under the fill) is the band's *apparent* color:
-		// primary-500 flattened over the white card at the band's own opacity
-		// (passed in as the inline --band-opacity). Because it's opaque and equal
-		// to what the band shows, it disappears inside the segment and only
-		// appears — as the band's color against the white page — where the number
-		// overflows a segment narrower than itself. (A translucent same-color halo
-		// can't do this: painted over the band, its alpha stacks and every halo
-		// drifts toward the full-opacity top color.)
-		&-count-text {
-			font-size: 16px;
-			font-weight: 600;
-			font-variant-numeric: tabular-nums;
-			paint-order: stroke;
-			stroke-width: 3px;
-			stroke-linejoin: round;
-			stroke: color-mix( in srgb, colors.$primary-500 calc( var( --band-opacity ) * 100% ), #fff );
-
-			&.is-on-dark {
-				fill: #fff;
-			}
-
-			&.is-on-light {
-				fill: wp-colors.$gray-900;
-			}
-		}
-
-		// Side-label column: equal-flex blocks align to the equal-height bands.
-		&-labels {
-			flex: 0 0 200px;
-			display: flex;
-			flex-direction: column;
-		}
-
-		&-label {
-			flex: 1 1 0;
-			display: flex;
-			flex-direction: column;
+			align-items: center;
 			justify-content: center;
+			min-height: 72px; // baseline; grows with wrapped content.
+			padding: 12px 8px;
+			box-sizing: border-box;
+			text-align: center;
 		}
 
-		&-legend {
-			list-style: none;
-			margin: 0;
-			padding: 0;
-			display: flex;
-			flex-direction: column;
-			gap: 12px;
+		// Fill: the single anchor color clipped to the per-band trapezoid (clip-path
+		// set inline). Opacity fades 1.0 → 0.6 via the inline --band-opacity. Sits
+		// BEHIND the text so the text is never clipped by the band edge.
+		&-fill {
+			position: absolute;
+			inset: 0;
+			z-index: 0;
+			background-color: colors.$primary-500;
+			opacity: var( --band-opacity, 1 );
 		}
 
-		&-legend-item {
+		&-content {
+			position: relative;
+			z-index: 1;
 			display: flex;
 			flex-direction: column;
+			align-items: center;
+			max-width: 160px; // wrap width for the descriptor lines.
 		}
 
 		&-label-name {
-			font-size: 13px;
+			font-size: 14px;
 			font-weight: 600;
-			color: wp-colors.$gray-900;
+			line-height: 1.2;
 		}
 
 		&-label-count {
-			font-size: 20px;
-			font-weight: 600;
+			font-size: 22px;
+			font-weight: 700;
 			font-variant-numeric: tabular-nums;
-			line-height: 1.2;
-			color: wp-colors.$gray-900;
+			line-height: 1.15;
 		}
 
-		// Stage descriptors: both muted gray. The drop-off is funnel context, not
-		// an alarm, and deliberately NOT red/green — red/green is reserved for the
-		// period-over-period scorecard deltas elsewhere on the page.
+		// Stage descriptors inherit the band's text color (white/dark); muted weight.
 		&-label-pct {
-			font-size: 13px;
-			font-weight: 400;
-			color: wp-colors.$gray-600;
+			margin-top: 4px;
+			font-size: 12px;
+			line-height: 1.35;
 		}
 
 		&-label-drop {
-			font-size: 13px;
-			font-weight: 400;
+			font-size: 12px;
+			line-height: 1.35;
 			font-variant-numeric: tabular-nums;
-			color: wp-colors.$gray-600;
-
-			&-arrow {
-				color: wp-colors.$gray-600;
-			}
 		}
 
 		&-empty {
@@ -627,6 +562,18 @@
 			font-size: 13px;
 			color: wp-colors.$gray-600;
 		}
+	}
+
+	// Contrast follows band opacity: white text on the dark upper bands (with a
+	// soft halo so any spill over the white card stays legible), dark text on the
+	// faded lower bands (reads on both the light fill and the card).
+	&__funnel-step.is-on-dark &__funnel-content {
+		color: #fff;
+		text-shadow: 0 1px 2px rgba( 13, 53, 102, 0.45 );
+	}
+
+	&__funnel-step.is-on-light &__funnel-content {
+		color: wp-colors.$gray-900;
 	}
 
 	// Sortable table affordances — shared across all tabs that embed SortableTable


### PR DESCRIPTION
## Summary

Rewrites the Insights `Funnel` component to a **self-labeling in-band layout** (NEWS-2586). Each stage now shows its **label above its count inside the band**, with the drop-off descriptors ("% of top" + "% drop-off") inside the band as well. The separate legend and the side-label layout mode are removed, so every viewport and step count uses one uniform layout.

Linear: [NEWS-2586 — Improve Funnel graphics](https://linear.app/a8c/issue/NEWS-2586/improve-funnel-graphics)

## What changed

- **Uniform in-band layout** — no more `isCompactMode` side/compact split and no separate legend. Each stage is an `<li>` with a clipped-trapezoid CSS fill layer behind a flowing HTML text layer (label / count / drop-off descriptors).
- **Rendering: SVG → HTML/CSS** — replaced the SVG `<text>` renderer with `clip-path` trapezoids + flowing text, so text wraps, grows the band, and is never clipped. Also an accessibility win: real DOM text in an `<ol>`/`<li>` instead of SVG `<text>`. The `ResizeObserver` is gone (the `clip-path` percentages scale intrinsically — no JS measurement needed).
- **Wider minimum band-width floor** (`MIN_SEGMENT_WIDTH_RATIO` 0.2 → 0.28) so the narrowest band's fill stays under its own text.
- **Container-driven width** capped at ~500px for solo cards, fluid in grid cells — no new props, no call-site changes.
- Removed an orphaned `.newspack-insights__funnel-svg` print rule and its stale ResizeObserver comment.

The funnel data shape (`FunnelStage`) and all consuming sections are unchanged.

## Testing

- Full JS suite green (81 suites / 673 tests); `tsc --noEmit` and eslint clean on the component.
- Visually validated in an isolated env with `NEWSPACK_INSIGHTS_FIXTURE_MODE`: the 5-step Reader Lifecycle funnel, the 3-step per-journey legs (including long labels like "Saw a subscription-intent surface"), the 2-step cross-upsell, and empty states — across solo (~500px) and grid (~320–490px) widths.

## Out of scope (flagged separately)

While setting up the test env I found that the Insights boot config fatals when WooCommerce is inactive (unguarded `wc_get_product()` in `class-donations.php`). Tracked separately; not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
