### PR TITLE
feat(insights): classify block-less button CTAs by href (NPPD-1837)

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
@@ -22,6 +22,16 @@ final class Newspack_Popups_Data_Api {
 	protected static $popups = [];
 
 	/**
+	 * Memoized site conversion URLs for block-less CTA classification.
+	 *
+	 * See get_site_conversion_urls(). A class property (rather than a
+	 * function-local static) so it can be reset between tests.
+	 *
+	 * @var array|null
+	 */
+	private static $conversion_urls_cache = null;
+
+	/**
 	 * Registers the hooks.
 	 */
 	public static function init() {
@@ -181,7 +191,304 @@ final class Newspack_Popups_Data_Api {
 			}
 		}
 
+		// NPPD-1837: block-less CTA classification (display-only).
+		// Runs only when no recognized conversion block was found, i.e. the exact
+		// population that would otherwise collapse to action_type='undefined'. The
+		// inferred intent lives on its own params and is NEVER written to a
+		// prompt_has_* flag or action_type, so it can never enter a conversion
+		// denominator (block-less prompts have no Newspack-tracked conversion).
+		if ( empty( $data['prompt_blocks'] ) ) {
+			$inferred = self::classify_blockless_cta( $popup['content'] );
+			if ( $inferred ) {
+				$data['inferred_cta_intent'] = $inferred['intent']; // One of donation, newsletter, subscription, event, sponsor, editorial.
+				$data['inferred_cta_source'] = $inferred['source']; // One of site_config, processor, pattern.
+			}
+		}
+
 		return $data;
+	}
+
+	/**
+	 * Classify a block-less prompt by its button link target(s).
+	 *
+	 * Only conversion-legible or clearly non-conversion targets return a value;
+	 * anything ambiguous returns null and the prompt stays 'undefined' (precision
+	 * over recall — a false conversion label is worse than an honest blank).
+	 *
+	 * @param string $content The prompt post_content.
+	 * @return array|null ['intent' => string, 'source' => string] or null to abstain.
+	 */
+	public static function classify_blockless_cta( $content ) {
+		$hrefs = self::extract_button_hrefs( $content );
+		if ( empty( $hrefs ) ) {
+			return null;
+		}
+
+		$config = self::get_site_conversion_urls();
+
+		// Classify every button; a prompt can hold more than one.
+		$hits = [];
+		foreach ( $hrefs as $href ) {
+			$hit = self::classify_href( $href, $config );
+			if ( $hit ) {
+				$hits[] = $hit;
+			}
+		}
+		if ( empty( $hits ) ) {
+			return null;
+		}
+
+		// Resolution when buttons disagree: a conversion intent wins over a
+		// non-conversion one; if two DIFFERENT conversion intents appear, abstain
+		// (don't guess). Precedence within conversion: donation, newsletter, subscription.
+		$precedence     = [
+			'donation'     => 1,
+			'newsletter'   => 2,
+			'subscription' => 3,
+		];
+		$conversion     = [];
+		$non_conversion = [];
+		foreach ( $hits as $hit ) {
+			if ( isset( $precedence[ $hit['intent'] ] ) ) {
+				$conversion[] = $hit;
+			} else {
+				$non_conversion[] = $hit;
+			}
+		}
+
+		if ( ! empty( $conversion ) ) {
+			$distinct = array_unique( array_column( $conversion, 'intent' ) );
+			if ( 1 < count( $distinct ) ) {
+				return null; // Conflicting conversion signals -> abstain.
+			}
+			usort(
+				$conversion,
+				function ( $a, $b ) use ( $precedence ) {
+					return $precedence[ $a['intent'] ] <=> $precedence[ $b['intent'] ];
+				}
+			);
+			return $conversion[0];
+		}
+
+		// Only non-conversion signals: report the first (sponsor/editorial/event) so
+		// the dashboard can show a non-conversion label instead of a bare "undefined".
+		return $non_conversion[0];
+	}
+
+	/**
+	 * Pull hrefs from core/button blocks in the prompt content.
+	 *
+	 * Scope is intentionally limited to button blocks (not every <a> in body copy)
+	 * to keep precision high. Reuses the recursive get_block_data() helper, so
+	 * buttons nested inside core/buttons wrappers are covered.
+	 *
+	 * @param string $content The prompt post_content.
+	 * @return string[] Lowercased hrefs.
+	 */
+	public static function extract_button_hrefs( $content ) {
+		$blocks  = \parse_blocks( $content );
+		$buttons = self::get_block_data( 'core/button', $blocks );
+		$hrefs   = [];
+		foreach ( $buttons as $button ) {
+			$url = $button['attrs']['url'] ?? '';
+			if ( empty( $url ) && ! empty( $button['innerHTML'] ) ) {
+				// Older button blocks store the href only in the saved markup.
+				if ( preg_match( '/href="([^"]+)"/i', $button['innerHTML'], $matches ) ) {
+					$url = $matches[1];
+				}
+			}
+			if ( ! empty( $url ) ) {
+				$hrefs[] = strtolower( $url );
+			}
+		}
+		return $hrefs;
+	}
+
+	/**
+	 * Classify a single href. Precedence:
+	 *   1) site-configured conversion URLs (highest confidence; catches the
+	 *      unguessable cases like a bespoke on-site donation page),
+	 *   2) known third-party processor domains,
+	 *   3) path / substring patterns,
+	 *   4) non-conversion tells (event, sponsor, editorial),
+	 *   else null (abstain).
+	 *
+	 * @param string $href   Lowercased href.
+	 * @param array  $config Output of get_site_conversion_urls().
+	 * @return array|null ['intent' => string, 'source' => string] or null.
+	 */
+	public static function classify_href( $href, $config ) {
+		// 1) Site config (substring match against this site's own configured URLs).
+		foreach ( [ 'donation', 'newsletter', 'subscription' ] as $intent ) {
+			foreach ( $config[ $intent ] as $configured ) {
+				if ( $configured && str_contains( $href, $configured ) ) {
+					return [
+						'intent' => $intent,
+						'source' => 'site_config',
+					];
+				}
+			}
+		}
+
+		// 2) Processor domains (empirically ranked in NPPD-1836; fundjournalism dominant).
+		$donation_processors = [ 'fundjournalism', 'donorbox', 'actblue', 'fundraiseup', 'classy.org', 'givebutter' ];
+		foreach ( $donation_processors as $needle ) {
+			if ( str_contains( $href, $needle ) ) {
+				return [
+					'intent' => 'donation',
+					'source' => 'processor',
+				];
+			}
+		}
+		// giving.<institution>.edu (e.g. giving.umich.edu) — institutional donation.
+		if ( preg_match( '#://giving\.[^/]+\.edu#', $href ) ) {
+			return [
+				'intent' => 'donation',
+				'source' => 'processor',
+			];
+		}
+
+		// 3) Path / substring patterns. Substring (not slash-anchored) on purpose, so
+		// membership fragments and newslettersignup slugs are caught (NPPD-1836).
+		// Order matters: donation, then newsletter, then subscription.
+		if ( preg_match( '/donate|donation|\/give|contribute|donor|membership|member\b|\/support\b/', $href ) ) {
+			return [
+				'intent' => 'donation',
+				'source' => 'pattern',
+			];
+		}
+		if ( str_contains( $href, 'newsletter' ) ) {
+			return [
+				'intent' => 'newsletter',
+				'source' => 'pattern',
+			];
+		}
+		if ( preg_match( '#://(account|app|subscribe|checkout|my-?account)\.#', $href )
+			|| preg_match( '/subscribe|subscription|\/checkout|my-?account|\/offer|\/join\b|\/digital|\/plans|\/pricing/', $href ) ) {
+			return [
+				'intent' => 'subscription',
+				'source' => 'pattern',
+			];
+		}
+
+		// 4) Non-conversion tells.
+		// Sponsor/ad: outbound link tagged utm_medium=referral.
+		// TODO(confirm): compare utm_source to the site slug/home host rather than
+		// matching the medium literally.
+		if ( str_contains( $href, 'utm_medium=referral' ) && self::is_external_host( $href ) ) {
+			return [
+				'intent' => 'sponsor',
+				'source' => 'pattern',
+			];
+		}
+		// Event / ticketing.
+		if ( preg_match( '#/events?(/|$)|eventbrite|tribfest|/fest\b#', $href ) ) {
+			return [
+				'intent' => 'event',
+				'source' => 'pattern',
+			];
+		}
+		// Editorial / navigation on this site's own domain (article slugs, author pages).
+		if ( ! self::is_external_host( $href )
+			&& preg_match( '#/[0-9]{4}/[0-9]{2}/|/author/|/[a-z0-9]+(?:-[a-z0-9]+){2,}(/[a-z]+)?/?($|\?)#', $href ) ) {
+			return [
+				'intent' => 'editorial',
+				'source' => 'pattern',
+			];
+		}
+
+		// Abstain: query-param forms (?form=), bare homepages, unrecognized externals.
+		return null;
+	}
+
+	/**
+	 * This site's configured conversion URLs, normalized to lowercase host+path
+	 * fragments suitable for str_contains() matching. Memoized per request.
+	 *
+	 * Side-effect-free by design: the donation page URL is read from the
+	 * newspack_donation_page_id option, NOT \Newspack\Donations::get_donation_page_info(),
+	 * which creates the page via wp_insert_post when none exists — unsafe on this
+	 * per-render path.
+	 *
+	 * Coverage ceiling: covers WooCommerce publishers whose button links to their own
+	 * donation page, checkout, or my-account. External processor URLs (fundjournalism
+	 * etc.) and bespoke campaign landing pages are not stored by Newspack — those are
+	 * handled by the processor dictionary and patterns in classify_href(), or not at all.
+	 *
+	 * @return array{donation:string[],newsletter:string[],subscription:string[]}
+	 */
+	public static function get_site_conversion_urls() {
+		if ( null !== self::$conversion_urls_cache ) {
+			return self::$conversion_urls_cache;
+		}
+
+		$urls = [
+			'donation'     => [],
+			'newsletter'   => [],
+			'subscription' => [],
+		];
+
+		// Donation: on-site donation page, read from the option (no side effects).
+		if ( class_exists( '\Newspack\Donations' ) ) {
+			$page_id = \get_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION, 0 );
+			if ( $page_id && 'page' === \get_post_type( $page_id ) ) {
+				$urls['donation'][] = self::normalize_url( \get_permalink( $page_id ) );
+			}
+		}
+
+		// Subscription / checkout.
+		if ( function_exists( 'wc_get_checkout_url' ) ) {
+			$urls['subscription'][] = self::normalize_url( wc_get_checkout_url() );
+		}
+		if ( function_exists( 'wc_get_page_permalink' ) ) {
+			$urls['subscription'][] = self::normalize_url( wc_get_page_permalink( 'myaccount' ) );
+		}
+
+		// Newsletter: nothing to wire — Newspack has no configured newsletter page
+		// (signup is the inline subscribe block). Newsletter recovery is pattern-only.
+
+		// Drop empties.
+		foreach ( $urls as $key => $list ) {
+			$urls[ $key ] = array_values( array_filter( $list ) );
+		}
+
+		self::$conversion_urls_cache = $urls;
+		return self::$conversion_urls_cache;
+	}
+
+	/**
+	 * Normalize a full URL to a lowercased host+path fragment for matching.
+	 *
+	 * @param string $url URL.
+	 * @return string
+	 */
+	private static function normalize_url( $url ) {
+		if ( empty( $url ) ) {
+			return '';
+		}
+		$parts = \wp_parse_url( strtolower( $url ) );
+		if ( empty( $parts['host'] ) ) {
+			return '';
+		}
+		$host = preg_replace( '/^www\./', '', $parts['host'] );
+		return $host . ( $parts['path'] ?? '' );
+	}
+
+	/**
+	 * Is this href pointing off the current site's host?
+	 *
+	 * @param string $href Lowercased href.
+	 * @return bool
+	 */
+	private static function is_external_host( $href ) {
+		$href_host = \wp_parse_url( $href, PHP_URL_HOST );
+		$home_host = \wp_parse_url( strtolower( \home_url() ), PHP_URL_HOST );
+		if ( empty( $href_host ) || empty( $home_host ) ) {
+			return false;
+		}
+		$href_host = preg_replace( '/^www\./', '', $href_host );
+		$home_host = preg_replace( '/^www\./', '', $home_host );
+		return $href_host !== $home_host;
 	}
 
 	/**
@@ -227,6 +534,8 @@ final class Newspack_Popups_Data_Api {
 		}
 
 		// @TODO: How to handle prompts with more than one block?
+		// Note: block-less prompts stay 'undefined' here but may carry a display-only
+		// inferred_cta_intent (NPPD-1837), which passes through as a top-level param.
 		$action_type = 'undefined';
 		if ( 1 === count( $popup_params['prompt_blocks'] ) ) {
 			$action_type = $popup_params['prompt_blocks'][0];

--- a/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
@@ -261,10 +261,17 @@ final class Newspack_Popups_Data_Api {
 			if ( 1 < count( $distinct ) ) {
 				return null; // Conflicting conversion signals -> abstain.
 			}
+			// All remaining hits share one intent, so break ties on source confidence
+			// (site_config > processor > pattern) for a deterministic, best-available source.
+			$source_rank = [
+				'site_config' => 1,
+				'processor'   => 2,
+				'pattern'     => 3,
+			];
 			usort(
 				$conversion,
-				function ( $a, $b ) use ( $precedence ) {
-					return $precedence[ $a['intent'] ] <=> $precedence[ $b['intent'] ];
+				function ( $a, $b ) use ( $source_rank ) {
+					return ( $source_rank[ $a['source'] ] ?? PHP_INT_MAX ) <=> ( $source_rank[ $b['source'] ] ?? PHP_INT_MAX );
 				}
 			);
 			return $conversion[0];

--- a/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
@@ -351,7 +351,12 @@ final class Newspack_Popups_Data_Api {
 		// 3) Path / substring patterns. Substring (not slash-anchored) on purpose, so
 		// membership fragments and newslettersignup slugs are caught (NPPD-1836).
 		// Order matters: donation, then newsletter, then subscription.
-		if ( preg_match( '/donate|donation|\/give|contribute|donor|membership|member\b|\/support\b/', $href ) ) {
+		// (?<![a-z]) applies only to the keyword branch so mid-word matches (e.g. "member"
+		// inside "remember") don't false-positive; the href is already lowercased. Digits,
+		// "-", "/", "#" and start-of-string are all valid boundaries, so "/donate",
+		// "-membership" and "#...-membership" still match. /give and /support stay
+		// slash-anchored exactly as before.
+		if ( preg_match( '/(?<![a-z])(?:donate|donation|contribute|donor|member|membership)|\/give\b|\/support\b/', $href ) ) {
 			return [
 				'intent' => 'donation',
 				'source' => 'pattern',
@@ -447,9 +452,18 @@ final class Newspack_Popups_Data_Api {
 		// Newsletter: nothing to wire — Newspack has no configured newsletter page
 		// (signup is the inline subscribe block). Newsletter recovery is pattern-only.
 
-		// Drop empties.
+		// Drop empties and any URL that normalized to a bare host with no meaningful
+		// path (e.g. a non-pretty permalink collapsing to "host/"), which would
+		// otherwise substring-match every same-host link.
 		foreach ( $urls as $key => $list ) {
-			$urls[ $key ] = array_values( array_filter( $list ) );
+			$urls[ $key ] = array_values(
+				array_filter(
+					$list,
+					static function ( $normalized ) {
+						return '' !== $normalized && 1 === preg_match( '#/[^/]#', $normalized );
+					}
+				)
+			);
 		}
 
 		self::$conversion_urls_cache = $urls;

--- a/plugins/newspack-popups/tests/mocks/class-donations.php
+++ b/plugins/newspack-popups/tests/mocks/class-donations.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Minimal mock of \Newspack\Donations for the popups data-api tests.
+ *
+ * The popups test suite does not load newspack-plugin, so \Newspack\Donations
+ * is absent. get_site_conversion_urls() only needs the option-name constant to
+ * read the configured donation page; that is all this mock provides.
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack;
+
+/**
+ * Donations mock.
+ */
+class Donations {
+	const DONATION_PAGE_ID_OPTION = 'newspack_donation_page_id';
+}

