### PR TITLE
fix(insights): fix subscribers per-product bare-parent collision

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -68,6 +68,21 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Bumped when the tab payload's shape changes so a deploy doesn't keep
+	 * serving a stale tab-level envelope. v2: the `subscriptions_by_product`
+	 * per-product table now folds bare-parent subscriptions into the parent
+	 * bucket and emits a synthetic "(no variation)" variation row (the
+	 * Subscribers_Metric metric-layer cache is invalidated in parallel by its
+	 * own CACHE_PREFIX bump). Only the subscribers envelope is busted — other
+	 * (BigQuery-backed) tabs keep their caches.
+	 *
+	 * @return string
+	 */
+	protected function cache_schema_version(): string {
+		return '2';
+	}
+
+	/**
 	 * Tab slug used as the cache namespace.
 	 *
 	 * @return string

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -42,7 +42,7 @@ class Subscribers_Metric {
 	 *
 	 * @var string
 	 */
-	const CACHE_PREFIX = 'newspack_insights_tab6_v5:';
+	const CACHE_PREFIX = 'newspack_insights_tab6_v6:';
 
 	/**
 	 * Cache TTL for windowed and snapshot metrics (30 min).

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -795,8 +795,16 @@ class HPOS_Storage implements Storage_Interface {
 	 *   - If parent_id > 0 (variation), attach to its parent's bucket
 	 *     and accumulate the parent's aggregates from the variation's
 	 *     numbers.
-	 *   - If parent_id == 0 (standalone simple/subscription product),
-	 *     emit as a single non-parent entry.
+	 *   - If parent_id == 0, the row is either a standalone
+	 *     simple/subscription product OR a bare-parent line item on a
+	 *     VARIABLE product (a subscription that recorded the parent
+	 *     product with _variation_id = 0 — e.g. a name-your-price / gift
+	 *     parent-level purchase). It resolves to the product's own id and
+	 *     MERGES into that bucket: when the bucket also owns variation
+	 *     rows it folds in as a synthetic "(no variation)" variation
+	 *     instead of overwriting the bucket and discarding the variations
+	 *     (NPPD-1616 regression). A bucket that only ever sees this branch
+	 *     stays a single non-parent entry.
 	 *
 	 * Variation labels come from the _subscription_period meta when
 	 * present (month→Monthly, year→Annual, week→Weekly, day→Daily),
@@ -825,60 +833,77 @@ class HPOS_Storage implements Storage_Interface {
 			$active_value     = (float) $row['active_value'];
 			$lifetime_revenue = (float) $row['lifetime_revenue'];
 
+			// Resolve the bucket this row belongs under. Variation rows fold
+			// into their parent product; bare-parent / standalone rows fold into
+			// the product's own id. Keying both into the SAME map by the effective
+			// product id and accumulating (rather than the parent branch creating
+			// and the standalone branch overwriting) is what stops a bare-parent
+			// row from clobbering a variable product's accumulated variations.
 			if ( $parent_id > 0 ) {
-				// Variation under a parent product.
-				if ( ! isset( $parents[ $parent_id ] ) ) {
-					$parents[ $parent_id ] = [
-						'product_id'       => $parent_id,
-						'name'             => '' !== $parent_name ? $parent_name : __( '(unnamed product)', 'newspack-plugin' ),
-						'is_parent'        => true,
-						'active_subs'      => 0,
-						'new_subs'         => 0,
-						'churned_subs'     => 0,
-						'active_value'     => 0.0,
-						'lifetime_revenue' => 0.0,
-						'variations'       => [],
-					];
-				}
-				$parents[ $parent_id ]['active_subs']      += $active_subs;
-				$parents[ $parent_id ]['new_subs']         += $new_subs;
-				$parents[ $parent_id ]['churned_subs']     += $churned_subs;
-				$parents[ $parent_id ]['active_value']     += $active_value;
-				$parents[ $parent_id ]['lifetime_revenue'] += $lifetime_revenue;
-				$parents[ $parent_id ]['variations'][]     = [
-					'variation_id'     => $variation_id,
-					'label'            => $this->variation_label( $period, $variation_name, $parent_name ),
-					'active_subs'      => $active_subs,
-					'new_subs'         => $new_subs,
-					'churned_subs'     => $churned_subs,
-					'active_value'     => $active_value,
-					'lifetime_revenue' => $lifetime_revenue,
-				];
+				$bucket_id   = $parent_id;
+				$bucket_name = '' !== $parent_name ? $parent_name : __( '(unnamed product)', 'newspack-plugin' );
+				$label       = $this->variation_label( $period, $variation_name, $parent_name );
 			} else {
-				// Standalone simple/subscription product.
-				$parents[ $variation_id ] = [
-					'product_id'       => $variation_id,
-					'name'             => '' !== $variation_name ? $variation_name : __( '(unnamed product)', 'newspack-plugin' ),
+				$bucket_id   = $variation_id;
+				$bucket_name = '' !== $variation_name ? $variation_name : __( '(unnamed product)', 'newspack-plugin' );
+				$label       = __( '(no variation)', 'newspack-plugin' );
+			}
+
+			if ( ! isset( $parents[ $bucket_id ] ) ) {
+				$parents[ $bucket_id ] = [
+					'product_id'       => $bucket_id,
+					'name'             => $bucket_name,
 					'is_parent'        => false,
-					'active_subs'      => $active_subs,
-					'new_subs'         => $new_subs,
-					'churned_subs'     => $churned_subs,
-					'active_value'     => $active_value,
-					'lifetime_revenue' => $lifetime_revenue,
+					'active_subs'      => 0,
+					'new_subs'         => 0,
+					'churned_subs'     => 0,
+					'active_value'     => 0.0,
+					'lifetime_revenue' => 0.0,
+					'variations'       => [],
 				];
 			}
+			$bucket = &$parents[ $bucket_id ];
+
+			// A real variation row promotes the bucket to a parent and supplies
+			// the canonical parent display name. Idempotent: a bare-parent row may
+			// have seeded the bucket first under the same product's title.
+			if ( $parent_id > 0 ) {
+				$bucket['is_parent'] = true;
+				$bucket['name']      = $bucket_name;
+			}
+
+			$bucket['active_subs']      += $active_subs;
+			$bucket['new_subs']         += $new_subs;
+			$bucket['churned_subs']     += $churned_subs;
+			$bucket['active_value']     += $active_value;
+			$bucket['lifetime_revenue'] += $lifetime_revenue;
+			$bucket['variations'][]      = [
+				'variation_id'     => $variation_id,
+				'label'            => $label,
+				'active_subs'      => $active_subs,
+				'new_subs'         => $new_subs,
+				'churned_subs'     => $churned_subs,
+				'active_value'     => $active_value,
+				'lifetime_revenue' => $lifetime_revenue,
+			];
+			unset( $bucket );
 		}
 
-		// Sort each parent's variations by active_subs DESC.
+		// Sort each parent's variations by active_subs DESC. Standalone (non-parent)
+		// buckets render as a single row, so drop the internal single-element
+		// variations scaffold to keep their payload shape on the renderer's
+		// is_parent contract (no variations key for simple products).
 		foreach ( $parents as &$entry ) {
-			if ( isset( $entry['variations'] ) ) {
-				usort(
-					$entry['variations'],
-					static function ( $a, $b ) {
-						return $b['active_subs'] <=> $a['active_subs'];
-					}
-				);
+			if ( ! $entry['is_parent'] ) {
+				unset( $entry['variations'] );
+				continue;
 			}
+			usort(
+				$entry['variations'],
+				static function ( $a, $b ) {
+					return $b['active_subs'] <=> $a['active_subs'];
+				}
+			);
 		}
 		unset( $entry );
 

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -764,57 +764,77 @@ class Legacy_Storage implements Storage_Interface {
 			$active_value     = (float) $row['active_value'];
 			$lifetime_revenue = (float) $row['lifetime_revenue'];
 
+			// Resolve the bucket this row belongs under. Variation rows fold
+			// into their parent product; bare-parent / standalone rows fold into
+			// the product's own id. Keying both into the SAME map by the effective
+			// product id and accumulating (rather than the parent branch creating
+			// and the standalone branch overwriting) is what stops a bare-parent
+			// row from clobbering a variable product's accumulated variations. See
+			// {@see HPOS_Storage::aggregate_performance_rows()} for the full note.
 			if ( $parent_id > 0 ) {
-				if ( ! isset( $parents[ $parent_id ] ) ) {
-					$parents[ $parent_id ] = [
-						'product_id'       => $parent_id,
-						'name'             => '' !== $parent_name ? $parent_name : __( '(unnamed product)', 'newspack-plugin' ),
-						'is_parent'        => true,
-						'active_subs'      => 0,
-						'new_subs'         => 0,
-						'churned_subs'     => 0,
-						'active_value'     => 0.0,
-						'lifetime_revenue' => 0.0,
-						'variations'       => [],
-					];
-				}
-				$parents[ $parent_id ]['active_subs']      += $active_subs;
-				$parents[ $parent_id ]['new_subs']         += $new_subs;
-				$parents[ $parent_id ]['churned_subs']     += $churned_subs;
-				$parents[ $parent_id ]['active_value']     += $active_value;
-				$parents[ $parent_id ]['lifetime_revenue'] += $lifetime_revenue;
-				$parents[ $parent_id ]['variations'][]     = [
-					'variation_id'     => $variation_id,
-					'label'            => $this->variation_label( $period, $variation_name, $parent_name ),
-					'active_subs'      => $active_subs,
-					'new_subs'         => $new_subs,
-					'churned_subs'     => $churned_subs,
-					'active_value'     => $active_value,
-					'lifetime_revenue' => $lifetime_revenue,
-				];
+				$bucket_id   = $parent_id;
+				$bucket_name = '' !== $parent_name ? $parent_name : __( '(unnamed product)', 'newspack-plugin' );
+				$label       = $this->variation_label( $period, $variation_name, $parent_name );
 			} else {
-				$parents[ $variation_id ] = [
-					'product_id'       => $variation_id,
-					'name'             => '' !== $variation_name ? $variation_name : __( '(unnamed product)', 'newspack-plugin' ),
+				$bucket_id   = $variation_id;
+				$bucket_name = '' !== $variation_name ? $variation_name : __( '(unnamed product)', 'newspack-plugin' );
+				$label       = __( '(no variation)', 'newspack-plugin' );
+			}
+
+			if ( ! isset( $parents[ $bucket_id ] ) ) {
+				$parents[ $bucket_id ] = [
+					'product_id'       => $bucket_id,
+					'name'             => $bucket_name,
 					'is_parent'        => false,
-					'active_subs'      => $active_subs,
-					'new_subs'         => $new_subs,
-					'churned_subs'     => $churned_subs,
-					'active_value'     => $active_value,
-					'lifetime_revenue' => $lifetime_revenue,
+					'active_subs'      => 0,
+					'new_subs'         => 0,
+					'churned_subs'     => 0,
+					'active_value'     => 0.0,
+					'lifetime_revenue' => 0.0,
+					'variations'       => [],
 				];
 			}
+			$bucket = &$parents[ $bucket_id ];
+
+			// A real variation row promotes the bucket to a parent and supplies
+			// the canonical parent display name. Idempotent: a bare-parent row may
+			// have seeded the bucket first under the same product's title.
+			if ( $parent_id > 0 ) {
+				$bucket['is_parent'] = true;
+				$bucket['name']      = $bucket_name;
+			}
+
+			$bucket['active_subs']      += $active_subs;
+			$bucket['new_subs']         += $new_subs;
+			$bucket['churned_subs']     += $churned_subs;
+			$bucket['active_value']     += $active_value;
+			$bucket['lifetime_revenue'] += $lifetime_revenue;
+			$bucket['variations'][]      = [
+				'variation_id'     => $variation_id,
+				'label'            => $label,
+				'active_subs'      => $active_subs,
+				'new_subs'         => $new_subs,
+				'churned_subs'     => $churned_subs,
+				'active_value'     => $active_value,
+				'lifetime_revenue' => $lifetime_revenue,
+			];
+			unset( $bucket );
 		}
 
+		// Standalone (non-parent) buckets render as a single row; drop the internal
+		// single-element variations scaffold to keep their payload on the renderer's
+		// is_parent contract. Parents get their variations sorted by active_subs DESC.
 		foreach ( $parents as &$entry ) {
-			if ( isset( $entry['variations'] ) ) {
-				usort(
-					$entry['variations'],
-					static function ( $a, $b ) {
-						return $b['active_subs'] <=> $a['active_subs'];
-					}
-				);
+			if ( ! $entry['is_parent'] ) {
+				unset( $entry['variations'] );
+				continue;
 			}
+			usort(
+				$entry['variations'],
+				static function ( $a, $b ) {
+					return $b['active_subs'] <=> $a['active_subs'];
+				}
+			);
 		}
 		unset( $entry );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -377,4 +377,18 @@
 			}
 		}
 	}
+
+	// Explanatory note(s) rendered beneath a table — e.g. defining a synthetic
+	// "(no variation)" row, or how the per-product (subscription-grain) totals
+	// differ from the page scorecards. Muted and small so it reads as a caption.
+	&__table-footnote {
+		margin: 8px 0 0;
+		font-size: 12px;
+		line-height: 1.5;
+		color: wp-colors.$gray-600;
+
+		& + & {
+			margin-top: 4px;
+		}
+	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
@@ -121,6 +121,18 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 					</tbody>
 				</table>
 			</div>
+			<p className="newspack-insights__table-footnote">
+				{ __(
+					'“(no variation)”: Subscriptions purchased at the product level without a specific variation — e.g. gift or name-your-price purchases of this product.',
+					'newspack-plugin'
+				) }
+			</p>
+			<p className="newspack-insights__table-footnote">
+				{ __(
+					'This table counts subscriptions (gross). The scorecards above count people: New subscribers is first-time distinct customers, and Churned is distinct customers net of those who still hold an active subscription — so per-product totals here will run higher than the scorecards.',
+					'newspack-plugin'
+				) }
+			</p>
 		</section>
 	);
 };

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscribers-performance.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscribers-performance.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Test the per-product "Subscriptions by product" aggregation.
+ *
+ * Regression guard for the bare-parent collision: a VARIABLE subscription
+ * product that also has a bare-parent line item (a subscription recorded
+ * against the parent product with `_variation_id = 0` — e.g. a
+ * name-your-price / gift parent-level purchase) used to emit BOTH a set of
+ * variation rows (keyed to the parent product id) AND a standalone row (keyed
+ * to the same product id). The standalone branch hard-overwrote the
+ * accumulated parent bucket, so the dominant product collapsed to just the
+ * bare sub's numbers and dropped all of its variations (and their new_subs /
+ * churn).
+ *
+ * `aggregate_performance_rows()` is a pure transformation over the flat SQL
+ * rows — no DB, no wpdb — so this exercises the exact code that carried the
+ * bug with synthetic rows, independent of any publisher data.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use ReflectionMethod;
+use WP_UnitTestCase;
+
+/**
+ * Subscriptions-by-product aggregation test.
+ *
+ * @group insights
+ */
+class Test_Subscribers_Performance extends WP_UnitTestCase {
+
+	/**
+	 * Invoke the private aggregate_performance_rows() on a storage backend.
+	 *
+	 * @param object $storage HPOS_Storage or Legacy_Storage instance.
+	 * @param array  $rows    Flat per-variation rows (SQL shape).
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function aggregate( $storage, array $rows ): array {
+		$method = new ReflectionMethod( $storage, 'aggregate_performance_rows' );
+		$method->setAccessible( true );
+		return $method->invoke( $storage, $rows );
+	}
+
+	/**
+	 * One flat row in the shape the performance SQL returns.
+	 *
+	 * @param array $overrides Field overrides.
+	 * @return array<string, mixed>
+	 */
+	private function row( array $overrides ): array {
+		return array_merge(
+			[
+				'variation_id'     => 0,
+				'variation_name'   => '',
+				'parent_id'        => 0,
+				'parent_name'      => '',
+				'sub_period'       => '',
+				'active_subs'      => 0,
+				'new_subs'         => 0,
+				'churned_subs'     => 0,
+				'active_value'     => 0.0,
+				'lifetime_revenue' => 0.0,
+			],
+			$overrides
+		);
+	}
+
+	/**
+	 * The collision scenario rows: variable parent 710333 "Fan Membership"
+	 * with Annual (710345) + Monthly (710344) variations, PLUS one bare-parent
+	 * sub (variation_id = 710333, parent_id = 0). A control variable product
+	 * "Fan Duo" (710339) with a variation but NO bare-parent sub, and a true
+	 * standalone simple product (720000).
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function collision_rows(): array {
+		return [
+			// Variable parent 710333 — Annual variation (the big one).
+			$this->row(
+				[
+					'variation_id'     => 710345,
+					'variation_name'   => 'Fan Membership - Annual',
+					'parent_id'        => 710333,
+					'parent_name'      => 'Fan Membership',
+					'sub_period'       => 'year',
+					'active_subs'      => 653,
+					'new_subs'         => 40,
+					'churned_subs'     => 6,
+					'active_value'     => 6530.0,
+					'lifetime_revenue' => 65300.0,
+				]
+			),
+			// Variable parent 710333 — Monthly variation.
+			$this->row(
+				[
+					'variation_id'     => 710344,
+					'variation_name'   => 'Fan Membership - Monthly',
+					'parent_id'        => 710333,
+					'parent_name'      => 'Fan Membership',
+					'sub_period'       => 'month',
+					'active_subs'      => 278,
+					'new_subs'         => 24,
+					'churned_subs'     => 3,
+					'active_value'     => 1390.0,
+					'lifetime_revenue' => 13900.0,
+				]
+			),
+			// Bare-parent sub on 710333 (variation_id = 0 → resolves to the parent
+			// product id; post_parent = 0). The 1-active row that used to clobber
+			// the whole parent bucket because it sorts last under active_subs DESC.
+			$this->row(
+				[
+					'variation_id'     => 710333,
+					'variation_name'   => 'Fan Membership',
+					'parent_id'        => 0,
+					'parent_name'      => '',
+					'sub_period'       => '',
+					'active_subs'      => 1,
+					'new_subs'         => 0,
+					'churned_subs'     => 0,
+					'active_value'     => 12.0,
+					'lifetime_revenue' => 48.0,
+				]
+			),
+			// Control: a different variable product with a variation but no bare sub.
+			$this->row(
+				[
+					'variation_id'     => 710350,
+					'variation_name'   => 'Fan Duo - Annual',
+					'parent_id'        => 710339,
+					'parent_name'      => 'Fan Duo',
+					'sub_period'       => 'year',
+					'active_subs'      => 40,
+					'new_subs'         => 6,
+					'churned_subs'     => 1,
+					'active_value'     => 800.0,
+					'lifetime_revenue' => 8000.0,
+				]
+			),
+			// Control: a true standalone simple subscription product.
+			$this->row(
+				[
+					'variation_id'     => 720000,
+					'variation_name'   => 'Supporter',
+					'parent_id'        => 0,
+					'parent_name'      => '',
+					'sub_period'       => 'month',
+					'active_subs'      => 10,
+					'new_subs'         => 3,
+					'churned_subs'     => 2,
+					'active_value'     => 100.0,
+					'lifetime_revenue' => 1000.0,
+				]
+			),
+		];
+	}
+
+	/**
+	 * Index the aggregated output by product_id for assertions. product_id is
+	 * already an int, so array_column's numeric keys need no further casting.
+	 *
+	 * @param array $out aggregate_performance_rows() output.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function by_product_id( array $out ): array {
+		return array_column( $out, null, 'product_id' );
+	}
+
+	/**
+	 * The data providers run every assertion against both storage backends.
+	 *
+	 * @return array<string, array{0:object}>
+	 */
+	public function backend_provider(): array {
+		return [
+			'HPOS'   => [ new HPOS_Storage( [] ) ],
+			'legacy' => [ new Legacy_Storage( [] ) ],
+		];
+	}
+
+	/**
+	 * The bare-parent sub must MERGE into the variable parent's bucket — the
+	 * parent retains its summed variation totals (including new_subs, the exact
+	 * column the bug dropped) instead of being overwritten down to 1/0.
+	 *
+	 * @dataProvider backend_provider
+	 *
+	 * @param object $storage Storage backend.
+	 */
+	public function test_bare_parent_sub_merges_into_parent_bucket( $storage ) {
+		$out     = $this->aggregate( $storage, $this->collision_rows() );
+		$indexed = $this->by_product_id( $out );
+
+		$this->assertArrayHasKey( 710333, $indexed, 'The variable parent must be present, not dropped.' );
+		$parent = $indexed[710333];
+
+		$this->assertTrue( $parent['is_parent'], 'A product with variation rows is a parent.' );
+		$this->assertSame( 'Fan Membership', $parent['name'], 'Parent keeps the canonical product title, not the bare row label.' );
+
+		// 653 + 278 + 1 = 932 active; 40 + 24 + 0 = 64 new; 6 + 3 + 0 = 9 churn.
+		$this->assertSame( 932, $parent['active_subs'], 'Active subs sum all variations plus the bare-parent sub.' );
+		$this->assertSame( 64, $parent['new_subs'], 'New subs sum the variations (40 + 24); the bug reported this as 0.' );
+		$this->assertSame( 9, $parent['churned_subs'], 'Churn sums the variation churn (6 + 3); the bare row adds 0.' );
+		$this->assertEqualsWithDelta( 7932.0, $parent['active_value'], 0.001, 'Active value sums 6530 + 1390 + 12.' );
+		$this->assertEqualsWithDelta( 79248.0, $parent['lifetime_revenue'], 0.001, 'Lifetime revenue sums 65300 + 13900 + 48.' );
+	}
+
+	/**
+	 * The bare-parent sub appears as a synthetic "(no variation)" variation row,
+	 * and the renderer's invariant — parent aggregates equal the SUM of its
+	 * variation rows — holds after the merge, for every numeric column.
+	 *
+	 * @dataProvider backend_provider
+	 *
+	 * @param object $storage Storage backend.
+	 */
+	public function test_synthetic_no_variation_row_and_sum_invariant( $storage ) {
+		$out     = $this->aggregate( $storage, $this->collision_rows() );
+		$indexed = $this->by_product_id( $out );
+		$parent  = $indexed[710333];
+
+		$this->assertCount( 3, $parent['variations'], 'Two real variations plus the synthetic bare-parent row.' );
+
+		$labels = wp_list_pluck( $parent['variations'], 'label' );
+		$this->assertContains( '(no variation)', $labels, 'The bare-parent sub surfaces as a "(no variation)" row.' );
+
+		// The renderer relies on: parent totals == sum of variation rows.
+		foreach ( [ 'active_subs', 'new_subs', 'churned_subs' ] as $col ) {
+			$this->assertSame(
+				$parent[ $col ],
+				array_sum( wp_list_pluck( $parent['variations'], $col ) ),
+				"Parent $col equals the sum of its variation rows."
+			);
+		}
+		$this->assertEqualsWithDelta( $parent['active_value'], array_sum( wp_list_pluck( $parent['variations'], 'active_value' ) ), 0.001 );
+		$this->assertEqualsWithDelta( $parent['lifetime_revenue'], array_sum( wp_list_pluck( $parent['variations'], 'lifetime_revenue' ) ), 0.001 );
+
+		// The synthetic row carries the bare sub's numbers.
+		$no_variation = null;
+		foreach ( $parent['variations'] as $variation ) {
+			if ( '(no variation)' === $variation['label'] ) {
+				$no_variation = $variation;
+				break;
+			}
+		}
+		$this->assertNotNull( $no_variation );
+		$this->assertSame( 1, $no_variation['active_subs'], 'The synthetic row holds the single bare-parent sub.' );
+	}
+
+	/**
+	 * Order-independence: feeding the bare-parent row FIRST (before its
+	 * variations) must produce the same merged parent bucket. Guards against a
+	 * fix that only works because the SQL happens to ORDER BY active_subs DESC.
+	 *
+	 * @dataProvider backend_provider
+	 *
+	 * @param object $storage Storage backend.
+	 */
+	public function test_merge_is_order_independent( $storage ) {
+		$rows = $this->collision_rows();
+		// Move the bare-parent row (index 2) to the front.
+		$bare = $rows[2];
+		unset( $rows[2] );
+		array_unshift( $rows, $bare );
+
+		$out     = $this->aggregate( $storage, array_values( $rows ) );
+		$indexed = $this->by_product_id( $out );
+
+		$this->assertArrayHasKey( 710333, $indexed );
+		$parent = $indexed[710333];
+		$this->assertTrue( $parent['is_parent'], 'Bucket is a parent regardless of row order.' );
+		$this->assertSame( 932, $parent['active_subs'], 'Active subs merge the same way when the bare row comes first.' );
+		$this->assertSame( 64, $parent['new_subs'], 'New subs merge the same way regardless of order.' );
+		$this->assertCount( 3, $parent['variations'], 'All three rows survive regardless of order.' );
+	}
+
+	/**
+	 * A variable product WITHOUT a bare-parent sub is unaffected, and a true
+	 * standalone simple product still renders as a single non-parent row with
+	 * no variations scaffold.
+	 *
+	 * @dataProvider backend_provider
+	 *
+	 * @param object $storage Storage backend.
+	 */
+	public function test_control_products_unaffected( $storage ) {
+		$out     = $this->aggregate( $storage, $this->collision_rows() );
+		$indexed = $this->by_product_id( $out );
+
+		// Control variable product — single variation, no bare sub.
+		$this->assertArrayHasKey( 710339, $indexed );
+		$fan_duo = $indexed[710339];
+		$this->assertTrue( $fan_duo['is_parent'] );
+		$this->assertSame( 40, $fan_duo['active_subs'] );
+		$this->assertSame( 6, $fan_duo['new_subs'] );
+		$this->assertCount( 1, $fan_duo['variations'] );
+
+		// True standalone simple product — non-parent, no variations key.
+		$this->assertArrayHasKey( 720000, $indexed );
+		$supporter = $indexed[720000];
+		$this->assertFalse( $supporter['is_parent'] );
+		$this->assertSame( 10, $supporter['active_subs'] );
+		$this->assertArrayNotHasKey( 'variations', $supporter, 'Standalone products carry no variations scaffold.' );
+	}
+}


