### PR TITLE
fix(listings): authorize self-serve premium listing create/delete

### DIFF
--- a/plugins/newspack-listings/includes/products/class-products-ui.php
+++ b/plugins/newspack-listings/includes/products/class-products-ui.php
@@ -18,6 +18,27 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Products_Ui extends Products {
 	/**
+	 * Number of included listings granted to premium subscribers.
+	 *
+	 * @var int
+	 */
+	private $total_included_listings;
+
+	/**
+	 * Nonce action string for creating a listing.
+	 *
+	 * @var string
+	 */
+	private $create_nonce;
+
+	/**
+	 * Nonce action string for deleting a listing.
+	 *
+	 * @var string
+	 */
+	private $delete_nonce;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -525,6 +546,108 @@ final class Products_Ui extends Products {
 	}
 
 	/**
+	 * Check whether a user is allowed to delete a self-serve premium listing.
+	 *
+	 * Passing the delete nonce only proves the request came from the user's own
+	 * session; it is not an authorization check. A self-serve subscriber may only
+	 * delete premium listings they own, so ownership must be verified before
+	 * trashing anything. See NPPM-2965.
+	 *
+	 * @param int      $post_id Post ID of the listing to delete.
+	 * @param int|null $user_id User ID to check. Defaults to the current user.
+	 * @return bool True if the user may delete the listing.
+	 */
+	public function user_can_delete_premium_listing( $post_id, $user_id = null ) {
+		if ( null === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+		$user_id = (int) $user_id;
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return false;
+		}
+
+		// Must be a self-serve listing post type (Event or Marketplace).
+		$allowed_post_types = [
+			Core::NEWSPACK_LISTINGS_POST_TYPES['event'],
+			Core::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
+		];
+		if ( ! in_array( $post->post_type, $allowed_post_types, true ) ) {
+			return false;
+		}
+
+		// Must be a premium listing created via a subscription.
+		if ( ! get_post_meta( $post->ID, self::POST_META_KEYS['listing_subscription'], true ) ) {
+			return false;
+		}
+
+		// Must be owned by the requesting user.
+		return (int) $post->post_author === $user_id;
+	}
+
+	/**
+	 * Check whether a user may create another self-serve premium listing against
+	 * the given subscription.
+	 *
+	 * Verifies that the subscription belongs to the user, is an active premium
+	 * subscription, and still has included listings remaining. Passing the create
+	 * nonce only proves request origin, so these checks must not rely on the
+	 * attacker-supplied customer or subscription id. See NPPM-2965.
+	 *
+	 * @param int      $subscription_id Subscription ID to create the listing against.
+	 * @param int|null $user_id         User ID to check. Defaults to the current user.
+	 * @return bool True if the user may create a listing.
+	 */
+	public function user_can_create_premium_listing( $subscription_id, $user_id = null ) {
+		if ( null === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+		$user_id         = (int) $user_id;
+		$subscription_id = (int) $subscription_id;
+		if ( ! $user_id || ! $subscription_id || ! function_exists( 'wcs_get_subscription' ) ) {
+			return false;
+		}
+
+		$subscription = wcs_get_subscription( $subscription_id );
+		if ( ! $subscription ) {
+			return false;
+		}
+
+		// The subscription must belong to the requesting user.
+		if ( (int) $subscription->get_user_id() !== $user_id ) {
+			return false;
+		}
+
+		// Must be an active premium subscription.
+		$is_premium = 'active' === $subscription->get_status()
+			&& get_post_meta( $subscription_id, self::SUBSCRIPTION_META_KEYS['is_premium'], true );
+		if ( ! $is_premium ) {
+			return false;
+		}
+
+		// Must have included listings remaining.
+		$existing_listings = get_posts(
+			[
+				'meta_key'       => self::POST_META_KEYS['listing_subscription'],
+				'meta_value'     => $subscription_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'post_status'    => [ 'draft', 'future', 'pending', 'private', 'publish' ],
+				'post_type'      => [
+					Core::NEWSPACK_LISTINGS_POST_TYPES['event'],
+					Core::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
+				],
+				'posts_per_page' => $this->total_included_listings, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+				'fields'         => 'ids',
+			]
+		);
+
+		return count( $existing_listings ) < $this->total_included_listings;
+	}
+
+	/**
 	 * Intercept GET params and create a Marketplace or Event listing for a premium subscription.
 	 */
 	public function create_or_delete_premium_listing() {
@@ -551,6 +674,12 @@ final class Products_Ui extends Products {
 				return;
 			}
 
+			// The nonce only proves request origin, not authorization: verify the
+			// current user actually owns the listing before trashing it (NPPM-2965).
+			if ( ! $this->user_can_delete_premium_listing( $delete_post ) ) {
+				return;
+			}
+
 			wp_trash_post( $delete_post );
 			wp_safe_redirect( $redirect_uri );
 			exit;
@@ -561,10 +690,15 @@ final class Products_Ui extends Products {
 			return;
 		}
 
-		// Get order info and remaining premium listings.
-		$subscription = new \WC_Subscription( $subscription_id );
-		$args         = [
-			'post_author' => $customer_id,
+		// Verify the current user owns the subscription and has quota remaining
+		// before creating a listing; the nonce alone is not authorization (NPPM-2965).
+		if ( ! $this->user_can_create_premium_listing( $subscription_id ) ) {
+			return;
+		}
+
+		// Attribute the new listing to the current user, not an attacker-supplied id.
+		$args = [
+			'post_author' => get_current_user_id(),
 			'post_status' => 'draft',
 			'post_title'  => sprintf(
 				// translators: default "untitled" listing title.

--- a/plugins/newspack-listings/includes/products/class-products-ui.php
+++ b/plugins/newspack-listings/includes/products/class-products-ui.php
@@ -630,6 +630,24 @@ final class Products_Ui extends Products {
 		}
 
 		// Must have included listings remaining.
+		return $this->get_remaining_included_listings( $subscription_id ) > 0;
+	}
+
+	/**
+	 * Count the self-serve premium listings still available on a subscription.
+	 *
+	 * A premium subscription grants up to `$this->total_included_listings`
+	 * Event/Marketplace listings; this returns how many remain unused.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 * @return int Remaining included listings (never negative).
+	 */
+	public function get_remaining_included_listings( $subscription_id ) {
+		$subscription_id = (int) $subscription_id;
+		if ( ! $subscription_id ) {
+			return 0;
+		}
+
 		$existing_listings = get_posts(
 			[
 				'meta_key'       => self::POST_META_KEYS['listing_subscription'],
@@ -644,7 +662,7 @@ final class Products_Ui extends Products {
 			]
 		);
 
-		return count( $existing_listings ) < $this->total_included_listings;
+		return max( 0, $this->total_included_listings - count( $existing_listings ) );
 	}
 
 	/**
@@ -689,6 +707,10 @@ final class Products_Ui extends Products {
 		if ( ! wp_verify_nonce( $nonce, $this->create_nonce ) ) {
 			return;
 		}
+
+		// Normalize the subscription id once so the ownership/quota checks and the
+		// stored listing meta all use the same value (NPPM-2965).
+		$subscription_id = (int) $subscription_id;
 
 		// Verify the current user owns the subscription and has quota remaining
 		// before creating a listing; the nonce alone is not authorization (NPPM-2965).

--- a/plugins/newspack-listings/tests/test-products-ui.php
+++ b/plugins/newspack-listings/tests/test-products-ui.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Class Products_Ui Test
+ *
+ * Covers the access-control checks that guard self-serve premium listing
+ * creation and deletion (NPPM-2965).
+ *
+ * @package Newspack_Listings
+ */
+
+use Newspack_Listings\Core;
+use Newspack_Listings\Products;
+use Newspack_Listings\Products_Ui;
+
+/**
+ * Test the self-serve listings authorization helpers.
+ */
+class ProductsUiTest extends WP_UnitTestCase {
+	/**
+	 * Products_Ui instance under test.
+	 *
+	 * @var Products_Ui
+	 */
+	private $products_ui;
+
+	/**
+	 * Meta key marking a post as a self-serve premium listing.
+	 *
+	 * @var string
+	 */
+	private $subscription_meta_key;
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		$this->products_ui           = new Products_Ui();
+		$this->subscription_meta_key = Products::POST_META_KEYS['listing_subscription'];
+	}
+
+	/**
+	 * Create a self-serve premium listing owned by a given user.
+	 *
+	 * @param int    $author_id       Author/owner of the listing.
+	 * @param string $type            Listing type slug (event|marketplace).
+	 * @param bool   $with_meta       Whether to attach the subscription meta.
+	 * @param int    $subscription_id Subscription id to store in meta.
+	 * @return int Listing post ID.
+	 */
+	private function create_premium_listing( $author_id, $type = 'event', $with_meta = true, $subscription_id = 1 ) {
+		$listing_id = self::factory()->post->create(
+			[
+				'post_type'   => Core::NEWSPACK_LISTINGS_POST_TYPES[ $type ],
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			]
+		);
+		if ( $with_meta ) {
+			update_post_meta( $listing_id, $this->subscription_meta_key, $subscription_id );
+		}
+		return $listing_id;
+	}
+
+	/**
+	 * The owner of a self-serve premium listing may delete it.
+	 */
+	public function test_owner_can_delete_own_premium_listing() {
+		$owner_id   = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$listing_id = $this->create_premium_listing( $owner_id );
+
+		$this->assertTrue(
+			$this->products_ui->user_can_delete_premium_listing( $listing_id, $owner_id )
+		);
+	}
+
+	/**
+	 * A user may not delete a premium listing owned by someone else.
+	 */
+	public function test_cannot_delete_another_users_premium_listing() {
+		$owner_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$attacker_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$listing_id  = $this->create_premium_listing( $owner_id );
+
+		$this->assertFalse(
+			$this->products_ui->user_can_delete_premium_listing( $listing_id, $attacker_id )
+		);
+	}
+
+	/**
+	 * A subscriber may not delete an arbitrary post (e.g. an admin's article).
+	 */
+	public function test_cannot_delete_arbitrary_non_listing_post() {
+		$admin_id    = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$attacker_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$post_id     = self::factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_author' => $admin_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$this->assertFalse(
+			$this->products_ui->user_can_delete_premium_listing( $post_id, $attacker_id )
+		);
+	}
+
+	/**
+	 * Even if a user authors a non-listing post, this endpoint must not delete it.
+	 */
+	public function test_cannot_delete_own_non_listing_post() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_author' => $user_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$this->assertFalse(
+			$this->products_ui->user_can_delete_premium_listing( $post_id, $user_id )
+		);
+	}
+
+	/**
+	 * A listing CPT that is not a self-serve premium listing (no subscription
+	 * meta) must not be deletable via this endpoint, even by its author.
+	 */
+	public function test_cannot_delete_listing_without_subscription_meta() {
+		$user_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$listing_id = $this->create_premium_listing( $user_id, 'event', false );
+
+		$this->assertFalse(
+			$this->products_ui->user_can_delete_premium_listing( $listing_id, $user_id )
+		);
+	}
+
+	/**
+	 * A logged-out request may not delete any listing.
+	 */
+	public function test_cannot_delete_when_logged_out() {
+		$owner_id   = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$listing_id = $this->create_premium_listing( $owner_id );
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse(
+			$this->products_ui->user_can_delete_premium_listing( $listing_id )
+		);
+	}
+
+	/**
+	 * A non-existent post id must be rejected.
+	 */
+	public function test_cannot_delete_nonexistent_post() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$this->assertFalse(
+			$this->products_ui->user_can_delete_premium_listing( 999999, $user_id )
+		);
+	}
+
+	/**
+	 * When no user id is passed, the current user is used.
+	 */
+	public function test_defaults_to_current_user() {
+		$owner_id   = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$listing_id = $this->create_premium_listing( $owner_id );
+
+		wp_set_current_user( $owner_id );
+
+		$this->assertTrue(
+			$this->products_ui->user_can_delete_premium_listing( $listing_id )
+		);
+	}
+}

--- a/plugins/newspack-listings/tests/test-products-ui.php
+++ b/plugins/newspack-listings/tests/test-products-ui.php
@@ -172,4 +172,62 @@ class ProductsUiTest extends WP_UnitTestCase {
 			$this->products_ui->user_can_delete_premium_listing( $listing_id )
 		);
 	}
