### PR TITLE
fix(insights): temporarily hide completion-rate card and table

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.test.tsx
@@ -66,6 +66,43 @@ describe( 'EngagementTab', () => {
 		expect( screen.getByText( '3.2' ) ).toBeInTheDocument();
 	} );
 
+	it( 'hides the completion-rate card and table while keeping the other metrics (SHOW_COMPLETION_METRICS=false)', () => {
+		// Populate every quality metric so each Scorecard would render if not hidden
+		// (Scorecard returns null when its field is absent).
+		const metric = { value: 1, computable: true, type: 'decimal' };
+		mockHook.mockReturnValue( {
+			status: 'success',
+			error: null,
+			refetch: () => {},
+			data: {
+				current: {
+					avg_pages_per_session: metric,
+					avg_engaged_session_duration: metric,
+					bounce_rate: metric,
+					article_completion_rate: metric,
+				},
+				previous: null,
+			},
+			computedAt: '2026-06-10T18:42:13Z',
+			source: 'external',
+			cooldownUntil: null,
+		} );
+
+		render( <EngagementTab range={ range } previousRange={ null } /> );
+
+		// The three non-completion quality cards still render.
+		expect( screen.getByText( 'Avg Pages per Session' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Avg Engaged Session Duration' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Bounce Rate' ) ).toBeInTheDocument();
+		// The two remaining content tables still render.
+		expect( screen.getByText( 'Most-Engaged Articles' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Authors by Avg Engagement Time' ) ).toBeInTheDocument();
+
+		// The completion-rate card and table are hidden.
+		expect( screen.queryByText( 'Completion Rate' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Articles by Completion Rate' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'suppresses comparison deltas when the toggle is off (no previousRange)', () => {
 		mockHook.mockReturnValue( {
 			status: 'success',

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Engagement tab feature flags.
+ */
+
+/**
+ * Completion-rate metrics — the "Completion rate" quality card and the
+ * "Articles by Completion Rate" table — are derived from GA4 scroll depth
+ * (the `scroll` event + percent_scrolled >= 90). The Newspack-owned GA4
+ * property feeding the BigQuery source does not collect scroll, so both
+ * metrics are structurally 0 until that data flows.
+ *
+ * TEMPORARY: hide them (card + table) until scroll data lands. Flip this one
+ * flag to `true` to restore both. Nothing else is removed — the components,
+ * hook fields, orchestrator wiring, and hub builders all stay in place.
+ */
+export const SHOW_COMPLETION_METRICS: boolean = false;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 import type { InsightsWindow } from '../../../api/audience';
 import MetricTable from '../../components/MetricTable';
 import SectionHeading from '../../components/SectionHeading';
+import { SHOW_COMPLETION_METRICS } from '../constants';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -28,9 +29,10 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 			title={ __( 'Content engagement', 'newspack-plugin' ) }
 			description={ __( 'What holds reader attention.', 'newspack-plugin' ) }
 		/>
-		{ /* 2-col grid: Most-Read + Completion Rate share row 1; Top Authors wraps
-		     to row 2, occupying one column (~50%, left-aligned) so 10-row tables
-		     have width and the third doesn't stretch full-width. */ }
+		{ /* 2-col grid. With completion shown: Most-Engaged + Completion share row 1
+		     and Top Authors wraps to row 2 (one column, ~50%, left-aligned). With
+		     completion hidden (SHOW_COMPLETION_METRICS=false) the two remaining
+		     tables fill row 1 as a clean 2-up — no full-width stretch. */ }
 		<div className="newspack-insights__table-grid newspack-insights__table-grid--cols-2">
 			<div>
 				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-Engaged Articles', 'newspack-plugin' ) }</h3>
@@ -44,18 +46,21 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 					] }
 				/>
 			</div>
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by Completion Rate', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.articles_by_completion_rate }
-					emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
-					columns={ [
-						ARTICLE_COL,
-						{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					] }
-				/>
-			</div>
+			{ /* Completion is GA4-scroll-derived; hidden until scroll data flows. See ../constants. */ }
+			{ SHOW_COMPLETION_METRICS && (
+				<div>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by Completion Rate', 'newspack-plugin' ) }</h3>
+					<MetricTable
+						payload={ current.articles_by_completion_rate }
+						emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
+						columns={ [
+							ARTICLE_COL,
+							{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+							{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						] }
+					/>
+				</div>
+			) }
 			<div>
 				<h3 className="newspack-insights__chart-card-title">{ __( 'Top Authors by Avg Engagement Time', 'newspack-plugin' ) }</h3>
 				<MetricTable

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 import type { InsightsWindow } from '../../../api/audience';
 import Scorecard from '../../components/Scorecard';
 import SectionHeading from '../../components/SectionHeading';
+import { SHOW_COMPLETION_METRICS } from '../constants';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -33,7 +34,9 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 			description={ __( 'How deeply readers engage.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid">
+		{ /* Drop to 3 even columns when the completion card is hidden so the row
+		     doesn't leave a trailing gap under the base auto-fill grid. */ }
+		<div className={ `newspack-insights__metric-grid${ SHOW_COMPLETION_METRICS ? '' : ' newspack-insights__metric-grid--cols-3' }` }>
 			<Scorecard
 				label={ __( 'Avg Pages per Session', 'newspack-plugin' ) }
 				description={ __( 'Pages viewed per visit', 'newspack-plugin' ) }
@@ -53,16 +56,19 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 				previous={ previous?.bounce_rate }
 				lowerIsBetter
 			/>
-			<Scorecard
-				label={ __( 'Completion Rate', 'newspack-plugin' ) }
-				description={
-					// "% of page views read to the end" is literal copy; the "%" is a percent sign, not a format placeholder.
-					// eslint-disable-next-line @wordpress/i18n-translator-comments
-					__( '% of page views read to the end', 'newspack-plugin' )
-				}
-				current={ current.article_completion_rate }
-				previous={ previous?.article_completion_rate }
-			/>
+			{ /* Completion rate is GA4-scroll-derived; hidden until scroll data flows. See ../constants. */ }
+			{ SHOW_COMPLETION_METRICS && (
+				<Scorecard
+					label={ __( 'Completion Rate', 'newspack-plugin' ) }
+					description={
+						// "% of page views read to the end" is literal copy; the "%" is a percent sign, not a format placeholder.
+						// eslint-disable-next-line @wordpress/i18n-translator-comments
+						__( '% of page views read to the end', 'newspack-plugin' )
+					}
+					current={ current.article_completion_rate }
+					previous={ previous?.article_completion_rate }
+				/>
+			) }
 		</div>
 	</section>
 );


### PR DESCRIPTION
## What

Temporarily hides the two completion-rate visualizations on the Insights › Engagement tab, behind a single flag:

1. The **Completion rate** KPI card (4th card in "Overall engagement quality") — `QualitySection.tsx`, backed by `article_completion_rate`.
2. The **Articles by Completion Rate** table (in "Content engagement") — `ContentEngagementSection.tsx`, backed by `articles_by_completion_rate`.

## Why

Completion is derived from GA4 scroll (the `scroll` event + `percent_scrolled >= 90`). The Newspack-owned GA4 property feeding the BigQuery source doesn't collect scroll, so both metrics are structurally 0 until that data flows. This hides them — it does not touch the data layer.

## How

- New `engagement/constants.ts` exports `SHOW_COMPLETION_METRICS = false` (typed `: boolean` so the render branches aren't treated as dead code), with a comment explaining the scroll dependency and that it's temporary.
- Both section files reference that one flag to conditionally render nothing for the card and the table. **One switch to flip when data lands.**
- Nothing deleted — the JSX, hook fields (`article_completion_rate`, `articles_by_completion_rate`), orchestrator wiring, and hub builders all stay in place.

## Layout

- **QualitySection 4 → 3 cards:** the base `metric-grid` is `auto-fill minmax(220px,1fr)`, which keeps empty tracks (→ trailing gap). Conditionally applies the existing `--cols-3` modifier when completion is hidden so the three cards fill evenly; reverts to the base grid when the flag is `true`.
- **ContentEngagementSection 3 → 2 tables:** it's a `--cols-2` grid, so the two remaining tables (Most-Engaged Articles + Top Authors) fill row 1 as a clean 2-up — no orphan, no CSS change.

## Verification

- Engagement tab tests green (8/8). Added a test asserting the 3 remaining Quality cards (Avg Pages per Session, Avg Engaged Session Duration, Bounce Rate) and 2 remaining tables (Most-Engaged Articles, Top Authors by Avg Engagement Time) render, and the Completion Rate card + Articles by Completion Rate table do not. (No snapshots exist for these components, so none to regenerate.)
- `newspack-plugin` webpack build clean; `tsc` reports zero errors in the touched source files; wp-prettier clean.