### PR TITLE
fix(insights): fan out pre-warm into per-window actions

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
@@ -84,6 +84,26 @@ trait Cached_Controller_Trait {
 	}
 
 	/**
+	 * Compute the versioned durable key parts for a window WITHOUT warming.
+	 *
+	 * The no-warm sibling of warm_window(): returns the same key array that
+	 * warm_window() stores under, so the pre-warm prune step can build the
+	 * current-preset keep-list without issuing any BigQuery query.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array Versioned key parts (same shape as warm_window() return).
+	 */
+	public function durable_key_for( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->versioned_key_parts_from(
+			$start->format( 'Y-m-d' ),
+			$end->format( 'Y-m-d' ),
+			null,
+			null
+		);
+	}
+
+	/**
 	 * Cache-aware GET wrapper.
 	 *
 	 * @param WP_REST_Request $request       Incoming request.

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
@@ -4,9 +4,10 @@
  *
  * Warms the five fixed timeframe presets for every registered windowed tab into
  * the durable cache, so opening Insights renders from cache. Scheduling is
- * triggered on admin_init (once/day, guarded) and the actual work runs in an
- * async Action Scheduler job — never inline on a request. Stale durable entries
- * trigger a background refresh (stale-while-revalidate). NEWS-2581 Phase 1.
+ * triggered on admin_init (once/day, guarded) and fans out into one small async
+ * Action Scheduler job per (tab, window) — so no single job times out.
+ * Stale durable entries trigger a background refresh (stale-while-revalidate).
+ * NEWS-2581 Phase 1.
  *
  * @package Newspack
  */