--- a/plugins/newspack-popups/tests/test-data-api.php
+++ b/plugins/newspack-popups/tests/test-data-api.php
@@ -20,7 +20,14 @@ class DataApiTest extends WP_UnitTestCase {
 
 	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		parent::set_up();
-		// Reset the memoized conversion-URL cache between tests.
+		$this->reset_conversion_cache();
+	}
+
+	/**
+	 * Reset the memoized conversion-URL cache (it is per-request; tests that change
+	 * options or permalinks after a prior call must reset before re-reading).
+	 */
+	private function reset_conversion_cache() {
 		$property = new \ReflectionProperty( 'Newspack_Popups_Data_Api', 'conversion_urls_cache' );
 		$property->setAccessible( true );
 		$property->setValue( null, null );
@@ -82,18 +89,25 @@ class DataApiTest extends WP_UnitTestCase {
 	 * A button to the site's configured donation page (read via the option) is site_config.
 	 */
 	public function test_configured_donation_page_is_site_config() {
+		// Pretty permalinks so get_permalink() yields a real path (not a bare host).
+		$this->set_permalink_structure( '/%postname%/' );
 		$page_id = self::factory()->post->create(
 			[
 				'post_type'  => 'page',
+				'post_name'  => 'support-us',
 				'post_title' => 'Support us',
 			]
 		);
 		update_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION, $page_id );
+		$this->reset_conversion_cache();
 
-		$hit = Newspack_Popups_Data_Api::classify_href(
-			strtolower( get_permalink( $page_id ) ),
-			Newspack_Popups_Data_Api::get_site_conversion_urls()
-		);
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+
+		// The donation config entry carries the page's path, not a bare host.
+		$this->assertNotEmpty( $config['donation'] );
+		$this->assertStringContainsString( 'support-us', $config['donation'][0] );
+
+		$hit = Newspack_Popups_Data_Api::classify_href( strtolower( get_permalink( $page_id ) ), $config );
 		$this->assertEquals(
 			[
 				'intent' => 'donation',
@@ -101,6 +115,37 @@ class DataApiTest extends WP_UnitTestCase {
 			],
 			$hit
 		);
+
+		// An unrelated own-domain URL does NOT match the configured donation URL.
+		$other = Newspack_Popups_Data_Api::classify_href( 'https://example.org/some-other-page/', $config );
+		$this->assertNotEquals( 'site_config', $other['source'] ?? null );
+
+		delete_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION );
+		$this->set_permalink_structure( '' );
+	}
+
+	/**
+	 * Fix 2: a configured page whose permalink normalizes to a bare host (plain
+	 * permalinks) is filtered out, so it can't substring-match every same-host link.
+	 */
+	public function test_bare_host_config_url_is_filtered_out() {
+		// Plain permalinks: get_permalink() is "host/?page_id=N", normalizing to bare "host/".
+		$this->set_permalink_structure( '' );
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Support us',
+			]
+		);
+		update_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION, $page_id );
+		$this->reset_conversion_cache();
+
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$this->assertEmpty( $config['donation'], 'Bare-host donation URL should be filtered out.' );
+
+		// With no usable config entry, an arbitrary own-domain URL does not classify as site_config.
+		$hit = Newspack_Popups_Data_Api::classify_href( 'https://example.org/anything/', $config );
+		$this->assertNotEquals( 'site_config', $hit['source'] ?? null );
 
 		delete_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION );
 	}
