### PR TITLE
feat(insights): add win-back subscribers card

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -68,17 +68,16 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 
 	/**
 	 * Bumped when the tab payload's shape changes so a deploy doesn't keep
-	 * serving a stale tab-level envelope. v2: the `subscriptions_by_product`
-	 * per-product table now folds bare-parent subscriptions into the parent
-	 * bucket and emits a synthetic "(no variation)" variation row (the
-	 * Subscribers_Metric metric-layer cache is invalidated in parallel by its
-	 * own CACHE_PREFIX bump). Only the subscribers envelope is busted — other
-	 * (BigQuery-backed) tabs keep their caches.
+	 * serving a stale tab-level envelope. Overrides the global default so only
+	 * the subscribers envelope is busted — other (BigQuery-backed) tabs keep
+	 * their caches. History: v2 reshaped `subscriptions_by_product` (bare-parent
+	 * merge + synthetic "(no variation)" row); v3 adds `winback_subscribers` to
+	 * each window payload.
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '2';
+		return '3';
 	}
 
 	/**
@@ -227,6 +226,7 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	 */
 	private function build_window( Subscribers_Metric $metric, DateTimeImmutable $start, DateTimeImmutable $end ): array {
 		$new_subscribers     = $metric->get_new_subscribers_in_window( $start, $end );
+		$winback_subscribers = $metric->get_winback_subscribers_in_window( $start, $end );
 		$churned_subscribers = $metric->get_churned_subscribers_in_window( $start, $end );
 		$revenue_gross       = $metric->get_subscription_revenue_gross( $start, $end );
 		$revenue_net         = $metric->get_subscription_revenue_net( $start, $end );
@@ -237,6 +237,7 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 				'end'   => $end->format( 'Y-m-d' ),
 			],
 			'new_subscribers'           => $new_subscribers,
+			'winback_subscribers'       => $winback_subscribers,
 			'churned_subscribers'       => $churned_subscribers,
 			'revenue_gross'             => $revenue_gross,
 			'revenue_net'               => $revenue_net,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -192,6 +192,24 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Win-back subscribers in window. See storage contract for semantics.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return int
