### PR TITLE
feat(insights): render inferred CTA label in prompts table (NPPD-1840)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-prompts-metric.php
@@ -77,6 +77,27 @@ final class Prompts_Metric {
 	];
 
 	/**
+	 * Display labels for NPPD-1837's inferred (block-less) CTA intents. Separate
+	 * from INTENT_LABELS because the classifier's tokens differ from the block
+	 * action_type keys ('newsletter' vs 'newsletters_subscription', 'subscription'
+	 * vs 'checkout') and because the three conversion intents carry an "(inferred)"
+	 * marker so they read as visibly distinct from block-tracked conversions. The
+	 * three conversion base strings intentionally match INTENT_LABELS
+	 * ('Donation' / 'Newsletter signup' / 'Subscription'); the non-conversion three
+	 * have no block-based equivalent.
+	 *
+	 * @var array<string, string>
+	 */
+	private const INFERRED_INTENT_LABELS = [
+		'donation'     => 'Donation (inferred)',
+		'newsletter'   => 'Newsletter signup (inferred)',
+		'subscription' => 'Subscription (inferred)',
+		'sponsor'      => 'Sponsored',
+		'event'        => 'Event',
+		'editorial'    => 'Editorial link',
+	];
+
+	/**
 	 * Conversion blocks scanned by the per-intent capability gate (NPPD-1720),
 	 * keyed by capability. A prompt is "capable" of an intent when any active
 	 * prompt contains the matching block. Mirrors the three blocks newspack-popups
@@ -1600,6 +1621,24 @@ final class Prompts_Metric {
 				? implode( ' + ', $capability_label_parts )
 				: ( self::INTENT_LABELS[ $intent ] ?? null );
 
+			// NPPD-1840: block-less CTA fallback (display-only). When the prompt carried no
+			// recognized conversion block, the block-based label above is null. If NPPD-1837's
+			// classifier inferred an intent from the button target, surface it as a display
+			// label. Block-based and inferred intents are mutually exclusive at the source
+			// (the emit-side classifier runs ONLY when the prompt has no block), so this can
+			// never override a real block label; the null guard is defense in depth.
+			$inferred_intent = (string) ( $row['inferred_cta_intent'] ?? '' );
+			$inferred_source = (string) ( $row['inferred_cta_source'] ?? '' );
+			$is_inferred     = null === $intent_label && '' !== $inferred_intent;
+			if ( $is_inferred ) {
+				$intent_label = self::INFERRED_INTENT_LABELS[ $inferred_intent ] ?? null;
+				// Unrecognized token (shouldn't happen — the classifier emits a fixed set):
+				// leave the label null for the frontend humanizer and don't mark the row.
+				if ( null === $intent_label ) {
+					$is_inferred = false;
+				}
+			}
+
 			// Both rates share the coherence guard + em-dash semantics via rate_value() (null =
 			// not computable: no impressions, or a >100% cross-surface ratio; a float incl. 0.0
 			// = a real rate, e.g. a donation-capable prompt that converted nobody). null = N/A
@@ -1613,6 +1652,11 @@ final class Prompts_Metric {
 				// when a single-intent prompt has no friendly override, so the frontend falls
 				// back to its humanizer (preserving title-casing).
 				'intent_label'                 => $intent_label,
+				// NPPD-1840: structured passthrough for the deferred frontend tooltip/styling
+				// slice. Display-only — never feeds a conversion denominator, rate, or count.
+				'is_inferred'                  => $is_inferred,
+				'inferred_cta_intent'          => '' !== $inferred_intent ? $inferred_intent : null,
+				'inferred_cta_source'          => '' !== $inferred_source ? $inferred_source : null,
 				'placement'                    => (string) ( $row['placement'] ?? '' ),
 				'impressions'                  => $impressions,
 				'unique_viewers'               => (int) ( $row['unique_viewers'] ?? 0 ),

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-prompts-metric.php
@@ -2009,6 +2009,9 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 				'prompt_title',
 				'intent',
 				'intent_label',
+				'is_inferred',
+				'inferred_cta_intent',
+				'inferred_cta_source',
 				'placement',
 				'impressions',
 				'unique_viewers',
@@ -2105,6 +2108,72 @@ class Test_Prompts_Metric extends WP_UnitTestCase {
 		// 0 capabilities + unmapped intent → unchanged null label (frontend humanizes).
 		$this->assertNull( $rows[4]['intent_label'] );
 		$this->assertSame( 'undefined', $rows[4]['intent'] );
+	}
+
+	/**
+	 * NPPD-1840: a block-less prompt (no recognized conversion block, so the block-based
+	 * label is null) gets its display label from NPPD-1837's inferred CTA intent, marked
+	 * with `is_inferred` for the deferred frontend tooltip. Block-based labels always win;
+	 * an unmapped/absent inferred token leaves the label null and the row unmarked.
+	 */
+	public function test_performance_by_prompt_labels_inferred_cta() {
+		$perf_rows = [
+			// Block-less, classifier inferred a donation from the button target.
+			array_merge(
+				$this->performance_row( 1, 'Support us', 'undefined', 100 ),
+				[
+					'inferred_cta_intent' => 'donation',
+					'inferred_cta_source' => 'processor',
+				]
+			),
+			// Block-less, non-conversion inferred intent.
+			array_merge(
+				$this->performance_row( 2, 'Read more', 'undefined', 80 ),
+				[
+					'inferred_cta_intent' => 'editorial',
+					'inferred_cta_source' => 'pattern',
+				]
+			),
+			// Real single donation block that ALSO carries an inferred field: block wins.
+			// The emit-side classifier never emits both; this locks the guard anyway.
+			array_merge(
+				$this->performance_row_with_capabilities( 3, 'Donate now', 'donation', 90, [ 'donation_impressions' => 12 ] ),
+				[
+					'inferred_cta_intent' => 'donation',
+					'inferred_cta_source' => 'processor',
+				]
+			),
+			// Neither a recognized block nor an inferred intent → unchanged null label.
+			$this->performance_row( 4, 'Informational', 'undefined', 30 ),
+		];
+		$proxy  = $this->make_performance_proxy( $perf_rows, [], [], 1 ); // Non-WC env: perf query only.
+		$metric = new Prompts_Metric( $proxy );
+		$result = $metric->get_performance_by_prompt( $this->start(), $this->end() );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$rows = $result['rows'];
+
+		// Inferred conversion intent → "(inferred)" label + marked, source passed through.
+		$this->assertSame( 'Donation (inferred)', $rows[0]['intent_label'] );
+		$this->assertTrue( $rows[0]['is_inferred'] );
+		$this->assertSame( 'donation', $rows[0]['inferred_cta_intent'] );
+		$this->assertSame( 'processor', $rows[0]['inferred_cta_source'] );
+		$this->assertSame( 'undefined', $rows[0]['intent'], 'raw intent is never rewritten' );
+
+		// Inferred non-conversion intent → its label + marked.
+		$this->assertSame( 'Editorial link', $rows[1]['intent_label'] );
+		$this->assertTrue( $rows[1]['is_inferred'] );
+
+		// Block label wins; the row is NOT marked inferred even though it carries the field.
+		$this->assertSame( 'Donation', $rows[2]['intent_label'] );
+		$this->assertFalse( $rows[2]['is_inferred'] );
+		$this->assertSame( 'donation', $rows[2]['intent'] );
+
+		// Neither → unchanged null label, unmarked, null passthrough.
+		$this->assertNull( $rows[3]['intent_label'] );
+		$this->assertFalse( $rows[3]['is_inferred'] );
+		$this->assertNull( $rows[3]['inferred_cta_intent'] );
+		$this->assertNull( $rows[3]['inferred_cta_source'] );
 	}
 
 	/**


### PR DESCRIPTION
## What & why (NPPD-1840)

The consumer half of the block-less CTA labeling chain. NPPD-1837 (merged) emits `inferred_cta_intent` / `inferred_cta_source` for block-less prompts; NPPD-1839 (merged) projects them on each `prompts_performance_by_prompt` hub row. This bakes the locked display label into `intent_label` for those rows and passes two structured fields (`is_inferred`, `inferred_cta_source`) through for a **later** frontend enhancement.

**PHP-only.** The hover tooltip / badge styling is a separate React slice (deferred) — no `.js`/`.tsx` touched here.

## The change (in `Prompts_Metric::get_performance_by_prompt()`)

1. New `INFERRED_INTENT_LABELS` constant beside `INTENT_LABELS` — the locked six-token map (`donation`/`newsletter`/`subscription` carry the `(inferred)` marker; `sponsor`/`event`/`editorial` don't).
2. Fill `intent_label` from the inferred intent **only when the block-based label is null** — block always wins. Block-based and inferred intents are mutually exclusive at the source (the emit-side classifier runs only when a prompt has no recognized block); the null guard is defense-in-depth. An unmapped token leaves the label null and unmarked.
3. Pass `is_inferred`, `inferred_cta_intent`, `inferred_cta_source` through on the row (next to `intent_label`). Raw `intent` (`action_type`) is untouched.

## Guardrails

- **Display-only.** `intent_label` / `is_inferred` / `inferred_cta_*` never feed a conversion denominator, rate, or count — not referenced in any `get_*_conversion_*`, `get_*_revenue_*`, `fetch_*_impressions*`, or `rate_value` path.
- **Block always wins**; only fills a null label, never overwrites a single/compound block label.
- **Raw `intent` unchanged**; six-token taxonomy only.
- **Absent-key safe** (`?? ''`): emit (NPPD-1837) isn't deployed to production yet, so `inferred_cta_intent` is NULL on every current hub row → `is_inferred` is false and behavior is unchanged until emit ships. A missing column does not warn/error.

Scope: only `get_performance_by_prompt()`. `get_performance_by_intent` / `get_performance_by_placement` are untouched (block-less inference is per-prompt only).

## Tests

- New `test_performance_by_prompt_labels_inferred_cta` covering all four cases: inferred conversion → `Donation (inferred)` + `is_inferred=true` + source passthrough; inferred non-conversion → `Editorial link` + marked; real block row also carrying an inferred field → block label wins, unmarked; neither → null label, unmarked, null passthrough.
- Updated the locked `test_performance_by_prompt_row_schema_is_locked` contract with the three new keys in order.
- Full `@group insights` suite: **648 tests green**. `phpcs` (workspace root standard): **clean**.
