### PR TITLE
fix(access-control): restore long-lived institutional IP access cookie

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
@@ -35,6 +35,19 @@ class IP_Access_Rule {
 	const COOKIE_NAME = 'wp_nocache_ip';
 
 	/**
+	 * Lifetime of the IP-access bypass cookie.
+	 *
+	 * This is the effective re-validation interval for anonymous institutional
+	 * visitors: without the cookie, gated pages are served from the page cache
+	 * and the per-request IP check cannot run, so once it expires the visitor
+	 * is walled out until they re-visit /institutional-access. Keep it
+	 * long-lived — the cookie grants nothing by itself (the visitor's IP is
+	 * re-checked server-side on every uncached request), so a long lifetime
+	 * carries no access risk.
+	 */
+	const COOKIE_EXPIRATION = YEAR_IN_SECONDS;
+
+	/**
 	 * The endpoint for institutional access.
 	 */
 	const ENDPOINT = 'institutional-access';
@@ -723,7 +736,7 @@ class IP_Access_Rule {
 	 * the page cache so the IP check can run server-side.
 	 */
 	private static function set_cookie() {
-		$expiry = time() + HOUR_IN_SECONDS;
+		$expiry = time() + self::COOKIE_EXPIRATION;
 		if ( ! headers_sent() ) {
 			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 			setcookie(

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -89,6 +89,15 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the bypass cookie lifetime is long enough to keep institutional
+	 * access persistent (see the COOKIE_EXPIRATION docblock).
+	 */
+	public function test_bypass_cookie_lifetime_is_at_least_thirty_days() {
+		$thirty_days_in_seconds = 30 * DAY_IN_SECONDS;
+		$this->assertGreaterThanOrEqual( $thirty_days_in_seconds, IP_Access_Rule::COOKIE_EXPIRATION );
+	}
+
+	/**
 	 * Test that the REST route is registered.
 	 */
 	public function test_rest_route_registered() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Hotfix** (supersedes #508, same commit cherry-picked onto `release`).

The `set_cookie()` consolidation in #136 hardcoded a **1-hour** lifetime for the `wp_nocache_ip` institutional-access bypass cookie, silently reverting #4749, which had deliberately raised it to **1 year** (and before that it was 30 days). The regression shipped in `newspack-plugin` 6.43.0.

The cookie's lifetime is the effective re-validation interval for anonymous institutional visitors: without it, gated pages are served from the page cache where the per-request IP check cannot run, so once it lapses the visitor is walled out until they re-visit the `/institutional-access` validation page. Since 6.43.0 that means re-validating on virtually every visit instead of (at most) every 30 days — reported by a live site's institutional partner whose members are being sent to the validation URL every session.

This PR:

- extracts the lifetime into a documented `IP_Access_Rule::COOKIE_EXPIRATION` constant, restored to `YEAR_IN_SECONDS` per #4749;
- adds a regression test pinning the lifetime to at least 30 days, so a future refactor can't silently shorten it again (the new test fails against the current `release` with `3600 is not >= 2592000`).

Everything else #136 did to this cookie is preserved: the single `set_cookie()` helper, the hardened attributes (`HttpOnly`, `SameSite=Lax`, `secure`), and the unification of the REST and redirect paths (which had drifted to 1 year vs 30 days). Only the lifetime value changes. A long lifetime carries no access risk: the cookie is a cache-skip sentinel only — the visitor's IP is re-checked server-side on every uncached request, so revoked/changed IP ranges take effect immediately regardless of the cookie.

### How to test the changes in this Pull Request:

1. On an env with `NEWSPACK_CONTENT_GATES` enabled, create an institution whose IP range covers your requests, e.g. `wp eval '\Newspack\Institution::create( "Test U", "", [ "ip_range" => "172.16.0.0/12,127.0.0.0/8,192.168.0.0/16" ] );'`, and a content gate with an Institutional access rule pointing at it, applied to posts.
2. As a logged-out visitor, load a gated post — you get the gate. Hit `https://<site>/wp-json/newspack/v1/institutional-access/check?institution_id=<id>` and inspect the `Set-Cookie` header: on `release` it carries `Max-Age=3600` (1 hour); on this branch `Max-Age=31536000` (1 year). The `?institutional-access=1` redirect path sets the same cookie.
3. Reload the gated post with the cookie — full content. Delete the cookie (simulating expiry) — the gate returns, which is why the lifetime must be long.
4. `n test-php --group Access_Rules` — 64 tests green, including the new `test_bypass_cookie_lifetime_is_at_least_thirty_days`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx7SAEsNkTyS1rsHutKEwu