### PR DESCRIPTION
## Problem

On the Subscribers tab, the **Subscriptions by product** table omitted the site's dominant subscription product, so its per-product totals disagreed with the page scorecards. On our test site the dominant "Fan Membership" product (932 active subs, 64 new, 9 churned in the window) rendered as **1 active / 0 new** and its variations vanished.

## Root cause

`aggregate_performance_rows()` (in **both** `HPOS_Storage` and `Legacy_Storage`) keyed its `$parents` map by `parent_id` for variation rows but by the product's own id for standalone rows, and the standalone branch **hard-overwrote**. When a variable product also has a **bare-parent** line item — a subscription recorded against the parent product with `_variation_id = 0` (e.g. a name-your-price / gift parent-level purchase via Modal Checkout) — the SQL emits both a parent bucket (its variations) *and* a standalone row keyed to the same id. Sorted `active_subs DESC`, the 1-active bare row lands last and clobbers the accumulated parent bucket, collapsing 932/64/9 → 1/0/0 and discarding the variations. Only products with a bare-parent sub trigger it, which is why a single product was affected.

## Fix

Both backends now key by the **effective product id** and **merge + accumulate** instead of overwriting:

- A real variation row promotes the bucket to `is_parent` and supplies the canonical name (order-independent).
- The bare-parent sub folds into the parent totals **and** surfaces as a synthetic **"(no variation)"** variation row, so the renderer's invariant (parent aggregates == sum of variation rows) holds.
- True standalone simple products still render as a single non-parent row (the internal `variations` scaffold is dropped for them).