+
+	/**
+	 * A subscription with no listings yet has its full included allowance.
+	 */
+	public function test_remaining_included_listings_full_when_none_used() {
+		$this->assertSame( 10, $this->products_ui->get_remaining_included_listings( 500 ) );
+	}
+
+	/**
+	 * Each premium listing attributed to the subscription decrements the allowance.
+	 */
+	public function test_remaining_included_listings_decrements_with_usage() {
+		$owner = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->create_premium_listing( $owner, 'event', true, 501 );
+		}
+
+		$this->assertSame( 7, $this->products_ui->get_remaining_included_listings( 501 ) );
+	}
+
+	/**
+	 * The allowance bottoms out at zero once fully used (quota exhausted).
+	 */
+	public function test_remaining_included_listings_zero_when_exhausted() {
+		$owner = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		for ( $i = 0; $i < 10; $i++ ) {
+			$this->create_premium_listing( $owner, 'event', true, 502 );
+		}
+
+		$this->assertSame( 0, $this->products_ui->get_remaining_included_listings( 502 ) );
+	}
+
+	/**
+	 * Listings belonging to other subscriptions do not count against the allowance.
+	 */
+	public function test_remaining_included_listings_ignores_other_subscriptions() {
+		$owner = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$this->create_premium_listing( $owner, 'event', true, 601 );
+		$this->create_premium_listing( $owner, 'event', true, 602 );
+
+		$this->assertSame( 9, $this->products_ui->get_remaining_included_listings( 601 ) );
+	}
+
+	/**
+	 * An invalid subscription id yields no allowance.
+	 */
+	public function test_remaining_included_listings_zero_for_invalid_subscription() {
+		$this->assertSame( 0, $this->products_ui->get_remaining_included_listings( 0 ) );
+	}
+
+	/**
+	 * Create authorization fails closed when WooCommerce Subscriptions is
+	 * unavailable (as in this test harness) — no subscription can be verified.
+	 */
+	public function test_cannot_create_premium_listing_without_woocommerce() {
+		$this->assertFalse( function_exists( 'wcs_get_subscription' ), 'WooCommerce Subscriptions should be absent in the listings test harness.' );
+		$this->assertFalse( $this->products_ui->user_can_create_premium_listing( 500, 20 ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Security hotfix for a broken-access-control issue in the self-serve listings feature (`Products_Ui`). Its front-end create and delete handlers were gated only by a static-action nonce. A nonce confirms a request came from the user's own session, but it is **not** an authorization check — so any logged-in low-privilege user (e.g. a listings subscriber) could:

- **Delete**: trash arbitrary posts, pages, CPTs, products, or orders by id — the delete handler trashed whatever post id it was handed.
- **Create**: mint premium listings past their paid quota, attributed to another account — the create handler trusted attacker-supplied `customer_id`/`subscription_id`.

This PR adds per-object authorization:

- **Delete** — only the owner of a self-serve premium listing may trash it: the target must be an Event/Marketplace listing created via a subscription and owned by the current user.
- **Create** — the subscription must belong to the current user, be active and premium, and have included listings remaining; the new listing is attributed to the current user rather than an attacker-supplied id.

Notes:
- A raw `current_user_can( 'delete_post', … )` gate is intentionally **not** used: these listing CPTs register with the default `post` capability type, and subscribers/customers lack the `delete_*` capabilities, so that check would break legitimate self-serve deletion of a user's own listings. Ownership is the correct gate.
- Hardening only — no change to the legitimate self-serve create/delete UX.

Closes NPPM-2965.

### How to test the changes in this Pull Request:

1. On a site with WooCommerce, WooCommerce Subscriptions, and newspack-listings active, define `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` and create the self-serve products from Listings settings.
2. As a premium-listing subscriber, open the WooCommerce **View subscription** page and confirm the legitimate flows are unchanged: you can still create (up to quota) and delete your **own** Event/Marketplace listings.
3. Copy the delete nonce from one of your own Delete links, then send `GET /?customer_id=<you>&subscription_id=<yours>&delete=<a post id you do NOT own>&redirect_uri=%2Fwp-admin%2F&_wpnonce=<nonce>`. Confirm the target post is **not** trashed (previously it was).
4. With the same nonce, try to delete **another customer's** listing id — confirm it is **not** trashed.
5. Try to create a listing against a `subscription_id` you don't own, or past your included quota — confirm no listing is created and no listing is attributed to another account.
6. Run the automated tests: from `plugins/newspack-listings`, `n test-php` — includes the new `ProductsUiTest` (8 cases covering delete authorization). Full listings suite: 12 tests / 48 assertions passing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
