### PR TITLE
fix(insights): represent mixed recurring/one-time donation products

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -53,16 +53,19 @@ class Donors_REST_Controller extends WP_REST_Controller {
 	/**
 	 * Bumped when the tab payload's shape changes so a deploy doesn't keep
 	 * serving a stale tab-level envelope. v2: the `donations_by_tier` per-product
-	 * table now folds bare-parent donations into the parent bucket and emits a
-	 * synthetic "(no variation)" variation row (the Donors_Metric metric-layer
-	 * cache is invalidated in parallel by its own CACHE_PREFIX bump). Only the
-	 * donors envelope is busted — other (BigQuery-backed) tabs keep their caches.
-	 * Matches the subscribers sibling's version so the twin tabs stay in lockstep.
+	 * table folds bare-parent donations into the parent bucket and emits a
+	 * synthetic "(no variation)" variation row. v3: each row's billing nature is
+	 * now two independent flags (`has_recurring` / `has_one_time`) instead of a
+	 * single `billing_model` enum, so a stale v2 payload would lack the flags and
+	 * the renderer would dash out every applicability-gated column. The
+	 * Donors_Metric metric-layer cache is invalidated in parallel by its own
+	 * CACHE_PREFIX bump. Only the donors envelope is busted — other
+	 * (BigQuery-backed) tabs keep their caches.
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '2';
+		return '3';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -37,7 +37,7 @@ class Donors_Metric {
 	 *
 	 * @var string
 	 */
-	const CACHE_PREFIX = 'newspack_insights_tab7_v10:';
+	const CACHE_PREFIX = 'newspack_insights_tab7_v11:';
 
 	/**
 	 * Cache TTL for windowed and snapshot metrics (30 min).

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -264,7 +264,8 @@ interface Donors_Storage_Interface {
 	 *     'product_id'              => int,
 	 *     'name'                    => string,
 	 *     'is_parent'               => bool,
-	 *     'billing_model'           => 'recurring' | 'one_time',
+	 *     'has_recurring'           => bool,
+	 *     'has_one_time'            => bool,
 	 *     'active_recurring_donors' => int,
 	 *     'lapsed_donors_in_window' => int,
 	 *     'new_donors_in_window'    => int,
@@ -275,7 +276,8 @@ interface Donors_Storage_Interface {
 	 *       [
 	 *         'variation_id'              => int,
 	 *         'label'                     => string,  // 'Monthly' / 'Annual' / etc
-	 *         'billing_model'             => 'recurring' | 'one_time',
+	 *         'has_recurring'             => bool,
+	 *         'has_one_time'              => bool,
 	 *         'active_recurring_donors'   => int,
 	 *         'lapsed_donors_in_window'   => int,
 	 *         'new_donors_in_window'      => int,
@@ -287,15 +289,18 @@ interface Donors_Storage_Interface {
 	 *     ],
 	 *   ]
 	 *
-	 * `billing_model` is derived from the product's `_subscription_period`
-	 * meta: `recurring` when the period meta is in (day, week, month,
-	 * year), else `one_time`. Parent rows inherit `recurring` if ANY
-	 * variation is recurring (the canonical Newspack donation shape),
-	 * else `one_time`. The UI uses this to render cells that don't
-	 * apply to the product's billing model as em-dashes ("—") instead
-	 * of misleading zeros: a one-time product can't have recurring
-	 * donors, recurring revenue, or lapsed donors; a recurring
-	 * product can't have one-time gifts.
+	 * `has_recurring` / `has_one_time` are two INDEPENDENT flags derived
+	 * from each contributing row's `_subscription_period` meta (recurring
+	 * when the period is in day/week/month/year, else one-time). A leaf
+	 * variation is purely one nature, so exactly one flag is set. A parent
+	 * latches EACH flag true as matching variation rows land, so a variable
+	 * product that has recurring variations AND a one-time (bare-parent)
+	 * gift carries BOTH — the recurring signal never clobbers the one-time
+	 * one. The UI shows a column iff its flag is set, rendering the rest as
+	 * em-dashes ("—") instead of misleading zeros: a purely one-time product
+	 * can't have recurring donors, recurring revenue, or lapsed donors; a
+	 * purely recurring product can't have one-time gifts; a mixed product
+	 * shows both.
 	 *
 	 * `lapsed_donors_in_window` is bucketed-per-product using the same
 	 * cohort definition as {@see get_lapsed_donors_in_window()}

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -1143,8 +1143,7 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 			$recurring_revenue         = (float) $row['recurring_revenue_in_window'];
 			$lifetime_donation_revenue = (float) $row['lifetime_donation_revenue'];
 
-			$is_recurring   = in_array( $period, [ 'day', 'week', 'month', 'year' ], true );
-			$billing_model  = $is_recurring ? 'recurring' : 'one_time';
+			$is_recurring = in_array( $period, [ 'day', 'week', 'month', 'year' ], true );
 
 			// Resolve the bucket this row belongs under. Variation rows fold
 			// into their parent product; bare-parent / standalone rows fold into
@@ -1167,11 +1166,15 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 					'product_id'                  => $bucket_id,
 					'name'                        => $bucket_name,
 					'is_parent'                   => false,
-					// Bucket inherits 'recurring' if ANY constituent row is
-					// recurring (the canonical Newspack donation shape: a variable
-					// product with Monthly + Yearly variations). 'one_time' is the
-					// floor; upgraded below whenever a recurring row lands here.
-					'billing_model'               => 'one_time',
+					// A product's billing nature is tracked as two INDEPENDENT
+					// flags, not a single promoted enum: a variable donation
+					// product can be recurring AND one-time at once (e.g. a
+					// Monthly/Yearly product that also took a one-time gift at the
+					// parent level). Both start false and latch true as matching
+					// rows land, so the recurring signal never clobbers the
+					// one-time one. The renderer shows a column iff its flag is set.
+					'has_recurring'               => false,
+					'has_one_time'                => false,
 					'active_recurring_donors'     => 0,
 					'lapsed_donors_in_window'     => 0,
 					'new_donors_in_window'        => 0,
@@ -1190,8 +1193,12 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				$parents[ $bucket_id ]['name']      = $bucket_name;
 			}
 
+			// Latch the bucket's billing nature. A recurring row sets has_recurring;
+			// a one-time row sets has_one_time. A mixed product ends up with both.
 			if ( $is_recurring ) {
-				$parents[ $bucket_id ]['billing_model'] = 'recurring';
+				$parents[ $bucket_id ]['has_recurring'] = true;
+			} else {
+				$parents[ $bucket_id ]['has_one_time'] = true;
 			}
 
 			$parents[ $bucket_id ]['active_recurring_donors']     += $active_recurring_donors;
@@ -1203,7 +1210,9 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 			$parents[ $bucket_id ]['variations'][]                 = [
 				'variation_id'                => $variation_id,
 				'label'                       => $label,
-				'billing_model'               => $billing_model,
+				// A single variation row is purely one nature; exactly one flag set.
+				'has_recurring'               => $is_recurring,
+				'has_one_time'                => ! $is_recurring,
 				'active_recurring_donors'     => $active_recurring_donors,
 				'lapsed_donors_in_window'     => $lapsed_donors,
 				'new_donors_in_window'        => $new_donors,

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -1093,8 +1093,7 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 			$recurring_revenue         = (float) $row['recurring_revenue_in_window'];
 			$lifetime_donation_revenue = (float) $row['lifetime_donation_revenue'];
 
-			$is_recurring  = in_array( $period, [ 'day', 'week', 'month', 'year' ], true );
-			$billing_model = $is_recurring ? 'recurring' : 'one_time';
+			$is_recurring = in_array( $period, [ 'day', 'week', 'month', 'year' ], true );
 
 			// Resolve the bucket this row belongs under. Variation rows fold
 			// into their parent product; bare-parent / standalone rows fold into
@@ -1118,9 +1117,11 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 					'product_id'                  => $bucket_id,
 					'name'                        => $bucket_name,
 					'is_parent'                   => false,
-					// Bucket inherits 'recurring' if ANY constituent row is
-					// recurring; 'one_time' is the floor, upgraded below.
-					'billing_model'               => 'one_time',
+					// Two INDEPENDENT billing-nature flags, not a promoted enum, so
+					// a mixed product's recurring signal never clobbers its one-time
+					// one. See {@see HPOS_Donors_Storage::aggregate_tier_rows()}.
+					'has_recurring'               => false,
+					'has_one_time'                => false,
 					'active_recurring_donors'     => 0,
 					'lapsed_donors_in_window'     => 0,
 					'new_donors_in_window'        => 0,
@@ -1139,8 +1140,11 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				$parents[ $bucket_id ]['name']      = $bucket_name;
 			}
 
+			// Latch the bucket's billing nature; a mixed product ends up with both.
 			if ( $is_recurring ) {
-				$parents[ $bucket_id ]['billing_model'] = 'recurring';
+				$parents[ $bucket_id ]['has_recurring'] = true;
+			} else {
+				$parents[ $bucket_id ]['has_one_time'] = true;
 			}
 
 			$parents[ $bucket_id ]['active_recurring_donors']     += $active_recurring_donors;
@@ -1152,7 +1156,9 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 			$parents[ $bucket_id ]['variations'][]                 = [
 				'variation_id'                => $variation_id,
 				'label'                       => $label,
-				'billing_model'               => $billing_model,
+				// A single variation row is purely one nature; exactly one flag set.
+				'has_recurring'               => $is_recurring,
+				'has_one_time'                => ! $is_recurring,
 				'active_recurring_donors'     => $active_recurring_donors,
 				'lapsed_donors_in_window'     => $lapsed_donors,
 				'new_donors_in_window'        => $new_donors,

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -45,12 +45,19 @@ export interface DonorsSnapshot {
 }
 
 /**
- * Whether a product is sold as recurring or one-time. Derived
- * server-side from the product's `_subscription_period` meta. The
- * UI uses this to render cells that don't apply to the product's
- * billing model as em-dashes instead of misleading zeros.
+ * A product's billing nature, tracked as two INDEPENDENT flags rather
+ * than one enum. Derived server-side from each contributing row's
+ * `_subscription_period` meta. A leaf variation is purely one nature
+ * (exactly one flag set); a variable parent latches EACH flag as its
+ * variation rows land, so a product that is recurring AND took a
+ * one-time (bare-parent) gift carries both. The UI shows a column iff
+ * its flag is set, rendering the rest as em-dashes instead of
+ * misleading zeros.
  */
-export type BillingModel = 'recurring' | 'one_time';
+export interface BillingNature {
+	has_recurring: boolean;
+	has_one_time: boolean;
+}
 
 /**
  * A rate metric whose denominator may legitimately be zero. The UI
@@ -64,10 +71,9 @@ export interface DonorsRateValue {
 	denominator: number;
 }
 
-export interface DonorsTierVariationRow {
+export interface DonorsTierVariationRow extends BillingNature {
 	variation_id: number;
 	label: string;
-	billing_model: BillingModel;
 	active_recurring_donors: number;
 	lapsed_donors_in_window: number;
 	new_donors_in_window: number;
@@ -76,15 +82,10 @@ export interface DonorsTierVariationRow {
 	lifetime_donation_revenue: number;
 }
 
-export interface DonorsTierRow {
+export interface DonorsTierRow extends BillingNature {
 	product_id: number;
 	name: string;
 	is_parent: boolean;
-	/**
-	 * For variable subscription parents, this is `recurring` if ANY
-	 * variation is recurring (the canonical Newspack donation shape).
-	 */
-	billing_model: BillingModel;
 	active_recurring_donors: number;
 	lapsed_donors_in_window: number;
 	new_donors_in_window: number;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
@@ -11,12 +11,17 @@
  *   Recurring revenue | Lifetime revenue
  *
  * Mixed temporal scope (current state + window + lifetime) is called
- * out in the section caption. Cells that don't apply to the row's
- * billing model — recurring donors / lapsed donors / recurring
- * revenue on a one-time product, one-time gifts on a recurring
- * product — render as em-dash ("—") rather than 0/$0.00, which
- * would read as "could be higher but isn't" instead of "doesn't
- * apply."
+ * out in the section caption. Cells that don't apply to a row —
+ * recurring donors / lapsed donors / recurring revenue on a row with
+ * no recurring nature, one-time gifts on a row with no one-time nature
+ * — render as em-dash ("—") rather than 0/$0.00, which would read as
+ * "could be higher but isn't" instead of "doesn't apply."
+ *
+ * A product's nature is two INDEPENDENT flags (`has_recurring`,
+ * `has_one_time`), not one enum, so a MIXED parent — a variable product
+ * with recurring variations that also took a one-time gift at the parent
+ * level (the "(no variation)" row) — shows BOTH its recurring columns and
+ * its one-time gifts. Leaf variation rows are purely one nature.
  */
 
 /**
@@ -28,7 +33,7 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { BillingModel, DonorsTierRow, DonorsTierVariationRow } from '../../api/donors';
+import type { DonorsTierRow, DonorsTierVariationRow } from '../../api/donors';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { getPostEditUrl } from '../components/adminLinks';
@@ -47,16 +52,13 @@ const NotApplicable = () => (
 const renderCount = ( applies: boolean, value: number ) => ( applies ? formatNumber( value ) : <NotApplicable /> );
 const renderCurrency = ( applies: boolean, value: number ) => ( applies ? formatCurrency( value ).display : <NotApplicable /> );
 
-const isRecurring = ( m: BillingModel ) => m === 'recurring';
-const isOneTime = ( m: BillingModel ) => m === 'one_time';
-
 const renderRowCells = ( row: DonorsTierRow | DonorsTierVariationRow ) => (
 	<>
-		<td className="newspack-insights__table-num">{ renderCount( isRecurring( row.billing_model ), row.active_recurring_donors ) }</td>
-		<td className="newspack-insights__table-num">{ renderCount( isRecurring( row.billing_model ), row.lapsed_donors_in_window ) }</td>
+		<td className="newspack-insights__table-num">{ renderCount( row.has_recurring, row.active_recurring_donors ) }</td>
+		<td className="newspack-insights__table-num">{ renderCount( row.has_recurring, row.lapsed_donors_in_window ) }</td>
 		<td className="newspack-insights__table-num">{ formatNumber( row.new_donors_in_window ) }</td>
-		<td className="newspack-insights__table-num">{ renderCount( isOneTime( row.billing_model ), row.one_time_gifts_in_window ) }</td>
-		<td className="newspack-insights__table-num">{ renderCurrency( isRecurring( row.billing_model ), row.recurring_revenue_in_window ) }</td>
+		<td className="newspack-insights__table-num">{ renderCount( row.has_one_time, row.one_time_gifts_in_window ) }</td>
+		<td className="newspack-insights__table-num">{ renderCurrency( row.has_recurring, row.recurring_revenue_in_window ) }</td>
 		<td className="newspack-insights__table-num">{ formatCurrency( row.lifetime_donation_revenue ).display }</td>
 	</>
 );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donors-performance.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donors-performance.php
@@ -199,7 +199,8 @@ class Test_Donors_Performance extends WP_UnitTestCase {
 	 * The bare-parent gift must MERGE into the variable parent's bucket — the
 	 * parent retains its summed variation totals and gains a synthetic
 	 * "(no variation)" row, instead of being overwritten down to the bare gift's
-	 * numbers. The parent's recurring billing_model survives the one-time merge.
+	 * numbers. The parent is flagged as BOTH recurring and one-time (mixed) — the
+	 * recurring signal does not clobber the one-time one.
 	 *
 	 * @dataProvider backend_provider
 	 *
@@ -214,7 +215,8 @@ class Test_Donors_Performance extends WP_UnitTestCase {
 
 		$this->assertTrue( $parent['is_parent'], 'A product with variation rows is a parent.' );
 		$this->assertSame( 'Reader Donation', $parent['name'], 'Parent keeps the canonical product title, not the bare row label.' );
-		$this->assertSame( 'recurring', $parent['billing_model'], 'Parent stays recurring (any recurring variation promotes it) despite the one-time bare gift.' );
+		$this->assertTrue( $parent['has_recurring'], 'The parent has recurring variations.' );
+		$this->assertTrue( $parent['has_one_time'], 'The parent also took a one-time bare gift, so it is mixed — the recurring flag does not clobber the one-time signal.' );
 
 		// 200 + 90 + 0 = 290 — the omission is gone.
 		$this->assertSame( 290, $parent['active_recurring_donors'], 'Active recurring donors sum all variations plus the bare-parent row.' );
@@ -269,7 +271,8 @@ class Test_Donors_Performance extends WP_UnitTestCase {
 		}
 		$this->assertNotNull( $no_variation );
 		$this->assertSame( 7, $no_variation['one_time_gifts_in_window'], 'The synthetic row holds the bare-parent one-time gifts.' );
-		$this->assertSame( 'one_time', $no_variation['billing_model'], 'The bare-parent gift has no sub period, so it is one-time.' );
+		$this->assertTrue( $no_variation['has_one_time'], 'The bare-parent gift has no sub period, so it is one-time.' );
+		$this->assertFalse( $no_variation['has_recurring'], 'A leaf variation is purely one nature — the bare gift is not recurring.' );
 	}
 
 	/**
@@ -294,7 +297,8 @@ class Test_Donors_Performance extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 810333, $indexed );
 		$parent = $indexed[810333];
 		$this->assertTrue( $parent['is_parent'], 'Bucket is a parent regardless of row order.' );
-		$this->assertSame( 'recurring', $parent['billing_model'], 'billing_model promotes to recurring even when the one-time bare row comes first.' );
+		$this->assertTrue( $parent['has_recurring'], 'has_recurring latches regardless of row order.' );
+		$this->assertTrue( $parent['has_one_time'], 'has_one_time latches even when the one-time bare row comes first.' );
 		$this->assertSame( 290, $parent['active_recurring_donors'], 'Active recurring donors merge the same way when the bare row comes first.' );
 		$this->assertCount( 3, $parent['variations'], 'All three rows survive regardless of order.' );
 	}
@@ -316,7 +320,8 @@ class Test_Donors_Performance extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 810339, $indexed );
 		$member_gift = $indexed[810339];
 		$this->assertTrue( $member_gift['is_parent'] );
-		$this->assertSame( 'recurring', $member_gift['billing_model'] );
+		$this->assertTrue( $member_gift['has_recurring'] );
+		$this->assertFalse( $member_gift['has_one_time'], 'A purely recurring product carries no one-time flag (one-time gifts render as em-dash).' );
 		$this->assertSame( 25, $member_gift['active_recurring_donors'] );
 		$this->assertCount( 1, $member_gift['variations'] );
 
@@ -324,7 +329,8 @@ class Test_Donors_Performance extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 820000, $indexed );
 		$one_time = $indexed[820000];
 		$this->assertFalse( $one_time['is_parent'] );
-		$this->assertSame( 'one_time', $one_time['billing_model'] );
+		$this->assertFalse( $one_time['has_recurring'], 'A purely one-time product carries no recurring flag.' );
+		$this->assertTrue( $one_time['has_one_time'] );
 		$this->assertSame( 15, $one_time['one_time_gifts_in_window'] );
 		$this->assertArrayNotHasKey( 'variations', $one_time, 'Standalone products carry no variations scaffold.' );
 	}


### PR DESCRIPTION
## What

Follow-up to #483 (donors bare-parent collision, now merged). Folding a one-time bare-parent gift into a **recurring** donation parent surfaced a representation gap: a variable donation product can be **both** recurring (its monthly/annual variations) **and** one-time (a gift taken at the parent level during a campaign) — but the single `billing_model` enum was promoted to `recurring` for such a parent, so the renderer dashed out ("—") the very one-time gifts its total already contained.

Concretely, a donor who holds a monthly subscription *and* drops a one-time campaign gift against the same product is counted correctly in the data (once under Active recurring donors, once under One-time gifts), but the parent row couldn't display both.

## How

Track a product's billing nature as **two independent flags** — `has_recurring` and `has_one_time` — instead of one promoted enum:
- A leaf variation is purely one nature (exactly one flag set).
- A parent **latches each flag** as its variation rows land, so a mixed product carries both — the recurring signal never clobbers the one-time one.
- The renderer shows a column iff its flag is set: a **mixed** parent shows both its recurring columns and its one-time gifts; a purely recurring product still dashes one-time gifts and a purely one-time product still dashes the recurring columns. `"—"` = "doesn't apply" is preserved on every non-mixed row.

Replaces `billing_model` / `BillingModel` end-to-end: storage payload (both HPOS + legacy), the storage-interface docblock, `donors.ts` types (new `BillingNature` interface), the renderer, and the reflection test.

## Testing
- `class-test-donors-performance.php` now asserts the mixed parent carries **both** `has_recurring` and `has_one_time`, the synthetic `"(no variation)"` row is purely one-time, and pure products carry a single flag.
- PHPUnit: donors test **8/8** (82 assertions); full `--group insights` **619/619** green.
- PHPCS clean vs workspace-root `phpcs.xml`; Prettier OK; changed TS files type-clean.