### PR TITLE
fix(newspack-popups): cache empty popups_for_post() results

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -17,13 +17,30 @@ final class Newspack_Popups_Inserter {
 	const ADMIN_SCRIPT_HANDLE = 'newspack-popups-admin-bar';
 
 	/**
-	 * The popup objects to display, memoized per request.
-	 * Null means "not yet computed" for this request; an empty array is a
-	 * valid, cacheable result (no popups eligible for the current post).
+	 * Prompts eligible for display in the current request, before the
+	 * per-post should_display() filter is applied. This doesn't depend on
+	 * the current post, so — unlike self::$popups below — it's safe to
+	 * memoize once for the whole request. Null means "not yet computed";
+	 * an empty array is a valid, cacheable result.
 	 *
 	 * @var array|null
 	 */
-	protected static $popups = null;
+	protected static $eligible_popups = null;
+
+	/**
+	 * The popup objects to display, keyed by post ID and memoized per post
+	 * within the current request. should_display() and
+	 * assess_has_disabled_popups() both depend on the current post (post
+	 * meta, post type, taxonomy terms), so a single request-wide cache can
+	 * return the wrong result for a post other than the one it was computed
+	 * for — e.g. on an archive page looping over posts with different
+	 * categories. An empty array value for a given post ID is a valid,
+	 * cacheable "no popups eligible for this post" result, distinct from
+	 * the key being absent, which means "not yet computed for this post".
+	 *
+	 * @var array<int, array>
+	 */
+	protected static $popups = [];
 
 	/**
 	 * Segments for displayed popups.
@@ -156,10 +173,6 @@ final class Newspack_Popups_Inserter {
 	 * @return array Popup objects.
 	 */
 	public static function popups_for_post() {
-		if ( null !== self::$popups ) {
-			return self::$popups;
-		}
-
 		// Get the previewed popup and return early.
 		if ( Newspack_Popups::previewed_popup_id() ) {
 			$preview_popup = Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
@@ -170,27 +183,51 @@ final class Newspack_Popups_Inserter {
 			return [ $preset_popup ];
 		}
 
-		// Popups disabled for this page.
+		// Popups disabled for this page. The default filter checks post meta
+		// via get_the_ID(), so this must be evaluated on every call, not just
+		// the first one for the request.
 		if ( self::assess_has_disabled_popups() ) {
 			return [];
 		}
 
-		$view_as_spec        = Newspack_Popups_View_As::parse_view_as();
-		$campaign_id         = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
-		$include_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
+		// should_display() checks the current post's type and taxonomy terms,
+		// so the final eligible-popups list can legitimately differ per post
+		// within the same request (e.g. an archive page looping over posts
+		// with different categories). Memoize per post ID rather than once
+		// for the whole request.
+		$post_id = get_the_ID() ?: 0;
+		if ( array_key_exists( $post_id, self::$popups ) ) {
+			return self::$popups[ $post_id ];
+		}
 
-		// Retrieve all prompts eligible for display.
-		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_eligible_popups( $include_unpublished, $campaign_id );
-		$popups_to_display       = array_filter(
-			$popups_to_maybe_display,
+		// The eligibility query itself doesn't depend on the current post, so
+		// — unlike should_display() above — it's safe, and worth it since
+		// it's the expensive part, to memoize once for the whole request.
+		if ( null !== self::$eligible_popups ) {
+			$eligible_popups = self::$eligible_popups;
+		} else {
+			$view_as_spec        = Newspack_Popups_View_As::parse_view_as();
+			$campaign_id         = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
+			$include_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
+
+			$eligible_popups = Newspack_Popups_Model::retrieve_eligible_popups( $include_unpublished, $campaign_id );
+
+			if ( ! defined( 'IS_TEST_ENV' ) || ! IS_TEST_ENV ) {
+				self::$eligible_popups = $eligible_popups;
+			}
+		}
+
+		$popups_to_display = array_filter(
+			$eligible_popups,
 			function( $popup ) {
 				return self::should_display( $popup, true );
 			}
 		);
 
-		// Cache results so we don't have to query again.
+		// Cache results so we don't have to re-run should_display() for this
+		// post again.
 		if ( ! defined( 'IS_TEST_ENV' ) || ! IS_TEST_ENV ) {
-			self::$popups = $popups_to_display;
+			self::$popups[ $post_id ] = $popups_to_display;
 		}
 
 		return $popups_to_display;

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -17,11 +17,13 @@ final class Newspack_Popups_Inserter {
 	const ADMIN_SCRIPT_HANDLE = 'newspack-popups-admin-bar';
 
 	/**
-	 * The popup objects to display.
+	 * The popup objects to display, memoized per request.
+	 * Null means "not yet computed" for this request; an empty array is a
+	 * valid, cacheable result (no popups eligible for the current post).
 	 *
-	 * @var array
+	 * @var array|null
 	 */
-	protected static $popups = [];
+	protected static $popups = null;
 
 	/**
 	 * Segments for displayed popups.
@@ -154,7 +156,7 @@ final class Newspack_Popups_Inserter {
 	 * @return array Popup objects.
 	 */
 	public static function popups_for_post() {
-		if ( ! empty( self::$popups ) ) {
+		if ( null !== self::$popups ) {
 			return self::$popups;
 		}
 

--- a/plugins/newspack-popups/tests/test-block-theme-header-insertion.php
+++ b/plugins/newspack-popups/tests/test-block-theme-header-insertion.php
@@ -104,10 +104,14 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 	/**
 	 * Prepare inserter cache with popup objects for deterministic tests.
 	 *
+	 * self::$popups is now keyed by post ID (see popups_for_post()), so seed
+	 * it at whatever post ID is current when popups_for_post() will actually
+	 * be called, rather than as a flat list.
+	 *
 	 * @param array $popups Popup objects.
 	 */
 	private function seed_inserter_popups( $popups ) {
-		self::$inserter_popups_property->setValue( null, $popups );
+		self::$inserter_popups_property->setValue( null, [ get_the_ID() ?: 0 => $popups ] );
 		self::$header_template_part_has_rendered_property->setValue( null, false );
 	}
 

--- a/plugins/newspack-popups/tests/test-overlay-queueing.php
+++ b/plugins/newspack-popups/tests/test-overlay-queueing.php
@@ -177,11 +177,13 @@ class OverlayQueueingTest extends WP_UnitTestCase {
 
 		// Force `popups_for_post()` to return our overlay rather than running
 		// the eligibility query, which depends on a fully bootstrapped request.
+		// self::$popups is keyed by post ID (see popups_for_post()), so seed
+		// it at the post ID that will be current when it's called below.
 		$reflection_class = new ReflectionClass( 'Newspack_Popups_Inserter' );
 		$popups_property  = $reflection_class->getProperty( 'popups' );
 		$popups_property->setAccessible( true );
 		$prior_popups = $popups_property->getValue();
-		$popups_property->setValue( null, [ $overlay_popup ] );
+		$popups_property->setValue( null, [ get_the_ID() ?: 0 => [ $overlay_popup ] ] );
 
 		ob_start();
 		Newspack_Popups_Inserter::insert_popups_after_header();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Re-opened against the monorepo — originally submitted as [Automattic/newspack-popups#1563](https://github.com/Automattic/newspack-popups/pull/1563), auto-closed since that repo is now a read-only mirror.

## Problem

`Newspack_Popups_Inserter::popups_for_post()` (`plugins/newspack-popups/includes/class-newspack-popups-inserter.php`) memoizes its result in `self::$popups`, guarded by:

```php
protected static $popups = [];

public static function popups_for_post() {
	if ( ! empty( self::$popups ) ) {
		return self::$popups;
	}
	...
	self::$popups = $popups_to_display; // may be []
	return $popups_to_display;
}
```

`empty( [] )` is always `true`, so whenever no campaign is eligible for the current request, the cache is written but never read back as a hit. Every subsequent call in the same request re-runs `assess_has_disabled_popups()`, `parse_view_as()`, `Newspack_Popups_Model::retrieve_eligible_popups()` (a `WP_Query`) and a `should_display()` pass over every campaign.

`popups_for_post()` is called from `insert_popups_in_content()`, `insert_popups_after_header()`, `insert_before_header()` and `insert_inline_prompt_in_archive_pages()`, so on an archive page this repeats **once per post** instead of once per request. On a site where no campaigns match the request context (e.g. all campaigns are scoped to a segment/view that excludes the current visitor), this turns into 40-50+ redundant query + evaluation passes on a single archive page load.

## Fix

Use `null` instead of `[]` as the "not yet computed" sentinel, since an empty array is a legitimate, cacheable result:

```php
protected static $popups = null;

public static function popups_for_post() {
	if ( null !== self::$popups ) {
		return self::$popups;
	}
	...
}
```

No other change in behavior: the `IS_TEST_ENV` branch already skips writing the cache, so tests are unaffected either way, and nothing else reads `Newspack_Popups_Inserter::$popups` directly (the data-api class has its own unrelated `$popups` property).

Closes # .

### How to test the changes in this Pull Request:

1. `php -l` on the changed file
2. Verify prompts still render on posts/pages that have eligible campaigns
3. Verify archive pages with zero eligible campaigns no longer re-run `retrieve_eligible_popups()` per post (checked via query count / profiling)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?