### PR TITLE
feat(components): rework tabbed navigation on @wordpress/ui tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"prepare": "husky || true; pnpm run build:packages",
 		"lint": "pnpm --filter './plugins/*' --filter './themes/*' run lint:js && composer phpcs",
 		"lint:changed": "pnpm --filter '...[origin/main]' run lint:js",
-		"test:js": "pnpm --filter './plugins/*' --filter './themes/*' run test",
+		"test:js": "pnpm --filter './packages/*' --filter './plugins/*' --filter './themes/*' run --if-present test",
 		"test:php": "composer test",
 		"format": "pnpm --filter './plugins/*' --filter './themes/*' run format:js",
 		"cm": "commit"

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
 			"@typescript-eslint/parser": "8.61.0",
 			"prettier": "npm:wp-prettier@^3.0.3",
 			"react": "18.3.1",
-			"react-dom": "18.3.1",
-			"@wordpress/private-apis": "1.49.0"
+			"react-dom": "18.3.1"
 		},
 		"patchedDependencies": {
 			"multi-semantic-release": "patches/multi-semantic-release.patch"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
 			"@typescript-eslint/parser": "8.61.0",
 			"prettier": "npm:wp-prettier@^3.0.3",
 			"react": "18.3.1",
-			"react-dom": "18.3.1"
+			"react-dom": "18.3.1",
+			"@wordpress/private-apis": "1.49.0"
 		},
 		"patchedDependencies": {
 			"multi-semantic-release": "patches/multi-semantic-release.patch"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,7 +25,6 @@
 	"dependencies": {
 		"@wordpress/admin-ui": "2.4.0",
 		"@wordpress/style-runtime": "0.4.0",
-		"@wordpress/theme": "^0.16.0",
 		"@wordpress/ui": "^0.16.0",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,7 @@
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "2.4.0",
-		"@wordpress/style-runtime": "0.4.0",
+		"@wordpress/style-runtime": "^0.5.0",
 		"@wordpress/theme": "^0.16.0",
 		"@wordpress/ui": "^0.16.0",
 		"classnames": "^2.3.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,8 +25,8 @@
 	"dependencies": {
 		"@wordpress/admin-ui": "2.4.0",
 		"@wordpress/style-runtime": "0.4.0",
-		"@wordpress/theme": "0.15.0",
-		"@wordpress/ui": "0.15.0",
+		"@wordpress/theme": "^0.16.0",
+		"@wordpress/ui": "^0.16.0",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"moment-range": "^3.1.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@wordpress/admin-ui": "2.4.0",
 		"@wordpress/style-runtime": "0.4.0",
+		"@wordpress/theme": "^0.16.0",
 		"@wordpress/ui": "^0.16.0",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -58,7 +58,8 @@
 		"@babel/preset-env": "^7.29.7",
 		"@babel/preset-react": "^7.29.7",
 		"@babel/preset-typescript": "^7.29.7",
-		"recursive-copy": "^2.0.0"
+		"recursive-copy": "^2.0.0",
+		"newspack-scripts": "workspace:*"
 	},
 	"babel": {
 		"ignore": [
@@ -72,6 +73,7 @@
 		"compile:cjs": "babel src --config-file ./babel.config.cjs.js --extensions='.js,.jsx,.ts,.tsx' --out-dir dist/cjs",
 		"compile:esm": "babel src --extensions='.js,.jsx,.ts,.tsx' --out-dir dist/esm",
 		"compile": "npm run compile:cjs && npm run compile:esm",
+		"test": "newspack-scripts test",
 		"prepublishOnly": "npm run clean && npm run compile && node copy-styles.js",
 		"postpublish": "npm run clean",
 		"build": "npm run clean && npm run compile && node copy-styles.js"

--- a/packages/components/src/divider/style.scss
+++ b/packages/components/src/divider/style.scss
@@ -46,6 +46,6 @@
 	}
 
 	&--variant-tertiary {
-		background-color: wp-colors.$gray-100;
+		background-color: var( --wpds-color-stroke-surface-neutral-weak );
 	}
 }

--- a/packages/components/src/divider/style.scss
+++ b/packages/components/src/divider/style.scss
@@ -46,6 +46,8 @@
 	}
 
 	&--variant-tertiary {
-		background-color: var( --wpds-color-stroke-surface-neutral-weak );
+		// Fallback for consumers whose bundle doesn't carry the wpds token sheet
+		// (it ships with the Page header's stylesheet).
+		background-color: var( --wpds-color-stroke-surface-neutral-weak, #{wp-colors.$gray-100} );
 	}
 }

--- a/packages/components/src/page/index.js
+++ b/packages/components/src/page/index.js
@@ -3,6 +3,7 @@
  */
 import { NavigableRegion } from '@wordpress/admin-ui';
 import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { cloneElement, isValidElement } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import { Stack, Text } from '@wordpress/ui';
 
@@ -22,20 +23,29 @@ import './style.scss';
  * Newspack page region: a sticky header block (breadcrumbs, actions, optional
  * tabbed navigation) followed by the page content.
  *
+ * This intentionally does not use `@wordpress/admin-ui`'s `Page`: that
+ * component has no slot for content rendered between the header and the body
+ * inside the sticky region, which is exactly where the tab bar must live. Until
+ * admin-ui grows such a slot, the header markup is assembled here from the same
+ * design-system primitives and tokens, so it can be swapped back later.
+ *
  * @param {Object} props
  * @param {Array}  props.breadcrumbItems    Trail items: `{ label, url? }`.
  * @param {*}      [props.badges]
  * @param {*}      [props.subTitle]
  * @param {*}      [props.actions]
- * @param {*}      [props.tabbedNavigation] Tabbed navigation, rendered inside the sticky header block.
+ * @param {*}      [props.tabbedNavigation] A `TabbedNavigation` element; its bar renders inside
+ *                                          the sticky header block and the page children render
+ *                                          inside its active tab panel.
  * @param {string} [props.className]
  * @param {*}      props.children
  * @return {JSX.Element} Page component.
  */
 const Page = ( { breadcrumbItems = [], badges, subTitle, actions, tabbedNavigation, className, children } ) => {
 	const currentLabel = breadcrumbItems[ breadcrumbItems.length - 1 ]?.label;
-	return (
-		<NavigableRegion className={ classnames( 'newspack-page', className ) } ariaLabel={ currentLabel }>
+
+	const renderShell = ( tabBar, content ) => (
+		<>
 			<Stack direction="column" className="newspack-page__header-region">
 				<Stack direction="column" className="newspack-page__header">
 					<Stack direction="row" gap="sm" justify="space-between">
@@ -60,9 +70,17 @@ const Page = ( { breadcrumbItems = [], badges, subTitle, actions, tabbedNavigati
 						</Text>
 					) }
 				</Stack>
-				{ tabbedNavigation }
+				{ tabBar }
 			</Stack>
-			{ children }
+			{ content }
+		</>
+	);
+
+	return (
+		<NavigableRegion className={ classnames( 'newspack-page', className ) } ariaLabel={ currentLabel }>
+			{ isValidElement( tabbedNavigation )
+				? cloneElement( tabbedNavigation, { renderShell, content: children } )
+				: renderShell( null, children ) }
 		</NavigableRegion>
 	);
 };

--- a/packages/components/src/page/index.js
+++ b/packages/components/src/page/index.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies.
  */
-import { Page as AdminUIPage } from '@wordpress/admin-ui';
+import { NavigableRegion } from '@wordpress/admin-ui';
 import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Icon } from '@wordpress/icons';
+import { Stack, Text } from '@wordpress/ui';
 
 /**
  * External dependencies.
@@ -18,40 +19,51 @@ import Breadcrumbs from '../breadcrumbs';
 import './style.scss';
 
 /**
- * Newspack page header + content region, built on @wordpress/admin-ui's Page.
- *
- * The branded Newspack logo is supplied as admin-ui's decorative (aria-hidden)
- * `visual` slot. The breadcrumb trail (with the current page as the single h1)
- * is supplied as admin-ui's `breadcrumbs` ReactNode.
+ * Newspack page region: a sticky header block (breadcrumbs, actions, optional
+ * tabbed navigation) followed by the page content.
  *
  * @param {Object} props
- * @param {Array}  props.breadcrumbItems Trail items: `{ label, url? }`.
+ * @param {Array}  props.breadcrumbItems    Trail items: `{ label, url? }`.
  * @param {*}      [props.badges]
  * @param {*}      [props.subTitle]
  * @param {*}      [props.actions]
+ * @param {*}      [props.tabbedNavigation] Tabbed navigation, rendered inside the sticky header block.
  * @param {string} [props.className]
  * @param {*}      props.children
  * @return {JSX.Element} Page component.
  */
-const Page = ( { breadcrumbItems = [], badges, subTitle, actions, className, children } ) => {
+const Page = ( { breadcrumbItems = [], badges, subTitle, actions, tabbedNavigation, className, children } ) => {
 	const currentLabel = breadcrumbItems[ breadcrumbItems.length - 1 ]?.label;
 	return (
-		<AdminUIPage
-			className={ classnames( 'newspack-page', className ) }
-			ariaLabel={ currentLabel }
-			visual={ <Icon icon={ newspack } /> }
-			breadcrumbs={
-				<HStack className="newspack-page__breadcrumbs" justify="flex-start">
-					<Breadcrumbs items={ breadcrumbItems } />
-				</HStack>
-			}
-			badges={ badges }
-			subTitle={ subTitle }
-			actions={ actions }
-			hasPadding={ false }
-		>
+		<NavigableRegion className={ classnames( 'newspack-page', className ) } ariaLabel={ currentLabel }>
+			<Stack direction="column" className="newspack-page__header-region">
+				<Stack direction="column" className="newspack-page__header">
+					<Stack direction="row" gap="sm" justify="space-between">
+						<Stack direction="row" gap="sm" align="center" justify="start">
+							<div className="newspack-page__header-visual" aria-hidden="true">
+								<Icon icon={ newspack } />
+							</div>
+							<HStack className="newspack-page__breadcrumbs" justify="flex-start">
+								<Breadcrumbs items={ breadcrumbItems } />
+							</HStack>
+							{ badges }
+						</Stack>
+						{ actions && (
+							<Stack direction="row" gap="sm" align="center" className="newspack-page__header-actions">
+								{ actions }
+							</Stack>
+						) }
+					</Stack>
+					{ subTitle && (
+						<Text render={ <p /> } variant="body-md" className="newspack-page__header-subtitle">
+							{ subTitle }
+						</Text>
+					) }
+				</Stack>
+				{ tabbedNavigation }
+			</Stack>
 			{ children }
-		</AdminUIPage>
+		</NavigableRegion>
 	);
 };
 

--- a/packages/components/src/page/style.scss
+++ b/packages/components/src/page/style.scss
@@ -1,3 +1,4 @@
+@use "../../../colors/colors.module" as colors;
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "~@wordpress/base-styles/mixins" as wp-mixins;
 @use "~@wordpress/base-styles/variables" as wp-vars;
@@ -12,6 +13,30 @@
 // build time.
 /* stylelint-disable-next-line no-invalid-position-at-import-rule -- sass @use must precede the CSS @import; postcss-import inlines it at build time. */
 @import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
+
+// Newspack brand mapping: the wpds brand color tokens ship in WordPress
+// blue; remap them onto the Newspack primary scale so every design-system
+// component (focus rings, brand buttons, toggles) renders in brand colors
+// without per-component overrides.
+/* stylelint-disable plugin-wpds/no-setting-wpds-custom-properties -- deliberate Newspack brand override of the wpds brand tokens. */
+:root {
+	--wpds-color-background-interactive-brand-strong: #{colors.$primary-600};
+	--wpds-color-background-interactive-brand-strong-active: #{colors.$primary-800};
+	--wpds-color-background-interactive-brand-weak-active: #{colors.$primary-000};
+	--wpds-color-background-surface-brand: #{colors.$primary-000};
+	--wpds-color-background-thumb-brand: #{colors.$primary-600};
+	--wpds-color-background-thumb-brand-active: #{colors.$primary-600};
+	--wpds-color-foreground-interactive-brand: #{colors.$primary-600};
+	--wpds-color-foreground-interactive-brand-active: #{colors.$primary-800};
+	--wpds-color-foreground-interactive-brand-disabled: #{colors.$primary-400};
+	--wpds-color-stroke-focus: #{colors.$primary-600};
+	--wpds-color-stroke-interactive-brand: #{colors.$primary-600};
+	--wpds-color-stroke-interactive-brand-active: #{colors.$primary-800};
+	--wpds-color-stroke-interactive-brand-disabled: #{colors.$primary-100};
+	--wpds-color-stroke-surface-brand: #{colors.$primary-000};
+	--wpds-color-stroke-surface-brand-strong: #{colors.$primary-600};
+}
+/* stylelint-enable plugin-wpds/no-setting-wpds-custom-properties */
 
 [role="region"].newspack-page {
 	background-color: wp-colors.$white;

--- a/packages/components/src/page/style.scss
+++ b/packages/components/src/page/style.scss
@@ -1,4 +1,5 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
 @use "~@wordpress/base-styles/variables" as wp-vars;
 
 [role="region"].newspack-page {
@@ -6,9 +7,11 @@
 }
 
 .newspack-page__header-region {
-	position: sticky;
-	top: var(--wp-admin--admin-bar--height);
-	z-index: 3;
+	@include wp-mixins.break-medium {
+		position: sticky;
+		top: var(--wp-admin--admin-bar--height);
+		z-index: 3;
+	}
 }
 
 .newspack-page__header {

--- a/packages/components/src/page/style.scss
+++ b/packages/components/src/page/style.scss
@@ -5,18 +5,41 @@
 	background-color: wp-colors.$white;
 }
 
-.newspack-page > [class*="__header"] {
+.newspack-page__header-region {
+	position: sticky;
 	top: var(--wp-admin--admin-bar--height);
+	z-index: 3;
 }
 
-.newspack-page > .newspack-tabbed-navigation {
-	position: static;
+.newspack-page__header {
+	/* stylelint-disable-next-line plugin-wpds/no-unknown-ds-tokens -- the plugin's token list lags the prebuilt design-tokens.css names. */
+	background: var(--wpds-color-background-surface-neutral-strong);
+	border-block-end: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
 }
 
-.newspack-page [class*="header-visual"] svg path {
-	transform: scale(1.1111);
-	transform-box: view-box;
-	transform-origin: center;
+.newspack-page__header-actions {
+	flex-shrink: 0;
+}
+
+.newspack-page__header-subtitle {
+	/* stylelint-disable-next-line plugin-wpds/no-unknown-ds-tokens -- the plugin's token list lags the prebuilt design-tokens.css names. */
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	padding-block-end: var(--wpds-dimension-padding-xs);
+}
+
+.newspack-page__header-visual {
+	display: grid;
+	flex-shrink: 0;
+	height: 24px;
+	place-items: center;
+	width: 24px;
+
+	svg path {
+		transform: scale(1.1111);
+		transform-box: view-box;
+		transform-origin: center;
+	}
 }
 
 .newspack-page__breadcrumbs {

--- a/packages/components/src/page/style.scss
+++ b/packages/components/src/page/style.scss
@@ -3,6 +3,13 @@
 @use "~@wordpress/base-styles/variables" as wp-vars;
 
 // Design-system tokens ride with the Page header into any consuming bundle.
+// Known tech debt: this reaches past the package's public exports entry
+// (`@wordpress/theme/design-tokens.css`) into its internal layout, because
+// postcss-import cannot resolve exports maps, and resolving the public
+// specifier through sass/webpack leaks a bogus `wp-theme/design-tokens.css`
+// script dependency into consumers' asset manifests, which silently blocks
+// their enqueues. If upstream moves `src/prebuilt/`, this fails loudly at
+// build time.
 /* stylelint-disable-next-line no-invalid-position-at-import-rule -- sass @use must precede the CSS @import; postcss-import inlines it at build time. */
 @import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
 

--- a/packages/components/src/page/style.scss
+++ b/packages/components/src/page/style.scss
@@ -2,6 +2,10 @@
 @use "~@wordpress/base-styles/mixins" as wp-mixins;
 @use "~@wordpress/base-styles/variables" as wp-vars;
 
+// Design-system tokens ride with the Page header into any consuming bundle.
+/* stylelint-disable-next-line no-invalid-position-at-import-rule -- sass @use must precede the CSS @import; postcss-import inlines it at build time. */
+@import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
+
 [role="region"].newspack-page {
 	background-color: wp-colors.$white;
 }

--- a/packages/components/src/page/style.scss
+++ b/packages/components/src/page/style.scss
@@ -5,6 +5,14 @@
 	background-color: wp-colors.$white;
 }
 
+.newspack-page > [class*="__header"] {
+	top: var(--wp-admin--admin-bar--height);
+}
+
+.newspack-page > .newspack-tabbed-navigation {
+	position: static;
+}
+
 .newspack-page [class*="header-visual"] svg path {
 	transform: scale(1.1111);
 	transform-box: view-box;

--- a/packages/components/src/route-match.js
+++ b/packages/components/src/route-match.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies.
+ */
+import Router from './proxied-imports/router';
+
+const { matchPath } = Router;
+
+/**
+ * Whether a wildcard pattern (`'/base/*'` or `'/base*'`) matches a pathname.
+ * The wildcard is anchored at a `/` boundary: `'/segments*'` matches
+ * `/segments` and `/segments/123`, never `/segments-old`.
+ *
+ * @param {string} pattern  Pattern ending in `*`.
+ * @param {string} pathname Current router pathname.
+ * @return {boolean} Whether the pattern matches.
+ */
+const matchesWildcard = ( pattern, pathname ) => {
+	const base = pattern.slice( 0, -1 ).replace( /\/$/, '' );
+	return pathname === base || pathname.startsWith( base + '/' );
+};
+
+/**
+ * Single route matcher shared by breadcrumb selection and tabbed navigation.
+ *
+ * An item matches when one of its `activeTabPaths` hits (exact string, or a
+ * `*` wildcard anchored at a `/` boundary), or — falling through on a miss —
+ * when its `path` matches the pathname. Path matching is prefix-based except
+ * for the root path and items opting in via `exact: true`, mirroring how the
+ * wizard registers its `<Route>`s (`exact={ section.exact ?? false }`).
+ *
+ * @param {Object} item     Route item (`{ path?, exact?, activeTabPaths? }`).
+ * @param {string} pathname Current router pathname.
+ * @return {boolean} Whether the item matches the pathname.
+ */
+export const matchesRoute = ( item, pathname ) => {
+	if ( Array.isArray( item.activeTabPaths ) ) {
+		const wildcardHit = item.activeTabPaths.some( path => ( path.endsWith( '*' ) ? matchesWildcard( path, pathname ) : path === pathname ) );
+		if ( wildcardHit ) {
+			return true;
+		}
+	}
+	if ( ! item.path ) {
+		return false;
+	}
+	const exact = '/' === item.path || item.exact === true;
+	return !! matchPath( pathname, { path: item.path, exact } );
+};

--- a/packages/components/src/route-match.test.js
+++ b/packages/components/src/route-match.test.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies.
+ */
+import { matchesRoute } from './route-match';
+
+describe( 'matchesRoute', () => {
+	it( 'matches the root path exactly, never as a prefix', () => {
+		expect( matchesRoute( { path: '/' }, '/' ) ).toBe( true );
+		expect( matchesRoute( { path: '/' }, '/segments' ) ).toBe( false );
+	} );
+
+	it( 'matches a path as a prefix by default, at segment boundaries', () => {
+		expect( matchesRoute( { path: '/segments' }, '/segments' ) ).toBe( true );
+		expect( matchesRoute( { path: '/segments' }, '/segments/123' ) ).toBe( true );
+		expect( matchesRoute( { path: '/segments' }, '/segments-old' ) ).toBe( false );
+		expect( matchesRoute( { path: '/segments' }, '/donations' ) ).toBe( false );
+	} );
+
+	it( 'matches exactly when the item opts in via exact', () => {
+		expect( matchesRoute( { path: '/segments', exact: true }, '/segments' ) ).toBe( true );
+		expect( matchesRoute( { path: '/segments', exact: true }, '/segments/123' ) ).toBe( false );
+	} );
+
+	it( 'matches an activeTabPaths entry exactly', () => {
+		const item = { path: '/other', activeTabPaths: [ '/segments/new' ] };
+		expect( matchesRoute( item, '/segments/new' ) ).toBe( true );
+		expect( matchesRoute( item, '/segments/123' ) ).toBe( false );
+	} );
+
+	it( 'anchors an activeTabPaths wildcard at a segment boundary', () => {
+		const item = { path: '/other', activeTabPaths: [ '/segments/*' ] };
+		expect( matchesRoute( item, '/segments' ) ).toBe( true );
+		expect( matchesRoute( item, '/segments/123' ) ).toBe( true );
+		expect( matchesRoute( item, '/segments-old' ) ).toBe( false );
+
+		const noSlash = { path: '/other', activeTabPaths: [ '/segments*' ] };
+		expect( matchesRoute( noSlash, '/segments' ) ).toBe( true );
+		expect( matchesRoute( noSlash, '/segments/123' ) ).toBe( true );
+		expect( matchesRoute( noSlash, '/segments-old' ) ).toBe( false );
+	} );
+
+	it( 'falls through to path matching when activeTabPaths misses', () => {
+		expect( matchesRoute( { path: '/segments', activeTabPaths: [ '/elsewhere' ] }, '/segments/123' ) ).toBe( true );
+	} );
+
+	it( 'never matches an item without a path when activeTabPaths misses', () => {
+		expect( matchesRoute( {}, '/segments' ) ).toBe( false );
+		expect( matchesRoute( { activeTabPaths: [ '/elsewhere' ] }, '/segments' ) ).toBe( false );
+	} );
+} );

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies.
  */
-import { ThemeProvider } from '@wordpress/theme';
 import { Tabs } from '@wordpress/ui';
 
 /**
@@ -19,19 +18,6 @@ const { useHistory, useLocation } = Router;
 
 const getItemValue = item => item.path || item.href;
 
-/**
- * Whether a navigation item is the active one.
- *
- * Router-driven items match on `path` (exact by default, prefix when
- * `exact: false`) and optionally on `activeTabPaths` (a trailing `*` makes an
- * entry a prefix match) so hidden subpages can keep a parent tab selected.
- * Outside a router, an item is active when explicitly marked `selected` or
- * when its `href` is the current URL.
- *
- * @param {Object}      item     Navigation item.
- * @param {string|null} pathname Current router pathname, or null when rendered outside a router.
- * @return {boolean} Whether the item is active.
- */
 export const isItemActive = ( item, pathname ) => {
 	if ( item.selected ) {
 		return true;
@@ -46,39 +32,16 @@ export const isItemActive = ( item, pathname ) => {
 		return item.activeTabPaths.some( path => ( path.endsWith( '*' ) ? pathname.startsWith( path.slice( 0, -1 ) ) : path === pathname ) );
 	}
 	if ( false === item.exact && item.path ) {
-		// Segment-aware prefix match (mirrors react-router's matchPath): `/segments`
-		// matches `/segments/123` but not a prefix-colliding sibling like `/segments-old`.
 		return pathname === item.path || pathname.startsWith( item.path + '/' );
 	}
 	return false;
 };
 
-/**
- * Tabbed navigation, built on @wordpress/ui's Tabs.
- *
- * Tabs render as anchors so navigation stays native: hash links when items
- * provide a router `path`, full URLs when they provide an `href`. Selection is
- * controlled from the current location rather than by the Tabs component, so
- * the active tab always mirrors the route (or a `selected` flag).
- *
- * @param {Object}      props
- * @param {Array}       props.items             Items: `{ path?, href?, label, exact?, activeTabPaths?, selected?, isHiddenInTabbedNavigation? }`.
- * @param {string}      [props.className]
- * @param {boolean}     [props.disableUpcoming] Disable tabs after the active one.
- * @param {Object}      [props.history]         Router history, when rendered inside a router.
- * @param {string|null} [props.pathname]        Current router pathname, or null outside a router.
- * @param {*}           [props.children]
- * @return {JSX.Element} Tabbed navigation component.
- */
 const TabbedNavigationView = ( { items, className, disableUpcoming, history = null, pathname = null, children = null } ) => {
 	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
 	const activeIndex = displayedItems.findIndex( item => isItemActive( item, pathname ) );
 	const activeValue = activeIndex > -1 ? getItemValue( displayedItems[ activeIndex ] ) : null;
 
-	// Route through history.push (like NavLink) rather than native hash
-	// navigation: a raw hashchange reaches the router as a POP, which
-	// `history.block` guards (e.g. unsaved-changes dialogs) can't intercept
-	// cleanly. Modified/middle clicks fall through to the href.
 	const onTabClick = ( event, item ) => {
 		if ( ! history || ! item.path ) {
 			return;
@@ -94,52 +57,39 @@ const TabbedNavigationView = ( { items, className, disableUpcoming, history = nu
 
 	return (
 		<div className={ classnames( 'newspack-tabbed-navigation', className ) }>
-			<ThemeProvider>
-				<Tabs.Root value={ activeValue } className="newspack-tabbed-navigation__tabs">
-					<Tabs.List activateOnFocus={ false }>
-						{ displayedItems.map( ( item, index ) => {
-							const isDisabled = disableUpcoming && index > activeIndex;
-							const href = item.path ? `#${ item.path }` : item.href;
-							return (
-								<Tabs.Tab
-									key={ getItemValue( item ) }
-									value={ getItemValue( item ) }
-									disabled={ isDisabled }
-									nativeButton={ false }
-									render={
-										// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- content is supplied via the Tab children through @wordpress/ui's render prop, and disabled tabs intentionally drop the href.
-										<a
-											href={ isDisabled ? undefined : href }
-											onClick={ isDisabled ? undefined : event => onTabClick( event, item ) }
-										/>
-									}
-								>
-									{ item.label }
-								</Tabs.Tab>
-							);
-						} ) }
-					</Tabs.List>
-					{ /* The real "panel" is the routed page content rendered outside this
-					     component; these empty panels keep the required tab/panel ARIA pairing. */ }
-					{ displayedItems.map( item => (
-						<Tabs.Panel key={ getItemValue( item ) } value={ getItemValue( item ) } tabIndex={ -1 } />
-					) ) }
-				</Tabs.Root>
-			</ThemeProvider>
+			<Tabs.Root value={ activeValue } className="newspack-tabbed-navigation__tabs">
+				<Tabs.List activateOnFocus={ false }>
+					{ displayedItems.map( ( item, index ) => {
+						const isDisabled = disableUpcoming && index > activeIndex;
+						const href = item.path ? `#${ item.path }` : item.href;
+						return (
+							<Tabs.Tab
+								key={ getItemValue( item ) }
+								value={ getItemValue( item ) }
+								disabled={ isDisabled }
+								nativeButton={ false }
+								render={
+									// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- content is supplied via the Tab children through @wordpress/ui's render prop, and disabled tabs intentionally drop the href.
+									<a
+										href={ isDisabled ? undefined : href }
+										onClick={ isDisabled ? undefined : event => onTabClick( event, item ) }
+									/>
+								}
+							>
+								{ item.label }
+							</Tabs.Tab>
+						);
+					} ) }
+				</Tabs.List>
+				{ displayedItems.map( item => (
+					<Tabs.Panel key={ getItemValue( item ) } value={ getItemValue( item ) } tabIndex={ -1 } />
+				) ) }
+			</Tabs.Root>
 			{ children }
 		</div>
 	);
 };
 
-/**
- * Router-driven variant: navigates via history and mirrors the current route.
- * Only rendered when items navigate by router `path`, since the router hooks
- * require a router ancestor. `useLocation` provides the re-render on route
- * change — `useHistory` alone reads a stable context and never re-renders.
- *
- * @param {Object} props See TabbedNavigationView.
- * @return {JSX.Element} Tabbed navigation component.
- */
 const RoutedTabbedNavigation = props => {
 	const history = useHistory();
 	const { pathname } = useLocation();

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies.
  */
+import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
 
 /**
@@ -12,11 +13,12 @@ import Router from '../proxied-imports/router';
 /**
  * Internal dependencies.
  */
+import { matchesRoute } from '../route-match';
 import './style.scss';
 
 const { useHistory, useLocation } = Router;
 
-const getItemValue = item => item.path || item.href;
+const getItemValue = ( item, index ) => item.path || item.href || `item-${ index }`;
 
 export const isItemActive = ( item, pathname ) => {
 	if ( item.selected ) {
@@ -25,80 +27,154 @@ export const isItemActive = ( item, pathname ) => {
 	if ( null === pathname ) {
 		return Boolean( item.href ) && window.location.href === item.href;
 	}
-	if ( item.path === pathname ) {
-		return true;
-	}
-	if ( Array.isArray( item.activeTabPaths ) ) {
-		return item.activeTabPaths.some( path => ( path.endsWith( '*' ) ? pathname.startsWith( path.slice( 0, -1 ) ) : path === pathname ) );
-	}
-	if ( false === item.exact && item.path ) {
-		return pathname === item.path || pathname.startsWith( item.path + '/' );
-	}
-	return false;
+	return matchesRoute( item, pathname );
 };
 
-const TabbedNavigationView = ( { items, className, disableUpcoming, history = null, pathname = null, children = null } ) => {
+/**
+ * Default layout when `Page` doesn't inject one: bar above content.
+ */
+const defaultRenderShell = ( bar, content ) => (
+	<>
+		{ bar }
+		{ content }
+	</>
+);
+
+/**
+ * Router-driven tabs: a real WAI-ARIA tabs widget. The routed page content
+ * renders inside the active tab's `Tabs.Panel`, so each tab's `aria-controls`
+ * points at the panel that actually contains its content.
+ */
+const RoutedTabbedNavigation = ( { items, className, disableUpcoming, content = null, renderShell = defaultRenderShell, children = null } ) => {
+	const history = useHistory();
+	const { pathname } = useLocation();
 	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
-	const activeIndex = displayedItems.findIndex( item => isItemActive( item, pathname ) );
-	const activeValue = activeIndex > -1 ? getItemValue( displayedItems[ activeIndex ] ) : null;
+
+	// Most-specific match wins, so a tab is never outranked by a sibling that
+	// happens to prefix-match the same pathname.
+	const activeIndex = displayedItems.reduce( ( best, item, index ) => {
+		if ( ! isItemActive( item, pathname ) ) {
+			return best;
+		}
+		if ( best === -1 || ( item.path?.length || 0 ) > ( displayedItems[ best ].path?.length || 0 ) ) {
+			return index;
+		}
+		return best;
+	}, -1 );
+	const activeValue = activeIndex > -1 ? getItemValue( displayedItems[ activeIndex ], activeIndex ) : null;
 
 	const onTabClick = ( event, item ) => {
-		if ( ! history || ! item.path ) {
+		// Modified clicks (new tab/window) keep native anchor behavior. Middle
+		// clicks never reach onClick (they dispatch auxclick), so the anchor's
+		// href handles those natively too.
+		if ( event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
 			return;
 		}
-		if ( event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0 ) {
-			return;
-		}
+		// Route through the history object so navigation guards registered via
+		// history.block() (unsaved-changes prompts) are consulted.
 		event.preventDefault();
 		if ( item.path !== pathname ) {
 			history.push( item.path );
 		}
 	};
 
-	return (
+	const bar = (
 		<div className={ classnames( 'newspack-tabbed-navigation', className ) }>
-			<Tabs.Root value={ activeValue } className="newspack-tabbed-navigation__tabs">
-				<Tabs.List activateOnFocus={ false }>
-					{ displayedItems.map( ( item, index ) => {
-						const isDisabled = disableUpcoming && index > activeIndex;
-						const href = item.path ? `#${ item.path }` : item.href;
-						return (
-							<Tabs.Tab
-								key={ getItemValue( item ) }
-								value={ getItemValue( item ) }
-								disabled={ isDisabled }
-								nativeButton={ false }
-								render={
-									// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- content is supplied via the Tab children through @wordpress/ui's render prop, and disabled tabs intentionally drop the href.
-									<a
-										href={ isDisabled ? undefined : href }
-										onClick={ isDisabled ? undefined : event => onTabClick( event, item ) }
-									/>
-								}
-							>
-								{ item.label }
-							</Tabs.Tab>
-						);
-					} ) }
-				</Tabs.List>
-				{ displayedItems.map( item => (
-					<Tabs.Panel key={ getItemValue( item ) } value={ getItemValue( item ) } tabIndex={ -1 } />
-				) ) }
-			</Tabs.Root>
+			<Tabs.List activateOnFocus={ false }>
+				{ displayedItems.map( ( item, index ) => {
+					const isDisabled = disableUpcoming && index > activeIndex;
+					const href = item.path ? `#${ item.path }` : item.href;
+					return (
+						<Tabs.Tab
+							key={ getItemValue( item, index ) }
+							value={ getItemValue( item, index ) }
+							disabled={ isDisabled }
+							nativeButton={ false }
+							render={
+								// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- content is supplied via the Tab children through @wordpress/ui's render prop, and disabled tabs intentionally drop the href.
+								<a
+									href={ isDisabled ? undefined : href }
+									onClick={ isDisabled || ! item.path ? undefined : event => onTabClick( event, item ) }
+								/>
+							}
+						>
+							{ item.label }
+						</Tabs.Tab>
+					);
+				} ) }
+			</Tabs.List>
 			{ children }
 		</div>
 	);
+
+	// Panels must stay 1:1 with the tabs above (@wordpress/ui validates the
+	// pairing in development builds); only the active panel holds the content.
+	const panels = displayedItems.map( ( item, index ) => {
+		const value = getItemValue( item, index );
+		return (
+			<Tabs.Panel key={ value } value={ value } tabIndex={ -1 } className="newspack-tabbed-navigation__panel">
+				{ value === activeValue ? content : null }
+			</Tabs.Panel>
+		);
+	} );
+
+	return (
+		<Tabs.Root value={ activeValue } className="newspack-tabbed-navigation__root">
+			{ renderShell( bar, panels ) }
+		</Tabs.Root>
+	);
 };
 
-const RoutedTabbedNavigation = props => {
-	const history = useHistory();
-	const { pathname } = useLocation();
-	return <TabbedNavigationView { ...props } history={ history } pathname={ pathname } />;
+/**
+ * Link-driven "tabs": plain navigation for items that trigger full page loads
+ * (e.g. the PHP-rendered wizards admin header). These are not tabs in the ARIA
+ * sense — there is no in-page panel to control — so they render as a `nav` of
+ * links with `aria-current`, styled to match the tabs widget.
+ */
+const LinkTabbedNavigation = ( { items, className, content = null, renderShell = defaultRenderShell, children = null } ) => {
+	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
+	const bar = (
+		<nav
+			className={ classnames( 'newspack-tabbed-navigation', 'newspack-tabbed-navigation--links', className ) }
+			aria-label={ __( 'Secondary navigation', 'newspack-plugin' ) }
+		>
+			{ displayedItems.map( ( item, index ) => (
+				<a
+					key={ getItemValue( item, index ) }
+					href={ item.href }
+					className="newspack-tabbed-navigation__link"
+					aria-current={ isItemActive( item, null ) ? 'page' : undefined }
+				>
+					{ item.label }
+				</a>
+			) ) }
+			{ children }
+		</nav>
+	);
+	return renderShell( bar, content );
 };
 
+/**
+ * Tabbed navigation over `{ label, path? | href?, exact?, activeTabPaths?, selected?, isHiddenInTabbedNavigation? }` items.
+ *
+ * Items with router `path`s render as a real tabs widget whose active panel
+ * contains `content`; href-only items render as plain navigation links.
+ *
+ * `renderShell( bar, content )` is a layout injection point used by `Page` to
+ * place the bar inside its sticky header region while the content flows below.
+ *
+ * @param {Object}  props
+ * @param {Array}   props.items             Navigation items.
+ * @param {boolean} [props.disableUpcoming] Disable tabs after the active one (setup flows).
+ * @param {*}       [props.content]         Page content, rendered inside the active tab's panel.
+ * @param {*}       [props.renderShell]     Layout callback `( bar, content ) => element`.
+ * @param {string}  [props.className]
+ * @param {*}       [props.children]        Extra elements rendered inside the bar (e.g. error notices).
+ * @return {JSX.Element} Tabbed navigation.
+ */
 const TabbedNavigation = props => {
 	const hasRoutedItems = props.items.some( item => item.path );
-	return hasRoutedItems ? <RoutedTabbedNavigation { ...props } /> : <TabbedNavigationView { ...props } />;
+	return hasRoutedItems ? <RoutedTabbedNavigation { ...props } /> : <LinkTabbedNavigation { ...props } />;
 };
 
 export default TabbedNavigation;

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -32,7 +32,7 @@ const getItemValue = item => item.path || item.href;
  * @param {string|null} pathname Current router pathname, or null when rendered outside a router.
  * @return {boolean} Whether the item is active.
  */
-const isItemActive = ( item, pathname ) => {
+export const isItemActive = ( item, pathname ) => {
 	if ( item.selected ) {
 		return true;
 	}
@@ -106,7 +106,10 @@ const TabbedNavigationView = ( { items, className, disableUpcoming, history = nu
 									nativeButton={ false }
 									render={
 										// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- content is supplied via the Tab children through @wordpress/ui's render prop, and disabled tabs intentionally drop the href.
-										<a href={ isDisabled ? undefined : href } onClick={ event => onTabClick( event, item ) } />
+										<a
+											href={ isDisabled ? undefined : href }
+											onClick={ isDisabled ? undefined : event => onTabClick( event, item ) }
+										/>
 									}
 								>
 									{ item.label }

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -46,7 +46,9 @@ export const isItemActive = ( item, pathname ) => {
 		return item.activeTabPaths.some( path => ( path.endsWith( '*' ) ? pathname.startsWith( path.slice( 0, -1 ) ) : path === pathname ) );
 	}
 	if ( false === item.exact && item.path ) {
-		return pathname.startsWith( item.path );
+		// Segment-aware prefix match (mirrors react-router's matchPath): `/segments`
+		// matches `/segments/123` but not a prefix-colliding sibling like `/segments-old`.
+		return pathname === item.path || pathname.startsWith( item.path + '/' );
 	}
 	return false;
 };

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -1,8 +1,13 @@
 /**
+ * WordPress dependencies.
+ */
+import { ThemeProvider } from '@wordpress/theme';
+import { Tabs } from '@wordpress/ui';
+
+/**
  * External dependencies.
  */
 import classnames from 'classnames';
-import findIndex from 'lodash/findIndex';
 import Router from '../proxied-imports/router';
 
 /**
@@ -10,51 +15,135 @@ import Router from '../proxied-imports/router';
  */
 import './style.scss';
 
-const { NavLink, useHistory } = Router;
+const { useHistory, useLocation } = Router;
 
-const TabbedNavigation = ( { items, className, disableUpcoming, children = null } ) => {
-	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
-	const { location } = useHistory();
-	const currentIndex = findIndex( displayedItems, [ 'path', location.pathname ] );
+const getItemValue = item => item.path || item.href;
 
-	function isActive( item, match, pathname ) {
-		if ( item.path === pathname ) {
-			return true;
-		}
-		if ( Array.isArray( item?.activeTabPaths ) ) {
-			return item.activeTabPaths.some( path => {
-				if ( path.endsWith( '*' ) ) {
-					const basePath = path.slice( 0, -1 );
-					return pathname.startsWith( basePath );
-				}
-				return item.activeTabPaths.includes( pathname );
-			} );
-		}
-		return match;
+/**
+ * Whether a navigation item is the active one.
+ *
+ * Router-driven items match on `path` (exact by default, prefix when
+ * `exact: false`) and optionally on `activeTabPaths` (a trailing `*` makes an
+ * entry a prefix match) so hidden subpages can keep a parent tab selected.
+ * Outside a router, an item is active when explicitly marked `selected` or
+ * when its `href` is the current URL.
+ *
+ * @param {Object}      item     Navigation item.
+ * @param {string|null} pathname Current router pathname, or null when rendered outside a router.
+ * @return {boolean} Whether the item is active.
+ */
+const isItemActive = ( item, pathname ) => {
+	if ( item.selected ) {
+		return true;
 	}
+	if ( null === pathname ) {
+		return Boolean( item.href ) && window.location.href === item.href;
+	}
+	if ( item.path === pathname ) {
+		return true;
+	}
+	if ( Array.isArray( item.activeTabPaths ) ) {
+		return item.activeTabPaths.some( path => ( path.endsWith( '*' ) ? pathname.startsWith( path.slice( 0, -1 ) ) : path === pathname ) );
+	}
+	if ( false === item.exact && item.path ) {
+		return pathname.startsWith( item.path );
+	}
+	return false;
+};
+
+/**
+ * Tabbed navigation, built on @wordpress/ui's Tabs.
+ *
+ * Tabs render as anchors so navigation stays native: hash links when items
+ * provide a router `path`, full URLs when they provide an `href`. Selection is
+ * controlled from the current location rather than by the Tabs component, so
+ * the active tab always mirrors the route (or a `selected` flag).
+ *
+ * @param {Object}      props
+ * @param {Array}       props.items             Items: `{ path?, href?, label, exact?, activeTabPaths?, selected?, isHiddenInTabbedNavigation? }`.
+ * @param {string}      [props.className]
+ * @param {boolean}     [props.disableUpcoming] Disable tabs after the active one.
+ * @param {Object}      [props.history]         Router history, when rendered inside a router.
+ * @param {string|null} [props.pathname]        Current router pathname, or null outside a router.
+ * @param {*}           [props.children]
+ * @return {JSX.Element} Tabbed navigation component.
+ */
+const TabbedNavigationView = ( { items, className, disableUpcoming, history = null, pathname = null, children = null } ) => {
+	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
+	const activeIndex = displayedItems.findIndex( item => isItemActive( item, pathname ) );
+	const activeValue = activeIndex > -1 ? getItemValue( displayedItems[ activeIndex ] ) : null;
+
+	// Route through history.push (like NavLink) rather than native hash
+	// navigation: a raw hashchange reaches the router as a POP, which
+	// `history.block` guards (e.g. unsaved-changes dialogs) can't intercept
+	// cleanly. Modified/middle clicks fall through to the href.
+	const onTabClick = ( event, item ) => {
+		if ( ! history || ! item.path ) {
+			return;
+		}
+		if ( event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0 ) {
+			return;
+		}
+		event.preventDefault();
+		if ( item.path !== pathname ) {
+			history.push( item.path );
+		}
+	};
 
 	return (
 		<div className={ classnames( 'newspack-tabbed-navigation', className ) }>
-			<ul>
-				{ displayedItems.map( ( item, index ) => (
-					<li key={ index }>
-						<NavLink
-							to={ item.path }
-							isActive={ ( match, { pathname } ) => isActive( item, match, pathname ) }
-							exact={ item.hasOwnProperty( 'exact' ) ? item.exact : true }
-							activeClassName={ 'selected' }
-							className={ classnames( {
-								disabled: disableUpcoming && index > currentIndex,
-							} ) }
-						>
-							{ item.label }
-						</NavLink>
-					</li>
-				) ) }
-			</ul>
+			<ThemeProvider>
+				<Tabs.Root value={ activeValue } className="newspack-tabbed-navigation__tabs">
+					<Tabs.List activateOnFocus={ false }>
+						{ displayedItems.map( ( item, index ) => {
+							const isDisabled = disableUpcoming && index > activeIndex;
+							const href = item.path ? `#${ item.path }` : item.href;
+							return (
+								<Tabs.Tab
+									key={ getItemValue( item ) }
+									value={ getItemValue( item ) }
+									disabled={ isDisabled }
+									nativeButton={ false }
+									render={
+										// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- content is supplied via the Tab children through @wordpress/ui's render prop, and disabled tabs intentionally drop the href.
+										<a href={ isDisabled ? undefined : href } onClick={ event => onTabClick( event, item ) } />
+									}
+								>
+									{ item.label }
+								</Tabs.Tab>
+							);
+						} ) }
+					</Tabs.List>
+					{ /* The real "panel" is the routed page content rendered outside this
+					     component; these empty panels keep the required tab/panel ARIA pairing. */ }
+					{ displayedItems.map( item => (
+						<Tabs.Panel key={ getItemValue( item ) } value={ getItemValue( item ) } tabIndex={ -1 } />
+					) ) }
+				</Tabs.Root>
+			</ThemeProvider>
 			{ children }
 		</div>
 	);
+};
+
+/**
+ * Router-driven variant: navigates via history and mirrors the current route.
+ * Only rendered when items navigate by router `path`, since the router hooks
+ * require a router ancestor. `useLocation` provides the re-render on route
+ * change — `useHistory` alone reads a stable context and never re-renders.
+ *
+ * @param {Object} props See TabbedNavigationView.
+ * @return {JSX.Element} Tabbed navigation component.
+ */
+const RoutedTabbedNavigation = props => {
+	const history = useHistory();
+	const { pathname } = useLocation();
+	return <TabbedNavigationView { ...props } history={ history } pathname={ pathname } />;
+};
+
+const TabbedNavigation = props => {
+	const hasRoutedItems = props.items.some( item => item.path );
+	return hasRoutedItems ? <RoutedTabbedNavigation { ...props } /> : <TabbedNavigationView { ...props } />;
 };
 
 export default TabbedNavigation;

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -1,0 +1,73 @@
+/**
+ * Internal dependencies.
+ */
+import { isItemActive } from './index';
+
+describe( 'isItemActive', () => {
+	it( 'treats an explicitly selected item as active regardless of pathname', () => {
+		expect( isItemActive( { selected: true, path: '/other' }, '/current' ) ).toBe( true );
+		expect( isItemActive( { selected: true }, null ) ).toBe( true );
+	} );
+
+	describe( 'outside a router (pathname is null)', () => {
+		afterEach( () => {
+			delete window.location;
+			window.location = new URL( 'http://localhost/' );
+		} );
+
+		it( 'is active when the href matches the current URL', () => {
+			delete window.location;
+			window.location = new URL( 'http://example.com/wp-admin/admin.php?page=ads' );
+			expect( isItemActive( { href: 'http://example.com/wp-admin/admin.php?page=ads' }, null ) ).toBe( true );
+		} );
+
+		it( 'is inactive when the href does not match', () => {
+			delete window.location;
+			window.location = new URL( 'http://example.com/wp-admin/admin.php?page=ads' );
+			expect( isItemActive( { href: 'http://example.com/wp-admin/admin.php?page=other' }, null ) ).toBe( false );
+		} );
+
+		it( 'is inactive when the item has no href', () => {
+			expect( isItemActive( { path: '/ads' }, null ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'inside a router', () => {
+		it( 'matches on an exact path', () => {
+			expect( isItemActive( { path: '/donations' }, '/donations' ) ).toBe( true );
+			expect( isItemActive( { path: '/donations' }, '/segments' ) ).toBe( false );
+		} );
+
+		it( 'does not treat a path prefix as a match by default', () => {
+			expect( isItemActive( { path: '/segments' }, '/segments/123' ) ).toBe( false );
+		} );
+
+		it( 'matches a path prefix when exact is false', () => {
+			expect( isItemActive( { path: '/segments', exact: false }, '/segments/123' ) ).toBe( true );
+			expect( isItemActive( { path: '/segments', exact: false }, '/donations' ) ).toBe( false );
+		} );
+
+		it( 'matches an activeTabPaths entry exactly', () => {
+			const item = { path: '/segments', activeTabPaths: [ '/segments', '/segments/new' ] };
+			expect( isItemActive( item, '/segments/new' ) ).toBe( true );
+			expect( isItemActive( item, '/segments/123' ) ).toBe( false );
+		} );
+
+		it( 'matches an activeTabPaths wildcard as a prefix', () => {
+			const item = { path: '/segments', activeTabPaths: [ '/segments/*' ] };
+			expect( isItemActive( item, '/segments/123' ) ).toBe( true );
+			expect( isItemActive( item, '/segments' ) ).toBe( false );
+			expect( isItemActive( item, '/donations' ) ).toBe( false );
+		} );
+
+		it( 'keeps the parent tab active on a hidden subpage via wildcard', () => {
+			const item = { path: '/additional-brands', activeTabPaths: [ '/additional-brands/*' ] };
+			expect( isItemActive( item, '/additional-brands/new' ) ).toBe( true );
+		} );
+
+		it( 'is inactive when nothing matches', () => {
+			expect( isItemActive( { path: '/donations' }, '/segments' ) ).toBe( false );
+			expect( isItemActive( {}, '/segments' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -1,7 +1,37 @@
 /**
+ * External dependencies.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, useHistory } from 'react-router-dom';
+
+/**
  * Internal dependencies.
  */
-import { isItemActive } from './index';
+import TabbedNavigation, { isItemActive } from './index';
+
+const HistoryGrabber = ( { historyRef } ) => {
+	historyRef.current = useHistory();
+	return null;
+};
+
+const ITEMS = [
+	{ label: 'Stories', path: '/stories' },
+	{ label: 'Budgets', path: '/budgets' },
+	{ label: 'Sites', path: '/sites' },
+];
+
+const renderTabs = ( { initialEntries = [ '/stories' ], ...props } = {} ) => {
+	const historyRef = { current: null };
+	render(
+		<MemoryRouter initialEntries={ initialEntries }>
+			<HistoryGrabber historyRef={ historyRef } />
+			<TabbedNavigation items={ ITEMS } content={ <div>Routed content</div> } { ...props } />
+		</MemoryRouter>
+	);
+	return historyRef.current;
+};
+
+const getTab = name => screen.getByRole( 'tab', { name } );
 
 describe( 'isItemActive', () => {
 	it( 'treats an explicitly selected item as active regardless of pathname', () => {
@@ -32,48 +62,118 @@ describe( 'isItemActive', () => {
 		} );
 	} );
 
-	describe( 'inside a router', () => {
-		it( 'matches on an exact path', () => {
-			expect( isItemActive( { path: '/donations' }, '/donations' ) ).toBe( true );
-			expect( isItemActive( { path: '/donations' }, '/segments' ) ).toBe( false );
+	describe( 'inside a router (delegates to the shared route matcher)', () => {
+		it( 'matches a path as a prefix by default', () => {
+			expect( isItemActive( { path: '/stories' }, '/stories' ) ).toBe( true );
+			expect( isItemActive( { path: '/stories' }, '/stories/new' ) ).toBe( true );
+			expect( isItemActive( { path: '/stories' }, '/budgets' ) ).toBe( false );
 		} );
 
-		it( 'does not treat a path prefix as a match by default', () => {
-			expect( isItemActive( { path: '/segments' }, '/segments/123' ) ).toBe( false );
-		} );
-
-		it( 'matches a path prefix when exact is false', () => {
-			expect( isItemActive( { path: '/segments', exact: false }, '/segments' ) ).toBe( true );
-			expect( isItemActive( { path: '/segments', exact: false }, '/segments/123' ) ).toBe( true );
-			expect( isItemActive( { path: '/segments', exact: false }, '/donations' ) ).toBe( false );
-		} );
-
-		it( 'does not match a prefix-colliding sibling when exact is false', () => {
-			expect( isItemActive( { path: '/segments', exact: false }, '/segments-old' ) ).toBe( false );
-			expect( isItemActive( { path: '/segments', exact: false }, '/segmentsnew' ) ).toBe( false );
-		} );
-
-		it( 'matches an activeTabPaths entry exactly', () => {
-			const item = { path: '/segments', activeTabPaths: [ '/segments', '/segments/new' ] };
-			expect( isItemActive( item, '/segments/new' ) ).toBe( true );
-			expect( isItemActive( item, '/segments/123' ) ).toBe( false );
-		} );
-
-		it( 'matches an activeTabPaths wildcard as a prefix', () => {
-			const item = { path: '/other', activeTabPaths: [ '/segments/*' ] };
-			expect( isItemActive( item, '/segments/123' ) ).toBe( true );
-			expect( isItemActive( item, '/segments' ) ).toBe( false );
-			expect( isItemActive( item, '/donations' ) ).toBe( false );
+		it( 'matches exactly when the item opts in via exact', () => {
+			expect( isItemActive( { path: '/stories', exact: true }, '/stories/new' ) ).toBe( false );
 		} );
 
 		it( 'keeps the parent tab active on a hidden subpage via wildcard', () => {
 			const item = { path: '/additional-brands', activeTabPaths: [ '/additional-brands/*' ] };
 			expect( isItemActive( item, '/additional-brands/new' ) ).toBe( true );
 		} );
+	} );
+} );
 
-		it( 'is inactive when nothing matches', () => {
-			expect( isItemActive( { path: '/donations' }, '/segments' ) ).toBe( false );
-			expect( isItemActive( {}, '/segments' ) ).toBe( false );
+describe( 'TabbedNavigation with routed items', () => {
+	it( 'renders the routed content inside the active tab panel', () => {
+		renderTabs( { initialEntries: [ '/budgets' ] } );
+		expect( getTab( 'Budgets' ) ).toHaveAttribute( 'aria-selected', 'true' );
+
+		const content = screen.getByText( 'Routed content' );
+		const panel = content.closest( '[role="tabpanel"]' );
+		expect( panel ).not.toBeNull();
+		expect( getTab( 'Budgets' ) ).toHaveAttribute( 'aria-controls', panel.id );
+	} );
+
+	it( 'keeps the tab active and the content in its panel on a nested route', () => {
+		renderTabs( { initialEntries: [ '/stories/new' ] } );
+		expect( getTab( 'Stories' ) ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).not.toBeNull();
+	} );
+
+	it( 'prefers the most specific tab when paths nest', () => {
+		render(
+			<MemoryRouter initialEntries={ [ '/stories/new' ] }>
+				<TabbedNavigation
+					items={ [
+						{ label: 'Stories', path: '/stories' },
+						{ label: 'New story', path: '/stories/new' },
+					] }
+				/>
+			</MemoryRouter>
+		);
+		expect( getTab( 'New story' ) ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( getTab( 'Stories' ) ).toHaveAttribute( 'aria-selected', 'false' );
+	} );
+
+	it( 'navigates through history.push on click', () => {
+		const history = renderTabs();
+		fireEvent.click( getTab( 'Sites' ) );
+		expect( history.location.pathname ).toBe( '/sites' );
+		expect( getTab( 'Sites' ) ).toHaveAttribute( 'aria-selected', 'true' );
+	} );
+
+	it( 'leaves modified clicks to the browser', () => {
+		const history = renderTabs();
+		fireEvent.click( getTab( 'Sites' ), { metaKey: true } );
+		expect( history.location.pathname ).toBe( '/stories' );
+	} );
+
+	it( 'consults history.block guards before navigating', () => {
+		const history = renderTabs();
+		const unblock = history.block( () => false );
+		fireEvent.click( getTab( 'Sites' ) );
+		expect( history.location.pathname ).toBe( '/stories' );
+		expect( getTab( 'Stories' ) ).toHaveAttribute( 'aria-selected', 'true' );
+		unblock();
+	} );
+
+	it( 'disables tabs after the active one with disableUpcoming', () => {
+		renderTabs( { initialEntries: [ '/budgets' ], disableUpcoming: true } );
+		expect( getTab( 'Stories' ) ).toHaveAttribute( 'href' );
+		expect( getTab( 'Sites' ) ).not.toHaveAttribute( 'href' );
+		expect( getTab( 'Sites' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		fireEvent.click( getTab( 'Sites' ) );
+		expect( getTab( 'Budgets' ) ).toHaveAttribute( 'aria-selected', 'true' );
+	} );
+
+	it( 'disables every tab with disableUpcoming when no route matches', () => {
+		renderTabs( { initialEntries: [ '/unknown' ], disableUpcoming: true } );
+		ITEMS.forEach( ( { label } ) => {
+			expect( getTab( label ) ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
+	} );
+
+	it( 'navigates when the active tab changes so panels follow the route', () => {
+		const history = renderTabs();
+		act( () => history.push( '/budgets' ) );
+		expect( getTab( 'Budgets' ) ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ).id ).toBe(
+			getTab( 'Budgets' ).getAttribute( 'aria-controls' )
+		);
+	} );
+} );
+
+describe( 'TabbedNavigation with href-only items', () => {
+	const LINK_ITEMS = [
+		{ label: 'Newsletters', href: 'http://example.com/wp-admin/admin.php?page=newsletters', selected: true },
+		{ label: 'Ads', href: 'http://example.com/wp-admin/admin.php?page=ads' },
+	];
+
+	it( 'renders plain navigation links instead of a tabs widget', () => {
+		render( <TabbedNavigation items={ LINK_ITEMS } /> );
+		expect( screen.queryByRole( 'tab' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'navigation' ) ).toBeInTheDocument();
+
+		const active = screen.getByRole( 'link', { name: 'Newsletters' } );
+		expect( active ).toHaveAttribute( 'aria-current', 'page' );
+		expect( screen.getByRole( 'link', { name: 'Ads' } ) ).not.toHaveAttribute( 'aria-current' );
 	} );
 } );

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -43,8 +43,14 @@ describe( 'isItemActive', () => {
 		} );
 
 		it( 'matches a path prefix when exact is false', () => {
+			expect( isItemActive( { path: '/segments', exact: false }, '/segments' ) ).toBe( true );
 			expect( isItemActive( { path: '/segments', exact: false }, '/segments/123' ) ).toBe( true );
 			expect( isItemActive( { path: '/segments', exact: false }, '/donations' ) ).toBe( false );
+		} );
+
+		it( 'does not match a prefix-colliding sibling when exact is false', () => {
+			expect( isItemActive( { path: '/segments', exact: false }, '/segments-old' ) ).toBe( false );
+			expect( isItemActive( { path: '/segments', exact: false }, '/segmentsnew' ) ).toBe( false );
 		} );
 
 		it( 'matches an activeTabPaths entry exactly', () => {
@@ -54,7 +60,9 @@ describe( 'isItemActive', () => {
 		} );
 
 		it( 'matches an activeTabPaths wildcard as a prefix', () => {
-			const item = { path: '/segments', activeTabPaths: [ '/segments/*' ] };
+			// Distinct path so the exact-path check does not short-circuit and the
+			// wildcard branch is what is exercised.
+			const item = { path: '/other', activeTabPaths: [ '/segments/*' ] };
 			expect( isItemActive( item, '/segments/123' ) ).toBe( true );
 			expect( isItemActive( item, '/segments' ) ).toBe( false );
 			expect( isItemActive( item, '/donations' ) ).toBe( false );

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -60,8 +60,6 @@ describe( 'isItemActive', () => {
 		} );
 
 		it( 'matches an activeTabPaths wildcard as a prefix', () => {
-			// Distinct path so the exact-path check does not short-circuit and the
-			// wildcard branch is what is exercised.
 			const item = { path: '/other', activeTabPaths: [ '/segments/*' ] };
 			expect( isItemActive( item, '/segments/123' ) ).toBe( true );
 			expect( isItemActive( item, '/segments' ) ).toBe( false );

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -155,9 +155,7 @@ describe( 'TabbedNavigation with routed items', () => {
 		const history = renderTabs();
 		act( () => history.push( '/budgets' ) );
 		expect( getTab( 'Budgets' ) ).toHaveAttribute( 'aria-selected', 'true' );
-		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ).id ).toBe(
-			getTab( 'Budgets' ).getAttribute( 'aria-controls' )
-		);
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ).id ).toBe( getTab( 'Budgets' ).getAttribute( 'aria-controls' ) );
 	} );
 } );
 

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -29,7 +29,7 @@
 			box-shadow: none;
 		}
 
-		&[data-disabled] {
+		&[aria-disabled="true"] {
 			pointer-events: none;
 		}
 	}

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -2,10 +2,12 @@
  * Tabbed Navigation
  */
 
+@use "../../../colors/colors.module" as colors;
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-tabbed-navigation {
 	background: white;
+	box-shadow: 0 -1px 0 inset wp-colors.$gray-300;
 	width: 100%;
 
 	@media only screen and ( min-width: 600px ) {
@@ -18,65 +20,32 @@
 		top: 32px;
 	}
 
-	ul {
-		box-shadow: 0 -1px 0 inset wp-colors.$gray-300;
-		display: flex;
-		flex-wrap: wrap;
-		margin: 0;
+	// Newspack accent for the active-tab indicator. Scoped inside the
+	// ThemeProvider subtree, whose inline token values would otherwise win.
+	.newspack-tabbed-navigation__tabs {
+		/* stylelint-disable-next-line plugin-wpds/no-setting-wpds-custom-properties -- deliberate Newspack brand override of the indicator token. */
+		--wpds-color-stroke-interactive-neutral-strong: #{colors.$primary-600};
 	}
 
-	li {
-		margin-bottom: 0;
-		width: 100%;
+	// @wordpress/ui's tab styles live in the `wp-ui` cascade layer, so
+	// wp-admin's unlayered link rules would otherwise win these properties.
+	// Values mirror the design-system foreground-interactive-neutral tokens.
+	a[role="tab"] {
+		color: wp-colors.$gray-900;
+		text-decoration: none;
 
-		@media screen and ( min-width: 600px ) {
-			width: auto;
+		&:hover,
+		&:active,
+		&[aria-selected="true"] {
+			color: wp-colors.$gray-900;
 		}
 
-		a {
-			align-items: center;
-			color: wp-colors.$gray-900;
-			display: flex;
-			font-weight: bold;
-			height: 48px;
-			outline: none;
-			padding: 12px 15px;
-			text-decoration: none;
+		&:focus {
+			box-shadow: none;
+		}
 
-			@media screen and ( min-width: 600px ) {
-				border-bottom: 4px solid transparent;
-				padding-bottom: 8px;
-			}
-
-			&:active,
-			&:focus,
-			&:hover {
-				color: var(--wp-admin-theme-color);
-			}
-
-			&:focus-visible {
-				outline: 2px solid var(--wp-admin-theme-color);
-				outline-offset: -2px;
-			}
-
-			&.selected {
-				box-shadow: inset 0 0 0 2px white, inset 0 0 0 4px var(--wp-admin-theme-color);
-
-				@media screen and ( min-width: 600px ) {
-					border-color: var(--wp-admin-theme-color);
-					box-shadow: none;
-				}
-			}
-
-			&.disabled {
-				cursor: not-allowed;
-				opacity: 0.3;
-				pointer-events: none;
-
-				&:hover {
-					color: inherit;
-				}
-			}
+		&[data-disabled] {
+			pointer-events: none;
 		}
 	}
 }

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -7,7 +7,7 @@
 
 .newspack-tabbed-navigation {
 	background: white;
-	box-shadow: 0 -1px 0 inset wp-colors.$gray-300;
+	border-bottom: var( --wpds-border-width-xs, 1px ) solid var( --wpds-color-stroke-surface-neutral-weak, #{ wp-colors.$gray-200 } );
 	width: 100%;
 
 	@media only screen and ( min-width: 600px ) {

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -10,16 +10,6 @@
 	border-bottom: var( --wpds-border-width-xs ) solid var( --wpds-color-stroke-surface-neutral-weak );
 	width: 100%;
 
-	@media only screen and ( min-width: 600px ) {
-		position: sticky;
-		top: 46px;
-		z-index: 3;
-	}
-
-	@media only screen and ( min-width: 783px ) {
-		top: 32px;
-	}
-
 	.newspack-tabbed-navigation__tabs {
 		/* stylelint-disable-next-line plugin-wpds/no-setting-wpds-custom-properties -- deliberate Newspack brand override of the indicator token. */
 		--wpds-color-stroke-interactive-neutral-strong: #{colors.$primary-600};

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -4,33 +4,75 @@
 
 @use "../../../colors/colors.module" as colors;
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
+// The Tabs.Root wrapper spans the tab bar and the tab panels so the panels can
+// contain the routed content; it plays no layout role of its own.
+.newspack-tabbed-navigation__root {
+	display: contents;
+}
 
 .newspack-tabbed-navigation {
-	background: white;
-	border-bottom: var( --wpds-border-width-xs ) solid var( --wpds-color-stroke-surface-neutral-weak );
+	background: wp-colors.$white;
+	border-bottom: var( --wpds-border-width-xs, #{wp-vars.$border-width} ) solid var( --wpds-color-stroke-surface-neutral-weak, #{wp-colors.$gray-100} );
 	width: 100%;
 
-	.newspack-tabbed-navigation__tabs {
-		/* stylelint-disable-next-line plugin-wpds/no-setting-wpds-custom-properties -- deliberate Newspack brand override of the indicator token. */
-		--wpds-color-stroke-interactive-neutral-strong: #{colors.$primary-600};
-	}
+	/* stylelint-disable-next-line plugin-wpds/no-setting-wpds-custom-properties -- deliberate Newspack brand override of the indicator token. */
+	--wpds-color-stroke-interactive-neutral-strong: #{colors.$primary-600};
 
 	a[role="tab"] {
-		color: wp-colors.$gray-900;
 		text-decoration: none;
 
-		&:hover,
-		&:active,
-		&[aria-selected="true"] {
+		// wp-admin's unlayered `a { color }` beats every rule inside the design
+		// system's @layer wp-ui, so anchor tabs need their colors restated here:
+		// gray-900 for enabled tabs, and the DS disabled token for disabled ones.
+		&:not([data-disabled]):not([aria-disabled="true"]) {
 			color: wp-colors.$gray-900;
+
+			&:hover,
+			&:active,
+			&[aria-selected="true"] {
+				color: wp-colors.$gray-900;
+			}
 		}
 
 		&:focus {
 			box-shadow: none;
 		}
 
+		&[data-disabled],
 		&[aria-disabled="true"] {
+			color: var( --wpds-color-foreground-interactive-neutral-disabled, #{wp-colors.$gray-600} );
 			pointer-events: none;
+		}
+	}
+
+	// Link-driven variant: plain navigation styled to match the tabs widget.
+	&--links {
+		align-items: stretch;
+		display: flex;
+		overflow-x: auto;
+	}
+
+	.newspack-tabbed-navigation__link {
+		align-items: center;
+		color: wp-colors.$gray-900;
+		display: flex;
+		font-size: var( --wpds-typography-font-size-md, #{wp-vars.$default-font-size} );
+		height: wp-vars.$grid-unit-60; // Matches @wordpress/ui's horizontal tab height.
+		line-height: 1.2;
+		padding-inline: var( --wpds-dimension-padding-lg, #{wp-vars.$grid-unit-20} );
+		text-decoration: none;
+		white-space: nowrap;
+
+		&:hover,
+		&:active,
+		&:focus {
+			color: wp-colors.$gray-900;
+		}
+
+		&[aria-current="page"] {
+			box-shadow: inset 0 calc( var( --wpds-border-width-focus, #{wp-vars.$border-width-focus-fallback} ) * -1 ) 0 var( --wpds-color-stroke-interactive-neutral-strong, #{colors.$primary-600} );
 		}
 	}
 }

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -36,8 +36,14 @@
 			}
 		}
 
+		// wp-admin's common.css and the wizard shell both decorate a:focus with a
+		// box-shadow ring, a 2px border-radius, and a transparent outline. Reset
+		// all three so the component's own :focus-visible ring (an inset outline
+		// on its ::after, shipped by @wordpress/ui) is the only focus treatment.
 		&:focus {
+			border-radius: 0;
 			box-shadow: none;
+			outline: none;
 		}
 
 		&[data-disabled],
@@ -69,6 +75,19 @@
 		&:active,
 		&:focus {
 			color: wp-colors.$gray-900;
+		}
+
+		// Mirror the tabs widget's focus ring (an inset outline) with plain
+		// outline + offset, replacing wp-admin's box-shadow focus decoration.
+		&:focus {
+			box-shadow: none;
+			outline: none;
+		}
+
+		&:focus-visible {
+			border-radius: var( --wpds-border-radius-sm, #{wp-vars.$radius-small} );
+			outline: var( --wpds-border-width-focus, var( --wp-admin-border-width-focus, #{wp-vars.$border-width-focus-fallback} ) ) solid var( --wpds-color-stroke-focus, var( --wp-admin-theme-color ) );
+			outline-offset: calc( var( --wpds-dimension-padding-md, #{wp-vars.$grid-unit-15} ) * -1 );
 		}
 
 		&[aria-current="page"] {

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -7,7 +7,7 @@
 
 .newspack-tabbed-navigation {
 	background: white;
-	border-bottom: var( --wpds-border-width-xs, 1px ) solid var( --wpds-color-stroke-surface-neutral-weak, #{ wp-colors.$gray-200 } );
+	border-bottom: var( --wpds-border-width-xs ) solid var( --wpds-color-stroke-surface-neutral-weak );
 	width: 100%;
 
 	@media only screen and ( min-width: 600px ) {
@@ -20,16 +20,11 @@
 		top: 32px;
 	}
 
-	// Newspack accent for the active-tab indicator. Scoped inside the
-	// ThemeProvider subtree, whose inline token values would otherwise win.
 	.newspack-tabbed-navigation__tabs {
 		/* stylelint-disable-next-line plugin-wpds/no-setting-wpds-custom-properties -- deliberate Newspack brand override of the indicator token. */
 		--wpds-color-stroke-interactive-neutral-strong: #{colors.$primary-600};
 	}
 
-	// @wordpress/ui's tab styles live in the `wp-ui` cascade layer, so
-	// wp-admin's unlayered link rules would otherwise win these properties.
-	// Values mirror the design-system foreground-interactive-neutral tokens.
 	a[role="tab"] {
 		color: wp-colors.$gray-900;
 		text-decoration: none;

--- a/packages/components/src/tabbed-navigation/style.scss
+++ b/packages/components/src/tabbed-navigation/style.scss
@@ -46,6 +46,11 @@
 			outline: none;
 		}
 
+		// Square the component's focus ring corners.
+		&::after {
+			border-radius: 0;
+		}
+
 		&[data-disabled],
 		&[aria-disabled="true"] {
 			color: var( --wpds-color-foreground-interactive-neutral-disabled, #{wp-colors.$gray-600} );
@@ -80,12 +85,12 @@
 		// Mirror the tabs widget's focus ring (an inset outline) with plain
 		// outline + offset, replacing wp-admin's box-shadow focus decoration.
 		&:focus {
+			border-radius: 0;
 			box-shadow: none;
 			outline: none;
 		}
 
 		&:focus-visible {
-			border-radius: var( --wpds-border-radius-sm, #{wp-vars.$radius-small} );
 			outline: var( --wpds-border-width-focus, var( --wp-admin-border-width-focus, #{wp-vars.$border-width-focus-fallback} ) ) solid var( --wpds-color-stroke-focus, var( --wp-admin-theme-color ) );
 			outline-offset: calc( var( --wpds-dimension-padding-md, #{wp-vars.$grid-unit-15} ) * -1 );
 		}

--- a/packages/components/src/with-wizard-screen/index.js
+++ b/packages/components/src/with-wizard-screen/index.js
@@ -72,15 +72,15 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton,
 					{ ...overridingProps }
 				/>
 			);
+		const tabbedNavigationRegion = tabbedNavigation && (
+			<TabbedNavigation
+				disableUpcoming={ disableUpcomingInTabbedNavigation }
+				items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
+			/>
+		);
+
 		const content = (
 			<>
-				{ tabbedNavigation && (
-					<TabbedNavigation
-						disableUpcoming={ disableUpcomingInTabbedNavigation }
-						items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
-					/>
-				) }
-
 				<HandoffMessage />
 
 				<div className={ classnames( 'newspack-wizard newspack-wizard__content', className ) }>
@@ -109,9 +109,17 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton,
 				<>
 					{ newspack_aux_data.is_debug_mode && <Notice debugMode /> }
 					{ hideHeader ? (
-						content
+						<>
+							{ tabbedNavigationRegion }
+							{ content }
+						</>
 					) : (
-						<Page breadcrumbItems={ pageBreadcrumbs } subTitle={ subHeaderText } actions={ headerActions }>
+						<Page
+							breadcrumbItems={ pageBreadcrumbs }
+							subTitle={ subHeaderText }
+							actions={ headerActions }
+							tabbedNavigation={ tabbedNavigationRegion }
+						>
 							{ content }
 						</Page>
 					) }

--- a/packages/components/src/with-wizard-screen/index.js
+++ b/packages/components/src/with-wizard-screen/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { cloneElement } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { Button, Handoff, Notice, HandoffMessage, TabbedNavigation, Page } from '../';
@@ -109,10 +114,9 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton,
 				<>
 					{ newspack_aux_data.is_debug_mode && <Notice debugMode /> }
 					{ hideHeader ? (
-						<>
-							{ tabbedNavigationRegion }
-							{ content }
-						</>
+						// Without the Page shell the tabs still own the content: it
+						// renders inside the active tab's panel.
+						<>{ tabbedNavigationRegion ? cloneElement( tabbedNavigationRegion, { content } ) : content }</>
 					) : (
 						<Page
 							breadcrumbItems={ pageBreadcrumbs }

--- a/packages/components/src/wizard/breadcrumbs-select.js
+++ b/packages/components/src/wizard/breadcrumbs-select.js
@@ -1,25 +1,7 @@
 /**
  * Internal dependencies.
  */
-import Router from '../proxied-imports/router';
-
-const { matchPath } = Router;
-
-const sectionMatches = ( section, pathname ) => {
-	if ( Array.isArray( section.activeTabPaths ) ) {
-		const wildcardHit = section.activeTabPaths.some( path =>
-			path.endsWith( '*' ) ? pathname.startsWith( path.slice( 0, -1 ) ) : path === pathname
-		);
-		if ( wildcardHit ) {
-			return true;
-		}
-	}
-	if ( ! section.path ) {
-		return false;
-	}
-	const exact = '/' === section.path || section.exact === true;
-	return !! matchPath( pathname, { path: section.path, exact } );
-};
+import { matchesRoute } from '../route-match';
 
 /**
  * Select the active section's explicit breadcrumb trail by current route. Falls
@@ -33,7 +15,7 @@ export const activeBreadcrumbs = ( sections = [], pathname ) => {
 	if ( ! sections?.length ) {
 		return [];
 	}
-	const match = sections.find( section => sectionMatches( section, pathname ) ) || sections[ 0 ];
+	const match = sections.find( section => matchesRoute( section, pathname ) ) || sections[ 0 ];
 	return match.breadcrumbs || [];
 };
 

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState, forwardRef } from '@wordpress/element';
+import { cloneElement, isValidElement, useEffect, useState, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category, chevronLeft, moreVertical } from '@wordpress/icons';
 
@@ -62,12 +62,12 @@ const WizardHeaderRegion = ( { hideHeader, headerText, sections, sectionName, su
 	const { pathname } = useLocation();
 
 	if ( hideHeader ) {
-		return (
-			<>
-				{ tabbedNavigation }
-				{ children }
-			</>
-		);
+		// Without the Page shell the tabs still own the content: it renders
+		// inside the active tab's panel.
+		if ( isValidElement( tabbedNavigation ) ) {
+			return cloneElement( tabbedNavigation, { content: children } );
+		}
+		return children;
 	}
 
 	let breadcrumbItems = activeBreadcrumbs( sections, pathname );

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -58,11 +58,16 @@ const ResetHeaderData = () => {
  * Wizard header + content region. Rendered inside the wizard's HashRouter so it
  * can read the current route and derive the active-tab breadcrumb.
  */
-const WizardHeaderRegion = ( { hideHeader, headerText, sections, sectionName, subTitle, actions, children } ) => {
+const WizardHeaderRegion = ( { hideHeader, headerText, sections, sectionName, subTitle, actions, tabbedNavigation, children } ) => {
 	const { pathname } = useLocation();
 
 	if ( hideHeader ) {
-		return children;
+		return (
+			<>
+				{ tabbedNavigation }
+				{ children }
+			</>
+		);
 	}
 
 	let breadcrumbItems = activeBreadcrumbs( sections, pathname );
@@ -74,7 +79,7 @@ const WizardHeaderRegion = ( { hideHeader, headerText, sections, sectionName, su
 	breadcrumbItems = appendSectionName( breadcrumbItems, sectionName );
 
 	return (
-		<Page breadcrumbItems={ breadcrumbItems } subTitle={ subTitle } actions={ actions }>
+		<Page breadcrumbItems={ breadcrumbItems } subTitle={ subTitle } actions={ actions } tabbedNavigation={ tabbedNavigation }>
 			{ children }
 		</Page>
 	);
@@ -113,7 +118,6 @@ const Wizard = (
 		renderAboveSections,
 		requiredPlugins = [],
 		isInitialFetchTriggered = true,
-		fixedHeader = false,
 		hideHeader = false,
 	},
 	ref
@@ -151,13 +155,14 @@ const Wizard = (
 	// the PluginInstaller. Use it for routing so the installer actually mounts and runs.
 	const routedSections = pluginRequirementsSatisfied ? sections : displayedSections;
 
+	const tabbedNavigation = displayedSections.length > 1 && (
+		<TabbedNavigation items={ displayedSections }>
+			<WizardError />
+		</TabbedNavigation>
+	);
+
 	const content = (
 		<>
-			{ displayedSections.length > 1 && (
-				<TabbedNavigation items={ displayedSections }>
-					<WizardError />
-				</TabbedNavigation>
-			) }
 			<HandoffMessage />
 
 			{ sections.length > 1 && <ResetHeaderData /> }
@@ -270,7 +275,6 @@ const Wizard = (
 			<div
 				className={ classnames( isLoading ? 'newspack-wizard__is-loading' : 'newspack-wizard__is-loaded', {
 					'newspack-wizard__is-loading-quiet': isQuietLoading,
-					'newspack-wizard__fixed-header': fixedHeader,
 				} ) }
 			>
 				<HashRouter hashType="slash">
@@ -282,6 +286,7 @@ const Wizard = (
 						sectionName={ sectionName }
 						subTitle={ subHeaderText }
 						actions={ headerActions }
+						tabbedNavigation={ tabbedNavigation }
 					>
 						{ content }
 					</WizardHeaderRegion>

--- a/packages/scripts/scripts/test.js
+++ b/packages/scripts/scripts/test.js
@@ -19,6 +19,9 @@ const JEST_CONFIG = {
 	rootDir: modules.rootDirectory,
 	setupFilesAfterEnv: [ path.resolve( __dirname, 'utils/jestSetup.js' ) ],
 	testMatch: [ '<rootDir>/**/*test.js?(x)' ],
+	// Skip compiled copies (packages compile src into dist/ and shared/) and
+	// PHP vendor trees; <rootDir> anchors keep plugin src/shared/ tests running.
+	testPathIgnorePatterns: [ '/node_modules/', '<rootDir>/dist/', '<rootDir>/shared/', '/vendor/' ],
 	transform: {
 		'^.+\\.(j|t)sx?$': path.resolve( __dirname, 'utils/babelJestTransformer.js' ),
 	},

--- a/packages/scripts/scripts/utils/jestSetup.js
+++ b/packages/scripts/scripts/utils/jestSetup.js
@@ -54,3 +54,22 @@ Object.defineProperty( global, 'IntersectionObserver', {
 	configurable: true,
 	value: MockIntersectionObserver,
 } );
+
+// ResizeObserver does not exist in JSDOM (used by e.g. @wordpress/ui Tabs).
+class MockResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+Object.defineProperty( window, 'ResizeObserver', {
+	writable: true,
+	configurable: true,
+	value: MockResizeObserver,
+} );
+
+Object.defineProperty( global, 'ResizeObserver', {
+	writable: true,
+	configurable: true,
+	value: MockResizeObserver,
+} );

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -1,6 +1,9 @@
 @use "../../node_modules/tachyons/css/tachyons.min.css";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
+/* stylelint-disable-next-line no-invalid-position-at-import-rule -- @use must precede it; postcss-import inlines it and needs the physical path (exports map is not honored). */
+@import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
+
 :root {
 	/* Sections */
 	--newspack-wizard-section-width: 1006px;

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -1,7 +1,7 @@
 @use "../../node_modules/tachyons/css/tachyons.min.css";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
-/* stylelint-disable-next-line no-invalid-position-at-import-rule -- @use must precede it; postcss-import inlines it and needs the physical path (exports map is not honored). */
+/* stylelint-disable-next-line no-invalid-position-at-import-rule -- sass @use must precede the CSS @import. */
 @import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
 
 :root {

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -1,9 +1,6 @@
 @use "../../node_modules/tachyons/css/tachyons.min.css";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
-/* stylelint-disable-next-line no-invalid-position-at-import-rule -- sass @use must precede the CSS @import. */
-@import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
-
 :root {
 	/* Sections */
 	--newspack-wizard-section-width: 1006px;

--- a/plugins/newspack-plugin/src/wizards/admin-header/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/admin-header/index.tsx
@@ -1,5 +1,5 @@
 import { render } from '@wordpress/element';
-import { Page } from '../../../packages/components/src';
+import { Page, TabbedNavigation } from '../../../packages/components/src';
 import './style.scss';
 
 type Crumb = { label: string; url?: string };
@@ -24,20 +24,13 @@ export function WizardsAdminHeader( {
 		// a static, empty div; do not give this component state that could re-render.
 		<Page breadcrumbItems={ breadcrumbs } actions={ <div id="newspack-wizards-admin-header-actions" /> }>
 			{ tabs.length > 0 && (
-				<div className="newspack-tabbed-navigation">
-					<ul>
-						{ tabs.map( ( tab, i ) => {
-							const selected = tab.forceSelected ? true : window.location.href === tab.href;
-							return (
-								<li key={ `${ tab.textContent }:${ i }` }>
-									<a href={ tab.href } className={ selected ? 'selected' : '' }>
-										{ tab.textContent }
-									</a>
-								</li>
-							);
-						} ) }
-					</ul>
-				</div>
+				<TabbedNavigation
+					items={ tabs.map( tab => ( {
+						label: tab.textContent,
+						href: tab.href,
+						selected: tab.forceSelected,
+					} ) ) }
+				/>
 			) }
 		</Page>
 	);

--- a/plugins/newspack-plugin/src/wizards/admin-header/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/admin-header/index.tsx
@@ -22,17 +22,21 @@ export function WizardsAdminHeader( {
 		// node is rendered once and never re-rendered or unmounted here — React
 		// reconciliation on a re-render would wipe the portalled children. Keep it
 		// a static, empty div; do not give this component state that could re-render.
-		<Page breadcrumbItems={ breadcrumbs } actions={ <div id="newspack-wizards-admin-header-actions" /> }>
-			{ tabs.length > 0 && (
-				<TabbedNavigation
-					items={ tabs.map( tab => ( {
-						label: tab.textContent,
-						href: tab.href,
-						selected: tab.forceSelected,
-					} ) ) }
-				/>
-			) }
-		</Page>
+		<Page
+			breadcrumbItems={ breadcrumbs }
+			actions={ <div id="newspack-wizards-admin-header-actions" /> }
+			tabbedNavigation={
+				tabs.length > 0 && (
+					<TabbedNavigation
+						items={ tabs.map( tab => ( {
+							label: tab.textContent,
+							href: tab.href,
+							selected: tab.forceSelected,
+						} ) ) }
+					/>
+				)
+			}
+		/>
 	);
 }
 

--- a/plugins/newspack-plugin/src/wizards/admin-header/style.scss
+++ b/plugins/newspack-plugin/src/wizards/admin-header/style.scss
@@ -1,3 +1,10 @@
 .newspack-wizards-admin-header {
 	margin-left: -20px;
+	position: sticky;
+	top: var(--wp-admin--admin-bar--height);
+	z-index: 3;
+
+	.newspack-tabbed-navigation {
+		position: static;
+	}
 }

--- a/plugins/newspack-plugin/src/wizards/admin-header/style.scss
+++ b/plugins/newspack-plugin/src/wizards/admin-header/style.scss
@@ -1,8 +1,13 @@
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
+
 .newspack-wizards-admin-header {
 	margin-left: -20px;
-	position: sticky;
-	top: var(--wp-admin--admin-bar--height);
-	z-index: 3;
+
+	@include wp-mixins.break-medium {
+		position: sticky;
+		top: var(--wp-admin--admin-bar--height);
+		z-index: 3;
+	}
 
 	// The sticky unit here is this mount (the React tree holds only the header
 	// block; the page content is PHP-rendered below it).

--- a/plugins/newspack-plugin/src/wizards/admin-header/style.scss
+++ b/plugins/newspack-plugin/src/wizards/admin-header/style.scss
@@ -4,7 +4,9 @@
 	top: var(--wp-admin--admin-bar--height);
 	z-index: 3;
 
-	.newspack-tabbed-navigation {
+	// The sticky unit here is this mount (the React tree holds only the header
+	// block; the page content is PHP-rendered below it).
+	.newspack-page__header-region {
 		position: static;
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/index.js
@@ -45,7 +45,6 @@ const AudienceContentGates = ( props, ref ) => {
 			headerText={ BASE_HEADER_TEXT }
 			ref={ ref }
 			sharedProps={ { updateGatesData } }
-			fixedHeader
 			sections={ [
 				{
 					path: '/content-gates',

--- a/plugins/newspack-plugin/src/wizards/newsletters/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/index.js
@@ -22,7 +22,6 @@ const NewslettersWizard = () => (
 	<Wizard
 		headerText={ __( 'Newsletters', 'newspack-plugin' ) }
 		requiredPlugins={ [ 'newspack-newsletters' ] }
-		fixedHeader
 		sections={ [
 			{
 				path: '/',

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/premium-newsletters/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/premium-newsletters/index.js
@@ -40,7 +40,6 @@ const PremiumNewsletters = ( props, ref ) => {
 			headerText={ BASE_HEADER_TEXT }
 			ref={ ref }
 			sharedProps={ { updateGatesData } }
-			fixedHeader
 			sections={ [
 				{
 					path: '/content-gates',

--- a/plugins/newspack-story-budget/src/app/index.js
+++ b/plugins/newspack-story-budget/src/app/index.js
@@ -100,60 +100,60 @@ const StoryBudget = () => {
 
 	return (
 		<div className="wrap">
-			<AppHeader breadcrumbItems={ breadcrumbItems } />
-			<TabbedNavigation items={ navigationItems } />
-			<div className="newspack-story-budget__content">
-				<Switch>
-					<Route path="/stories">
-						<AppHeaderActions>
-							{ canManage && (
-								<Button variant="primary" href="#/stories/new">
-									{ __( 'Add Story', 'newspack-story-budget' ) }
+			<AppHeader breadcrumbItems={ breadcrumbItems } tabbedNavigation={ <TabbedNavigation items={ navigationItems } /> }>
+				<div className="newspack-story-budget__content">
+					<Switch>
+						<Route path="/stories">
+							<AppHeaderActions>
+								{ canManage && (
+									<Button variant="primary" href="#/stories/new">
+										{ __( 'Add Story', 'newspack-story-budget' ) }
+									</Button>
+								) }
+								<SitesNav />
+							</AppHeaderActions>
+							<Stories />
+							<Switch>
+								<Route path="/stories/sites" exact>
+									<ModalPage
+										title={ __( 'Connect to remote site', 'newspack-story-budget' ) }
+										closeHref="#/stories"
+										name={ 'sites' }
+										size="medium"
+									>
+										<Sites />
+									</ModalPage>
+								</Route>
+								<Route path="/stories/new" exact>
+									<ModalPage title={ __( 'Add Story', 'newspack-story-budget' ) } closeHref="#/stories" name={ 'create-new-story' }>
+										<CreateNewStory onClose={ () => ( window.location.href = '#/stories' ) } />
+									</ModalPage>
+								</Route>
+								<Route path="/stories/:id">
+									<StoryPage />
+								</Route>
+							</Switch>
+						</Route>
+						<Route path="/budgets">
+							<AppHeaderActions>
+								<Button variant="primary" href="#/budgets/new">
+									{ __( 'Add Budget', 'newspack-story-budget' ) }
 								</Button>
-							) }
-							<SitesNav />
-						</AppHeaderActions>
-						<Stories />
-						<Switch>
-							<Route path="/stories/sites" exact>
-								<ModalPage
-									title={ __( 'Connect to remote site', 'newspack-story-budget' ) }
-									closeHref="#/stories"
-									name={ 'sites' }
-									size="medium"
-								>
-									<Sites />
-								</ModalPage>
-							</Route>
-							<Route path="/stories/new" exact>
-								<ModalPage title={ __( 'Add Story', 'newspack-story-budget' ) } closeHref="#/stories" name={ 'create-new-story' }>
-									<CreateNewStory onClose={ () => ( window.location.href = '#/stories' ) } />
-								</ModalPage>
-							</Route>
-							<Route path="/stories/:id">
-								<StoryPage />
-							</Route>
-						</Switch>
-					</Route>
-					<Route path="/budgets">
-						<AppHeaderActions>
-							<Button variant="primary" href="#/budgets/new">
-								{ __( 'Add Budget', 'newspack-story-budget' ) }
-							</Button>
-							<SitesNav />
-						</AppHeaderActions>
-						<Budgets />
-						<Switch>
-							<Route path="/budgets/new">
-								<ModalPage title={ __( 'Add Budget', 'newspack-story-budget' ) } closeHref="#/budgets" name={ 'create-budget' }>
-									<CreateBudgetModal onClose={ () => ( window.location.href = '#/budgets' ) } />
-								</ModalPage>
-							</Route>
-						</Switch>
-					</Route>
-					<Redirect to="/stories" />
-				</Switch>
-			</div>
+								<SitesNav />
+							</AppHeaderActions>
+							<Budgets />
+							<Switch>
+								<Route path="/budgets/new">
+									<ModalPage title={ __( 'Add Budget', 'newspack-story-budget' ) } closeHref="#/budgets" name={ 'create-budget' }>
+										<CreateBudgetModal onClose={ () => ( window.location.href = '#/budgets' ) } />
+									</ModalPage>
+								</Route>
+							</Switch>
+						</Route>
+						<Redirect to="/stories" />
+					</Switch>
+				</div>
+			</AppHeader>
 			<div className="newspack-story-budget__notices">
 				{ notices.map( notice => (
 					<Snackbar key={ notice.id } onDismiss={ notice.onDismiss } politeness={ 'error' === notice.status ? 'assertive' : 'polite' }>

--- a/plugins/newspack-story-budget/src/components/app-header.js
+++ b/plugins/newspack-story-budget/src/components/app-header.js
@@ -14,6 +14,10 @@ export const AppHeaderActions = ( { children } ) => {
 	return <Fill>{ children }</Fill>;
 };
 
-export default ( { breadcrumbItems, subHeaderText } ) => {
-	return <Page breadcrumbItems={ breadcrumbItems } subTitle={ subHeaderText } actions={ <Slot /> } />;
+export default ( { breadcrumbItems, subHeaderText, tabbedNavigation, children } ) => {
+	return (
+		<Page breadcrumbItems={ breadcrumbItems } subTitle={ subHeaderText } actions={ <Slot /> } tabbedNavigation={ tabbedNavigation }>
+			{ children }
+		</Page>
+	);
 };

--- a/plugins/newspack-story-budget/src/style.scss
+++ b/plugins/newspack-story-budget/src/style.scss
@@ -462,15 +462,6 @@ body.toplevel_page_newspack-story-budget {
 	}
 }
 
-// Fix Tabbed Navigation
-.newspack-tabbed-navigation {
-	z-index: 10;
-	position: static;
-	li a {
-		box-sizing: border-box;
-	}
-}
-
 // Fix menu item cursor.
 div[role="menuitem"] {
 	cursor: pointer;

--- a/plugins/newspack-story-budget/src/style.scss
+++ b/plugins/newspack-story-budget/src/style.scss
@@ -3,7 +3,6 @@
 @use "~@wordpress/base-styles/mixins" as wp-mixins;
 @use "~@wordpress/base-styles/variables" as wp-vars;
 @import "@wordpress/dataviews/build-style/style.css";
-@import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
 
 body.toplevel_page_newspack-story-budget {
 	background: #fff;

--- a/plugins/newspack-story-budget/src/style.scss
+++ b/plugins/newspack-story-budget/src/style.scss
@@ -3,6 +3,7 @@
 @use "~@wordpress/base-styles/mixins" as wp-mixins;
 @use "~@wordpress/base-styles/variables" as wp-vars;
 @import "@wordpress/dataviews/build-style/style.css";
+@import "@wordpress/theme/src/prebuilt/css/design-tokens.css";
 
 body.toplevel_page_newspack-story-budget {
 	background: #fff;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/blocks':
         specifier: ^15.21.0
-        version: 15.21.0(react@18.3.1)
+        version: 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components':
         specifier: ^30.6.0
         version: 30.9.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -49,7 +49,7 @@ importers:
         version: 7.46.0(react@18.3.1)
       '@wordpress/data':
         specifier: ^10.48.0
-        version: 10.48.0(react@18.3.1)
+        version: 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews':
         specifier: ^10.2.0
         version: 10.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -85,7 +85,7 @@ importers:
         version: 4.48.0
       '@wordpress/plugins':
         specifier: ^7.48.0
-        version: 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+        version: 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/primitives':
         specifier: ^3.0.0
         version: 3.56.0
@@ -150,7 +150,7 @@ importers:
         version: 7.46.0(react@18.3.1)
       '@wordpress/data':
         specifier: ^10.48.0
-        version: 10.48.0(react@18.3.1)
+        version: 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews':
         specifier: ^10.2.0
         version: 10.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -179,11 +179,11 @@ importers:
         specifier: 0.4.0
         version: 0.4.0
       '@wordpress/theme':
-        specifier: 0.15.0
-        version: 0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+        specifier: ^0.16.0
+        version: 0.16.0(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/ui':
-        specifier: 0.15.0
-        version: 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+        specifier: ^0.16.0
+        version: 0.16.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url':
         specifier: ^4.48.0
         version: 4.48.0
@@ -1634,12 +1634,12 @@ packages:
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@emotion/native@11.11.0':
-    resolution: {integrity: sha512-t1b5bLv+o5OUNLqXlnw+LJYU10OpmYkLC/1W873Y1ohG+vObx5TT3o3Eh1okXb2KCuZTTBPgsEnU/Sl7NNkJ9Q==}
+    resolution: {integrity: sha512-t1b5bLv+o5OUNLqXlnw+LJYU10OpmYkLC/1W873Y1ohG+vObx5TT3o3Eh1okXb2KCuZTTBPgsEnU/Sl7NNkJ9Q==, tarball: https://registry.npmjs.org/@emotion/native/-/native-11.11.0.tgz}
     peerDependencies:
       react-native: '>=0.14.0 <1'
 
   '@emotion/primitives-core@11.13.2':
-    resolution: {integrity: sha512-+MX60ROt1fDi5EYafhE/zs78XD4OuFUn6j0Z274wo5wVMT8sSBRx2CKPMbOUnmCcT0K5GPog+41mtkcppzkMmg==}
+    resolution: {integrity: sha512-+MX60ROt1fDi5EYafhE/zs78XD4OuFUn6j0Z274wo5wVMT8sSBRx2CKPMbOUnmCcT0K5GPog+41mtkcppzkMmg==, tarball: https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-11.13.2.tgz}
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
       react: 18.3.1
@@ -1907,7 +1907,7 @@ packages:
     engines: {node: '>= 8'}
 
   '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==, tarball: https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz}
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
 
   '@nodelib/fs.walk@1.2.8':
@@ -3532,7 +3532,7 @@ packages:
       react-dom: 18.3.1
 
   '@wordpress/components@35.0.0':
-    resolution: {integrity: sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==}
+    resolution: {integrity: sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==, tarball: https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: 18.3.1
@@ -3562,7 +3562,7 @@ packages:
       react: 18.3.1
 
   '@wordpress/compose@8.2.0':
-    resolution: {integrity: sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==}
+    resolution: {integrity: sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==, tarball: https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18.3.27
@@ -3585,7 +3585,7 @@ packages:
       react: 18.3.1
 
   '@wordpress/data@10.49.0':
-    resolution: {integrity: sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==}
+    resolution: {integrity: sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==, tarball: https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18.3.27
@@ -3602,7 +3602,7 @@ packages:
       react-dom: 18.3.1
 
   '@wordpress/dataviews@16.0.0':
-    resolution: {integrity: sha512-02rbslxalTNasLV8w/zAifCsUU5Pug8GiduWIEKRiNtazvJ8duz8fIcQ2Jgl31ruRItcu3fcG7XUk1OtwsdcZQ==}
+    resolution: {integrity: sha512-02rbslxalTNasLV8w/zAifCsUU5Pug8GiduWIEKRiNtazvJ8duz8fIcQ2Jgl31ruRItcu3fcG7XUk1OtwsdcZQ==, tarball: https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: 18.3.1
@@ -3613,7 +3613,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/date@5.49.0':
-    resolution: {integrity: sha512-6Q7tvwjwNI2W0KDIATd4WAOc1n5Ppp/v/ofOwPjvaXr/9O4s2fsduR//ziQL3c5a5oYohCIsNHSHmOic+/Jofg==}
+    resolution: {integrity: sha512-6Q7tvwjwNI2W0KDIATd4WAOc1n5Ppp/v/ofOwPjvaXr/9O4s2fsduR//ziQL3c5a5oYohCIsNHSHmOic+/Jofg==, tarball: https://registry.npmjs.org/@wordpress/date/-/date-5.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dependency-extraction-webpack-plugin@6.44.0':
@@ -3627,7 +3627,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/deprecated@4.49.0':
-    resolution: {integrity: sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==}
+    resolution: {integrity: sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==, tarball: https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dom-ready@4.48.0':
@@ -3946,7 +3946,7 @@ packages:
       redux: '>=4'
 
   '@wordpress/redux-routine@5.49.0':
-    resolution: {integrity: sha512-pisFM/iQv23hmrBkWwlQZoMtqR3wXWoaAAf9d++laxlPRkFNfe/AG7gUK9tljhk5k6lP9pdeet4t+qSeQPDxpg==}
+    resolution: {integrity: sha512-pisFM/iQv23hmrBkWwlQZoMtqR3wXWoaAAf9d++laxlPRkFNfe/AG7gUK9tljhk5k6lP9pdeet4t+qSeQPDxpg==, tarball: https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       redux: '>=4'
@@ -4021,11 +4021,11 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/style-runtime@0.4.0':
-    resolution: {integrity: sha512-frzAg1rsn8X0KNgrxxLxszLvWCKY0Nk2e8j8Mjm2pI2URmS8Et7NefuXP3JnHBD4U1L1Ug9yKO/FA65ojQ7CEA==}
+    resolution: {integrity: sha512-frzAg1rsn8X0KNgrxxLxszLvWCKY0Nk2e8j8Mjm2pI2URmS8Et7NefuXP3JnHBD4U1L1Ug9yKO/FA65ojQ7CEA==, tarball: https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.4.0.tgz}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
   '@wordpress/style-runtime@0.5.0':
-    resolution: {integrity: sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==}
+    resolution: {integrity: sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==, tarball: https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
   '@wordpress/stylelint-config@23.40.0':
@@ -4133,7 +4133,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/warning@3.49.0':
-    resolution: {integrity: sha512-00KmZy5kT8vm48HKNQxsgiq3GXdgaPGClneMFTe9EWjop9Ghyq8MaYIqjYY75eOgPTFVcKKQyXK9/DAAQxsQuA==}
+    resolution: {integrity: sha512-00KmZy5kT8vm48HKNQxsgiq3GXdgaPGClneMFTe9EWjop9Ghyq8MaYIqjYY75eOgPTFVcKKQyXK9/DAAQxsQuA==, tarball: https://registry.npmjs.org/@wordpress/warning/-/warning-3.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/widgets@4.48.0':
@@ -4303,7 +4303,7 @@ packages:
     engines: {node: '>=8'}
 
   ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz}
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
@@ -4388,7 +4388,7 @@ packages:
     engines: {node: '>=8'}
 
   array-union@3.0.1:
-    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==, tarball: https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz}
+    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
     engines: {node: '>=12'}
 
   array-uniq@1.0.3:
@@ -4556,13 +4556,13 @@ packages:
       '@babel/core': ^7.0.0
 
   balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz}
 
   balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz}
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
   bare-events@2.8.2:
@@ -4739,7 +4739,7 @@ packages:
     engines: {node: '>=10'}
 
   camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==, tarball: https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -5293,7 +5293,7 @@ packages:
     engines: {node: '>=10'}
 
   cosmiconfig@8.3.6:
-    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==, tarball: https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz}
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -5302,7 +5302,7 @@ packages:
         optional: true
 
   cosmiconfig@9.0.1:
-    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==, tarball: https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz}
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -5337,7 +5337,7 @@ packages:
     resolution: {integrity: sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==}
 
   css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==, tarball: https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz}
     engines: {node: '>=4'}
 
   css-declaration-sorter@7.4.0:
@@ -5366,14 +5366,14 @@ packages:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
   css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==, tarball: https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz}
 
   css-tree@2.2.1:
-    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==, tarball: https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz}
+    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
   css-tree@2.3.1:
-    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==, tarball: https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz}
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.2.1:
@@ -5388,7 +5388,7 @@ packages:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==, tarball: https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz}
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
 
@@ -5487,7 +5487,7 @@ packages:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   date-fns@4.4.0:
-    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==, tarball: https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -5496,7 +5496,7 @@ packages:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
   debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==, tarball: https://registry.npmjs.org/debug/-/debug-2.6.9.tgz}
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -5554,7 +5554,7 @@ packages:
     engines: {node: '>=6'}
 
   deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==, tarball: https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz}
     engines: {node: '>=0.10.0'}
 
   default-gateway@6.0.3:
@@ -5725,13 +5725,13 @@ packages:
     engines: {node: '>=12'}
 
   emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==, tarball: https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz}
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@7.0.3:
-    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==, tarball: https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz}
+    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==, tarball: https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz}
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -5781,7 +5781,7 @@ packages:
     engines: {node: ^18.17 || >=20.6.1}
 
   env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==, tarball: https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz}
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
   envinfo@7.21.0:
@@ -6201,7 +6201,7 @@ packages:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==, tarball: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz}
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
@@ -6364,7 +6364,7 @@ packages:
     hasBin: true
 
   flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==, tarball: https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz}
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==, tarball: https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz}
@@ -6618,11 +6618,11 @@ packages:
     engines: {node: '>=18'}
 
   global-modules@0.2.3:
-    resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==, tarball: https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz}
+    resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
     engines: {node: '>=0.10.0'}
 
   global-modules@1.0.0:
-    resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==, tarball: https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz}
+    resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
 
   global-modules@2.0.0:
@@ -6630,11 +6630,11 @@ packages:
     engines: {node: '>=6'}
 
   global-prefix@0.1.5:
-    resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==, tarball: https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz}
+    resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==}
     engines: {node: '>=0.10.0'}
 
   global-prefix@1.0.2:
-    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==, tarball: https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz}
+    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
 
   global-prefix@3.0.0:
@@ -6742,11 +6742,11 @@ packages:
     engines: {node: '>= 0.4'}
 
   has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==, tarball: https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz}
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==, tarball: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz}
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
@@ -7012,7 +7012,7 @@ packages:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==, tarball: https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
   indent-string@4.0.0:
@@ -7035,14 +7035,14 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==, tarball: https://registry.npmjs.org/ini/-/ini-1.3.8.tgz}
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@3.0.1:
     resolution: {integrity: sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==, tarball: https://registry.npmjs.org/ini/-/ini-4.1.1.tgz}
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   inline-style-parser@0.2.7:
@@ -7168,19 +7168,19 @@ packages:
     engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==, tarball: https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz}
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
     engines: {node: '>=4'}
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==, tarball: https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz}
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
   is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==, tarball: https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz}
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
 
   is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==, tarball: https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz}
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
   is-generator-fn@2.1.0:
@@ -7236,7 +7236,7 @@ packages:
     engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==, tarball: https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz}
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
   is-plain-object@5.0.0:
@@ -7657,7 +7657,7 @@ packages:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==, tarball: https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz}
 
   kind-of@2.0.1:
-    resolution: {integrity: sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==, tarball: https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz}
+    resolution: {integrity: sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==}
     engines: {node: '>=0.10.0'}
 
   kind-of@3.2.2:
@@ -7665,7 +7665,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==, tarball: https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz}
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
@@ -7990,10 +7990,10 @@ packages:
     engines: {node: '>=0.10.0'}
 
   mdn-data@2.0.28:
-    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==, tarball: https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz}
+    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
   mdn-data@2.0.30:
-    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==, tarball: https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz}
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==, tarball: https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz}
@@ -8379,7 +8379,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, tarball: https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz}
     engines: {node: '>=0.10.0'}
 
   normalize-url@9.0.0:
@@ -8721,7 +8721,7 @@ packages:
     engines: {node: '>=0.8'}
 
   parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==, tarball: https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz}
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
     engines: {node: '>=4'}
 
   parse-json@5.2.0:
@@ -8729,7 +8729,7 @@ packages:
     engines: {node: '>=8'}
 
   parse-json@8.3.0:
-    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==, tarball: https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz}
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
   parse-ms@4.0.0:
@@ -8840,7 +8840,7 @@ packages:
     engines: {node: '>=4'}
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==, tarball: https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz}
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
@@ -9271,7 +9271,7 @@ packages:
       postcss: ^8.4.31
 
   postcss-scss@4.0.9:
-    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==, tarball: https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz}
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.29
@@ -9281,7 +9281,7 @@ packages:
     engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
-    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==, tarball: https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz}
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
   postcss-svgo@6.0.3:
@@ -9314,7 +9314,7 @@ packages:
       postcss: ^8.3.0
 
   postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==, tarball: https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz}
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -9712,7 +9712,7 @@ packages:
     resolution: {integrity: sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==}
 
   remove-accents@0.5.0:
-    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==, tarball: https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz}
 
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
@@ -9765,7 +9765,7 @@ packages:
     engines: {node: '>=4'}
 
   resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==, tarball: https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz}
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
   resolve-pathname@3.0.0:
@@ -10071,7 +10071,7 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==, tarball: https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz}
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
   signale@1.4.0:
@@ -10105,7 +10105,7 @@ packages:
     engines: {node: '>=8'}
 
   slash@4.0.0:
-    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==, tarball: https://registry.npmjs.org/slash/-/slash-4.0.0.tgz}
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
   slice-ansi@4.0.0:
@@ -10258,19 +10258,19 @@ packages:
     engines: {node: '>=10'}
 
   string-width@3.1.0:
-    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==, tarball: https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz}
+    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
     engines: {node: '>=6'}
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==, tarball: https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz}
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
   string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==, tarball: https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz}
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
   string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==, tarball: https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz}
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
   string.prototype.includes@2.0.1:
@@ -10310,7 +10310,7 @@ packages:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz}
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
 
   strip-ansi@6.0.1:
@@ -10318,7 +10318,7 @@ packages:
     engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz}
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom@3.0.0:
@@ -10932,7 +10932,7 @@ packages:
       react: 18.3.1
 
   util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==, tarball: https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz}
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -11125,7 +11125,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==, tarball: https://registry.npmjs.org/which/-/which-1.3.1.tgz}
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
 
   which@2.0.2:
@@ -11164,7 +11164,7 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   write-file-atomic@4.0.2:
-    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==, tarball: https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz}
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   write-file-atomic@5.0.1:
@@ -15952,9 +15952,9 @@ snapshots:
   '@wordpress/admin-ui@2.3.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/route': 0.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/style-runtime': 0.4.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
@@ -16033,36 +16033,36 @@ snapshots:
       '@wordpress/base-styles': 9.1.0
       '@wordpress/blob': 4.48.0
       '@wordpress/block-serialization-default-parser': 5.48.0
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/commands': 1.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/compose': 8.1.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/date': 5.48.0
       '@wordpress/deprecated': 4.48.0
       '@wordpress/dom': 4.48.0
       '@wordpress/element': 8.0.0
       '@wordpress/escape-html': 3.48.0
-      '@wordpress/global-styles-engine': 1.15.0(react@18.3.1)
+      '@wordpress/global-styles-engine': 1.15.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/hooks': 4.48.0
       '@wordpress/html-entities': 4.48.0
       '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/image-cropper': 1.12.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/interactivity': 6.48.0
       '@wordpress/is-shallow-equal': 5.48.0
-      '@wordpress/keyboard-shortcuts': 5.48.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/keycodes': 4.48.0
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/priority-queue': 3.48.0
       '@wordpress/private-apis': 1.48.0
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/style-engine': 2.48.0
       '@wordpress/token-list': 3.48.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/upload-media': 0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/upload-media': 0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url': 4.48.0
       '@wordpress/warning': 3.48.0
       '@wordpress/wordcount': 4.48.0
@@ -16095,43 +16095,43 @@ snapshots:
   '@wordpress/block-library@9.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@arraypress/waveform-player': 1.2.1
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/autop': 4.48.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/blob': 4.48.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/date': 5.48.0
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/dom': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/escape-html': 3.48.0
-      '@wordpress/hooks': 4.48.0
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/dom': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/escape-html': 3.49.0
+      '@wordpress/hooks': 4.49.0
       '@wordpress/html-entities': 4.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/interactivity': 6.48.0
       '@wordpress/interactivity-router': 2.48.0
-      '@wordpress/keyboard-shortcuts': 5.48.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.0
+      '@wordpress/keyboard-shortcuts': 5.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
       '@wordpress/latex-to-mathml': 1.16.0
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/patterns': 2.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/reusable-blocks': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
-      '@wordpress/server-side-render': 6.24.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/server-side-render': 6.24.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/shortcode': 4.48.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/upload-media': 0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/upload-media': 0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url': 4.48.0
-      '@wordpress/viewport': 6.48.0(react@18.3.1)
+      '@wordpress/viewport': 6.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/wordcount': 4.48.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -16156,12 +16156,12 @@ snapshots:
 
   '@wordpress/block-serialization-default-parser@5.48.0': {}
 
-  '@wordpress/blocks@15.21.0(react@18.3.1)':
+  '@wordpress/blocks@15.21.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       '@wordpress/autop': 4.48.0
       '@wordpress/blob': 4.48.0
       '@wordpress/block-serialization-default-parser': 5.48.0
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/deprecated': 4.48.0
       '@wordpress/dom': 4.48.0
       '@wordpress/element': 8.0.0
@@ -16170,7 +16170,7 @@ snapshots:
       '@wordpress/i18n': 6.21.0
       '@wordpress/is-shallow-equal': 5.48.0
       '@wordpress/private-apis': 1.48.0
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/shortcode': 4.48.0
       '@wordpress/warning': 3.48.0
       change-case: 4.1.2
@@ -16185,6 +16185,8 @@ snapshots:
       showdown: 1.9.1
       simple-html-tokenizer: 0.5.11
       uuid: 14.0.0
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/browserslist-config@6.48.0': {}
 
@@ -16192,13 +16194,13 @@ snapshots:
     dependencies:
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.48.0(react@18.3.1)
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/warning': 3.48.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16243,7 +16245,7 @@ snapshots:
       '@wordpress/keycodes': 4.48.0
       '@wordpress/primitives': 4.48.0(react@18.3.1)
       '@wordpress/private-apis': 1.48.0
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/warning': 3.48.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -16285,26 +16287,26 @@ snapshots:
       '@types/highlight-words-core': 1.2.1
       '@types/react': 18.3.31
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/base-styles': 9.1.0
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/date': 5.48.0
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/dom': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/escape-html': 3.48.0
-      '@wordpress/hooks': 4.48.0
-      '@wordpress/html-entities': 4.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.48.0
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/date': 5.49.0
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/dom': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/escape-html': 3.49.0
+      '@wordpress/hooks': 4.49.0
+      '@wordpress/html-entities': 4.49.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.49.0
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/private-apis': 1.49.0
+      '@wordpress/rich-text': 7.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/style-runtime': 0.4.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/warning': 3.48.0
+      '@wordpress/warning': 3.49.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -16412,21 +16414,23 @@ snapshots:
       react: 18.3.1
       use-memo-one: 1.1.3(react@18.3.1)
 
-  '@wordpress/compose@8.1.0(react@18.3.1)':
+  '@wordpress/compose@8.1.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/dom': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/is-shallow-equal': 5.48.0
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/priority-queue': 3.48.0
-      '@wordpress/private-apis': 1.48.0
-      '@wordpress/undo-manager': 1.48.0
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/dom': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/is-shallow-equal': 5.49.0
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/priority-queue': 3.49.0
+      '@wordpress/private-apis': 1.49.0
+      '@wordpress/undo-manager': 1.49.0
       change-case: 4.1.2
       mousetrap: 1.6.5
       react: 18.3.1
       use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/compose@8.2.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
@@ -16450,18 +16454,18 @@ snapshots:
     dependencies:
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/element': 8.0.0
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/element': 8.1.0
       '@wordpress/html-entities': 4.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/is-shallow-equal': 5.48.0
-      '@wordpress/private-apis': 1.48.0
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/is-shallow-equal': 5.49.0
+      '@wordpress/private-apis': 1.49.0
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/sync': 1.48.0
-      '@wordpress/undo-manager': 1.48.0
+      '@wordpress/undo-manager': 1.49.0
       '@wordpress/url': 4.48.0
       '@wordpress/warning': 3.48.0
       change-case: 4.1.2
@@ -16481,9 +16485,9 @@ snapshots:
       - stylelint
       - supports-color
 
-  '@wordpress/data@10.48.0(react@18.3.1)':
+  '@wordpress/data@10.48.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.1.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/deprecated': 4.48.0
       '@wordpress/element': 8.0.0
       '@wordpress/is-shallow-equal': 5.48.0
@@ -16498,6 +16502,8 @@ snapshots:
       redux: 5.0.1
       rememo: 4.0.2
       use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/data@10.49.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
@@ -16525,7 +16531,7 @@ snapshots:
       '@wordpress/base-styles': 6.20.0
       '@wordpress/components': 30.9.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.46.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/date': 5.48.0
       '@wordpress/element': 6.46.0
       '@wordpress/i18n': 6.21.0
@@ -16553,18 +16559,18 @@ snapshots:
       '@ariakit/react': 0.4.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/date': 5.48.0
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/date': 5.49.0
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/warning': 3.48.0
+      '@wordpress/warning': 3.49.0
       clsx: 2.1.1
       colord: 2.9.3
       date-fns: 4.4.0
@@ -16600,7 +16606,7 @@ snapshots:
 
   '@wordpress/deprecated@4.48.0':
     dependencies:
-      '@wordpress/hooks': 4.48.0
+      '@wordpress/hooks': 4.49.0
 
   '@wordpress/deprecated@4.49.0':
     dependencies:
@@ -16612,7 +16618,7 @@ snapshots:
 
   '@wordpress/dom@4.48.0':
     dependencies:
-      '@wordpress/deprecated': 4.48.0
+      '@wordpress/deprecated': 4.49.0
 
   '@wordpress/dom@4.49.0':
     dependencies:
@@ -16643,30 +16649,30 @@ snapshots:
       '@wordpress/base-styles': 9.1.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/block-library': 9.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/commands': 1.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.1.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/deprecated': 4.48.0
       '@wordpress/dom': 4.48.0
       '@wordpress/editor': 14.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/element': 8.0.0
-      '@wordpress/global-styles-engine': 1.15.0(react@18.3.1)
+      '@wordpress/global-styles-engine': 1.15.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/hooks': 4.48.0
       '@wordpress/html-entities': 4.48.0
       '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.48.0(react@18.3.1)
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/keycodes': 4.48.0
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/private-apis': 1.48.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url': 4.48.0
-      '@wordpress/viewport': 6.48.0(react@18.3.1)
+      '@wordpress/viewport': 6.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/warning': 3.48.0
       '@wordpress/widgets': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       clsx: 2.1.1
@@ -16688,46 +16694,46 @@ snapshots:
 
   '@wordpress/editor@14.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/blob': 4.48.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/block-serialization-default-parser': 5.48.0
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/commands': 1.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/date': 5.48.0
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/dom': 4.48.0
-      '@wordpress/element': 8.0.0
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/dom': 4.49.0
+      '@wordpress/element': 8.1.0
       '@wordpress/fields': 0.40.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/global-styles-engine': 1.15.0(react@18.3.1)
+      '@wordpress/global-styles-engine': 1.15.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/global-styles-ui': 1.15.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/hooks': 4.48.0
+      '@wordpress/hooks': 4.49.0
       '@wordpress/html-entities': 4.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/interface': 9.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/keyboard-shortcuts': 5.48.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.0
+      '@wordpress/keyboard-shortcuts': 5.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
       '@wordpress/media-editor': 0.11.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/media-fields': 0.13.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/media-utils': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/patterns': 2.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/reusable-blocks': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/rich-text': 7.48.0(react@18.3.1)
-      '@wordpress/server-side-render': 6.24.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/server-side-render': 6.24.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/upload-media': 0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/upload-media': 0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url': 4.48.0
       '@wordpress/views': 1.15.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/warning': 3.48.0
@@ -16782,8 +16788,8 @@ snapshots:
     dependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/escape-html': 3.48.0
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/escape-html': 3.49.0
       change-case: 4.1.2
       is-plain-object: 5.0.0
       react: 18.3.1
@@ -16878,27 +16884,27 @@ snapshots:
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/blob': 4.48.0
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/date': 5.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/hooks': 4.48.0
+      '@wordpress/date': 5.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/hooks': 4.49.0
       '@wordpress/html-entities': 4.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/media-utils': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/patterns': 2.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
-      '@wordpress/router': 1.48.0(react@18.3.1)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/private-apis': 1.49.0
+      '@wordpress/router': 1.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url': 4.48.0
-      '@wordpress/warning': 3.48.0
+      '@wordpress/warning': 3.49.0
       '@wordpress/wordcount': 4.48.0
       change-case: 4.1.2
       client-zip: 2.5.0
@@ -16916,11 +16922,11 @@ snapshots:
       - stylelint
       - supports-color
 
-  '@wordpress/global-styles-engine@1.15.0(react@18.3.1)':
+  '@wordpress/global-styles-engine@1.15.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/i18n': 6.21.0
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/i18n': 6.22.0
       '@wordpress/style-engine': 2.48.0
       colord: 2.9.3
       deepmerge: 4.3.1
@@ -16928,26 +16934,27 @@ snapshots:
       is-plain-object: 5.0.0
       memize: 2.1.1
     transitivePeerDependencies:
+      - '@types/react'
       - react
 
   '@wordpress/global-styles-ui@1.15.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/date': 5.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/global-styles-engine': 1.15.0(react@18.3.1)
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/date': 5.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/global-styles-engine': 1.15.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/private-apis': 1.49.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -16994,12 +17001,14 @@ snapshots:
       change-case: 4.1.2
       react: 18.3.1
 
-  '@wordpress/icons@13.3.0(react@18.3.1)':
+  '@wordpress/icons@13.3.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/element': 8.0.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/icons@15.0.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
@@ -17013,8 +17022,8 @@ snapshots:
   '@wordpress/image-cropper@1.12.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
       clsx: 2.1.1
       dequal: 2.0.3
       react: 18.3.1
@@ -17029,7 +17038,7 @@ snapshots:
 
   '@wordpress/interactivity-router@2.48.0':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/interactivity': 6.48.0
       es-module-lexer: 1.7.0
 
@@ -17040,19 +17049,19 @@ snapshots:
 
   '@wordpress/interface@9.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/admin-ui': 2.4.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/viewport': 6.48.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/viewport': 6.48.0(@types/react@18.3.31)(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17087,12 +17096,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wordpress/keyboard-shortcuts@5.48.0(react@18.3.1)':
+  '@wordpress/keyboard-shortcuts@5.48.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/keycodes': 4.48.0
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/keycodes@4.48.0':
     dependencies:
@@ -17113,19 +17124,19 @@ snapshots:
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/date': 5.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/date': 5.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/interface': 9.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/keyboard-shortcuts': 5.48.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/keyboard-shortcuts': 5.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       clsx: 2.1.1
       gl-matrix: 3.4.4
@@ -17148,15 +17159,15 @@ snapshots:
     dependencies:
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/date': 5.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
+      '@wordpress/date': 5.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/url': 4.48.0
       clsx: 2.1.1
       react: 18.3.1
@@ -17178,14 +17189,14 @@ snapshots:
       '@wordpress/blob': 4.48.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/media-fields': 0.13.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/views': 1.15.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       clsx: 2.1.1
@@ -17201,16 +17212,17 @@ snapshots:
       - stylelint
       - supports-color
 
-  '@wordpress/notices@5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/notices@5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - react-dom
       - react-native
       - stylelint
@@ -17222,20 +17234,20 @@ snapshots:
 
   '@wordpress/patterns@2.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
       '@wordpress/html-entities': 4.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17249,14 +17261,14 @@ snapshots:
       - stylelint
       - supports-color
 
-  '@wordpress/plugins@7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/plugins@7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.1.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/deprecated': 4.48.0
       '@wordpress/element': 8.0.0
       '@wordpress/hooks': 4.48.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.48.0
       memize: 2.1.1
       react: 18.3.1
@@ -17264,6 +17276,7 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - react-native
       - stylelint
       - supports-color
@@ -17275,24 +17288,25 @@ snapshots:
       postcss: 8.5.15
       postcss-import: 16.1.1(postcss@8.5.15)
 
-  '@wordpress/preferences@4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/preferences@4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/a11y': 4.48.0
+      '@wordpress/a11y': 4.49.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/private-apis': 1.49.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - react-native
       - stylelint
       - supports-color
@@ -17309,7 +17323,7 @@ snapshots:
 
   '@wordpress/primitives@4.48.0(react@18.3.1)':
     dependencies:
-      '@wordpress/element': 8.0.0
+      '@wordpress/element': 8.1.0
       clsx: 2.1.1
       react: 18.3.1
 
@@ -17351,15 +17365,15 @@ snapshots:
     dependencies:
       '@wordpress/base-styles': 9.1.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17373,21 +17387,23 @@ snapshots:
       - stylelint
       - supports-color
 
-  '@wordpress/rich-text@7.48.0(react@18.3.1)':
+  '@wordpress/rich-text@7.48.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/a11y': 4.48.0
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/dom': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/escape-html': 3.48.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/a11y': 4.49.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/dom': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/escape-html': 3.49.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/private-apis': 1.49.0
       colord: 2.9.3
       memize: 2.1.1
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/rich-text@7.49.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
@@ -17411,7 +17427,7 @@ snapshots:
     dependencies:
       '@tanstack/history': 1.162.0
       '@tanstack/react-router': 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       react: 18.3.1
     transitivePeerDependencies:
       - react-dom
@@ -17425,15 +17441,17 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@wordpress/router@1.48.0(react@18.3.1)':
+  '@wordpress/router@1.48.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
       history: 5.3.0
       react: 18.3.1
       route-recognizer: 0.3.4
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/scripts@30.27.0(@playwright/test@1.59.1)(@types/eslint@9.6.1)(@types/node@25.6.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)))(type-fest@4.41.0)(typescript@5.9.3)':
     dependencies:
@@ -17531,22 +17549,23 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@wordpress/server-side-render@6.24.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/server-side-render@6.24.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/api-fetch': 7.48.0
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/deprecated': 4.48.0
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.49.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
       '@wordpress/url': 4.48.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - react-native
       - stylelint
       - supports-color
@@ -17579,9 +17598,9 @@ snapshots:
   '@wordpress/sync@1.48.0':
     dependencies:
       '@wordpress/api-fetch': 7.48.0
-      '@wordpress/hooks': 4.48.0
-      '@wordpress/private-apis': 1.48.0
-      '@wordpress/undo-manager': 1.48.0
+      '@wordpress/hooks': 4.49.0
+      '@wordpress/private-apis': 1.49.0
+      '@wordpress/undo-manager': 1.49.0
       diff: 8.0.4
       fast-deep-equal: 3.1.3
       lib0: 0.2.99
@@ -17590,7 +17609,7 @@ snapshots:
 
   '@wordpress/theme@0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
-      '@wordpress/element': 8.0.0
+      '@wordpress/element': 8.1.0
       '@wordpress/private-apis': 1.48.0
       '@wordpress/style-runtime': 0.4.0
       colorjs.io: 0.6.1
@@ -17619,14 +17638,14 @@ snapshots:
   '@wordpress/ui@0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.48.0
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/a11y': 4.49.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/style-runtime': 0.4.0
       '@wordpress/theme': 0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       clsx: 2.1.1
@@ -17667,21 +17686,21 @@ snapshots:
 
   '@wordpress/undo-manager@1.48.0':
     dependencies:
-      '@wordpress/is-shallow-equal': 5.48.0
+      '@wordpress/is-shallow-equal': 5.49.0
 
   '@wordpress/undo-manager@1.49.0':
     dependencies:
       '@wordpress/is-shallow-equal': 5.49.0
 
-  '@wordpress/upload-media@0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/upload-media@0.33.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/blob': 4.48.0
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
       '@wordpress/vips': 2.1.0
       react: 18.3.1
@@ -17690,6 +17709,7 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - react-native
       - stylelint
       - supports-color
@@ -17698,21 +17718,23 @@ snapshots:
     dependencies:
       remove-accents: 0.5.0
 
-  '@wordpress/viewport@6.48.0(react@18.3.1)':
+  '@wordpress/viewport@6.48.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
-      '@wordpress/compose': 8.1.0(react@18.3.1)
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/views@1.15.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
+      '@wordpress/data': 10.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/dataviews': 16.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/element': 8.0.0
-      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/element': 8.1.0
+      '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/private-apis': 1.49.0
       dequal: 2.0.3
     transitivePeerDependencies:
       - '@date-fns/tz'
@@ -17740,15 +17762,15 @@ snapshots:
       '@wordpress/api-fetch': 7.48.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/block-editor': 15.21.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/blocks': 15.21.0(react@18.3.1)
+      '@wordpress/blocks': 15.21.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components': 35.0.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/compose': 8.1.0(react@18.3.1)
+      '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/core-data': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/data': 10.48.0(react@18.3.1)
-      '@wordpress/element': 8.0.0
-      '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
+      '@wordpress/data': 10.48.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 8.1.0
+      '@wordpress/i18n': 6.22.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   prettier: npm:wp-prettier@^3.0.3
   react: 18.3.1
   react-dom: 18.3.1
+  '@wordpress/private-apis': 1.49.0
 
 patchedDependencies:
   multi-semantic-release:
@@ -3929,10 +3930,6 @@ packages:
 
   '@wordpress/priority-queue@3.49.0':
     resolution: {integrity: sha512-UcVHYan6qYvDNTFEwEnPBU9I1SnImLjEh54ISgqvvndc7jfxtdi+Akwj2kgxeLRY+bsXzMQr6byD/x4dw56yqA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/private-apis@1.48.0':
-    resolution: {integrity: sha512-HHOSXLCAlBggfMozwWtX36wgsSt22g2tZwpka47Rjzr3hNY1BZ6SrrFJumiNxooy5PDKbRgcF092PAF82hdJXg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/private-apis@1.49.0':
@@ -15997,7 +15994,7 @@ snapshots:
   '@wordpress/api-fetch@7.48.0':
     dependencies:
       '@wordpress/i18n': 6.21.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
 
   '@wordpress/autop@4.48.0': {}
@@ -16057,7 +16054,7 @@ snapshots:
       '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/priority-queue': 3.48.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/style-engine': 2.48.0
       '@wordpress/token-list': 3.48.0
@@ -16169,7 +16166,7 @@ snapshots:
       '@wordpress/html-entities': 4.48.0
       '@wordpress/i18n': 6.21.0
       '@wordpress/is-shallow-equal': 5.48.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/shortcode': 4.48.0
       '@wordpress/warning': 3.48.0
@@ -16244,7 +16241,7 @@ snapshots:
       '@wordpress/is-shallow-equal': 5.48.0
       '@wordpress/keycodes': 4.48.0
       '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/warning': 3.48.0
       change-case: 4.1.2
@@ -16492,7 +16489,7 @@ snapshots:
       '@wordpress/element': 8.0.0
       '@wordpress/is-shallow-equal': 5.48.0
       '@wordpress/priority-queue': 3.48.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/redux-routine': 5.48.0(redux@5.0.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
@@ -16538,7 +16535,7 @@ snapshots:
       '@wordpress/icons': 11.8.0(react@18.3.1)
       '@wordpress/keycodes': 4.48.0
       '@wordpress/primitives': 4.48.0(react@18.3.1)
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
       '@wordpress/warning': 3.48.0
       clsx: 2.1.1
@@ -16669,7 +16666,7 @@ snapshots:
       '@wordpress/notices': 5.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/plugins': 7.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/preferences': 4.48.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/url': 4.48.0
       '@wordpress/viewport': 6.48.0(@types/react@18.3.31)(react@18.3.1)
@@ -17343,8 +17340,6 @@ snapshots:
     dependencies:
       requestidlecallback: 0.3.0
 
-  '@wordpress/private-apis@1.48.0': {}
-
   '@wordpress/private-apis@1.49.0': {}
 
   '@wordpress/redux-routine@5.48.0(redux@5.0.1)':
@@ -17610,7 +17605,7 @@ snapshots:
   '@wordpress/theme@0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/element': 8.1.0
-      '@wordpress/private-apis': 1.48.0
+      '@wordpress/private-apis': 1.49.0
       '@wordpress/style-runtime': 0.4.0
       colorjs.io: 0.6.1
       memize: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,6 @@ overrides:
   prettier: npm:wp-prettier@^3.0.3
   react: 18.3.1
   react-dom: 18.3.1
-  '@wordpress/private-apis': 1.49.0
 
 patchedDependencies:
   multi-semantic-release:
@@ -177,8 +176,8 @@ importers:
         specifier: ^4.48.0
         version: 4.48.0
       '@wordpress/style-runtime':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@wordpress/theme':
         specifier: ^0.16.0
         version: 0.16.0(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
@@ -225,6 +224,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.29.7
         version: 7.29.7(@babel/core@7.29.7)
+      newspack-scripts:
+        specifier: workspace:*
+        version: link:../scripts
       recursive-copy:
         specifier: ^2.0.0
         version: 2.0.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       '@wordpress/style-runtime':
         specifier: 0.4.0
         version: 0.4.0
-      '@wordpress/theme':
-        specifier: ^0.16.0
-        version: 0.16.0(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/ui':
         specifier: ^0.16.0
         version: 0.16.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
@@ -1455,10 +1452,10 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@cacheable/memory@2.0.8':
-    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==, tarball: https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz}
+    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
 
   '@cacheable/utils@2.4.1':
-    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==, tarball: https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz}
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
   '@changesets/types@4.1.0':
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
@@ -1556,13 +1553,13 @@ packages:
         optional: true
 
   '@csstools/css-parser-algorithms@3.0.5':
-    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==, tarball: https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz}
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-syntax-patches-for-csstree@1.1.3':
-    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==, tarball: https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz}
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -1570,7 +1567,7 @@ packages:
         optional: true
 
   '@csstools/css-tokenizer@3.0.4':
-    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==, tarball: https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz}
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
   '@csstools/media-query-list-parser@3.0.1':
@@ -1581,14 +1578,14 @@ packages:
       '@csstools/css-tokenizer': ^3.0.1
 
   '@csstools/media-query-list-parser@4.0.3':
-    resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==, tarball: https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz}
+    resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/selector-specificity@5.0.0':
-    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==, tarball: https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz}
+    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
@@ -1604,7 +1601,7 @@ packages:
     engines: {node: '>=10.0.0'}
 
   '@dual-bundle/import-meta-resolve@4.2.1':
-    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==, tarball: https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz}
+    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==, tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz}
@@ -1876,13 +1873,13 @@ packages:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@keyv/bigmap@1.3.1':
-    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==, tarball: https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz}
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       keyv: ^5.6.0
 
   '@keyv/serialize@1.1.1':
-    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==, tarball: https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz}
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3680,7 +3677,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/element@8.1.0':
-    resolution: {integrity: sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==}
+    resolution: {integrity: sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==, tarball: https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/escape-html@2.58.0':
@@ -3748,7 +3745,7 @@ packages:
     hasBin: true
 
   '@wordpress/i18n@6.22.0':
-    resolution: {integrity: sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==}
+    resolution: {integrity: sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==, tarball: https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
@@ -3914,7 +3911,7 @@ packages:
       react: 18.3.1
 
   '@wordpress/primitives@4.49.0':
-    resolution: {integrity: sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==}
+    resolution: {integrity: sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==, tarball: https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18.3.27
@@ -3936,7 +3933,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/private-apis@1.49.0':
-    resolution: {integrity: sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==}
+    resolution: {integrity: sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==, tarball: https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/redux-routine@5.48.0':
@@ -4078,7 +4075,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/ui@0.15.0':
-    resolution: {integrity: sha512-7aAx1ovnC6JOb4Qfcnfk8ESfB0RTm6rqsdFrUn7TEY3LON/aEQisCb/bd7Yb8s9txb1GfaJYkgjiTvrr0M6EWA==}
+    resolution: {integrity: sha512-7aAx1ovnC6JOb4Qfcnfk8ESfB0RTm6rqsdFrUn7TEY3LON/aEQisCb/bd7Yb8s9txb1GfaJYkgjiTvrr0M6EWA==, tarball: https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.0.tgz}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
     peerDependencies:
       react: 18.3.1
@@ -4100,7 +4097,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/undo-manager@1.49.0':
-    resolution: {integrity: sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==}
+    resolution: {integrity: sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==, tarball: https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/upload-media@0.33.0':
@@ -4438,7 +4435,7 @@ packages:
     engines: {node: '>=4'}
 
   astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==, tarball: https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz}
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
   async-function@1.0.0:
@@ -4559,7 +4556,7 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@2.0.0:
-    resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz}
+    resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -4701,7 +4698,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   cacheable@2.3.4:
-    resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==, tarball: https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz}
+    resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
 
   cachedir@2.3.0:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
@@ -5347,7 +5344,7 @@ packages:
       postcss: ^8.0.9
 
   css-functions-list@3.3.3:
-    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==, tarball: https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz}
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
     engines: {node: '>=12'}
 
   css-loader@6.11.0:
@@ -5377,7 +5374,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==, tarball: https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz}
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.2.2:
@@ -6214,7 +6211,7 @@ packages:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastest-levenshtein@1.0.16:
-    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==, tarball: https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz}
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
 
   fastq@1.20.1:
@@ -6257,7 +6254,7 @@ packages:
     engines: {node: '>=18'}
 
   file-entry-cache@11.1.2:
-    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==, tarball: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz}
+    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -6357,7 +6354,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
 
   flat-cache@6.1.22:
-    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==, tarball: https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz}
+    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
 
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
@@ -6626,7 +6623,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   global-modules@2.0.0:
-    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==, tarball: https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz}
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
     engines: {node: '>=6'}
 
   global-prefix@0.1.5:
@@ -6638,7 +6635,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   global-prefix@3.0.0:
-    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==, tarball: https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz}
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
     engines: {node: '>=6'}
 
   globals@13.24.0:
@@ -6654,7 +6651,7 @@ packages:
     engines: {node: '>=10'}
 
   globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==, tarball: https://registry.npmjs.org/globby/-/globby-11.1.0.tgz}
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
   globby@12.2.0:
@@ -6662,7 +6659,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   globjoin@0.1.4:
-    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==, tarball: https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz}
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -6769,7 +6766,7 @@ packages:
     engines: {node: '>= 0.4.0'}
 
   hashery@1.5.1:
-    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==, tarball: https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz}
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
     engines: {node: '>=20'}
 
   hasown@2.0.2:
@@ -6825,10 +6822,10 @@ packages:
     resolution: {integrity: sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==}
 
   hookified@1.15.1:
-    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==, tarball: https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz}
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   hookified@2.1.1:
-    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==, tarball: https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz}
+    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -6874,7 +6871,7 @@ packages:
         optional: true
 
   html-tags@3.3.1:
-    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==, tarball: https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz}
+    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
 
   htmlparser2@10.0.0:
@@ -6978,7 +6975,7 @@ packages:
     engines: {node: '>= 4'}
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==, tarball: https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz}
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   image-size@1.2.1:
@@ -7654,7 +7651,7 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   keyv@5.6.0:
-    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==, tarball: https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz}
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   kind-of@2.0.1:
     resolution: {integrity: sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==}
@@ -7677,7 +7674,7 @@ packages:
     engines: {node: '>= 8'}
 
   known-css-properties@0.37.0:
-    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==, tarball: https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz}
+    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -7849,7 +7846,7 @@ packages:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
   lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==, tarball: https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz}
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -7983,7 +7980,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   mathml-tag-names@2.1.3:
-    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==, tarball: https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz}
+    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
   maximatch@0.1.0:
     resolution: {integrity: sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==}
@@ -7996,7 +7993,7 @@ packages:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==, tarball: https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz}
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdn-data@2.28.1:
     resolution: {integrity: sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==}
@@ -8023,7 +8020,7 @@ packages:
     engines: {node: '>= 0.10.0'}
 
   meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==, tarball: https://registry.npmjs.org/meow/-/meow-13.2.0.tgz}
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
   meow@8.1.2:
@@ -8379,7 +8376,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, tarball: https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz}
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
   normalize-url@9.0.0:
@@ -9262,10 +9259,10 @@ packages:
       postcss: ^8.4.32
 
   postcss-resolve-nested-selector@0.1.6:
-    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==, tarball: https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz}
+    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
 
   postcss-safe-parser@7.0.1:
-    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==, tarball: https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz}
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
       postcss: ^8.4.31
@@ -9430,7 +9427,7 @@ packages:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qified@0.9.1:
-    resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==, tarball: https://registry.npmjs.org/qified/-/qified-0.9.1.tgz}
+    resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==}
     engines: {node: '>=20'}
 
   qs@6.14.2:
@@ -10109,7 +10106,7 @@ packages:
     engines: {node: '>=12'}
 
   slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==, tarball: https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz}
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
   slice-ansi@5.0.0:
@@ -10407,7 +10404,7 @@ packages:
       stylelint: ^16.8.2
 
   stylelint@16.26.1:
-    resolution: {integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==, tarball: https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz}
+    resolution: {integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==}
     engines: {node: '>=18.12.0'}
     hasBin: true
 
@@ -10431,7 +10428,7 @@ packages:
     engines: {node: '>=10'}
 
   supports-hyperlinks@3.2.0:
-    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==, tarball: https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz}
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
 
   supports-preserve-symlinks-flag@1.0.0:
@@ -10442,7 +10439,7 @@ packages:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
   svg-tags@1.0.0:
-    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==, tarball: https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz}
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
   svgo@3.3.3:
     resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
@@ -10469,7 +10466,7 @@ packages:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
   table@6.9.0:
-    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==, tarball: https://registry.npmjs.org/table/-/table-6.9.0.tgz}
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
   tachyons@4.12.0:
@@ -11168,7 +11165,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   write-file-atomic@5.0.1:
-    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==, tarball: https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz}
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   ws@7.5.10:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@wordpress/style-runtime':
         specifier: 0.4.0
         version: 0.4.0
+      '@wordpress/theme':
+        specifier: ^0.16.0
+        version: 0.16.0(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/ui':
         specifier: ^0.16.0
         version: 0.16.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
@@ -675,35 +678,35 @@ packages:
     engines: {node: '>=6.0.0'}
 
   '@ariakit/components@0.1.2':
-    resolution: {integrity: sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw==}
+    resolution: {integrity: sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw==, tarball: https://registry.npmjs.org/@ariakit/components/-/components-0.1.2.tgz}
 
   '@ariakit/react-components@0.1.2':
-    resolution: {integrity: sha512-SM+SPMAVlOZmGAfWNBza+0k9y4mkA5/dJhDoOyhE96cbNARy665uLdwowSJl1JGuFfcZzuzAwGon7f/rYeyfkQ==}
+    resolution: {integrity: sha512-SM+SPMAVlOZmGAfWNBza+0k9y4mkA5/dJhDoOyhE96cbNARy665uLdwowSJl1JGuFfcZzuzAwGon7f/rYeyfkQ==, tarball: https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.1.2.tgz}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
 
   '@ariakit/react-store@0.1.2':
-    resolution: {integrity: sha512-1r1Gn0tqhnOS0LFvHNGzn5/8C5aOANO5vb0Gxh94oR/be4zwCSE2zfQjOjRfpL+BBDhOcProME2+G6UslEJxbg==}
+    resolution: {integrity: sha512-1r1Gn0tqhnOS0LFvHNGzn5/8C5aOANO5vb0Gxh94oR/be4zwCSE2zfQjOjRfpL+BBDhOcProME2+G6UslEJxbg==, tarball: https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.2.tgz}
     peerDependencies:
       react: 18.3.1
 
   '@ariakit/react-utils@0.1.2':
-    resolution: {integrity: sha512-Rnl6D1542Mqu80xK++oUv1JXS0PtNmKXd9nkdud5nyvySiBDTrmPqRW44/D+5GbuZrboreQuY3tPYwKL7a7onQ==}
+    resolution: {integrity: sha512-Rnl6D1542Mqu80xK++oUv1JXS0PtNmKXd9nkdud5nyvySiBDTrmPqRW44/D+5GbuZrboreQuY3tPYwKL7a7onQ==, tarball: https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.2.tgz}
     peerDependencies:
       react: 18.3.1
 
   '@ariakit/react@0.4.29':
-    resolution: {integrity: sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==}
+    resolution: {integrity: sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==, tarball: https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
 
   '@ariakit/store@0.1.2':
-    resolution: {integrity: sha512-SS7bV4+a+1q9M9i0WV6DD4P/ypRKlCvII8soo2UMe1yuaxZA/Fc0htHe+EZwjJ6TMLjHfHh2TDSnXyrjC7QImA==}
+    resolution: {integrity: sha512-SS7bV4+a+1q9M9i0WV6DD4P/ypRKlCvII8soo2UMe1yuaxZA/Fc0htHe+EZwjJ6TMLjHfHh2TDSnXyrjC7QImA==, tarball: https://registry.npmjs.org/@ariakit/store/-/store-0.1.2.tgz}
 
   '@ariakit/utils@0.1.2':
-    resolution: {integrity: sha512-lBJhtBWpKjIck/9i7G8cahvaUgLsyGklI/Pjv+VtY9KTzyuzX5GpRbbLKMS/e1qLnFPS4C3CybYB70b1bVcAkw==}
+    resolution: {integrity: sha512-lBJhtBWpKjIck/9i7G8cahvaUgLsyGklI/Pjv+VtY9KTzyuzX5GpRbbLKMS/e1qLnFPS4C3CybYB70b1bVcAkw==, tarball: https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.2.tgz}
 
   '@arraypress/waveform-player@1.2.1':
     resolution: {integrity: sha512-PsgOZStUN+1GnY0tujbwk2PYE3HMT/Vl3wEvunqH16hIJWzisf8GEngy5EbswTAjQ1aV3Tk4XBkAskc8eslY1A==}
@@ -1452,10 +1455,10 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@cacheable/memory@2.0.8':
-    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
+    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==, tarball: https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz}
 
   '@cacheable/utils@2.4.1':
-    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==, tarball: https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz}
 
   '@changesets/types@4.1.0':
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
@@ -1553,13 +1556,13 @@ packages:
         optional: true
 
   '@csstools/css-parser-algorithms@3.0.5':
-    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==, tarball: https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-syntax-patches-for-csstree@1.1.3':
-    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==, tarball: https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -1567,7 +1570,7 @@ packages:
         optional: true
 
   '@csstools/css-tokenizer@3.0.4':
-    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==, tarball: https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz}
     engines: {node: '>=18'}
 
   '@csstools/media-query-list-parser@3.0.1':
@@ -1578,14 +1581,14 @@ packages:
       '@csstools/css-tokenizer': ^3.0.1
 
   '@csstools/media-query-list-parser@4.0.3':
-    resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==}
+    resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==, tarball: https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/selector-specificity@5.0.0':
-    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
+    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==, tarball: https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz}
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
@@ -1601,7 +1604,7 @@ packages:
     engines: {node: '>=10.0.0'}
 
   '@dual-bundle/import-meta-resolve@4.2.1':
-    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
+    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==, tarball: https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==, tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz}
@@ -1631,12 +1634,12 @@ packages:
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@emotion/native@11.11.0':
-    resolution: {integrity: sha512-t1b5bLv+o5OUNLqXlnw+LJYU10OpmYkLC/1W873Y1ohG+vObx5TT3o3Eh1okXb2KCuZTTBPgsEnU/Sl7NNkJ9Q==, tarball: https://registry.npmjs.org/@emotion/native/-/native-11.11.0.tgz}
+    resolution: {integrity: sha512-t1b5bLv+o5OUNLqXlnw+LJYU10OpmYkLC/1W873Y1ohG+vObx5TT3o3Eh1okXb2KCuZTTBPgsEnU/Sl7NNkJ9Q==}
     peerDependencies:
       react-native: '>=0.14.0 <1'
 
   '@emotion/primitives-core@11.13.2':
-    resolution: {integrity: sha512-+MX60ROt1fDi5EYafhE/zs78XD4OuFUn6j0Z274wo5wVMT8sSBRx2CKPMbOUnmCcT0K5GPog+41mtkcppzkMmg==, tarball: https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-11.13.2.tgz}
+    resolution: {integrity: sha512-+MX60ROt1fDi5EYafhE/zs78XD4OuFUn6j0Z274wo5wVMT8sSBRx2CKPMbOUnmCcT0K5GPog+41mtkcppzkMmg==}
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
       react: 18.3.1
@@ -1873,13 +1876,13 @@ packages:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@keyv/bigmap@1.3.1':
-    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==, tarball: https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz}
     engines: {node: '>= 18'}
     peerDependencies:
       keyv: ^5.6.0
 
   '@keyv/serialize@1.1.1':
-    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==, tarball: https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3529,7 +3532,7 @@ packages:
       react-dom: 18.3.1
 
   '@wordpress/components@35.0.0':
-    resolution: {integrity: sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==, tarball: https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz}
+    resolution: {integrity: sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: 18.3.1
@@ -3559,7 +3562,7 @@ packages:
       react: 18.3.1
 
   '@wordpress/compose@8.2.0':
-    resolution: {integrity: sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==, tarball: https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz}
+    resolution: {integrity: sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18.3.27
@@ -3745,7 +3748,7 @@ packages:
     hasBin: true
 
   '@wordpress/i18n@6.22.0':
-    resolution: {integrity: sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==, tarball: https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz}
+    resolution: {integrity: sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
@@ -3825,7 +3828,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/keycodes@4.49.0':
-    resolution: {integrity: sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==}
+    resolution: {integrity: sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==, tarball: https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18.3.27
@@ -4097,7 +4100,7 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/undo-manager@1.49.0':
-    resolution: {integrity: sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==, tarball: https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz}
+    resolution: {integrity: sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/upload-media@0.33.0':
@@ -4435,7 +4438,7 @@ packages:
     engines: {node: '>=4'}
 
   astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==, tarball: https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz}
     engines: {node: '>=8'}
 
   async-function@1.0.0:
@@ -4556,7 +4559,7 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@2.0.0:
-    resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
+    resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -4698,7 +4701,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   cacheable@2.3.4:
-    resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
+    resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==, tarball: https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz}
 
   cachedir@2.3.0:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
@@ -4736,7 +4739,7 @@ packages:
     engines: {node: '>=10'}
 
   camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==, tarball: https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz}
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -5334,7 +5337,7 @@ packages:
     resolution: {integrity: sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==}
 
   css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==, tarball: https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz}
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
 
   css-declaration-sorter@7.4.0:
@@ -5344,7 +5347,7 @@ packages:
       postcss: ^8.0.9
 
   css-functions-list@3.3.3:
-    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==, tarball: https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz}
     engines: {node: '>=12'}
 
   css-loader@6.11.0:
@@ -5363,7 +5366,7 @@ packages:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
   css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==, tarball: https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz}
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -5374,7 +5377,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==, tarball: https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.2.2:
@@ -6211,7 +6214,7 @@ packages:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastest-levenshtein@1.0.16:
-    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==, tarball: https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz}
     engines: {node: '>= 4.9.1'}
 
   fastq@1.20.1:
@@ -6254,7 +6257,7 @@ packages:
     engines: {node: '>=18'}
 
   file-entry-cache@11.1.2:
-    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==}
+    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==, tarball: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -6354,7 +6357,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
 
   flat-cache@6.1.22:
-    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
+    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==, tarball: https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz}
 
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
@@ -6623,7 +6626,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   global-modules@2.0.0:
-    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==, tarball: https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz}
     engines: {node: '>=6'}
 
   global-prefix@0.1.5:
@@ -6635,7 +6638,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   global-prefix@3.0.0:
-    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==, tarball: https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz}
     engines: {node: '>=6'}
 
   globals@13.24.0:
@@ -6651,7 +6654,7 @@ packages:
     engines: {node: '>=10'}
 
   globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==, tarball: https://registry.npmjs.org/globby/-/globby-11.1.0.tgz}
     engines: {node: '>=10'}
 
   globby@12.2.0:
@@ -6659,7 +6662,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   globjoin@0.1.4:
-    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==, tarball: https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -6766,7 +6769,7 @@ packages:
     engines: {node: '>= 0.4.0'}
 
   hashery@1.5.1:
-    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==, tarball: https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz}
     engines: {node: '>=20'}
 
   hasown@2.0.2:
@@ -6822,10 +6825,10 @@ packages:
     resolution: {integrity: sha512-t+UerCsQviSymAInD01Pw+Dn/usmz1sRO+3Zk1+lx8eg+WKpD2ulcwWqHHL0+aseRBr+3+vIhiG1K1JTwaIcTA==}
 
   hookified@1.15.1:
-    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==, tarball: https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz}
 
   hookified@2.1.1:
-    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
+    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==, tarball: https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -6871,7 +6874,7 @@ packages:
         optional: true
 
   html-tags@3.3.1:
-    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
+    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==, tarball: https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz}
     engines: {node: '>=8'}
 
   htmlparser2@10.0.0:
@@ -6975,7 +6978,7 @@ packages:
     engines: {node: '>= 4'}
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==, tarball: https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz}
     engines: {node: '>= 4'}
 
   image-size@1.2.1:
@@ -7651,7 +7654,7 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   keyv@5.6.0:
-    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==, tarball: https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz}
 
   kind-of@2.0.1:
     resolution: {integrity: sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==}
@@ -7674,7 +7677,7 @@ packages:
     engines: {node: '>= 8'}
 
   known-css-properties@0.37.0:
-    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
+    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==, tarball: https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -7846,7 +7849,7 @@ packages:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
   lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==, tarball: https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -7980,7 +7983,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   mathml-tag-names@2.1.3:
-    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
+    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==, tarball: https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz}
 
   maximatch@0.1.0:
     resolution: {integrity: sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==}
@@ -7993,7 +7996,7 @@ packages:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==, tarball: https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz}
 
   mdn-data@2.28.1:
     resolution: {integrity: sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==}
@@ -8020,7 +8023,7 @@ packages:
     engines: {node: '>= 0.10.0'}
 
   meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==, tarball: https://registry.npmjs.org/meow/-/meow-13.2.0.tgz}
     engines: {node: '>=18'}
 
   meow@8.1.2:
@@ -8376,7 +8379,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, tarball: https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz}
     engines: {node: '>=0.10.0'}
 
   normalize-url@9.0.0:
@@ -9259,10 +9262,10 @@ packages:
       postcss: ^8.4.32
 
   postcss-resolve-nested-selector@0.1.6:
-    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
+    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==, tarball: https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz}
 
   postcss-safe-parser@7.0.1:
-    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==, tarball: https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz}
     engines: {node: '>=18.0'}
     peerDependencies:
       postcss: ^8.4.31
@@ -9427,7 +9430,7 @@ packages:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qified@0.9.1:
-    resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==}
+    resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==, tarball: https://registry.npmjs.org/qified/-/qified-0.9.1.tgz}
     engines: {node: '>=20'}
 
   qs@6.14.2:
@@ -10106,7 +10109,7 @@ packages:
     engines: {node: '>=12'}
 
   slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==, tarball: https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz}
     engines: {node: '>=10'}
 
   slice-ansi@5.0.0:
@@ -10404,7 +10407,7 @@ packages:
       stylelint: ^16.8.2
 
   stylelint@16.26.1:
-    resolution: {integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==}
+    resolution: {integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==, tarball: https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz}
     engines: {node: '>=18.12.0'}
     hasBin: true
 
@@ -10428,7 +10431,7 @@ packages:
     engines: {node: '>=10'}
 
   supports-hyperlinks@3.2.0:
-    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==, tarball: https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz}
     engines: {node: '>=14.18'}
 
   supports-preserve-symlinks-flag@1.0.0:
@@ -10439,7 +10442,7 @@ packages:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
   svg-tags@1.0.0:
-    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==, tarball: https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz}
 
   svgo@3.3.3:
     resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
@@ -10466,7 +10469,7 @@ packages:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
   table@6.9.0:
-    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==, tarball: https://registry.npmjs.org/table/-/table-6.9.0.tgz}
     engines: {node: '>=10.0.0'}
 
   tachyons@4.12.0:
@@ -11165,7 +11168,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   write-file-atomic@5.0.1:
-    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==, tarball: https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   ws@7.5.10:
@@ -16287,23 +16290,23 @@ snapshots:
       '@wordpress/a11y': 4.49.0
       '@wordpress/base-styles': 9.1.0
       '@wordpress/compose': 8.2.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/date': 5.49.0
+      '@wordpress/date': 5.48.0
       '@wordpress/deprecated': 4.49.0
       '@wordpress/dom': 4.49.0
       '@wordpress/element': 8.1.0
       '@wordpress/escape-html': 3.49.0
       '@wordpress/hooks': 4.49.0
-      '@wordpress/html-entities': 4.49.0
+      '@wordpress/html-entities': 4.48.0
       '@wordpress/i18n': 6.22.0
       '@wordpress/icons': 13.3.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.49.0
       '@wordpress/keycodes': 4.49.0(@types/react@18.3.31)
       '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/private-apis': 1.49.0
-      '@wordpress/rich-text': 7.49.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/style-runtime': 0.4.0
       '@wordpress/ui': 0.15.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
-      '@wordpress/warning': 3.49.0
+      '@wordpress/warning': 3.48.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Stacked on #472. Replaces the bespoke `TabbedNavigation` component with an implementation built on `@wordpress/ui` Tabs, so wizard/admin tabs match the WordPress design system used by the shared page header.

- The shared `TabbedNavigation` keeps its public API: `Wizard`, `withWizardScreen`, the Setup wizard, and Story Budget consume it unchanged. Route-driven selection, `activeTabPaths` wildcards, `exact`, and `disableUpcoming` all behave as before, and tabs now share one route matcher with breadcrumbs.
- The wizards admin header (PHP-localized tabs on CPT/taxonomy screens, e.g. Newsletters ads) now renders the same shared component instead of raw markup; `forceSelected` maps to a `selected` item flag. Because these tabs are cross-page links with no in-page panel to control, they render as a `nav` of anchors with `aria-current`, styled to match the tabs widget.
- Tabs render as real anchors, so middle/cmd-click opens in a new tab. Plain clicks route through `history.push` (like the previous `NavLink`) so `history.block` guards such as unsaved-changes dialogs keep working; a raw hashchange would reach the router as an uninterceptable POP.
- wp-admin doesn't define the `--wpds-*` design tokens, so the components package ships them with the shared `Page` header styles: `page/style.scss` inlines `@wordpress/theme`'s prebuilt `design-tokens.css` (via the physical path; resolving the public specifier through sass/webpack leaks a bogus script dependency into consumers' asset manifests) and remaps the wpds brand tokens onto the Newspack primary scale on `:root`. The active-tab indicator override to `primary-600` is scoped to the tab bar, and every token usage carries a wp-vars fallback for contexts where the sheet isn't loaded.
- Routed page content renders inside the active `Tabs.Panel`, so each tab's `aria-controls` points at real panel content. Panels stay 1:1 with the tabs, which `@wordpress/ui` dev builds validate.

Part of DSGNEWS-143.

### How to test the changes in this Pull Request:

1. Go to Audience → Campaigns. The tabs (Campaigns / Segments / Settings) should render in the WP design-system style with a `primary-600` underline under the active tab. Click through them: URL hash, breadcrumb, and content should stay in sync.
2. Keyboard: focus the tab list, use Left/Right arrows to move between tabs (focus moves without navigating), then Enter to activate. Cmd/middle-click a tab and confirm it opens in a new browser tab.
3. Go to Newspack → Settings. Navigate to Additional Brands → Add New Brand (`#/additional-brands/new`): the "Additional Brands" tab should stay selected on this hidden subpage (`activeTabPaths` wildcard). Navigating away from a dirty brand form should still trigger the unsaved-changes dialog.
4. Go to Newsletters → Advertising (PHP-driven admin-header tabs). "Ads" should be selected; clicking "Advertisers" performs a full page load and selects it there.
5. Run the Setup wizard (`admin.php?page=newspack-setup-wizard`): tabs are hidden on the welcome screen; mid-flow, upcoming tabs are disabled (not clickable, no href) while previous tabs remain enabled.
6. Go to Story Budget and switch between Stories / Budgets.
7. Confirm the tab bar remains sticky below the admin bar on scroll (≥600px viewports).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
