### PR TITLE
fix(insights): relabel engaged reader columns to "Engaged readers"

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -39,7 +39,7 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 					emptyMessage={ __( 'No article engagement data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
 						ARTICLE_COL,
-						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
 						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
 					] }
 				/>
@@ -63,7 +63,7 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 					emptyMessage={ __( 'No author engagement data in this timeframe.', 'newspack-plugin' ) }
 					columns={ [
 						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
-						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
 						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
 					] }
 				/>


### PR DESCRIPTION
## What

Relabels the **Readers** column header to **Engaged readers** on two Insights › Engagement tab tables:

1. **Most-Engaged Articles**
2. **Top Authors by Avg Engagement Time**

## Why

Both tables' reader counts are engaged-scope — the underlying BigQuery builders (`build_most_read_articles` and `build_top_authors_by_avg_engagement_time`) both gate on `engagement_time_msec > 0`, so the number is "distinct readers who spent engaged time," not all openers. The bare "Readers" label understated that and didn't foot with raw pageview counts.

Pairs with the manager-admin fix that corrects `build_most_read_articles` to read engagement time from `user_engagement` rows (Automattic/newspack-manager-admin#477), which is what makes the Most-Engaged Articles count engaged-scope.

## Not changed

- **Articles by Completion Rate** keeps its **Readers** header — it's `page_view` scope (all openers), a different definition, being hidden under a separate change. Each of the three tables defines its column label inline in `ContentEngagementSection.tsx`, so this touches only the two intended tables (verified the completion table's header is unchanged).
- No "Readers" labels on other tabs (Audience, etc.) touched.

## Verification

- `EngagementTab.test.tsx` runs green (3/3); the "renders sections" case exercises `ContentEngagementSection`. No test or snapshot asserts these table headers, so nothing to regenerate.
- wp-prettier `--check` clean. Uses sentence case + `__( 'Engaged readers', 'newspack-plugin' )`.

Layout note: table `th` is uppercase with no `white-space: nowrap`, so "ENGAGED READERS" can wrap at narrow widths (values are narrow numerics, so the header sets column width). Not pixel-verified in a live render; low severity if it does wrap.