### PR TITLE
feat(newsletters): allow WC-native blocks when Woo renderer is on

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -547,11 +547,11 @@ final class Newspack_Newsletters_Editor {
 			 * Whether to allow the experimental audio/video blocks. They have no
 			 * inline playback in email — the WC engine renders them as static
 			 * fallbacks (audio: a "Listen" link; video: a play-poster link), so
-			 * they ship on by default but behind their own switch.
+			 * they ship off by default and can be opted into via this filter.
 			 *
 			 * @param bool $enabled Whether experimental blocks are allowed.
 			 */
-			if ( apply_filters( 'newspack_newsletters_wc_experimental_blocks', true ) ) {
+			if ( apply_filters( 'newspack_newsletters_wc_experimental_blocks', false ) ) {
 				$allowed_block_types[] = 'core/audio';
 				$allowed_block_types[] = 'core/video';
 			}

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php
@@ -528,6 +528,34 @@ final class Newspack_Newsletters_Editor {
 			'remote-data-blocks/foundation-movie',
 			'remote-data-blocks/foundation-movies',
 		);
+
+		// Blocks the WC email-editor engine can render but the legacy MJML
+		// renderer cannot. Only offer them when the WC engine is active, so a
+		// site still on MJML can't insert a block that renders empty at send.
+		if ( \Newspack\Newsletters\Email_Renderers\Feature_Flag::is_enabled() ) {
+			$allowed_block_types = array_merge(
+				$allowed_block_types,
+				array(
+					'core/table',
+					'core/gallery',
+					'core/media-text',
+					'core/cover',
+				)
+			);
+
+			/**
+			 * Whether to allow the experimental audio/video blocks. They have no
+			 * inline playback in email — the WC engine renders them as static
+			 * fallbacks (audio: a "Listen" link; video: a play-poster link), so
+			 * they ship on by default but behind their own switch.
+			 *
+			 * @param bool $enabled Whether experimental blocks are allowed.
+			 */
+			if ( apply_filters( 'newspack_newsletters_wc_experimental_blocks', true ) ) {
+				$allowed_block_types[] = 'core/audio';
+				$allowed_block_types[] = 'core/video';
+			}
+		}
 		/**
 		 * Filters the allowed block types for the Newsletter CPT.
 		 *

--- a/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
@@ -135,7 +135,7 @@ class Full_Bleed_Sections {
 					$run        = '';
 				}
 				$cover      = $xpath->query( $cover_query, $node )->item( 0 );
-				$segments[] = [ 'band', self::build_cover_band( $cover, $dom, $xpath ) ];
+				$segments[] = [ 'band', self::build_cover_band( $cover, $dom, $xpath, $root_padding ) ];
 				++$band_count;
 				if ( isset( $nodes[ $i + 1 ] ) && self::is_mso_close( $nodes[ $i + 1 ] ) ) {
 					++$i;
@@ -324,21 +324,47 @@ class Full_Bleed_Sections {
 	 *
 	 * The cover table already carries its background image at `width:100%`, so emitting
 	 * it at body level (outside the content-width wrapper) is enough to bleed it. Its
-	 * inner content is capped to the content width and re-centered so it lines up with
-	 * normal blocks rather than sprawling to the email edge.
+	 * inner content is then capped to the content width and re-centered so it lines up
+	 * with normal blocks: `border-box` + the same horizontal gutter (`root padding`)
+	 * `build_band()` uses, so the inner content column matches paragraphs/tables exactly
+	 * rather than overhanging by the gutter. Outlook ignores `max-width`, so the inner
+	 * container is also wrapped in an MSO ghost table pinned to the content width — the
+	 * same technique `build_band()` relies on.
 	 *
-	 * @param \DOMElement  $cover The alignfull cover table.
-	 * @param \DOMDocument $dom   Owner document (for serializing).
-	 * @param \DOMXPath    $xpath XPath over the document.
+	 * @param \DOMElement  $cover        The alignfull cover table.
+	 * @param \DOMDocument $dom          Owner document (for serializing).
+	 * @param \DOMXPath    $xpath        XPath over the document.
+	 * @param string       $root_padding Horizontal gutter to inset the inner content by.
 	 * @return string Full-width cover band HTML.
 	 */
-	private static function build_cover_band( \DOMElement $cover, \DOMDocument $dom, \DOMXPath $xpath ): string {
+	private static function build_cover_band( \DOMElement $cover, \DOMDocument $dom, \DOMXPath $xpath, string $root_padding ): string {
 		$inner = $xpath->query( ".//div[contains(concat(' ', normalize-space(@class), ' '), ' wp-block-cover__inner-container ')]", $cover )->item( 0 );
 		if ( $inner instanceof \DOMElement ) {
+			// border-box + gutter so the inner content width equals normal blocks
+			// (content-size cap includes the gutter). The later padding-left/right win
+			// over any left/right in the cover's own padding shorthand.
 			$style = rtrim( trim( $inner->getAttribute( 'style' ) ), ';' );
 			$style = ( '' === $style ? '' : $style . ';' )
-				. sprintf( 'max-width:%dpx;margin-left:auto;margin-right:auto;', self::CONTENT_WIDTH );
+				. sprintf(
+					'box-sizing:border-box;max-width:%1$dpx;margin-left:auto;margin-right:auto;padding-left:%2$s;padding-right:%2$s;',
+					self::CONTENT_WIDTH,
+					$root_padding
+				);
 			$inner->setAttribute( 'style', $style );
+
+			// Outlook/Word ignore max-width; pin the inner content to the content width
+			// with an MSO ghost table wrapped around the inner container.
+			$parent = $inner->parentNode; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
+			if ( $parent instanceof \DOMNode ) {
+				$open  = $dom->createComment( '[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" width="' . self::CONTENT_WIDTH . '" style="width:' . self::CONTENT_WIDTH . 'px"><tr><td><![endif]' );
+				$close = $dom->createComment( '[if mso | IE]></td></tr></table><![endif]' );
+				$parent->insertBefore( $open, $inner );
+				if ( $inner->nextSibling ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
+					$parent->insertBefore( $close, $inner->nextSibling ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
+				} else {
+					$parent->appendChild( $close );
+				}
+			}
 		}
 		return $dom->saveHTML( $cover );
 	}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-full-bleed-sections.php
@@ -55,8 +55,12 @@ class Full_Bleed_Sections {
 	 * @return string Transformed HTML, or the input unchanged when not applicable.
 	 */
 	public static function transform( string $html ): string {
-		// Fast bail: nothing to bleed without an alignfull background group.
-		if ( false === strpos( $html, 'alignfull' ) || false === strpos( $html, 'has-background' ) ) {
+		// Fast bail: nothing to bleed without an alignfull block. The bleeders are
+		// background groups (`has-background`) and cover blocks (`email-block-cover`).
+		if ( false === strpos( $html, 'alignfull' ) ) {
+			return $html;
+		}
+		if ( false === strpos( $html, 'has-background' ) && false === strpos( $html, 'email-block-cover' ) ) {
 			return $html;
 		}
 
@@ -87,6 +91,13 @@ class Full_Bleed_Sections {
 			. "contains(concat(' ', normalize-space(@class), ' '), ' alignfull ') and "
 			. "contains(concat(' ', normalize-space(@class), ' '), ' has-background ')]";
 
+		// A top-level alignfull cover renders as a bare `email-block-layout` wrapper whose
+		// own child is the cover table; it carries its background image at width:100%, so
+		// hoisting the table to body level lets that background bleed.
+		$cover_query = './table['
+			. "contains(concat(' ', normalize-space(@class), ' '), ' email-block-cover ') and "
+			. "contains(concat(' ', normalize-space(@class), ' '), ' alignfull ')]";
+
 		$root_padding = self::detect_root_padding( $xpath, $container );
 		$nodes        = iterator_to_array( $container->childNodes ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOM API property.
 		$node_count   = count( $nodes );
@@ -96,13 +107,14 @@ class Full_Bleed_Sections {
 		for ( $i = 0; $i < $node_count; $i++ ) {
 			$node = $nodes[ $i ];
 
-			// Drop a band's own per-block MSO ghost-table wrapper: build_band emits a fresh
-			// one, so skip the opening comment that immediately precedes a band element.
-			if ( self::is_mso_open( $node ) && isset( $nodes[ $i + 1 ] ) && self::is_band( $nodes[ $i + 1 ], $xpath, $band_query ) ) {
+			// Drop a hoisted section's own per-block MSO ghost-table wrapper (band or cover):
+			// each emits its own body-level markup, so skip the opening comment before it.
+			if ( self::is_mso_open( $node ) && isset( $nodes[ $i + 1 ] )
+				&& ( self::is_hoistable( $nodes[ $i + 1 ], $xpath, $band_query ) || self::is_hoistable( $nodes[ $i + 1 ], $xpath, $cover_query ) ) ) {
 				continue;
 			}
 
-			if ( self::is_band( $node, $xpath, $band_query ) ) {
+			if ( self::is_hoistable( $node, $xpath, $band_query ) ) {
 				if ( '' !== $run ) {
 					$segments[] = [ 'normal', $run ];
 					$run        = '';
@@ -111,6 +123,20 @@ class Full_Bleed_Sections {
 				$segments[] = [ 'band', self::build_band( $group, $dom, $xpath, $root_padding ) ];
 				++$band_count;
 				// Skip the band's closing ghost-table comment too.
+				if ( isset( $nodes[ $i + 1 ] ) && self::is_mso_close( $nodes[ $i + 1 ] ) ) {
+					++$i;
+				}
+				continue;
+			}
+
+			if ( self::is_hoistable( $node, $xpath, $cover_query ) ) {
+				if ( '' !== $run ) {
+					$segments[] = [ 'normal', $run ];
+					$run        = '';
+				}
+				$cover      = $xpath->query( $cover_query, $node )->item( 0 );
+				$segments[] = [ 'band', self::build_cover_band( $cover, $dom, $xpath ) ];
+				++$band_count;
 				if ( isset( $nodes[ $i + 1 ] ) && self::is_mso_close( $nodes[ $i + 1 ] ) ) {
 					++$i;
 				}
@@ -280,16 +306,41 @@ class Full_Bleed_Sections {
 	}
 
 	/**
-	 * Whether a node is a top-level band: an element directly wrapping an alignfull
-	 * background group table.
+	 * Whether a node is a top-level hoistable section: an element directly wrapping a
+	 * table matched by the given relative query (an alignfull background group, or an
+	 * alignfull cover).
 	 *
-	 * @param \DOMNode  $node       Node to test.
-	 * @param \DOMXPath $xpath      XPath over the document.
-	 * @param string    $band_query Relative XPath matching the band group table.
+	 * @param \DOMNode  $node  Node to test.
+	 * @param \DOMXPath $xpath XPath over the document.
+	 * @param string    $query Relative XPath matching the hoistable table.
 	 * @return bool
 	 */
-	private static function is_band( \DOMNode $node, \DOMXPath $xpath, string $band_query ): bool {
-		return $node instanceof \DOMElement && $xpath->query( $band_query, $node )->item( 0 ) instanceof \DOMElement;
+	private static function is_hoistable( \DOMNode $node, \DOMXPath $xpath, string $query ): bool {
+		return $node instanceof \DOMElement && $xpath->query( $query, $node )->item( 0 ) instanceof \DOMElement;
+	}
+
+	/**
+	 * Build a body-level full-width band from an alignfull cover.
+	 *
+	 * The cover table already carries its background image at `width:100%`, so emitting
+	 * it at body level (outside the content-width wrapper) is enough to bleed it. Its
+	 * inner content is capped to the content width and re-centered so it lines up with
+	 * normal blocks rather than sprawling to the email edge.
+	 *
+	 * @param \DOMElement  $cover The alignfull cover table.
+	 * @param \DOMDocument $dom   Owner document (for serializing).
+	 * @param \DOMXPath    $xpath XPath over the document.
+	 * @return string Full-width cover band HTML.
+	 */
+	private static function build_cover_band( \DOMElement $cover, \DOMDocument $dom, \DOMXPath $xpath ): string {
+		$inner = $xpath->query( ".//div[contains(concat(' ', normalize-space(@class), ' '), ' wp-block-cover__inner-container ')]", $cover )->item( 0 );
+		if ( $inner instanceof \DOMElement ) {
+			$style = rtrim( trim( $inner->getAttribute( 'style' ) ), ';' );
+			$style = ( '' === $style ? '' : $style . ';' )
+				. sprintf( 'max-width:%dpx;margin-left:auto;margin-right:auto;', self::CONTENT_WIDTH );
+			$inner->setAttribute( 'style', $style );
+		}
+		return $dom->saveHTML( $cover );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/src/editor/index.js
+++ b/plugins/newspack-newsletters/src/editor/index.js
@@ -69,12 +69,13 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 	 * wider-than-content alignments (wide/full) rather than offer options that
 	 * render at content width anyway. */
 	if ( [ 'core/table', 'core/gallery', 'core/media-text', 'core/audio', 'core/video' ].includes( name ) ) {
-		const current =
-			true === settings.supports?.align
-				? [ 'left', 'center', 'right', 'wide', 'full' ]
-				: Array.isArray( settings.supports?.align )
-				? settings.supports.align
-				: [];
+		const align = settings.supports?.align;
+		let current = [];
+		if ( true === align ) {
+			current = [ 'left', 'center', 'right', 'wide', 'full' ];
+		} else if ( Array.isArray( align ) ) {
+			current = align;
+		}
 		settings.supports = {
 			...settings.supports,
 			align: current.filter( alignment => 'wide' !== alignment && 'full' !== alignment ),

--- a/plugins/newspack-newsletters/src/editor/index.js
+++ b/plugins/newspack-newsletters/src/editor/index.js
@@ -70,16 +70,21 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 	 * render at content width anyway. */
 	if ( [ 'core/table', 'core/gallery', 'core/media-text', 'core/audio', 'core/video' ].includes( name ) ) {
 		const align = settings.supports?.align;
-		let current = [];
+		let current;
 		if ( true === align ) {
 			current = [ 'left', 'center', 'right', 'wide', 'full' ];
 		} else if ( Array.isArray( align ) ) {
 			current = align;
 		}
-		settings.supports = {
-			...settings.supports,
-			align: current.filter( alignment => 'wide' !== alignment && 'full' !== alignment ),
-		};
+		// Only rewrite blocks that already opt into alignment support; writing
+		// `align: []` to a block with no align support would opt it in with zero
+		// options rather than leave it untouched.
+		if ( current ) {
+			settings.supports = {
+				...settings.supports,
+				align: current.filter( alignment => 'wide' !== alignment && 'full' !== alignment ),
+			};
+		}
 	}
 
 	/* This bundle is only enqueued in the email editor (see

--- a/plugins/newspack-newsletters/src/editor/index.js
+++ b/plugins/newspack-newsletters/src/editor/index.js
@@ -60,8 +60,25 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 	if ( 'core/paragraph' === name || 'core/columns' === name || 'core/separator' === name ) {
 		settings.supports = { ...settings.supports, align: [] };
 	}
-	if ( 'core/group' === name ) {
+	/* Group and cover are the only blocks whose alignfull bleeds full-width in the
+	 * email render (see Full_Bleed_Sections), so they keep the full-width option. */
+	if ( 'core/group' === name || 'core/cover' === name ) {
 		settings.supports = { ...settings.supports, align: [ 'full' ] };
+	}
+	/* The remaining WC-native blocks have no full-bleed support, so drop the
+	 * wider-than-content alignments (wide/full) rather than offer options that
+	 * render at content width anyway. */
+	if ( [ 'core/table', 'core/gallery', 'core/media-text', 'core/audio', 'core/video' ].includes( name ) ) {
+		const current =
+			true === settings.supports?.align
+				? [ 'left', 'center', 'right', 'wide', 'full' ]
+				: Array.isArray( settings.supports?.align )
+				? settings.supports.align
+				: [];
+		settings.supports = {
+			...settings.supports,
+			align: current.filter( alignment => 'wide' !== alignment && 'full' !== alignment ),
+		};
 	}
 
 	/* This bundle is only enqueued in the email editor (see

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -188,6 +188,29 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Count `email-block-cover` tables that sit at body level — i.e. outside the
+	 * content-width `email_layout_wrapper` — the signature of a bled full-width cover.
+	 *
+	 * @param string $html Email HTML.
+	 * @return int Number of body-level cover tables.
+	 */
+	private function count_body_level_covers( $html ) {
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING );
+		libxml_clear_errors();
+		$xpath  = new DOMXPath( $dom );
+		$covers = $xpath->query( "//table[contains(concat(' ', normalize-space(@class), ' '), ' email-block-cover ')]" );
+		$count  = 0;
+		foreach ( $covers as $cover ) {
+			if ( 0 === $xpath->query( "ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' email_layout_wrapper ')]", $cover )->length ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	/**
 	 * A top-level alignfull group with a background bleeds to a body-level full-width
 	 * band, while its content survives (NEWS-1901 default-layout full-bleed).
 	 */
@@ -234,6 +257,50 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $this->count_body_level_bands( $html ) );
 		$this->assertStringContainsString( 'Just a paragraph', $html );
+	}
+
+	/**
+	 * A top-level alignfull cover bleeds to a body-level full-width section (its
+	 * background image spans the email), while its content survives.
+	 */
+	public function test_render_wc_bleeds_alignfull_cover() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:paragraph --><p>Intro</p><!-- /wp:paragraph -->'
+			. '<!-- wp:cover {"url":"https://example.com/bg.jpg","align":"full","minHeight":240} -->'
+			. '<div class="wp-block-cover alignfull" style="min-height:240px">'
+			. '<span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span>'
+			. '<img class="wp-block-cover__image-background" src="https://example.com/bg.jpg" data-object-fit="cover"/>'
+			. '<div class="wp-block-cover__inner-container">'
+			. '<!-- wp:heading {"textAlign":"center"} --><h2 class="wp-block-heading has-text-align-center">Hero heading</h2><!-- /wp:heading -->'
+			. '</div></div>'
+			. '<!-- /wp:cover -->'
+			. '<!-- wp:paragraph --><p>Outro</p><!-- /wp:paragraph -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 1, $this->count_body_level_covers( $html ), 'An alignfull cover must bleed to a body-level full-width section.' );
+		$this->assertStringContainsString( 'Hero heading', $html, 'Cover content must survive the transform.' );
+		$this->assertStringContainsString( 'Intro', $html, 'Surrounding content must survive.' );
+		$this->assertStringContainsString( 'Outro', $html );
+	}
+
+	/**
+	 * A cover without full alignment stays inside the content-width wrapper — only
+	 * alignfull covers bleed.
+	 */
+	public function test_render_wc_does_not_bleed_default_cover() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:cover {"url":"https://example.com/bg.jpg","minHeight":240} -->'
+			. '<div class="wp-block-cover" style="min-height:240px">'
+			. '<span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span>'
+			. '<img class="wp-block-cover__image-background" src="https://example.com/bg.jpg"/>'
+			. '<div class="wp-block-cover__inner-container"><!-- wp:paragraph --><p>Constrained cover</p><!-- /wp:paragraph --></div></div>'
+			. '<!-- /wp:cover -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 0, $this->count_body_level_covers( $html ), 'A non-aligned cover must stay inside the content-width wrapper.' );
+		$this->assertStringContainsString( 'Constrained cover', $html );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-renderer-controller.php
@@ -195,10 +195,11 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 	 * @return int Number of body-level cover tables.
 	 */
 	private function count_body_level_covers( $html ) {
-		$dom = new DOMDocument();
-		libxml_use_internal_errors( true );
+		$dom  = new DOMDocument();
+		$prev = libxml_use_internal_errors( true );
 		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING );
 		libxml_clear_errors();
+		libxml_use_internal_errors( $prev );
 		$xpath  = new DOMXPath( $dom );
 		$covers = $xpath->query( "//table[contains(concat(' ', normalize-space(@class), ' '), ' email-block-cover ')]" );
 		$count  = 0;
@@ -208,6 +209,28 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 			}
 		}
 		return $count;
+	}
+
+	/**
+	 * Read the inline style of the inner container inside a body-level (bled) cover,
+	 * so tests can assert its content is capped to the content width.
+	 *
+	 * @param string $html Email HTML.
+	 * @return string The inner-container style, or '' if no body-level cover.
+	 */
+	private function bled_cover_inner_style( $html ) {
+		$dom  = new DOMDocument();
+		$prev = libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $prev );
+		$xpath = new DOMXPath( $dom );
+		$inner = $xpath->query(
+			"//table[contains(concat(' ', normalize-space(@class), ' '), ' email-block-cover ')]"
+			. "[not(ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' email_layout_wrapper ')])]"
+			. "//div[contains(concat(' ', normalize-space(@class), ' '), ' wp-block-cover__inner-container ')]"
+		)->item( 0 );
+		return $inner instanceof DOMElement ? $inner->getAttribute( 'style' ) : '';
 	}
 
 	/**
@@ -282,6 +305,36 @@ class Test_Renderer_Controller extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Hero heading', $html, 'Cover content must survive the transform.' );
 		$this->assertStringContainsString( 'Intro', $html, 'Surrounding content must survive.' );
 		$this->assertStringContainsString( 'Outro', $html );
+
+		// The bled cover's content must be capped to the content width with the same
+		// border-box + gutter as normal blocks, so the overlay text lines up with them.
+		$inner_style = $this->bled_cover_inner_style( $html );
+		$this->assertStringContainsString( 'box-sizing:border-box', $inner_style, 'Bled cover content must use border-box so its width matches normal blocks.' );
+		$this->assertStringContainsString( 'max-width:' . \Newspack\Newsletters\Email_Renderers\Full_Bleed_Sections::CONTENT_WIDTH . 'px', $inner_style, 'Bled cover content must cap at the content width.' );
+		$this->assertMatchesRegularExpression( '/padding-left:\s*\d+px/', $inner_style, 'Bled cover content must carry the horizontal gutter.' );
+		// Outlook ignores max-width, so the inner content is pinned via an MSO ghost table.
+		$this->assertStringContainsString( 'width="' . \Newspack\Newsletters\Email_Renderers\Full_Bleed_Sections::CONTENT_WIDTH . '"', $html, 'Bled cover must pin its inner content for Outlook via an MSO ghost table.' );
+	}
+
+	/**
+	 * A cover nested inside another block (Group/Columns) must NOT be hoisted — only
+	 * top-level covers bleed. Mirrors the nested-background-group guard.
+	 */
+	public function test_render_wc_does_not_bleed_nested_cover() {
+		\Newspack\Newsletters\Email_Renderers\Editor_Bootstrap::init();
+		$content = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:cover {"url":"https://example.com/bg.jpg","align":"full","minHeight":200} -->'
+			. '<div class="wp-block-cover alignfull" style="min-height:200px">'
+			. '<span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span>'
+			. '<img class="wp-block-cover__image-background" src="https://example.com/bg.jpg"/>'
+			. '<div class="wp-block-cover__inner-container"><!-- wp:paragraph --><p>Nested cover</p><!-- /wp:paragraph --></div></div>'
+			. '<!-- /wp:cover -->'
+			. '</div><!-- /wp:group -->';
+
+		$html = Renderer_Controller::render_wc( get_post( $this->create_newsletter( $content ) ) );
+
+		$this->assertSame( 0, $this->count_body_level_covers( $html ), 'A cover nested inside a group must not be hoisted wholesale.' );
+		$this->assertStringContainsString( 'Nested cover', $html );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-native-editor.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-native-editor.php
@@ -182,6 +182,87 @@ class Test_Theme_Native_Editor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Call newsletters_allowed_block_types() with the global $post primed to a
+	 * newsletter so is_editing_email() resolves true.
+	 *
+	 * @param \WP_Post $newsletter Newsletter post.
+	 * @return array The resolved allow-list.
+	 */
+	private function resolve_allowed_blocks( \WP_Post $newsletter ): array {
+		global $post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post = $newsletter;
+		setup_postdata( $newsletter );
+		$result = \Newspack_Newsletters_Editor::newsletters_allowed_block_types( true, $newsletter );
+		wp_reset_postdata();
+		return (array) $result;
+	}
+
+	/**
+	 * The WC engine can render table/gallery/media-text/cover, so they join the
+	 * allow-list when the WC renderer flag is on.
+	 */
+	public function test_allowed_block_types_adds_wc_native_blocks_when_flag_on() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
+
+		foreach ( [ 'core/table', 'core/gallery', 'core/media-text', 'core/cover' ] as $block ) {
+			$this->assertContains(
+				$block,
+				$result,
+				"WC-native block '$block' must be allowed when the WC renderer flag is on."
+			);
+		}
+	}
+
+	/**
+	 * The legacy MJML renderer cannot render these blocks, so they must be absent
+	 * from the allow-list when the WC renderer flag is off.
+	 */
+	public function test_allowed_block_types_excludes_wc_native_blocks_when_flag_off() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
+
+		foreach ( [ 'core/table', 'core/gallery', 'core/media-text', 'core/cover', 'core/audio', 'core/video' ] as $block ) {
+			$this->assertNotContains(
+				$block,
+				$result,
+				"Block '$block' must not be allowed under the legacy MJML renderer."
+			);
+		}
+	}
+
+	/**
+	 * Audio and video render as static link/poster fallbacks in email (no inline
+	 * playback), so they ship as a labeled experiment — on by default when the WC
+	 * flag is on.
+	 */
+	public function test_allowed_block_types_includes_experimental_media_when_flag_on() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
+
+		$this->assertContains( 'core/audio', $result, 'Experimental audio block should be allowed by default with the WC flag on.' );
+		$this->assertContains( 'core/video', $result, 'Experimental video block should be allowed by default with the WC flag on.' );
+	}
+
+	/**
+	 * The experimental audio/video blocks can be turned off independently via the
+	 * newspack_newsletters_wc_experimental_blocks filter without affecting the
+	 * solid WC-native blocks.
+	 */
+	public function test_experimental_blocks_filter_disables_audio_video_only() {
+		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
+		add_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_false' );
+
+		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
+
+		remove_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_false' );
+
+		$this->assertNotContains( 'core/audio', $result, 'Audio must drop out when experimental blocks are filtered off.' );
+		$this->assertNotContains( 'core/video', $result, 'Video must drop out when experimental blocks are filtered off.' );
+		$this->assertContains( 'core/table', $result, 'Solid WC-native blocks must remain when only experimental blocks are filtered off.' );
+	}
+
+	/**
 	 * Passes the incoming value through unchanged for non-newsletter
 	 * posts, leaving standard post editors access to all registered blocks.
 	 */

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-native-editor.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-native-editor.php
@@ -233,33 +233,32 @@ class Test_Theme_Native_Editor extends WP_UnitTestCase {
 
 	/**
 	 * Audio and video render as static link/poster fallbacks in email (no inline
-	 * playback), so they ship as a labeled experiment — on by default when the WC
-	 * flag is on.
+	 * playback), so they ship as a labeled experiment — off by default, even with
+	 * the WC flag on.
 	 */
-	public function test_allowed_block_types_includes_experimental_media_when_flag_on() {
+	public function test_allowed_block_types_excludes_experimental_media_by_default() {
 		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
 		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
 
-		$this->assertContains( 'core/audio', $result, 'Experimental audio block should be allowed by default with the WC flag on.' );
-		$this->assertContains( 'core/video', $result, 'Experimental video block should be allowed by default with the WC flag on.' );
+		$this->assertNotContains( 'core/audio', $result, 'Experimental audio block must be off by default.' );
+		$this->assertNotContains( 'core/video', $result, 'Experimental video block must be off by default.' );
+		$this->assertContains( 'core/table', $result, 'Solid WC-native blocks must still be allowed by default.' );
 	}
 
 	/**
-	 * The experimental audio/video blocks can be turned off independently via the
-	 * newspack_newsletters_wc_experimental_blocks filter without affecting the
-	 * solid WC-native blocks.
+	 * The experimental audio/video blocks can be opted into via the
+	 * newspack_newsletters_wc_experimental_blocks filter.
 	 */
-	public function test_experimental_blocks_filter_disables_audio_video_only() {
+	public function test_experimental_blocks_filter_enables_audio_video() {
 		add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
-		add_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_false' );
+		add_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_true' );
 
 		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
 
-		remove_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_false' );
+		remove_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_true' );
 
-		$this->assertNotContains( 'core/audio', $result, 'Audio must drop out when experimental blocks are filtered off.' );
-		$this->assertNotContains( 'core/video', $result, 'Video must drop out when experimental blocks are filtered off.' );
-		$this->assertContains( 'core/table', $result, 'Solid WC-native blocks must remain when only experimental blocks are filtered off.' );
+		$this->assertContains( 'core/audio', $result, 'Audio must be allowed when experimental blocks are enabled.' );
+		$this->assertContains( 'core/video', $result, 'Video must be allowed when experimental blocks are enabled.' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/email-renderers/test-theme-native-editor.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-theme-native-editor.php
@@ -190,10 +190,14 @@ class Test_Theme_Native_Editor extends WP_UnitTestCase {
 	 */
 	private function resolve_allowed_blocks( \WP_Post $newsletter ): array {
 		global $post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$post = $newsletter;
+		$previous_post = $post;
+		$post          = $newsletter;
 		setup_postdata( $newsletter );
 		$result = \Newspack_Newsletters_Editor::newsletters_allowed_block_types( true, $newsletter );
 		wp_reset_postdata();
+		// Restore the prior global $post — wp_reset_postdata() alone can leave it
+		// mutated (backupGlobals is off), making tests order-dependent.
+		$post = $previous_post;
 		return (array) $result;
 	}
 
@@ -255,8 +259,7 @@ class Test_Theme_Native_Editor extends WP_UnitTestCase {
 
 		$result = $this->resolve_allowed_blocks( $this->create_newsletter_post() );
 
-		remove_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_true' );
-
+		// Both filters are removed in tear_down().
 		$this->assertContains( 'core/audio', $result, 'Audio must be allowed when experimental blocks are enabled.' );
 		$this->assertContains( 'core/video', $result, 'Video must be allowed when experimental blocks are enabled.' );
 	}
@@ -313,8 +316,12 @@ class Test_Theme_Native_Editor extends WP_UnitTestCase {
 	public function tear_down() {
 		// Remove only the flag callbacks these tests add — not every callback on the
 		// hook — so we don't strip production/other-test filters (order-independence).
+		// Cleaning up here (rather than inline) guarantees removal even if a test
+		// assertion fails or an exception is thrown mid-test.
 		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' );
 		remove_filter( 'newspack_newsletters_use_woo_renderer', '__return_false' );
+		remove_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_true' );
+		remove_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_false' );
 
 		if ( null === $this->strip_globals_backup['pagenow'] ) {
 			unset( $GLOBALS['pagenow'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Opens up the email-safe blocks the WC email-editor engine already renders, and makes their full-width alignment behave correctly in email.** The WooCommerce email-editor package ships renderers for a superset of the newsletter allow-list; this lets editors reach them, and cleans up how alignment behaves for the ones that can't bleed.

* **New blocks when the Woo renderer is on** — `core/table`, `core/gallery`, `core/media-text`, and `core/cover` join the allow-list. All four render to email-correct output straight from the package, so no Newspack block-renderer overrides were needed.
* **Audio/video as an opt-in experiment** — `core/audio` and `core/video` sit behind a new `newspack_newsletters_wc_experimental_blocks` filter that is **off by default**. They have no inline playback in email, so the package renders them as static fallbacks (audio → a "Listen" link, video → a poster + play overlay). Opt in with `add_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_true' )`.
* **Full-width cover** — a top-level `align:full` cover now bleeds edge-to-edge (background image spans the full email; heading/text stay centered at content width), extending the same `Full_Bleed_Sections` treatment that background groups already get.
* **Alignment cleanup** — the full-width (and wide) option is removed from `table`/`gallery`/`media-text`/`audio`/`video`, which have no full-bleed rendering. Only `group` and `cover` — the blocks that actually bleed — keep the full-width option.
* **Gated on the WC engine** — everything above is gated on `Feature_Flag::is_enabled()`. The legacy MJML renderer can't render any of these blocks, so an MJML site never sees a block that would render empty at send. Nothing changes for MJML sites.

Related tracking: NEWS-1904 (per-block audit under NEWS-1901).

### How to test the changes in this Pull Request:

**Setup**
1. Enable the WC renderer: `wp option update newspack_newsletters_use_woo_renderer 1` (or `add_filter( 'newspack_newsletters_use_woo_renderer', '__return_true' )`).

**New blocks + alignment**
2. Create a newsletter and open the inserter. Confirm **Table**, **Gallery**, **Media & Text**, and **Cover** are insertable; **Audio** and **Video** are NOT (off by default).
3. Insert each and use **Preview email** — confirm table (borders/caption), gallery (grid), media-text (side-by-side), and cover (background + overlay text) all render.
4. Select a Table (or gallery/media-text): its alignment toolbar offers only None/Left/Center/Right — no Wide/Full. Select the Cover: it offers None/Full width.
5. Set the Cover to **Full width**, add surrounding paragraphs, and Preview email — the cover's background bleeds edge-to-edge while its text and the other blocks stay at content width.

**Experimental opt-in**
6. Add `add_filter( 'newspack_newsletters_wc_experimental_blocks', '__return_true' )`. Confirm Audio and Video now appear in the inserter and render as static fallbacks in the email.

**Regression (WC renderer off — the default)**
7. Turn the flag off. Confirm none of the new blocks appear, and existing newsletters render through MJML exactly as before (including alignfull background groups still bleeding).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

---

## For AI

- **Allow-list gate:** `Newspack_Newsletters_Editor::newsletters_allowed_block_types()` merges the four solid blocks (and, behind the `newspack_newsletters_wc_experimental_blocks` filter, audio/video) only inside `if ( \Newspack\Newsletters\Email_Renderers\Feature_Flag::is_enabled() )`.
- **No block-renderer overrides:** the package renderers under `vendor/woocommerce/email-editor/.../Renderer/Blocks/` are email-correct for all six against the vanilla-WP reference model, so nothing was added under `includes/email-renderers/blocks/`.
- **Cover full-bleed** (`includes/email-renderers/class-full-bleed-sections.php`): the fast-bail was widened to recognize `email-block-cover` (covers carry no `has-background`); `is_band()` was generalized to `is_hoistable()`; and a new `build_cover_band()` hoists the cover's own `width:100%` table to body level and caps its `wp-block-cover__inner-container` to `CONTENT_WIDTH`. This reuses the package's cover rendering rather than rebuilding it. Group bleed is unchanged and still covered by the existing tests.
- **Alignment restriction** (`src/editor/index.js`): the existing `blocks.registerBlockType` filter now adds `core/cover` to the `align: ['full']` set and strips `wide`/`full` from `table`/`gallery`/`media-text`/`audio`/`video`.
- **Known quirk (video):** the package's video renderer links the play-poster to the newsletter post permalink rather than the video `src`. Acceptable while video is an opt-in experiment; a self-registering override in `includes/email-renderers/blocks/` could re-point it if video is promoted.
- **Tests:** `tests/email-renderers/test-theme-native-editor.php` (allow-list + experimental gating) and `tests/email-renderers/test-renderer-controller.php` (cover-bleeds / default-cover-doesn't, alongside the existing group-bleed cases).
