### PR TITLE
feat(insights): export current tab data as JSON

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
@@ -105,11 +105,12 @@ describe( 'LastUpdated', () => {
 		const origRevokeObjectURL = URL.revokeObjectURL;
 		let downloadName = '';
 		let capturedBlob: Blob | null = null;
-		( global.URL as any ).createObjectURL = jest.fn( ( blob: Blob ) => {
+		const urlMock = global.URL as unknown as { createObjectURL: typeof URL.createObjectURL; revokeObjectURL: typeof URL.revokeObjectURL };
+		urlMock.createObjectURL = jest.fn( ( blob: Blob ) => {
 			capturedBlob = blob;
 			return 'blob:mock';
 		} );
-		( global.URL as any ).revokeObjectURL = jest.fn( () => undefined );
+		urlMock.revokeObjectURL = jest.fn( () => undefined );
 		const clickSpy = jest.spyOn( HTMLAnchorElement.prototype, 'click' ).mockImplementation( function ( this: HTMLAnchorElement ) {
 			downloadName = this.download;
 		} );
@@ -128,8 +129,9 @@ describe( 'LastUpdated', () => {
 		expect( downloadName ).toBe( '2026-06-10-engagement-last-30-days.json' );
 		expect( capturedBlob ).not.toBeNull();
 
-		( global.URL as any ).createObjectURL = origCreateObjectURL;
-		( global.URL as any ).revokeObjectURL = origRevokeObjectURL;
+		const urlRestoreMock = global.URL as unknown as { createObjectURL: typeof URL.createObjectURL; revokeObjectURL: typeof URL.revokeObjectURL };
+		urlRestoreMock.createObjectURL = origCreateObjectURL;
+		urlRestoreMock.revokeObjectURL = origRevokeObjectURL;
 		clickSpy.mockRestore();
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
@@ -115,24 +115,32 @@ describe( 'LastUpdated', () => {
 			downloadName = this.download;
 		} );
 
-		seedSlot( 'engagement', {
-			status: 'success',
-			computedAt: '2026-06-10T18:42:13Z',
-			data: { current: { views: 5 } },
-		} );
+		// try/finally so a failed assertion still restores the mutated URL
+		// globals and the click spy — otherwise a throw here would leak them
+		// into later tests in the same worker.
+		try {
+			seedSlot( 'engagement', {
+				status: 'success',
+				computedAt: '2026-06-10T18:42:13Z',
+				data: { current: { views: 5 } },
+			} );
 
-		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
-		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
-		fireEvent.click( screen.getByRole( 'menuitem', { name: /export json/i } ) );
+			render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
+			fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
+			fireEvent.click( screen.getByRole( 'menuitem', { name: /export json/i } ) );
 
-		expect( clickSpy ).toHaveBeenCalledTimes( 1 );
-		expect( downloadName ).toBe( '2026-06-10-engagement-last-30-days.json' );
-		expect( capturedBlob ).not.toBeNull();
-
-		const urlRestoreMock = global.URL as unknown as { createObjectURL: typeof URL.createObjectURL; revokeObjectURL: typeof URL.revokeObjectURL };
-		urlRestoreMock.createObjectURL = origCreateObjectURL;
-		urlRestoreMock.revokeObjectURL = origRevokeObjectURL;
-		clickSpy.mockRestore();
+			expect( clickSpy ).toHaveBeenCalledTimes( 1 );
+			expect( downloadName ).toBe( '2026-06-10-engagement-last-30-days.json' );
+			expect( capturedBlob ).not.toBeNull();
+		} finally {
+			const urlRestoreMock = global.URL as unknown as {
+				createObjectURL: typeof URL.createObjectURL;
+				revokeObjectURL: typeof URL.revokeObjectURL;
+			};
+			urlRestoreMock.createObjectURL = origCreateObjectURL;
+			urlRestoreMock.revokeObjectURL = origRevokeObjectURL;
+			clickSpy.mockRestore();
+		}
 	} );
 
 	it( 'disables Export JSON while the slot is loading', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.test.tsx
@@ -96,4 +96,58 @@ describe( 'LastUpdated', () => {
 		const item = screen.getByRole( 'menuitem', { name: /save as pdf/i } );
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
+
+	it( 'exports JSON with a computedAt+tab+preset filename on Export JSON', () => {
+		// jsdom does not implement URL.createObjectURL / URL.revokeObjectURL, so
+		// jest.spyOn would throw (can't spy on undefined). Assign directly and
+		// save/restore to prevent cross-suite pollution.
+		const origCreateObjectURL = URL.createObjectURL;
+		const origRevokeObjectURL = URL.revokeObjectURL;
+		let downloadName = '';
+		let capturedBlob: Blob | null = null;
+		( global.URL as any ).createObjectURL = jest.fn( ( blob: Blob ) => {
+			capturedBlob = blob;
+			return 'blob:mock';
+		} );
+		( global.URL as any ).revokeObjectURL = jest.fn( () => undefined );
+		const clickSpy = jest.spyOn( HTMLAnchorElement.prototype, 'click' ).mockImplementation( function ( this: HTMLAnchorElement ) {
+			downloadName = this.download;
+		} );
+
+		seedSlot( 'engagement', {
+			status: 'success',
+			computedAt: '2026-06-10T18:42:13Z',
+			data: { current: { views: 5 } },
+		} );
+
+		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /export json/i } ) );
+
+		expect( clickSpy ).toHaveBeenCalledTimes( 1 );
+		expect( downloadName ).toBe( '2026-06-10-engagement-last-30-days.json' );
+		expect( capturedBlob ).not.toBeNull();
+
+		( global.URL as any ).createObjectURL = origCreateObjectURL;
+		( global.URL as any ).revokeObjectURL = origRevokeObjectURL;
+		clickSpy.mockRestore();
+	} );
+
+	it( 'disables Export JSON while the slot is loading', () => {
+		seedSlot( 'engagement', { status: 'loading', computedAt: '2026-06-10T18:42:13Z', data: { a: 1 } } );
+
+		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
+		const item = screen.getByRole( 'menuitem', { name: /export json/i } );
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'disables Export JSON when the slot has no data', () => {
+		seedSlot( 'engagement', { status: 'success', computedAt: '2026-06-10T18:42:13Z', data: null } );
+
+		render( <LastUpdated tab="engagement" range={ range } previousRange={ null } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /options/i } ) );
+		const item = screen.getByRole( 'menuitem', { name: /export json/i } );
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -23,6 +23,7 @@ import { insightsCache, makeSlotKey, type CacheSlot } from '../state/insightsCac
 import { useInvokeRefresh } from '../state/refreshRegistry';
 import useCountdown from '../hooks/useCountdown';
 import { buildPdfFilename, printCurrentTab } from '../lib/pdfExport';
+import { buildJsonFilename, downloadJson } from '../lib/jsonExport';
 
 export interface LastUpdatedProps {
 	tab: string | null;
@@ -55,7 +56,9 @@ const LastUpdated = ( { tab, range, previousRange }: LastUpdatedProps ) => {
 	// expires — even if the slot itself hasn't mutated since.
 	const cooldownActive = useCountdown( slot.cooldownUntil ) !== null;
 
-	if ( ! tab || ! slot.computedAt ) {
+	const { computedAt } = slot;
+
+	if ( ! tab || ! computedAt ) {
 		return null;
 	}
 
@@ -65,7 +68,7 @@ const LastUpdated = ( { tab, range, previousRange }: LastUpdatedProps ) => {
 				{ sprintf(
 					/* translators: %s is a formatted timestamp */
 					__( 'Last updated: %s', 'newspack-plugin' ),
-					dateI18n( 'M j, Y H:i:s', slot.computedAt )
+					dateI18n( 'M j, Y H:i:s', computedAt )
 				) }
 			</span>
 			<RefreshMenu
@@ -73,6 +76,8 @@ const LastUpdated = ( { tab, range, previousRange }: LastUpdatedProps ) => {
 				disabled={ slot.status === 'loading' || cooldownActive }
 				onDownloadPdf={ () => printCurrentTab( buildPdfFilename( tab, range ) ) }
 				downloadDisabled={ slot.status === 'loading' }
+				onDownloadJson={ () => downloadJson( buildJsonFilename( tab, range.preset, computedAt ), slot.data ) }
+				jsonDisabled={ slot.status === 'loading' || ! slot.data }
 			/>
 		</div>
 	);

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -2,7 +2,7 @@
  * LastUpdated
  *
  * Renders the active tab's cache freshness ("Last updated: …") plus a
- * kebab DropdownMenu with a "Refresh now" item. Reads the active tab's
+ * kebab DropdownMenu with Refresh now, Print / Save as PDF…, and Export JSON… items. Reads the active tab's
  * cache slot via insightsCache; fires the registered refresh callback
  * via RefreshRegistry.
  */

--- a/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/LastUpdated.tsx
@@ -2,9 +2,9 @@
  * LastUpdated
  *
  * Renders the active tab's cache freshness ("Last updated: …") plus a
- * kebab DropdownMenu with Refresh now, Print / Save as PDF…, and Export JSON… items. Reads the active tab's
- * cache slot via insightsCache; fires the registered refresh callback
- * via RefreshRegistry.
+ * kebab DropdownMenu with Refresh now, Print / Save as PDF…, and
+ * Export JSON… items. Reads the active tab's cache slot via
+ * insightsCache; fires the registered refresh callback via RefreshRegistry.
  */
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/components/RefreshMenu.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/RefreshMenu.tsx
@@ -1,6 +1,6 @@
 /**
  * RefreshMenu — the "Insights options" header kebab dropdown. Holds
- * "Refresh now" and "Print / Save as PDF…" (NPPD-1661).
+ * "Refresh now", "Print / Save as PDF…" (NPPD-1661), and "Export JSON…".
  */
 
 /**
@@ -17,9 +17,13 @@ export interface RefreshMenuProps {
 	onDownloadPdf: () => void;
 	/** Disable the export while the tab is still loading its data. */
 	downloadDisabled: boolean;
+	/** Trigger the per-tab JSON export (Blob download). */
+	onDownloadJson: () => void;
+	/** Disable the JSON export while the tab is loading or has no data. */
+	jsonDisabled: boolean;
 }
 
-const RefreshMenu = ( { onRefresh, disabled, onDownloadPdf, downloadDisabled }: RefreshMenuProps ) => (
+const RefreshMenu = ( { onRefresh, disabled, onDownloadPdf, downloadDisabled, onDownloadJson, jsonDisabled }: RefreshMenuProps ) => (
 	<DropdownMenu
 		icon={ moreVertical }
 		label={ __( 'Insights options', 'newspack-plugin' ) }
@@ -34,6 +38,11 @@ const RefreshMenu = ( { onRefresh, disabled, onDownloadPdf, downloadDisabled }: 
 				title: __( 'Print / Save as PDF…', 'newspack-plugin' ),
 				onClick: onDownloadPdf,
 				isDisabled: downloadDisabled,
+			},
+			{
+				title: __( 'Export JSON…', 'newspack-plugin' ),
+				onClick: onDownloadJson,
+				isDisabled: jsonDisabled,
 			},
 		] }
 	/>

--- a/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.test.ts
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { buildJsonFilename } from './jsonExport';
+import { buildJsonFilename, downloadJson } from './jsonExport';
 
 describe( 'buildJsonFilename', () => {
 	const computedAt = '2026-07-01T09:30:00Z';
@@ -34,5 +34,75 @@ describe( 'buildJsonFilename', () => {
 
 	it( 'renders the date in site time (UTC in tests) from the computedAt timestamp', () => {
 		expect( buildJsonFilename( 'donors', 'last-30', '2026-12-31T23:59:59Z' ) ).toBe( '2026-12-31-donors-last-30-days.json' );
+	} );
+} );
+
+describe( 'downloadJson', () => {
+	let createObjectURL: jest.Mock;
+	let revokeObjectURL: jest.Mock;
+	let clickSpy: jest.SpyInstance;
+	let capturedBlob: Blob | null;
+
+	// jsdom does not implement URL.createObjectURL / URL.revokeObjectURL, so
+	// jest.spyOn would throw (can't spy on undefined). We assign them directly
+	// and save/restore around each test to prevent cross-suite pollution.
+	let origCreateObjectURL: typeof URL.createObjectURL;
+	let origRevokeObjectURL: typeof URL.revokeObjectURL;
+
+	beforeEach( () => {
+		capturedBlob = null;
+		origCreateObjectURL = URL.createObjectURL;
+		origRevokeObjectURL = URL.revokeObjectURL;
+
+		createObjectURL = jest.fn( ( blob: Blob ) => {
+			capturedBlob = blob;
+			return 'blob:mock-url';
+		} );
+		revokeObjectURL = jest.fn( () => undefined );
+		( global.URL as any ).createObjectURL = createObjectURL;
+		( global.URL as any ).revokeObjectURL = revokeObjectURL;
+		clickSpy = jest.spyOn( HTMLAnchorElement.prototype, 'click' ).mockImplementation( () => undefined );
+	} );
+
+	afterEach( () => {
+		clickSpy.mockRestore();
+		// Restore URL globals so later suites in the same worker are not polluted.
+		( global.URL as any ).createObjectURL = origCreateObjectURL;
+		( global.URL as any ).revokeObjectURL = origRevokeObjectURL;
+	} );
+
+	it( 'triggers a download with the given filename', () => {
+		let downloadName = '';
+		clickSpy.mockImplementation( function ( this: HTMLAnchorElement ) {
+			downloadName = this.download;
+		} );
+
+		downloadJson( 'audience-export.json', { a: 1 } );
+
+		expect( clickSpy ).toHaveBeenCalledTimes( 1 );
+		expect( downloadName ).toBe( 'audience-export.json' );
+	} );
+
+	it( 'writes pretty-printed JSON of the data into an application/json blob', async () => {
+		const data = { current: { views: 10 }, previous: null };
+		downloadJson( 'x.json', data );
+
+		expect( capturedBlob ).not.toBeNull();
+		expect( capturedBlob!.type ).toBe( 'application/json' );
+
+		// jsdom does not implement Blob.prototype.text(), so read via FileReader.
+		const text = await new Promise< string >( ( resolve, reject ) => {
+			const reader = new FileReader();
+			reader.onload = () => resolve( reader.result as string );
+			reader.onerror = () => reject( reader.error );
+			reader.readAsText( capturedBlob! );
+		} );
+		expect( text ).toBe( JSON.stringify( data, null, 2 ) );
+	} );
+
+	it( 'revokes the object URL it created', () => {
+		downloadJson( 'x.json', { a: 1 } );
+		expect( createObjectURL ).toHaveBeenCalledTimes( 1 );
+		expect( revokeObjectURL ).toHaveBeenCalledWith( 'blob:mock-url' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for the JSON export helpers (NEWS-2587).
+ */
+
+/**
+ * Internal dependencies
+ */
+import { buildJsonFilename } from './jsonExport';
+
+describe( 'buildJsonFilename', () => {
+	const computedAt = '2026-07-01T09:30:00Z';
+
+	it( 'builds <computedAt date>-<tab>-<presetSlug>.json for a last-N preset', () => {
+		expect( buildJsonFilename( 'engagement', 'last-7', computedAt ) ).toBe( '2026-07-01-engagement-last-7-days.json' );
+	} );
+
+	it( 'uses "custom-dates" for the custom preset', () => {
+		expect( buildJsonFilename( 'engagement', 'custom', computedAt ) ).toBe( '2026-07-01-engagement-custom-dates.json' );
+	} );
+
+	it( 'maps every preset to its filename slug', () => {
+		const cases: Array< [ Parameters< typeof buildJsonFilename >[ 1 ], string ] > = [
+			[ 'last-7', 'last-7-days' ],
+			[ 'last-30', 'last-30-days' ],
+			[ 'last-90', 'last-90-days' ],
+			[ 'this-month', 'this-month' ],
+			[ 'last-month', 'last-month' ],
+			[ 'custom', 'custom-dates' ],
+		];
+		cases.forEach( ( [ preset, slug ] ) => {
+			expect( buildJsonFilename( 'audience', preset, computedAt ) ).toBe( `2026-07-01-audience-${ slug }.json` );
+		} );
+	} );
+
+	it( 'renders the date in site time (UTC in tests) from the computedAt timestamp', () => {
+		expect( buildJsonFilename( 'donors', 'last-30', '2026-12-31T23:59:59Z' ) ).toBe( '2026-12-31-donors-last-30-days.json' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.test.ts
@@ -59,16 +59,18 @@ describe( 'downloadJson', () => {
 			return 'blob:mock-url';
 		} );
 		revokeObjectURL = jest.fn( () => undefined );
-		( global.URL as any ).createObjectURL = createObjectURL;
-		( global.URL as any ).revokeObjectURL = revokeObjectURL;
+		const urlMock = global.URL as unknown as { createObjectURL: typeof URL.createObjectURL; revokeObjectURL: typeof URL.revokeObjectURL };
+		urlMock.createObjectURL = createObjectURL;
+		urlMock.revokeObjectURL = revokeObjectURL;
 		clickSpy = jest.spyOn( HTMLAnchorElement.prototype, 'click' ).mockImplementation( () => undefined );
 	} );
 
 	afterEach( () => {
 		clickSpy.mockRestore();
 		// Restore URL globals so later suites in the same worker are not polluted.
-		( global.URL as any ).createObjectURL = origCreateObjectURL;
-		( global.URL as any ).revokeObjectURL = origRevokeObjectURL;
+		const urlMock = global.URL as unknown as { createObjectURL: typeof URL.createObjectURL; revokeObjectURL: typeof URL.revokeObjectURL };
+		urlMock.createObjectURL = origCreateObjectURL;
+		urlMock.revokeObjectURL = origRevokeObjectURL;
 	} );
 
 	it( 'triggers a download with the given filename', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.ts
@@ -56,7 +56,13 @@ export const downloadJson = ( filename: string, data: unknown ): void => {
 	anchor.href = url;
 	anchor.download = filename;
 	document.body.appendChild( anchor );
-	anchor.click();
-	document.body.removeChild( anchor );
-	URL.revokeObjectURL( url );
+	// Guarantee the anchor is detached and the object URL is revoked even if
+	// click() throws (e.g. a patched click in an embedded webview), so we
+	// never strand a DOM node or leak the object URL.
+	try {
+		anchor.click();
+	} finally {
+		document.body.removeChild( anchor );
+		URL.revokeObjectURL( url );
+	}
 };

--- a/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.ts
@@ -39,3 +39,24 @@ const PRESET_SLUG: Record< DateRangePreset, string > = {
  */
 export const buildJsonFilename = ( tab: string, preset: DateRangePreset, computedAt: string ): string =>
 	`${ dateI18n( 'Y-m-d', computedAt ) }-${ tab }-${ PRESET_SLUG[ preset ] }.json`;
+
+/**
+ * Serialize `data` as pretty-printed JSON and trigger a browser download
+ * under `filename`. Uses a Blob object URL + a transient `<a download>`
+ * click (no dependency, works across supported browsers). No-ops in
+ * non-DOM environments (SSR / unit tests without a document).
+ */
+export const downloadJson = ( filename: string, data: unknown ): void => {
+	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
+		return;
+	}
+	const blob = new Blob( [ JSON.stringify( data, null, 2 ) ], { type: 'application/json' } );
+	const url = URL.createObjectURL( blob );
+	const anchor = document.createElement( 'a' );
+	anchor.href = url;
+	anchor.download = filename;
+	document.body.appendChild( anchor );
+	anchor.click();
+	document.body.removeChild( anchor );
+	URL.revokeObjectURL( url );
+};

--- a/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/lib/jsonExport.ts
@@ -1,0 +1,41 @@
+/**
+ * JSON export helpers (NEWS-2587).
+ *
+ * The Insights "Export JSON…" export ships the currently viewed tab's
+ * `data` payload (the `data` key of its cache envelope) as a downloaded
+ * `.json` file. The suggested filename encodes the data's computed-at
+ * date, the tab slug, and the active date-range preset so exports are
+ * self-describing, e.g. `2026-07-01-engagement-last-7-days.json`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { dateI18n } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRangePreset } from '../state/useDateRange';
+
+/**
+ * Filename slug for each date-range preset. Numeric "Last N days" presets
+ * carry a `-days` suffix; calendar presets use their key verbatim; a custom
+ * range collapses to `custom-dates` (the exact bounds live in the payload).
+ */
+const PRESET_SLUG: Record< DateRangePreset, string > = {
+	'last-7': 'last-7-days',
+	'last-30': 'last-30-days',
+	'last-90': 'last-90-days',
+	'this-month': 'this-month',
+	'last-month': 'last-month',
+	custom: 'custom-dates',
+};
+
+/**
+ * Build the suggested JSON filename for a tab + preset + computed-at
+ * timestamp, e.g. `2026-07-01-engagement-last-7-days.json`. The date is
+ * rendered in site time via `dateI18n`, matching the "Last updated" line.
+ */
+export const buildJsonFilename = ( tab: string, preset: DateRangePreset, computedAt: string ): string =>
+	`${ dateI18n( 'Y-m-d', computedAt ) }-${ tab }-${ PRESET_SLUG[ preset ] }.json`;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds an **"Export JSON…"** item to the Insights tab-page options (kebab) menu, alongside "Print / Save as PDF…". Clicking it downloads the **currently viewed tab's** data as a JSON file.

The default filename is prefixed with the data's `computed_at` date (no timestamp) and includes the viewed tab and the selected time-window preset — or `custom-dates` for a custom range. For example: `2026-07-01-engagement-last-7-days.json` or `2026-07-01-engagement-custom-dates.json`.

The file contains exactly the `data` payload used to render the tab (pretty-printed). With comparison mode on, that payload naturally includes both the current and previous windows.

This is a deliberately barebones first cut (current tab only) and a prerequisite for a future feature that feeds the exported JSON into AI models for analysis. All-tabs and CSV export are intentionally out of scope here.

Closes NEWS-2587.

### How to test the changes in this Pull Request:

1. On an Insights-enabled site (branch `feat/insights-rsm`), open **Newspack › Insights**.
2. Select a tab that has data (e.g. **Engagement**) and a time window (e.g. **Last 7 days**).
3. Open the options (kebab / ⋮) menu at the top-right of the tab. Confirm a third item **"Export JSON…"** appears under "Print / Save as PDF…".
4. Click **Export JSON…**. The browser downloads a file named `<computed_at date>-<tab>-<preset>.json` (e.g. `2026-07-01-engagement-last-7-days.json`).
5. Switch the time window to a **custom** date range and export again. Confirm the filename uses `custom-dates` (e.g. `2026-07-01-engagement-custom-dates.json`).
6. Open the downloaded file. Confirm it is pretty-printed JSON equal to the tab's `data` payload (with comparison mode enabled, it includes both `current` and `previous`).
7. While a tab is still loading (or has no data), confirm **Export JSON…** is disabled.
8. Run `npm test` in `plugins/newspack-plugin` and confirm the full JS suite is green (includes new `jsonExport` and `LastUpdated` tests).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
