### PR TITLE
feat(insights): real subscription trend + cohort heatmap

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -429,7 +429,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 					$error,
 					[
 						'weeks'  => [],
-						'series' => [ 'registration_rate', 'subscription_attempt_rate' ],
+						'series' => [ 'registration_rate', 'subscription_conversion_rate' ],
 					]
 				),
 				// Section 7 — influenced scalars.
@@ -551,7 +551,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'weekly_conversion_rates'          => [
 					'state'  => 'empty',
 					'weeks'  => [],
-					'series' => [ 'registration_rate', 'subscription_attempt_rate' ],
+					'series' => [ 'registration_rate', 'subscription_conversion_rate' ],
 				],
 				// Section 7 — influenced scalars (non-computable zeros).
 				'influenced_registration_rate_7d'  => $scalar_zero( 'rate' ),
@@ -788,7 +788,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 			$weeks[]    = [
 				'week'                         => $week_start->format( 'Y-m-d' ),
 				'registration_conversion_rate' => $reg_rate,
-				'subscription_attempt_rate'    => $sub_rate,
+				'subscription_conversion_rate' => $sub_rate,
 			];
 		}
 
@@ -890,7 +890,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 				'weekly_conversion_rates'          => [
 					'state'  => 'populated',
 					'weeks'  => $weeks,
-					'series' => [ 'registration_rate', 'subscription_attempt_rate' ],
+					'series' => [ 'registration_rate', 'subscription_conversion_rate' ],
 				],
 				// Section 7.
 				'influenced_registration_rate_7d'  => $influenced_reg,

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/conversion-fixture.php
@@ -264,7 +264,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 								'value'  => 0.0,
 							],
 							[
-								'period' => 2,
+								'period' => 3,
 								'value'  => 0.009,
 							],
 						],
