### PR TITLE
fix(subscriptions): expire on-hold subs after Radar cancels retry

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -183,7 +183,9 @@ class On_Hold_Duration {
 		}
 
 		foreach ( wcs_get_subscriptions_for_renewal_order( $retry->get_order_id() ) as $subscription ) {
-			// Stranded = on-hold with no retry queued.
+			// Stranded = on-hold with no retry queued. WCS clears payment_retry at priority 0
+			// on this hook (only for the last retry), so a still-pending newer retry keeps the
+			// date set and is skipped by this priority-10 callback.
 			if ( 'on-hold' === $subscription->get_status() && 0 === $subscription->get_date( 'payment_retry' ) ) {
 				self::maybe_schedule_expiration( $subscription );
 			}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -167,31 +167,23 @@ class On_Hold_Duration {
 	}
 
 	/**
-	 * Re-arm the on-hold expiration when a payment retry ends without a
-	 * replacement retry being scheduled.
+	 * Re-arm the on-hold expiration when a payment retry ends with no replacement.
 	 *
-	 * The primary scheduler ({@see maybe_schedule_expiration}) only runs on the
-	 * transition into the on-hold status. When a pending retry is cancelled —
-	 * e.g. by the Stripe gateway after Stripe Radar blocks a renewal payment —
-	 * the subscription is already on-hold, so that hook never fires again. Both
-	 * expiration paths (the retry-rule progression and the scheduled action) are
-	 * then lost, leaving the subscription on-hold indefinitely.
-	 *
-	 * This listens for a retry reaching a terminal status and, when the related
-	 * subscription is left on-hold with no pending retry, schedules the
-	 * expiration so the On-Hold Duration is still honored.
+	 * The main scheduler only fires on the transition into on-hold. When a retry is
+	 * cancelled (e.g. by the Stripe gateway on a Radar block) the sub is already
+	 * on-hold, so that hook never re-fires and the sub would otherwise never expire.
 	 *
 	 * @param \WCS_Retry $retry      The retry whose status changed.
 	 * @param string     $new_status The new retry status.
 	 */
 	public static function maybe_reschedule_expiration_on_retry_end( $retry, $new_status ) {
-		// Pending/processing retries still drive their own progression; only act once the retry has stopped.
+		// Pending/processing retries still progress on their own.
 		if ( in_array( $new_status, [ 'pending', 'processing' ], true ) ) {
 			return;
 		}
 
 		foreach ( wcs_get_subscriptions_for_renewal_order( $retry->get_order_id() ) as $subscription ) {
-			// A subscription is only stranded when it is left on-hold with no further retry queued.
+			// Stranded = on-hold with no retry queued.
 			if ( 'on-hold' === $subscription->get_status() && 0 === $subscription->get_date( 'payment_retry' ) ) {
 				self::maybe_schedule_expiration( $subscription );
 			}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -31,6 +31,7 @@ class On_Hold_Duration {
 		add_action( 'woocommerce_subscription_status_on-hold', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 1 );
 		add_action( 'woocommerce_subscription_status_active', [ __CLASS__, 'maybe_unschedule_expiration' ], 10, 1 );
 		add_action( 'woocommerce_subscriptions_after_apply_retry_rule', [ __CLASS__, 'maybe_unschedule_expiration_on_retry' ], 10, 3 );
+		add_action( 'woocommerce_subscriptions_retry_status_updated', [ __CLASS__, 'maybe_reschedule_expiration_on_retry_end' ], 10, 2 );
 		add_action( 'woocommerce_subscription_payment_failed', [ __CLASS__, 'trash_subscription_on_failed_payment' ], 10, 2 );
 		add_action( self::AS_HOOK, [ __CLASS__, 'handle_scheduled_action' ] );
 	}
@@ -162,6 +163,38 @@ class On_Hold_Duration {
 	public static function maybe_unschedule_expiration_on_retry( $retry_rule, $last_order, $subscription ) {
 		if ( $subscription->get_date( 'payment_retry' ) > 0 ) {
 			self::maybe_unschedule_expiration( $subscription );
+		}
+	}
+
+	/**
+	 * Re-arm the on-hold expiration when a payment retry ends without a
+	 * replacement retry being scheduled.
+	 *
+	 * The primary scheduler ({@see maybe_schedule_expiration}) only runs on the
+	 * transition into the on-hold status. When a pending retry is cancelled —
+	 * e.g. by the Stripe gateway after Stripe Radar blocks a renewal payment —
+	 * the subscription is already on-hold, so that hook never fires again. Both
+	 * expiration paths (the retry-rule progression and the scheduled action) are
+	 * then lost, leaving the subscription on-hold indefinitely.
+	 *
+	 * This listens for a retry reaching a terminal status and, when the related
+	 * subscription is left on-hold with no pending retry, schedules the
+	 * expiration so the On-Hold Duration is still honored.
+	 *
+	 * @param \WCS_Retry $retry      The retry whose status changed.
+	 * @param string     $new_status The new retry status.
+	 */
+	public static function maybe_reschedule_expiration_on_retry_end( $retry, $new_status ) {
+		// Pending/processing retries still drive their own progression; only act once the retry has stopped.
+		if ( in_array( $new_status, [ 'pending', 'processing' ], true ) ) {
+			return;
+		}
+
+		foreach ( wcs_get_subscriptions_for_renewal_order( $retry->get_order_id() ) as $subscription ) {
+			// A subscription is only stranded when it is left on-hold with no further retry queued.
+			if ( 'on-hold' === $subscription->get_status() && 0 === $subscription->get_date( 'payment_retry' ) ) {
+				self::maybe_schedule_expiration( $subscription );
+			}
 		}
 	}
 

--- a/plugins/newspack-plugin/tests/mocks/on-hold-duration-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/on-hold-duration-mocks.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Mocks for On_Hold_Duration tests.
+ *
+ * @package Newspack\Tests
+ */
+
+if ( ! function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
+	/**
+	 * Return the subscriptions for a renewal order.
+	 *
+	 * Mirrors the teams-for-memberships mock contract: returns whatever the
+	 * test placed in $GLOBALS['teams_mock_subscriptions'], ignoring the order
+	 * argument. Guarded so it coexists with that mock regardless of load order.
+	 *
+	 * @param mixed $order Renewal order (ignored).
+	 * @return array
+	 */
+	function wcs_get_subscriptions_for_renewal_order( $order ) {
+		return $GLOBALS['teams_mock_subscriptions'] ?? [];
+	}
+}

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -435,6 +435,9 @@ class WC_Subscription {
 	public function needs_payment() {
 		return ! empty( $this->data['needs_payment'] );
 	}
+	public function is_manual() {
+		return ! empty( $this->data['is_manual'] );
+	}
 	public function get_view_order_url() {
 		return $this->data['view_order_url'] ?? 'https://example.test/my-account/view-order/' . $this->get_id();
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests the On-Hold Duration retry-cancellation expiration handling.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\On_Hold_Duration;
+
+require_once __DIR__ . '/../../../mocks/wc-mocks.php';
+require_once __DIR__ . '/../../../mocks/on-hold-duration-mocks.php';
+
+/**
+ * Test On_Hold_Duration expiration (re)scheduling when a payment retry ends.
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ */
+class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
+	/**
+	 * Action Scheduler group used by On_Hold_Duration.
+	 */
+	const AS_GROUP = 'newspack';
+
+	/**
+	 * Reset mock state before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$GLOBALS['teams_mock_subscriptions'] = [];
+		update_option( 'newspack_subscriptions_on_hold_duration', 30 );
+		update_option( 'woocommerce_subscriptions_enable_retry', 'yes' );
+	}
+
+	/**
+	 * Reset mock state after each test.
+	 */
+	public function tear_down() {
+		$GLOBALS['teams_mock_subscriptions'] = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * A minimal WCS_Retry test double; the handler only reads get_order_id().
+	 *
+	 * @param int $order_id Renewal order ID.
+	 * @return object
+	 */
+	private function mock_retry( $order_id ) {
+		return new class( $order_id ) {
+			/**
+			 * Renewal order ID.
+			 *
+			 * @var int
+			 */
+			private $order_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $order_id Renewal order ID.
+			 */
+			public function __construct( $order_id ) {
+				$this->order_id = $order_id;
+			}
+
+			/**
+			 * Get the renewal order ID.
+			 *
+			 * @return int
+			 */
+			public function get_order_id() {
+				return $this->order_id;
+			}
+		};
+	}
+
+	/**
+	 * Build a mock subscription with the given id/status/payment_retry.
+	 *
+	 * @param int    $id            Subscription ID.
+	 * @param string $status        Subscription status.
+	 * @param int    $payment_retry payment_retry date (0 = none).
+	 * @return WC_Subscription
+	 */
+	private function make_subscription( $id, $status, $payment_retry = 0 ) {
+		return new WC_Subscription(
+			[
+				'id'        => $id,
+				'status'    => $status,
+				'is_manual' => false,
+				'dates'     => [ 'payment_retry' => $payment_retry ],
+				'times'     => [ 'next_payment' => time() + MONTH_IN_SECONDS ],
+			]
+		);
+	}
+
+	/**
+	 * Whether an expiration action is scheduled for a subscription id.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 * @return bool
+	 */
+	private function expiration_is_scheduled( $subscription_id ) {
+		return false !== as_next_scheduled_action( On_Hold_Duration::AS_HOOK, [ $subscription_id ], self::AS_GROUP );
+	}
+
+	/**
+	 * A terminal retry that leaves the subscription on-hold with no pending
+	 * retry should (re)schedule the expiration.
+	 */
+	public function test_schedules_expiration_when_retry_ends_and_subscription_stuck_on_hold() {
+		$sub_id                              = 90001;
+		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', 0 ) ];
+
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), 'cancelled' );
+
+		$this->assertTrue( $this->expiration_is_scheduled( $sub_id ) );
+	}
+
+	/**
+	 * Pending/processing retries still drive their own progression, so the
+	 * handler must not schedule an expiration for them.
+	 *
+	 * @dataProvider non_terminal_statuses
+	 * @param string $status A non-terminal retry status.
+	 */
+	public function test_does_nothing_for_non_terminal_retry( $status ) {
+		$sub_id                              = 90002;
+		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', 0 ) ];
+
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), $status );
+
+		$this->assertFalse( $this->expiration_is_scheduled( $sub_id ) );
+	}
+
+	/**
+	 * Non-terminal retry statuses.
+	 *
+	 * @return array
+	 */
+	public function non_terminal_statuses() {
+		return [
+			'pending'    => [ 'pending' ],
+			'processing' => [ 'processing' ],
+		];
+	}
+
+	/**
+	 * A subscription that is not on-hold (e.g. reactivated) is not stranded,
+	 * so no expiration should be scheduled.
+	 */
+	public function test_skips_when_subscription_not_on_hold() {
+		$sub_id                              = 90003;
+		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'active', 0 ) ];
+
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), 'cancelled' );
+
+		$this->assertFalse( $this->expiration_is_scheduled( $sub_id ) );
+	}
+
+	/**
+	 * When a pending retry remains, the retry progression still drives
+	 * expiration, so the handler must not schedule anything.
+	 */
+	public function test_skips_when_payment_retry_still_pending() {
+		$sub_id                              = 90004;
+		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', time() + DAY_IN_SECONDS ) ];
+
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), 'failed' );
+
+		$this->assertFalse( $this->expiration_is_scheduled( $sub_id ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -61,19 +61,20 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 	/**
 	 * Build a mock subscription with the given id/status/payment_retry.
 	 *
-	 * @param int    $id            Subscription ID.
-	 * @param string $status        Subscription status.
-	 * @param int    $payment_retry payment_retry date (0 = none).
+	 * @param int      $id            Subscription ID.
+	 * @param string   $status        Subscription status.
+	 * @param int      $payment_retry payment_retry date (0 = none).
+	 * @param int|null $next_payment  next_payment time (defaults to one month out).
 	 * @return WC_Subscription
 	 */
-	private function make_subscription( $id, $status, $payment_retry = 0 ) {
+	private function make_subscription( $id, $status, $payment_retry = 0, $next_payment = null ) {
 		return new WC_Subscription(
 			[
 				'id'        => $id,
 				'status'    => $status,
 				'is_manual' => false,
 				'dates'     => [ 'payment_retry' => $payment_retry ],
-				'times'     => [ 'next_payment' => time() + MONTH_IN_SECONDS ],
+				'times'     => [ 'next_payment' => $next_payment ?? time() + MONTH_IN_SECONDS ],
 			]
 		);
 	}
@@ -94,11 +95,16 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 	 */
 	public function test_schedules_expiration_when_retry_ends_and_subscription_stuck_on_hold() {
 		$sub_id                              = 90001;
-		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', 0 ) ];
+		$next_payment                        = time() + MONTH_IN_SECONDS;
+		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', 0, $next_payment ) ];
 
 		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry(), 'cancelled' );
 
-		$this->assertTrue( $this->expiration_is_scheduled( $sub_id ) );
+		$scheduled = as_next_scheduled_action( On_Hold_Duration::AS_HOOK, [ $sub_id ], self::AS_GROUP );
+		$this->assertNotFalse( $scheduled );
+		// Automatic subscription: expiry lands at next_payment + on-hold duration (no manual grace).
+		$expected = $next_payment + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS );
+		$this->assertEqualsWithDelta( $expected, $scheduled, 2 );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -40,36 +40,20 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A minimal WCS_Retry test double; the handler only reads get_order_id().
+	 * A minimal WCS_Retry double. The handler only reads get_order_id(), and the
+	 * mocked wcs_get_subscriptions_for_renewal_order() ignores the id, so it's fixed.
 	 *
-	 * @param int $order_id Renewal order ID.
 	 * @return object
 	 */
-	private function mock_retry( $order_id ) {
-		return new class( $order_id ) {
+	private function mock_retry() {
+		return new class() {
 			/**
-			 * Renewal order ID.
-			 *
-			 * @var int
-			 */
-			private $order_id;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param int $order_id Renewal order ID.
-			 */
-			public function __construct( $order_id ) {
-				$this->order_id = $order_id;
-			}
-
-			/**
-			 * Get the renewal order ID.
+			 * Stubbed renewal order ID.
 			 *
 			 * @return int
 			 */
 			public function get_order_id() {
-				return $this->order_id;
+				return 1;
 			}
 		};
 	}
@@ -112,7 +96,7 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 		$sub_id                              = 90001;
 		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', 0 ) ];
 
-		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), 'cancelled' );
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry(), 'cancelled' );
 
 		$this->assertTrue( $this->expiration_is_scheduled( $sub_id ) );
 	}
