### PR TITLE
feat(insights): 3-year supporter CLV cards (NEWS-2603 Phase 2)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -60,12 +60,14 @@ class Donors_REST_Controller extends WP_REST_Controller {
 	 * the renderer would dash out every applicability-gated column. The
 	 * Donors_Metric metric-layer cache is invalidated in parallel by its own
 	 * CACHE_PREFIX bump. Only the donors envelope is busted — other
-	 * (BigQuery-backed) tabs keep their caches.
+	 * (BigQuery-backed) tabs keep their caches. v4 adds the NEWS-2603 snapshot
+	 * fields `newsletter_conversion` and `supporter_clv_3yr` (a stale v3 envelope
+	 * would lack them and the cards would dereference `undefined`).
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '3';
+		return '4';
 	}
 
 	/**
@@ -181,6 +183,9 @@ class Donors_REST_Controller extends WP_REST_Controller {
 				// NEWS-2603: newsletter -> donation conversion (hub, mature-cohort
 				// snapshot). Anchored on the report end date; window-independent.
 				'newsletter_conversion'               => ( new Conversion_Metric() )->get_newsletter_to_donation_conversion( $start, $end ),
+				// NEWS-2603: modeled 3-year supporter CLV (local Woo). Snapshot anchored
+				// on the report end date; window-independent.
+				'supporter_clv_3yr'                   => $metric->get_supporter_clv_3yr( $end ),
 			],
 			'current'        => $this->build_window( $metric, $start, $end ),
 			'previous'       => null,

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -72,12 +72,14 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	 * the subscribers envelope is busted — other (BigQuery-backed) tabs keep
 	 * their caches. History: v2 reshaped `subscriptions_by_product` (bare-parent
 	 * merge + synthetic "(no variation)" row); v3 adds `winback_subscribers` to
-	 * each window payload.
+	 * each window payload; v4 adds the NEWS-2603 snapshot fields
+	 * `newsletter_conversion` and `supporter_clv_3yr` (a stale v3 envelope would
+	 * lack them and the cards would dereference `undefined`).
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '3';
+		return '4';
 	}
 
 	/**
@@ -193,6 +195,9 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 				// NEWS-2603: newsletter -> subscription conversion (hub, mature-cohort
 				// snapshot). Anchored on the report end date; window-independent.
 				'newsletter_conversion'      => ( new Conversion_Metric() )->get_newsletter_to_subscription_conversion( $start, $end ),
+				// NEWS-2603: modeled 3-year supporter CLV (local Woo). Snapshot anchored
+				// on the report end date; window-independent.
+				'supporter_clv_3yr'          => $metric->get_supporter_clv_3yr( $end ),
 			],
 			'current'        => $this->build_window( $metric, $start, $end ),
 			'previous'       => null,

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-donors.php
@@ -56,6 +56,7 @@ class Insights_Section_Donors {
 		include_once $base . 'storage/class-donors-storage-interface.php';
 		include_once $base . 'storage/class-hpos-donors-storage.php';
 		include_once $base . 'storage/class-legacy-donors-storage.php';
+		include_once $base . 'metrics/class-clv-model.php';
 		include_once $base . 'metrics/class-donors-metric.php';
 		include_once $base . 'api/class-donors-rest-controller.php';
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-subscribers.php
@@ -65,6 +65,7 @@ class Insights_Section_Subscribers {
 		include_once $base . 'storage/class-hpos-storage.php';
 		include_once $base . 'storage/class-legacy-storage.php';
 		include_once $base . 'classifiers/class-donation-product-classifier.php';
+		include_once $base . 'metrics/class-clv-model.php';
 		include_once $base . 'metrics/class-subscribers-metric.php';
 		include_once $base . 'api/class-subscribers-rest-controller.php';
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-clv-model.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-clv-model.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Newspack Insights — Reader Revenue Development 3-year CLV model (NEWS-2603).
+ *
+ * Pure, storage-free implementation of the RDP "Reader Revenue CLV" worksheet's
+ * per-supporter lifetime-value formula. Shared by Subscribers_Metric,
+ * Donors_Metric, and the Audience newsletter-CLV card so the model lives in one
+ * place and is unit-testable without a database.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Modeled 3-year customer lifetime value.
+ */
+final class Clv_Model {
+
+	/**
+	 * Flat maintenance cost (payment-processing fees, servicing) as a share of
+	 * revenue, per the worksheet's 5% assumption.
+	 *
+	 * @var float
+	 */
+	const MAINTENANCE_RATE = 0.05;
+
+	/**
+	 * Per-supporter modeled 3-year CLV.
+	 *
+	 *   CLV = (1 - MAINTENANCE_RATE) * ARPU * (r + r^2 + r^3) - discount
+	 *
+	 * Each of three years earns ARPU scaled by cumulative survival to that year
+	 * (r, r^2, r^3), net of the flat maintenance rate, less an optional Year-1
+	 * intro discount. This applies the maintenance subtraction uniformly to all
+	 * three years — the worksheet's Year 1 cell has a sign slip that adds the
+	 * cost instead; the intended subtraction is used here. Result clamped to >= 0.
+	 *
+	 * @param float $arpu     Average annual revenue per supporter (>= 0).
+	 * @param float $r        12-month retention as a fraction; clamped to [0, 1].
+	 * @param float $discount Per-supporter Year-1 intro discount (default 0).
+	 * @return float CLV rounded to cents.
+	 */
+	public static function three_year( float $arpu, float $r, float $discount = 0.0 ): float {
+		$r   = max( 0.0, min( 1.0, $r ) );
+		$net = ( 1.0 - self::MAINTENANCE_RATE ) * $arpu * ( $r + ( $r ** 2 ) + ( $r ** 3 ) );
+		return max( 0.0, round( $net - $discount, 2 ) );
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -190,9 +190,12 @@ class Donors_Metric {
 	 *
 	 *   ARPU = donation ARR / active recurring donors (recurring revenue per head).
 	 *   r    = 12-month recurring-donor retention (cohort: donors active 12 months
-	 *          before @end still active), clamped to [0, 1].
+	 *          before the report end date still active), clamped to [0, 1]. When that
+	 *          cohort can't be measured the whole card is non-computable (em-dash),
+	 *          not a misleading $0.00.
 	 *
-	 * Snapshot anchored on @end. A modeled estimate — labeled as such in the UI.
+	 * Snapshot anchored on the report end date. A modeled estimate — labeled as
+	 * such in the UI.
 	 *
 	 * @param DateTimeInterface $end Report end date (the "now" anchor).
 	 * @return array{value: float, computable: bool, denominator: int}
@@ -211,9 +214,16 @@ class Donors_Metric {
 
 		$year_ago  = \DateTimeImmutable::createFromInterface( $end )->sub( new \DateInterval( 'P365D' ) );
 		$retention = $this->get_recurring_donor_retention( $year_ago, $end );
-		$r         = ( ! empty( $retention['computable'] ) && isset( $retention['value'] ) )
-			? (float) $retention['value']
-			: 0.0;
+		if ( empty( $retention['computable'] ) || ! isset( $retention['value'] ) ) {
+			// No 12-month cohort to measure retention against (e.g. every recurring
+			// donor is newer than a year): render the em-dash, not a modeled $0.00.
+			return [
+				'value'       => 0.0,
+				'computable'  => false,
+				'denominator' => $active,
+			];
+		}
+		$r = (float) $retention['value'];
 
 		return [
 			'value'       => Clv_Model::three_year( $arpu, $r ),

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-donors-metric.php
@@ -182,6 +182,47 @@ class Donors_Metric {
 	}
 
 	/**
+	 * Modeled 3-year supporter lifetime value for recurring donors (NEWS-2603).
+	 * Same Reader Revenue Development CLV model as the subscribers sibling
+	 * ({@see Subscribers_Metric::get_supporter_clv_3yr()}):
+	 * 0.95 * ARPU * (r + r^2 + r^3) — three years of ARPU scaled by cumulative
+	 * survival, less a flat 5% maintenance cost, no intro discount.
+	 *
+	 *   ARPU = donation ARR / active recurring donors (recurring revenue per head).
+	 *   r    = 12-month recurring-donor retention (cohort: donors active 12 months
+	 *          before @end still active), clamped to [0, 1].
+	 *
+	 * Snapshot anchored on @end. A modeled estimate — labeled as such in the UI.
+	 *
+	 * @param DateTimeInterface $end Report end date (the "now" anchor).
+	 * @return array{value: float, computable: bool, denominator: int}
+	 */
+	public function get_supporter_clv_3yr( DateTimeInterface $end ): array {
+		$active = $this->get_active_recurring_donors();
+		$arr    = $this->get_donation_arr();
+		if ( $active <= 0 || $arr <= 0.0 ) {
+			return [
+				'value'       => 0.0,
+				'computable'  => false,
+				'denominator' => $active,
+			];
+		}
+		$arpu = $arr / $active;
+
+		$year_ago  = \DateTimeImmutable::createFromInterface( $end )->sub( new \DateInterval( 'P365D' ) );
+		$retention = $this->get_recurring_donor_retention( $year_ago, $end );
+		$r         = ( ! empty( $retention['computable'] ) && isset( $retention['value'] ) )
+			? (float) $retention['value']
+			: 0.0;
+
+		return [
+			'value'       => Clv_Model::three_year( $arpu, $r ),
+			'computable'  => true,
+			'denominator' => $active,
+		];
+	}
+
+	/**
 	 * Upcoming donation renewals in the next 30 days.
 	 *
 	 * @return array{count: int, total_value: float}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -272,13 +272,12 @@ class Subscribers_Metric {
 	 * instead; the intended, uniform subtraction is used here.
 	 *
 	 *   ARPU = ARR / active subscribers (annualized recurring revenue per head).
-	 *   r    = 12-month retention. Subscriptions carry no cohort-retention series,
-	 *          so r is annualized from churn over the trailing 12 months before
+	 *   r    = 12-month retention. Subscriptions carry no cohort-retention series, so
+	 *          r is annualized from churn over the trailing 12 months before the report
+	 *          end date: r = 1 - churned / active, clamped to [0, 1].
 	 *
-	 *          @end: r = 1 - churned / active, clamped to [0, 1].
-	 *
-	 * Snapshot anchored on @end, independent of the picker start. A modeled
-	 * estimate — labeled as such in the UI.
+	 * Snapshot anchored on the report end date, independent of the picker start.
+	 * A modeled estimate — labeled as such in the UI.
 	 *
 	 * @param DateTimeInterface $end Report end date (the "now" anchor).
 	 * @return array{value: float, computable: bool, denominator: int}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -261,6 +261,53 @@ class Subscribers_Metric {
 	}
 
 	/**
+	 * Modeled 3-year supporter lifetime value (NEWS-2603), per the Reader
+	 * Revenue Development CLV worksheet.
+	 *
+	 * Per-supporter CLV = 0.95 * ARPU * (r + r^2 + r^3): each of three years
+	 * earns ARPU scaled by cumulative survival to that year (r, r^2, r^3), less
+	 * a flat 5% maintenance cost (payment fees / servicing). No intro discount is
+	 * modeled (worksheet default 0). We apply the 5% subtraction to all three
+	 * years — the worksheet's Year 1 cell has a sign slip that adds the cost
+	 * instead; the intended, uniform subtraction is used here.
+	 *
+	 *   ARPU = ARR / active subscribers (annualized recurring revenue per head).
+	 *   r    = 12-month retention. Subscriptions carry no cohort-retention series,
+	 *          so r is annualized from churn over the trailing 12 months before
+	 *
+	 *          @end: r = 1 - churned / active, clamped to [0, 1].
+	 *
+	 * Snapshot anchored on @end, independent of the picker start. A modeled
+	 * estimate — labeled as such in the UI.
+	 *
+	 * @param DateTimeInterface $end Report end date (the "now" anchor).
+	 * @return array{value: float, computable: bool, denominator: int}
+	 */
+	public function get_supporter_clv_3yr( DateTimeInterface $end ): array {
+		$active = $this->get_active_non_donation_subscribers();
+		$arr    = $this->get_arr();
+		if ( $active <= 0 || $arr <= 0.0 ) {
+			return [
+				'value'       => 0.0,
+				'computable'  => false,
+				'denominator' => $active,
+			];
+		}
+		$arpu = $arr / $active;
+
+		// 12-month retention annualized from churn (no subscriber cohort series).
+		$year_ago = \DateTimeImmutable::createFromInterface( $end )->sub( new \DateInterval( 'P365D' ) );
+		$churned  = $this->get_churned_subscribers_in_window( $year_ago, $end );
+		$r        = 1.0 - ( $churned / $active );
+
+		return [
+			'value'       => Clv_Model::three_year( $arpu, $r ),
+			'computable'  => true,
+			'denominator' => $active,
+		];
+	}
+
+	/**
 	 * Gross subscription revenue in window.
 	 *
 	 * @param DateTimeInterface $start Window start.

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -44,6 +44,8 @@ export interface DonorsSnapshot {
 	upcoming_donation_cancellations_30d: UpcomingDonationCancellations;
 	/** Newsletter → donation conversion (NEWS-2603): mature-cohort snapshot rate. */
 	newsletter_conversion: DonorsRateValue;
+	/** Modeled 3-year supporter CLV (NEWS-2603): snapshot currency value ({value, computable, denominator}). */
+	supporter_clv_3yr: DonorsRateValue;
 }
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -61,6 +61,8 @@ export interface SubscribersSnapshot {
 	upcoming_cancellations_30d: UpcomingCancellations;
 	/** Newsletter → subscription conversion (NEWS-2603): mature-cohort snapshot rate. */
 	newsletter_conversion: SubscribersRateValue;
+	/** Modeled 3-year supporter CLV (NEWS-2603): snapshot currency value ({value, computable, denominator}). */
+	supporter_clv_3yr: SubscribersRateValue;
 }
 
 export interface PerformanceVariationRow {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -58,7 +58,6 @@ const DonorsTab = ( { range, previousRange }: DonorsTabProps ) => {
 						current={ data.current }
 						previous={ data.previous }
 						activeDonors={ data.snapshot.active_donors }
-						newsletterConversion={ data.snapshot.newsletter_conversion }
 					/>
 					<RetentionSection current={ data.current } previous={ data.previous } />
 					<PerformanceSection rows={ data.current.donations_by_tier } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -62,7 +62,6 @@ const SubscribersTab = ( { range, previousRange }: SubscribersTabProps ) => {
 						current={ data.current }
 						previous={ data.previous }
 						activeSubscribers={ data.snapshot.active_subscribers }
-						newsletterConversion={ data.snapshot.newsletter_conversion }
 					/>
 					<TenureSection rows={ data.snapshot.tenure_distribution } />
 					<PerformanceSection rows={ data.current.subscriptions_by_product } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Tests for the Donors ScorecardSection — focused on the NEWS-2603 3-year
+ * supporter CLV card's computable / not-computable rendering.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ScorecardSection from './ScorecardSection';
+import type { DonorsSnapshot } from '../../api/donors';
+
+const makeSnapshot = ( over: Partial< DonorsSnapshot > = {} ): DonorsSnapshot => ( {
+	active_donors: 300,
+	active_recurring_donors: 180,
+	donation_mrr: 900,
+	donation_arr: 10800,
+	upcoming_donation_renewals_30d: { count: 4, total_value: 200 },
+	upcoming_donation_cancellations_30d: { count: 2, total_value: 40 },
+	newsletter_conversion: { value: 0.04, computable: true, denominator: 100 },
+	supporter_clv_3yr: { value: 152.0, computable: true, denominator: 180 },
+	...over,
+} );
+
+describe( 'Donors ScorecardSection — 3-year supporter value card', () => {
+	it( 'renders the modeled CLV card when computable', () => {
+		render( <ScorecardSection snapshot={ makeSnapshot() } /> );
+		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough recurring-donor history to model yet.' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders an em-dash with explanatory copy when not computable', () => {
+		render( <ScorecardSection snapshot={ makeSnapshot( { supporter_clv_3yr: { value: 0, computable: false, denominator: 0 } } ) } /> );
+		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough recurring-donor history to model yet.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
@@ -26,16 +26,23 @@ const makeSnapshot = ( over: Partial< DonorsSnapshot > = {} ): DonorsSnapshot =>
 	...over,
 } );
 
-describe( 'Donors ScorecardSection — 3-year supporter value card', () => {
-	it( 'renders the modeled CLV card when computable', () => {
+describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
+	it( 'renders the modeled CLV and newsletter-conversion cards when computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot() } /> );
 		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough recurring-donor history to model yet.' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders an em-dash with explanatory copy when not computable', () => {
+	it( 'renders the CLV card as an em-dash with explanatory copy when not computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot( { supporter_clv_3yr: { value: 0, computable: false, denominator: 0 } } ) } /> );
 		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough recurring-donor history to model yet.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the newsletter-conversion card as an em-dash when the cohort is not yet mature', () => {
+		render( <ScorecardSection snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0 } } ) } /> );
+		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough newsletter signups with a full year of history yet.' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -79,6 +79,17 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				) }
 			/>
 			<MetricCard
+				label={ __( 'Newsletter → donation', 'newspack-plugin' ) }
+				value={ snapshot.newsletter_conversion.value }
+				format="percent"
+				notComputableMessage={
+					snapshot.newsletter_conversion.computable
+						? undefined
+						: __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
+				}
+				description={ __( 'Share of newsletter signups who became a donor within 12 months.', 'newspack-plugin' ) }
+			/>
+			<MetricCard
 				label={ __( 'Upcoming renewals (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_donation_renewals_30d.count }
 				format="number"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -67,6 +67,18 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Active recurring donations normalized to a monthly rate', 'newspack-plugin' ) }
 			/>
 			<MetricCard
+				label={ __( '3-year supporter value', 'newspack-plugin' ) }
+				value={ snapshot.supporter_clv_3yr.value }
+				format="currency"
+				notComputableMessage={
+					snapshot.supporter_clv_3yr.computable ? undefined : __( 'Not enough recurring-donor history to model yet.', 'newspack-plugin' )
+				}
+				description={ __(
+					'Modeled lifetime value of an average recurring donor over 3 years, from current ARPU and retention. An estimate.',
+					'newspack-plugin'
+				) }
+			/>
+			<MetricCard
 				label={ __( 'Upcoming renewals (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_donation_renewals_30d.count }
 				format="number"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
@@ -52,8 +52,6 @@ const revenueBreakdownText = ( container: HTMLElement ): string => {
 	return card?.querySelector( '.newspack-insights__metric-card-secondary' )?.textContent ?? '';
 };
 
-const NLC = { value: 0.05, computable: true, denominator: 100 };
-
 describe( 'WindowedSection empty states', () => {
 	it( 'collapses to a no_opportunity EmptyMetricSection when the window saw no activity', () => {
 		const current = makeWindow( {
@@ -65,9 +63,7 @@ describe( 'WindowedSection empty states', () => {
 			total_revenue: 0,
 			average_gift: 0,
 		} );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Assert body on the container — the Notice's speak() duplicates copy into a
@@ -82,9 +78,7 @@ describe( 'WindowedSection empty states', () => {
 		// Section has revenue and a lapse but no first-time donors: the New donors card
 		// gets the existing-donor context line, while the real revenue cards still render.
 		const current = makeWindow( { new_donors: 0, lapsed_donors: 2, total_revenue: 1500 } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeDonors={ 42 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeDonors={ 42 } /> );
 
 		// No whole-section empty state — the section is NOT collapsed.
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
@@ -99,20 +93,17 @@ describe( 'WindowedSection empty states', () => {
 		// the card renders a plain zero, not the "existing donors active" line. (In practice
 		// has_window_activity would usually be false here, but guard the per-card branch.)
 		const current = makeWindow( { new_donors: 0, lapsed_donors: 1, total_revenue: 500 } );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } newsletterConversion={ NLC } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 0 } /> );
 
 		expect( screen.queryByText( /existing donors active/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders every card (incl. the newsletter conversion card) with the full one-time + recurring breakdown when populated', () => {
+	it( 'renders every card with the full one-time + recurring breakdown when populated', () => {
 		const current = makeWindow();
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 200 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'New donors' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
 
 		const breakdown = revenueBreakdownText( container );
 		expect( breakdown ).toMatch( /one-time/ );
@@ -120,26 +111,9 @@ describe( 'WindowedSection empty states', () => {
 		expect( breakdown ).toContain( '+' );
 	} );
 
-	it( 'renders the newsletter conversion card as an em-dash when the cohort is not yet mature', () => {
-		render(
-			<WindowedSection
-				range={ RANGE }
-				current={ makeWindow() }
-				previous={ null }
-				activeDonors={ 200 }
-				newsletterConversion={ { value: 0, computable: false, denominator: 0 } }
-			/>
-		);
-
-		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Not enough newsletter signups with 12 months of history yet.' ) ).toBeInTheDocument();
-	} );
-
 	it( 'suppresses the empty mode in the revenue breakdown — recurring-only window', () => {
 		const current = makeWindow( { one_time_revenue: 0, recurring_revenue: 1200, total_revenue: 1200, average_gift: 0 } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } /> );
 
 		// The breakdown line shows recurring only — no "one-time" half, no "$0 one-time", no "+".
 		const breakdown = revenueBreakdownText( container );
@@ -152,9 +126,7 @@ describe( 'WindowedSection empty states', () => {
 
 	it( 'suppresses the empty mode in the revenue breakdown — one-time-only window', () => {
 		const current = makeWindow( { one_time_revenue: 800, recurring_revenue: 0, total_revenue: 800, average_gift: 40 } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 50 } /> );
 
 		const breakdown = revenueBreakdownText( container );
 		expect( breakdown ).toMatch( /one-time/ );
@@ -173,7 +145,7 @@ describe( 'WindowedSection empty states', () => {
 			total_revenue: 0,
 			average_gift: 0,
 		} );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 30 } newsletterConversion={ NLC } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 30 } /> );
 
 		expect( screen.getByText( 'No donations in this timeframe' ) ).toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -32,7 +32,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { DonorsRateValue, DonorsWindow } from '../../api/donors';
+import type { DonorsWindow } from '../../api/donors';
 import type { DateRange } from '../../state/useDateRange';
 import EmptyMetricSection from '../components/EmptyMetricSection';
 import MetricCard from '../components/MetricCard';
@@ -50,12 +50,6 @@ export interface WindowedSectionProps {
 	 * donors, just none new in this timeframe.
 	 */
 	activeDonors: number;
-	/**
-	 * Newsletter → donation conversion (NEWS-2603): a mature-cohort snapshot rate from
-	 * the hub. Window-independent — it sits in this windowed section for grouping, but
-	 * the value doesn't change with the date range.
-	 */
-	newsletterConversion: DonorsRateValue;
 }
 
 const parseISO = ( s: string ): Date => {
@@ -119,7 +113,7 @@ const revenueBreakdown = ( current: DonorsWindow ): string | undefined => {
 	return undefined;
 };
 
-const WindowedSection = ( { range, current, previous, activeDonors, newsletterConversion }: WindowedSectionProps ) => {
+const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSectionProps ) => {
 	// Whole-section empty: nothing happened this window. Collapse the grid to a
 	// single callout (NPPD-1694 `EmptyMetricSection`). Checked first so the
 	// per-card states below only fire inside a section that has real data —
@@ -147,11 +141,6 @@ const WindowedSection = ( { range, current, previous, activeDonors, newsletterCo
 
 	const donationsLabel = __( 'donations', 'newspack-plugin' );
 	const oneTimeGiftsLabel = __( 'one-time gifts', 'newspack-plugin' );
-	// Snapshot rate: an em-dash (not a misleading 0%) until a mature cohort of
-	// newsletter signups with a full 12 months of history exists.
-	const newsletterConversionEmptyMessage = ! newsletterConversion.computable
-		? __( 'Not enough newsletter signups with 12 months of history yet.', 'newspack-plugin' )
-		: undefined;
 
 	return (
 		<section
@@ -178,16 +167,6 @@ const WindowedSection = ( { range, current, previous, activeDonors, newsletterCo
 							: undefined
 					}
 					description={ __( 'First-time donors in selected timeframe', 'newspack-plugin' ) }
-				/>
-				<MetricCard
-					label={ __( 'Newsletter → donation', 'newspack-plugin' ) }
-					value={ newsletterConversion.value }
-					format="percent"
-					notComputableMessage={ newsletterConversionEmptyMessage }
-					description={ __(
-						'Of newsletter signups with a full 12 months of history, the share who became a donor within 12 months of signing up. A snapshot — not affected by the selected timeframe.',
-						'newspack-plugin'
-					) }
 				/>
 				<MetricCard
 					label={ __( 'Lapsed donors', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Tests for the Subscribers ScorecardSection — focused on the NEWS-2603
+ * 3-year supporter CLV card's computable / not-computable rendering.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ScorecardSection from './ScorecardSection';
+import type { SubscribersSnapshot } from '../../api/subscribers';
+
+const makeSnapshot = ( over: Partial< SubscribersSnapshot > = {} ): SubscribersSnapshot => ( {
+	active_subscribers: 200,
+	mrr: 1000,
+	arr: 12000,
+	tenure_distribution: [],
+	upcoming_renewals_30d: { count: 5, total_value: 250 },
+	upcoming_cancellations_30d: { count: 1, total_value: 20 },
+	newsletter_conversion: { value: 0.05, computable: true, denominator: 100 },
+	supporter_clv_3yr: { value: 185.44, computable: true, denominator: 200 },
+	...over,
+} );
+
+describe( 'Subscribers ScorecardSection — 3-year supporter value card', () => {
+	it( 'renders the modeled CLV card when computable', () => {
+		render( <ScorecardSection snapshot={ makeSnapshot() } /> );
+		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough subscription history to model yet.' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders an em-dash with explanatory copy when not computable', () => {
+		render( <ScorecardSection snapshot={ makeSnapshot( { supporter_clv_3yr: { value: 0, computable: false, denominator: 0 } } ) } /> );
+		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough subscription history to model yet.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
@@ -26,16 +26,23 @@ const makeSnapshot = ( over: Partial< SubscribersSnapshot > = {} ): SubscribersS
 	...over,
 } );
 
-describe( 'Subscribers ScorecardSection — 3-year supporter value card', () => {
-	it( 'renders the modeled CLV card when computable', () => {
+describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
+	it( 'renders the modeled CLV and newsletter-conversion cards when computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot() } /> );
 		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough subscription history to model yet.' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders an em-dash with explanatory copy when not computable', () => {
+	it( 'renders the CLV card as an em-dash with explanatory copy when not computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot( { supporter_clv_3yr: { value: 0, computable: false, denominator: 0 } } ) } /> );
 		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough subscription history to model yet.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the newsletter-conversion card as an em-dash when the cohort is not yet mature', () => {
+		render( <ScorecardSection snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0 } } ) } /> );
+		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough newsletter signups with a full year of history yet.' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -62,6 +62,18 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Normalized across billing periods', 'newspack-plugin' ) }
 			/>
 			<MetricCard
+				label={ __( '3-year supporter value', 'newspack-plugin' ) }
+				value={ snapshot.supporter_clv_3yr.value }
+				format="currency"
+				notComputableMessage={
+					snapshot.supporter_clv_3yr.computable ? undefined : __( 'Not enough subscription history to model yet.', 'newspack-plugin' )
+				}
+				description={ __(
+					'Modeled lifetime value of an average subscriber over 3 years, from current ARPU and retention. An estimate.',
+					'newspack-plugin'
+				) }
+			/>
+			<MetricCard
 				label={ __( 'Upcoming renewals (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_renewals_30d.count }
 				format="number"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -74,6 +74,17 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				) }
 			/>
 			<MetricCard
+				label={ __( 'Newsletter → subscription', 'newspack-plugin' ) }
+				value={ snapshot.newsletter_conversion.value }
+				format="percent"
+				notComputableMessage={
+					snapshot.newsletter_conversion.computable
+						? undefined
+						: __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
+				}
+				description={ __( 'Share of newsletter signups who became a paid subscriber within 12 months.', 'newspack-plugin' ) }
+			/>
+			<MetricCard
 				label={ __( 'Upcoming renewals (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_renewals_30d.count }
 				format="number"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -43,8 +43,6 @@ const cardValueByLabel = ( container: HTMLElement, label: string ): string => {
 	return card?.querySelector( '.newspack-insights__metric-card-value' )?.textContent ?? '';
 };
 
-const NLC = { value: 0.05, computable: true, denominator: 100 };
-
 describe( 'Subscribers WindowedSection empty states', () => {
 	it( 'collapses to a no_opportunity EmptyMetricSection when the window saw no activity', () => {
 		const current = makeWindow( {
@@ -56,9 +54,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 			refund_rate: { value: 0, computable: false, denominator: 0 },
 			failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 },
 		} );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Assert on the container — the Notice's speak() duplicates copy into a live-region.
@@ -69,9 +65,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 	it( 'renders the per-card no-acquisition state on New subscribers without collapsing the section', () => {
 		const current = makeWindow( { new_subscribers: 0, churned_subscribers: 2 } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 128 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 128 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( '128 active subscribers, but none new this timeframe' ) ).toBeInTheDocument();
@@ -88,7 +82,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 	it( 'does NOT show the no-acquisition line when there are no active subscribers either', () => {
 		const current = makeWindow( { new_subscribers: 0, churned_subscribers: 1 } );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } newsletterConversion={ NLC } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 0 } /> );
 
 		expect( screen.queryByText( /existing subscribers are active/ ) ).not.toBeInTheDocument();
 	} );
@@ -96,9 +90,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 	it( 'GOOD ZERO: zero churn renders the card normally, NOT an empty state', () => {
 		// Activity present (new subscribers + revenue), but zero churn this window.
 		const current = makeWindow( { new_subscribers: 9, churned_subscribers: 0 } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 200 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ makeWindow() } activeSubscribers={ 200 } /> );
 
 		// Section is NOT collapsed and the churn card is a real card showing 0.
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
@@ -108,9 +100,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 	it( 'GOOD ZERO: zero failed payments reframes positively (NPPD-1726), section intact', () => {
 		const current = makeWindow( { failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 } } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'No failed payments in this timeframe.' ) ).toBeInTheDocument();
@@ -122,9 +112,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		// Orders exist (gross > 0) but no refunds → refund rate is a computable 0%,
 		// a good zero. Renders the em-dash + positive line, not a literal "0%".
 		const current = makeWindow( { refund_rate: { value: 0, computable: true, denominator: 120 } } );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'No refund requests in this timeframe.' ) ).toBeInTheDocument();
@@ -145,9 +133,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 			refund_rate: { value: 0, computable: false, denominator: 0 },
 			failed_payment_retry_rate: { value: 0, computable: false, denominator: 0 },
 		} );
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
-		);
+		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
 
 		expect( cardValueByLabel( container, 'Refund rate' ) ).toBe( '—' );
 		expect( cardValueByLabel( container, 'Failed payment recovery' ) ).toBe( '—' );
@@ -166,37 +152,19 @@ describe( 'Subscribers WindowedSection empty states', () => {
 			revenue_net: 0,
 			refund_rate: { value: 0, computable: false, denominator: 0 },
 		} );
-		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 50 } newsletterConversion={ NLC } /> );
+		render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 50 } /> );
 
 		// Gross + Net both fall back (shared MetricCard helper renders "…in this timeframe").
 		expect( screen.getAllByText( 'No subscription orders in this timeframe' ).length ).toBeGreaterThanOrEqual( 2 );
 	} );
 
-	it( 'renders every card when fully populated, including the newsletter conversion card', () => {
-		const { container } = render(
-			<WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } newsletterConversion={ NLC } />
-		);
+	it( 'renders every card when fully populated', () => {
+		const { container } = render( <WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'New subscribers' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Refund rate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Failed payment recovery' ) ).toBeInTheDocument();
-	} );
-
-	it( 'renders the newsletter conversion card as an em-dash when the cohort is not yet mature', () => {
-		render(
-			<WindowedSection
-				range={ RANGE }
-				current={ makeWindow() }
-				previous={ null }
-				activeSubscribers={ 200 }
-				newsletterConversion={ { value: 0, computable: false, denominator: 0 } }
-			/>
-		);
-
-		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Not enough newsletter signups with 12 months of history yet.' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -56,12 +56,6 @@ export interface WindowedSectionProps {
 	 * subscribers, just none new in this timeframe.
 	 */
 	activeSubscribers: number;
-	/**
-	 * Newsletter → subscription conversion (NEWS-2603): a mature-cohort snapshot rate
-	 * from the hub. Window-independent — it sits in this windowed section for grouping,
-	 * but the value doesn't change with the date range.
-	 */
-	newsletterConversion: SubscribersRateValue;
 }
 
 const parseISO = ( s: string ): Date => {
@@ -116,7 +110,7 @@ const retriesCohortSubtitle = ( denominator: number ): string =>
 		)
 	);
 
-const WindowedSection = ( { range, current, previous, activeSubscribers, newsletterConversion }: WindowedSectionProps ) => {
+const WindowedSection = ( { range, current, previous, activeSubscribers }: WindowedSectionProps ) => {
 	// Whole-section empty: nothing happened this window. Collapse the grid to a
 	// single callout (NPPD-1694 `EmptyMetricSection`). Checked first so the
 	// per-card states below only fire inside a section that has real data.
@@ -166,11 +160,6 @@ const WindowedSection = ( { range, current, previous, activeSubscribers, newslet
 	const retryEmptyMessage = ! retry.computable ? __( 'No failed payments in this timeframe.', 'newspack-plugin' ) : undefined;
 	const refundPrevious = previous?.refund_rate?.computable ? previous.refund_rate.value : null;
 	const retryPrevious = previous?.failed_payment_retry_rate?.computable ? previous.failed_payment_retry_rate.value : null;
-	// Snapshot rate: an em-dash (not a misleading 0%) until a mature cohort of
-	// newsletter signups with a full 12 months of history exists.
-	const newsletterConversionEmptyMessage = ! newsletterConversion.computable
-		? __( 'Not enough newsletter signups with 12 months of history yet.', 'newspack-plugin' )
-		: undefined;
 
 	return (
 		<section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
@@ -200,16 +189,6 @@ const WindowedSection = ( { range, current, previous, activeSubscribers, newslet
 					format="number"
 					previousValue={ previous?.winback_subscribers }
 					description={ __( 'Previously churned subscribers who resubscribed', 'newspack-plugin' ) }
-				/>
-				<MetricCard
-					label={ __( 'Newsletter → subscription', 'newspack-plugin' ) }
-					value={ newsletterConversion.value }
-					format="percent"
-					notComputableMessage={ newsletterConversionEmptyMessage }
-					description={ __(
-						'Of newsletter signups with a full 12 months of history, the share who became a paid subscriber within 12 months of signing up. A snapshot — not affected by the selected timeframe.',
-						'newspack-plugin'
-					) }
 				/>
 				<MetricCard
 					label={ __( 'Churned subscribers', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-clv-model.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-clv-model.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test Clv_Model (NEWS-2603).
+ *
+ * Covers the pure Reader Revenue Development 3-year CLV formula —
+ * `Clv_Model::three_year()` — a storage-free function shared by the Subscribers,
+ * Donors, and Audience CLV cards. Tested directly (no DB, no mock).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Clv_Model;
+use WP_UnitTestCase;
+
+/**
+ * Clv_Model test class.
+ *
+ * @group insights
+ */
+class Test_Clv_Model extends WP_UnitTestCase {
+
+	/**
+	 * Canonical case: three years of ARPU scaled by cumulative survival
+	 * (r, r^2, r^3), each net of the 5% maintenance rate.
+	 * arpu 100, r 0.8: 0.95 * 100 * (0.8 + 0.64 + 0.512) = 185.44.
+	 */
+	public function test_canonical_value() {
+		$this->assertSame( 185.44, Clv_Model::three_year( 100.0, 0.8 ) );
+	}
+
+	/**
+	 * Perfect retention keeps all three years at full ARPU:
+	 * 0.95 * arpu * 3 = 2.85 * arpu.
+	 */
+	public function test_full_retention() {
+		$this->assertSame( 285.0, Clv_Model::three_year( 100.0, 1.0 ) );
+	}
+
+	/**
+	 * Zero ARPU or zero retention yields zero value.
+	 */
+	public function test_zero_inputs() {
+		$this->assertSame( 0.0, Clv_Model::three_year( 0.0, 0.9 ) );
+		$this->assertSame( 0.0, Clv_Model::three_year( 100.0, 0.0 ) );
+	}
+
+	/**
+	 * Retention is clamped to [0, 1]: out-of-range inputs behave as the bound.
+	 */
+	public function test_retention_is_clamped() {
+		$this->assertSame( Clv_Model::three_year( 100.0, 1.0 ), Clv_Model::three_year( 100.0, 1.5 ) );
+		$this->assertSame( 0.0, Clv_Model::three_year( 100.0, -0.5 ) );
+	}
+
+	/**
+	 * A Year-1 intro discount is subtracted from the modeled value.
+	 */
+	public function test_intro_discount_is_subtracted() {
+		$this->assertSame( 275.0, Clv_Model::three_year( 100.0, 1.0, 10.0 ) );
+	}
+
+	/**
+	 * A discount larger than the modeled value floors at zero, never negative.
+	 */
+	public function test_never_negative() {
+		$this->assertSame( 0.0, Clv_Model::three_year( 1.0, 0.1, 1000.0 ) );
+	}
+}


### PR DESCRIPTION
## Summary

**NEWS-2603 Phase 2** — modeled 3-year supporter lifetime value on the Subscribers and Donors **"at a glance"** scorecards, per the Reader Revenue Development CLV worksheet. Plugin-only (all inputs are local Woo — no hub query).

Also folds in a **Phase 1 follow-up**: relocates the merged newsletter → subscription/donation conversion cards from the windowed section to the at-a-glance scorecard, since they're timeframe-independent snapshots (per Katie's feedback), and trims their descriptions.

## CLV model

Shared pure helper `Clv_Model::three_year($arpu, $r, $discount = 0)`:

```
CLV = (1 − 0.05) × ARPU × (r + r² + r³) − discount     [discount default 0; floored at 0]
```

Each of three years earns ARPU scaled by cumulative survival (`r`, `r²`, `r³`), net a flat 5% maintenance cost. The worksheet subtracts that cost only in Years 2–3 (its Year-1 cell has a sign slip that *adds* it) — we subtract uniformly. No intro discount by default.

- **Subscribers:** `ARPU = ARR / active`; `r = 1 − churned_12mo / active` (annualized churn — subscriptions have no cohort-retention series).
- **Donors:** `ARPU = donation_ARR / active_recurring_donors`; `r` = 12-month recurring-donor cohort retention.

Both are `@end`-anchored snapshots returning a `{value, computable, denominator}` envelope; the card shows an em-dash (never a misleading 0%) when not computable.

## Changes

- `Clv_Model` helper + `get_supporter_clv_3yr()` on both metrics.
- Snapshot TS types + REST snapshot wiring (`supporter_clv_3yr`); both tab cache schema versions bumped 3→4 for the new snapshot field.
- CLV + relocated newsletter cards on both ScorecardSections.
- Newsletter cards removed from both WindowedSections (+ tests moved to the scorecard suites).

## Testing

- `Clv_Model` PHPUnit (6 cases; math also verified standalone).
- JS: 16 WindowedSection + 6 ScorecardSection tests green (CLV + newsletter, computable + em-dash each).
- eslint + root-PHPCS clean; verified live on localhost (Subscribers CLV computes; Donors correctly shows the em-dash where the dev site has no recurring donors).