### PR TITLE
feat(insights): subscriptions & donations by campaign tables (NEWS-2591, NEWS-2580)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -227,6 +227,7 @@ class Donors_REST_Controller extends WP_REST_Controller {
 			'lapsed_donor_recovery_rate' => $metric->get_lapsed_donor_recovery_rate( $start, $end ),
 			'recurring_donor_retention'  => $metric->get_recurring_donor_retention( $start, $end ),
 			'donations_by_tier'          => $metric->get_donations_by_tier( $start, $end ),
+			'donations_by_campaign'      => $metric->get_donations_by_campaign( $start, $end ),
 			// Derived empty-state signal (NPPD-1696): true when the window saw any
 			// donation activity at all. Pure derivation from values already fetched
 			// above — no extra query — kept in the metric class alongside the other

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -244,6 +244,7 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 			'refund_rate'               => $metric->get_subscription_refund_rate( $start, $end ),
 			'failed_payment_retry_rate' => $metric->get_failed_payment_retry_rate( $start, $end ),
 			'subscriptions_by_product'  => $metric->get_subscriptions_by_product( $start, $end ),
+			'subscriptions_by_campaign' => $metric->get_subscriptions_by_campaign( $start, $end ),
 			'cancellation_reasons'      => $metric->get_cancellation_reasons( $start, $end ),
 			// Derived empty-state signal (NPPD-1695): true when the window saw any
 			// subscription activity. Pure derivation from values already fetched

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -497,7 +497,10 @@ class Donors_Metric {
 					$this->storage->get_donation_campaign_rows( $start, $end ),
 					'utm_campaign',
 					'revenue',
-					[ 'untagged_label' => __( '(no campaign)', 'newspack-plugin' ) ]
+					// Locale-stable sentinel, NOT __()'d: this output is cached under a
+					// locale-agnostic key, so the display label is localized at render
+					// time from the is_untagged flag (see CampaignSection.tsx).
+					[ 'untagged_label' => '(no campaign)' ]
 				);
 			}
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -475,6 +475,35 @@ class Donors_Metric {
 	}
 
 	/**
+	 * Donations in the window grouped by `utm_campaign` (NEWS-2580).
+	 *
+	 * Anonymous-inclusive, Woo-only (no GA4 / hub). Reads one row per donation order
+	 * from the storage layer (per store: HPOS `wc_orders_meta`, legacy `postmeta`),
+	 * then folds by campaign via {@see Metric_Grouping::group_records_by_key()}.
+	 * Untagged orders collapse into a single trailing "(no campaign)" row. Coverage
+	 * is the UTM-tagged subset — see formulas/tab-7-donors.md.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{value: string, count: int, amount: float, is_untagged: bool}>
+	 */
+	public function get_donations_by_campaign( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return (array) $this->cached(
+			'donations_by_campaign',
+			$this->window_key( $start, $end ),
+			self::TTL_DEFAULT, // Grouping an already-fetched record set, not a heavy join.
+			function () use ( $start, $end ) {
+				return Metric_Grouping::group_records_by_key(
+					$this->storage->get_donation_campaign_rows( $start, $end ),
+					'utm_campaign',
+					'revenue',
+					[ 'untagged_label' => __( '(no campaign)', 'newspack-plugin' ) ]
+				);
+			}
+		);
+	}
+
+	/**
 	 * Flush all Tab 7 metric caches. Hook point for NPPD-1605.
 	 *
 	 * @return void

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-grouping.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-grouping.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Newspack Insights — shared metric grouping helper (NEWS-2591 / NEWS-2580).
+ *
+ * Pure fold of windowed conversion records into grouped
+ * { value, count, amount } rows for the "by campaign" tables and any future
+ * group-by-order-meta table. Generic over record type AND meta key: callers
+ * pass rows + which key groups + which key sums. Both the Subscribers (Tab 6)
+ * and Donors (Tab 7) by-campaign tables call this; only the reader differs.
+ *
+ * Mirrors the pure-static, directly-testable shape of
+ * {@see Subscribers_Metric::bucket_attributed_subscription_orders()}.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared grouping fold for order-meta-keyed Insights tables.
+ */
+class Metric_Grouping {
+
+	/**
+	 * Fold per-record rows into grouped { value, count, amount } rows.
+	 *
+	 * @param array<int, array<string, mixed>> $rows       One row per conversion in the window.
+	 * @param string                           $group_key  Row key holding the grouping value, e.g. 'utm_campaign'.
+	 * @param string                           $amount_key Row key holding the numeric amount to sum, e.g. 'revenue'.
+	 *                                                      Pass '' for count-only (amount always 0.0).
+	 * @param array                            $opts       Grouping options (all optional):
+	 *   - untagged_label: non-null string => rows whose normalized value is '' collapse into one trailing
+	 *       row with this label (is_untagged: true). Null/omitted => untagged rows are dropped.
+	 *   - normalize: value normalizer applied before grouping; defaults to trim(). Return '' to route a
+	 *       value into the untagged bucket.
+	 *   - limit: if > 0, keep top N tagged rows and fold the rest into one 'other' row (after ranked rows,
+	 *       before untagged). Omit/0 for the full table.
+	 *   - other_label: label for the folded-tail row; defaults to '(other)'.
+	 *
+	 * @return array<int, array{value: string, count: int, amount: float, is_untagged: bool}>
+	 *   Ranked count desc, amount desc, value asc. 'other' row (if any) after ranked rows; untagged row
+	 *   (if enabled) always last.
+	 */
+	public static function group_records_by_key( array $rows, string $group_key, string $amount_key = '', array $opts = [] ): array {
+		$untagged_label = array_key_exists( 'untagged_label', $opts ) ? $opts['untagged_label'] : null;
+		$normalize      = $opts['normalize'] ?? 'trim';
+		$limit          = isset( $opts['limit'] ) ? (int) $opts['limit'] : 0;
+		$other_label    = $opts['other_label'] ?? '(other)';
+
+		$tagged   = [];
+		$untagged = [
+			'count'  => 0,
+			'amount' => 0.0,
+		];
+
+		foreach ( $rows as $row ) {
+			$raw    = isset( $row[ $group_key ] ) ? (string) $row[ $group_key ] : '';
+			$value  = (string) call_user_func( $normalize, $raw );
+			$amount = ( '' !== $amount_key && isset( $row[ $amount_key ] ) ) ? (float) $row[ $amount_key ] : 0.0;
+
+			if ( '' === $value ) {
+				++$untagged['count'];
+				$untagged['amount'] += $amount;
+				continue;
+			}
+
+			if ( ! isset( $tagged[ $value ] ) ) {
+				$tagged[ $value ] = [
+					'count'  => 0,
+					'amount' => 0.0,
+				];
+			}
+			++$tagged[ $value ]['count'];
+			$tagged[ $value ]['amount'] += $amount;
+		}
+
+		$ranked = [];
+		foreach ( $tagged as $value => $agg ) {
+			$ranked[] = [
+				'value'       => (string) $value,
+				'count'       => $agg['count'],
+				'amount'      => $agg['amount'],
+				'is_untagged' => false,
+			];
+		}
+
+		usort(
+			$ranked,
+			static function ( $a, $b ) {
+				return [ $b['count'], $b['amount'], $a['value'] ] <=> [ $a['count'], $a['amount'], $b['value'] ];
+			}
+		);
+
+		if ( $limit > 0 && count( $ranked ) > $limit ) {
+			$head  = array_slice( $ranked, 0, $limit );
+			$tail  = array_slice( $ranked, $limit );
+			$other = [
+				'value'       => $other_label,
+				'count'       => 0,
+				'amount'      => 0.0,
+				'is_untagged' => false,
+			];
+			foreach ( $tail as $r ) {
+				$other['count']  += $r['count'];
+				$other['amount'] += $r['amount'];
+			}
+			$ranked   = $head;
+			$ranked[] = $other;
+		}
+
+		if ( null !== $untagged_label && $untagged['count'] > 0 ) {
+			$ranked[] = [
+				'value'       => $untagged_label,
+				'count'       => $untagged['count'],
+				'amount'      => $untagged['amount'],
+				'is_untagged' => true,
+			];
+		}
+
+		return $ranked;
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -544,7 +544,10 @@ class Subscribers_Metric {
 					$this->storage->get_new_subscription_campaign_rows( $start, $end ),
 					'utm_campaign',
 					'revenue',
-					[ 'untagged_label' => __( '(no campaign)', 'newspack-plugin' ) ]
+					// Locale-stable sentinel, NOT __()'d: this output is cached under a
+					// locale-agnostic key, so the display label is localized at render
+					// time from the is_untagged flag (see CampaignSection.tsx).
+					[ 'untagged_label' => '(no campaign)' ]
 				);
 			}
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -521,6 +521,36 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * New subscriptions in the window grouped by `utm_campaign` (NEWS-2591).
+	 *
+	 * Anonymous-inclusive, Woo-only (no GA4 / hub). Reads one row per initial
+	 * subscription order from the storage layer (per store: HPOS `wc_orders_meta`,
+	 * legacy `postmeta`), then folds by campaign via
+	 * {@see Metric_Grouping::group_records_by_key()}. Untagged orders collapse into a
+	 * single trailing "(no campaign)" row. Coverage is the UTM-tagged subset — see
+	 * formulas/tab-6-subscribers.md.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{value: string, count: int, amount: float, is_untagged: bool}>
+	 */
+	public function get_subscriptions_by_campaign( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return (array) $this->cached(
+			'subscriptions_by_campaign',
+			$this->window_key( $start, $end ),
+			self::TTL_DEFAULT, // Grouping an already-fetched record set, not a heavy join.
+			function () use ( $start, $end ) {
+				return Metric_Grouping::group_records_by_key(
+					$this->storage->get_new_subscription_campaign_rows( $start, $end ),
+					'utm_campaign',
+					'revenue',
+					[ 'untagged_label' => __( '(no campaign)', 'newspack-plugin' ) ]
+				);
+			}
+		);
+	}
+
+	/**
 	 * Subscription conversion-lag rows (customer_id, registered_ts, first_sub_ts)
 	 * for the 4.2 time-to-subscribe distribution. List-param — NOT cached.
 	 *

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -393,4 +393,23 @@ interface Donors_Storage_Interface {
 	 * @return array<string, array{conversions:int, revenue:float}> popup_id => { conversions, revenue }.
 	 */
 	public function get_prompt_attributed_donation_conversions( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
+	 * Donation campaign attribution rows for the window (NEWS-2580).
+	 *
+	 * One row per completed/processing donation order in [$start, $end]. utm_campaign
+	 * is read from the donation order meta via the same read path as
+	 * get_prompt_attributed_donation_conversions() (_newspack_popup_id). Per store:
+	 * HPOS reads wc_orders_meta via a MIN() subquery (utm_campaign is written
+	 * non-unique, so a JOIN would inflate), legacy reads postmeta. Every donation
+	 * order is emitted; untagged orders carry '' so the grouping layer can surface a
+	 * "(no campaign)" bucket. Renewals excluded.
+	 *
+	 * revenue = donation order total (one-time gift amount).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{utm_campaign: string, revenue: float}>
+	 */
+	public function get_donation_campaign_rows( DateTimeInterface $start, DateTimeInterface $end ): array;
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -1454,4 +1454,62 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 		}
 		return $out;
 	}
