### PR TITLE
fix(insights): newsletter-subscriber funnel + incalculable rate display

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/README.md
+++ b/plugins/newspack-plugin/includes/wizards/insights/README.md
@@ -222,7 +222,7 @@ Lead with the count where it's a standing population (active donors / subscriber
 A "good zero" is a metric whose zero is the desired outcome. Rule, split by format:
 
 - **Rate-format good-zeros** get explicit positive/neutral copy via the em-dash treatment — e.g. Subscribers' *"No refund requests in this timeframe."* (orders but no refunds) and *"No failed payments in this timeframe."* (no retries to recover).
-- **Count-format good-zeros** rely on the native `lowerIsBetter` visual (the green down-delta) and render the real `0` with no editorial copy — e.g. Churned subscribers, Lapsed donors.
+- **Count-format good-zeros** rely on the native `lowerIsBetter` visual (the green down-delta) and render the real `0` with no editorial copy — e.g. Churned subscribers, Lapsed donors. This holds even when there is no underlying population at all (e.g. a site with zero donors): a *count* of zero **is** the observation, so it renders `0`, not an em-dash — unlike an incalculable *rate* over an empty population (§7). (NEWS-2593.)
 
 A computable zero that is *not* good (e.g. a 0% recovery rate when retries did happen) renders as the real value, not a reframe.
 
@@ -236,8 +236,9 @@ A computable zero that is *not* good (e.g. a 0% recovery rate when retries did h
 - Render the **em-dash (`—`)** hero when the value carries no signal: no opportunity count (`zeroFallback` denominator 0), not capable, not computable, or a good-zero reframe.
 - Render the **real value** when the zero itself is the observation — the per-card `no_conversions` states (New donors `0`, Total Revenue `$0.00`) keep their real hero plus a secondary line.
 - Render a **text fallback** (`0 of 17`, `0 conversions`) when a zero needs companion context to read honestly.
+- **Incalculable rates render the em-dash automatically (NEWS-2593).** A populated *rate* whose population is empty — `computable === false`, i.e. a `0/0` (e.g. Influenced Donation Rate on a site with no donations, or Completion Rate on a property emitting no `scroll` events) — is routed to the em-dash treatment by the scalar mappers themselves (`tabs/components/metrics.ts` `payloadToCard`, `tabs/conversion/scalarToCard.ts`), with a generic *"Not enough data to calculate."* line that a section can override. This is **scoped to rate format**: `count`/`currency`/`decimal` metrics with an empty population keep their real `0` (§5) — a count of zero is the observation, a rate over zero is not.
 
-This is the existing convention — codified, not changed.
+The em-dash-for-incalculable-*rates* rule is enforced in the scalar mappers (NEWS-2593); the rest is the existing convention, codified.
 
 ### 8. Period-delta suppression
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -552,7 +552,7 @@ final class Conversion_Metric {
 			'step_1_anonymous',
 			'step_2_engaged',
 			'step_3_registered',
-			'step_4_subscriber',
+			'step_4_newsletter_subscriber',
 			'step_5_supporter',
 		];
 		$stages = [];

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.test.ts
@@ -67,6 +67,34 @@ describe( 'payloadToCard', () => {
 		} );
 		expect( card?.previousValue ).toBeNull();
 	} );