@@ -128,7 +112,7 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 		$sub_id                              = 90002;
 		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', 0 ) ];
 
-		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), $status );
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry(), $status );
 
 		$this->assertFalse( $this->expiration_is_scheduled( $sub_id ) );
 	}
@@ -153,7 +137,7 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 		$sub_id                              = 90003;
 		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'active', 0 ) ];
 
-		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), 'cancelled' );
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry(), 'cancelled' );
 
 		$this->assertFalse( $this->expiration_is_scheduled( $sub_id ) );
 	}
@@ -166,7 +150,7 @@ class Newspack_Test_On_Hold_Duration extends WP_UnitTestCase {
 		$sub_id                              = 90004;
 		$GLOBALS['teams_mock_subscriptions'] = [ $this->make_subscription( $sub_id, 'on-hold', time() + DAY_IN_SECONDS ) ];
 
-		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry( 1 ), 'failed' );
+		On_Hold_Duration::maybe_reschedule_expiration_on_retry_end( $this->mock_retry(), 'failed' );
 
 		$this->assertFalse( $this->expiration_is_scheduled( $sub_id ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Ensures a failed subscription still expires after its On-Hold Duration when a payment retry is cancelled mid-cycle.**

When a renewal payment is blocked by Stripe Radar, the Stripe gateway cancels the pending WooCommerce Subscriptions retry and clears the subscription's `payment_retry` date. That's intended — it stops Radar-blocked charges from retrying and inflating the block rate. But it left the subscription **stranded on-hold forever**: it would never transition to `expired` at the On-Hold Duration mark.

The reason is a gap in how our On-Hold Duration tool arms the expiration:

- The expiration is scheduled on the **transition into on-hold** (`woocommerce_subscription_status_on-hold`), but only when there's no pending retry.
- When a renewal fails, WCS first sets the subscription on-hold *and* schedules a retry, so the expiration timer is (correctly) not armed — the retry rules will drive expiration instead.
- When the Radar integration then cancels that retry, the subscription is **already** on-hold, so the transition hook never re-fires. Both expiration paths (the retry-rule progression and the standalone scheduled action) are lost.

This PR adds a listener on `woocommerce_subscriptions_retry_status_updated`: when a retry reaches a terminal status and the related subscription is left on-hold with no pending retry, it re-arms the On-Hold Duration expiration. The fix is general — it covers any code path that cancels a retry, with the Stripe Radar integration being the known trigger.

**Behavior notes:**
- No change to the normal failed-renewal flow — while a retry is pending, expiration is still driven by the retry rules (nothing is scheduled early).
- Only on-hold subscriptions with no pending retry are affected; active/expired/cancelled subscriptions are untouched.
- Purely additive (one new hook + method); no existing signatures or behavior changed.

Closes NPPM-2896.

### How to test the changes in this Pull Request:

Requires WooCommerce Subscriptions + the Stripe gateway in **test mode**, automatic-payment retries enabled, and On-Hold Duration set (default 30 days).

**Repro (the bug, verify it's fixed):**
1. Create a Stripe test customer with the fraudulent/Radar-block test payment method (`tok_chargeDeclinedFraudulent`, `outcome.type=blocked`) and attach it.
2. Create an automatic monthly subscription (status `active`) using that customer/source (`_stripe_customer_id`, `_stripe_source_id`).
3. Create a renewal order and run the scheduled renewal payment for it (e.g. `WC_Subscriptions_Payment_Gateways::trigger_gateway_renewal_payment_hook( $renewal )` inside a scheduled-attempt context).
4. Confirm the renewal order gets the note *"Stripe Radar blocked payment… The automatic retry has been cancelled…"*, the subscription is **on-hold**, and `payment_retry` is cleared.
5. **Expected (fixed):** a `newspack_expire_manual_subscription` action is now scheduled for the subscription (`as_next_scheduled_action( 'newspack_expire_manual_subscription', [ $sub_id ], 'newspack' )` returns a timestamp). Before this PR it returned `false` → the subscription would never expire.

**Regression (normal decline — no Radar block):**
6. Repeat with a normal declined card (`tok_chargeDeclined`, not a Radar block).
7. **Expected (unchanged):** the subscription is on-hold with a **pending** `payment_retry` and **no** expiration action scheduled — expiration is still driven by the retry rules, exactly as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — See "For AI" note: no automated coverage exists for `On_Hold_Duration` and the unit harness has no WCS retry / Action Scheduler infrastructure; verified via live end-to-end reproduction instead.
* [x] Have you successfully run tests with your changes locally? (PHPCS clean; live reproduction before/after on the real WCS + Stripe stack.)

---

## For AI

**Root cause.** `On_Hold_Duration` (`includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php`) schedules the `newspack_expire_manual_subscription` Action Scheduler job in `maybe_schedule_expiration()`, hooked to `woocommerce_subscription_status_on-hold`, guarded by `payment_retry === 0`. During a failed renewal, `WCS_Retry_Manager::maybe_apply_retry_rule()` sets the subscription on-hold *and then* sets `payment_retry`, and `maybe_unschedule_expiration_on_retry()` (on `woocommerce_subscriptions_after_apply_retry_rule`) tears down any timer — so expiration rides on the retry rules. The custom Stripe fork's `process_subscription_payment()` (in `woocommerce-gateway-stripe`, `trait-wc-stripe-subscriptions.php`) then cancels the pending retry (`$last_retry->update_status('cancelled')`) and deletes `payment_retry` when `is_charge_blocked_by_radar()` is truthy. Because the subscription is already on-hold at that point, the on-hold transition hook never re-fires, so neither expiration path remains. Terminal outcome: on-hold indefinitely.

**Fix.** New listener `maybe_reschedule_expiration_on_retry_end( $retry, $new_status )` on `woocommerce_subscriptions_retry_status_updated` (priority 10, after WCS's own priority-0 `maybe_delete_payment_retry_date` has cleared the date). It skips `pending`/`processing` transitions, and for each subscription of the retry's renewal order that is on-hold with `payment_retry === 0`, calls the existing `maybe_schedule_expiration()`. Idempotent via `as_has_scheduled_action()` inside `schedule_expiration()`.

**Cross-plugin note.** The trigger lives in the Stripe fork; the fix lives in newspack-plugin and communicates only via the stable WCS retry-lifecycle hook, so no coordinated change to the Stripe fork is required. This contract (`third-party-integrations`) is consumed by newspack-blocks / newspack-manager, but this change is additive and does not alter any consumed signature.

**Verification.** Two-scenario live reproduction on `site.test` (real WCS + Stripe test mode). Radar-block scenario: before → on-hold, retry cancelled, `payment_retry` cleared, **no** expiration scheduled (stuck); after → same state but **expiration scheduled**. Normal-decline scenario: unchanged (pending retry, no early expiration) in both.
