### PR TITLE
feat(insights): per-tab next-steps help links (NPPD-1842)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -492,7 +492,10 @@ class Insights_Wizard extends Wizard {
 	 * @return array<string, array<int, array{label: string, url: string}>> Map of tab key => ordered list of { label, url }.
 	 */
 	protected static function get_next_steps_links() {
-		$base = 'https://help.newspack.com/playbooks/';
+		// TEMPORARY: the Playbooks pages currently live only on the STAGING help
+		// site. Flip this base to https://help.newspack.com/playbooks/ once they
+		// are published to production help (NPPD-1843/1844/1845).
+		$base = 'https://help.newspackstaging.com/playbooks/';
 
 		$grow_newsletter_signups = [
 			'label' => __( 'Grow newsletter signups', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -468,7 +468,64 @@ class Insights_Wizard extends Wizard {
 			// the client explicitly here.
 			'feedbackBeaconUrl'   => rest_url( 'newspack-insights/v1/feedback' ),
 			'feedbackBeaconNonce' => wp_create_nonce( 'wp_rest' ),
+			// Per-tab "next steps" links (NPPD-1842) — outcome-worded entry points
+			// to the matching help-site Playbooks flow, rendered as a strip in the
+			// tab footer. Product-owned mapping; see get_next_steps_links().
+			'nextStepsLinks'      => self::get_next_steps_links(),
 		];
+	}
+
+	/**
+	 * Per-tab "next steps" links (NPPD-1842).
+	 *
+	 * The in-product half of NPPD-1723: a static, outcome-framed strip pinned
+	 * below the metrics on each relevant tab, linking to the matching help-site
+	 * "Playbooks" goal flow. The whole bet is the copy — a link is worded as the
+	 * outcome ("Grow reader revenue"), never a generic "Help" or "Learn more".
+	 *
+	 * Product-owned mapping, held to 1–2 links per tab. A tab only gets a link
+	 * when the outcome squarely matches it, so tabs with no strong match (Gates,
+	 * Campaigns, Advertising in v1) are intentionally absent and render no strip.
+	 * The whole map is filterable so the mapping and copy can be tuned without a
+	 * code change.
+	 *
+	 * @return array<string, array<int, array{label: string, url: string}>> Map of tab key => ordered list of { label, url }.
+	 */
+	protected static function get_next_steps_links() {
+		$base = 'https://help.newspack.com/playbooks/';
+
+		$grow_newsletter_signups = [
+			'label' => __( 'Grow newsletter signups', 'newspack-plugin' ),
+			'url'   => $base . 'grow-newsletter-signups/',
+		];
+		$grow_reader_revenue = [
+			'label' => __( 'Grow reader revenue', 'newspack-plugin' ),
+			'url'   => $base . 'grow-reader-revenue/',
+		];
+		$recover_lapsed_donors = [
+			'label' => __( 'Recover lapsed donors', 'newspack-plugin' ),
+			'url'   => $base . 'recover-lapsed-donors/',
+		];
+
+		$links = [
+			'audience'    => [ $grow_newsletter_signups ],
+			'engagement'  => [ $grow_newsletter_signups ],
+			'conversion'  => [ $grow_newsletter_signups, $grow_reader_revenue ],
+			'subscribers' => [ $grow_reader_revenue ],
+			'donors'      => [ $grow_reader_revenue, $recover_lapsed_donors ],
+		];
+
+		/**
+		 * Filters the per-tab Insights "next steps" links (NPPD-1842).
+		 *
+		 * Keys are Insights tab slugs (audience, engagement, conversion, gates,
+		 * prompts, subscribers, donors, advertising); each value is an ordered
+		 * list of `[ 'label' => string, 'url' => string ]`. Return an empty list
+		 * (or omit the key) to hide the strip on that tab.
+		 *
+		 * @param array<string, array<int, array{label: string, url: string}>> $links Map of tab key => list of { label, url }.
+		 */
+		return apply_filters( 'newspack_insights_next_steps_links', $links );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -525,7 +525,35 @@ class Insights_Wizard extends Wizard {
 		 *
 		 * @param array<string, array<int, array{label: string, url: string}>> $links Map of tab key => list of { label, url }.
 		 */
-		return apply_filters( 'newspack_insights_next_steps_links', $links );
+		$filtered = apply_filters( 'newspack_insights_next_steps_links', $links );
+
+		// Harden: the filtered value is fed to the client and rendered into an
+		// href, so a malformed or malicious filter must not reach React. Keep only
+		// well-formed entries with a safe http(s) URL — esc_url_raw() strips
+		// disallowed schemes (e.g. javascript:), returning '' for them.
+		$sanitized = [];
+		if ( is_array( $filtered ) ) {
+			foreach ( $filtered as $tab => $tab_links ) {
+				if ( ! is_array( $tab_links ) ) {
+					continue;
+				}
+				foreach ( $tab_links as $link ) {
+					if ( ! is_array( $link ) || empty( $link['label'] ) || empty( $link['url'] ) ) {
+						continue;
+					}
+					$url = esc_url_raw( (string) $link['url'], [ 'http', 'https' ] );
+					if ( '' === $url ) {
+						continue;
+					}
+					$sanitized[ $tab ][] = [
+						'label' => (string) $link['label'],
+						'url'   => $url,
+					];
+				}
+			}
+		}
+
+		return $sanitized;
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -30,6 +30,7 @@ import DateRangePicker from './DateRangePicker';
 import CooldownNotice from './CooldownNotice';
 import PrintDocumentMeta from './PrintDocumentMeta';
 import TabFeedback from './TabFeedback';
+import NextSteps from './NextSteps';
 import FeedbackShipCallback from './FeedbackShipCallback';
 import TabSpinner from '../tabs/components/TabSpinner';
 import useComparisonMode from '../state/useComparisonMode';
@@ -41,6 +42,14 @@ export type TabKey = 'audience' | 'engagement' | 'conversion' | 'gates' | 'promp
 export interface TabDef {
 	key: TabKey;
 	label: string;
+}
+
+/** A single outcome-worded "next steps" link (NPPD-1842). */
+export interface NextStepLink {
+	/** Outcome-worded label, e.g. "Grow reader revenue" — never a generic "Help". */
+	label: string;
+	/** Absolute help-site URL. */
+	url: string;
 }
 
 export const ALL_TABS: TabDef[] = [
@@ -71,6 +80,14 @@ export interface InsightsBootConfig {
 	feedbackBeaconUrl: string;
 	/** `wp_rest` nonce for the abandon beacon (rides as a `_wpnonce` query param). */
 	feedbackBeaconNonce: string;
+	/**
+	 * Per-tab outcome-worded "next steps" links, rendered as a strip in the tab
+	 * footer below the metrics (NPPD-1842). Product-owned mapping supplied by
+	 * `get_next_steps_links()` in class-insights-wizard.php. Tabs with no strong
+	 * outcome match (Gates, Campaigns, Advertising in v1) are simply absent from
+	 * the map and render no strip. Optional so config fixtures need not set it.
+	 */
+	nextStepsLinks?: Partial< Record< TabKey, NextStepLink[] > >;
 }
 
 export interface InsightsWizardProps {
@@ -173,6 +190,7 @@ interface TabSectionRenderProps extends TabSectionProps {
 	tabKey: TabKey;
 	tabLabel: string;
 	publisherName: string;
+	nextStepsLinks: NextStepLink[];
 	feedbackBeaconUrl: string;
 	feedbackBeaconNonce: string;
 }
@@ -188,7 +206,16 @@ interface TabSectionRenderProps extends TabSectionProps {
  * `context` — even when a tab chunk fails to load (feedback about a broken tab
  * is still signal).
  */
-const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange, feedbackBeaconUrl, feedbackBeaconNonce }: TabSectionRenderProps ) => (
+const TabSection = ( {
+	tabKey,
+	tabLabel,
+	publisherName,
+	range,
+	previousRange,
+	nextStepsLinks,
+	feedbackBeaconUrl,
+	feedbackBeaconNonce,
+}: TabSectionRenderProps ) => (
 	<>
 		<PrintDocumentMeta tabLabel={ tabLabel } publisherName={ publisherName } range={ range } previousRange={ previousRange } />
 		<CooldownNotice tab={ tabKey } range={ range } previousRange={ previousRange } />
@@ -197,6 +224,7 @@ const TabSection = ( { tabKey, tabLabel, publisherName, range, previousRange, fe
 			<Suspense fallback={ <Fallback /> }>{ renderTabComponent( tabKey, { range, previousRange } ) }</Suspense>
 		</TabErrorBoundary>
 		<footer className="newspack-insights__tab-footer">
+			<NextSteps links={ nextStepsLinks } />
 			<TabFeedback context={ tabKey } beaconUrl={ feedbackBeaconUrl } beaconNonce={ feedbackBeaconNonce } />
 		</footer>
 	</>
@@ -267,6 +295,7 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 			range,
 			previousRange,
 			publisherName: config.publisherName,
+			nextStepsLinks: config.nextStepsLinks?.[ t.key ] ?? [],
 			feedbackBeaconUrl: config.feedbackBeaconUrl,
 			feedbackBeaconNonce: config.feedbackBeaconNonce,
 		},

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -220,11 +220,11 @@ const TabSection = ( {
 		<PrintDocumentMeta tabLabel={ tabLabel } publisherName={ publisherName } range={ range } previousRange={ previousRange } />
 		<CooldownNotice tab={ tabKey } range={ range } previousRange={ previousRange } />
 		<FeedbackShipCallback context={ tabKey } />
+		<NextSteps links={ nextStepsLinks } />
 		<TabErrorBoundary key={ tabKey }>
 			<Suspense fallback={ <Fallback /> }>{ renderTabComponent( tabKey, { range, previousRange } ) }</Suspense>
 		</TabErrorBoundary>
 		<footer className="newspack-insights__tab-footer">
-			<NextSteps links={ nextStepsLinks } />
 			<TabFeedback context={ tabKey } beaconUrl={ feedbackBeaconUrl } beaconNonce={ feedbackBeaconNonce } />
 		</footer>
 	</>

--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Tests for the NextSteps strip (NPPD-1842).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import NextSteps from './NextSteps';
+import type { NextStepLink } from './InsightsWizard';
+
+const links: NextStepLink[] = [
+	{ label: 'Grow reader revenue', url: 'https://help.newspack.com/playbooks/grow-reader-revenue/' },
+	{ label: 'Recover lapsed donors', url: 'https://help.newspack.com/playbooks/recover-lapsed-donors/' },
+];
+
+describe( 'NextSteps', () => {
+	it( 'renders nothing when there are no links', () => {
+		const { container } = render( <NextSteps links={ [] } /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'renders each link with its outcome label and href, opening in a new tab', () => {
+		render( <NextSteps links={ links } /> );
+
+		const revenue = screen.getByRole( 'link', { name: 'Grow reader revenue' } );
+		expect( revenue ).toHaveAttribute( 'href', 'https://help.newspack.com/playbooks/grow-reader-revenue/' );
+		expect( revenue ).toHaveAttribute( 'target', '_blank' );
+		expect( revenue ).toHaveAttribute( 'rel', 'noreferrer' );
+
+		expect( screen.getByRole( 'link', { name: 'Recover lapsed donors' } ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'link' ) ).toHaveLength( 2 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.test.tsx
@@ -35,4 +35,25 @@ describe( 'NextSteps', () => {
 		expect( screen.getByRole( 'link', { name: 'Recover lapsed donors' } ) ).toBeInTheDocument();
 		expect( screen.getAllByRole( 'link' ) ).toHaveLength( 2 );
 	} );
+
+	it( 'drops links with an unsafe (non-http(s)) URL', () => {
+		const { container } = render(
+			<NextSteps
+				links={ [
+					// eslint-disable-next-line no-script-url
+					{ label: 'Bad', url: 'javascript:alert(1)' },
+					{ label: 'Grow reader revenue', url: 'https://help.newspack.com/playbooks/grow-reader-revenue/' },
+				] }
+			/>
+		);
+		expect( screen.getAllByRole( 'link' ) ).toHaveLength( 1 );
+		expect( screen.getByRole( 'link', { name: 'Grow reader revenue' } ) ).toBeInTheDocument();
+		expect( container.textContent ).not.toContain( 'Bad' );
+	} );
+
+	it( 'renders nothing when every link is unsafe', () => {
+		// eslint-disable-next-line no-script-url
+		const { container } = render( <NextSteps links={ [ { label: 'Bad', url: 'javascript:alert(1)' } ] } /> );
+		expect( container.firstChild ).toBeNull();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
@@ -25,15 +25,25 @@ export interface NextStepsProps {
 	links: NextStepLink[];
 }
 
+/**
+ * Defense in depth: the links originate from a PHP filter
+ * (`newspack_insights_next_steps_links`) and land in an `href`, so only render
+ * absolute http(s) URLs. The server already sanitizes with esc_url_raw(); this
+ * guards the client too, so a bad filter can never put a `javascript:` (or other
+ * unsafe-scheme) URL into the DOM.
+ */
+const isSafeUrl = ( url: string ): boolean => /^https?:\/\//i.test( url );
+
 const NextSteps = ( { links }: NextStepsProps ) => {
-	if ( ! links.length ) {
+	const safeLinks = links.filter( link => isSafeUrl( link.url ) );
+	if ( ! safeLinks.length ) {
 		return null;
 	}
 	return (
 		<nav className="newspack-insights__next-steps" aria-label={ __( 'Next steps', 'newspack-plugin' ) }>
 			<span className="newspack-insights__next-steps-label">{ __( 'Next steps', 'newspack-plugin' ) }</span>
 			<ul className="newspack-insights__next-steps-list">
-				{ links.map( link => (
+				{ safeLinks.map( link => (
 					<li key={ link.url }>
 						<a className="newspack-insights__next-steps-link" href={ link.url } target="_blank" rel="noreferrer">
 							{ link.label }

--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
@@ -1,0 +1,48 @@
+/**
+ * NextSteps (NPPD-1842)
+ *
+ * Static, outcome-framed "next steps" strip pinned in each Insights tab
+ * footer, below the metrics (Option B placement). Holds 1–2 links to the
+ * matching help-site "Playbooks" goal flow. Renders nothing when the tab has
+ * no mapped links (Gates, Campaigns, and Advertising in v1). The link label
+ * IS the outcome ("Grow reader revenue") — never a generic "Help" / "Learn
+ * more"; the wording is the whole point of the affordance. The mapping is
+ * product-owned and arrives via the boot config (see get_next_steps_links()
+ * in class-insights-wizard.php).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { NextStepLink } from './InsightsWizard';
+
+export interface NextStepsProps {
+	links: NextStepLink[];
+}
+
+const NextSteps = ( { links }: NextStepsProps ) => {
+	if ( ! links.length ) {
+		return null;
+	}
+	return (
+		<nav className="newspack-insights__next-steps" aria-label={ __( 'Next steps', 'newspack-plugin' ) }>
+			<span className="newspack-insights__next-steps-label">{ __( 'Next steps', 'newspack-plugin' ) }</span>
+			<ul className="newspack-insights__next-steps-list">
+				{ links.map( link => (
+					<li key={ link.url }>
+						<a className="newspack-insights__next-steps-link" href={ link.url } target="_blank" rel="noreferrer">
+							{ link.label }
+						</a>
+					</li>
+				) ) }
+			</ul>
+		</nav>
+	);
+};
+
+export default NextSteps;

--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
@@ -1,10 +1,11 @@
 /**
  * NextSteps (NPPD-1842)
  *
- * Static, outcome-framed "next steps" strip pinned in each Insights tab
- * footer, below the metrics (Option B placement). Holds 1–2 links to the
- * matching help-site "Playbooks" goal flow. Renders nothing when the tab has
- * no mapped links (Gates, Campaigns, and Advertising in v1). The link label
+ * Static, outcome-framed "next steps" affordance for each Insights tab: a small
+ * floating card pinned to the bottom-right corner of the viewport (styled in
+ * _next-steps.scss), holding 1–2 links to the matching help-site "Playbooks"
+ * goal flow. Renders nothing when the tab has no mapped links (Gates, Campaigns,
+ * and Advertising in v1). The link label
  * IS the outcome ("Grow reader revenue") — never a generic "Help" / "Learn
  * more"; the wording is the whole point of the affordance. The mapping is
  * product-owned and arrives via the boot config (see get_next_steps_links()

--- a/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
@@ -1,26 +1,34 @@
 /**
- * Newspack Insights — per-tab "next steps" strip (NPPD-1842).
+ * Newspack Insights — per-tab "next steps" affordance (NPPD-1842).
  *
- * Outcome-worded links to the matching help-site Playbooks flow, rendered by
- * `NextSteps` in the tab footer, above the feedback affordance. Reads as a
- * light, native guidance row: the outcome labels take the admin accent so
- * they're clearly actionable, but the strip stays quiet chrome rather than a
- * loud CTA card. Loaded by `src/wizards/insights/style.scss`.
+ * A small floating card pinned to the bottom-right corner of the viewport,
+ * holding outcome-worded links to the matching help-site Playbooks flow. It
+ * stays put as the tab scrolls, so the next action is always one glance away
+ * without living in the tab body. Rendered by `NextSteps`; hidden when the tab
+ * has no mapped links. Loaded by `src/wizards/insights/style.scss`.
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-insights {
 
-	// Sits inside the footer band (above the feedback row). The footer owns the
-	// top border + spacing; the strip only needs to separate itself from the
-	// feedback prompt below it.
+	// Floating corner card, fixed to the viewport so it rides along on scroll.
+	// Sits above tab content but below the WP admin bar and any modals.
 	&__next-steps {
+		position: fixed;
+		right: 24px;
+		bottom: 24px;
+		z-index: 100;
 		display: flex;
-		flex-wrap: wrap;
-		align-items: baseline;
-		gap: 4px 16px;
-		margin-bottom: 20px;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 6px;
+		max-width: 260px;
+		padding: 12px 16px;
+		background: #fff;
+		border: 1px solid wp-colors.$gray-200;
+		border-radius: 6px;
+		box-shadow: 0 2px 8px rgba( 0, 0, 0, 0.15 );
 
 		@media print {
 			display: none;
@@ -28,15 +36,15 @@
 	}
 
 	&__next-steps-label {
-		font-size: 13px;
+		font-size: 12px;
 		font-weight: 600;
 		color: wp-colors.$gray-700;
 	}
 
 	&__next-steps-list {
 		display: flex;
-		flex-wrap: wrap;
-		gap: 8px 20px;
+		flex-direction: column;
+		gap: 6px;
 		margin: 0;
 		padding: 0;
 		list-style: none;

--- a/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
@@ -1,0 +1,65 @@
+/**
+ * Newspack Insights — per-tab "next steps" strip (NPPD-1842).
+ *
+ * Outcome-worded links to the matching help-site Playbooks flow, rendered by
+ * `NextSteps` in the tab footer, above the feedback affordance. Reads as a
+ * light, native guidance row: the outcome labels take the admin accent so
+ * they're clearly actionable, but the strip stays quiet chrome rather than a
+ * loud CTA card. Loaded by `src/wizards/insights/style.scss`.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+.newspack-insights {
+
+	// Sits inside the footer band (above the feedback row). The footer owns the
+	// top border + spacing; the strip only needs to separate itself from the
+	// feedback prompt below it.
+	&__next-steps {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 4px 16px;
+		margin-bottom: 20px;
+
+		@media print {
+			display: none;
+		}
+	}
+
+	&__next-steps-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: wp-colors.$gray-700;
+	}
+
+	&__next-steps-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px 20px;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	&__next-steps-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 13px;
+		font-weight: 500;
+		text-decoration: none;
+		color: var( --wp-admin-theme-color );
+
+		// Small external-link cue, since these open the help site in a new tab.
+		&::after {
+			content: "\2197";
+			font-size: 14px;
+		}
+
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+		}
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -18,6 +18,7 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "tabs/components/sections";
 @use "components/feedback";
+@use "components/next-steps";
 @use "print";
 
 .newspack-insights {


### PR DESCRIPTION
## What

The in-product half of [NPPD-1723](https://linear.app/a8c/issue/NPPD-1723)'s contextual guidance: a static, outcome-worded "next steps" strip pinned in each Insights tab footer (Option B — below the metrics, above the feedback widget), linking to the matching help-site "Playbooks" goal flow.

Resolves [NPPD-1842](https://linear.app/a8c/issue/NPPD-1842/insights-per-tab-contextual-guidance-entry-point-v1a).

## The bet

The whole value is the copy: links are worded as the **outcome** ("Grow reader revenue"), never a generic "Help" or "Learn more."

## Mapping

Product-owned, held to 1–2 links per tab, in `get_next_steps_links()` (filterable via `newspack_insights_next_steps_links`):

| Tab | Links |
| --- | --- |
| Audience | Grow newsletter signups |
| Engagement | Grow newsletter signups |
| Conversion Journey | Grow newsletter signups · Grow reader revenue |
| Subscribers | Grow reader revenue |
| Donors | Grow reader revenue · Recover lapsed donors |
| Campaigns, Gates, Advertising | — (no strip) |

Refined from the ticket's provisional mapping: dropped newsletter-signups → Subscribers (that tab is paid subs, not newsletter signups) and added Conversion Journey (its funnels cover both growth outcomes). A tab with no mapped outcome renders no strip.

## How

- **PHP** (`class-insights-wizard.php`): `get_next_steps_links()` returns the map (outcome-worded labels + `https://help.newspack.com/playbooks/<slug>/` URLs) and is exposed on the boot config as `nextStepsLinks`, behind the `newspack_insights_next_steps_links` filter.
- **React** (`NextSteps.tsx`): renders the strip in the existing `TabSection` footer; returns `null` when the tab has no links. Typed via a new `NextStepLink` on `InsightsBootConfig` (optional, so config fixtures need not set it).
- **SCSS** (`_next-steps.scss`): a light, native guidance row (label + admin-accent links), intentionally quieter than a CTA card.

## Dependency

The links target `https://help.newspack.com/playbooks/…`. Those pages (from NPPD-1843/1844/1845) currently exist as drafts on the staging help site and must be published to production help before the URLs resolve.

## Verification

- `php -l` + PHPCS (workspace WordPress standard): clean
- `tsc --noEmit`: clean
- ESLint + Stylelint (changed files): clean
- Jest `NextSteps.test.tsx`: 2 passing (renders links; renders nothing when empty)

## Test plan

1. Open Insights → each tab; confirm the strip appears in the footer per the mapping above, with outcome-worded links opening the help site in a new tab.
2. Confirm Campaigns / Gates / Advertising show **no** strip.
3. (Optional) `add_filter( 'newspack_insights_next_steps_links', … )` and confirm the strip reflects the override.