+
+	it( 'renders an incalculable rate (0/0) as the em-dash not-computable treatment (NEWS-2593)', () => {
+		const card = payloadToCard( {
+			label: 'Completion Rate',
+			current: { value: 0, computable: false, type: 'rate', denominator: 0 },
+		} );
+		expect( card?.notComputableMessage ).toBe( 'Not enough data to calculate.' );
+		// No bare 0% hero.
+		expect( card ).not.toHaveProperty( 'value' );
+	} );
+
+	it( 'lets the caller override the not-computable copy', () => {
+		const card = payloadToCard( {
+			label: 'Completion Rate',
+			current: { value: 0, computable: false, type: 'rate' },
+			notComputableMessage: 'No scroll data in this timeframe.',
+		} );
+		expect( card?.notComputableMessage ).toBe( 'No scroll data in this timeframe.' );
+	} );
+
+	it( 'keeps a non-computable count as a real value, not an em-dash (scope is percentages)', () => {
+		const card = payloadToCard( {
+			label: 'x',
+			current: { value: 0, computable: false, type: 'count' },
+		} );
+		expect( card ).not.toHaveProperty( 'notComputableMessage' );
+		expect( card?.value ).toBe( 0 );
+	} );
 } );
 
 describe( 'toSeries', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
@@ -9,6 +9,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type { MetricCardProps, MetricFormat, MetricCardOverlay } from './MetricCard';
@@ -92,6 +97,13 @@ export interface PayloadToCardArgs {
 	current?: MetricPayload;
 	previous?: MetricPayload | null;
 	lowerIsBetter?: boolean;
+	/**
+	 * "No population to calculate from" copy (NEWS-2593). Routed to MetricCard's
+	 * em-dash treatment when a rate metric is populated but incalculable
+	 * (`computable === false`). Falls back to a generic message when omitted.
+	 * Ignored for non-rate payloads.
+	 */
+	notComputableMessage?: string;
 }
 
 /**
@@ -99,7 +111,7 @@ export interface PayloadToCardArgs {
  * is hidden in v1 (caller skips rendering the card entirely).
  */
 export const payloadToCard = ( args: PayloadToCardArgs ): MetricCardProps | null => {
-	const { label, description, current, previous, lowerIsBetter } = args;
+	const { label, description, current, previous, lowerIsBetter, notComputableMessage } = args;
 
 	if ( ! current || current.hidden_in_v1 ) {
 		return null;
@@ -112,6 +124,20 @@ export const payloadToCard = ( args: PayloadToCardArgs ): MetricCardProps | null
 	}
 	if ( current.not_configured ) {
 		return { label, description, notConfigured: true };
+	}
+	// Incalculable percentage (NEWS-2593): a populated rate with no population to
+	// divide from (`computable === false`, e.g. Completion Rate on a site that
+	// emits no scroll events) carries no signal. Render MetricCard's em-dash hero +
+	// explanatory line rather than a misleading `0%`. Scoped to rate format so
+	// count/currency/decimal good-zeros keep their real `0`. A generic fallback
+	// guarantees the em-dash even if a call site omits its per-metric copy.
+	if ( current.computable === false && current.type === 'rate' ) {
+		return {
+			label,
+			description,
+			lowerIsBetter,
+			notComputableMessage: notComputableMessage ?? __( 'Not enough data to calculate.', 'newspack-plugin' ),
+		};
 	}
 
 	const previousValue = previous && previous.computable && typeof previous.value === 'number' ? previous.value : null;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the Conversion tab-local scalarToCard adapter, focused on the
+ * incalculable-rate routing added in NEWS-2593: a percentage/rate metric with
+ * no population (0/0 → `computable: false`) renders MetricCard's em-dash
+ * not-computable treatment instead of a misleading `0%`. Precedence under test:
+ * error > data_missing > not-computable > normal value. Count/currency/decimal
+ * scalars are intentionally out of scope (only percentages get the em-dash).
+ */
+
+/**
+ * Internal dependencies
+ */
+import { scalarToMetricCardProps } from './scalarToCard';
+import type { ConversionScalarMetric } from '../../api/conversion';
+
+const scalar = ( overrides: Partial< ConversionScalarMetric > = {} ): ConversionScalarMetric => ( {
+	state: 'populated',
+	value: 0,
+	computable: true,
+	denominator: null,
+	placeholder_type: 'rate',
+	data_missing: false,
+	...overrides,
+} );
+
+describe( 'conversion scalarToMetricCardProps — incalculable rate routing (NEWS-2593)', () => {
+	it( 'routes a non-computable rate (0/0, no population) to the em-dash treatment', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'Influenced Donation Rate',
+			description: 'd',
+			current: scalar( { computable: false, denominator: 0 } ),
+		} );
+		expect( props.notComputableMessage ).toBe( 'Not enough data to calculate.' );
+		// The value path is skipped entirely — no bare 0% hero.
+		expect( props ).not.toHaveProperty( 'value' );
+	} );
+
+	it( 'lets the section override the not-computable copy', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'Influenced Donation Rate',
+			description: 'd',
+			current: scalar( { computable: false, denominator: 0 } ),
+			notComputableMessage: 'No donations in this timeframe.',
+		} );
+		expect( props.notComputableMessage ).toBe( 'No donations in this timeframe.' );
+	} );
+
+	it( 'leaves a computable rate on the normal value path', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: scalar( { value: 0.25, computable: true } ),
+		} );
+		expect( props.value ).toBe( 0.25 );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+	} );
+
+	it( 'does NOT em-dash a non-rate scalar even when non-computable (scope is percentages)', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: scalar( { placeholder_type: 'count', value: 0, computable: false } ),
+		} );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+		expect( props.value ).toBe( 0 );
+	} );
+
+	it( 'lets the error treatment win over not-computable', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: scalar( { state: 'error', computable: false, error_message: 'boom' } ),
+		} );
+		expect( props.error ).toBe( 'boom' );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+	} );
+
+	it( 'lets data_missing win over not-computable', () => {
+		const props = scalarToMetricCardProps( {
+			label: 'x',
+			description: 'd',
+			current: scalar( { computable: false, data_missing: true } ),
+		} );
+		expect( props.dataMissing ).toBe( true );
+		expect( props ).not.toHaveProperty( 'notComputableMessage' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/scalarToCard.ts
@@ -30,10 +30,17 @@ export interface ScalarCardProps {
 	description: string;
 	current: ConversionScalarMetric;
 	previous?: ConversionScalarMetric | null;
+	/**
+	 * "No population to calculate from" copy (NEWS-2593). Routed to MetricCard's
+	 * em-dash treatment when a rate metric is populated but incalculable
+	 * (`computable === false`, i.e. a zero denominator / 0-of-0). Falls back to a
+	 * generic message when a section omits it. Ignored for non-rate scalars.
+	 */
+	notComputableMessage?: string;
 }
 
 export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
-	const { label, description, current, previous } = props;
+	const { label, description, current, previous, notComputableMessage } = props;
 	// A failed query renders MetricCard's shared error treatment rather than a
 	// misleading zero. The raw message stays server-side; the card shows generic
 	// copy keyed off the `error` prop.
@@ -42,6 +49,19 @@ export const scalarToMetricCardProps = ( props: ScalarCardProps ) => {
 	}
 	if ( current.state === 'populated' && current.data_missing ) {
 		return { label, description, dataMissing: true };
+	}
+	// Incalculable percentage (NEWS-2593): a populated rate whose population is
+	// empty (0/0 → `computable: false`, e.g. an Influenced Donation Rate on a site
+	// with no donations) carries no signal. Render MetricCard's em-dash hero +
+	// explanatory line instead of a misleading `0%`. Scoped to rate format so
+	// count/currency/decimal good-zeros keep their real `0`. A generic fallback
+	// guarantees the em-dash even if a call site omits its per-metric copy.
+	if ( current.state === 'populated' && current.computable === false && current.placeholder_type === 'rate' ) {
+		return {
+			label,
+			description,
+			notComputableMessage: notComputableMessage ?? __( 'Not enough data to calculate.', 'newspack-plugin' ),
+		};
 	}
 	return {
 		label,

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -227,11 +227,11 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_lifecycle_funnel_returns_populated_stages_on_success() {
 		$row    = [
-			'step_1_anonymous'  => 1000,
-			'step_2_engaged'    => 600,
-			'step_3_registered' => 300,
-			'step_4_subscriber' => 120,
-			'step_5_supporter'  => 60,
+			'step_1_anonymous'             => 1000,
+			'step_2_engaged'               => 600,
+			'step_3_registered'            => 300,
+			'step_4_newsletter_subscriber' => 120,
+			'step_5_supporter'             => 60,
 		];
 		$metric = new Conversion_Metric( $this->proxy_returning( [ $row ] ) );
 		[ $start, $end ] = $this->window();
@@ -244,6 +244,13 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		// Stage 1: top of funnel → pct_of_top must be 1.0.
 		$this->assertSame( 1000, $result['stages'][0]['count'] );
 		$this->assertSame( 1.0, $result['stages'][0]['pct_of_top'] );
+
+		// Stage 4: Newsletter subscriber must read the hub's
+		// `step_4_newsletter_subscriber` alias (regression: NEWS-2593 — the
+		// consumer previously read `step_4_subscriber`, which the hub never
+		// emits, so this stage always rendered 0).
+		$this->assertSame( __( 'Newsletter subscriber', 'newspack-plugin' ), $result['stages'][3]['label'] );
+		$this->assertSame( 120, $result['stages'][3]['count'] );
 
 		// Stage 5: 60 / 1000 = 0.06.
 		$this->assertSame( 60, $result['stages'][4]['count'] );
@@ -261,11 +268,11 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_lifecycle_funnel_guards_zero_top_stage() {
 		$row    = [
-			'step_1_anonymous'  => 0,
-			'step_2_engaged'    => 0,
-			'step_3_registered' => 0,
-			'step_4_subscriber' => 0,
-			'step_5_supporter'  => 0,
+			'step_1_anonymous'             => 0,
+			'step_2_engaged'               => 0,
+			'step_3_registered'            => 0,
+			'step_4_newsletter_subscriber' => 0,
+			'step_5_supporter'             => 0,
 		];
 		$metric = new Conversion_Metric( $this->proxy_returning( [ $row ] ) );
 		[ $start, $end ] = $this->window();


### PR DESCRIPTION
## Summary

Part of [NEWS-2593](https://linear.app/a8c/issue/NEWS-2593). This is the **consumer** (`newspack-plugin`) half; the **hub** (`newspack-manager-admin`) half is Automattic/newspack-manager-admin#483.

Two independent fixes for Insights metrics that consistently returned `0` on Richland Source.

### 1. Newsletter-subscriber lifecycle funnel always `0` (bug)

The reader-lifecycle funnel read `$row['step_4_subscriber']`, but the hub BigQuery query emits the column alias `step_4_newsletter_subscriber`. The key was never present, so the "Newsletter subscriber" stage always rendered `0`. (Verified on Richland Source: the real value is ≈ **20,217**.) The consumer's own test fixture also used the wrong key, so the bug passed CI — this fixes the fixture and adds a stage-4 assertion so it can't silently regress.

### 2. Incalculable (`0/0`) rate metrics rendered `0%` instead of `–`

Rate metrics whose population is empty (`computable: false` — e.g. Influenced Donation Rate on a site with no donations, or Completion Rate on a site with no scroll data) rendered as a misleading `0%`. The scalar mappers (`payloadToCard`, `tabs/conversion/scalarToCard.ts`) now route these to `MetricCard`'s existing em-dash treatment + a "Not enough data to calculate." line (section-overridable). **Scoped to rate format** — count good-zeros (Lapsed Donors, Churned Subscribers) keep their real `0` per the empty-state convention. README §5/§7 updated to codify the rule.

## Testing

- PHPUnit `--group insights`: 646 pass.
- JS/Jest full suite: 699 pass.
- `tsc --noEmit`, PHPCS, ESLint clean.

## Notes

- Based off `feat/insights-rsm`.
- The Completion Rate `–` (fix #2) depends on the hub companion Automattic/newspack-manager-admin#483 emitting `NULL` when a site has no scroll events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
