### PR TITLE
fix(insights): sum BigQuery conversion flag, drop Woo join

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -749,6 +749,14 @@ final class Conversion_Metric {
 				'stages' => [],
 			];
 		}
+		// NEWS-2598: `became_subscriber` is the sole source of step 3. A hub on the
+		// pre-NEWS-2598 schema emits `{ uid, saw_subscription_surface }` without it;
+		// treat that as malformed rather than silently reporting a populated funnel
+		// with 0 conversions. BigQuery returns the column for all rows or none, so the
+		// first row (already guaranteed an array by the guard above) is representative.
+		if ( ! array_key_exists( 'became_subscriber', $rows[0] ) ) {
+			return $this->malformed_collection( 'stages' );
+		}
 		$step_1 = count( $rows );
 		$step_2 = 0;
 		$step_3 = 0;
@@ -829,6 +837,14 @@ final class Conversion_Metric {
 				'state'  => 'empty',
 				'stages' => [],
 			];
+		}
+		// NEWS-2598: `became_donor` is the sole source of step 3. A hub on the
+		// pre-NEWS-2598 schema emits `{ uid, saw_donation_surface }` without it; treat
+		// that as malformed rather than silently reporting a populated funnel with 0
+		// conversions. BigQuery returns the column for all rows or none, so the first
+		// row (already guaranteed an array by the guard above) is representative.
+		if ( ! array_key_exists( 'became_donor', $rows[0] ) ) {
+			return $this->malformed_collection( 'stages' );
 		}
 		$step_1 = count( $rows );
 		$step_2 = 0;

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -706,9 +706,12 @@ final class Conversion_Metric {
 	 * Registered → Subscriber funnel (C10 / 2.2) — three stages, non-donation
 	 * subscriptions only. Dispatches
 	 * `conversion_journey_funnel_registered_to_subscriber`; the hub returns
-	 * rows `{ uid, saw_subscription_surface }`. Step 3 count is the number of
-	 * those UIDs who currently hold an active non-donation subscription,
-	 * resolved via {@see Subscribers_Metric::count_active_non_donation_subscribers_by_customer_ids()}.
+	 * rows `{ uid, saw_subscription_surface, became_subscriber }`. Step 3 count
+	 * is the SUM of the per-uid `became_subscriber` flag — the number of
+	 * registered-in-window uids who ALSO fired a subscription conversion event in
+	 * the same window, computed inside BigQuery (NEWS-2598). This replaces the
+	 * former Woo customer_id join, which always returned 0 because the BQ uid is a
+	 * GA4 pseudo-id, never a WooCommerce customer_id.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -748,16 +751,15 @@ final class Conversion_Metric {
 		}
 		$step_1 = count( $rows );
 		$step_2 = 0;
-		$uids   = [];
+		$step_3 = 0;
 		foreach ( $rows as $row ) {
 			if ( ! is_array( $row ) ) {
 				return $this->malformed_collection( 'stages' );
 			}
 			$step_2 += (int) ( $row['saw_subscription_surface'] ?? 0 );
-			$uids[]  = (int) ( $row['uid'] ?? 0 );
+			$step_3 += (int) ( $row['became_subscriber'] ?? 0 );
 		}
-		$step_3 = $this->subscribers_metric->count_active_non_donation_subscribers_by_customer_ids( $uids );
-		$safe   = $step_1 > 0 ? $step_1 : 1;
+		$safe = $step_1 > 0 ? $step_1 : 1;
 		return [
 			'state'  => 'populated',
 			'stages' => [
@@ -783,9 +785,12 @@ final class Conversion_Metric {
 	/**
 	 * Registered → Donor funnel (C11 / 2.3) — three stages. Dispatches
 	 * `conversion_journey_funnel_registered_to_donor`; the hub returns rows
-	 * `{ uid, saw_donation_surface }`. Step 3 count is the number of those
-	 * UIDs who have at least one completed donation order, resolved via
-	 * {@see Donors_Metric::count_completed_donation_order_customers_by_customer_ids()}.
+	 * `{ uid, saw_donation_surface, became_donor }`. Step 3 count is the SUM of
+	 * the per-uid `became_donor` flag — the number of registered-in-window uids
+	 * who ALSO fired a donation conversion event in the same window, computed
+	 * inside BigQuery (NEWS-2598). This replaces the former Woo customer_id join,
+	 * which always returned 0 because the BQ uid is a GA4 pseudo-id, never a
+	 * WooCommerce customer_id.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -827,16 +832,15 @@ final class Conversion_Metric {
 		}
 		$step_1 = count( $rows );
 		$step_2 = 0;
-		$uids   = [];
+		$step_3 = 0;
 		foreach ( $rows as $row ) {
 			if ( ! is_array( $row ) ) {
 				return $this->malformed_collection( 'stages' );
 			}
 			$step_2 += (int) ( $row['saw_donation_surface'] ?? 0 );
-			$uids[]  = (int) ( $row['uid'] ?? 0 );
+			$step_3 += (int) ( $row['became_donor'] ?? 0 );
 		}
-		$step_3 = $this->donors_metric->count_completed_donation_order_customers_by_customer_ids( $uids );
-		$safe   = $step_1 > 0 ? $step_1 : 1;
+		$safe = $step_1 > 0 ? $step_1 : 1;
 		return [
 			'state'  => 'populated',
 			'stages' => [

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -395,17 +395,6 @@ class Donors_Metric {
 	}
 
 	/**
-	 * COUNT(DISTINCT customer_id) among $customer_ids who have at least one
-	 * completed donation order (any time). List-param — NOT cached.
-	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_completed_donation_order_customers_by_customer_ids( array $customer_ids ): int {
-		return $this->storage->count_completed_donation_order_customers_by_customer_ids( $customer_ids );
-	}
-
-	/**
 	 * Earliest completed/processing donation order date per customer for the
 	 * given set. List-param — NOT cached (result varies per call). Keyed by
 	 * customer_id.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -455,17 +455,6 @@ class Subscribers_Metric {
 	}
 
 	/**
-	 * COUNT(DISTINCT customer_id) among the given list who have an active
-	 * non-donation subscription. List-param — NOT cached (result varies per call).
-	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_active_non_donation_subscribers_by_customer_ids( array $customer_ids ): int {
-		return $this->storage->count_active_non_donation_subscribers_by_customer_ids( $customer_ids );
-	}
-
-	/**
 	 * Count of registered readers with no active non-donation subscription and
 	 * no completed donation in the trailing 365 days. Phase-A approximation.
 	 * Point-in-time snapshot; cached TTL_DEFAULT (30 min).

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-donors-storage-interface.php
@@ -242,16 +242,6 @@ interface Donors_Storage_Interface {
 	public function get_subscriber_donors_in_window( array $subscriber_ids, DateTimeInterface $start, DateTimeInterface $end ): int;
 
 	/**
-	 * COUNT(DISTINCT customer_id) among $customer_ids who have at least one
-	 * completed donation order at any time (status wc-completed/wc-processing,
-	 * product IN donation IDs). Empty input returns 0 immediately.
-	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_completed_donation_order_customers_by_customer_ids( array $customer_ids ): int;
-
-	/**
 	 * Per-product donor performance breakdown. One entry per parent
 	 * donation product (or standalone product), sorted by lifetime
 	 * revenue descending, top 50. Parent entries carry a `variations`

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -674,34 +674,6 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_completed_donation_order_customers_by_customer_ids( array $customer_ids ): int {
-		if ( empty( $customer_ids ) ) {
-			return 0;
-		}
-
-		global $wpdb;
-		$prefix    = $wpdb->prefix;
-		$donations = $this->id_list( $this->donation_product_ids );
-		$ids       = $this->id_list( $customer_ids );
-
-		// No date filter — any completed donation order at any time.
-		$sql = "SELECT COUNT(DISTINCT o.customer_id)
-			FROM {$prefix}wc_orders o
-			JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
-			WHERE o.type = 'shop_order'
-			  AND o.status IN ('wc-completed', 'wc-processing')
-			  AND opl.product_id IN ($donations)
-			  AND o.customer_id IN ($ids)";
-
-		return (int) $wpdb->get_var( $sql );
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1069,36 +1069,6 @@ class HPOS_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_active_non_donation_subscribers_by_customer_ids( array $customer_ids ): int {
-		if ( empty( $customer_ids ) ) {
-			return 0;
-		}
-
-		global $wpdb;
-		$prefix    = $wpdb->prefix;
-		$donations = $this->id_list( $this->donation_product_ids );
-		$ids       = $this->id_list( $customer_ids );
-
-		$sql = "SELECT COUNT(DISTINCT o.customer_id)
-			FROM {$prefix}wc_orders o
-			JOIN {$prefix}woocommerce_order_items oi
-				ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
-			JOIN {$prefix}woocommerce_order_itemmeta oim
-				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
-			WHERE o.type = 'shop_subscription'
-			  AND o.status = 'wc-active'
-			  AND oim.meta_value NOT IN ($donations)
-			  AND o.customer_id IN ($ids)";
-
-		return (int) $wpdb->get_var( $sql );
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * @return int
 	 */
 	public function get_stale_registered_users(): int {

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -665,35 +665,6 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_completed_donation_order_customers_by_customer_ids( array $customer_ids ): int {
-		if ( empty( $customer_ids ) ) {
-			return 0;
-		}
-
-		global $wpdb;
-		$prefix    = $wpdb->prefix;
-		$donations = $this->id_list( $this->donation_product_ids );
-		$ids       = $this->id_list( $customer_ids );
-
-		$sql = "SELECT COUNT(DISTINCT CAST(cust.meta_value AS UNSIGNED))
-			FROM {$prefix}posts p
-			JOIN {$prefix}postmeta cust
-				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
-			JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
-			WHERE p.post_type = 'shop_order'
-			  AND p.post_status IN ('wc-completed', 'wc-processing')
-			  AND opl.product_id IN ($donations)
-			  AND CAST(cust.meta_value AS UNSIGNED) IN ($ids)";
-
-		return (int) $wpdb->get_var( $sql );
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -996,38 +996,6 @@ class Legacy_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_active_non_donation_subscribers_by_customer_ids( array $customer_ids ): int {
-		if ( empty( $customer_ids ) ) {
-			return 0;
-		}
-
-		global $wpdb;
-		$prefix    = $wpdb->prefix;
-		$donations = $this->id_list( $this->donation_product_ids );
-		$ids       = $this->id_list( $customer_ids );
-
-		$sql = "SELECT COUNT(DISTINCT cust.meta_value)
-			FROM {$prefix}posts p
-			JOIN {$prefix}postmeta cust
-				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
-			JOIN {$prefix}woocommerce_order_items oi
-				ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
-			JOIN {$prefix}woocommerce_order_itemmeta oim
-				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
-			WHERE p.post_type = 'shop_subscription'
-			  AND p.post_status = 'wc-active'
-			  AND oim.meta_value NOT IN ($donations)
-			  AND CAST(cust.meta_value AS UNSIGNED) IN ($ids)";
-
-		return (int) $wpdb->get_var( $sql );
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
 	 * @return int
 	 */
 	public function get_stale_registered_users(): int {

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -282,16 +282,6 @@ interface Storage_Interface {
 	public function get_active_non_donation_subscriber_customer_ids(): array;
 
 	/**
-	 * Given an explicit customer-ID list, COUNT(DISTINCT customer_id) who have
-	 * at least one active non-donation subscription right now. Empty input
-	 * returns 0 immediately (no DB round-trip).
-	 *
-	 * @param int[] $customer_ids Customer IDs to check.
-	 * @return int
-	 */
-	public function count_active_non_donation_subscribers_by_customer_ids( array $customer_ids ): int;
-
-	/**
 	 * Count of REGISTERED READERS who have no active non-donation subscription
 	 * AND no completed donation order in the trailing 365 days.
 	 *

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-journey-storage.php
@@ -8,10 +8,9 @@
  *   CONTRACT / INTERFACE CHECKS — verify the four storage classes implement
  *   the expected Storage_Interface and Donors_Storage_Interface method sets.
  *
- *   EMPTY-LIST SHORT-CIRCUIT GUARDS — verify the PHP early-return guards
- *   (before any SQL is issued) in count_* / get_subscriber_donors_in_window /
- *   count_completed_donation_order_customers_by_customer_ids return 0 for an
- *   empty input list. These exercise real PHP logic, not the database.
+ *   EMPTY-LIST SHORT-CIRCUIT GUARDS — verify the PHP early-return guard
+ *   (before any SQL is issued) in get_subscriber_donors_in_window() returns 0
+ *   for an empty input list. This exercises real PHP logic, not the database.
  *
  *   METRIC-WRAPPER DELEGATION + CACHING — verify Subscribers_Metric and
  *   Donors_Metric delegate to storage, cache results in transients, and pass
@@ -22,8 +21,7 @@
  *
  *   The SQL bodies of get_at_risk_subscribers(), get_active_non_donation_
  *   subscriber_customer_ids(), get_stale_registered_users(),
- *   get_subscriber_donors_in_window() (non-empty list),
- *   count_completed_donation_order_customers_by_customer_ids() (non-empty list)
+ *   get_subscriber_donors_in_window() (non-empty list)
  *   and every other method that queries wc_orders / posts / wc_order_product_
  *   lookup cannot be behaviorally unit-tested here: the test bootstrap does not
  *   install WooCommerce DB tables (consistent with how the existing Subscribers
@@ -119,68 +117,48 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 	// =========================================================================
 
 	/**
-	 * HPOS_Storage implements the three new Storage_Interface methods.
+	 * HPOS_Storage implements the subscriber Storage_Interface methods.
 	 */
 	public function test_hpos_storage_implements_new_subscriber_interface_methods(): void {
 		$storage = new HPOS_Storage( [] );
 		$this->assertInstanceOf( Storage_Interface::class, $storage );
 		$this->assertTrue( method_exists( $storage, 'get_at_risk_subscribers' ) );
 		$this->assertTrue( method_exists( $storage, 'get_active_non_donation_subscriber_customer_ids' ) );
-		$this->assertTrue( method_exists( $storage, 'count_active_non_donation_subscribers_by_customer_ids' ) );
 		$this->assertTrue( method_exists( $storage, 'get_stale_registered_users' ) );
 	}
 
 	/**
-	 * Legacy_Storage implements the three new Storage_Interface methods.
+	 * Legacy_Storage implements the subscriber Storage_Interface methods.
 	 */
 	public function test_legacy_storage_implements_new_subscriber_interface_methods(): void {
 		$storage = new Legacy_Storage( [] );
 		$this->assertInstanceOf( Storage_Interface::class, $storage );
 		$this->assertTrue( method_exists( $storage, 'get_at_risk_subscribers' ) );
 		$this->assertTrue( method_exists( $storage, 'get_active_non_donation_subscriber_customer_ids' ) );
-		$this->assertTrue( method_exists( $storage, 'count_active_non_donation_subscribers_by_customer_ids' ) );
 		$this->assertTrue( method_exists( $storage, 'get_stale_registered_users' ) );
 	}
 
 	/**
-	 * HPOS_Donors_Storage implements the two new Donors_Storage_Interface methods.
+	 * HPOS_Donors_Storage implements the donor Donors_Storage_Interface method.
 	 */
 	public function test_hpos_donors_storage_implements_new_donor_interface_methods(): void {
 		$storage = new HPOS_Donors_Storage( [] );
 		$this->assertInstanceOf( Donors_Storage_Interface::class, $storage );
 		$this->assertTrue( method_exists( $storage, 'get_subscriber_donors_in_window' ) );
-		$this->assertTrue( method_exists( $storage, 'count_completed_donation_order_customers_by_customer_ids' ) );
 	}
 
 	/**
-	 * Legacy_Donors_Storage implements the two new Donors_Storage_Interface methods.
+	 * Legacy_Donors_Storage implements the donor Donors_Storage_Interface method.
 	 */
 	public function test_legacy_donors_storage_implements_new_donor_interface_methods(): void {
 		$storage = new Legacy_Donors_Storage( [] );
 		$this->assertInstanceOf( Donors_Storage_Interface::class, $storage );
 		$this->assertTrue( method_exists( $storage, 'get_subscriber_donors_in_window' ) );
-		$this->assertTrue( method_exists( $storage, 'count_completed_donation_order_customers_by_customer_ids' ) );
 	}
 
 	// =========================================================================
 	// Empty-list short-circuit — storage layer (no DB needed).
 	// =========================================================================
-
-	/**
-	 * HPOS: count_active_non_donation_subscribers_by_customer_ids([]) → 0.
-	 */
-	public function test_hpos_count_active_non_donation_empty_list_returns_zero(): void {
-		$storage = new HPOS_Storage( [] );
-		$this->assertSame( 0, $storage->count_active_non_donation_subscribers_by_customer_ids( [] ) );
-	}
-
-	/**
-	 * Legacy: count_active_non_donation_subscribers_by_customer_ids([]) → 0.
-	 */
-	public function test_legacy_count_active_non_donation_empty_list_returns_zero(): void {
-		$storage = new Legacy_Storage( [] );
-		$this->assertSame( 0, $storage->count_active_non_donation_subscribers_by_customer_ids( [] ) );
-	}
 
 	/**
 	 * HPOS: get_subscriber_donors_in_window([], ...) → 0.
@@ -196,22 +174,6 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 	public function test_legacy_get_subscriber_donors_in_window_empty_list_returns_zero(): void {
 		$storage = new Legacy_Donors_Storage( [] );
 		$this->assertSame( 0, $storage->get_subscriber_donors_in_window( [], $this->make_date( '2026-01-01' ), $this->make_date( '2026-01-31' ) ) );
-	}
-
-	/**
-	 * HPOS: count_completed_donation_order_customers_by_customer_ids([]) → 0.
-	 */
-	public function test_hpos_count_completed_donation_empty_list_returns_zero(): void {
-		$storage = new HPOS_Donors_Storage( [] );
-		$this->assertSame( 0, $storage->count_completed_donation_order_customers_by_customer_ids( [] ) );
-	}
-
-	/**
-	 * Legacy: count_completed_donation_order_customers_by_customer_ids([]) → 0.
-	 */
-	public function test_legacy_count_completed_donation_empty_list_returns_zero(): void {
-		$storage = new Legacy_Donors_Storage( [] );
-		$this->assertSame( 0, $storage->count_completed_donation_order_customers_by_customer_ids( [] ) );
 	}
 
 	// =========================================================================
@@ -277,34 +239,6 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 	}
 
 	/**
-	 * List-param count method delegates directly (no caching — list varies per call).
-	 */
-	public function test_subscribers_metric_count_by_ids_delegates_directly(): void {
-		$mock = $this->createMock( Storage_Interface::class );
-		// Two separate calls with different lists → storage is called twice.
-		$mock->expects( $this->exactly( 2 ) )
-			->method( 'count_active_non_donation_subscribers_by_customer_ids' )
-			->willReturnOnConsecutiveCalls( 3, 1 );
-
-		$metric = $this->make_subscribers_metric( $mock );
-
-		$this->assertSame( 3, $metric->count_active_non_donation_subscribers_by_customer_ids( [ 1, 2, 3 ] ) );
-		$this->assertSame( 1, $metric->count_active_non_donation_subscribers_by_customer_ids( [ 99 ] ) );
-	}
-
-	/**
-	 * Empty list short-circuits to 0 via storage's own guard.
-	 */
-	public function test_subscribers_metric_count_by_ids_empty_list(): void {
-		$mock = $this->createMock( Storage_Interface::class );
-		$mock->method( 'count_active_non_donation_subscribers_by_customer_ids' )
-			->willReturn( 0 );
-
-		$metric = $this->make_subscribers_metric( $mock );
-		$this->assertSame( 0, $metric->count_active_non_donation_subscribers_by_customer_ids( [] ) );
-	}
-
-	/**
 	 * Stale-registered count delegates to storage and is cached.
 	 */
 	public function test_subscribers_metric_get_stale_registered_users_delegates(): void {
@@ -356,21 +290,6 @@ class Test_Conversion_Journey_Storage extends WP_UnitTestCase {
 		$end    = $this->make_date( '2026-03-31' );
 
 		$this->assertSame( 0, $metric->get_subscriber_donors_in_window( [], $start, $end ) );
-	}
-
-	/**
-	 * Completed-donation count delegates directly (no caching — list varies).
-	 */
-	public function test_donors_metric_count_completed_donation_delegates(): void {
-		$mock = $this->createMock( Donors_Storage_Interface::class );
-		$mock->expects( $this->exactly( 2 ) )
-			->method( 'count_completed_donation_order_customers_by_customer_ids' )
-			->willReturnOnConsecutiveCalls( 4, 0 );
-
-		$metric = $this->make_donors_metric( $mock );
-
-		$this->assertSame( 4, $metric->count_completed_donation_order_customers_by_customer_ids( [ 1, 2, 3, 4 ] ) );
-		$this->assertSame( 0, $metric->count_completed_donation_order_customers_by_customer_ids( [] ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1313,14 +1313,17 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	// --- C10: get_registered_to_subscriber_funnel --------------------------
 
 	/**
-	 * Build a mock Subscribers_Metric that stubs count_active_non_donation_subscribers_by_customer_ids.
+	 * Build a mock Subscribers_Metric whose subscription leg reads as configured.
 	 *
-	 * @param int $return Value to return for the stub.
+	 * NEWS-2598: step 3 of the Registered → Subscriber funnel is now computed
+	 * inside BigQuery (the hub emits a per-uid `became_subscriber` flag), so the
+	 * metric no longer resolves step 3 via a Woo customer_id join. This mock only
+	 * needs to mark the leg configured so the compute path runs.
+	 *
 	 * @return Subscribers_Metric
 	 */
-	private function subscribers_metric_returning_count( int $return ): Subscribers_Metric {
+	private function subscribers_metric_configured(): Subscribers_Metric {
 		$mock = $this->createMock( Subscribers_Metric::class );
-		$mock->method( 'count_active_non_donation_subscribers_by_customer_ids' )->willReturn( $return );
 		// NPPD-1742: a non-empty active-subscriber set marks the subscription leg
 		// configured, so the funnel logic runs instead of returning the hidden leg.
 		$mock->method( 'get_active_non_donation_subscriber_customer_ids' )->willReturn( [ 101 ] );
@@ -1328,14 +1331,17 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Build a mock Donors_Metric that stubs count_completed_donation_order_customers_by_customer_ids.
+	 * Build a mock Donors_Metric whose donation leg reads as configured.
 	 *
-	 * @param int $return Value to return for the stub.
+	 * NEWS-2598: step 3 of the Registered → Donor funnel is now computed inside
+	 * BigQuery (the hub emits a per-uid `became_donor` flag), so the metric no
+	 * longer resolves step 3 via a Woo customer_id join. This mock only needs to
+	 * mark the leg configured so the compute path runs.
+	 *
 	 * @return Donors_Metric
 	 */
-	private function donors_metric_returning_count( int $return ): Donors_Metric {
+	private function donors_metric_configured(): Donors_Metric {
 		$mock = $this->createMock( Donors_Metric::class );
-		$mock->method( 'count_completed_donation_order_customers_by_customer_ids' )->willReturn( $return );
 		// NPPD-1742: active donors > 0 marks the donation leg configured, so the
 		// funnel logic runs instead of returning the hidden leg.
 		$mock->method( 'get_active_donors' )->willReturn( 1 );
@@ -1343,31 +1349,38 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * C10 populated: proxy returns rows with uid + saw_subscription_surface →
-	 * three stages built with correct counts and labels.
+	 * C10 populated: proxy returns rows with uid + saw_subscription_surface +
+	 * became_subscriber → three stages built with correct counts and labels.
+	 *
+	 * NEWS-2598: step 3 (Became subscriber) is the SUM of the hub-provided
+	 * per-uid `became_subscriber` flag, not a downstream Woo customer_id join.
 	 */
 	public function test_registered_to_subscriber_funnel_returns_populated_stages_on_success() {
 		$rows = [
 			[
 				'uid'                      => 1,
 				'saw_subscription_surface' => 1,
+				'became_subscriber'        => 1,
 			],
 			[
 				'uid'                      => 2,
 				'saw_subscription_surface' => 1,
+				'became_subscriber'        => 0,
 			],
 			[
 				'uid'                      => 3,
 				'saw_subscription_surface' => 0,
+				'became_subscriber'        => 0,
 			],
 			[
 				'uid'                      => 4,
 				'saw_subscription_surface' => 0,
+				'became_subscriber'        => 0,
 			],
 		];
 
 		$proxy = $this->proxy_returning( $rows );
-		$subs  = $this->subscribers_metric_returning_count( 1 );
+		$subs  = $this->subscribers_metric_configured();
 
 		$metric          = new Conversion_Metric( $proxy, $subs );
 		[ $start, $end ] = $this->window();
@@ -1386,7 +1399,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 2, $result['stages'][1]['count'] );
 		$this->assertEqualsWithDelta( 0.5, $result['stages'][1]['pct_of_top'], 1e-9 );
 
-		// step_3: from mock = 1; pct = 1/4 = 0.25.
+		// step_3: sum of became_subscriber = 1; pct = 1/4 = 0.25.
 		$this->assertSame( 1, $result['stages'][2]['count'] );
 		$this->assertEqualsWithDelta( 0.25, $result['stages'][2]['pct_of_top'], 1e-9 );
 
@@ -1400,7 +1413,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C10 empty: proxy returns [] → state 'empty', empty stages.
 	 */
 	public function test_registered_to_subscriber_funnel_returns_empty_state_on_no_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), $this->subscribers_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), $this->subscribers_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1415,7 +1428,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_registered_to_subscriber_funnel_returns_error_on_proxy_error() {
 		$wp_error        = new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 500' );
-		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), $this->subscribers_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), $this->subscribers_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1428,7 +1441,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C10 malformed: proxy returns non-array first row → state 'error' (malformed).
 	 */
 	public function test_registered_to_subscriber_funnel_returns_error_on_malformed_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), $this->subscribers_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), $this->subscribers_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1446,7 +1459,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			'uid'                      => 1,
 			'saw_subscription_surface' => 1,
 		];
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), $this->subscribers_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), $this->subscribers_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
 
@@ -1458,31 +1471,38 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	// --- C11: get_registered_to_donor_funnel --------------------------------
 
 	/**
-	 * C11 populated: proxy returns rows with uid + saw_donation_surface →
-	 * three stages built with correct counts.
+	 * C11 populated: proxy returns rows with uid + saw_donation_surface +
+	 * became_donor → three stages built with correct counts.
+	 *
+	 * NEWS-2598: step 3 (Became donor) is the SUM of the hub-provided per-uid
+	 * `became_donor` flag, not a downstream Woo customer_id join.
 	 */
 	public function test_registered_to_donor_funnel_returns_populated_stages_on_success() {
 		$rows = [
 			[
 				'uid'                  => 1,
 				'saw_donation_surface' => 1,
+				'became_donor'         => 1,
 			],
 			[
 				'uid'                  => 2,
 				'saw_donation_surface' => 1,
+				'became_donor'         => 1,
 			],
 			[
 				'uid'                  => 3,
 				'saw_donation_surface' => 1,
+				'became_donor'         => 0,
 			],
 			[
 				'uid'                  => 4,
 				'saw_donation_surface' => 0,
+				'became_donor'         => 0,
 			],
 		];
 
 		$proxy  = $this->proxy_returning( $rows );
-		$donors = $this->donors_metric_returning_count( 2 );
+		$donors = $this->donors_metric_configured();
 
 		$metric          = new Conversion_Metric( $proxy, null, $donors );
 		[ $start, $end ] = $this->window();
@@ -1501,7 +1521,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 3, $result['stages'][1]['count'] );
 		$this->assertEqualsWithDelta( 0.75, $result['stages'][1]['pct_of_top'], 1e-9 );
 
-		// step_3: from mock = 2; pct = 2/4 = 0.5.
+		// step_3: sum of became_donor = 2; pct = 2/4 = 0.5.
 		$this->assertSame( 2, $result['stages'][2]['count'] );
 		$this->assertEqualsWithDelta( 0.5, $result['stages'][2]['pct_of_top'], 1e-9 );
 
@@ -1514,7 +1534,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C11 empty: proxy returns [] → state 'empty', empty stages.
 	 */
 	public function test_registered_to_donor_funnel_returns_empty_state_on_no_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), null, $this->donors_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [] ), null, $this->donors_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
@@ -1528,7 +1548,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 */
 	public function test_registered_to_donor_funnel_returns_error_on_proxy_error() {
 		$wp_error        = new \WP_Error( 'bigquery_proxy_http_error', 'HTTP 502' );
-		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), null, $this->donors_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( $wp_error ), null, $this->donors_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
@@ -1541,7 +1561,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * C11 malformed: proxy returns non-array first row → state 'error' (malformed).
 	 */
 	public function test_registered_to_donor_funnel_returns_error_on_malformed_rows() {
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), null, $this->donors_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ 'not-an-array' ] ), null, $this->donors_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 
@@ -1559,7 +1579,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			'uid'                  => 1,
 			'saw_donation_surface' => 1,
 		];
-		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, $this->donors_metric_returning_count( 0 ) );
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, $this->donors_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -1468,6 +1468,29 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( [], $result['stages'] );
 	}
 
+	/**
+	 * C10 schema drift (NEWS-2598): rows arrive without the hub-provided
+	 * `became_subscriber` key — e.g. a pre-NEWS-2598 hub that still emits the old
+	 * `{ uid, saw_subscription_surface }` shape. Because that flag is now the sole
+	 * source of step 3, treat the absent key as malformed rather than silently
+	 * reporting a populated funnel with 0 conversions (a plausible-but-false result).
+	 */
+	public function test_registered_to_subscriber_funnel_errors_on_missing_conversion_flag() {
+		$rows = [
+			[
+				'uid'                      => 1,
+				'saw_subscription_surface' => 1,
+			],
+		];
+		$metric          = new Conversion_Metric( $this->proxy_returning( $rows ), $this->subscribers_metric_configured() );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_registered_to_subscriber_funnel( $start, $end );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( [], $result['stages'] );
+	}
+
 	// --- C11: get_registered_to_donor_funnel --------------------------------
 
 	/**
@@ -1580,6 +1603,29 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 			'saw_donation_surface' => 1,
 		];
 		$metric          = new Conversion_Metric( $this->proxy_returning( [ $valid_row, 'not-an-array' ] ), null, $this->donors_metric_configured() );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
+
+		$this->assertSame( 'error', $result['state'] );
+		$this->assertSame( 'bigquery_proxy_malformed_rows', $result['error_code'] );
+		$this->assertSame( [], $result['stages'] );
+	}
+
+	/**
+	 * C11 schema drift (NEWS-2598): rows arrive without the hub-provided
+	 * `became_donor` key — e.g. a pre-NEWS-2598 hub still emitting the old
+	 * `{ uid, saw_donation_surface }` shape. Because that flag is now the sole
+	 * source of step 3, treat the absent key as malformed rather than silently
+	 * reporting a populated funnel with 0 conversions.
+	 */
+	public function test_registered_to_donor_funnel_errors_on_missing_conversion_flag() {
+		$rows = [
+			[
+				'uid'                  => 1,
+				'saw_donation_surface' => 1,
+			],
+		];
+		$metric          = new Conversion_Metric( $this->proxy_returning( $rows ), null, $this->donors_metric_configured() );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_registered_to_donor_funnel( $start, $end );
 


### PR DESCRIPTION
## What & why

On the Insights **Conversion Journey** tab, the **Registered → Subscriber** and
**Registered → Donor** funnels always reported **0** for step 3 ("Became subscriber" /
"Became donor") — on every site.

**Root cause:** step 3 collected the BigQuery `uid`s, cast them with `(int)`, and passed them
to a WooCommerce query as `customer_id`s. But `uid = COALESCE(user_id, user_pseudo_id)` is a
GA4 pseudo-id (e.g. `1578582642.1782819943`), never a WP user / Woo customer id, so the join
matched nothing.

## Change (consumer side)

`compute_registered_to_subscriber_funnel` / `compute_registered_to_donor_funnel` now sum the
per-uid `became_subscriber` / `became_donor` flag the hub emits (computed inside BigQuery —
see companion PR), instead of joining pseudo-ids against WooCommerce `customer_id`.

The pseudo-id-based Woo join is removed. Since nothing else called them, the now-dead storage
methods are deleted too:

- `Subscribers_Metric::count_active_non_donation_subscribers_by_customer_ids`
- `Donors_Metric::count_completed_donation_order_customers_by_customer_ids`
- their `Storage_Interface` / `Donors_Storage_Interface` declarations and all four HPOS/legacy
  implementations, plus the tests that covered them.

### ⚠️ Semantic change (product-approved)

Step 3 now means *"registered in window AND completed a purchase in window"* (event) rather
than *"registered in window AND holds an active subscription / completed donation now"*
(state). **Signed off by @katie.rethman.**

## Testing

- Populated funnel tests now carry `became_*` rows and assert step 3 = SUM(flag); mock helpers
  renamed to `*_configured()` (they only mark the leg configured now).
- Full `--group insights`: **665 tests / 2597 assertions OK**; PHPCS clean.
- PHP-only change; no `src/` touched, and the funnel output payload shape is unchanged (only
  step-3 computation moved hub-side), so no fixtures needed updating.

## Notes

- Depends on the hub emitting the `became_*` columns; ship together with the companion PR.
  A missing key degrades to 0 (today's behavior), so no hard break in either deploy order.

Resolves [NEWS-2598](https://linear.app/a8c/issue/NEWS-2598).

---
**Companion PR:** Automattic/newspack-manager-admin#484 (hub). Ship together.
