### PR TITLE
[DO NOT MERGE] test: exercise branch-zip bundling (NPPM-2918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,94 @@ jobs:
           ./vendor/bin/phpunit -c "$config"
 
   # ----------------------------------------------------------------------------
+  # Build installable ZIPs for each affected plugin/theme, so a branch can be
+  # installed on a site via newspack-manager's release channels. One job per
+  # affected package; packages without a `release:archive` script (shared
+  # packages) produce nothing and are skipped.
+  # ----------------------------------------------------------------------------
+  build-zips:
+    name: Build ZIP / ${{ matrix.package }}
+    needs: [changed-packages, install]
+    if: needs.changed-packages.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.changed-packages.outputs.js-matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+          coverage: none
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Resolve package directory
+        id: pkg
+        run: echo "dir=$(pnpm --silent --filter '${{ matrix.package }}' exec pwd)" >> "$GITHUB_OUTPUT"
+      - name: Build assets
+        run: pnpm --filter "${{ matrix.package }}" run --if-present build
+      # The distributable ZIP includes vendor/ (see each plugin's .distignore),
+      # so production composer deps must be present before archiving.
+      - name: Install production composer deps
+        run: |
+          dir="${{ steps.pkg.outputs.dir }}"
+          if [ -f "$dir/composer.json" ]; then
+            composer install -d "$dir" --no-interaction --no-progress --prefer-dist --no-dev
+          fi
+      - name: Archive distributable
+        run: |
+          dir="${{ steps.pkg.outputs.dir }}"
+          rm -rf "$dir/release"
+          pnpm --filter "${{ matrix.package }}" run --if-present release:archive
+          mkdir -p "$GITHUB_WORKSPACE/branch-zips"
+          if compgen -G "$dir/release/*.zip" > /dev/null; then
+            cp "$dir"/release/*.zip "$GITHUB_WORKSPACE/branch-zips/"
+          fi
+      # job-index keeps the staging artifact name valid: matrix package names
+      # like `@automattic/newspack-blocks` contain characters artifacts reject.
+      - name: Stage built ZIPs
+        uses: actions/upload-artifact@v4
+        with:
+          name: branch-zips-staging-${{ strategy.job-index }}
+          path: branch-zips/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ----------------------------------------------------------------------------
+  # Bundle every package's `<slug>.zip` into one artifact that newspack-manager
+  # downloads to install a branch. Change detection keeps the bundle small.
+  # ----------------------------------------------------------------------------
+  bundle-zips:
+    name: Bundle branch ZIPs
+    needs: build-zips
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: branch-zips-staging-*
+          path: staging
+          merge-multiple: true
+      - name: Collect ZIPs
+        run: |
+          mkdir -p bundle
+          find staging -name '*.zip' -exec cp {} bundle/ \; 2>/dev/null || true
+          ls -la bundle 2>/dev/null || true
+      - name: Upload branch bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: newspack-branch-zips
+          path: bundle/*.zip
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ----------------------------------------------------------------------------
   # Summary gate: fail the workflow if any needed job failed.
   # ----------------------------------------------------------------------------
   ci-ok:
@@ -293,7 +381,7 @@ jobs:
     # `install` is in the needs list so a `--frozen-lockfile` failure on a
     # root-deps-only PR (empty js/php matrices) is treated as a CI failure
     # rather than masked by the skipped matrix jobs.
-    needs: [install, js, php-lint, php-test]
+    needs: [install, js, php-lint, php-test, build-zips, bundle-zips]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/plugins/newspack-listings/newspack-listings.php
+++ b/plugins/newspack-listings/newspack-listings.php
@@ -14,6 +14,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+// CI: trigger branch-zip bundling smoke test (NPPM-2918, throwaway branch).
+
 // Define plugin constants.
 if ( ! defined( 'NEWSPACK_LISTINGS_PLUGIN_FILE' ) ) {
 	define( 'NEWSPACK_LISTINGS_FILE', __FILE__ );

--- a/plugins/republication-tracker-tool/republication-tracker-tool.php
+++ b/plugins/republication-tracker-tool/republication-tracker-tool.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// CI: trigger branch-zip bundling smoke test (NPPM-2918, throwaway branch).
+
 // Define plugin constants.
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 $plugin_data = get_plugin_data( __FILE__, false, false );


### PR DESCRIPTION
**Throwaway / do not merge.** Proves the [#142](https://github.com/Automattic/newspack-workspace/pull/142) branch-zip pipeline actually runs end-to-end, which #142's own CI can't show (it touches only `ci.yml`, so change-detection reports `any=false` and the new jobs skip).

This branch = current `main` + #142's `ci.yml` (cherry-picked, conflict in `ci-ok.needs` resolved to union both) + a no-op comment in `newspack-listings` and `republication-tracker-tool` so change-detection flags two packages.

Expected: `Build ZIP` runs for both plugins, `Bundle branch ZIPs` uploads a `newspack-branch-zips` artifact containing `newspack-listings.zip` + `republication-tracker-tool.zip`.

Will be closed + branch deleted after inspection.