@@ -347,7 +347,7 @@ return function ( string $variant = 'populated', bool $compare = false ): array 
 								'value'  => 1.0,
 							],
 							[
-								'period' => 2,
+								'period' => 3,
 								'value'  => 0.94,
 							],
 						],

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1648,54 +1648,60 @@ final class Conversion_Metric {
 	/**
 	 * Weekly conversion rates (6) — multi-series LineChart. Dispatches
 	 * `conversion_journey_weekly_rates`; the hub returns per-week rows with
-	 * { week_start, registration_conversion_rate, subscription_attempt_rate }.
-	 * The `series` keys name the two tracked rates and are preserved in every
-	 * state so React can always build its legend without guarding for absence.
+	 * { week_start, registration_conversion_rate, new_registrations }. The
+	 * subscription series is computed HERE: real completed subscriptions per week
+	 * (local Woo, via Subscribers_Metric::get_new_subscribers_by_week) divided by the
+	 * hub's per-week `new_registrations`, so both series share the hub's registration
+	 * definition. The `series` keys (registration_rate, subscription_conversion_rate)
+	 * are preserved in every state so React can always build its legend.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array{state: string, weeks: array, series: string[]}
 	 */
 	public function get_weekly_conversion_rates( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$rows = $this->proxy->query( 'conversion_journey_weekly_rates', $start, $end );
+		$series = [ 'registration_rate', 'subscription_conversion_rate' ];
+		$rows   = $this->proxy->query( 'conversion_journey_weekly_rates', $start, $end );
 		if ( is_wp_error( $rows ) ) {
-			return array_merge(
-				$this->error_collection( 'weeks', $rows ),
-				[ 'series' => [ 'registration_rate', 'subscription_attempt_rate' ] ]
-			);
+			return array_merge( $this->error_collection( 'weeks', $rows ), [ 'series' => $series ] );
 		}
 		if ( ! is_array( $rows ) || ( ! empty( $rows ) && ! is_array( $rows[0] ) ) ) {
-			return array_merge(
-				$this->malformed_collection( 'weeks' ),
-				[ 'series' => [ 'registration_rate', 'subscription_attempt_rate' ] ]
-			);
+			return array_merge( $this->malformed_collection( 'weeks' ), [ 'series' => $series ] );
 		}
 		if ( empty( $rows ) ) {
 			return [
 				'state'  => 'empty',
 				'weeks'  => [],
-				'series' => [ 'registration_rate', 'subscription_attempt_rate' ],
+				'series' => $series,
 			];
 		}
+
+		// Real completed subscriptions per week come from the local Woo store (the
+		// Subscribers-tab mechanism), keyed on the same Sunday-starting week_start the
+		// hub uses for registrations. Dividing here keeps "registration" defined as the
+		// hub's np_reader_registered count on both series. Mirrors the unconditional
+		// Subscribers_Metric use in get_source_mix_subscribers().
+		$subs_by_week = $this->subscribers_metric->get_new_subscribers_by_week( $start, $end );
+
 		$weeks = [];
 		foreach ( $rows as $row ) {
 			if ( ! is_array( $row ) ) {
-				return array_merge(
-					$this->malformed_collection( 'weeks' ),
-					[ 'series' => [ 'registration_rate', 'subscription_attempt_rate' ] ]
-				);
+				return array_merge( $this->malformed_collection( 'weeks' ), [ 'series' => $series ] );
 			}
-			$week_start = $row['week_start'] ?? '';
-			$weeks[]    = [
-				'week'                         => is_scalar( $week_start ) ? (string) $week_start : '',
+			$week_start        = $row['week_start'] ?? '';
+			$week_key          = is_scalar( $week_start ) ? (string) $week_start : '';
+			$new_registrations = (int) ( $row['new_registrations'] ?? 0 );
+			$subscriptions     = (int) ( $subs_by_week[ $week_key ] ?? 0 );
+			$weeks[]           = [
+				'week'                         => $week_key,
 				'registration_conversion_rate' => (float) ( $row['registration_conversion_rate'] ?? 0.0 ),
-				'subscription_attempt_rate'    => (float) ( $row['subscription_attempt_rate'] ?? 0.0 ),
+				'subscription_conversion_rate' => $new_registrations > 0 ? $subscriptions / $new_registrations : 0.0,
 			];
 		}
 		return [
 			'state'  => 'populated',
 			'weeks'  => $weeks,
-			'series' => [ 'registration_rate', 'subscription_attempt_rate' ],
+			'series' => $series,
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1665,7 +1665,7 @@ final class Conversion_Metric {
 		if ( is_wp_error( $rows ) ) {
 			return array_merge( $this->error_collection( 'weeks', $rows ), [ 'series' => $series ] );
 		}
-		if ( ! is_array( $rows ) || ( ! empty( $rows ) && ! is_array( $rows[0] ) ) ) {
+		if ( ! is_array( $rows ) ) {
 			return array_merge( $this->malformed_collection( 'weeks' ), [ 'series' => $series ] );
 		}
 		if ( empty( $rows ) ) {
@@ -1674,6 +1674,13 @@ final class Conversion_Metric {
 				'weeks'  => [],
 				'series' => $series,
 			];
+		}
+		// Validate the full payload before the local Woo query below, so a malformed
+		// row short-circuits without an unnecessary database hit.
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				return array_merge( $this->malformed_collection( 'weeks' ), [ 'series' => $series ] );
+			}
 		}
 
 		// Real completed subscriptions per week come from the local Woo store (the
@@ -1685,9 +1692,6 @@ final class Conversion_Metric {
 
 		$weeks = [];
 		foreach ( $rows as $row ) {
-			if ( ! is_array( $row ) ) {
-				return array_merge( $this->malformed_collection( 'weeks' ), [ 'series' => $series ] );
-			}
 			$week_start        = $row['week_start'] ?? '';
 			$week_key          = is_scalar( $week_start ) ? (string) $week_start : '';
 			$new_registrations = (int) ( $row['new_registrations'] ?? 0 );

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -174,6 +174,25 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * New subscribers bucketed by the Sunday-starting week of their first subscription,
+	 * for the Conversion tab's weekly subscription-conversion trend.
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string,int> Map of week_start ('Y-m-d') to new-subscriber count.
+	 */
+	public function get_new_subscribers_by_week( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return (array) $this->cached(
+			'new_subscribers_by_week',
+			$this->window_key( $start, $end ),
+			self::TTL_DEFAULT,
+			function () use ( $start, $end ) {
+				return $this->storage->get_new_subscribers_by_week( $start, $end );
+			}
+		);
+	}
+
+	/**
 	 * Churned subscribers in window. See storage contract for semantics.
 	 *
 	 * @param DateTimeInterface $start Window start.

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -173,6 +173,57 @@ class HPOS_Storage implements Storage_Interface {
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string,int>
+	 */
+	public function get_new_subscribers_by_week( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Same "customer's earliest non-donation subscription in window" cohort as
+		// get_new_subscribers_in_window(), bucketed by the Sunday-starting week of that
+		// first _schedule_start. Sunday-start (DAYOFWEEK: Sun=1) matches BigQuery's
+		// DATE_TRUNC(date, WEEK) the hub's registration series uses, so both align on
+		// week_start. _schedule_start is UTC while the hub's GA4 weeks are property-
+		// local, so a subscription within hours of a week boundary can land one
+		// bucket over. Acceptable trend fuzz.
+		$sql = $wpdb->prepare(
+			"SELECT
+				DATE(DATE_SUB(first_subs.first_start, INTERVAL (DAYOFWEEK(first_subs.first_start) - 1) DAY)) AS week_start,
+				COUNT(*) AS new_subscribers
+			FROM (
+				SELECT o.customer_id, MIN(om.meta_value) AS first_start
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}wc_orders_meta om
+					ON om.order_id = o.id AND om.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE o.type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND om.meta_value != ''
+				GROUP BY o.customer_id
+			) AS first_subs
+			WHERE first_subs.first_start BETWEEN %s AND %s
+			GROUP BY week_start
+			ORDER BY week_start",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$result = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$result[ (string) $row['week_start'] ] = (int) $row['new_subscribers'];
+		}
+		return $result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
 	 * @return int
 	 */
 	public function get_churned_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int {

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -196,6 +196,55 @@ class Legacy_Storage implements Storage_Interface {
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
+	 * @return array<string,int>
+	 */
+	public function get_new_subscribers_by_week( DateTimeInterface $start, DateTimeInterface $end ): array {
+		global $wpdb;
+		$prefix    = $wpdb->prefix;
+		$donations = $this->id_list( $this->donation_product_ids );
+
+		// Legacy (CPT) mirror of the HPOS by-week query: same first-subscription
+		// cohort, bucketed by the Sunday-starting week of _schedule_start to align
+		// with the hub's BigQuery DATE_TRUNC(date, WEEK) registration series.
+		$sql = $wpdb->prepare(
+			"SELECT
+				DATE(DATE_SUB(first_subs.first_start, INTERVAL (DAYOFWEEK(first_subs.first_start) - 1) DAY)) AS week_start,
+				COUNT(*) AS new_subscribers
+			FROM (
+				SELECT cust.meta_value AS customer_id, MIN(start.meta_value) AS first_start
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start
+					ON start.post_id = p.ID AND start.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND oim.meta_value NOT IN ($donations)
+				  AND start.meta_value != ''
+				GROUP BY cust.meta_value
+			) AS first_subs
+			WHERE first_subs.first_start BETWEEN %s AND %s
+			GROUP BY week_start
+			ORDER BY week_start",
+			$this->fmt( $start ),
+			$this->fmt( $end )
+		);
+
+		$result = [];
+		foreach ( (array) $wpdb->get_results( $sql, ARRAY_A ) as $row ) {
+			$result[ (string) $row['week_start'] ] = (int) $row['new_subscribers'];
+		}
+		return $result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param DateTimeInterface $start Window start.
+	 * @param DateTimeInterface $end   Window end.
 	 * @return int
 	 */
 	public function get_churned_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int {

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-storage-interface.php
@@ -52,6 +52,17 @@ interface Storage_Interface {
 	public function get_new_subscribers_in_window( DateTimeInterface $start, DateTimeInterface $end ): int;
 
 	/**
+	 * The same new-subscriber cohort as get_new_subscribers_in_window(), bucketed by
+	 * the Sunday-starting week of each customer's first non-donation subscription
+	 * start — for the Conversion tab's weekly subscription-conversion trend.
+	 *
+	 * @param DateTimeInterface $start Inclusive window start.
+	 * @param DateTimeInterface $end   Inclusive window end.
+	 * @return array<string,int> Map of week_start ('Y-m-d', Sunday) to new-subscriber count.
+	 */
+	public function get_new_subscribers_by_week( DateTimeInterface $start, DateTimeInterface $end ): array;
+
+	/**
 	 * Distinct customers whose ALL non-donation subscriptions ended in the
 	 * window (cancelled or expired) AND who have no other active non-donation
 	 * subscriptions. Losing one product while keeping another doesn't count.

--- a/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/conversion.ts
@@ -180,7 +180,7 @@ export interface ConversionCohortData extends ConversionErrorFields {
 export interface ConversionWeekPoint {
 	week: string;
 	registration_conversion_rate: number;
-	subscription_attempt_rate: number;
+	subscription_conversion_rate: number;
 }
 
 export interface ConversionWeeklyTrendsData extends ConversionErrorFields {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for the CohortHeatmap grid: rows/columns from the cohort union, percent
+ * formatting, blank cells for missing periods, caption + target callout, empty state.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CohortHeatmap, { type CohortHeatmapRow } from './CohortHeatmap';
+
+const cohorts: CohortHeatmapRow[] = [
+	{
+		label: '2025-07',
+		points: [
+			{ period: 0, value: 1 },
+			{ period: 3, value: 0.8 },
+			{ period: 6, value: 0.68 },
+		],
+	},
+	{
+		label: '2025-08',
+		points: [
+			{ period: 0, value: 1 },
+			{ period: 3, value: 0.84 },
+		],
+	},
+];
+
+describe( 'CohortHeatmap', () => {
+	it( 'renders a row per cohort and a column per period in the union', () => {
+		render( <CohortHeatmap cohorts={ cohorts } /> );
+		expect( screen.getByRole( 'rowheader', { name: '2025-07' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'rowheader', { name: '2025-08' } ) ).toBeInTheDocument();
+		// Period-6 column exists even though only one cohort reached it.
+		expect( screen.getByRole( 'columnheader', { name: '6' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'formats cell values as percentages by default', () => {
+		render( <CohortHeatmap cohorts={ cohorts } /> );
+		expect( screen.getByText( '80%' ) ).toBeInTheDocument();
+		expect( screen.getByText( '68%' ) ).toBeInTheDocument();
+		expect( screen.getByText( '84%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves a blank cell where a cohort has no point for a period', () => {
+		const { container } = render( <CohortHeatmap cohorts={ cohorts } /> );
+		// 2025-08 has no period-6 value → exactly one is-empty cell.
+		expect( container.querySelectorAll( '.newspack-insights__cohort-heatmap-cell.is-empty' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'renders the columns caption and the target callout', () => {
+		render( <CohortHeatmap cohorts={ cohorts } columnsLabel="Months since cohort start" referenceLabel="70% at 12 months" /> );
+		expect( screen.getByText( 'Months since cohort start' ) ).toBeInTheDocument();
+		expect( screen.getByText( /70% at 12 months/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the empty message when no cohort carries any points', () => {
+		render( <CohortHeatmap cohorts={ [ { label: '2025-07', points: [] } ] } emptyMessage="No cohort data available yet." /> );
+		expect( screen.getByText( 'No cohort data available yet.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.tsx
@@ -1,0 +1,144 @@
+/**
+ * CohortHeatmap — cohort retention/conversion as a shaded grid (Conversion tab viz cleanup).
+ *
+ * Replaces the many-series cohort LineChart (unreadable "spaghetti" past a handful of
+ * cohorts) with the standard cohort-matrix view: one row per cohort, one column per
+ * period-since-start, each cell shaded by its value. Reading DOWN a column compares
+ * cohorts at the same age (the core cohort question); reading ACROSS a row ages a
+ * single cohort. The upper-right blanks are cohorts too young to have reached that
+ * period yet.
+ *
+ * Color is scaled to the visible value range (relative shading) so both a high-
+ * magnitude series (retention, ~60–100%) and a low-magnitude one (early conversion,
+ * a few %) read with contrast; the exact value is printed in every cell so magnitude
+ * stays honest. Dependency-free.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatPercent } from './format';
+
+export interface CohortHeatmapRow {
+	label: string;
+	points: { period: number; value: number }[];
+}
+
+export interface CohortHeatmapProps {
+	cohorts: CohortHeatmapRow[];
+	/** Format a cell value. Defaults to `formatPercent` (values are 0–1 shares). */
+	formatValue?: ( value: number ) => string;
+	/** Column header for a period index. Defaults to the raw period number. */
+	formatPeriod?: ( period: number ) => string;
+	/** Caption naming what the columns are (e.g. "Months since cohort start"). */
+	columnsLabel?: string;
+	/** Optional target callout shown under the grid (e.g. "70% at 12 months"). */
+	referenceLabel?: string;
+	/** Empty-state copy. */
+	emptyMessage?: string;
+}
+
+// Sequential blue ramp endpoints (light → dark), matching the tab's chart palette.
+const LIGHT: [ number, number, number ] = [ 230, 241, 251 ]; // #E6F1FB
+const DARK: [ number, number, number ] = [ 24, 95, 165 ]; // #185FA5
+
+const lerp = ( a: number, b: number, t: number ): number => Math.round( a + ( b - a ) * t );
+
+/** Cell background for a normalized value `t` in [0, 1]. */
+const cellColor = ( t: number ): string =>
+	`rgb(${ lerp( LIGHT[ 0 ], DARK[ 0 ], t ) }, ${ lerp( LIGHT[ 1 ], DARK[ 1 ], t ) }, ${ lerp( LIGHT[ 2 ], DARK[ 2 ], t ) })`;
+
+const CohortHeatmap = ( {
+	cohorts,
+	formatValue = formatPercent,
+	formatPeriod = ( period: number ) => String( period ),
+	columnsLabel,
+	referenceLabel,
+	emptyMessage,
+}: CohortHeatmapProps ) => {
+	const rows = cohorts.filter( c => c.points.length > 0 );
+	if ( ! rows.length ) {
+		return <p className="newspack-insights__chart-empty">{ emptyMessage ?? __( 'No cohort data available yet.', 'newspack-plugin' ) }</p>;
+	}
+
+	// Columns = the sorted union of every period present across cohorts.
+	const periods = Array.from( new Set( rows.flatMap( c => c.points.map( p => p.period ) ) ) ).sort( ( a, b ) => a - b );
+
+	// Value range drives the relative shading; the printed value keeps magnitude honest.
+	const values = rows.flatMap( c => c.points.map( p => p.value ) );
+	const min = Math.min( ...values );
+	const span = Math.max( ...values ) - min || 1;
+
+	return (
+		<div className="newspack-insights__cohort-heatmap">
+			<table className="newspack-insights__cohort-heatmap-table">
+				{ columnsLabel && <caption>{ columnsLabel }</caption> }
+				<thead>
+					<tr>
+						<th className="newspack-insights__cohort-heatmap-corner" scope="col">
+							{ __( 'Cohort', 'newspack-plugin' ) }
+						</th>
+						{ periods.map( period => (
+							<th key={ `col-${ period }` } className="newspack-insights__cohort-heatmap-colhead" scope="col">
+								{ formatPeriod( period ) }
+							</th>
+						) ) }
+					</tr>
+				</thead>
+				<tbody>
+					{ rows.map( cohort => {
+						const lookup = new Map( cohort.points.map( p => [ p.period, p.value ] ) );
+						return (
+							<tr key={ cohort.label }>
+								<th className="newspack-insights__cohort-heatmap-rowhead" scope="row">
+									{ cohort.label }
+								</th>
+								{ periods.map( period => {
+									const value = lookup.get( period );
+									if ( undefined === value ) {
+										return (
+											<td key={ `${ cohort.label }-${ period }` } className="newspack-insights__cohort-heatmap-cell is-empty" />
+										);
+									}
+									const t = ( value - min ) / span;
+									return (
+										<td
+											key={ `${ cohort.label }-${ period }` }
+											className="newspack-insights__cohort-heatmap-cell"
+											style={ { backgroundColor: cellColor( t ), color: t > 0.55 ? '#fff' : '#0c447c' } }
+										>
+											{ formatValue( value ) }
+										</td>
+									);
+								} ) }
+							</tr>
+						);
+					} ) }
+				</tbody>
+			</table>
+			<div className="newspack-insights__cohort-heatmap-footer">
+				<span className="newspack-insights__cohort-heatmap-scale">
+					{ __( 'Lower', 'newspack-plugin' ) }
+					<span className="newspack-insights__cohort-heatmap-swatches" aria-hidden="true">
+						{ [ 0, 0.25, 0.5, 0.75, 1 ].map( t => (
+							<span key={ `sw-${ t }` } style={ { backgroundColor: cellColor( t ) } } />
+						) ) }
+					</span>
+					{ __( 'Higher', 'newspack-plugin' ) }
+				</span>
+				{ referenceLabel && (
+					<span className="newspack-insights__cohort-heatmap-target">
+						{ __( 'Target', 'newspack-plugin' ) }: { referenceLabel }
+					</span>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default CohortHeatmap;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -402,6 +402,86 @@
 		}
 	}
 
+	// Cohort heatmap (Section 5) — cohort-matrix grid replacing the many-series
+	// cohort LineChart. Cell background/text colors are computed inline (scaled to
+	// the value range); these rules own only structure. Horizontal scroll keeps a
+	// wide period axis from overflowing the card.
+	&__cohort-heatmap {
+		overflow-x: auto;
+	}
+
+	&__cohort-heatmap-table {
+		border-collapse: separate;
+		border-spacing: 3px;
+		font-size: 12px;
+		font-variant-numeric: tabular-nums;
+
+		caption {
+			caption-side: top;
+			margin-bottom: 6px;
+			text-align: left;
+			font-size: 11px;
+			color: wp-colors.$gray-600;
+		}
+	}
+
+	&__cohort-heatmap-corner,
+	&__cohort-heatmap-colhead {
+		padding: 0 6px 4px;
+		font-weight: 500;
+		color: wp-colors.$gray-700;
+		text-align: center;
+	}
+
+	&__cohort-heatmap-corner {
+		padding-left: 0;
+		text-align: left;
+	}
+
+	&__cohort-heatmap-rowhead {
+		padding-right: 10px;
+		font-weight: 400;
+		color: wp-colors.$gray-900;
+		text-align: left;
+		white-space: nowrap;
+	}
+
+	&__cohort-heatmap-cell {
+		min-width: 40px;
+		padding: 6px 10px;
+		border-radius: 4px;
+		text-align: center;
+		font-variant-numeric: tabular-nums;
+
+		&.is-empty {
+			background: transparent;
+		}
+	}
+
+	&__cohort-heatmap-footer {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+		margin-top: 10px;
+		font-size: 11px;
+		color: wp-colors.$gray-600;
+	}
+
+	&__cohort-heatmap-scale {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	&__cohort-heatmap-swatches {
+		display: inline-flex;
+
+		span {
+			width: 18px;
+			height: 12px;
+		}
+	}
+
 	// Dark hover panel shared by the line + bar charts (NPPD-1649 fix #5).
 	// Base = the line variant, positioned absolutely at a data point's
 	// coordinates (inline left/top) and floated above it.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
@@ -60,34 +60,31 @@ describe( 'CohortRetentionSection', () => {
 		expect( screen.getAllByText( /Unable to load this section/ ) ).toHaveLength( 2 );
 	} );
 
-	it( 'shows the 5.2 reference line but suppresses the 5.1 one even when present', () => {
+	it( 'shows the 5.2 target callout but suppresses the 5.1 one even when present', () => {
 		const current = {
 			...makeConversionWindow( { cohortState: 'populated' } ),
-			// 5.1 deliberately carries a value to prove the parent never wires a
-			// 5.1 reference line, independent of payload (real payload is null).
+			// 5.1 deliberately carries a value to prove the parent never wires a 5.1
+			// target callout, independent of payload (real payload is null).
 			registration_to_conversion_cohort: populatedCohort( { value: 0.15, label: '15% at 6 months' } ),
 			subscriber_retention_cohort: populatedCohort( { value: 0.7, label: '70% at 12 months' } ),
 		};
 		const { container } = render( <CohortRetentionSection current={ current } /> );
-		expect( screen.getByText( '70% at 12 months' ) ).toBeInTheDocument();
-		expect( screen.queryByText( '15% at 6 months' ) ).not.toBeInTheDocument();
-		expect( container.querySelectorAll( '.newspack-insights__line-reference' ) ).toHaveLength( 1 );
-		expect( container.querySelectorAll( '.newspack-insights__line-reference-label' ) ).toHaveLength( 1 );
+		expect( screen.getByText( /70% at 12 months/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /15% at 6 months/ ) ).not.toBeInTheDocument();
+		// Exactly one heatmap renders a target callout (the 5.2 retention chart).
+		expect( container.querySelectorAll( '.newspack-insights__cohort-heatmap-target' ) ).toHaveLength( 1 );
 	} );
 
-	it( 'autoscales the 5.1 axis so small-magnitude cohort curves fill the chart', () => {
+	it( 'renders a cohort-matrix grid per chart for populated cohorts', () => {
 		const current = {
 			...makeConversionWindow( { cohortState: 'populated' } ),
 			registration_to_conversion_cohort: populatedCohort( null ),
 			subscriber_retention_cohort: populatedCohort( { value: 0.7, label: '70% at 12 months' } ),
 		};
 		const { container } = render( <CohortRetentionSection current={ current } /> );
-		// First cohort cell is 5.1 (Registration → conversion).
-		const cell51 = container.querySelectorAll( '.newspack-insights__conversion-cohort-cell' )[ 0 ];
-		const ys = Array.from( cell51.querySelectorAll( '.newspack-insights__line-point' ) ).map( p => parseFloat( p.getAttribute( 'cy' ) ?? '0' ) );
-		// Autoscaled: the 0.02 peak reaches the top band (cy ≈ 8). With the old
-		// yMax=1 it would sit near the bottom (cy ≈ 149 of the 160-tall chart),
-		// so a tight ceiling guards against a regression to the fixed axis.
-		expect( Math.min( ...ys ) ).toBeLessThan( 20 );
+		// One heatmap table per cohort chart (5.1 and 5.2).
+		expect( container.querySelectorAll( '.newspack-insights__cohort-heatmap-table' ) ).toHaveLength( 2 );
+		// The 0.02 cohort value is shaded and printed as a percentage cell.
+		expect( screen.getAllByText( '2%' ).length ).toBeGreaterThan( 0 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -1,11 +1,11 @@
 /**
  * CohortRetentionSection (NPPD-1609, Section 5).
  *
- * Two stacked multi-series cohort LineCharts (registration → conversion,
- * subscriber retention). 5.2 keeps a fixed 0–100% axis with a 70% retention
- * target line; 5.1 autoscales with no default reference line (the hardcoded
- * 15% benchmark was removed — a self-relative baseline is planned).
- * Snapshot — refreshed weekly, independent of the date picker.
+ * Two stacked cohort heatmaps (registration → conversion, subscriber retention):
+ * rows are monthly cohorts, columns are months since start, cells shaded by value.
+ * This replaced the many-series LineCharts, which became unreadable "spaghetti"
+ * once a site had more than a handful of cohorts. Snapshot — refreshed weekly,
+ * independent of the date picker.
  *
  * Each chart's rendering is gated on the metric's `state` envelope.
  */
@@ -20,9 +20,8 @@ import { __ } from '@wordpress/i18n';
  */
 import type { ConversionCohortData } from '../../api/conversion';
 import SectionHeading from '../components/SectionHeading';
-import LineChart, { type LineSeries, type LineReferenceLine } from '../components/LineChart';
+import CohortHeatmap from '../components/CohortHeatmap';
 import { formatPercent } from '../components/format';
-import { monthLabel } from './labels';
 import SectionState from './SectionState';
 
 export interface CohortRetentionSectionProps {
@@ -32,24 +31,18 @@ export interface CohortRetentionSectionProps {
 	};
 }
 
-/** Map cohort series (period → value) to LineChart series. */
-const toCohortSeries = ( data: ConversionCohortData ): LineSeries[] =>
-	data.cohorts.map( cohort => ( {
-		name: cohort.label,
-		points: cohort.points.map( p => ( { label: String( p.period ), value: p.value } ) ),
-	} ) );
-
 interface CohortChartProps {
 	title: string;
 	data: ConversionCohortData;
-	yAxisLabel: string;
-	yMax?: number;
-	referenceLine?: LineReferenceLine;
+	/** One-line explanation of what a cell means (the two charts read oppositely). */
+	caption: string;
+	referenceLabel?: string;
 }
 
-const CohortChart = ( { title, data, yAxisLabel, yMax, referenceLine }: CohortChartProps ) => (
+const CohortChart = ( { title, data, caption, referenceLabel }: CohortChartProps ) => (
 	<div className="newspack-insights__conversion-cohort-cell">
 		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
+		<p className="newspack-insights__conversion-subcaption">{ caption }</p>
 		<SectionState
 			state={ data.state }
 			comingSoonMessage={ __(
@@ -58,14 +51,11 @@ const CohortChart = ( { title, data, yAxisLabel, yMax, referenceLine }: CohortCh
 			) }
 			emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
 		>
-			<LineChart
-				series={ toCohortSeries( data ) }
-				referenceLine={ referenceLine }
-				yMax={ yMax }
-				formatLabel={ monthLabel }
+			<CohortHeatmap
+				cohorts={ data.cohorts }
 				formatValue={ formatPercent }
-				xAxisLabel={ __( 'Months', 'newspack-plugin' ) }
-				yAxisLabel={ yAxisLabel }
+				columnsLabel={ __( 'Months since cohort start', 'newspack-plugin' ) }
+				referenceLabel={ referenceLabel }
 				emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
 			/>
 		</SectionState>
@@ -81,30 +71,34 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
 			id="newspack-insights-conversion-cohort-heading"
 			title={ __( 'Cohort retention', 'newspack-plugin' ) }
 			description={ __(
-				'Retention curves by monthly cohort. The vertical axis is the share of each cohort still on a given lifecycle stage at each point in time. Updated weekly.',
+				'Each row is a monthly cohort; each column is months since that cohort started. Read down a column to compare cohorts at the same age, and across a row to watch one cohort over time. Updated weekly.',
 				'newspack-plugin'
 			) }
 		/>
 		<div className="newspack-insights__conversion-cohort-stack">
 			<CohortChart
 				/*
-				 * TODO: default a self-relative reference line here — the median
+				 * TODO: default a self-relative reference callout here — the median
 				 * cumulative conversion of mature (>=12-month) cohorts at the 6-month
 				 * mark — and expose it as a configurable Newspack publisher setting.
-				 * For now the 5.1 axis autoscales (no yMax) and shows no reference
-				 * line; the hardcoded 15% was removed because no fixed-% default fits
-				 * the network (publisher conversion models diverge widely).
+				 * For now 5.1 shows no target; the hardcoded 15% was removed because no
+				 * fixed-% default fits the network (publisher models diverge widely).
 				 */
 				title={ __( 'Registration → conversion', 'newspack-plugin' ) }
+				caption={ __(
+					'Of the readers who registered each month, the share who had become a paying subscriber or donor by that many months later. Starts at 0% and climbs.',
+					'newspack-plugin'
+				) }
 				data={ current.registration_to_conversion_cohort }
-				yAxisLabel={ __( 'Percent converted', 'newspack-plugin' ) }
 			/>
 			<CohortChart
 				title={ __( 'Subscriber retention', 'newspack-plugin' ) }
+				caption={ __(
+					'Of the subscribers who started each month, the share still subscribed that many months later. Starts at 100% and declines.',
+					'newspack-plugin'
+				) }
 				data={ current.subscriber_retention_cohort }
-				yMax={ 1 }
-				yAxisLabel={ __( 'Percent retained', 'newspack-plugin' ) }
-				referenceLine={ current.subscriber_retention_cohort.reference_line ?? undefined }
+				referenceLabel={ current.subscriber_retention_cohort.reference_line?.label }
 			/>
 		</div>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -37,12 +37,12 @@ export interface ConversionRateTrendsSectionProps {
  */
 const SERIES_BY_KEY: Record< string, { label: string; value: ( w: ConversionWeekPoint ) => number } > = {
 	registration_rate: {
-		label: __( 'Registration rate', 'newspack-plugin' ),
+		label: __( 'Registrations (per active reader)', 'newspack-plugin' ),
 		value: w => w.registration_conversion_rate,
 	},
-	subscription_attempt_rate: {
-		label: __( 'Subscription attempt rate', 'newspack-plugin' ),
-		value: w => w.subscription_attempt_rate,
+	subscription_conversion_rate: {
+		label: __( 'Subscriptions (per registered reader)', 'newspack-plugin' ),
+		value: w => w.subscription_conversion_rate,
 	},
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -127,11 +127,14 @@
 		@include conversion-chart-card;
 	}
 
-	// Section 5 — two cohort curves stacked vertically.
+	// Section 5 — two cohort heatmaps side by side (wrapping to one column when
+	// the container is narrow). The heatmaps are compact, so stacking them left a
+	// lot of empty space to the right.
 	&__conversion-cohort-stack {
-		display: flex;
-		flex-direction: column;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 		gap: 24px;
+		align-items: stretch;
 	}
 
 	&__conversion-cohort-cell {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/fixtures.ts
@@ -138,7 +138,7 @@ const cohort = ( referenceLine: ConversionReferenceLine | null, state: Conversio
 const weekly = ( state: ConversionMetricState = 'coming_soon' ): ConversionWeeklyTrendsData => ( {
 	state,
 	weeks: [],
-	series: [ 'registration_rate', 'subscription_attempt_rate' ],
+	series: [ 'registration_rate', 'subscription_conversion_rate' ],
 } );
 
 const topPages = ( state: ConversionMetricState = 'coming_soon' ): ConversionTopPagesTable => ( { state, rows: [], threshold_pageviews: 100 } );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -618,37 +618,49 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	// --- C6: get_weekly_conversion_rates -----------------------------------
 
 	/**
-	 * C6 populated: proxy returns rows of {week_start,
-	 * registration_conversion_rate, subscription_attempt_rate} → state
-	 * 'populated', `weeks` carries each row keyed by the three columns.
+	 * C6 populated: proxy returns rows of {week_start, registration_conversion_rate,
+	 * new_registrations}; the subscription series is computed here from real Woo
+	 * completions (Subscribers_Metric::get_new_subscribers_by_week) divided by the
+	 * hub's per-week new_registrations, keyed on the shared week_start.
 	 */
 	public function test_weekly_conversion_rates_returns_populated_weeks_on_success() {
-		$rows   = [
+		$rows = [
 			[
 				'week_start'                   => '2026-03-22',
 				'registration_conversion_rate' => 0.12,
-				'subscription_attempt_rate'    => 0.08,
+				'new_registrations'            => 200,
 			],
 			[
 				'week_start'                   => '2026-03-29',
 				'registration_conversion_rate' => 0.15,
-				'subscription_attempt_rate'    => 0.09,
+				'new_registrations'            => 300,
 			],
 		];
-		$metric = new Conversion_Metric( $this->proxy_returning( $rows ) );
+		// Real completed subscriptions per week (local Woo), keyed on the same week_start.
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscribers_by_week' )->willReturn(
+			[
+				'2026-03-22' => 16, // 16 / 200 = 0.08.
+				'2026-03-29' => 27, // 27 / 300 = 0.09.
+			]
+		);
+		$metric          = new Conversion_Metric( $this->proxy_returning( $rows ), $subs );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_weekly_conversion_rates( $start, $end );
 
 		$this->assertSame( 'populated', $result['state'] );
 		$this->assertArrayNotHasKey( 'pending', $result );
-		$this->assertSame( [ 'registration_rate', 'subscription_attempt_rate' ], $result['series'] );
+		$this->assertSame( [ 'registration_rate', 'subscription_conversion_rate' ], $result['series'] );
 		$this->assertCount( 2, $result['weeks'] );
 
-		// First week row: keys and cast values.
+		// First week: registration rate passes through; subscription rate = subs ÷ new_registrations.
 		$week0 = $result['weeks'][0];
 		$this->assertSame( '2026-03-22', $week0['week'] );
 		$this->assertEqualsWithDelta( 0.12, $week0['registration_conversion_rate'], 1e-9 );
-		$this->assertEqualsWithDelta( 0.08, $week0['subscription_attempt_rate'], 1e-9 );
+		$this->assertEqualsWithDelta( 0.08, $week0['subscription_conversion_rate'], 1e-9 );
+
+		// Second week likewise: 27 ÷ 300 = 0.09.
+		$this->assertEqualsWithDelta( 0.09, $result['weeks'][1]['subscription_conversion_rate'], 1e-9 );
 	}
 
 	/**
@@ -661,7 +673,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 
 		$this->assertSame( 'empty', $result['state'] );
 		$this->assertSame( [], $result['weeks'] );
-		$this->assertSame( [ 'registration_rate', 'subscription_attempt_rate' ], $result['series'] );
+		$this->assertSame( [ 'registration_rate', 'subscription_conversion_rate' ], $result['series'] );
 	}
 
 	/**
@@ -678,7 +690,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'bigquery_proxy_http_error', $result['error_code'] );
 		$this->assertSame( 'HTTP 502', $result['error_message'] );
 		$this->assertSame( [], $result['weeks'] );
-		$this->assertSame( [ 'registration_rate', 'subscription_attempt_rate' ], $result['series'] );
+		$this->assertSame( [ 'registration_rate', 'subscription_conversion_rate' ], $result['series'] );
 	}
 
 	/**
@@ -687,15 +699,18 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	 * conversion" warning. The non-scalar coerces to an empty `week` string
 	 * while the sibling scalar columns are still read. Regression test for the
 	 * production warning in Conversion_Metric::get_weekly_conversion_rates().
+	 */
 	public function test_weekly_conversion_rates_coerces_non_scalar_week_start() {
-		$rows            = [
+		$rows = [
 			[
 				'week_start'                   => [ 'value' => '2026-03-22' ],
 				'registration_conversion_rate' => 0.12,
-				'subscription_attempt_rate'    => 0.08,
+				'new_registrations'            => 100,
 			],
 		];
-		$metric          = new Conversion_Metric( $this->proxy_returning( $rows ) );
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscribers_by_week' )->willReturn( [] );
+		$metric          = new Conversion_Metric( $this->proxy_returning( $rows ), $subs );
 		[ $start, $end ] = $this->window();
 		$result          = $metric->get_weekly_conversion_rates( $start, $end );
 
@@ -703,9 +718,31 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertCount( 1, $result['weeks'] );
 		// Non-scalar week_start coerces to '' rather than the literal "Array".
 		$this->assertSame( '', $result['weeks'][0]['week'] );
-		// Sibling scalar columns are still read.
+		// The sibling registration rate is still read.
 		$this->assertEqualsWithDelta( 0.12, $result['weeks'][0]['registration_conversion_rate'], 1e-9 );
-		$this->assertEqualsWithDelta( 0.08, $result['weeks'][0]['subscription_attempt_rate'], 1e-9 );
+		// No matching Woo week → subscription conversion rate 0.0.
+		$this->assertEqualsWithDelta( 0.0, $result['weeks'][0]['subscription_conversion_rate'], 1e-9 );
+	}
+
+	/**
+	 * C6 div-by-zero: a week with zero new_registrations yields a 0.0 subscription
+	 * conversion rate (no division), even if Woo reports subscriptions that week.
+	 */
+	public function test_weekly_conversion_rates_zero_registrations_yields_zero_rate() {
+		$rows = [
+			[
+				'week_start'                   => '2026-03-22',
+				'registration_conversion_rate' => 0.0,
+				'new_registrations'            => 0,
+			],
+		];
+		$subs = $this->createMock( Subscribers_Metric::class );
+		$subs->method( 'get_new_subscribers_by_week' )->willReturn( [ '2026-03-22' => 5 ] );
+		$metric          = new Conversion_Metric( $this->proxy_returning( $rows ), $subs );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_weekly_conversion_rates( $start, $end );
+
+		$this->assertEqualsWithDelta( 0.0, $result['weeks'][0]['subscription_conversion_rate'], 1e-9 );
 	}
 
 	// --- C7: get_influenced_registration_rate_7d ---------------------------
@@ -1981,7 +2018,7 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		// Section 6 — weekly rates: weeks array + series keys.
 		$this->assertSame( 'populated', $current['weekly_conversion_rates']['state'] );
 		$this->assertNotEmpty( $current['weekly_conversion_rates']['weeks'] );
-		$this->assertSame( [ 'registration_rate', 'subscription_attempt_rate' ], $current['weekly_conversion_rates']['series'] );
+		$this->assertSame( [ 'registration_rate', 'subscription_conversion_rate' ], $current['weekly_conversion_rates']['series'] );
 
 		// Section 7 — influenced scalars.
 		$this->assertSame( 'populated', $current['influenced_registration_rate_7d']['state'] );


### PR DESCRIPTION
Two Conversion Journey (Tab 3) improvements, bundled per request since both are frontend/plugin changes on the same tab.

## 1. "Conversion rate trends": intent → real conversion
The subscription line plotted `subscription_attempt_rate` — GA4 checkout *attempts* (intent), not completed orders. It now plots **real completed Woo subscriptions**.

- New `Subscribers_Metric::get_new_subscribers_by_week()` (+ HPOS & legacy storage) counts each customer's first non-donation `shop_subscription` by `_schedule_start`, bucketed into **Sunday-start weeks** to align with the hub.
- `Conversion_Metric::get_weekly_conversion_rates()` merges the hub's per-week `new_registrations` with the local Woo counts and computes `subscription_conversion_rate = subs ÷ new_registrations` (0 when no registrations).
- Denominator stays `new_registrations` (any new reader account — newsletter signup, block, checkout, OAuth — via `np_reader_registered`), so both lines share the same "registration" definition. Labels: **"Registrations (per active reader)"** and **"Subscriptions (per registered reader)"** — the two lines are sequential funnel steps with different bases, so the names carry the base.
- TZ note: `_schedule_start` is UTC while the hub's GA4 weeks are property-local, so a sub within hours of a week boundary can land one bucket over — minor trend fuzz (documented in code).

**Requires the paired hub PR** (Automattic/newspack-manager-admin#487), which changes `conversion_journey_weekly_rates` to return `new_registrations`. Merge together.

## 2. Cohort charts: spaghetti → heatmap
Section 5's two many-series cohort LineCharts were unreadable past a handful of cohorts (overlapping lines + black-dot hover blobs). Replaced with a new shared **`CohortHeatmap`**: rows = cohort, columns = months-since-start, cells shaded by value (exact % printed, blanks for un-aged periods). The two grids sit side by side; the 5.2 "70% at 12 months" target is a caption callout. Each chart carries a one-line caption naming what its cells mean (conversion accumulates from 0%, retention decays from 100%).

## Testing
- **164 PHP tests** (Conversion_Metric merge + Subscribers_Metric + storage) green; the week-bucketing SQL validated live on the dev DB (all week_starts = Sunday).
- **68 conversion-tab JS tests** green, incl. 5 new `CohortHeatmap` tests + rewritten cohort-section tests.
- tsc, ESLint/prettier, root-PHPCS, SCSS-lint all clean.
- Verified live in the local dev site (fixture mode).