@@ -127,6 +172,32 @@ class DataApiTest extends WP_UnitTestCase {
 		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
 		$hit    = Newspack_Popups_Data_Api::classify_href( 'https://example.org/2026/06/12/some-long-slug/story', $config );
 		$this->assertEquals( 'editorial', $hit['intent'] );
+	}
+
+	/**
+	 * Fix 1: a donation keyword inside a longer word (e.g. "member" in "remember")
+	 * must not false-positive as donation; the article falls through to editorial.
+	 */
+	public function test_donation_keyword_midword_does_not_false_positive() {
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$hit    = Newspack_Popups_Data_Api::classify_href( 'https://example.org/2026/06/12/things-to-remember-this-summer/', $config );
+		$this->assertEquals( 'editorial', $hit['intent'] );
+	}
+
+	/**
+	 * Fix 1 keep-alive: a hyphen/fragment-preceded membership token still matches
+	 * donation (the boundary is a non-letter, so the lookbehind allows it).
+	 */
+	public function test_hyphen_preceded_membership_still_donation() {
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$hit    = Newspack_Popups_Data_Api::classify_href( 'https://example.org/about/#example-membership', $config );
+		$this->assertEquals(
+			[
+				'intent' => 'donation',
+				'source' => 'pattern',
+			],
+			$hit
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-data-api.php
+++ b/plugins/newspack-popups/tests/test-data-api.php
@@ -40,9 +40,11 @@ class DataApiTest extends WP_UnitTestCase {
 	 * @return string Prompt post_content.
 	 */
 	private function button_prompt( $href ) {
+		// Embed the raw URL, matching how Gutenberg serializes core/button attrs.
+		// esc_url() would entity-encode characters like "&" and skew classification.
 		return sprintf(
 			'<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button {"url":"%1$s"} --><div class="wp-block-button"><a class="wp-block-button__link" href="%1$s">Act now</a></div><!-- /wp:button --></div><!-- /wp:buttons -->',
-			esc_url( $href )
+			$href
 		);
 	}
 
@@ -260,6 +262,23 @@ class DataApiTest extends WP_UnitTestCase {
 		$content .= $this->button_prompt( 'https://fundjournalism.org/donate/' );
 		$hit      = Newspack_Popups_Data_Api::classify_blockless_cta( $content );
 		$this->assertEquals( 'donation', $hit['intent'] );
+	}
+
+	/**
+	 * Same intent from different sources resolves deterministically to the
+	 * highest-confidence source (processor beats pattern).
+	 */
+	public function test_same_intent_prefers_higher_confidence_source() {
+		$content  = $this->button_prompt( 'https://example.org/donate/' ); // Donation via pattern.
+		$content .= $this->button_prompt( 'https://fundjournalism.org/give/' ); // Donation via processor.
+		$hit      = Newspack_Popups_Data_Api::classify_blockless_cta( $content );
+		$this->assertEquals(
+			[
+				'intent' => 'donation',
+				'source' => 'processor',
+			],
+			$hit
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-data-api.php
+++ b/plugins/newspack-popups/tests/test-data-api.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Class Data API Test
+ *
+ * Covers NPPD-1837: block-less button CTA classification (display-only).
+ *
+ * @package Newspack_Popups
+ */
+
+// The popups suite does not load newspack-plugin, so provide the constant that
+// get_site_conversion_urls() reads for the configured donation page.
+if ( ! class_exists( '\Newspack\Donations' ) ) {
+	require_once __DIR__ . '/mocks/class-donations.php';
+}
+
+/**
+ * Data API test case.
+ */
+class DataApiTest extends WP_UnitTestCase {
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		// Reset the memoized conversion-URL cache between tests.
+		$property = new \ReflectionProperty( 'Newspack_Popups_Data_Api', 'conversion_urls_cache' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Build a block-less prompt whose only content is a button linking to $href.
+	 *
+	 * @param string $href The button target.
+	 * @return string Prompt post_content.
+	 */
+	private function button_prompt( $href ) {
+		return sprintf(
+			'<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button {"url":"%1$s"} --><div class="wp-block-button"><a class="wp-block-button__link" href="%1$s">Act now</a></div><!-- /wp:button --></div><!-- /wp:buttons -->',
+			esc_url( $href )
+		);
+	}
+
+	/**
+	 * Run get_popup_metadata() + prepare_popup_params_for_ga() on a prompt.
+	 *
+	 * @param string $content Prompt post_content.
+	 * @return array The GA-ready params.
+	 */
+	private function ga_params_for( $content ) {
+		$data = Newspack_Popups_Data_Api::get_popup_metadata(
+			[
+				'id'      => 123,
+				'title'   => 'A prompt',
+				'content' => $content,
+			]
+		);
+		return Newspack_Popups_Data_Api::prepare_popup_params_for_ga( $data );
+	}
+
+	/**
+	 * Assert the guardrail: no conversion flag was written for an inferred intent.
+	 *
+	 * @param array $params GA params.
+	 */
+	private function assertNoConversionFlags( $params ) {
+		foreach ( array_keys( $params ) as $key ) {
+			$this->assertStringStartsNotWith( 'prompt_has_', $key, "Unexpected conversion flag: $key" );
+		}
+		$this->assertEquals( 'undefined', $params['action_type'], 'action_type must stay undefined for block-less prompts.' );
+	}
+
+	/**
+	 * A processor domain (fundjournalism) is a donation, and no conversion flag leaks.
+	 */
+	public function test_processor_donation_emits_display_only_intent() {
+		$params = $this->ga_params_for( $this->button_prompt( 'https://fundjournalism.org/donate/campaign/' ) );
+		$this->assertEquals( 'donation', $params['inferred_cta_intent'] );
+		$this->assertEquals( 'processor', $params['inferred_cta_source'] );
+		$this->assertNoConversionFlags( $params );
+	}
+
+	/**
+	 * A button to the site's configured donation page (read via the option) is site_config.
+	 */
+	public function test_configured_donation_page_is_site_config() {
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Support us',
+			]
+		);
+		update_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION, $page_id );
+
+		$hit = Newspack_Popups_Data_Api::classify_href(
+			strtolower( get_permalink( $page_id ) ),
+			Newspack_Popups_Data_Api::get_site_conversion_urls()
+		);
+		$this->assertEquals(
+			[
+				'intent' => 'donation',
+				'source' => 'site_config',
+			],
+			$hit
+		);
+
+		delete_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION );
+	}
+
+	/**
+	 * A newslettersignup slug is a newsletter (pattern).
+	 */
+	public function test_newsletter_signup_slug_is_pattern() {
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$hit    = Newspack_Popups_Data_Api::classify_href( 'https://example.org/orlando-newslettersignup-page/', $config );
+		$this->assertEquals(
+			[
+				'intent' => 'newsletter',
+				'source' => 'pattern',
+			],
+			$hit
+		);
+	}
+
+	/**
+	 * An own-domain dated article slug is editorial (non-conversion).
+	 */
+	public function test_own_domain_article_is_editorial() {
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$hit    = Newspack_Popups_Data_Api::classify_href( 'https://example.org/2026/06/12/some-long-slug/story', $config );
+		$this->assertEquals( 'editorial', $hit['intent'] );
+	}
+
+	/**
+	 * An outbound utm_medium=referral link is a sponsor (non-conversion).
+	 */
+	public function test_external_referral_is_sponsor() {
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$hit    = Newspack_Popups_Data_Api::classify_href( 'https://statefarm.com/agents?utm_medium=referral&utm_source=partner', $config );
+		$this->assertEquals( 'sponsor', $hit['intent'] );
+	}
+
+	/**
+	 * Ambiguous targets abstain (null) — precision over recall.
+	 *
+	 * @dataProvider abstain_hrefs
+	 * @param string $href The href that should not classify.
+	 */
+	public function test_ambiguous_targets_abstain( $href ) {
+		$config = Newspack_Popups_Data_Api::get_site_conversion_urls();
+		$this->assertNull( Newspack_Popups_Data_Api::classify_href( $href, $config ), "Should abstain: $href" );
+	}
+
+	/**
+	 * Hrefs that must not classify.
+	 *
+	 * @return array
+	 */
+	public function abstain_hrefs() {
+		return [
+			'query-param form' => [ 'https://example.org/?form=123' ],
+			'bare homepage'    => [ 'https://example.org/' ],
+			'unknown external' => [ 'https://randomvendor.com/' ],
+		];
+	}
+
+	/**
+	 * A block-less prompt with an unrecognized target emits no inferred params.
+	 */
+	public function test_abstain_emits_nothing() {
+		$params = $this->ga_params_for( $this->button_prompt( 'https://example.org/?form=123' ) );
+		$this->assertArrayNotHasKey( 'inferred_cta_intent', $params );
+		$this->assertArrayNotHasKey( 'inferred_cta_source', $params );
+		$this->assertNoConversionFlags( $params );
+	}
+
+	/**
+	 * Conflicting conversion intents across buttons abstain (don't guess).
+	 */
+	public function test_conflicting_conversion_intents_abstain() {
+		$content  = $this->button_prompt( 'https://donorbox.org/give' );
+		$content .= $this->button_prompt( 'https://account.example.com/subscribe' );
+		$this->assertNull( Newspack_Popups_Data_Api::classify_blockless_cta( $content ) );
+	}
+
+	/**
+	 * A conversion intent wins over a co-occurring non-conversion one.
+	 */
+	public function test_conversion_wins_over_non_conversion() {
+		$content  = $this->button_prompt( 'https://example.org/2026/06/12/some-long-slug/story' );
+		$content .= $this->button_prompt( 'https://fundjournalism.org/donate/' );
+		$hit      = Newspack_Popups_Data_Api::classify_blockless_cta( $content );
+		$this->assertEquals( 'donation', $hit['intent'] );
+	}
+
+	/**
+	 * Buttons nested in a core/buttons wrapper are found by extract_button_hrefs().
+	 */
+	public function test_extract_button_hrefs_covers_nested_buttons() {
+		$hrefs = Newspack_Popups_Data_Api::extract_button_hrefs( $this->button_prompt( 'https://fundjournalism.org/DONATE/' ) );
+		$this->assertEquals( [ 'https://fundjournalism.org/donate/' ], $hrefs );
+	}
+
+	/**
+	 * A prompt WITH a recognized conversion block never runs the classifier.
+	 */
+	public function test_prompt_with_block_is_unchanged() {
+		$content = '<!-- wp:newspack-blocks/donate /-->';
+		$data    = Newspack_Popups_Data_Api::get_popup_metadata(
+			[
+				'id'      => 456,
+				'title'   => 'Donate prompt',
+				'content' => $content,
+			]
+		);
+		$this->assertArrayNotHasKey( 'inferred_cta_intent', $data );
+		$this->assertContains( 'donation', $data['prompt_blocks'] );
+
+		$params = Newspack_Popups_Data_Api::prepare_popup_params_for_ga( $data );
+		$this->assertEquals( 1, $params['prompt_has_donation'] );
+		$this->assertEquals( 'donation', $params['action_type'] );
+		$this->assertArrayNotHasKey( 'inferred_cta_intent', $params );
+	}
+}


### PR DESCRIPTION
## What & why (NPPD-1837)

When a prompt has **none** of the four recognized conversion blocks it collapses to `action_type='undefined'`. Many of those are hand-rolled button CTAs whose intent is legible from the link target (discovery NPPD-1734 / sizing NPPD-1836). This classifies them by button `href` and emits a **display-only** intent so the Prompts tab can later label them — **without affecting conversion tracking in any way**.

## How

In `Newspack_Popups_Data_Api::get_popup_metadata()`, immediately after the `$watched_blocks` loop and **only when no recognized block was found** (`prompt_blocks` empty), classify the prompt's button hrefs and emit two new top-level params:

- `inferred_cta_intent` ∈ { `donation`, `newsletter`, `subscription`, `event`, `sponsor`, `editorial` }
- `inferred_cta_source` ∈ { `site_config`, `processor`, `pattern` }

Classification precedence in `classify_href()`: **site-config → processor dictionary → path/substring patterns → non-conversion tells (event/sponsor/editorial) → `null` (abstain).** Precision over recall — anything ambiguous returns `null` and the prompt stays `undefined`.

## Guardrails (non-negotiable, all held)

- Never writes a `prompt_has_*` flag for an inferred intent.
- Never sets or alters `action_type` — it stays `undefined` for block-less prompts.
- `inferred_cta_*` are separate params that cannot enter any conversion denominator.
- `get_site_conversion_urls()` is **side-effect-free**: donation page URL read from the `newspack_donation_page_id` option + `get_permalink()`, **not** `\Newspack\Donations::get_donation_page_info()` (which `wp_insert_post`s a page as a side effect — unsafe on this per-render path).

The two new params sit at the top level of `$data`, so they pass through `prepare_popup_params_for_ga()` unchanged with no edit needed there.

## Deliberate divergence from the attached DRAFT (please note)

The draft memoized `get_site_conversion_urls()` with a **function-local** `static $cached`, which can't be reset between PHPUnit methods in one process (making the site_config path non-deterministic to test). Moved the cache to a private class property `$conversion_urls_cache`. **Runtime behavior is identical** (memoized once per request); it's just resettable via reflection in tests.

## Tests

New `tests/test-data-api.php` (13 tests / 29 assertions). Each conversion/label assertion **also** asserts no `prompt_has_*` was set and `action_type` is unchanged. Covers: processor→donation, configured donation page (via the option)→site_config, newslettersignup→newsletter, own-domain article→editorial, external `utm_medium=referral`→sponsor, all three abstain cases, multi-button conflict→abstain, conversion-wins-over-non-conversion, nested-button extraction, and prompt-with-a-block (classifier never runs).

- Full popups PHPUnit suite: **230 tests green**. `DataApiTest`: **13 green**.
- `phpcs` against the workspace-root `phpcs.xml` (CI standard): **clean**.

A minimal `\Newspack\Donations` mock (`tests/mocks/class-donations.php`) is included because the popups suite does not load newspack-plugin.

## Out of scope (separate slices)

- Hub SQL projection in `newspack-manager-admin` (surface the new params in the per-prompt query).
- Consumer/frontend `intent_label` "(inferred)" rendering — **blocked on a copy decision**.
- The sponsor `utm_source`-vs-site-slug refinement — left as a `TODO(confirm)`.