### PR TITLE
Sync: release → main back-merge (manual test-conflict resolution)

### DIFF
--- a/plugins/newspack-blocks/CHANGELOG.md
+++ b/plugins/newspack-blocks/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @automattic/newspack-blocks [4.26.8](https://github.com/Automattic/newspack-workspace/compare/newspack-blocks@4.26.7...newspack-blocks@4.26.8) (2026-07-02)
+
+
+### Bug Fixes
+
+* **blocks:** restrict articles endpoint to viewable post types ([cde3e84](https://github.com/Automattic/newspack-workspace/commit/cde3e84ebf2c8e653f085560799f32c69bd75a36))
+
 ## @automattic/newspack-blocks [4.26.7](https://github.com/Automattic/newspack-workspace/compare/newspack-blocks@4.26.6...newspack-blocks@4.26.7) (2026-06-30)
 
 

--- a/plugins/newspack-blocks/newspack-blocks.php
+++ b/plugins/newspack-blocks/newspack-blocks.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.com/
  * Text Domain:     newspack-blocks
  * Domain Path:     /languages
- * Version:         4.26.7
+ * Version:         4.26.8
  *
  * @package         Newspack_Blocks
  */
@@ -15,7 +15,7 @@
 define( 'NEWSPACK_BLOCKS__PLUGIN_FILE', __FILE__ );
 define( 'NEWSPACK_BLOCKS__BLOCKS_DIRECTORY', 'dist/' );
 define( 'NEWSPACK_BLOCKS__PLUGIN_DIR', plugin_dir_path( NEWSPACK_BLOCKS__PLUGIN_FILE ) );
-define( 'NEWSPACK_BLOCKS__VERSION', '4.26.7' );
+define( 'NEWSPACK_BLOCKS__VERSION', '4.26.8' );
 
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks.php';
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'includes/class-newspack-blocks-api.php';

--- a/plugins/newspack-blocks/package.json
+++ b/plugins/newspack-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/newspack-blocks",
-	"version": "4.26.7",
+	"version": "4.26.8",
 	"author": "Automattic",
 	"description": "=== Newspack Blocks === Contributors: (this should be a list of wordpress.org userid's) Donate link: https://example.com/ Tags: comments, spam Requires at least: 4.5 Tested up to: 5.1.1 Stable tag: 0.1.0 License: GPLv2 or later License URI: https://www.gnu.org/licenses/gpl-2.0.html",
 	"repository": {

--- a/plugins/newspack-blocks/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -129,6 +129,15 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			$exclude_ids = [];
 		}
 
+		// This endpoint is public, so restrict it to publicly viewable post types — matching
+		// what WordPress exposes on the front end. The editor endpoints are capability-gated.
+		$attributes['postType'] = self::filter_viewable_post_types( $attributes['postType'] );
+		if ( empty( $attributes['postType'] ) ) {
+			// Every requested post type was non-viewable; return nothing rather than
+			// substituting a different post type.
+			return self::articles_response();
+		}
+
 		$article_query_args = Newspack_Blocks::build_articles_query( $attributes, apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/homepage-articles' ) );
 
 		// If using exclude_ids, don't worry about pagination. Just get the next postsToShow number of results without the excluded posts. Otherwise, use standard WP pagination.
@@ -192,13 +201,39 @@ class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
 			);
 		}
 
+		return self::articles_response( $items, $ids, $next_url );
+	}
+
+	/**
+	 * Build the articles endpoint response.
+	 *
+	 * @param array  $items Rendered article items.
+	 * @param array  $ids   Post ids in the response.
+	 * @param string $next  URL for the next page, or empty string when there is none.
+	 * @return WP_REST_Response
+	 */
+	private static function articles_response( $items = [], $ids = [], $next = '' ) {
 		return rest_ensure_response(
 			[
 				'items' => $items,
 				'ids'   => $ids,
-				'next'  => $next_url,
+				'next'  => $next,
 			]
 		);
+	}
+
+	/**
+	 * Restrict a list of post types to those that are publicly viewable.
+	 *
+	 * Used to keep the public articles endpoint from exposing post types that
+	 * WordPress would not surface on the front end. Non-viewable types are dropped;
+	 * the returned list may be empty when none qualify (the caller then returns no results).
+	 *
+	 * @param array|string $post_types Requested post type(s).
+	 * @return array Viewable post types (may be empty).
+	 */
+	private static function filter_viewable_post_types( $post_types ) {
+		return array_values( array_filter( (array) $post_types, 'is_post_type_viewable' ) );
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -9,6 +9,63 @@
  * Homepage Posts Block test case.
  */
 class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+
+	/**
+	 * Post types registered during a test, unregistered in tear_down() so the
+	 * suite stays order-independent even if a test fails mid-way.
+	 *
+	 * @var string[]
+	 */
+	private $registered_post_types = [];
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		foreach ( $this->registered_post_types as $post_type ) {
+			if ( post_type_exists( $post_type ) ) {
+				unregister_post_type( $post_type );
+			}
+		}
+		$this->registered_post_types = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a non-viewable (private, not in REST) CPT for the duration of a test.
+	 *
+	 * @param string $name Post type name.
+	 * @return string The registered post type name.
+	 */
+	private function register_non_viewable_cpt( $name = 'newspack_secret_cpt' ) {
+		register_post_type(
+			$name,
+			[
+				'public'       => false,
+				'show_in_rest' => false,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$this->registered_post_types[] = $name;
+		return $name;
+	}
+
+	/**
+	 * Register a publicly viewable CPT for the duration of a test.
+	 *
+	 * @param string $name Post type name.
+	 * @return string The registered post type name.
+	 */
+	private function register_viewable_cpt( $name = 'newspack_public_cpt' ) {
+		register_post_type(
+			$name,
+			[
+				'public'       => true,
+				'show_in_rest' => true,
+				'supports'     => [ 'title', 'editor' ],
+			]
+		);
+		$this->registered_post_types[] = $name;
+		return $name;
+	}
+
 	/**
 	 * HPB query from attributes.
 	 */
@@ -78,5 +135,149 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		self::assertEquals( 1, count( $query->posts ), 'There is one post returned.' );
 		self::assertEquals( $post_id, $query->posts[0]->ID, 'The post returned is the one with the CAP author assigned.' );
+	}
+
+	/**
+	 * The public /articles endpoint must not return posts from non-viewable post types.
+	 */
+	public function test_articles_endpoint_excludes_non_viewable_post_types() {
+		$secret    = $this->register_non_viewable_cpt();
+		$secret_id = self::factory()->post->create(
+			[
+				'post_type'    => $secret,
+				'post_status'  => 'publish',
+				'post_title'   => 'Secret CPT title',
+				'post_content' => 'Secret CPT body.',
+			]
+		);
+		// A regular published post exists, to prove the endpoint returns nothing here
+		// rather than silently substituting a different post type.
+		self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ $secret ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertNotContains(
+			$secret_id,
+			$ids,
+			'A non-viewable post type must not be returned by the public articles endpoint.'
+		);
+		self::assertEmpty(
+			$ids,
+			'A request for only non-viewable post types returns no results, not substituted posts.'
+		);
+	}
+
+	/**
+	 * Mixed input keeps the viewable post types and drops the non-viewable ones.
+	 */
+	public function test_articles_endpoint_filters_mixed_post_types() {
+		$secret     = $this->register_non_viewable_cpt();
+		$secret_id  = self::factory()->post->create(
+			[
+				'post_type'   => $secret,
+				'post_status' => 'publish',
+			]
+		);
+		$regular_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'post', $secret ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertContains( $regular_id, $ids, 'The viewable post type is kept.' );
+		self::assertNotContains( $secret_id, $ids, 'The non-viewable post type is dropped.' );
+	}
+
+	/**
+	 * A publicly viewable custom post type is still returned by the endpoint.
+	 */
+	public function test_articles_endpoint_allows_viewable_post_types() {
+		$public    = $this->register_viewable_cpt();
+		$public_id = self::factory()->post->create(
+			[
+				'post_type'   => $public,
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ $public ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertContains(
+			$public_id,
+			$ids,
+			'A publicly viewable post type must still be returned by the public articles endpoint.'
+		);
+	}
+
+	/**
+	 * The specific-posts selection mode must not surface a non-viewable post by ID
+	 * (requested post type is itself non-viewable — the empty-guard path).
+	 */
+	public function test_articles_endpoint_excludes_non_viewable_in_specific_posts_mode() {
+		$secret    = $this->register_non_viewable_cpt();
+		$secret_id = self::factory()->post->create(
+			[
+				'post_type'   => $secret,
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ $secret ] );
+		$request->set_param( 'specificMode', 1 );
+		$request->set_param( 'specificPosts', [ $secret_id ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertNotContains(
+			$secret_id,
+			$ids,
+			'Specific-posts mode must not surface a non-viewable post by ID.'
+		);
+	}
+
+	/**
+	 * Specific-posts mode must not surface a non-viewable post by ID even when the
+	 * requested postType is viewable. This reaches the WP_Query post_type + post__in
+	 * intersection (the realistic attack), not the empty-guard short-circuit.
+	 */
+	public function test_articles_endpoint_excludes_non_viewable_specific_post_under_viewable_type() {
+		$secret    = $this->register_non_viewable_cpt();
+		$secret_id = self::factory()->post->create(
+			[
+				'post_type'   => $secret,
+				'post_status' => 'publish',
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$controller = new WP_REST_Newspack_Articles_Controller();
+		$request    = new WP_REST_Request( 'GET', '/newspack-blocks/v1/articles' );
+		$request->set_param( 'postType', [ 'post' ] ); // Viewable — survives the filter.
+		$request->set_param( 'specificMode', 1 );
+		$request->set_param( 'specificPosts', [ $secret_id ] );
+		$request->set_param( 'postsToShow', 10 );
+		$ids = $controller->get_items( $request )->get_data()['ids'];
+
+		self::assertNotContains(
+			$secret_id,
+			$ids,
+			'A non-viewable post requested by ID must not surface even under a viewable postType.'
+		);
 	}
 }

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.44.5](https://github.com/Automattic/newspack-workspace/compare/newspack@6.44.4...newspack@6.44.5) (2026-07-02)
+
+
+### Bug Fixes
+
+* **group-subscription:** validate invite before creating an account ([ee44068](https://github.com/Automattic/newspack-workspace/commit/ee440684908c11eb7b174b4ee40031ca9140312d))
+
 ## newspack [6.44.4](https://github.com/Automattic/newspack-workspace/compare/newspack@6.44.3...newspack@6.44.4) (2026-07-02)
 
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -542,6 +542,29 @@ class Group_Subscription_Invite {
 	}
 
 	/**
+	 * Whether an invite key is valid for the given subscription and email.
+	 *
+	 * Mirrors the invite checks in accept_invite(), for use as a gate before an
+	 * account is created for a new invitee.
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 * @param string               $key          The invite key.
+	 * @param string               $email        The invited email address.
+	 * @return bool
+	 */
+	private static function is_valid_invite( $subscription, $key, $email ) {
+		$subscription_obj = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		if ( ! $subscription_obj || ! $subscription_obj->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
+			return false;
+		}
+		$invite = self::get_invite_by_key( $subscription_obj, $key );
+		if ( ! $invite || $invite['email'] !== $email || self::is_invite_expired( $invite ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Get the invite URL for a group subscription invitation.
 	 *
 	 * @param int    $subscription_id The subscription ID.
@@ -655,6 +678,12 @@ class Group_Subscription_Invite {
 		}
 
 		// Case 3: New user — auto-create account, verify email, and accept.
+		// Validate the invite first, so an invalid key cannot force account
+		// creation, email verification, and login for an arbitrary address.
+		if ( ! self::is_valid_invite( $subscription_id, $key, $email ) ) {
+			self::redirect_with_result( 'error_invite_invalid' );
+			return;
+		}
 		$user_id = Reader_Activation::register_reader( $email, false );
 		if ( is_wp_error( $user_id ) || ! $user_id ) {
 			do_action(

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.44.4
+ * Version: 6.44.5
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.44.4' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.44.5' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.44.4",
+	"version": "6.44.5",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Tests for Group_Subscription_Invite request handling.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ */
+
+use Newspack\Group_Subscription_Invite;
+
+/**
+ * Tests the group subscription invite request handler.
+ */
+class Test_Group_Subscription_Invite extends WP_UnitTestCase {
+
+	const REDIRECTED = 'group-invite-test-redirected'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
+	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		unset( $_GET['action'], $_GET['key'], $_GET['email'], $_GET['subscription'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Run process_invite_request(), converting its terminal redirect into a
+	 * catchable signal so the test can continue.
+	 *
+	 * Only the redirect is treated as expected; any other exception propagates,
+	 * and the absence of a redirect fails the test.
+	 *
+	 * @throws \RuntimeException If the request fails for a reason other than the redirect.
+	 */
+	private function run_invite_request() {
+		$redirect = function () {
+			throw new \RuntimeException( self::REDIRECTED ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		};
+		add_filter( 'wp_redirect', $redirect, 1 );
+		try {
+			Group_Subscription_Invite::process_invite_request();
+			$this->fail( 'Expected the invite request to end in a redirect.' );
+		} catch ( \RuntimeException $e ) {
+			if ( self::REDIRECTED !== $e->getMessage() ) {
+				throw $e;
+			}
+		} finally {
+			remove_filter( 'wp_redirect', $redirect, 1 );
+		}
+	}
+
+	/**
+	 * An invalid invite key must not create a reader account for a new email.
+	 */
+	public function test_invalid_key_does_not_create_account() {
+		$email = 'nppm2966-invitee@example.test';
+		self::assertFalse( get_user_by( 'email', $email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = 'this-key-is-not-valid';
+		$_GET['email']        = $email;
+		$_GET['subscription'] = '999';
+
+		$this->run_invite_request();
+
+		self::assertFalse(
+			get_user_by( 'email', $email ),
+			'An invalid invite key must not create a reader account.'
+		);
+	}
+
+	/**
+	 * A valid invite still creates a reader account for a new invitee.
+	 */
+	public function test_valid_key_creates_account() {
+		$email        = 'nppm2966-valid@example.test';
+		$key          = 'valid-invite-key';
+		$subscription = wcs_create_subscription(
+			[
+				'id'     => 10,
+				'status' => 'active',
+				'meta'   => [
+					'newspack_group_subscription_invites' => [
+						$key => [
+							'email'      => $email,
+							'expiration' => time() + HOUR_IN_SECONDS,
+						],
+					],
+				],
+			]
+		);
+		self::assertFalse( get_user_by( 'email', $email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = $key;
+		$_GET['email']        = $email;
+		$_GET['subscription'] = (string) $subscription->get_id();
+
+		$this->run_invite_request();
+
+		self::assertInstanceOf(
+			WP_User::class,
+			get_user_by( 'email', $email ),
+			'A valid invite creates a reader account for a new invitee.'
+		);
+	}
+
+	/**
+	 * A wrong key against a real active subscription is rejected at the invite-key
+	 * lookup (past the subscription check) and creates no account.
+	 */
+	public function test_wrong_key_with_active_subscription_does_not_create_account() {
+		$email        = 'nppm2966-wrongkey@example.test';
+		$subscription = wcs_create_subscription(
+			[
+				'id'     => 20,
+				'status' => 'active',
+				'meta'   => [
+					'newspack_group_subscription_invites' => [
+						'the-real-key' => [
+							'email'      => $email,
+							'expiration' => time() + HOUR_IN_SECONDS,
+						],
+					],
+				],
+			]
+		);
+		self::assertFalse( get_user_by( 'email', $email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = 'not-the-real-key';
+		$_GET['email']        = $email;
+		$_GET['subscription'] = (string) $subscription->get_id();
+
+		$this->run_invite_request();
+
+		self::assertFalse(
+			get_user_by( 'email', $email ),
+			'A wrong key against an active subscription must not create an account.'
+		);
+	}
+
+	/**
+	 * A valid key whose invite is for a different email is rejected at the email-match
+	 * check and creates no account for the requesting address.
+	 */
+	public function test_mismatched_email_with_valid_key_does_not_create_account() {
+		$invited_email  = 'nppm2966-invited@example.test';
+		$attacker_email = 'nppm2966-attacker@example.test';
+		$key            = 'the-real-key';
+		$subscription   = wcs_create_subscription(
+			[
+				'id'     => 21,
+				'status' => 'active',
+				'meta'   => [
+					'newspack_group_subscription_invites' => [
+						$key => [
+							'email'      => $invited_email,
+							'expiration' => time() + HOUR_IN_SECONDS,
+						],
+					],
+				],
+			]
+		);
+		self::assertFalse( get_user_by( 'email', $attacker_email ), 'Precondition: no account for the email.' );
+
+		$_GET['action']       = Group_Subscription_Invite::QUERY_ARG;
+		$_GET['key']          = $key;
+		$_GET['email']        = $attacker_email;
+		$_GET['subscription'] = (string) $subscription->get_id();
+
+		$this->run_invite_request();
+
+		self::assertFalse(
+			get_user_by( 'email', $attacker_email ),
+			'A valid key with a mismatched email must not create an account for the requesting address.'
+		);
+	}
+}


### PR DESCRIPTION
## What this is

The automated **`release → main` back-merge** ([failed post-release run](https://github.com/Automattic/newspack-workspace/actions/runs/28593589117/job/84784285488)) hit merge conflicts and aborted. 

I could've sworn I saw something similar that opened up a merge PR, but I don't see one, so this is *it*.  This PR completes that sync manually. (`release → alpha` synced fine; only `main` was left behind — ~75 commits.)

## Why it conflicted

Two independent tracks added **same-named test classes/methods** to the same files:
- The **hotfix track** (`release`) — the NPPM-2960 security batch (#461 / #470 / #471 / #475 / #488).
- The **feature track** (`main`) — #279 (NPPD-1593) and the tag-labels work.

Only **test files** conflicted; all production code auto-merged cleanly.

## Resolution — combined, not chosen

| File | Resolution |
|---|---|
| `class-group-subscription-invite.php` | Unified `Test_Group_Subscription_Invite`: link-invite acceptance (#279 / NPPD-1593) **+** invite-request-handler / `is_valid_invite` gate (#488 / NPPM-2966). 7 tests. |
| `test-homepage-posts-block.php` | tag-labels REST tests (`main`) **+** viewable-post-type tests (#471 / NPPM-2964). 9 tests. |

Verified locally against the merged tree: **invite 8/8 pass; homepage 7 pass + 2 self-skipped** (the tag-labels stub guards, same as on `main`). The merged **production** invite class contains both `is_valid_invite` / `process_invite_request` (#488) and `process_link_invite_request` / `LINK_QUERY_ARG` (#279).

## ⚠️ Merge method: use a merge commit, NOT squash

This is a branch promotion (`release → main`) — `main` must genuinely contain `release` so the next automated back-merge stays clean. Squashing would re-diverge and re-conflict.

cc @adekbadek (authored the colliding #279 change).
