### PR TITLE
fix(group-subscription): validate invite before creating an account

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -542,6 +542,29 @@ class Group_Subscription_Invite {
 	}
 
 	/**
+	 * Whether an invite key is valid for the given subscription and email.
+	 *
+	 * Mirrors the invite checks in accept_invite(), for use as a gate before an
+	 * account is created for a new invitee.
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 * @param string               $key          The invite key.
+	 * @param string               $email        The invited email address.
+	 * @return bool
+	 */
+	private static function is_valid_invite( $subscription, $key, $email ) {
+		$subscription_obj = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		if ( ! $subscription_obj || ! $subscription_obj->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
+			return false;
+		}
+		$invite = self::get_invite_by_key( $subscription_obj, $key );
+		if ( ! $invite || $invite['email'] !== $email || self::is_invite_expired( $invite ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Get the invite URL for a group subscription invitation.
 	 *
 	 * @param int    $subscription_id The subscription ID.
@@ -655,6 +678,12 @@ class Group_Subscription_Invite {
 		}
 
 		// Case 3: New user — auto-create account, verify email, and accept.
+		// Validate the invite first, so an invalid key cannot force account
+		// creation, email verification, and login for an arbitrary address.
+		if ( ! self::is_valid_invite( $subscription_id, $key, $email ) ) {
+			self::redirect_with_result( 'error_invite_invalid' );
+			return;
+		}
 		$user_id = Reader_Activation::register_reader( $email, false );
 		if ( is_wp_error( $user_id ) || ! $user_id ) {
 			do_action(

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -13,6 +13,8 @@ use Newspack\Group_Subscription_Invite;
  */
 class Test_Group_Subscription_Invite extends WP_UnitTestCase {
 
+	const REDIRECTED = 'group-invite-test-redirected'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
 	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		parent::set_up_before_class();
 		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
@@ -31,21 +33,27 @@ class Test_Group_Subscription_Invite extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Run process_invite_request(), swallowing its terminal redirect.
+	 * Run process_invite_request(), converting its terminal redirect into a
+	 * catchable signal so the test can continue.
+	 *
+	 * Only the redirect is treated as expected; any other exception propagates,
+	 * and the absence of a redirect fails the test.
 	 */
 	private function run_invite_request() {
 		$redirect = function () {
-			throw new \Exception( 'redirect' );
+			throw new \RuntimeException( self::REDIRECTED );
 		};
 		add_filter( 'wp_redirect', $redirect, 1 );
 		try {
 			Group_Subscription_Invite::process_invite_request();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// The handler ends in a redirect + exit; the filter above turns that into
-			// a catchable exception so the test can continue.
-			unset( $e );
+			$this->fail( 'Expected the invite request to end in a redirect.' );
+		} catch ( \RuntimeException $e ) {
+			if ( self::REDIRECTED !== $e->getMessage() ) {
+				throw $e;
+			}
+		} finally {
+			remove_filter( 'wp_redirect', $redirect, 1 );
 		}
-		remove_filter( 'wp_redirect', $redirect, 1 );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -38,10 +38,12 @@ class Test_Group_Subscription_Invite extends WP_UnitTestCase {
 	 *
 	 * Only the redirect is treated as expected; any other exception propagates,
 	 * and the absence of a redirect fails the test.
+	 *
+	 * @throws \RuntimeException If the request fails for a reason other than the redirect.
 	 */
 	private function run_invite_request() {
 		$redirect = function () {
-			throw new \RuntimeException( self::REDIRECTED );
+			throw new \RuntimeException( self::REDIRECTED ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		};
 		add_filter( 'wp_redirect', $redirect, 1 );
 		try {

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -113,4 +113,76 @@ class Test_Group_Subscription_Invite extends WP_UnitTestCase {
 			'A valid invite creates a reader account for a new invitee.'
 		);
 	}
+
+	/**
+	 * A wrong key against a real active subscription is rejected at the invite-key
+	 * lookup (past the subscription check) and creates no account.
+	 */
+	public function test_wrong_key_with_active_subscription_does_not_create_account() {
+		$email        = 'nppm2966-wrongkey@example.test';
+		$subscription = wcs_create_subscription(
+			[
+				'id'     => 20,
+				'status' => 'active',
+				'meta'   => [
+					'newspack_group_subscription_invites' => [
+						'the-real-key' => [
+							'email'      => $email,
+							'expiration' => time() + HOUR_IN_SECONDS,
+						],
+					],
+				],
+			]
+		);
+		self::assertFalse( get_user_by( 'email', $email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = 'not-the-real-key';
+		$_GET['email']        = $email;
+		$_GET['subscription'] = (string) $subscription->get_id();
+
+		$this->run_invite_request();
+
+		self::assertFalse(
+			get_user_by( 'email', $email ),
+			'A wrong key against an active subscription must not create an account.'
+		);
+	}
+
+	/**
+	 * A valid key whose invite is for a different email is rejected at the email-match
+	 * check and creates no account for the requesting address.
+	 */
+	public function test_mismatched_email_with_valid_key_does_not_create_account() {
+		$invited_email  = 'nppm2966-invited@example.test';
+		$attacker_email = 'nppm2966-attacker@example.test';
+		$key            = 'the-real-key';
+		$subscription   = wcs_create_subscription(
+			[
+				'id'     => 21,
+				'status' => 'active',
+				'meta'   => [
+					'newspack_group_subscription_invites' => [
+						$key => [
+							'email'      => $invited_email,
+							'expiration' => time() + HOUR_IN_SECONDS,
+						],
+					],
+				],
+			]
+		);
+		self::assertFalse( get_user_by( 'email', $attacker_email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = $key;
+		$_GET['email']        = $attacker_email;
+		$_GET['subscription'] = (string) $subscription->get_id();
+
+		$this->run_invite_request();
+
+		self::assertFalse(
+			get_user_by( 'email', $attacker_email ),
+			'A valid key with a mismatched email must not create an account for the requesting address.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for Group_Subscription_Invite request handling.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ */
+
+use Newspack\Group_Subscription_Invite;
+
+/**
+ * Tests the group subscription invite request handler.
+ */
+class Test_Group_Subscription_Invite extends WP_UnitTestCase {
+
+	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		unset( $_GET['action'], $_GET['key'], $_GET['email'], $_GET['subscription'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Run process_invite_request(), swallowing its terminal redirect.
+	 */
+	private function run_invite_request() {
+		$redirect = function () {
+			throw new \Exception( 'redirect' );
+		};
+		add_filter( 'wp_redirect', $redirect, 1 );
+		try {
+			Group_Subscription_Invite::process_invite_request();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// The handler ends in a redirect + exit; the filter above turns that into
+			// a catchable exception so the test can continue.
+			unset( $e );
+		}
+		remove_filter( 'wp_redirect', $redirect, 1 );
+	}
+
+	/**
+	 * An invalid invite key must not create a reader account for a new email.
+	 */
+	public function test_invalid_key_does_not_create_account() {
+		$email = 'nppm2966-invitee@example.test';
+		self::assertFalse( get_user_by( 'email', $email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = 'this-key-is-not-valid';
+		$_GET['email']        = $email;
+		$_GET['subscription'] = '999';
+
+		$this->run_invite_request();
+
+		self::assertFalse(
+			get_user_by( 'email', $email ),
+			'An invalid invite key must not create a reader account.'
+		);
+	}
+
+	/**
+	 * A valid invite still creates a reader account for a new invitee.
+	 */
+	public function test_valid_key_creates_account() {
+		$email        = 'nppm2966-valid@example.test';
+		$key          = 'valid-invite-key';
+		$subscription = wcs_create_subscription(
+			[
+				'id'     => 10,
+				'status' => 'active',
+				'meta'   => [
+					'newspack_group_subscription_invites' => [
+						$key => [
+							'email'      => $email,
+							'expiration' => time() + HOUR_IN_SECONDS,
+						],
+					],
+				],
+			]
+		);
+		self::assertFalse( get_user_by( 'email', $email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = $key;
+		$_GET['email']        = $email;
+		$_GET['subscription'] = (string) $subscription->get_id();
+
+		$this->run_invite_request();
+
+		self::assertInstanceOf(
+			WP_User::class,
+			get_user_by( 'email', $email ),
+			'A valid invite creates a reader account for a new invitee.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The group subscription invite handler now validates the invitation before
creating a reader account for a new invitee, so account creation (and the email
verification and sign-in that follow) only proceeds for a valid invitation. The
validation mirrors the checks already used when accepting an invite.

Part of NPPM-2966.

### How to test the changes in this Pull Request:

1. Run the tests: `n test-php --filter Test_Group_Subscription_Invite` (2 pass).
2. An invite request with an invalid key does not create an account; a valid invitation still creates one.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