+
+	/**
+	 * Donation campaign attribution rows for the window (NEWS-2580).
+	 *
+	 * One row per completed/processing donation order in [$start, $end]. Reuses the
+	 * read path of get_prompt_attributed_donation_conversions() but keyed on
+	 * `utm_campaign` instead of `_newspack_popup_id`: HPOS reads `wc_orders_meta`
+	 * via a correlated MIN() subquery (the meta is written non-unique, so a JOIN
+	 * would inflate). Unlike the popup reader there is NO popup EXISTS filter and NO
+	 * GROUP BY — every donation order is emitted, untagged ones carrying '', so the
+	 * Metric_Grouping fold can surface a "(no campaign)" bucket. Renewals excluded
+	 * via NOT EXISTS `_subscription_renewal`.
+	 *
+	 * revenue = donation order total (one-time gift amount).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{utm_campaign: string, revenue: float}>
+	 */
+	public function get_donation_campaign_rows( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		$sql = $wpdb->prepare(
+			"SELECT
+				(
+					SELECT MIN(c.meta_value)
+					FROM {$prefix}wc_orders_meta c
+					WHERE c.order_id = ord.id AND c.meta_key = 'utm_campaign' AND c.meta_value <> ''
+				) AS utm_campaign,
+				ord.total_amount AS revenue
+			FROM {$prefix}wc_orders ord
+			WHERE ord.type = 'shop_order'
+			  AND ord.status IN ('wc-completed', 'wc-processing')
+			  AND ord.date_created_gmt BETWEEN %s AND %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM {$prefix}wc_orders_meta rn
+			      WHERE rn.order_id = ord.id AND rn.meta_key = '_subscription_renewal'
+			        AND rn.meta_value NOT IN ('', '0')
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+			      WHERE opl.order_id = ord.id AND opl.product_id IN ($donations)
+			  )",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$out = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$out[] = [
+				'utm_campaign' => (string) ( $row['utm_campaign'] ?? '' ),
+				'revenue'      => (float) ( $row['revenue'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1591,6 +1591,67 @@ class HPOS_Storage implements Storage_Interface {
 	}
 
 	/**
+	 * New-subscription campaign attribution rows for the window (NEWS-2591).
+	 *
+	 * The subscription twin of get_donation_campaign_rows(): one row per INITIAL
+	 * (non-renewal) completed/processing order containing a non-donation
+	 * subscription product in [$start, $end], keyed on `utm_campaign` read off that
+	 * initial order. Mirrors get_attributed_subscription_orders() exactly — same
+	 * initial-order scope, renewal + donation-product exclusion, and correlated
+	 * MIN() (the meta is written non-unique, so a JOIN would inflate) — but WITHOUT
+	 * its gate/popup-attribution requirement, so every subscription order is emitted
+	 * (untagged → '') for the "(no campaign)" bucket. HPOS reads `wc_orders_meta`.
+	 *
+	 * revenue = initial subscription order total (not recurring / MRR).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{utm_campaign: string, revenue: float}>
+	 */
+	public function get_new_subscription_campaign_rows( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix        = $wpdb->prefix;
+		$donations     = $this->id_list( $this->donation_product_ids );
+		$subscriptions = $this->subscription_product_ids_sql();
+
+		$sql = $wpdb->prepare(
+			"SELECT
+				(
+					SELECT MIN(c.meta_value)
+					FROM {$prefix}wc_orders_meta c
+					WHERE c.order_id = ord.id AND c.meta_key = 'utm_campaign' AND c.meta_value <> ''
+				) AS utm_campaign,
+				ord.total_amount AS revenue
+			FROM {$prefix}wc_orders ord
+			WHERE ord.type = 'shop_order'
+			  AND ord.status IN ('wc-completed', 'wc-processing')
+			  AND ord.date_created_gmt BETWEEN %s AND %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM {$prefix}wc_orders_meta rn
+			      WHERE rn.order_id = ord.id AND rn.meta_key = '_subscription_renewal'
+			        AND rn.meta_value NOT IN ('', '0')
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+			      WHERE opl.order_id = ord.id
+			        AND opl.product_id IN ($subscriptions)
+			        AND opl.product_id NOT IN ($donations)
+			  )",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$out = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$out[] = [
+				'utm_campaign' => (string) ( $row['utm_campaign'] ?? '' ),
+				'revenue'      => (float) ( $row['revenue'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
+
+	/**
 	 * Normalize raw attributed-subscription-order rows to the typed per-order shape.
 	 * A null gate/popup id (no such meta on the order) stays null so the orchestrator
 	 * can apply gate precedence; `order_total` is coerced to float. Shared row shape

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -1405,4 +1405,65 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		}
 		return $out;
 	}
+
+	/**
+	 * Donation campaign attribution rows for the window (NEWS-2580).
+	 *
+	 * Legacy CPT equivalent of the HPOS get_donation_campaign_rows(): one row per
+	 * completed/processing donation order in [$start, $end], keyed on `utm_campaign`
+	 * read from {prefix}postmeta via a correlated MIN() subquery (the meta is written
+	 * non-unique, so a JOIN would inflate). No popup filter and no GROUP BY — every
+	 * donation order is emitted (untagged → ''), so the Metric_Grouping fold can
+	 * surface a "(no campaign)" bucket. Renewals excluded via NOT EXISTS
+	 * `_subscription_renewal`.
+	 *
+	 * revenue = donation order total (`_order_total`, one-time gift amount).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{utm_campaign: string, revenue: float}>
+	 */
+	public function get_donation_campaign_rows( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		$sql = $wpdb->prepare(
+			"SELECT
+				(
+					SELECT MIN(c.meta_value)
+					FROM {$prefix}postmeta c
+					WHERE c.post_id = p.ID AND c.meta_key = 'utm_campaign' AND c.meta_value <> ''
+				) AS utm_campaign,
+				(
+					SELECT MAX(CAST(tot.meta_value AS DECIMAL(15,2)))
+					FROM {$prefix}postmeta tot
+					WHERE tot.post_id = p.ID AND tot.meta_key = '_order_total'
+				) AS revenue
+			FROM {$prefix}posts p
+			WHERE p.post_type = 'shop_order'
+			  AND p.post_status IN ('wc-completed', 'wc-processing')
+			  AND p.post_date_gmt BETWEEN %s AND %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM {$prefix}postmeta rn
+			      WHERE rn.post_id = p.ID AND rn.meta_key = '_subscription_renewal'
+			        AND rn.meta_value NOT IN ('', '0')
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+			      WHERE opl.order_id = p.ID AND opl.product_id IN ($donations)
+			  )",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$out = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$out[] = [
+				'utm_campaign' => (string) ( $row['utm_campaign'] ?? '' ),
+				'revenue'      => (float) ( $row['revenue'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1511,6 +1511,71 @@ class Legacy_Storage implements Storage_Interface {
 	}
 
 	/**
+	 * New-subscription campaign attribution rows for the window (NEWS-2591).
+	 *
+	 * Legacy CPT equivalent of the HPOS get_new_subscription_campaign_rows(): one
+	 * row per INITIAL (non-renewal) completed/processing order containing a
+	 * non-donation subscription product in [$start, $end], keyed on `utm_campaign`
+	 * read off that initial order from {prefix}postmeta via a correlated MIN() (the
+	 * meta is written non-unique, so a JOIN would inflate). Mirrors
+	 * get_attributed_subscription_orders() minus its gate/popup-attribution
+	 * requirement, so every subscription order is emitted (untagged → '') for the
+	 * "(no campaign)" bucket.
+	 *
+	 * revenue = initial subscription order total (`_order_total`, not recurring / MRR).
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<int, array{utm_campaign: string, revenue: float}>
+	 */
+	public function get_new_subscription_campaign_rows( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix        = $wpdb->prefix;
+		$donations     = $this->id_list( $this->donation_product_ids );
+		$subscriptions = $this->subscription_product_ids_sql();
+
+		$sql = $wpdb->prepare(
+			"SELECT
+				(
+					SELECT MIN(c.meta_value)
+					FROM {$prefix}postmeta c
+					WHERE c.post_id = p.ID AND c.meta_key = 'utm_campaign' AND c.meta_value <> ''
+				) AS utm_campaign,
+				(
+					SELECT MAX(CAST(tot.meta_value AS DECIMAL(15,2)))
+					FROM {$prefix}postmeta tot
+					WHERE tot.post_id = p.ID AND tot.meta_key = '_order_total'
+				) AS revenue
+			FROM {$prefix}posts p
+			WHERE p.post_type = 'shop_order'
+			  AND p.post_status IN ('wc-completed', 'wc-processing')
+			  AND p.post_date_gmt BETWEEN %s AND %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM {$prefix}postmeta rn
+			      WHERE rn.post_id = p.ID AND rn.meta_key = '_subscription_renewal'
+			        AND rn.meta_value NOT IN ('', '0')
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM {$prefix}wc_order_product_lookup opl
+			      WHERE opl.order_id = p.ID
+			        AND opl.product_id IN ($subscriptions)
+			        AND opl.product_id NOT IN ($donations)
+			  )",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$out = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$out[] = [
+				'utm_campaign' => (string) ( $row['utm_campaign'] ?? '' ),
+				'revenue'      => (float) ( $row['revenue'] ?? 0 ),
+			];
+		}
+		return $out;
+	}
+
+	/**
 	 * Normalize raw attributed-subscription-order rows to the typed per-order shape.
 	 * A null gate/popup id (no such meta on the order) stays null so the orchestrator
 	 * can apply gate precedence; `order_total` is coerced to float. Shared row shape

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -414,6 +414,25 @@ interface Storage_Interface {
 	public function get_attributed_subscription_orders( DateTimeInterface $start, DateTimeInterface $end ): array;
 
 	/**
+	 * New-subscription campaign attribution rows for the window (NEWS-2591).
+	 *
+	 * One row per INITIAL (non-renewal) completed/processing order containing a
+	 * non-donation subscription product in [$start, $end]. utm_campaign is read off
+	 * that initial order (same initial-order scope as get_attributed_subscription_orders(),
+	 * minus its gate/popup requirement). Per store: HPOS reads wc_orders_meta via a
+	 * MIN() subquery (utm_campaign is written non-unique, so a JOIN would inflate),
+	 * legacy reads postmeta. Every subscription order is emitted; untagged orders
+	 * carry '' so the grouping layer can surface a "(no campaign)" bucket.
+	 *
+	 * revenue = initial subscription order total (not recurring / MRR).
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<int, array{utm_campaign: string, revenue: float}>
+	 */
+	public function get_new_subscription_campaign_rows( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
 	 * Subscription schedule intervals for the trailing-365-day new-subscriber
 	 * cohort (5.2 retention input). One row per (customer, non-donation
 	 * subscription) for every customer whose EARLIEST non-donation subscription

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -96,6 +96,22 @@ export interface DonorsTierRow extends BillingNature {
 	variations?: DonorsTierVariationRow[];
 }
 
+/**
+ * One "Donations by campaign" row (NEWS-2580). Shape emitted by the shared
+ * Metric_Grouping fold: campaign value, donation count, attributed revenue, and
+ * the untagged flag for the trailing "(no campaign)" denominator row.
+ */
+export interface DonorsCampaignRow {
+	/** Campaign name, or the localized "(no campaign)" untagged label. */
+	value: string;
+	/** Donations attributed to this campaign in the window. */
+	count: number;
+	/** Attributed donation-order revenue for this campaign in the window. */
+	amount: number;
+	/** True for the trailing untagged "(no campaign)" denominator row. */
+	is_untagged: boolean;
+}
+
 export interface DonorsWindow {
 	window: { start: string; end: string };
 	new_donors: number;
@@ -119,6 +135,12 @@ export interface DonorsWindow {
 	 */
 	recurring_donor_retention: DonorsRateValue;
 	donations_by_tier: DonorsTierRow[];
+	/**
+	 * Donations grouped by `utm_campaign` (NEWS-2580). Ranked count desc; the
+	 * trailing `is_untagged` "(no campaign)" row is the untagged denominator.
+	 * Coverage is the UTM-tagged subset — see formulas/tab-7-donors.md.
+	 */
+	donations_by_campaign: DonorsCampaignRow[];
 	/**
 	 * Derived empty-state signal (NPPD-1696): true when the window saw
 	 * any donation activity (revenue, a new donor, or a lapse). Drives

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -91,6 +91,22 @@ export interface CancellationReasonRow {
 	count: number;
 }
 
+/**
+ * One "Subscriptions by campaign" row (NEWS-2591). Shape emitted by the shared
+ * Metric_Grouping fold: campaign value, new-subscription count, attributed
+ * revenue, and the untagged flag for the trailing "(no campaign)" denominator row.
+ */
+export interface SubscribersCampaignRow {
+	/** Campaign name, or the localized "(no campaign)" untagged label. */
+	value: string;
+	/** New subscriptions attributed to this campaign in the window. */
+	count: number;
+	/** Attributed initial-order revenue for this campaign in the window. */
+	amount: number;
+	/** True for the trailing untagged "(no campaign)" denominator row. */
+	is_untagged: boolean;
+}
+
 export interface SubscribersWindow {
 	window: { start: string; end: string };
 	new_subscribers: number;
@@ -110,6 +126,12 @@ export interface SubscribersWindow {
 	 */
 	failed_payment_retry_rate: SubscribersRateValue;
 	subscriptions_by_product: PerformanceRow[];
+	/**
+	 * New subscriptions grouped by `utm_campaign` (NEWS-2591). Ranked count desc;
+	 * the trailing `is_untagged` "(no campaign)" row is the untagged denominator.
+	 * Coverage is the UTM-tagged subset — see formulas/tab-6-subscribers.md.
+	 */
+	subscriptions_by_campaign: SubscribersCampaignRow[];
 	cancellation_reasons: CancellationReasonRow[];
 	/**
 	 * Derived empty-state signal (NPPD-1695): true when the window saw

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -27,6 +27,7 @@ import ScorecardSection from './donors/ScorecardSection';
 import WindowedSection from './donors/WindowedSection';
 import RetentionSection from './donors/RetentionSection';
 import PerformanceSection from './donors/PerformanceSection';
+import CampaignSection from './donors/CampaignSection';
 import './donors/donors.scss';
 
 export interface DonorsTabProps {
@@ -60,6 +61,7 @@ const DonorsTab = ( { range, previousRange }: DonorsTabProps ) => {
 					/>
 					<RetentionSection current={ data.current } previous={ data.previous } />
 					<PerformanceSection rows={ data.current.donations_by_tier } />
+					<CampaignSection rows={ data.current.donations_by_campaign } />
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -31,6 +31,7 @@ import ScorecardSection from './subscribers/ScorecardSection';
 import WindowedSection from './subscribers/WindowedSection';
 import TenureSection from './subscribers/TenureSection';
 import PerformanceSection from './subscribers/PerformanceSection';
+import CampaignSection from './subscribers/CampaignSection';
 import './subscribers/subscribers.scss';
 
 export interface SubscribersTabProps {
@@ -64,6 +65,7 @@ const SubscribersTab = ( { range, previousRange }: SubscribersTabProps ) => {
 					/>
 					<TenureSection rows={ data.snapshot.tenure_distribution } />
 					<PerformanceSection rows={ data.current.subscriptions_by_product } />
+					<CampaignSection rows={ data.current.subscriptions_by_campaign } />
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -376,6 +376,13 @@
 				padding-left: 44px; // 20px table padding + 24px indent
 			}
 		}
+
+		// The trailing "(no campaign)" denominator row (NEWS-2580): renders its
+		// real count + revenue but muted (gray-600) so the untagged remainder reads
+		// as context rather than a ranked campaign. Backend orders it last.
+		&-row--untagged td {
+			color: wp-colors.$gray-600;
+		}
 	}
 
 	// Explanatory note(s) rendered beneath a table — e.g. defining a synthetic

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for the Donors CampaignSection (NEWS-2580): renders the by-campaign
+ * table, pins/mutes the untagged row, and shows the campaign-tagged empty state
+ * when there is nothing tagged (no rows, or only the "(no campaign)" row).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CampaignSection from './CampaignSection';
+import type { DonorsCampaignRow } from '../../api/donors';
+
+const untagged = ( over: Partial< DonorsCampaignRow > = {} ): DonorsCampaignRow => ( {
+	value: '(no campaign)',
+	count: 4,
+	amount: 120,
+	is_untagged: true,
+	...over,
+} );
+
+describe( 'Donors CampaignSection', () => {
+	it( 'renders tagged campaign rows with count and revenue', () => {
+		const rows: DonorsCampaignRow[] = [
+			{ value: 'spring-drive', count: 8, amount: 640, is_untagged: false },
+			{ value: 'buffer', count: 3, amount: 150, is_untagged: false },
+			untagged(),
+		];
+
+		render( <CampaignSection rows={ rows } /> );
+
+		expect( screen.getByText( 'Donations by campaign' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'spring-drive' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'buffer' ) ).toBeInTheDocument();
+		// The untagged row renders its real count (a denominator, not a blank).
+		expect( screen.getByText( '(no campaign)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'mutes the untagged row and renders it last', () => {
+		const rows: DonorsCampaignRow[] = [ { value: 'spring-drive', count: 8, amount: 640, is_untagged: false }, untagged() ];
+
+		const { container } = render( <CampaignSection rows={ rows } /> );
+
+		const bodyRows = container.querySelectorAll( 'tbody tr' );
+		expect( bodyRows ).toHaveLength( 2 );
+		// Untagged row is last and carries the muted modifier class.
+		const last = bodyRows[ bodyRows.length - 1 ];
+		expect( last ).toHaveClass( 'newspack-insights__table-row--untagged' );
+		expect( last ).toHaveTextContent( '(no campaign)' );
+		// Tagged rows are not muted.
+		expect( bodyRows[ 0 ] ).not.toHaveClass( 'newspack-insights__table-row--untagged' );
+	} );
+
+	it( 'shows the campaign-tagged empty state when there are no rows', () => {
+		render( <CampaignSection rows={ [] } /> );
+
+		expect( screen.getByText( 'No campaign-tagged donations in this window.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when only the untagged row is present', () => {
+		render( <CampaignSection rows={ [ untagged() ] } /> );
+
+		expect( screen.getByText( 'No campaign-tagged donations in this window.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
@@ -72,12 +72,12 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 						</tr>
 					</thead>
 					<tbody>
-						{ rows.map( ( row, index ) => (
+						{ rows.map( row => (
 							<tr
-								key={ row.is_untagged ? '__untagged__' : `${ index }-${ row.value }` }
+								key={ row.is_untagged ? '__untagged__' : `campaign:${ row.value }` }
 								className={ row.is_untagged ? 'newspack-insights__table-row--untagged' : undefined }
 							>
-								<td>{ row.value }</td>
+								<td>{ row.is_untagged ? __( '(no campaign)', 'newspack-plugin' ) : row.value }</td>
 								<td className="newspack-insights__table-num">{ formatNumber( row.count ) }</td>
 								<td className="newspack-insights__table-num">{ formatCurrency( row.amount ).display }</td>
 							</tr>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
@@ -1,0 +1,92 @@
+/**
+ * CampaignSection (NEWS-2580) — Donations by campaign.
+ *
+ * New donations in the selected timeframe grouped by the `utm_campaign` attached
+ * to the donation order (Woo order meta, anonymous-inclusive, no GA4). Static
+ * server-ordered table (ranked count desc), matching the adjacent
+ * "Donations by tier" section on this tab — not user-sortable.
+ *
+ * Coverage is the UTM-**tagged** subset only (donors who arrived via a tagged
+ * link). Untagged donations collapse into a single trailing "(no campaign)" row
+ * that renders its real count + revenue (a denominator, not a blank) and is
+ * visually de-emphasized. The backend already orders it last. The empty state
+ * fires when there is no data at all OR only the untagged row — i.e. no
+ * campaign-tagged donations in the window.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { DonorsCampaignRow } from '../../api/donors';
+import SectionEmpty from '../components/SectionEmpty';
+import SectionHeading from '../components/SectionHeading';
+import { formatCurrency, formatNumber } from '../components/format';
+
+export interface CampaignSectionProps {
+	rows: DonorsCampaignRow[];
+}
+
+const HEADING_ID = 'newspack-insights-donors-campaign-heading';
+
+const CampaignSection = ( { rows }: CampaignSectionProps ) => {
+	const title = __( 'Donations by campaign', 'newspack-plugin' );
+
+	// Empty when there is nothing tagged to show: no rows at all, or only the
+	// trailing "(no campaign)" untagged row.
+	const hasTagged = rows.some( row => ! row.is_untagged );
+	if ( ! hasTagged ) {
+		return (
+			<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+				<SectionHeading id={ HEADING_ID } title={ title } />
+				<SectionEmpty>{ __( 'No campaign-tagged donations in this window.', 'newspack-plugin' ) }</SectionEmpty>
+			</section>
+		);
+	}
+
+	return (
+		<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+			<SectionHeading
+				id={ HEADING_ID }
+				title={ title }
+				description={ __(
+					'New donations in the selected timeframe grouped by the UTM campaign on the order. Covers campaign-tagged donations only; untagged donations are grouped as “(no campaign).”',
+					'newspack-plugin'
+				) }
+			/>
+			<div className="newspack-insights__table-wrap">
+				<table className="newspack-insights__table">
+					<thead>
+						<tr>
+							<th scope="col">{ __( 'Campaign', 'newspack-plugin' ) }</th>
+							<th scope="col" className="newspack-insights__table-num">
+								{ __( 'Donations', 'newspack-plugin' ) }
+							</th>
+							<th scope="col" className="newspack-insights__table-num">
+								{ __( 'Revenue', 'newspack-plugin' ) }
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ rows.map( ( row, index ) => (
+							<tr
+								key={ row.is_untagged ? '__untagged__' : `${ index }-${ row.value }` }
+								className={ row.is_untagged ? 'newspack-insights__table-row--untagged' : undefined }
+							>
+								<td>{ row.value }</td>
+								<td className="newspack-insights__table-num">{ formatNumber( row.count ) }</td>
+								<td className="newspack-insights__table-num">{ formatCurrency( row.amount ).display }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</div>
+		</section>
+	);
+};
+
+export default CampaignSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
@@ -32,6 +32,7 @@ const makeWindow = ( over: Partial< DonorsWindow > = {} ): DonorsWindow => ( {
 	lapsed_donor_recovery_rate: { value: 0.1, computable: true, denominator: 30 },
 	recurring_donor_retention: { value: 0.8, computable: true, denominator: 50 },
 	donations_by_tier: [],
+	donations_by_campaign: [],
 	has_window_activity: true,
 	...over,
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for the Subscribers CampaignSection (NEWS-2591): renders the by-campaign
+ * table, pins/mutes the untagged row, and shows the campaign-tagged empty state
+ * when there is nothing tagged (no rows, or only the "(no campaign)" row).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CampaignSection from './CampaignSection';
+import type { SubscribersCampaignRow } from '../../api/subscribers';
+
+const untagged = ( over: Partial< SubscribersCampaignRow > = {} ): SubscribersCampaignRow => ( {
+	value: '(no campaign)',
+	count: 5,
+	amount: 250,
+	is_untagged: true,
+	...over,
+} );
+
+describe( 'Subscribers CampaignSection', () => {
+	it( 'renders tagged campaign rows with count and revenue', () => {
+		const rows: SubscribersCampaignRow[] = [
+			{ value: 'news-sub-drive', count: 9, amount: 900, is_untagged: false },
+			{ value: 'buffer', count: 2, amount: 120, is_untagged: false },
+			untagged(),
+		];
+
+		render( <CampaignSection rows={ rows } /> );
+
+		expect( screen.getByText( 'Subscriptions by campaign' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'news-sub-drive' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'buffer' ) ).toBeInTheDocument();
+		expect( screen.getByText( '(no campaign)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'mutes the untagged row and renders it last', () => {
+		const rows: SubscribersCampaignRow[] = [ { value: 'news-sub-drive', count: 9, amount: 900, is_untagged: false }, untagged() ];
+
+		const { container } = render( <CampaignSection rows={ rows } /> );
+
+		const bodyRows = container.querySelectorAll( 'tbody tr' );
+		expect( bodyRows ).toHaveLength( 2 );
+		const last = bodyRows[ bodyRows.length - 1 ];
+		expect( last ).toHaveClass( 'newspack-insights__table-row--untagged' );
+		expect( last ).toHaveTextContent( '(no campaign)' );
+		expect( bodyRows[ 0 ] ).not.toHaveClass( 'newspack-insights__table-row--untagged' );
+	} );
+
+	it( 'shows the campaign-tagged empty state when there are no rows', () => {
+		render( <CampaignSection rows={ [] } /> );
+
+		expect( screen.getByText( 'No campaign-tagged subscriptions in this window.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when only the untagged row is present', () => {
+		render( <CampaignSection rows={ [ untagged() ] } /> );
+
+		expect( screen.getByText( 'No campaign-tagged subscriptions in this window.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
@@ -1,0 +1,92 @@
+/**
+ * CampaignSection (NEWS-2591) — Subscriptions by campaign.
+ *
+ * New subscriptions in the selected timeframe grouped by the `utm_campaign` on
+ * the initial subscription order (Woo order meta, anonymous-inclusive, no GA4).
+ * Static server-ordered table (ranked count desc), matching the adjacent
+ * "Subscriptions by product" section on this tab — not user-sortable.
+ *
+ * Coverage is the UTM-**tagged** subset only (subscribers who arrived via a
+ * tagged link). Untagged subscriptions collapse into a single trailing
+ * "(no campaign)" row that renders its real count + revenue (a denominator, not
+ * a blank) and is visually de-emphasized. The backend already orders it last.
+ * The empty state fires when there is no data at all OR only the untagged row —
+ * i.e. no campaign-tagged subscriptions in the window.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { SubscribersCampaignRow } from '../../api/subscribers';
+import SectionEmpty from '../components/SectionEmpty';
+import SectionHeading from '../components/SectionHeading';
+import { formatCurrency, formatNumber } from '../components/format';
+
+export interface CampaignSectionProps {
+	rows: SubscribersCampaignRow[];
+}
+
+const HEADING_ID = 'newspack-insights-subscribers-campaign-heading';
+
+const CampaignSection = ( { rows }: CampaignSectionProps ) => {
+	const title = __( 'Subscriptions by campaign', 'newspack-plugin' );
+
+	// Empty when there is nothing tagged to show: no rows at all, or only the
+	// trailing "(no campaign)" untagged row.
+	const hasTagged = rows.some( row => ! row.is_untagged );
+	if ( ! hasTagged ) {
+		return (
+			<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+				<SectionHeading id={ HEADING_ID } title={ title } />
+				<SectionEmpty>{ __( 'No campaign-tagged subscriptions in this window.', 'newspack-plugin' ) }</SectionEmpty>
+			</section>
+		);
+	}
+
+	return (
+		<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+			<SectionHeading
+				id={ HEADING_ID }
+				title={ title }
+				description={ __(
+					'New subscriptions in the selected timeframe grouped by the UTM campaign on the initial order. Covers campaign-tagged subscriptions only; untagged subscriptions are grouped as “(no campaign).”',
+					'newspack-plugin'
+				) }
+			/>
+			<div className="newspack-insights__table-wrap">
+				<table className="newspack-insights__table">
+					<thead>
+						<tr>
+							<th scope="col">{ __( 'Campaign', 'newspack-plugin' ) }</th>
+							<th scope="col" className="newspack-insights__table-num">
+								{ __( 'New subscriptions', 'newspack-plugin' ) }
+							</th>
+							<th scope="col" className="newspack-insights__table-num">
+								{ __( 'Revenue', 'newspack-plugin' ) }
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ rows.map( ( row, index ) => (
+							<tr
+								key={ row.is_untagged ? '__untagged__' : `${ index }-${ row.value }` }
+								className={ row.is_untagged ? 'newspack-insights__table-row--untagged' : undefined }
+							>
+								<td>{ row.value }</td>
+								<td className="newspack-insights__table-num">{ formatNumber( row.count ) }</td>
+								<td className="newspack-insights__table-num">{ formatCurrency( row.amount ).display }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</div>
+		</section>
+	);
+};
+
+export default CampaignSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
@@ -72,12 +72,12 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 						</tr>
 					</thead>
 					<tbody>
-						{ rows.map( ( row, index ) => (
+						{ rows.map( row => (
 							<tr
-								key={ row.is_untagged ? '__untagged__' : `${ index }-${ row.value }` }
+								key={ row.is_untagged ? '__untagged__' : `campaign:${ row.value }` }
 								className={ row.is_untagged ? 'newspack-insights__table-row--untagged' : undefined }
 							>
-								<td>{ row.value }</td>
+								<td>{ row.is_untagged ? __( '(no campaign)', 'newspack-plugin' ) : row.value }</td>
 								<td className="newspack-insights__table-num">{ formatNumber( row.count ) }</td>
 								<td className="newspack-insights__table-num">{ formatCurrency( row.amount ).display }</td>
 							</tr>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -30,6 +30,7 @@ const makeWindow = ( over: Partial< SubscribersWindow > = {} ): SubscribersWindo
 	refund_rate: { value: 0.02, computable: true, denominator: 120 },
 	failed_payment_retry_rate: { value: 0.8, computable: true, denominator: 10 },
 	subscriptions_by_product: [],
+	subscriptions_by_campaign: [],
 	cancellation_reasons: [],
 	has_window_activity: true,
 	...over,

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-campaign-reader.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donation-campaign-reader.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * DB-backed integration tests for the donation campaign reader
+ * (get_donation_campaign_rows) on BOTH storage backends (NEWS-2580).
+ *
+ * Stands up the real WooCommerce order tables (via {@see Insights_Woo_Order_Fixtures})
+ * so the reader SQL runs against actual rows on legacy AND HPOS. Anchor case = the
+ * non-unique `utm_campaign` meta must not inflate: the reader derives one campaign
+ * per order via a correlated MIN() subquery (no JOIN), so a duplicate-meta order
+ * yields ONE row with un-doubled revenue.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Donors_Storage_Interface;
+use Newspack\Insights\HPOS_Donors_Storage;
+use Newspack\Insights\Legacy_Donors_Storage;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Integration tests for the donation campaign reader.
+ *
+ * @group insights
+ */
+class Test_Donation_Campaign_Reader extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Stand up the WC order tables once (InnoDB → per-test inserts roll back).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The reader under test for a backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Donors_Storage_Interface
+	 */
+	private function reader_for( string $backend ): Donors_Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Donors_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Donors_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert an order into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait).
+	 * @return void
+	 */
+	private function insert_order( string $backend, array $args ): void {
+		if ( 'hpos' === $backend ) {
+			$this->insert_hpos_order( $args );
+		} else {
+			$this->insert_legacy_order( $args );
+		}
+	}
+
+	/**
+	 * Run the reader for a window bracketing the fixtures' order dates.
+	 *
+	 * @param string $backend Backend key.
+	 * @return array
+	 */
+	private function run_reader( string $backend ): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return $this->reader_for( $backend )->get_donation_campaign_rows(
+			new DateTimeImmutable( '-15 days', $tz ),
+			new DateTimeImmutable( '+1 day', $tz )
+		);
+	}
+
+	/**
+	 * Sort per-order rows deterministically (no ORDER BY in the reader).
+	 *
+	 * @param array $rows Reader output.
+	 * @return array
+	 */
+	private function sorted( array $rows ): array {
+		usort(
+			$rows,
+			static function ( $a, $b ) {
+				return [ $a['utm_campaign'], $a['revenue'] ] <=> [ $b['utm_campaign'], $b['revenue'] ];
+			}
+		);
+		return $rows;
+	}
+
+	/**
+	 * A tagged donation order yields one row: its campaign + order total.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_tagged_order_row( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6001,
+				'total'     => 100.00,
+				'campaigns' => [ 'spring-drive' ],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'utm_campaign' => 'spring-drive',
+					'revenue'      => 100.00,
+				],
+			],
+			$this->run_reader( $backend )
+		);
+	}
+
+	/**
+	 * An untagged donation order is still emitted, carrying '' so the grouping
+	 * layer can fold it into "(no campaign)".
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_untagged_order_emitted_with_empty_campaign( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6002,
+				'total'     => 50.00,
+				'campaigns' => [],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'utm_campaign' => '',
+					'revenue'      => 50.00,
+				],
+			],
+			$this->run_reader( $backend )
+		);
+	}
+
+	/**
+	 * ANCHOR: non-unique `utm_campaign` meta (two identical rows) must NOT inflate.
+	 * The correlated MIN() subquery yields one campaign per order and there is no
+	 * JOIN, so the order appears once with un-doubled revenue.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_duplicate_campaign_meta_counted_once( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6003,
+				'total'     => 80.00,
+				'campaigns' => [ 'buffer', 'buffer' ],
+			]
+		);
+
+		$result = $this->run_reader( $backend );
+
+		$this->assertCount( 1, $result, 'duplicate meta must not multiply rows' );
+		$this->assertSame( 'buffer', $result[0]['utm_campaign'] );
+		$this->assertSame( 80.00, $result[0]['revenue'], 'revenue must not double' );
+	}
+
+	/**
+	 * Renewal orders (carry `_subscription_renewal`) are excluded; only the initial
+	 * donation is emitted.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_renewal_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6004,
+				'total'     => 40.00,
+				'campaigns' => [ 'x' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6005,
+				'total'     => 25.00,
+				'campaigns' => [ 'x' ],
+				'renewal'   => '9001',
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'utm_campaign' => 'x',
+					'revenue'      => 40.00,
+				],
+			],
+			$this->run_reader( $backend )
+		);
+	}
+
+	/**
+	 * Mixed set: one row per order (tagged + untagged), no grouping at the reader
+	 * layer — the fold groups later.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_emits_one_row_per_order( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6006,
+				'total'     => 10.00,
+				'campaigns' => [ 'alpha' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6007,
+				'total'     => 20.00,
+				'campaigns' => [ 'alpha' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 6008,
+				'total'     => 30.00,
+				'campaigns' => [],
+			]
+		);
+
+		$result = $this->sorted( $this->run_reader( $backend ) );
+
+		$this->assertCount( 3, $result );
+		$this->assertSame( [ '', 'alpha', 'alpha' ], array_column( $result, 'utm_campaign' ) );
+		$this->assertSame( 60.00, array_sum( array_column( $result, 'revenue' ) ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-grouping.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-grouping.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Tests for the shared Insights grouping helper (NEWS-2591 / NEWS-2580).
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Metric_Grouping;
+use WP_UnitTestCase;
+
+/**
+ * Pure-function tests for Metric_Grouping::group_records_by_key().
+ */
+class Test_Metric_Grouping extends WP_UnitTestCase {
+
+	/**
+	 * Groups by key, counts rows, and sums the amount column.
+	 */
+	public function test_groups_and_sums() {
+		$rows = [
+			[
+				'utm_campaign' => 'alpha',
+				'revenue'      => 10.0,
+			],
+			[
+				'utm_campaign' => 'alpha',
+				'revenue'      => 5.0,
+			],
+			[
+				'utm_campaign' => 'beta',
+				'revenue'      => 3.0,
+			],
+		];
+
+		$result = Metric_Grouping::group_records_by_key( $rows, 'utm_campaign', 'revenue' );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'alpha', $result[0]['value'] );
+		$this->assertSame( 2, $result[0]['count'] );
+		$this->assertSame( 15.0, $result[0]['amount'] );
+		$this->assertFalse( $result[0]['is_untagged'] );
+		$this->assertSame( 'beta', $result[1]['value'] );
+		$this->assertSame( 1, $result[1]['count'] );
+		$this->assertSame( 3.0, $result[1]['amount'] );
+	}
+
+	/**
+	 * Default trim() normalization collapses values that differ only by
+	 * surrounding whitespace into a single group.
+	 */
+	public function test_trim_collapses_whitespace_variants() {
+		$rows = [
+			[ 'utm_campaign' => 'buffer' ],
+			[ 'utm_campaign' => 'buffer ' ],
+			[ 'utm_campaign' => ' buffer' ],
+		];
+
+		$result = Metric_Grouping::group_records_by_key( $rows, 'utm_campaign' );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'buffer', $result[0]['value'] );
+		$this->assertSame( 3, $result[0]['count'] );
+	}
+
+	/**
+	 * Whitespace-only values and rows missing the group key route to the
+	 * untagged bucket, which renders last and is flagged is_untagged.
+	 */
+	public function test_untagged_bucket_last_and_flagged() {
+		$rows = [
+			[
+				'utm_campaign' => 'alpha',
+				'revenue'      => 4.0,
+			],
+			[
+				'utm_campaign' => '   ',
+				'revenue'      => 2.0,
+			], // whitespace-only → untagged.
+			[ 'revenue' => 1.0 ],                          // missing key → untagged.
+		];
+
+		$result = Metric_Grouping::group_records_by_key(
+			$rows,
+			'utm_campaign',
+			'revenue',
+			[ 'untagged_label' => '(no campaign)' ]
+		);
+
+		$this->assertCount( 2, $result );
+		// Tagged row first.
+		$this->assertSame( 'alpha', $result[0]['value'] );
+		$this->assertFalse( $result[0]['is_untagged'] );
+		// Untagged row always last, flagged, with the two untagged rows folded in.
+		$last = $result[ count( $result ) - 1 ];
+		$this->assertSame( '(no campaign)', $last['value'] );
+		$this->assertTrue( $last['is_untagged'] );
+		$this->assertSame( 2, $last['count'] );
+		$this->assertSame( 3.0, $last['amount'] );
+	}
+
+	/**
+	 * When no untagged_label is given, untagged rows are dropped entirely.
+	 */
+	public function test_untagged_dropped_when_no_label() {
+		$rows = [
+			[ 'utm_campaign' => 'alpha' ],
+			[ 'utm_campaign' => '' ],
+			[ 'utm_campaign' => '  ' ],
+		];
+
+		$result = Metric_Grouping::group_records_by_key( $rows, 'utm_campaign' );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'alpha', $result[0]['value'] );
+	}
+
+	/**
+	 * Count-only mode (empty amount_key) yields 0.0 amounts.
+	 */
+	public function test_count_only_yields_zero_amounts() {
+		$rows = [
+			[
+				'utm_campaign' => 'alpha',
+				'revenue'      => 99.0,
+			],
+			[
+				'utm_campaign' => 'alpha',
+				'revenue'      => 1.0,
+			],
+		];
+
+		$result = Metric_Grouping::group_records_by_key( $rows, 'utm_campaign', '' );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 2, $result[0]['count'] );
+		$this->assertSame( 0.0, $result[0]['amount'] );
+	}
+
+	/**
+	 * Ranking: count desc, then amount desc, then value asc.
+	 */
+	public function test_sort_order() {
+		$rows = [
+			// count 2, amount 10.
+			[
+				'utm_campaign' => 'x',
+				'revenue'      => 6.0,
+			],
+			[
+				'utm_campaign' => 'x',
+				'revenue'      => 4.0,
+			],
+			// count 2, amount 20 (higher amount → ranks above x on the count tie).
+			[
+				'utm_campaign' => 'y',
+				'revenue'      => 12.0,
+			],
+			[
+				'utm_campaign' => 'y',
+				'revenue'      => 8.0,
+			],
+			// count 3 (ranks first on count).
+			[
+				'utm_campaign' => 'z',
+				'revenue'      => 1.0,
+			],
+			[
+				'utm_campaign' => 'z',
+				'revenue'      => 1.0,
+			],
+			[
+				'utm_campaign' => 'z',
+				'revenue'      => 3.0,
+			],
+		];
+
+		$result = Metric_Grouping::group_records_by_key( $rows, 'utm_campaign', 'revenue' );
+
+		$this->assertSame( [ 'z', 'y', 'x' ], array_column( $result, 'value' ) );
+	}
+
+	/**
+	 * Value-ascending tiebreak when count and amount are equal.
+	 */
+	public function test_value_asc_tiebreak() {
+		$rows = [
+			[
+				'utm_campaign' => 'beta',
+				'revenue'      => 5.0,
+			],
+			[
+				'utm_campaign' => 'alpha',
+				'revenue'      => 5.0,
+			],
+		];
+
+		$result = Metric_Grouping::group_records_by_key( $rows, 'utm_campaign', 'revenue' );
+
+		$this->assertSame( [ 'alpha', 'beta' ], array_column( $result, 'value' ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscription-campaign-reader.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-subscription-campaign-reader.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * DB-backed integration tests for the subscription campaign reader
+ * (get_new_subscription_campaign_rows) on BOTH storage backends (NEWS-2591).
+ *
+ * The subscription twin of {@see Test_Donation_Campaign_Reader}. Mirrors the
+ * scope of get_attributed_subscription_orders (initial non-renewal orders with a
+ * non-donation subscription product) but keyed on `utm_campaign` and WITHOUT the
+ * gate/popup requirement, so untagged subscription orders are emitted too (for
+ * the "(no campaign)" bucket). Non-unique `utm_campaign` meta must not inflate
+ * (correlated MIN, no JOIN); renewals and donation-product orders are excluded.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Integration tests for the subscription campaign reader.
+ *
+ * @group insights
+ */
+class Test_Subscription_Campaign_Reader extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id, created fresh per test.
+	 *
+	 * @var int
+	 */
+	private $sub_product_id;
+
+	/**
+	 * Stand up the WC order tables once (InnoDB → per-test inserts roll back).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Create a non-donation subscription product and the (excluded) donation
+	 * product, both subscription-typed so `subscription_product_ids_sql()` returns
+	 * them and the donation NOT IN filter is exercised.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		if ( ! taxonomy_exists( 'product_type' ) ) {
+			register_taxonomy( 'product_type', 'product' );
+		}
+		$this->sub_product_id = (int) wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Membership',
+			]
+		);
+		wp_set_object_terms( $this->sub_product_id, 'subscription', 'product_type' );
+
+		wp_insert_post(
+			[
+				'import_id'   => self::DONATION_PRODUCT_ID,
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Recurring donation',
+			]
+		);
+		wp_set_object_terms( self::DONATION_PRODUCT_ID, 'subscription', 'product_type' );
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The reader under test for a backend, scoped to exclude the donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function reader_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert an order (defaults product to the subscription product).
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait).
+	 * @return void
+	 */
+	private function insert_order( string $backend, array $args ): void {
+		$args['product_id'] = $args['product_id'] ?? $this->sub_product_id;
+		if ( 'hpos' === $backend ) {
+			$this->insert_hpos_order( $args );
+		} else {
+			$this->insert_legacy_order( $args );
+		}
+	}
+
+	/**
+	 * Run the reader for a window bracketing the fixtures' order dates.
+	 *
+	 * @param string $backend Backend key.
+	 * @return array
+	 */
+	private function run_reader( string $backend ): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return $this->reader_for( $backend )->get_new_subscription_campaign_rows(
+			new DateTimeImmutable( '-15 days', $tz ),
+			new DateTimeImmutable( '+1 day', $tz )
+		);
+	}
+
+	/**
+	 * Sort per-order rows deterministically (no ORDER BY in the reader).
+	 *
+	 * @param array $rows Reader output.
+	 * @return array
+	 */
+	private function sorted( array $rows ): array {
+		usort(
+			$rows,
+			static function ( $a, $b ) {
+				return [ $a['utm_campaign'], $a['revenue'] ] <=> [ $b['utm_campaign'], $b['revenue'] ];
+			}
+		);
+		return $rows;
+	}
+
+	/**
+	 * A tagged subscription order yields one row: its campaign + initial order total.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_tagged_order_row( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7001,
+				'total'     => 120.00,
+				'campaigns' => [ 'news-sub-drive' ],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'utm_campaign' => 'news-sub-drive',
+					'revenue'      => 120.00,
+				],
+			],
+			$this->run_reader( $backend )
+		);
+	}
+
+	/**
+	 * An untagged subscription order is still emitted, carrying '' for the
+	 * "(no campaign)" fold.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_untagged_order_emitted_with_empty_campaign( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7002,
+				'total'     => 60.00,
+				'campaigns' => [],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'utm_campaign' => '',
+					'revenue'      => 60.00,
+				],
+			],
+			$this->run_reader( $backend )
+		);
+	}
+
+	/**
+	 * ANCHOR: non-unique `utm_campaign` meta must NOT inflate (correlated MIN, no
+	 * JOIN) — one row, un-doubled revenue.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_duplicate_campaign_meta_counted_once( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7003,
+				'total'     => 90.00,
+				'campaigns' => [ 'buffer', 'buffer' ],
+			]
+		);
+
+		$result = $this->run_reader( $backend );
+
+		$this->assertCount( 1, $result, 'duplicate meta must not multiply rows' );
+		$this->assertSame( 'buffer', $result[0]['utm_campaign'] );
+		$this->assertSame( 90.00, $result[0]['revenue'], 'revenue must not double' );
+	}
+
+	/**
+	 * Renewal orders are excluded; only the initial subscription order is emitted.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_renewal_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7004,
+				'total'     => 45.00,
+				'campaigns' => [ 'x' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7005,
+				'total'     => 30.00,
+				'campaigns' => [ 'x' ],
+				'renewal'   => '9001',
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'utm_campaign' => 'x',
+					'revenue'      => 45.00,
+				],
+			],
+			$this->run_reader( $backend )
+		);
+	}
+
+	/**
+	 * A donation-product order (subscription-typed, but a recurring donation) is
+	 * excluded — donations belong to the Donors tab, not here.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donation_product_order_excluded( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'   => 7006,
+				'total'      => 200.00,
+				'campaigns'  => [ 'y' ],
+				'product_id' => self::DONATION_PRODUCT_ID,
+			]
+		);
+
+		$this->assertSame( [], $this->run_reader( $backend ) );
+	}
+
+	/**
+	 * Mixed set: one row per initial subscription order (tagged + untagged); the
+	 * fold groups later.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_emits_one_row_per_order( string $backend ): void {
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7007,
+				'total'     => 10.00,
+				'campaigns' => [ 'alpha' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7008,
+				'total'     => 20.00,
+				'campaigns' => [ 'alpha' ],
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'  => 7009,
+				'total'     => 30.00,
+				'campaigns' => [],
+			]
+		);
+
+		$result = $this->sorted( $this->run_reader( $backend ) );
+
+		$this->assertCount( 3, $result );
+		$this->assertSame( [ '', 'alpha', 'alpha' ], array_column( $result, 'utm_campaign' ) );
+		$this->assertSame( 60.00, array_sum( array_column( $result, 'revenue' ) ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
@@ -113,6 +113,9 @@ trait Insights_Woo_Order_Fixtures {
 		foreach ( (array) ( $args['gate_ids'] ?? [] ) as $gid ) {
 			add_post_meta( $order_id, '_gate_post_id', $gid ); // unique = false → duplicates allowed (NPPD-1746).
 		}
+		foreach ( (array) ( $args['campaigns'] ?? [] ) as $campaign ) {
+			add_post_meta( $order_id, 'utm_campaign', $campaign ); // unique = false → non-unique meta (NEWS-2591).
+		}
 		if ( isset( $args['total'] ) ) {
 			add_post_meta( $order_id, '_order_total', $args['total'] );
 		}
@@ -166,6 +169,16 @@ trait Insights_Woo_Order_Fixtures {
 					'order_id'   => $order_id,
 					'meta_key'   => '_gate_post_id',
 					'meta_value' => $gid,
+				]
+			);
+		}
+		foreach ( (array) ( $args['campaigns'] ?? [] ) as $campaign ) {
+			$wpdb->insert(
+				"{$p}wc_orders_meta",
+				[
+					'order_id'   => $order_id,
+					'meta_key'   => 'utm_campaign',
+					'meta_value' => $campaign,
 				]
 			);
 		}


### PR DESCRIPTION
## What

Adds two new Insights tables, both grouping the window's new conversions by the `utm_campaign` on the Woo order — anonymous-inclusive, Woo-only (no GA4, no hub, no BigQuery):

- **Subscribers tab → "Subscriptions by campaign"**
- **Donors tab → "Donations by campaign"**

Closes NEWS-2591
Closes NEWS-2580

## How

- **Shared helper** `Metric_Grouping::group_records_by_key()` — a pure, unit-tested fold (group → count + sum revenue, trailing "(no campaign)" bucket, ranked count desc). Used by **both** verticals; only the storage reader differs.
- **Storage readers, per store** (routed by `Storage_Detector`): HPOS reads `wc_orders_meta` via a correlated `MIN()` subquery (`utm_campaign` is written non-unique, so a JOIN would inflate COUNT/SUM), legacy reads `wp_postmeta`. Scoped to **initial** completed/processing orders — renewals excluded (`_subscription_renewal`); donation-products excluded from the subscription set. Revenue = **initial order total** (not recurring/MRR).
  - Donations reader mirrors `get_prompt_attributed_donation_conversions` (NPPD-1685).
  - Subscriptions reader mirrors `get_attributed_subscription_orders` (NPPD-1746) — the initial-order, revenue-bearing twin — minus its gate/popup requirement, so untagged orders are emitted for the "(no campaign)" bucket.
- **Frontend**: static tables matching the adjacent "by product" / "by tier" sections (no client sort). The "(no campaign)" row renders its real count + revenue (a denominator, not a blank), muted and pinned last (backend already orders it last). Empty state fires when the window has no data **or** only the untagged row.

## Intentional non-reconciliation (please note in review)

Both tables count **orders**, not people, so their totals **intentionally do not match** the "New subscribers" / "New donors" scorecards: a reader who starts a second subscription, resubscribes after churning, or makes a repeat gift is counted again. This is an order/attribution view — the same relationship the attributed-conversion metrics have to their person counts. Documented in the tab-6 / tab-7 formula docs (`newspack-insights` repo).

Coverage is the **UTM-tagged subset** only (buyers who arrived via a tagged link); "(no campaign)" ≠ "direct."

## Deviations from the original issue spec
- **`METRIC_SOURCES` omitted** — it's a hub-tab (`tab_error`) construct; Donors/Subscribers are local-only and have no such registry.
- **No shared `SortableTable`** — matched the existing static per-tab tables instead; untagged-last is guaranteed by backend ordering.

## Testing
- **PHP: 57 tests / 127 assertions green** — `Metric_Grouping`; donation + subscription campaign readers on **both** backends; plus the existing attributed-subscription & prompt-attributed-donation readers as regression (the additive `campaigns` test-fixture arg is backward-compatible). PHPCS (workspace-root standard) clean.
- **Frontend: 4 suites / 24 tests green**, tsc clean on all changed source files.

## ⚠️ First canonical CI run of the JS tests — watch it
The local `newspack-scripts test` wrapper is currently broken (`babelJestTransformer` → `Cannot find module 'babel-jest'` under pnpm; it also swallows `--ci`/`--testPathPattern`). I ran the JS suites via a **hand-matched jest config** mirroring the canonical one (swapped transform to wp-scripts `babel-transform`, scss→stub). They pass there — but **this PR is the first time they run under real CI**, so please watch the JS check rather than assume it's green.

Note: the **HPOS** storage readers are unverified against live HPOS data (every reachable publisher is legacy-authoritative) — they're structural mirrors of the proven legacy queries + the existing HPOS readers, exercised by the DDL integration tests. Same posture as the NPPD-1685/1746 HPOS readers.

## Docs
`newspack-insights` formulas updated (tab-6, tab-7) + the non-reconciliation note — pushed to trunk.