+	 */
+	public function get_winback_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int {
+		return (int) $this->cached(
+			'winback_subscribers_in_window',
+			$this->window_key( $start, $end ),
+			self::TTL_DEFAULT,
+			function () use ( $start, $end ) {
+				return $this->storage->get_winback_subscribers_in_window( $start, $end );
+			}
+		);
+	}
+
+	/**
 	 * Monthly Recurring Revenue (snapshot).
 	 *
 	 * @return float

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -218,6 +218,68 @@ class HPOS_Storage implements Storage_Interface {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return int
+	 */
+	public function get_winback_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Distinct customers who started a non-donation subscription in the window
+		// (the "return") AND previously churned — i.e. they hold an earlier-started
+		// non-donation subscription that is cancelled or expired. Regardless of
+		// product. Disjoint from first-time subscribers by construction: a
+		// first-timer has no prior subscription, so no earlier churned one.
+		//
+		// The churned side is pre-aggregated to one row per customer (their earliest
+		// churned-sub start) and INNER-JOINed to the returns, rather than a
+		// correlated EXISTS per return row — same result, far cheaper on large
+		// publishers. The `min_churn_start < ret.start_val` string comparison is
+		// chronological because _schedule_start is stored zero-padded 'Y-m-d H:i:s'.
+		$sql = $wpdb->prepare(
+			"SELECT COUNT(DISTINCT ret.customer_id) FROM (
+				SELECT o.customer_id, om.meta_value AS start_val
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_orders_meta om
+					ON om.order_id = o.id AND om.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE o.type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND om.meta_value BETWEEN %s AND %s
+				  AND om.meta_value != ''
+			) AS ret
+			JOIN (
+				SELECT o2.customer_id, MIN(om2.meta_value) AS min_churn_start
+				FROM {$prefix}wc_orders o2
+				JOIN {$prefix}wc_orders_meta om2
+					ON om2.order_id = o2.id AND om2.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi2
+					ON oi2.order_id = o2.id AND oi2.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim2
+					ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
+				WHERE o2.type = 'shop_subscription'
+				  AND o2.status IN ('wc-cancelled', 'wc-expired')
+				  AND oim2.meta_value NOT IN ($donations)
+				  AND om2.meta_value != ''
+				GROUP BY o2.customer_id
+			) AS churned
+				ON churned.customer_id = ret.customer_id
+				AND churned.min_churn_start < ret.start_val",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return (int) $wpdb->get_var( $sql );
+	}
+
+	/**
+	 * {@inheritDoc}
 	 */
 	public function get_mrr(): float {
 		global $wpdb;

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -243,6 +243,66 @@ class Legacy_Storage implements Storage_Interface {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return int
+	 */
+	public function get_winback_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Legacy CPT equivalent of HPOS_Storage::get_winback_subscribers_in_window().
+		// Distinct customers who started a non-donation subscription in the window
+		// AND hold an earlier-started cancelled/expired non-donation subscription.
+		// Disjoint from first-time subscribers. Churned side pre-aggregated to one
+		// row per customer and INNER-JOINed (not a correlated EXISTS) for speed.
+		$sql = $wpdb->prepare(
+			"SELECT COUNT(DISTINCT ret.customer_id) FROM (
+				SELECT cust.meta_value AS customer_id, start.meta_value AS start_val
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start
+					ON start.post_id = p.ID AND start.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND start.meta_value BETWEEN %s AND %s
+				  AND start.meta_value != ''
+			) AS ret
+			JOIN (
+				SELECT cust2.meta_value AS customer_id, MIN(start2.meta_value) AS min_churn_start
+				FROM {$prefix}posts p2
+				JOIN {$prefix}postmeta cust2
+					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start2
+					ON start2.post_id = p2.ID AND start2.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi2
+					ON oi2.order_id = p2.ID AND oi2.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim2
+					ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
+				WHERE p2.post_type = 'shop_subscription'
+				  AND p2.post_status IN ('wc-cancelled', 'wc-expired')
+				  AND oim2.meta_value NOT IN ($donations)
+				  AND start2.meta_value != ''
+				GROUP BY cust2.meta_value
+			) AS churned
+				ON churned.customer_id = ret.customer_id
+				AND churned.min_churn_start < ret.start_val",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		return (int) $wpdb->get_var( $sql );
+	}
+
+	/**
+	 * {@inheritDoc}
 	 */
 	public function get_mrr(): float {
 		global $wpdb;

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -63,6 +63,18 @@ interface Storage_Interface {
 	public function get_churned_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int;
 
 	/**
+	 * Distinct customers who started a non-donation subscription in the window and
+	 * had previously churned — i.e. they hold an earlier-started non-donation
+	 * subscription that is cancelled or expired, regardless of product. Disjoint
+	 * from first-time subscribers (a first-timer has no prior subscription).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return int
+	 */
+	public function get_winback_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int;
+
+	/**
 	 * Monthly Recurring Revenue across all active non-donation subscriptions
 	 * right now. Yearly subs contribute `total / 12`; quarterly `total / 3`;
 	 * monthly contribute their total. Conservative fallback for unrecognized

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -94,6 +94,7 @@ export interface CancellationReasonRow {
 export interface SubscribersWindow {
 	window: { start: string; end: string };
 	new_subscribers: number;
+	winback_subscribers: number;
 	churned_subscribers: number;
 	revenue_gross: number;
 	revenue_net: number;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -23,6 +23,7 @@ const RANGE: DateRange = { preset: 'last-30', start: '2026-05-19', end: '2026-06
 const makeWindow = ( over: Partial< SubscribersWindow > = {} ): SubscribersWindow => ( {
 	window: { start: '2026-05-19', end: '2026-06-17' },
 	new_subscribers: 14,
+	winback_subscribers: 2,
 	churned_subscribers: 3,
 	revenue_gross: 5000,
 	revenue_net: 4800,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -184,6 +184,13 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'First-time subscribers', 'newspack-plugin' ) }
 				/>
 				<MetricCard
+					label={ __( 'Win-backs', 'newspack-plugin' ) }
+					value={ current.winback_subscribers }
+					format="number"
+					previousValue={ previous?.winback_subscribers }
+					description={ __( 'Previously churned subscribers who resubscribed', 'newspack-plugin' ) }
+				/>
+				<MetricCard
 					label={ __( 'Churned subscribers', 'newspack-plugin' ) }
 					value={ current.churned_subscribers }
 					format="number"

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -237,6 +237,31 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Subscribers_Metric::get_winback_subscribers_in_window() delegates to storage
+	 * and caches per window — a repeat call for the same window is served from the
+	 * transient; a distinct window is a cache miss that hits storage again.
+	 */
+	public function test_subscribers_metric_get_winback_subscribers_delegates(): void {
+		$start = $this->make_date( '2026-06-01' );
+		$end   = $this->make_date( '2026-06-30' );
+
+		$mock = $this->createMock( Storage_Interface::class );
+		$mock->expects( $this->exactly( 2 ) ) // once per distinct window; the repeat is cached.
+			->method( 'get_winback_subscribers_in_window' )
+			->willReturn( 18 );
+
+		$metric = $this->make_subscribers_metric( $mock );
+
+		$first  = $metric->get_winback_subscribers_in_window( $start, $end );
+		$second = $metric->get_winback_subscribers_in_window( $start, $end ); // cached — no storage call.
+		$other  = $metric->get_winback_subscribers_in_window( $start, $this->make_date( '2026-07-31' ) ); // distinct window → storage call.
+
+		$this->assertSame( 18, $first );
+		$this->assertSame( 18, $second );
+		$this->assertSame( 18, $other );
+	}
+
+	/**
 	 * Subscribers_Metric::get_active_non_donation_subscriber_customer_ids() delegates.
 	 */
 	public function test_subscribers_metric_get_customer_ids_delegates(): void {


### PR DESCRIPTION
## Summary

Adds a **Win-backs** scorecard to the Subscribers tab windowed section, between **New subscribers** and **Churned subscribers**.

A win-back = a distinct customer who started a non-donation subscription in the window **and** had previously churned — i.e. they hold an earlier-started non-donation subscription that is cancelled or expired, regardless of product. It's **disjoint from first-time subscribers** by construction (a first-timer has no prior subscription), so each subscriber-start lands in exactly one bucket (New vs Win-back) and the section reads as a clean flow: New → Win-back → Churned.

## Why / recon

Feasibility + volume were validated on real publisher data (read-only):
- **Reconciles cleanly:** on richlandsource, 51 first-time + **13 win-backs** = 64 of 70 gross window starts; 13 ≤ the 18 re-subscribers (the other 5 had a *non-churned* prior sub, correctly excluded). A meaningful ~13/month.
- This card was greenlit; sibling "upsell/downgrade" (native WCS switch) cards were **held after a multi-site probe** — switching is rare fleet-wide (0 of the top 15 publishers hit ≥5 switches/30d), so those cards aren't in this PR.

## Changes

- **Storage (both backends):** `get_winback_subscribers_in_window()` in `HPOS_Storage` and `Legacy_Storage`, added to `Storage_Interface`. Donation-excluded. Uses a pre-aggregated JOIN (earliest churned-sub start per customer) rather than a correlated `EXISTS` — same result, far cheaper on large publishers (the correlated form timed out on richlandsource).
- **Metric:** `Subscribers_Metric::get_winback_subscribers_in_window()` — cached per window (TTL_DEFAULT), mirroring new/churned.
- **REST:** `winback_subscribers` added to each window payload.
- **Frontend:** Win-backs `MetricCard` in `WindowedSection`, `SubscribersWindow` type field, test mock updated.
- **Cache:** subscribers-only `cache_schema_version` `'2'→'3'` (window payload shape changed) — other (BigQuery-backed) tabs keep their caches.

## Tests

- New metric delegation + per-window caching test (mock storage). Full `insights` PHPUnit group green (612 tests); PHPCS clean (root standard); TSX/TS prettier-clean.
- SQL body verified via live smoke test (the test bootstrap doesn't install WC tables, consistent with the other subscriber storage methods).