This threads through the `new_subs` column too, so the per-product **New subs** now reconciles (the originally-reported "6 vs 51" symptom).

## Copy (approved)

Two footnotes added beneath the table:
- Defines the **"(no variation)"** row.
- Explains that the table is **gross subscription-grain** while the scorecards are customer-level/net, so per-product totals run higher — a definitional difference, documented rather than "fixed".

## Cache invalidation

The table is cached in two tiers; the fix changes the payload shape, so both are busted on deploy:
- `Subscribers_Metric::CACHE_PREFIX` bumped (`v5` → `v6`) — metric-layer transients, fleet-wide.
- `cache_schema_version()` override (→ `'2'`) on the subscribers REST controller — busts only the subscribers tab-level `SOURCE_BIGQUERY` envelope (other BigQuery-backed tabs keep their caches, avoiding a needless fleet-wide BQ recompute).

## Tests

New data-independent reflection test `class-test-subscribers-performance.php` reproduces the collision (variable parent + variations + a bare-parent sub, processed `active_subs DESC`) across **both backends** and **both row orderings**, asserting the parent retains summed totals (active/new/churn) plus the synthetic row, and that controls (a bare-sub-less variable product, a true standalone) are unaffected. Verified to fail against the pre-fix code. Full `insights` PHPUnit group green (581 tests); PHPCS clean; TSX prettier-clean.