### PR TITLE
feat(insights): card and label Conversion Journey charts

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.test.tsx
@@ -67,4 +67,23 @@ describe( 'LineChart render', () => {
 		render( <LineChart points={ [] } /> );
 		expect( screen.getByText( 'No data in this timeframe.' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders x- and y-axis titles when provided', () => {
+		render( <LineChart points={ [ pt( '0', 0.1 ), pt( '30', 0.5 ) ] } xAxisLabel="Days" yAxisLabel="Percent registered" /> );
+		expect( screen.getByText( 'Days' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Percent registered' ) ).toBeInTheDocument();
+	} );
+
+	it( 'formats the single-series peak readout with formatValue', () => {
+		// A cumulative share of 1 must read as "100%", not a bare "1".
+		const asPercent = ( v: number ) => `${ Math.round( v * 100 ) }%`;
+		render( <LineChart points={ [ pt( '0', 0.25 ), pt( '30', 1 ) ] } formatValue={ asPercent } /> );
+		expect( screen.getByText( 'peak: 100%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'humanizes x-axis point labels through formatLabel in the meta row', () => {
+		render( <LineChart points={ [ pt( '0', 0.1 ), pt( '90', 0.9 ) ] } formatLabel={ d => `Day ${ d }` } /> );
+		expect( screen.getByText( 'Day 0' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Day 90' ) ).toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.tsx
@@ -52,6 +52,16 @@ export interface LineChartProps {
 	series?: LineSeries[];
 	/** Humanize an x-axis label for tooltips and the meta row. Defaults to identity. */
 	formatLabel?: ( label: string ) => string;
+	/**
+	 * Format a y-value for the tooltip and the single-series peak readout.
+	 * Defaults to `formatNumber`. Percentage curves pass `formatPercent` so a
+	 * cumulative share of `1` reads as "100%" rather than a bare "1".
+	 */
+	formatValue?: ( value: number ) => string;
+	/** Axis title rendered under the plot (e.g. "Days since first visit"). */
+	xAxisLabel?: string;
+	/** Axis title rendered above the plot (e.g. "% of readers converted"). */
+	yAxisLabel?: string;
 	/** Optional horizontal target line (value in the same units as the y-axis). */
 	referenceLine?: LineReferenceLine;
 	/**
@@ -69,7 +79,17 @@ const W = 600;
 const H = 160;
 const PAD = 8;
 
-const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenceLine, yMax, emptyMessage }: LineChartProps ) => {
+const LineChart = ( {
+	points,
+	series,
+	formatLabel = ( l: string ) => l,
+	formatValue = formatNumber,
+	xAxisLabel,
+	yAxisLabel,
+	referenceLine,
+	yMax,
+	emptyMessage,
+}: LineChartProps ) => {
 	const [ active, setActive ] = useState< number | null >( null );
 
 	const allSeries: LineSeries[] = series && series.length ? series : [ { name: '', points: points ?? [] } ];
@@ -103,10 +123,18 @@ const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenc
 	const xAt = ( i: number ) => PAD + i * stepX;
 	const yAt = ( v: number ) => H - PAD - ( ( ( v || 0 ) - min ) / span ) * ( H - PAD * 2 );
 
+	// Evenly-spaced horizontal gridlines across the value domain give the
+	// plotted line a floor to sit on instead of floating in the plot box. The
+	// lowest line (k === 0, at the domain minimum) is drawn as a stronger
+	// baseline; the rest are recessive hairlines behind the series.
+	const GRID_STEPS = 4;
+	const gridValues = Array.from( { length: GRID_STEPS + 1 }, ( _g, k ) => min + ( span * k ) / GRID_STEPS );
+
 	const tooltipTop = active === null ? 0 : Math.min( ...allSeries.map( s => yAt( s.points[ active ]?.value ?? 0 ) ) );
 
 	return (
 		<div className="newspack-insights__line" onMouseLeave={ () => setActive( null ) }>
+			{ yAxisLabel && <span className="newspack-insights__line-axis newspack-insights__line-axis--y">{ yAxisLabel }</span> }
 			<div className="newspack-insights__line-plot">
 				<svg
 					viewBox={ `0 0 ${ W } ${ H }` }
@@ -115,6 +143,16 @@ const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenc
 					aria-label={ __( 'Time-series chart', 'newspack-plugin' ) }
 					preserveAspectRatio="none"
 				>
+					{ gridValues.map( ( v, k ) => (
+						<line
+							key={ `grid-${ k }` }
+							className={ k === 0 ? 'newspack-insights__line-baseline' : 'newspack-insights__line-grid' }
+							x1={ PAD }
+							x2={ W - PAD }
+							y1={ yAt( v ) }
+							y2={ yAt( v ) }
+						/>
+					) ) }
 					{ referenceLine && (
 						<line
 							className="newspack-insights__line-reference"
@@ -168,7 +206,7 @@ const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenc
 							<span key={ `tt-${ si }` } className="newspack-insights__chart-tooltip-row">
 								{ isMulti && <span className={ `newspack-insights__chart-tooltip-swatch is-series-${ si }` } aria-hidden="true" /> }
 								{ isMulti && <span className="newspack-insights__chart-tooltip-name">{ s.name }</span> }
-								<span className="newspack-insights__chart-tooltip-value">{ formatNumber( s.points[ active ]?.value ?? 0 ) }</span>
+								<span className="newspack-insights__chart-tooltip-value">{ formatValue( s.points[ active ]?.value ?? 0 ) }</span>
 							</span>
 						) ) }
 					</div>
@@ -187,11 +225,12 @@ const LineChart = ( { points, series, formatLabel = ( l: string ) => l, referenc
 				<div className="newspack-insights__line-meta">
 					<span>{ formatLabel( base[ 0 ].label ) }</span>
 					<span>
-						{ __( 'peak', 'newspack-plugin' ) }: { formatNumber( dataMax ) }
+						{ __( 'peak', 'newspack-plugin' ) }: { formatValue( dataMax ) }
 					</span>
 					<span>{ formatLabel( base[ n - 1 ].label ) }</span>
 				</div>
 			) }
+			{ xAxisLabel && <span className="newspack-insights__line-axis newspack-insights__line-axis--x">{ xAxisLabel }</span> }
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -344,6 +344,21 @@
 		opacity: 0.12;
 	}
 
+	// Recessive horizontal gridlines behind the series — a light reference grid
+	// so the plotted line reads as sitting in a chart, not floating.
+	&__line-grid {
+		stroke: wp-colors.$gray-100;
+		stroke-width: 1;
+		vector-effect: non-scaling-stroke;
+	}
+
+	// The domain-minimum gridline, drawn stronger so the chart has a clear floor.
+	&__line-baseline {
+		stroke: wp-colors.$gray-300;
+		stroke-width: 1;
+		vector-effect: non-scaling-stroke;
+	}
+
 	&__line-stroke {
 		stroke: var( --series-color );
 		stroke-width: 2;
@@ -366,6 +381,25 @@
 		font-size: 11px;
 		color: wp-colors.$gray-600;
 		margin-top: 4px;
+	}
+
+	// Axis titles naming what each axis represents (e.g. "Days since first
+	// visit" under the x-axis, "% of readers converted" above the plot). The
+	// SVG uses non-uniform scaling, so axis titles live in HTML — not as SVG
+	// text that would stretch.
+	&__line-axis {
+		display: block;
+		font-size: 11px;
+		color: wp-colors.$gray-600;
+
+		&--y {
+			margin-bottom: 6px;
+		}
+
+		&--x {
+			margin-top: 6px;
+			text-align: center;
+		}
 	}
 
 	// Dark hover panel shared by the line + bar charts (NPPD-1649 fix #5).

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -21,6 +21,8 @@ import { __ } from '@wordpress/i18n';
 import type { ConversionCohortData } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
 import LineChart, { type LineSeries, type LineReferenceLine } from '../components/LineChart';
+import { formatPercent } from '../components/format';
+import { monthLabel } from './labels';
 import SectionState from './SectionState';
 
 export interface CohortRetentionSectionProps {
@@ -40,11 +42,12 @@ const toCohortSeries = ( data: ConversionCohortData ): LineSeries[] =>
 interface CohortChartProps {
 	title: string;
 	data: ConversionCohortData;
+	yAxisLabel: string;
 	yMax?: number;
 	referenceLine?: LineReferenceLine;
 }
 
-const CohortChart = ( { title, data, yMax, referenceLine }: CohortChartProps ) => (
+const CohortChart = ( { title, data, yAxisLabel, yMax, referenceLine }: CohortChartProps ) => (
 	<div className="newspack-insights__conversion-cohort-cell">
 		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
 		<SectionState
@@ -59,6 +62,10 @@ const CohortChart = ( { title, data, yMax, referenceLine }: CohortChartProps ) =
 				series={ toCohortSeries( data ) }
 				referenceLine={ referenceLine }
 				yMax={ yMax }
+				formatLabel={ monthLabel }
+				formatValue={ formatPercent }
+				xAxisLabel={ __( 'Months', 'newspack-plugin' ) }
+				yAxisLabel={ yAxisLabel }
 				emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
 			/>
 		</SectionState>
@@ -90,11 +97,13 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
 				 */
 				title={ __( 'Registration → conversion', 'newspack-plugin' ) }
 				data={ current.registration_to_conversion_cohort }
+				yAxisLabel={ __( 'Percent converted', 'newspack-plugin' ) }
 			/>
 			<CohortChart
 				title={ __( 'Subscriber retention', 'newspack-plugin' ) }
 				data={ current.subscriber_retention_cohort }
 				yMax={ 1 }
+				yAxisLabel={ __( 'Percent retained', 'newspack-plugin' ) }
 				referenceLine={ current.subscriber_retention_cohort.reference_line ?? undefined }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -19,6 +19,8 @@ import { __ } from '@wordpress/i18n';
 import type { ConversionWeekPoint, ConversionWeeklyTrendsData } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
 import LineChart, { type LineSeries } from '../components/LineChart';
+import { formatPercent } from '../components/format';
+import { weekLabel } from './labels';
 import SectionState from './SectionState';
 
 export interface ConversionRateTrendsSectionProps {
@@ -66,15 +68,21 @@ const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionPr
 				'newspack-plugin'
 			) }
 		/>
-		<SectionState
-			state={ current.weekly_conversion_rates.state }
-			emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
-		>
-			<LineChart
-				series={ toTrendSeries( current.weekly_conversion_rates ) }
+		<div className="newspack-insights__conversion-rate-trends-cell">
+			<SectionState
+				state={ current.weekly_conversion_rates.state }
 				emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
-			/>
-		</SectionState>
+			>
+				<LineChart
+					series={ toTrendSeries( current.weekly_conversion_rates ) }
+					formatLabel={ weekLabel }
+					formatValue={ formatPercent }
+					xAxisLabel={ __( 'Week', 'newspack-plugin' ) }
+					yAxisLabel={ __( 'Conversion rate', 'newspack-plugin' ) }
+					emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
+				/>
+			</SectionState>
+		</div>
 	</section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -22,7 +22,8 @@ import { __ } from '@wordpress/i18n';
  */
 import type { ConversionCumulativeMulti, ConversionCumulativePoint, ConversionWindow } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
-import { sourceLabel } from './labels';
+import { sourceLabel, dayLabel } from './labels';
+import { formatPercent } from '../components/format';
 import LineChart, { type LinePoint, type LineSeries } from '../components/LineChart';
 import SectionState from './SectionState';
 
@@ -78,6 +79,10 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 						<LineChart
 							points={ toLinePoints( current.time_to_register_distribution.points ) }
 							yMax={ 1 }
+							formatLabel={ dayLabel }
+							formatValue={ formatPercent }
+							xAxisLabel={ __( 'Days', 'newspack-plugin' ) }
+							yAxisLabel={ __( 'Percent registered', 'newspack-plugin' ) }
 							emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this timeframe.', 'newspack-plugin' ) }
 						/>
 					</SectionState>
@@ -91,6 +96,10 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 						<LineChart
 							series={ toLineSeries( current.time_to_subscribe_distribution ) }
 							yMax={ 1 }
+							formatLabel={ dayLabel }
+							formatValue={ formatPercent }
+							xAxisLabel={ __( 'Days', 'newspack-plugin' ) }
+							yAxisLabel={ __( 'Percent subscribed', 'newspack-plugin' ) }
 							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 						/>
 					</SectionState>
@@ -104,6 +113,10 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 						<LineChart
 							series={ toLineSeries( current.time_to_donate_distribution ) }
 							yMax={ 1 }
+							formatLabel={ dayLabel }
+							formatValue={ formatPercent }
+							xAxisLabel={ __( 'Days', 'newspack-plugin' ) }
+							yAxisLabel={ __( 'Percent donated', 'newspack-plugin' ) }
 							emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 						/>
 					</SectionState>
@@ -122,6 +135,10 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 							<LineChart
 								points={ toLinePoints( lag.points ) }
 								yMax={ 1 }
+								formatLabel={ dayLabel }
+								formatValue={ formatPercent }
+								xAxisLabel={ __( 'Days', 'newspack-plugin' ) }
+								yAxisLabel={ __( 'Percent who donated', 'newspack-plugin' ) }
 								emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
 							/>
 						</SectionState>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -17,6 +17,21 @@
 @use "../../../../../packages/colors/colors.module" as colors;
 @use "../components/insights-charts";
 
+// Shared card chrome for this tab's chart cells (pie / curve / cohort / rate
+// trends). Matches the funnel + scorecard + Audience-tab chart-card treatment
+// (white fill, gray-200 hairline, 4px radius, 16px padding) so every section
+// reads as the same bounded card instead of a chart floating on the page.
+// `height: 100%` lets cards in a row stretch to the tallest, keeping row edges
+// aligned.
+@mixin conversion-chart-card {
+	min-width: 0;
+	height: 100%;
+	padding: 16px;
+	background-color: #fff;
+	border: 1px solid wp-colors.$gray-200;
+	border-radius: 4px;
+}
+
 .newspack-insights {
 	&__conversion-tab {
 		display: flex;
@@ -93,11 +108,11 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 		gap: 24px;
-		align-items: start;
+		align-items: stretch;
 	}
 
 	&__conversion-pie-cell {
-		min-width: 0;
+		@include conversion-chart-card;
 	}
 
 	// Section 4 — 2×2 grid of cumulative-distribution curves.
@@ -105,11 +120,11 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 		gap: 24px;
-		align-items: start;
+		align-items: stretch;
 	}
 
 	&__conversion-curve-cell {
-		min-width: 0;
+		@include conversion-chart-card;
 	}
 
 	// Section 5 — two cohort curves stacked vertically.
@@ -120,7 +135,12 @@
 	}
 
 	&__conversion-cohort-cell {
-		min-width: 0;
+		@include conversion-chart-card;
+	}
+
+	// Section 6 — single full-width weekly rate-trends curve.
+	&__conversion-rate-trends-cell {
+		@include conversion-chart-card;
 	}
 
 	// Section 8.4 — top-pages table block.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/labels.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/labels.ts
@@ -34,7 +34,7 @@ export const sourceLabel = ( source: ConversionSource ): string => {
 
 /** X-axis point label for day-indexed cumulative curves (Section 4): "42" -> "Day 42". */
 export const dayLabel = ( day: string ): string =>
-	// translators: %s is a day number since the reader's first visit.
+	// translators: %s is a day number.
 	sprintf( __( 'Day %s', 'newspack-plugin' ), day );
 
 /** X-axis point label for month-indexed cohort curves (Section 5): "6" -> "Month 6". */

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/labels.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/labels.ts
@@ -3,14 +3,20 @@
  *
  * Maps the machine source keys (`gate` / `prompt` / `direct`) used by the
  * Section 3 PieCharts and the Section 4 multi-series distributions to their
- * translated display labels, so the sections stay declarative and the copy
- * lives in one place.
+ * translated display labels, plus the per-axis point labels the Section 4–6
+ * LineCharts feed to `formatLabel`, so the sections stay declarative and the
+ * copy lives in one place.
  */
 
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatShortDate } from '../components/format';
 
 export type ConversionSource = 'gate' | 'prompt' | 'direct';
 
@@ -25,3 +31,18 @@ export const sourceLabel = ( source: ConversionSource ): string => {
 			return __( 'Direct', 'newspack-plugin' );
 	}
 };
+
+/** X-axis point label for day-indexed cumulative curves (Section 4): "42" -> "Day 42". */
+export const dayLabel = ( day: string ): string =>
+	// translators: %s is a day number since the reader's first visit.
+	sprintf( __( 'Day %s', 'newspack-plugin' ), day );
+
+/** X-axis point label for month-indexed cohort curves (Section 5): "6" -> "Month 6". */
+export const monthLabel = ( period: string ): string =>
+	// translators: %s is a month number since the cohort started.
+	sprintf( __( 'Month %s', 'newspack-plugin' ), period );
+
+/** X-axis point label for weekly trend curves (Section 6): "2025-06-01" -> "Week of Jun 1". */
+export const weekLabel = ( week: string ): string =>
+	// translators: %s is the start date of a week, e.g. "Jun 1".
+	sprintf( __( 'Week of %s', 'newspack-plugin' ), formatShortDate( week.replace( /-/g, '' ) ) );


### PR DESCRIPTION
## What & why

Visual cleanup of the **Conversion Journey** tab (Tab 3). The line-chart sections read as "floating" — no card container, no gridlines, and hovers/axes were unlabeled bare numbers (a cumulative share of `1` showed as `1`, not `100%`).

### Changes
1. **Card the floating chart sections** — the source-mix pies, the four cumulative-distribution curves, the two cohort curves, and the weekly rate-trends chart now use the same card chrome (white fill, `1px` gray-200 hairline, `4px` radius, `16px` padding) already used by the funnels, scorecards, and Audience-tab charts. Funnel cells are intentionally left alone (the `Funnel` component draws its own card). Rows stretch so cards share a height.
2. **Ground the lines** — the shared `LineChart` now draws recessive horizontal gridlines plus a stronger baseline behind every series, so the plotted line sits on something instead of drifting.
3. **Label the axes and tooltips** — `LineChart` gains optional `xAxisLabel` / `yAxisLabel` (rendered in HTML, not the non-uniformly-scaled SVG) and a `formatValue` prop. Each section wires up its real units:

| Section | x-axis | tooltip x | y-axis | y-values |
|---|---|---|---|---|
| Time to register / subscribe / donate, sub→donor lag | Days | `Day 42` | Percent registered/subscribed/donated | `100%` |
| Cohort retention | Months | `Month 6` | Percent converted / retained | `70%` |
| Conversion rate trends | Week | `Week of Jun 1` | Conversion rate | `4.1%` |

So the old `42 / 1` hover now reads `Day 42 / 100%`.

The `LineChart`, `formatValue`, and gridline changes are shared, so the Audience tab's line charts get the same grounding — `formatValue` defaults to the previous number formatter, so nothing there changes visually.

## Testing
- Stylelint + ESLint clean (used "Percent …" rather than a leading `%`, which the i18n rule reads as a printf placeholder).
- **73 Jest tests green** — LineChart + every Conversion section + an Audience-tab regression check — including **3 new LineChart tests** covering the axis titles, `formatValue` peak readout, and `formatLabel` x-labels.
- Verified live in the local dev site (fixture mode) across all four line-chart sections.