@@ -23,15 +24,15 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Prewarm {
 
-	const WARM_ACTION         = 'newspack_insights_prewarm';
-	const WARM_REFRESH_ACTION = 'newspack_insights_warm_refresh';
-	const WARM_GROUP          = 'newspack-insights';
-	const MARKER_OPTION       = 'newspack_insights_last_prewarm_date';
+	const WARM_ACTION        = 'newspack_insights_prewarm';
+	const WARM_WINDOW_ACTION = 'newspack_insights_warm_window';
+	const WARM_GROUP         = 'newspack-insights';
+	const MARKER_OPTION      = 'newspack_insights_last_prewarm_date';
 
 	/**
-	 * Registry: tab slug => warmer callable( DateTimeImmutable, DateTimeImmutable ): void.
+	 * Registry: tab slug => [ 'warmer' => callable, 'key_for' => callable ].
 	 *
-	 * @var array<string, callable>
+	 * @var array<string, array{warmer: callable, key_for: callable}>
 	 */
 	private static $tabs = [];
 
@@ -55,26 +56,26 @@ final class Prewarm {
 		self::$hooks_registered = true;
 		add_action( 'admin_init', [ __CLASS__, 'maybe_schedule' ] );
 		add_action( self::WARM_ACTION, [ __CLASS__, 'run_prewarm' ] );
-		add_action( self::WARM_REFRESH_ACTION, [ __CLASS__, 'run_warm_refresh' ] );
+		add_action( self::WARM_WINDOW_ACTION, [ __CLASS__, 'run_warm_window' ] );
 		add_action( 'newspack_insights_durable_stale', [ __CLASS__, 'on_durable_stale' ], 10, 3 );
 	}
 
 	/**
-	 * Register a tab's warmer. The warmer builds + durably stores one base
-	 * window and RETURNS the versioned key parts it stored under. Typically
-	 * [ $controller, 'warm_window' ] — the Cached_Controller_Trait implementation
-	 * returns the key array from warm_window() so the prune keep-list is derived
-	 * from the actual stored key rather than a re-derived approximation.
+	 * Register a tab's warmer and key resolver.
 	 *
-	 * @param string   $tab    Tab slug.
-	 * @param callable $warmer fn( DateTimeImmutable $start, DateTimeImmutable $end ): array.
+	 * @param string   $tab     Tab slug.
+	 * @param callable $warmer  fn( DateTimeImmutable $start, DateTimeImmutable $end ): array — warms + stores a window and returns the versioned key parts.
+	 * @param callable $key_for fn( DateTimeImmutable $start, DateTimeImmutable $end ): array — returns the versioned key parts WITHOUT warming.
 	 */
-	public static function register_tab( string $tab, callable $warmer ): void {
-		self::$tabs[ $tab ] = $warmer;
+	public static function register_tab( string $tab, callable $warmer, callable $key_for ): void {
+		self::$tabs[ $tab ] = [
+			'warmer'  => $warmer,
+			'key_for' => $key_for,
+		];
 	}
 
 	/**
-	 * Test-only: clear the in-memory registry.
+	 * Test-only: clear the in-memory registry and hooks flag.
 	 */
 	public static function reset_registry_for_tests(): void {
 		self::$tabs             = [];
@@ -102,6 +103,11 @@ final class Prewarm {
 	/**
 	 * Schedule an async warm at most once per day on admin_init. Never computes
 	 * inline. Guards on environment, capability, and the daily marker.
+	 *
+	 * Marker semantics: the marker now means "fan-out was scheduled today", not
+	 * "warming completed successfully." Individual window failures are retried
+	 * automatically by Action Scheduler on each per-window job; a re-fan-out on
+	 * the same day is never needed.
 	 */
 	public static function maybe_schedule(): void {
 		if ( ! self::is_warmable() ) {
@@ -120,18 +126,18 @@ final class Prewarm {
 			return;
 		}
 		as_enqueue_async_action( self::WARM_ACTION, [], self::WARM_GROUP );
+		// Stamp the marker immediately: "fan-out scheduled today." Retry of
+		// individual failed windows is handled by Action Scheduler per-job
+		// retries, not by re-fanning-out the same day.
+		update_option( self::MARKER_OPTION, self::today(), false );
 	}
 
 	/**
-	 * WARM_ACTION handler. Warms every registered tab × preset, prunes orphaned
-	 * windows, and records the daily marker.
+	 * WARM_ACTION handler. Fans out one WARM_WINDOW_ACTION per (tab, window).
 	 *
-	 * The daily marker is only stamped when at least one window warmed
-	 * successfully across all tabs. A total-failure run (e.g. a BQ-proxy outage
-	 * that throws on every window) leaves the marker unchanged so the next
-	 * admin_init can re-enqueue a retry, still de-duped by as_has_scheduled_action.
-	 * A partial success (some tabs/windows succeeded) does stamp the marker —
-	 * real work was done.
+	 * This dispatcher does NO warming, pruning, or BQ calls — it cannot time
+	 * out. Each per-window job is retried independently by Action Scheduler if
+	 * it fails.
 	 */
 	public static function run_prewarm(): void {
 		if ( ! self::is_warmable() ) {
@@ -148,33 +154,68 @@ final class Prewarm {
 			}
 			return;
 		}
-		$windows     = Preset_Windows::all( current_datetime() );
-		$any_success = false;
-		foreach ( self::$tabs as $tab => $warmer ) {
-			$keep = [];
+		if ( ! function_exists( 'as_enqueue_async_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		$windows = Preset_Windows::all( current_datetime() );
+		foreach ( self::$tabs as $tab => $entry ) {
 			foreach ( $windows as $w ) {
-				try {
-					$key_parts = $warmer( $w['start'], $w['end'] );
-				} catch ( \Throwable $e ) {
-					self::log_failure( $tab, $w['preset'], $e );
+				$args = [
+					[
+						'tab'   => $tab,
+						'start' => $w['start']->format( 'Y-m-d' ),
+						'end'   => $w['end']->format( 'Y-m-d' ),
+					],
+				];
+				if ( as_has_scheduled_action( self::WARM_WINDOW_ACTION, $args, self::WARM_GROUP ) ) {
 					continue;
 				}
-				$keep[] = $key_parts; // the actual (versioned) key the warmer wrote.
-			}
-			// Only prune when at least one window warmed successfully. An empty
-			// $keep (total-failure run, e.g. BQ outage) would wipe all durable
-			// entries, removing yesterday's still-serveable cache on a transient error.
-			if ( ! empty( $keep ) ) {
-				Cache::prune_durable( $tab, $keep );
-				$any_success = true;
+				as_enqueue_async_action( self::WARM_WINDOW_ACTION, $args, self::WARM_GROUP );
 			}
 		}
-		// Only stamp the marker when real work was done. A total-failure run
-		// must leave the marker unchanged so the next admin_init re-enqueues a
-		// retry rather than skipping until tomorrow.
-		if ( $any_success ) {
-			update_option( self::MARKER_OPTION, self::today(), false );
+	}
+
+	/**
+	 * WARM_WINDOW_ACTION handler. Warms one (tab, window) and prunes orphaned
+	 * durable entries for that tab.
+	 *
+	 * Pruning always runs (even when the warm throws) — it only removes
+	 * orphaned/shifted-day options; the five current-preset keys are always in
+	 * the keep-list, so a not-yet-warmed window is never wrongly deleted.
+	 *
+	 * @param array $args [ 'tab' => string, 'start' => 'Y-m-d', 'end' => 'Y-m-d' ].
+	 */
+	public static function run_warm_window( array $args ): void {
+		if ( ! self::is_warmable() ) {
+			return;
 		}
+		$tab = $args['tab'] ?? '';
+		if ( ! isset( self::$tabs[ $tab ] ) ) {
+			return;
+		}
+		$tz    = wp_timezone();
+		$start = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['start'] ?? '' ), $tz );
+		$end   = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['end'] ?? '' ), $tz );
+		if ( ! $start || $start->format( 'Y-m-d' ) !== (string) ( $args['start'] ?? '' ) ) {
+			return;
+		}
+		if ( ! $end || $end->format( 'Y-m-d' ) !== (string) ( $args['end'] ?? '' ) ) {
+			return;
+		}
+		try {
+			( self::$tabs[ $tab ]['warmer'] )( $start->setTime( 0, 0, 0 ), $end->setTime( 23, 59, 59 ) );
+		} catch ( \Throwable $e ) {
+			self::log_failure( $tab, $args['start'] . '..' . $args['end'], $e );
+		}
+		// Prune orphaned durable entries for this tab regardless of warm result.
+		// The five current-preset keys are always included so no valid entry is removed.
+		$keep = array_map(
+			function ( $w ) use ( $tab ) {
+				return ( self::$tabs[ $tab ]['key_for'] )( $w['start'], $w['end'] );
+			},
+			Preset_Windows::all( current_datetime() )
+		);
+		Cache::prune_durable( $tab, $keep );
 	}
 
 	/**
@@ -201,39 +242,10 @@ final class Prewarm {
 				'end'   => $end,
 			],
 		];
-		if ( as_has_scheduled_action( self::WARM_REFRESH_ACTION, $args, self::WARM_GROUP ) ) {
+		if ( as_has_scheduled_action( self::WARM_WINDOW_ACTION, $args, self::WARM_GROUP ) ) {
 			return;
 		}
-		as_enqueue_async_action( self::WARM_REFRESH_ACTION, $args, self::WARM_GROUP );
-	}
-
-	/**
-	 * WARM_REFRESH_ACTION handler. Re-warms a single (tab, window).
-	 *
-	 * @param array $args [ 'tab' => string, 'start' => 'Y-m-d', 'end' => 'Y-m-d' ].
-	 */
-	public static function run_warm_refresh( array $args ): void {
-		if ( ! self::is_warmable() ) {
-			return;
-		}
-		$tab = $args['tab'] ?? '';
-		if ( ! isset( self::$tabs[ $tab ] ) ) {
-			return;
-		}
-		$tz    = wp_timezone();
-		$start = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['start'] ?? '' ), $tz );
-		$end   = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['end'] ?? '' ), $tz );
-		if ( ! $start || $start->format( 'Y-m-d' ) !== (string) ( $args['start'] ?? '' ) ) {
-			return;
-		}
-		if ( ! $end || $end->format( 'Y-m-d' ) !== (string) ( $args['end'] ?? '' ) ) {
-			return;
-		}
-		try {
-			( self::$tabs[ $tab ] )( $start->setTime( 0, 0, 0 ), $end->setTime( 23, 59, 59 ) );
-		} catch ( \Throwable $e ) {
-			self::log_failure( $tab, 'swr-refresh', $e );
-		}
+		as_enqueue_async_action( self::WARM_WINDOW_ACTION, $args, self::WARM_GROUP );
 	}
 
 	/**
@@ -249,7 +261,7 @@ final class Prewarm {
 	 * Log a warm failure without aborting the run.
 	 *
 	 * @param string     $tab    Tab slug.
-	 * @param string     $window Preset/window label.
+	 * @param string     $window Window label or date range.
 	 * @param \Throwable $e      Error.
 	 */
 	private static function log_failure( string $tab, string $window, \Throwable $e ): void {

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-prewarm.php
@@ -30,6 +30,19 @@ final class Prewarm {
 	const MARKER_OPTION      = 'newspack_insights_last_prewarm_date';
 
 	/**
+	 * Max attempts for a single per-window warm before giving up. Action Scheduler
+	 * does not auto-retry a single (non-recurring) async action, so run_warm_window()
+	 * re-enqueues a failed window itself up to this many times.
+	 */
+	const WARM_MAX_ATTEMPTS = 3;
+
+	/**
+	 * Base backoff in seconds between per-window warm retries; multiplied by the
+	 * attempt number for a simple linear backoff.
+	 */
+	const WARM_RETRY_BACKOFF = 15 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Registry: tab slug => [ 'warmer' => callable, 'key_for' => callable ].
 	 *
 	 * @var array<string, array{warmer: callable, key_for: callable}>
@@ -104,10 +117,12 @@ final class Prewarm {
 	 * Schedule an async warm at most once per day on admin_init. Never computes
 	 * inline. Guards on environment, capability, and the daily marker.
 	 *
-	 * Marker semantics: the marker now means "fan-out was scheduled today", not
-	 * "warming completed successfully." Individual window failures are retried
-	 * automatically by Action Scheduler on each per-window job; a re-fan-out on
-	 * the same day is never needed.
+	 * Marker semantics: the marker means "fan-out was scheduled today", not
+	 * "warming completed successfully." A re-fan-out on the same day is not needed
+	 * because each window is its own job: a window that fails is re-enqueued with a
+	 * bounded backoff by run_warm_window() (Action Scheduler does NOT auto-retry a
+	 * single async action), and once retries are exhausted the action is marked
+	 * failed so the outage is visible.
 	 */
 	public static function maybe_schedule(): void {
 		if ( ! self::is_warmable() ) {
@@ -126,9 +141,9 @@ final class Prewarm {
 			return;
 		}
 		as_enqueue_async_action( self::WARM_ACTION, [], self::WARM_GROUP );
-		// Stamp the marker immediately: "fan-out scheduled today." Retry of
-		// individual failed windows is handled by Action Scheduler per-job
-		// retries, not by re-fanning-out the same day.
+		// Stamp the marker immediately: "fan-out scheduled today." A failed window
+		// is recovered by run_warm_window()'s bounded self-re-enqueue, not by
+		// re-fanning-out the whole set the same day.
 		update_option( self::MARKER_OPTION, self::today(), false );
 	}
 
@@ -176,14 +191,19 @@ final class Prewarm {
 	}
 
 	/**
-	 * WARM_WINDOW_ACTION handler. Warms one (tab, window) and prunes orphaned
+	 * WARM_WINDOW_ACTION handler. Warms one (tab, window) then prunes orphaned
 	 * durable entries for that tab.
 	 *
-	 * Pruning always runs (even when the warm throws) — it only removes
-	 * orphaned/shifted-day options; the five current-preset keys are always in
-	 * the keep-list, so a not-yet-warmed window is never wrongly deleted.
+	 * On a warm failure the window is re-enqueued with a bounded backoff (up to
+	 * WARM_MAX_ATTEMPTS), since Action Scheduler does not auto-retry a single
+	 * async action; once attempts are exhausted the exception is re-thrown so the
+	 * action is marked failed and visible in the AS admin. Pruning runs only after
+	 * a successful warm, and the just-warmed key is always kept, so a job never
+	 * deletes the entry it just wrote (e.g. across a midnight roll, or an SWR
+	 * re-warm of a now-shifted preset).
 	 *
-	 * @param array $args [ 'tab' => string, 'start' => 'Y-m-d', 'end' => 'Y-m-d' ].
+	 * @param array $args [ 'tab' => string, 'start' => 'Y-m-d', 'end' => 'Y-m-d', 'attempt' => int ].
+	 * @throws \Throwable Re-thrown when retry attempts are exhausted.
 	 */
 	public static function run_warm_window( array $args ): void {
 		if ( ! self::is_warmable() ) {
@@ -191,30 +211,54 @@ final class Prewarm {
 		}
 		$tab = $args['tab'] ?? '';
 		if ( ! isset( self::$tabs[ $tab ] ) ) {
+			self::log_skip( $tab, $args, 'unregistered tab' );
 			return;
 		}
 		$tz    = wp_timezone();
 		$start = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['start'] ?? '' ), $tz );
 		$end   = DateTimeImmutable::createFromFormat( 'Y-m-d', (string) ( $args['end'] ?? '' ), $tz );
-		if ( ! $start || $start->format( 'Y-m-d' ) !== (string) ( $args['start'] ?? '' ) ) {
+		if ( ! $start || $start->format( 'Y-m-d' ) !== (string) ( $args['start'] ?? '' )
+			|| ! $end || $end->format( 'Y-m-d' ) !== (string) ( $args['end'] ?? '' ) ) {
+			self::log_skip( $tab, $args, 'invalid date argument' );
 			return;
 		}
-		if ( ! $end || $end->format( 'Y-m-d' ) !== (string) ( $args['end'] ?? '' ) ) {
-			return;
-		}
+
 		try {
-			( self::$tabs[ $tab ]['warmer'] )( $start->setTime( 0, 0, 0 ), $end->setTime( 23, 59, 59 ) );
+			$warmed_key = ( self::$tabs[ $tab ]['warmer'] )( $start->setTime( 0, 0, 0 ), $end->setTime( 23, 59, 59 ) );
 		} catch ( \Throwable $e ) {
 			self::log_failure( $tab, $args['start'] . '..' . $args['end'], $e );
+			$attempt = (int) ( $args['attempt'] ?? 1 );
+			if ( $attempt < self::WARM_MAX_ATTEMPTS && function_exists( 'as_schedule_single_action' ) ) {
+				as_schedule_single_action(
+					time() + ( $attempt * self::WARM_RETRY_BACKOFF ),
+					self::WARM_WINDOW_ACTION,
+					[
+						[
+							'tab'     => $tab,
+							'start'   => $args['start'],
+							'end'     => $args['end'],
+							'attempt' => $attempt + 1,
+						],
+					],
+					self::WARM_GROUP
+				);
+				return;
+			}
+			// Retries exhausted: re-throw so Action Scheduler records this action as
+			// failed (visible/monitorable) rather than silently complete.
+			throw $e;
 		}
-		// Prune orphaned durable entries for this tab regardless of warm result.
-		// The five current-preset keys are always included so no valid entry is removed.
+
+		// Prune orphaned durable entries for this tab. The five current-preset keys
+		// PLUS the key just warmed are kept, so a job never prunes what it just
+		// wrote even when its window is no longer one of today's presets.
 		$keep = array_map(
 			function ( $w ) use ( $tab ) {
 				return ( self::$tabs[ $tab ]['key_for'] )( $w['start'], $w['end'] );
 			},
 			Preset_Windows::all( current_datetime() )
 		);
+		$keep[] = $warmed_key;
 		Cache::prune_durable( $tab, $keep );
 	}
 
@@ -255,6 +299,31 @@ final class Prewarm {
 	 */
 	private static function today(): string {
 		return current_datetime()->format( 'Y-m-d' );
+	}
+
+	/**
+	 * Log a skipped per-window warm (unregistered tab or invalid date args), so a
+	 * fan-out/registry desync is diagnosable from logs rather than vanishing.
+	 *
+	 * @param string $tab    Tab slug (may be empty/unknown).
+	 * @param array  $args   The raw action args.
+	 * @param string $reason Why the window was skipped.
+	 */
+	private static function log_skip( string $tab, array $args, string $reason ): void {
+		if ( ! class_exists( '\Newspack\Logger' ) ) {
+			return;
+		}
+		\Newspack\Logger::newspack_log(
+			'newspack_insights_prewarm_skipped',
+			sprintf( '[%s] per-window warm skipped: %s', $tab, $reason ),
+			[
+				'tab'    => $tab,
+				'args'   => $args,
+				'reason' => $reason,
+				'header' => Cache::LOGGER_HEADER,
+			],
+			'warning'
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-audience.php
@@ -69,6 +69,6 @@ class Insights_Section_Audience {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'audience', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'audience', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-conversion.php
@@ -74,7 +74,7 @@ class Insights_Section_Conversion {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'conversion', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'conversion', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 		// Cohort pre-warm: handler runs both the one-off (cold-cache) and the
 		// weekly recurring refresh; the recurring schedule is ensured on init.
 		add_action( Conversion_Metric::COHORT_REFRESH_ACTION, [ Conversion_Metric::class, 'run_cohort_refresh' ] );

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
@@ -74,6 +74,6 @@ class Insights_Section_Donors {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'donors', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'donors', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-engagement.php
@@ -69,6 +69,6 @@ class Insights_Section_Engagement {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'engagement', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'engagement', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -76,6 +76,6 @@ class Insights_Section_Gates {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'gates', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'gates', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-prompts.php
@@ -73,6 +73,6 @@ class Insights_Section_Prompts {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'prompts', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'prompts', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -84,7 +84,7 @@ class Insights_Section_Subscribers {
 				$controller->register_routes();
 			}
 		);
-		\Newspack\Insights\Prewarm::register_tab( 'subscribers', [ $controller, 'warm_window' ] );
+		\Newspack\Insights\Prewarm::register_tab( 'subscribers', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 		Donation_Product_Classifier::register_hooks();
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for Insights Prewarm.
+ * Tests for Insights Prewarm (per-window fan-out model).
  *
  * @package Newspack
  */
@@ -28,48 +28,160 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Reset prewarm registry and marker option after each test.
+	 * Reset prewarm registry, marker option, and durable entries after each test.
 	 */
 	public function tearDown(): void {
 		delete_option( Prewarm::MARKER_OPTION );
+		Cache::prune_durable( 'gates', [] );
 		Prewarm::reset_registry_for_tests();
 		parent::tearDown();
 	}
 
 	/**
-	 * The run_prewarm method warms all five presets and records today's marker.
+	 * The versioned key a warmer/key_for closure returns for a window, matching
+	 * the shape Cached_Controller_Trait produces (global version prefix).
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
 	 */
-	public function test_run_prewarm_writes_durable_for_each_preset_and_sets_marker() {
-		$calls = [];
-		Prewarm::register_tab(
-			'gates',
-			function ( $start, $end ) use ( &$calls ) {
-				$calls[] = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
-				$key     = [
-					$start->format( 'Y-m-d' ),
-					$end->format( 'Y-m-d' ),
-					null,
-					null,
-				];
-				Cache::store_durable(
-					'gates',
-					Cache::SOURCE_BIGQUERY,
-					$key,
-					[ 'ok' => true ],
-					[
-						'start' => $start->format( 'Y-m-d' ),
-						'end'   => $end->format( 'Y-m-d' ),
-					]
-				);
-				return $key;
-			}
-		);
+	private function versioned_key( $start, $end ): array {
+		return [
+			Cache::ENVELOPE_SCHEMA_VERSION,
+			$start->format( 'Y-m-d' ),
+			$end->format( 'Y-m-d' ),
+			null,
+			null,
+		];
+	}
+
+	/**
+	 * Register a fake 'gates' tab whose warmer stores a durable entry and returns
+	 * its key, paired with a matching key_for resolver.
+	 *
+	 * @param array $warmed Reference collecting warmed window labels.
+	 * @return void
+	 */
+	private function register_fake_gates( array &$warmed ): void {
+		$key_for = function ( $start, $end ) {
+			return $this->versioned_key( $start, $end );
+		};
+		$warmer  = function ( $start, $end ) use ( &$warmed, $key_for ) {
+			$warmed[] = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
+			$key      = $key_for( $start, $end );
+			Cache::store_durable(
+				'gates',
+				Cache::SOURCE_BIGQUERY,
+				$key,
+				[ 'ok' => true ],
+				[
+					'start' => $start->format( 'Y-m-d' ),
+					'end'   => $end->format( 'Y-m-d' ),
+				]
+			);
+			return $key;
+		};
+		Prewarm::register_tab( 'gates', $warmer, $key_for );
+	}
+
+	/**
+	 * The dispatcher (run_prewarm) fans out one per-window action per preset and
+	 * warms NOTHING inline — this is the fix for the 300s monolithic-action timeout.
+	 */
+	public function test_run_prewarm_fans_out_per_window_and_warms_nothing_inline() {
+		$warmed = [];
+		$this->register_fake_gates( $warmed );
 
 		Prewarm::run_prewarm();
 
-		$this->assertCount( 5, $calls, 'All five presets warmed.' );
-		$today = current_datetime()->format( 'Y-m-d' );
-		$this->assertSame( $today, get_option( Prewarm::MARKER_OPTION ) );
+		$this->assertSame( [], $warmed, 'Dispatcher must not invoke warmers inline.' );
+
+		$windows = Preset_Windows::all( current_datetime() );
+		$this->assertCount( 5, $windows, 'Five preset windows.' );
+		foreach ( $windows as $w ) {
+			$args = [
+				[
+					'tab'   => 'gates',
+					'start' => $w['start']->format( 'Y-m-d' ),
+					'end'   => $w['end']->format( 'Y-m-d' ),
+				],
+			];
+			$this->assertTrue(
+				as_has_scheduled_action( Prewarm::WARM_WINDOW_ACTION, $args, Prewarm::WARM_GROUP ),
+				'A per-window warm action is enqueued for each preset.'
+			);
+		}
+	}
+
+	/**
+	 * The run_warm_window handler warms exactly the one requested window and prunes
+	 * orphaned (non-current-preset) durable entries for the tab.
+	 */
+	public function test_run_warm_window_warms_one_and_prunes_orphan() {
+		$warmed = [];
+		$this->register_fake_gates( $warmed );
+
+		// Seed an orphaned (old-date) durable entry that is not a current preset window.
+		$orphan_key = [ Cache::ENVELOPE_SCHEMA_VERSION, '2000-01-01', '2000-01-30', null, null ];
+		Cache::store_durable(
+			'gates',
+			Cache::SOURCE_BIGQUERY,
+			$orphan_key,
+			[ 'old' => true ],
+			[
+				'start' => '2000-01-01',
+				'end'   => '2000-01-30',
+			]
+		);
+
+		$windows = Preset_Windows::all( current_datetime() );
+		$w       = $windows[1]; // last-30.
+		Prewarm::run_warm_window(
+			[
+				'tab'   => 'gates',
+				'start' => $w['start']->format( 'Y-m-d' ),
+				'end'   => $w['end']->format( 'Y-m-d' ),
+			]
+		);
+
+		$this->assertSame( 1, count( $warmed ), 'Exactly one window warmed.' );
+		$this->assertNotNull(
+			Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $this->versioned_key( $w['start'], $w['end'] ) ),
+			'The warmed window is stored durably.'
+		);
+		$this->assertNull(
+			Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $orphan_key ),
+			'The orphaned (non-current-preset) entry is pruned.'
+		);
+	}
+
+	/**
+	 * The run_warm_window handler rejects an Action Scheduler date arg that does
+	 * not round-trip (e.g. a rolled-over 2026-02-30) before warming.
+	 */
+	public function test_run_warm_window_rejects_rolled_over_date() {
+		$called  = false;
+		$key_for = function ( $start, $end ) {
+			return $this->versioned_key( $start, $end );
+		};
+		Prewarm::register_tab(
+			'gates',
+			function ( $start, $end ) use ( &$called ) {
+				$called = true;
+				return [];
+			},
+			$key_for
+		);
+
+		Prewarm::run_warm_window(
+			[
+				'tab'   => 'gates',
+				'start' => '2026-02-30',
+				'end'   => '2026-03-01',
+			]
+		);
+
+		$this->assertFalse( $called, 'A rolled-over date must be rejected before warming.' );
 	}
 
 	/**
@@ -92,19 +204,23 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The maybe_schedule method enqueues an async action for a capable user with no marker.
+	 * The maybe_schedule method enqueues the dispatcher AND stamps the daily marker
+	 * for a capable user with no marker set.
 	 */
-	public function test_maybe_schedule_enqueues_for_capable_user_without_marker() {
+	public function test_maybe_schedule_enqueues_dispatcher_and_sets_marker() {
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 		Prewarm::maybe_schedule();
 		$this->assertTrue( as_has_scheduled_action( Prewarm::WARM_ACTION, [], Prewarm::WARM_GROUP ) );
+		$this->assertSame( current_datetime()->format( 'Y-m-d' ), get_option( Prewarm::MARKER_OPTION ) );
 	}
 
 	/**
-	 * The on_durable_stale method schedules a WARM_REFRESH_ACTION for a registered tab.
+	 * The on_durable_stale method schedules a WARM_WINDOW_ACTION (unified with the
+	 * fan-out path) for a registered tab.
 	 */
-	public function test_on_durable_stale_schedules_refresh() {
-		Prewarm::register_tab( 'gates', function ( $start, $end ) {} );
+	public function test_on_durable_stale_schedules_warm_window() {
+		$warmed = [];
+		$this->register_fake_gates( $warmed );
 		Prewarm::on_durable_stale( 'gates', '2026-06-01', '2026-06-30' );
 		$args = [
 			[
@@ -113,11 +229,11 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 				'end'   => '2026-06-30',
 			],
 		];
-		$this->assertTrue( as_has_scheduled_action( Prewarm::WARM_REFRESH_ACTION, $args, Prewarm::WARM_GROUP ) );
+		$this->assertTrue( as_has_scheduled_action( Prewarm::WARM_WINDOW_ACTION, $args, Prewarm::WARM_GROUP ) );
 	}
 
 	/**
-	 * Maybe_schedule() must not enqueue a warm when the cache is disabled.
+	 * The maybe_schedule method must not enqueue a warm when the cache is disabled.
 	 *
 	 * Runs in a separate process so the define() does not leak into the parent
 	 * and poison other tests (PHP constants cannot be unset).
@@ -133,65 +249,14 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A run where every warmer throws must NOT stamp the daily marker, so the
-	 * next admin_init can retry without waiting until tomorrow.
-	 */
-	public function test_run_prewarm_skips_marker_when_all_warmers_fail() {
-		delete_option( Prewarm::MARKER_OPTION );
-		Prewarm::register_tab(
-			'gates',
-			function ( $start, $end ) {
-				throw new \RuntimeException( 'BQ down' );
-			}
-		);
-		Prewarm::run_prewarm();
-		$this->assertFalse( get_option( Prewarm::MARKER_OPTION, false ) );
-	}
-
-	/**
-	 * The run_warm_refresh method calls the registered warmer with the correct DTI range.
-	 */
-	public function test_run_warm_refresh_calls_registered_warmer() {
-		$got = null;
-		Prewarm::register_tab(
-			'gates',
-			function ( $start, $end ) use ( &$got ) {
-				$got = $start->format( 'Y-m-d' ) . '..' . $end->format( 'Y-m-d' );
-				return [ $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), null, null ];
-			}
-		);
-		Prewarm::run_warm_refresh(
-			[
-				'tab'   => 'gates',
-				'start' => '2026-06-01',
-				'end'   => '2026-06-30',
-			]
-		);
-		$this->assertSame( '2026-06-01..2026-06-30', $got );
-	}
-
-	/**
-	 * REGRESSION — versioned-key prune correctness (FIX 1 / blocker).
+	 * Regression — the durable entry for a versioned tab survives the prune.
 	 *
-	 * Uses the real Gates_REST_Controller (now versioned via the global
-	 * Cache::ENVELOPE_SCHEMA_VERSION instead of the per-tab Gates_Metric::CACHE_PREFIX)
-	 * to prove that after run_prewarm() the durable entry SURVIVES the prune call
-	 * under the versioned key.
-	 *
-	 * The bug: run_prewarm() previously built its keep-list from unversioned key
-	 * parts [ $start, $end, null, null ], but warm_window() stored entries under
-	 * versioned parts [ version, $start, $end, null, null ]. The keep hash
-	 * never matched the stored hash, so prune_durable() deleted the entry the run
-	 * had just warmed, giving zero durable benefit on any tab with a non-empty
-	 * cache_schema_version(). This test FAILS against the pre-fix code and PASSES
-	 * after the fix.
-	 *
-	 * @group insights
+	 * Drives the real Gates_REST_Controller (versioned via the global
+	 * Cache::ENVELOPE_SCHEMA_VERSION) through run_warm_window() and asserts the
+	 * durable entry survives the prune under the versioned key — proving the
+	 * warm-write key and the prune keep-list agree for a versioned tab.
 	 */
 	public function test_versioned_tab_durable_entry_survives_prune() {
-		// Ensure the Gates controller and metric are loaded (they live in the gates
-		// section file which is only included when NEWSPACK_INSIGHTS_GATES_PREVIEW is
-		// set; in the unit harness we load them directly).
 		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
 		if ( ! class_exists( 'Newspack\Insights\Gates_Metric' ) ) {
 			include_once $base . 'metrics/class-gates-metric.php';
@@ -201,13 +266,8 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 		}
 
 		$controller = new \Newspack\Insights\Gates_REST_Controller();
+		Prewarm::register_tab( 'gates', [ $controller, 'warm_window' ], [ $controller, 'durable_key_for' ] );
 
-		Prewarm::register_tab( 'gates', [ $controller, 'warm_window' ] );
-
-		// Run the full prewarm (warms + prunes) against today's preset windows.
-		Prewarm::run_prewarm();
-
-		// Find the last-30 preset to check a concrete window.
 		$today   = current_datetime();
 		$windows = Preset_Windows::all( $today );
 		$last30  = null;
@@ -222,18 +282,20 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 		$start_str = $last30['start']->format( 'Y-m-d' );
 		$end_str   = $last30['end']->format( 'Y-m-d' );
 
-		// The durable entry must exist under the GLOBAL-VERSIONED key
-		// (Cache::ENVELOPE_SCHEMA_VERSION + window), not the old per-tab CACHE_PREFIX.
-		$versioned_key = array_merge(
-			[ Cache::ENVELOPE_SCHEMA_VERSION ],
-			[ $start_str, $end_str, null, null ]
+		Prewarm::run_warm_window(
+			[
+				'tab'   => 'gates',
+				'start' => $start_str,
+				'end'   => $end_str,
+			]
 		);
-		$durable = Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $versioned_key );
+
+		$versioned_key = [ Cache::ENVELOPE_SCHEMA_VERSION, $start_str, $end_str, null, null ];
+		$durable       = Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $versioned_key );
 
 		$this->assertNotNull(
 			$durable,
-			'Durable entry must survive prune under the versioned key. ' .
-			'If null, prune deleted the entry because the keep-list used unversioned keys (pre-fix bug).'
+			'Durable entry must survive prune under the versioned key.'
 		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-insights-prewarm.php
@@ -298,4 +298,151 @@ class Test_Insights_Prewarm extends WP_UnitTestCase {
 			'Durable entry must survive prune under the versioned key.'
 		);
 	}
+
+	/**
+	 * A failed warm re-enqueues the same window with an incremented attempt
+	 * counter (Action Scheduler does not auto-retry a single async action).
+	 */
+	public function test_run_warm_window_reenqueues_on_failure() {
+		$key_for = function ( $start, $end ) {
+			return $this->versioned_key( $start, $end );
+		};
+		Prewarm::register_tab(
+			'gates',
+			function ( $start, $end ) {
+				throw new \RuntimeException( 'BQ down' );
+			},
+			$key_for
+		);
+
+		Prewarm::run_warm_window(
+			[
+				'tab'   => 'gates',
+				'start' => '2026-06-01',
+				'end'   => '2026-06-30',
+			]
+		);
+
+		$retry_args = [
+			[
+				'tab'     => 'gates',
+				'start'   => '2026-06-01',
+				'end'     => '2026-06-30',
+				'attempt' => 2,
+			],
+		];
+		$this->assertTrue(
+			as_has_scheduled_action( Prewarm::WARM_WINDOW_ACTION, $retry_args, Prewarm::WARM_GROUP ),
+			'A bounded retry is scheduled for the failed window.'
+		);
+	}
+
+	/**
+	 * When retry attempts are exhausted, the failed warm re-throws so Action
+	 * Scheduler marks the action failed (visible) and schedules no further retry.
+	 */
+	public function test_run_warm_window_rethrows_when_attempts_exhausted() {
+		$key_for = function ( $start, $end ) {
+			return $this->versioned_key( $start, $end );
+		};
+		Prewarm::register_tab(
+			'gates',
+			function ( $start, $end ) {
+				throw new \RuntimeException( 'BQ down' );
+			},
+			$key_for
+		);
+
+		$threw = false;
+		try {
+			Prewarm::run_warm_window(
+				[
+					'tab'     => 'gates',
+					'start'   => '2026-06-01',
+					'end'     => '2026-06-30',
+					'attempt' => Prewarm::WARM_MAX_ATTEMPTS,
+				]
+			);
+		} catch ( \RuntimeException $e ) {
+			$threw = true;
+		}
+		$this->assertTrue( $threw, 'Exhausted retries re-throw for visibility.' );
+
+		$retry_args = [
+			[
+				'tab'     => 'gates',
+				'start'   => '2026-06-01',
+				'end'     => '2026-06-30',
+				'attempt' => Prewarm::WARM_MAX_ATTEMPTS + 1,
+			],
+		];
+		$this->assertFalse(
+			as_has_scheduled_action( Prewarm::WARM_WINDOW_ACTION, $retry_args, Prewarm::WARM_GROUP ),
+			'No further retry is scheduled past the attempt cap.'
+		);
+	}
+
+	/**
+	 * A window the job just warmed is never pruned, even when it is not one of
+	 * today's five presets (e.g. across a midnight roll or an SWR re-warm).
+	 */
+	public function test_run_warm_window_keeps_just_warmed_key_off_preset() {
+		$key_for = function ( $start, $end ) {
+			return $this->versioned_key( $start, $end );
+		};
+		$warmer  = function ( $start, $end ) use ( $key_for ) {
+			$key = $key_for( $start, $end );
+			Cache::store_durable(
+				'gates',
+				Cache::SOURCE_BIGQUERY,
+				$key,
+				[ 'ok' => true ],
+				[
+					'start' => $start->format( 'Y-m-d' ),
+					'end'   => $end->format( 'Y-m-d' ),
+				]
+			);
+			return $key;
+		};
+		Prewarm::register_tab( 'gates', $warmer, $key_for );
+
+		// An arbitrary window that is NOT one of today's five presets.
+		Prewarm::run_warm_window(
+			[
+				'tab'   => 'gates',
+				'start' => '2025-01-01',
+				'end'   => '2025-01-15',
+			]
+		);
+
+		$key = [ Cache::ENVELOPE_SCHEMA_VERSION, '2025-01-01', '2025-01-15', null, null ];
+		$this->assertNotNull(
+			Cache::peek_durable( 'gates', Cache::SOURCE_BIGQUERY, $key ),
+			'The just-warmed off-preset window survives its own prune.'
+		);
+	}
+
+	/**
+	 * The run_warm_window handler logs a warning when the tab is not registered,
+	 * so a fan-out/registry desync is diagnosable from logs.
+	 */
+	public function test_run_warm_window_logs_on_unregistered_tab() {
+		$codes = [];
+		add_action(
+			'newspack_log',
+			function ( $code ) use ( &$codes ) {
+				$codes[] = $code;
+			},
+			10,
+			1
+		);
+		Prewarm::run_warm_window(
+			[
+				'tab'   => 'not-registered',
+				'start' => '2026-06-01',
+				'end'   => '2026-06-30',
+			]
+		);
+		$this->assertContains( 'newspack_insights_prewarm_skipped', $codes );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a production bug in the Insights daily pre-warm (Phase 1 of NEWS-2581), found while testing on a live site.

**Root cause.** `Prewarm::run_prewarm()` warmed *every* registered tab × all 5 preset windows × their many BigQuery-proxy calls in a **single** Action Scheduler action. On a real site that runs 12–16 minutes, far exceeding Action Scheduler's 300-second failure watchdog — so every run is marked "failed after 300 seconds," and when PHP's execution limit kills the process first the run dies partway, leaving the cache only partially warmed (and Action Scheduler then retries, producing overlapping long-running jobs).

Evidence from the live site's Action Scheduler logs (one representative action):

```
02:37:50  action started via Async Request
02:43:48  action marked as failed after 300 seconds. Unknown error occurred...
02:53:58  action complete via Async Request      <-- actually finished ~16 min after starting
```

**Fix — fan out into one small action per (tab, window):**

- `maybe_schedule()` (on `admin_init`, once/day) enqueues a lightweight **dispatcher** action and stamps the daily marker immediately.
- The dispatcher (`run_prewarm`) does **no** warming/BQ — it just enqueues one `WARM_WINDOW_ACTION` per tab × preset window, so it cannot time out.
- `run_warm_window()` warms a **single** window (one `build_window_payload`, worst case ~tens of seconds) and then prunes that tab to its current preset keys.
- The stale-while-revalidate path is unified onto the same per-window action.

Marker semantics: it means "fan-out scheduled today." A window that fails is re-enqueued with a bounded backoff by the per-window handler (Action Scheduler does NOT auto-retry a single async action), and once retries are exhausted the action is marked failed and visible in the AS admin -- rather than re-running the whole warm.

No behavior change to the cached data itself; this only changes *how* the warm work is scheduled. Once deployed, the per-window prune also self-heals any partially-warmed/orphaned durable state left by the previous monolithic runs.

Part of NEWS-2581 (Phase 1 hardening).

### How to test the changes in this Pull Request:

Prereqs: a site with `NEWSPACK_INSIGHTS_ENABLED` true, `NEWSPACK_INSIGHTS_FIXTURE_MODE` off, connected to the Insights BigQuery proxy.

1. **Unit tests + lint:** from `plugins/newspack-plugin`, `n test-php --group insights` (619 passing) and `npm run lint:php` (0 errors).
2. **Dispatcher fans out, warms nothing inline:** as an admin, load any wp-admin page. Confirm a single `newspack_insights_prewarm` (dispatcher) action is enqueued, and that it in turn enqueues one `newspack_insights_warm_window` action per tab × preset (Tools → Scheduled Actions, or `wp action-scheduler list --group=newspack-insights`). The dispatcher itself completes near-instantly.
3. **Per-window actions succeed under the watchdog:** confirm each `newspack_insights_warm_window` action completes in well under 300 seconds (no "failed after 300 seconds"), and that `wp option list --search='newspack_insights_warm_*'` fills in for all warmed tabs (including gates/conversion/prompts, which previously timed out).
4. **Once-per-day:** reload an admin page the same day and confirm no second dispatcher is enqueued (daily marker). Clear the marker (`wp option delete newspack_insights_last_prewarm_date`) and confirm the next admin load re-enqueues.
5. **Prune / self-heal:** after a full warm, confirm only the current five preset windows per tab remain in `newspack_insights_warm_*` (orphaned prior-day windows pruned).
6. **Fast render:** open Insights and switch across all five presets — each renders from cache; "last updated" reflects the warm time.
7. **Escape hatches:** with `NEWSPACK_INSIGHTS_CACHE_DISABLED` set, confirm no dispatcher or window actions run (no BigQuery calls); with `NEWSPACK_INSIGHTS_FIXTURE_MODE`, warming is skipped.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

