### PR TITLE
ci: skip JS and ZIP jobs when js-matrix is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
   js:
     name: JS / ${{ matrix.package }}
     needs: [changed-packages, install]
-    if: needs.changed-packages.outputs.any == 'true'
+    if: needs.changed-packages.outputs.any == 'true' && needs.changed-packages.outputs.js-matrix != '{"include":[]}'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -296,7 +296,7 @@ jobs:
   build-zips:
     name: Build ZIP / ${{ matrix.package }}
     needs: [changed-packages, install]
-    if: needs.changed-packages.outputs.any == 'true'
+    if: needs.changed-packages.outputs.any == 'true' && needs.changed-packages.outputs.js-matrix != '{"include":[]}'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fixes the **"CI OK"** summary gate going red on PRs that change **only root dependency files** (`package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml`) with no workspace-package source changes.

On such a PR, the `changed-packages` detect job emits `any=true` (root deps changed) but `js-matrix={"include":[]}`. The `js` and `build-zips` jobs both consume `js-matrix` and had `if: needs.changed-packages.outputs.any == 'true'` with **no empty-matrix guard** — so they weren't skipped; they launched with an empty matrix and contributed a non-pass result to the `ci-ok` gate (`needs: [install, js, php-lint, php-test, build-zips, bundle-zips]`), turning it red even though nothing was actually wrong.

This adds the same guard the sibling `php-lint` / `php-test` jobs already carry (there against `php-matrix`), so `js` and `build-zips` skip cleanly when there's nothing to build. `install` stays required, so a `--frozen-lockfile` failure on a root-deps-only PR is still caught.

**Unblocks #299** (and the stack on it), whose root-only `package.json`/lockfile changes are the first (in this repo, anyway) to trigger this latent bug.

### Follow-up (not in this PR)

The `!= '{"include":[]}'` exact-string match is brittle; a `has-js` / `has-php` boolean output from the detect job would be more durable. Pre-existing (inherited from the existing PHP guards) — worth a separate cleanup.

### How to test

On this branch, a PR touching only root deps → **CI OK** is green, with `JS /…` and `Build ZIP /…` shown as *skipped* (not failed); `Install deps` still runs. A normal PR touching a package still runs both jobs.
