### PR TITLE
feat(insights): newsletter->paid conversion cards (NEWS-2603)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -178,6 +178,9 @@ class Donors_REST_Controller extends WP_REST_Controller {
 				'donation_arr'                        => $metric->get_donation_arr(),
 				'upcoming_donation_renewals_30d'      => $metric->get_upcoming_donation_renewals_30d(),
 				'upcoming_donation_cancellations_30d' => $metric->get_upcoming_donation_cancellations_30d(),
+				// NEWS-2603: newsletter -> donation conversion (hub, mature-cohort
+				// snapshot). Anchored on the report end date; window-independent.
+				'newsletter_conversion'               => ( new Conversion_Metric() )->get_newsletter_to_donation_conversion( $start, $end ),
 			],
 			'current'        => $this->build_window( $metric, $start, $end ),
 			'previous'       => null,

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -190,6 +190,9 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 				'tenure_distribution'        => $metric->get_subscription_tenure_distribution(),
 				'upcoming_renewals_30d'      => $metric->get_upcoming_renewals_30d(),
 				'upcoming_cancellations_30d' => $metric->get_upcoming_cancellations_30d(),
+				// NEWS-2603: newsletter -> subscription conversion (hub, mature-cohort
+				// snapshot). Anchored on the report end date; window-independent.
+				'newsletter_conversion'      => ( new Conversion_Metric() )->get_newsletter_to_subscription_conversion( $start, $end ),
 			],
 			'current'        => $this->build_window( $metric, $start, $end ),
 			'previous'       => null,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1806,6 +1806,11 @@ final class Conversion_Metric {
 	 * @return array
 	 */
 	public function get_newsletter_to_subscription_conversion( DateTimeInterface $start, DateTimeInterface $end ): array {
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			// Fixture-mode dev sites have no live hub — demo value: ~7% of newsletter
+			// signups became subscribers within 12 months (84 of 1,200).
+			return $this->populated_scalar( 0.07, true, 1200, 'rate' );
+		}
 		return $this->compute_influenced_rate_from_proxy(
 			'conversion_journey_newsletter_to_subscription',
 			'newsletter_conversion_rate',
@@ -1825,6 +1830,11 @@ final class Conversion_Metric {
 	 * @return array
 	 */
 	public function get_newsletter_to_donation_conversion( DateTimeInterface $start, DateTimeInterface $end ): array {
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			// Fixture-mode dev sites have no live hub — demo value: ~4% of newsletter
+			// signups became donors within 12 months (48 of 1,200).
+			return $this->populated_scalar( 0.04, true, 1200, 'rate' );
+		}
 		return $this->compute_influenced_rate_from_proxy(
 			'conversion_journey_newsletter_to_donation',
 			'newsletter_conversion_rate',

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1793,6 +1793,47 @@ final class Conversion_Metric {
 		);
 	}
 
+	/**
+	 * Newsletter -> subscription conversion (NEWS-2603): of the mature newsletter-signup
+	 * cohort, the share who made a first confirmed subscription checkout within 12 months
+	 * of signing up. Snapshot (window-independent) — the hub anchors on the report date;
+	 * consumed by the Subscribers tab. Dispatches
+	 * `conversion_journey_newsletter_to_subscription`; the hub returns one row with
+	 * `newsletter_conversion_rate` and the `newsletter_signups` denominator.
+	 *
+	 * @param DateTimeInterface $start Window start (unused by the snapshot query).
+	 * @param DateTimeInterface $end   Report date anchor.
+	 * @return array
+	 */
+	public function get_newsletter_to_subscription_conversion( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return $this->compute_influenced_rate_from_proxy(
+			'conversion_journey_newsletter_to_subscription',
+			'newsletter_conversion_rate',
+			'newsletter_signups',
+			$start,
+			$end
+		);
+	}
+
+	/**
+	 * Newsletter -> donation conversion (NEWS-2603): donor sibling of
+	 * get_newsletter_to_subscription_conversion, consumed by the Donors tab. Dispatches
+	 * `conversion_journey_newsletter_to_donation`; same one-row shape.
+	 *
+	 * @param DateTimeInterface $start Window start (unused by the snapshot query).
+	 * @param DateTimeInterface $end   Report date anchor.
+	 * @return array
+	 */
+	public function get_newsletter_to_donation_conversion( DateTimeInterface $start, DateTimeInterface $end ): array {
+		return $this->compute_influenced_rate_from_proxy(
+			'conversion_journey_newsletter_to_donation',
+			'newsletter_conversion_rate',
+			'newsletter_signups',
+			$start,
+			$end
+		);
+	}
+
 	// --- Section 8: Opportunity buckets ---------------------------------
 	// 8.1–8.3 are current-state snapshot counts: accept the window for
 	// signature parity, ignore it. All three are local-only (Woo-only, or

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -42,6 +42,8 @@ export interface DonorsSnapshot {
 	donation_arr: number;
 	upcoming_donation_renewals_30d: UpcomingDonationRenewals;
 	upcoming_donation_cancellations_30d: UpcomingDonationCancellations;
+	/** Newsletter → donation conversion (NEWS-2603): mature-cohort snapshot rate. */
+	newsletter_conversion: DonorsRateValue;
 }
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -59,6 +59,8 @@ export interface SubscribersSnapshot {
 	tenure_distribution: TenureDistributionRow[];
 	upcoming_renewals_30d: UpcomingRenewals;
 	upcoming_cancellations_30d: UpcomingCancellations;
+	/** Newsletter → subscription conversion (NEWS-2603): mature-cohort snapshot rate. */
+	newsletter_conversion: SubscribersRateValue;
 }
 
 export interface PerformanceVariationRow {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -58,6 +58,7 @@ const DonorsTab = ( { range, previousRange }: DonorsTabProps ) => {
 						current={ data.current }
 						previous={ data.previous }
 						activeDonors={ data.snapshot.active_donors }
+						newsletterConversion={ data.snapshot.newsletter_conversion }
 					/>
 					<RetentionSection current={ data.current } previous={ data.previous } />
 					<PerformanceSection rows={ data.current.donations_by_tier } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -62,6 +62,7 @@ const SubscribersTab = ( { range, previousRange }: SubscribersTabProps ) => {
 						current={ data.current }
 						previous={ data.previous }
 						activeSubscribers={ data.snapshot.active_subscribers }
+						newsletterConversion={ data.snapshot.newsletter_conversion }
 					/>
 					<TenureSection rows={ data.snapshot.tenure_distribution } />
 					<PerformanceSection rows={ data.current.subscriptions_by_product } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
@@ -104,7 +104,7 @@ describe( 'WindowedSection empty states', () => {
 		expect( screen.queryByText( /existing donors active/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders all four cards with the full one-time + recurring breakdown when populated', () => {
+	it( 'renders every card (incl. the newsletter conversion card) with the full one-time + recurring breakdown when populated', () => {
 		const current = makeWindow();
 		const { container } = render(
 			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 200 } newsletterConversion={ NLC } />
@@ -112,11 +112,27 @@ describe( 'WindowedSection empty states', () => {
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'New donors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
 
 		const breakdown = revenueBreakdownText( container );
 		expect( breakdown ).toMatch( /one-time/ );
 		expect( breakdown ).toMatch( /recurring/ );
 		expect( breakdown ).toContain( '+' );
+	} );
+
+	it( 'renders the newsletter conversion card as an em-dash when the cohort is not yet mature', () => {
+		render(
+			<WindowedSection
+				range={ RANGE }
+				current={ makeWindow() }
+				previous={ null }
+				activeDonors={ 200 }
+				newsletterConversion={ { value: 0, computable: false, denominator: 0 } }
+			/>
+		);
+
+		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough newsletter signups with 12 months of history yet.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'suppresses the empty mode in the revenue breakdown — recurring-only window', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
@@ -52,6 +52,8 @@ const revenueBreakdownText = ( container: HTMLElement ): string => {
 	return card?.querySelector( '.newspack-insights__metric-card-secondary' )?.textContent ?? '';
 };
 
+const NLC = { value: 0.05, computable: true, denominator: 100 };
+
 describe( 'WindowedSection empty states', () => {
 	it( 'collapses to a no_opportunity EmptyMetricSection when the window saw no activity', () => {
 		const current = makeWindow( {
@@ -63,7 +65,9 @@ describe( 'WindowedSection empty states', () => {
 			total_revenue: 0,
 			average_gift: 0,
 		} );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Assert body on the container — the Notice's speak() duplicates copy into a
@@ -78,7 +82,9 @@ describe( 'WindowedSection empty states', () => {
 		// Section has revenue and a lapse but no first-time donors: the New donors card
 		// gets the existing-donor context line, while the real revenue cards still render.
 		const current = makeWindow( { new_donors: 0, lapsed_donors: 2, total_revenue: 1500 } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeDonors={ 42 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeDonors={ 42 } newsletterConversion={ NLC } />
+		);
 
 		// No whole-section empty state — the section is NOT collapsed.
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
@@ -93,14 +99,16 @@ describe( 'WindowedSection empty states', () => {
 		// the card renders a plain zero, not the "existing donors active" line. (In practice
 		// has_window_activity would usually be false here, but guard the per-card branch.)
 		const current = makeWindow( { new_donors: 0, lapsed_donors: 1, total_revenue: 500 } );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } newsletterConversion={ NLC } /> );
 
 		expect( screen.queryByText( /existing donors active/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders all four cards with the full one-time + recurring breakdown when populated', () => {
 		const current = makeWindow();
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 200 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 200 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'New donors' ) ).toBeInTheDocument();
@@ -113,7 +121,9 @@ describe( 'WindowedSection empty states', () => {
 
 	it( 'suppresses the empty mode in the revenue breakdown — recurring-only window', () => {
 		const current = makeWindow( { one_time_revenue: 0, recurring_revenue: 1200, total_revenue: 1200, average_gift: 0 } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } newsletterConversion={ NLC } />
+		);
 
 		// The breakdown line shows recurring only — no "one-time" half, no "$0 one-time", no "+".
 		const breakdown = revenueBreakdownText( container );
@@ -126,7 +136,9 @@ describe( 'WindowedSection empty states', () => {
 
 	it( 'suppresses the empty mode in the revenue breakdown — one-time-only window', () => {
 		const current = makeWindow( { one_time_revenue: 800, recurring_revenue: 0, total_revenue: 800, average_gift: 40 } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } newsletterConversion={ NLC } />
+		);
 
 		const breakdown = revenueBreakdownText( container );
 		expect( breakdown ).toMatch( /one-time/ );
@@ -145,7 +157,7 @@ describe( 'WindowedSection empty states', () => {
 			total_revenue: 0,
 			average_gift: 0,
 		} );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 30 } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 30 } newsletterConversion={ NLC } /> );
 
 		expect( screen.getByText( 'No donations in this timeframe' ) ).toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -147,6 +147,11 @@ const WindowedSection = ( { range, current, previous, activeDonors, newsletterCo
 
 	const donationsLabel = __( 'donations', 'newspack-plugin' );
 	const oneTimeGiftsLabel = __( 'one-time gifts', 'newspack-plugin' );
+	// Snapshot rate: an em-dash (not a misleading 0%) until a mature cohort of
+	// newsletter signups with a full 12 months of history exists.
+	const newsletterConversionEmptyMessage = ! newsletterConversion.computable
+		? __( 'Not enough newsletter signups with 12 months of history yet.', 'newspack-plugin' )
+		: undefined;
 
 	return (
 		<section
@@ -178,6 +183,7 @@ const WindowedSection = ( { range, current, previous, activeDonors, newsletterCo
 					label={ __( 'Newsletter → donation', 'newspack-plugin' ) }
 					value={ newsletterConversion.value }
 					format="percent"
+					notComputableMessage={ newsletterConversionEmptyMessage }
 					description={ __(
 						'Of newsletter signups with a full 12 months of history, the share who became a donor within 12 months of signing up. A snapshot — not affected by the selected timeframe.',
 						'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -32,7 +32,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { DonorsWindow } from '../../api/donors';
+import type { DonorsRateValue, DonorsWindow } from '../../api/donors';
 import type { DateRange } from '../../state/useDateRange';
 import EmptyMetricSection from '../components/EmptyMetricSection';
 import MetricCard from '../components/MetricCard';
@@ -50,6 +50,12 @@ export interface WindowedSectionProps {
 	 * donors, just none new in this timeframe.
 	 */
 	activeDonors: number;
+	/**
+	 * Newsletter → donation conversion (NEWS-2603): a mature-cohort snapshot rate from
+	 * the hub. Window-independent — it sits in this windowed section for grouping, but
+	 * the value doesn't change with the date range.
+	 */
+	newsletterConversion: DonorsRateValue;
 }
 
 const parseISO = ( s: string ): Date => {
@@ -113,7 +119,7 @@ const revenueBreakdown = ( current: DonorsWindow ): string | undefined => {
 	return undefined;
 };
 
-const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSectionProps ) => {
+const WindowedSection = ( { range, current, previous, activeDonors, newsletterConversion }: WindowedSectionProps ) => {
 	// Whole-section empty: nothing happened this window. Collapse the grid to a
 	// single callout (NPPD-1694 `EmptyMetricSection`). Checked first so the
 	// per-card states below only fire inside a section that has real data —
@@ -167,6 +173,15 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 							: undefined
 					}
 					description={ __( 'First-time donors in selected timeframe', 'newspack-plugin' ) }
+				/>
+				<MetricCard
+					label={ __( 'Newsletter → donation', 'newspack-plugin' ) }
+					value={ newsletterConversion.value }
+					format="percent"
+					description={ __(
+						'Of newsletter signups with a full 12 months of history, the share who became a donor within 12 months of signing up. A snapshot — not affected by the selected timeframe.',
+						'newspack-plugin'
+					) }
 				/>
 				<MetricCard
 					label={ __( 'Lapsed donors', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -43,6 +43,8 @@ const cardValueByLabel = ( container: HTMLElement, label: string ): string => {
 	return card?.querySelector( '.newspack-insights__metric-card-value' )?.textContent ?? '';
 };
 
+const NLC = { value: 0.05, computable: true, denominator: 100 };
+
 describe( 'Subscribers WindowedSection empty states', () => {
 	it( 'collapses to a no_opportunity EmptyMetricSection when the window saw no activity', () => {
 		const current = makeWindow( {
@@ -54,7 +56,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 			refund_rate: { value: 0, computable: false, denominator: 0 },
 			failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 },
 		} );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Assert on the container — the Notice's speak() duplicates copy into a live-region.
@@ -65,7 +69,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 	it( 'renders the per-card no-acquisition state on New subscribers without collapsing the section', () => {
 		const current = makeWindow( { new_subscribers: 0, churned_subscribers: 2 } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 128 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 128 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( '128 active subscribers, but none new this timeframe' ) ).toBeInTheDocument();
@@ -82,7 +88,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 	it( 'does NOT show the no-acquisition line when there are no active subscribers either', () => {
 		const current = makeWindow( { new_subscribers: 0, churned_subscribers: 1 } );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } newsletterConversion={ NLC } /> );
 
 		expect( screen.queryByText( /existing subscribers are active/ ) ).not.toBeInTheDocument();
 	} );
@@ -90,7 +96,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 	it( 'GOOD ZERO: zero churn renders the card normally, NOT an empty state', () => {
 		// Activity present (new subscribers + revenue), but zero churn this window.
 		const current = makeWindow( { new_subscribers: 9, churned_subscribers: 0 } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 200 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 200 } newsletterConversion={ NLC } />
+		);
 
 		// Section is NOT collapsed and the churn card is a real card showing 0.
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
@@ -100,7 +108,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 	it( 'GOOD ZERO: zero failed payments reframes positively (NPPD-1726), section intact', () => {
 		const current = makeWindow( { failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 } } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'No failed payments in this timeframe.' ) ).toBeInTheDocument();
@@ -112,7 +122,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		// Orders exist (gross > 0) but no refunds → refund rate is a computable 0%,
 		// a good zero. Renders the em-dash + positive line, not a literal "0%".
 		const current = makeWindow( { refund_rate: { value: 0, computable: true, denominator: 120 } } );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'No refund requests in this timeframe.' ) ).toBeInTheDocument();
@@ -133,7 +145,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 			refund_rate: { value: 0, computable: false, denominator: 0 },
 			failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 },
 		} );
-		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
+		);
 
 		expect( cardValueByLabel( container, 'Refund rate' ) ).toBe( '—' );
 		expect( cardValueByLabel( container, 'Failed payment recovery' ) ).toBe( '—' );
@@ -152,14 +166,16 @@ describe( 'Subscribers WindowedSection empty states', () => {
 			revenue_net: 0,
 			refund_rate: { value: 0, computable: false, denominator: 0 },
 		} );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 50 } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 50 } newsletterConversion={ NLC } /> );
 
 		// Gross + Net both fall back (shared MetricCard helper renders "…in this timeframe").
 		expect( screen.getAllByText( 'No subscription orders in this timeframe' ).length ).toBeGreaterThanOrEqual( 2 );
 	} );
 
 	it( 'renders all six cards when fully populated', () => {
-		const { container } = render( <WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } /> );
+		const { container } = render(
+			<WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
+		);
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'New subscribers' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -172,15 +172,31 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		expect( screen.getAllByText( 'No subscription orders in this timeframe' ).length ).toBeGreaterThanOrEqual( 2 );
 	} );
 
-	it( 'renders all six cards when fully populated', () => {
+	it( 'renders every card when fully populated, including the newsletter conversion card', () => {
 		const { container } = render(
 			<WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
 		);
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'New subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Refund rate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Failed payment recovery' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the newsletter conversion card as an em-dash when the cohort is not yet mature', () => {
+		render(
+			<WindowedSection
+				range={ RANGE }
+				current={ makeWindow() }
+				previous={ null }
+				activeSubscribers={ 200 }
+				newsletterConversion={ { value: 0, computable: false, denominator: 0 } }
+			/>
+		);
+
+		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough newsletter signups with 12 months of history yet.' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -56,6 +56,12 @@ export interface WindowedSectionProps {
 	 * subscribers, just none new in this timeframe.
 	 */
 	activeSubscribers: number;
+	/**
+	 * Newsletter → subscription conversion (NEWS-2603): a mature-cohort snapshot rate
+	 * from the hub. Window-independent — it sits in this windowed section for grouping,
+	 * but the value doesn't change with the date range.
+	 */
+	newsletterConversion: SubscribersRateValue;
 }
 
 const parseISO = ( s: string ): Date => {
@@ -110,7 +116,7 @@ const retriesCohortSubtitle = ( denominator: number ): string =>
 		)
 	);
 
-const WindowedSection = ( { range, current, previous, activeSubscribers }: WindowedSectionProps ) => {
+const WindowedSection = ( { range, current, previous, activeSubscribers, newsletterConversion }: WindowedSectionProps ) => {
 	// Whole-section empty: nothing happened this window. Collapse the grid to a
 	// single callout (NPPD-1694 `EmptyMetricSection`). Checked first so the
 	// per-card states below only fire inside a section that has real data.
@@ -189,6 +195,15 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					format="number"
 					previousValue={ previous?.winback_subscribers }
 					description={ __( 'Previously churned subscribers who resubscribed', 'newspack-plugin' ) }
+				/>
+				<MetricCard
+					label={ __( 'Newsletter → subscription', 'newspack-plugin' ) }
+					value={ newsletterConversion.value }
+					format="percent"
+					description={ __(
+						'Of newsletter signups with a full 12 months of history, the share who became a paid subscriber within 12 months of signing up. A snapshot — not affected by the selected timeframe.',
+						'newspack-plugin'
+					) }
 				/>
 				<MetricCard
 					label={ __( 'Churned subscribers', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -166,6 +166,11 @@ const WindowedSection = ( { range, current, previous, activeSubscribers, newslet
 	const retryEmptyMessage = ! retry.computable ? __( 'No failed payments in this timeframe.', 'newspack-plugin' ) : undefined;
 	const refundPrevious = previous?.refund_rate?.computable ? previous.refund_rate.value : null;
 	const retryPrevious = previous?.failed_payment_retry_rate?.computable ? previous.failed_payment_retry_rate.value : null;
+	// Snapshot rate: an em-dash (not a misleading 0%) until a mature cohort of
+	// newsletter signups with a full 12 months of history exists.
+	const newsletterConversionEmptyMessage = ! newsletterConversion.computable
+		? __( 'Not enough newsletter signups with 12 months of history yet.', 'newspack-plugin' )
+		: undefined;
 
 	return (
 		<section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
@@ -200,6 +205,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers, newslet
 					label={ __( 'Newsletter → subscription', 'newspack-plugin' ) }
 					value={ newsletterConversion.value }
 					format="percent"
+					notComputableMessage={ newsletterConversionEmptyMessage }
 					description={ __(
 						'Of newsletter signups with a full 12 months of history, the share who became a paid subscriber within 12 months of signing up. A snapshot — not affected by the selected timeframe.',
 						'newspack-plugin'

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -369,6 +369,42 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NEWS-2603: newsletter -> subscription conversion scalar passes the hub row's
+	 * rate + newsletter-signups denominator straight through.
+	 */
+	public function test_newsletter_to_subscription_conversion_returns_scalar() {
+		$row             = [
+			'newsletter_conversion_rate' => 0.05,
+			'newsletter_signups'         => 200,
+		];
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $row ] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_newsletter_to_subscription_conversion( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertEqualsWithDelta( 0.05, $result['value'], 1e-9 );
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 200, $result['denominator'] );
+	}
+
+	/**
+	 * NEWS-2603: newsletter -> donation conversion scalar — same shape, donor query.
+	 */
+	public function test_newsletter_to_donation_conversion_returns_scalar() {
+		$row             = [
+			'newsletter_conversion_rate' => 0.02,
+			'newsletter_signups'         => 150,
+		];
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $row ] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_newsletter_to_donation_conversion( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertEqualsWithDelta( 0.02, $result['value'], 1e-9 );
+		$this->assertSame( 150, $result['denominator'] );
+	}
+
+	/**
 	 * C3 empty: proxy returns [] → state 'empty', empty stages array.
 	 */
 	public function test_anon_to_registered_funnel_returns_empty_state_on_no_rows() {


### PR DESCRIPTION
Part of NEWS-2603 (RDP metrics). Plugin half of the **newsletter → paid conversion** cards.

## What
Adds a "Newsletter → subscription" card to the **Subscribers** tab (between Win-backs and Churned) and a "Newsletter → donation" card to the **Donors** tab (between New donors and Lapsed donors). Each shows the share of newsletter signups who became a paid supporter within 12 months of signing up.

- `Conversion_Metric::get_newsletter_to_{subscription,donation}_conversion()` call the two new hub queries (via `compute_influenced_rate_from_proxy`, returning rate + newsletter-signup denominator).
- The Subscribers and Donors REST controllers add a `newsletter_conversion` field to their **snapshot** payloads (window-independent), threaded through the tabs into `WindowedSection`.
- Cards are labeled *"a snapshot — not affected by the selected timeframe"* since the rate is a mature-cohort snapshot.

This is one clean definition reused later by the newsletter-CLV metric (Phase 3).

## Requires the paired hub PR (merge together)
**Automattic/newspack-manager-admin#489** — adds `conversion_journey_newsletter_to_{subscription,donation}`.

## Testing
- **119 Conversion_Metric tests** (2 new for the metric methods) + **168 subscriber/donor tests** green.
- **16 JS section tests** green (both `WindowedSection` suites updated).
- tsc, ESLint/prettier, root-PHPCS all clean.

Note: on a fixture-mode dev site the two new hub queries aren't in the proxy fixture, so the cards render 0% / non-computable there (graceful) rather than demo numbers — real values come from the live hub.