### PR TITLE
feat(insights): compound intent label for multi-block prompts (NPPD-1832)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -1578,6 +1578,28 @@ final class Prompts_Metric {
 				: 'donation' === $intent;
 			$donation_conversions = $donation_capable ? (int) ( $donation_map[ $popup_id ]['conversions'] ?? 0 ) : 0;
 
+			// NPPD-1832: compound intent label for multi-block prompts. Recognized conversion
+			// capabilities are derived from the hub's per-popup prompt_has_* seen-impression
+			// counts (registration/donation/newsletter/checkout). When 2+ are present the raw
+			// action_type collapses to 'undefined', so compose a deterministic "A + B" label from
+			// the present capabilities in a fixed order; otherwise keep the single-intent label.
+			$capability_label_parts = [];
+			foreach (
+				[
+					'registration'             => (int) ( $row['registration_impressions'] ?? 0 ),
+					'donation'                 => (int) ( $row['donation_impressions'] ?? 0 ),
+					'newsletters_subscription' => (int) ( $row['newsletter_impressions'] ?? 0 ),
+					'checkout'                 => (int) ( $row['checkout_impressions'] ?? 0 ),
+				] as $capability_key => $capability_count
+			) {
+				if ( $capability_count > 0 ) {
+					$capability_label_parts[] = self::INTENT_LABELS[ $capability_key ];
+				}
+			}
+			$intent_label = count( $capability_label_parts ) >= 2
+				? implode( ' + ', $capability_label_parts )
+				: ( self::INTENT_LABELS[ $intent ] ?? null );
+
 			// Both rates share the coherence guard + em-dash semantics via rate_value() (null =
 			// not computable: no impressions, or a >100% cross-surface ratio; a float incl. 0.0
 			// = a real rate, e.g. a donation-capable prompt that converted nobody). null = N/A
@@ -1586,10 +1608,11 @@ final class Prompts_Metric {
 				'popup_id'                     => $popup_id,
 				'prompt_title'                 => (string) ( $row['prompt_title'] ?? '' ),
 				'intent'                       => $intent,
-				// Friendly display label (NPPD-1758), single source of truth shared with
-				// the per-intent table. Null when the intent has no friendly override, so
-				// the frontend falls back to its humanizer (preserving title-casing).
-				'intent_label'                 => self::INTENT_LABELS[ $intent ] ?? null,
+				// Friendly display label (NPPD-1758) or compound multi-block label (NPPD-1832),
+				// computed above. Single source of truth shared with the per-intent table. Null
+				// when a single-intent prompt has no friendly override, so the frontend falls
+				// back to its humanizer (preserving title-casing).
+				'intent_label'                 => $intent_label,
 				'placement'                    => (string) ( $row['placement'] ?? '' ),
 				'impressions'                  => $impressions,
 				'unique_viewers'               => (int) ( $row['unique_viewers'] ?? 0 ),

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -1632,6 +1632,23 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Performance-by-prompt row with explicit per-popup capability impression counts
+	 * (registration/donation/newsletter/checkout), for the NPPD-1832 compound-label tests.
+	 * Only the capability columns passed in are set, mirroring a hub row where a prompt
+	 * carries some conversion blocks but not others.
+	 *
+	 * @param int    $popup_id     Popup ID.
+	 * @param string $title        Prompt title.
+	 * @param string $intent       Raw action_type intent.
+	 * @param int    $impressions  Total impressions.
+	 * @param array  $capabilities Capability columns to set (others omitted).
+	 * @return array
+	 */
+	protected function performance_row_with_capabilities( int $popup_id, string $title, string $intent, int $impressions, array $capabilities ): array {
+		return array_merge( $this->performance_row( $popup_id, $title, $intent, $impressions ), $capabilities );
+	}
+
+	/**
 	 * Build a proxy mock that returns the performance-by-prompt rows on the
 	 * main query call and the given donation/subscription rows on the
 	 * augmentation queries (in dispatch order).
@@ -2007,6 +2024,87 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 			],
 			array_keys( $result['rows'][0] )
 		);
+	}
+
+	/**
+	 * NPPD-1832: a prompt carrying 2+ recognized conversion blocks gets a deterministic
+	 * compound `intent_label` ("A + B") composed from the per-popup capability impression
+	 * counts in a FIXED order (registration, donation, newsletter, subscription). The raw
+	 * `intent` field is never rewritten. Prompts with fewer than 2 capabilities keep the
+	 * existing single-intent label behavior (INTENT_LABELS lookup, else null).
+	 */
+	public function test_performance_by_prompt_composes_compound_intent_label() {
+		$perf_rows = [
+			// registration + checkout → "Registration + Subscription"; raw intent stays 'undefined'.
+			$this->performance_row_with_capabilities(
+				1,
+				'Reg plus checkout',
+				'undefined',
+				100,
+				[
+					'registration_impressions' => 40,
+					'checkout_impressions'     => 25,
+				]
+			),
+			// All four present → full compound in fixed order.
+			$this->performance_row_with_capabilities(
+				2,
+				'Everything',
+				'undefined',
+				200,
+				[
+					'registration_impressions' => 5,
+					'donation_impressions'     => 5,
+					'newsletter_impressions'   => 5,
+					'checkout_impressions'     => 5,
+				]
+			),
+			// donation + newsletter (registration/checkout absent) → order skips the gaps.
+			$this->performance_row_with_capabilities(
+				3,
+				'Donate plus news',
+				'undefined',
+				150,
+				[
+					'donation_impressions'   => 10,
+					'newsletter_impressions' => 3,
+				]
+			),
+			// Exactly one capability, intent carries it → unchanged single-intent label.
+			$this->performance_row_with_capabilities(
+				4,
+				'Donate only',
+				'donation',
+				90,
+				[ 'donation_impressions' => 12 ]
+			),
+			// Zero recognized capabilities + unmapped intent → unchanged null label.
+			$this->performance_row_with_capabilities( 5, 'Informational', 'undefined', 30, [] ),
+		];
+		$proxy  = $this->make_performance_proxy( $perf_rows, [], [], 1 ); // Non-WC env: perf query only.
+		$metric = new Prompts_Metric( $proxy );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$rows = $result['rows'];
+
+		// 2+ capabilities → compound label in fixed order; raw intent untouched.
+		$this->assertSame( 'Registration + Subscription', $rows[0]['intent_label'] );
+		$this->assertSame( 'undefined', $rows[0]['intent'] );
+
+		$this->assertSame( 'Registration + Donation + Newsletter signup + Subscription', $rows[1]['intent_label'] );
+		$this->assertSame( 'undefined', $rows[1]['intent'] );
+
+		$this->assertSame( 'Donation + Newsletter signup', $rows[2]['intent_label'] );
+		$this->assertSame( 'undefined', $rows[2]['intent'] );
+
+		// Exactly 1 capability → unchanged single-intent label; raw intent untouched.
+		$this->assertSame( 'Donation', $rows[3]['intent_label'] );
+		$this->assertSame( 'donation', $rows[3]['intent'] );
+
+		// 0 capabilities + unmapped intent → unchanged null label (frontend humanizes).
+		$this->assertNull( $rows[4]['intent_label'] );
+		$this->assertSame( 'undefined', $rows[4]['intent'] );
 	}
 
 	/**


### PR DESCRIPTION
Part of NPPD-1832 (Change 1 — per-prompt table). **Consumer half.** Pairs with the newspack-manager-admin SQL PR (#481) that ships the two new capability columns.

## Problem

A prompt carrying 2+ recognized conversion blocks has no single `action_type`, so it collapses to raw `'undefined'` in the per-prompt performance table — unhelpful for publishers.

## Fix

In `Prompts_Metric::get_performance_by_prompt`, compute how many of the four per-popup capability impression counts are `> 0`:

- `registration_impressions` → `INTENT_LABELS['registration']` ("Registration")
- `donation_impressions` → `INTENT_LABELS['donation']` ("Donation")
- `newsletter_impressions` → `INTENT_LABELS['newsletters_subscription']` ("Newsletter signup")
- `checkout_impressions` → `INTENT_LABELS['checkout']` ("Subscription")

If **2+** are present, set `intent_label` to the present capabilities joined with `' + '` in that **fixed order** (e.g. `"Registration + Subscription"`). Fewer than 2 → unchanged single-intent behavior. The raw `intent` field is never modified.

## Notes

- `intent_label` stays the single server-side source of truth; the frontend per-prompt table already renders `r.intent_label || humanizeTerm(r.intent)` (`PerformanceByPromptTable.tsx`), so no frontend change is needed and the row schema is unchanged.
- Depends on the two new hub columns from manager-admin#481; degrades gracefully (a column absent → that capability counts as 0).
- Per-intent rollup (Change 2) is out of scope.

## Tests

Added a compound-label test: 2+ capabilities → "A + B" in fixed order; exactly 1 → unchanged single label; 0 → unchanged null; raw `intent` asserted untouched. phpcs clean (Newspack ruleset); full `Test_Prompts_Metric` **OK (125 tests, 657 assertions)**.