### PR TITLE
feat(insights): newsletter subscriber value card on Audience (NEWS-2603 Phase 3)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -214,16 +214,23 @@ class Audience_REST_Controller extends WP_REST_Controller {
 			],
 		];
 
+		// Modeled 3-year value of a newsletter subscriber (NEWS-2603): local Woo +
+		// hub conversion rates, GA4-independent, so it's attached at top level next to
+		// registered_readers and renders even when the tab is a connect banner.
+		$newsletter_subscriber_value = ( new Conversion_Metric() )->get_newsletter_subscriber_value_3yr( $start, $end );
+
 		$current = Audience_Metric::get_all( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), false );
 		if ( isset( $current['tab_error'] ) ) {
-			$current['registered_readers'] = $registered_readers;
+			$current['registered_readers']          = $registered_readers;
+			$current['newsletter_subscriber_value'] = $newsletter_subscriber_value;
 			return $current;
 		}
 
 		$response = [
-			'current'            => $current,
-			'previous'           => null,
-			'registered_readers' => $registered_readers,
+			'current'                     => $current,
+			'previous'                    => null,
+			'registered_readers'          => $registered_readers,
+			'newsletter_subscriber_value' => $newsletter_subscriber_value,
 		];
 		if ( $compare_start && $compare_end ) {
 			$previous             = Audience_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/audience-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/audience-fixture.php
@@ -471,13 +471,13 @@ $build = function ( float $f ) use ( $scalar, $breakdown, $table, $series, $star
 };
 
 return [
-	'current'            => $build( 1.0 ),
-	'previous'           => $build( 0.88 ),
+	'current'                     => $build( 1.0 ),
+	'previous'                    => $build( 0.88 ),
 	// Registered readers (local wp_users, NPPD-1733): a window-independent total
 	// snapshot plus a windowed "new" count with its prior-window companion for the
 	// period delta. Lives at top level — not inside the windows — because it is
 	// GA4-independent and present even when the tab is a connect banner.
-	'registered_readers' => [
+	'registered_readers'          => [
 		'total' => [
 			'value'      => 24680,
 			'computable' => true,
@@ -495,5 +495,13 @@ return [
 				'type'       => 'count',
 			],
 		],
+	],
+	// Modeled 3-year value of a newsletter subscriber (NEWS-2603): expected reader
+	// revenue per newsletter signup across the subscription + donation paths. Local
+	// Woo + hub conversion rates, GA4-independent — top level, like registered_readers.
+	'newsletter_subscriber_value' => [
+		'value'       => 27.3,
+		'computable'  => true,
+		'denominator' => 1200,
 	],
 ];

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1844,6 +1844,66 @@ final class Conversion_Metric {
 		);
 	}
 
+	/**
+	 * Modeled 3-year value of a newsletter subscriber (NEWS-2603 Phase 3), per the
+	 * Reader Revenue Development "Newsletter CLV" worksheet: the expected reader
+	 * revenue a newsletter signup delivers over three years =
+	 *   Σ over paths [ P(convert to path within 12mo of signup) × 3-year supporter CLV ].
+	 *
+	 * Combines the two newsletter->paid conversion rates (this class) with the two
+	 * modeled supporter CLVs (Subscribers_Metric / Donors_Metric). Expected value is
+	 * additive across the subscription and donation paths by linearity of expectation,
+	 * even where a reader takes both. A path contributes only when BOTH its conversion
+	 * rate and its CLV are computable; the result is computable if either path
+	 * contributed, else an em-dash. Snapshot anchored on @end. Surfaced as an
+	 * at-a-glance card on the Audience tab.
+	 *
+	 * @param DateTimeInterface $start Picker start (passed through to the rate queries).
+	 * @param DateTimeInterface $end   Report end date (the "now" anchor).
+	 * @return array{value: float, computable: bool, denominator: int}
+	 */
+	public function get_newsletter_subscriber_value_3yr( DateTimeInterface $start, DateTimeInterface $end ): array {
+		$empty = [
+			'value'       => 0.0,
+			'computable'  => false,
+			'denominator' => 0,
+		];
+		// Both revenue paths need local Woo; no WooCommerce means no supporter CLV,
+		// so short-circuit before the hub calls.
+		if ( ! $this->woocommerce_active() ) {
+			return $empty;
+		}
+
+		$sub_rate = $this->get_newsletter_to_subscription_conversion( $start, $end );
+		$don_rate = $this->get_newsletter_to_donation_conversion( $start, $end );
+		$sub_clv  = $this->subscribers_metric->get_supporter_clv_3yr( $end );
+		$don_clv  = $this->donors_metric->get_supporter_clv_3yr( $end );
+
+		$value      = 0.0;
+		$computable = false;
+		$signups    = 0;
+
+		if ( ! empty( $sub_rate['computable'] ) && ! empty( $sub_clv['computable'] ) ) {
+			$value     += (float) $sub_rate['value'] * (float) $sub_clv['value'];
+			$computable = true;
+			$signups    = max( $signups, (int) ( $sub_rate['denominator'] ?? 0 ) );
+		}
+		if ( ! empty( $don_rate['computable'] ) && ! empty( $don_clv['computable'] ) ) {
+			$value     += (float) $don_rate['value'] * (float) $don_clv['value'];
+			$computable = true;
+			$signups    = max( $signups, (int) ( $don_rate['denominator'] ?? 0 ) );
+		}
+
+		if ( ! $computable ) {
+			return $empty;
+		}
+		return [
+			'value'       => round( $value, 2 ),
+			'computable'  => true,
+			'denominator' => $signups,
+		];
+	}
+
 	// --- Section 8: Opportunity buckets ---------------------------------
 	// 8.1–8.3 are current-state snapshot counts: accept the window for
 	// signature parity, ignore it. All three are local-only (Woo-only, or

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1863,15 +1863,16 @@ final class Conversion_Metric {
 	 * @return array{value: float, computable: bool, denominator: int}
 	 */
 	public function get_newsletter_subscriber_value_3yr( DateTimeInterface $start, DateTimeInterface $end ): array {
-		$empty = [
-			'value'       => 0.0,
-			'computable'  => false,
-			'denominator' => 0,
-		];
-		// Both revenue paths need local Woo; no WooCommerce means no supporter CLV,
-		// so short-circuit before the hub calls.
+		// Both revenue paths need local Woo; no WooCommerce means there is no reader-
+		// revenue model to value — a "not configured" state, distinct from a site that
+		// has Woo but not yet enough history. Short-circuits before the hub calls.
 		if ( ! $this->woocommerce_active() ) {
-			return $empty;
+			return [
+				'value'          => 0.0,
+				'computable'     => false,
+				'denominator'    => 0,
+				'not_configured' => true,
+			];
 		}
 
 		$sub_rate = $this->get_newsletter_to_subscription_conversion( $start, $end );
@@ -1894,13 +1895,33 @@ final class Conversion_Metric {
 			$signups    = max( $signups, (int) ( $don_rate['denominator'] ?? 0 ) );
 		}
 
-		if ( ! $computable ) {
-			return $empty;
+		if ( $computable ) {
+			return [
+				'value'       => round( $value, 2 ),
+				'computable'  => true,
+				'denominator' => $signups,
+			];
 		}
+
+		// Not computable: a hub proxy failure on a rate query is an error state, not
+		// "insufficient history" — surface it distinctly so the card doesn't imply the
+		// publisher just needs to wait for data.
+		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
+			if ( isset( $rate['state'] ) && 'error' === $rate['state'] ) {
+				return [
+					'value'       => 0.0,
+					'computable'  => false,
+					'denominator' => 0,
+					'error'       => $rate['error_message'] ?? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' ),
+				];
+			}
+		}
+
+		// Genuine insufficient-history state: neither path could be modeled yet.
 		return [
-			'value'       => round( $value, 2 ),
-			'computable'  => true,
-			'denominator' => $signups,
+			'value'       => 0.0,
+			'computable'  => false,
+			'denominator' => 0,
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/api/audience.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/audience.ts
@@ -45,6 +45,8 @@ export interface AudienceResponse {
 	current?: InsightsWindow;
 	previous?: InsightsWindow | null;
 	registered_readers?: RegisteredReaders;
+	/** Modeled 3-year value of a newsletter subscriber (NEWS-2603): expected reader revenue per newsletter signup. */
+	newsletter_subscriber_value?: MetricPayload;
 }
 
 export interface InsightsQuery {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -23,6 +23,7 @@ import TabStateView from './components/TabStateView';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ReachSection from './audience/sections/ReachSection';
 import RegisteredReadersSection from './audience/sections/RegisteredReadersSection';
+import NewsletterValueSection from './audience/sections/NewsletterValueSection';
 import CompositionSection from './audience/sections/CompositionSection';
 import TimeTrendsSection from './audience/sections/TimeTrendsSection';
 import TrafficSourcesSection from './audience/sections/TrafficSourcesSection';
@@ -46,6 +47,9 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 	// Registered readers (NPPD-1733) come from local wp_users, so they render even
 	// when GA4 isn't connected — present in both the banner and the normal branch.
 	const registeredReaders = data?.registered_readers ?? null;
+	// Modeled newsletter-subscriber value (NEWS-2603): GA4-independent, like
+	// registered readers — rendered in both branches.
+	const newsletterSubscriberValue = data?.newsletter_subscriber_value ?? null;
 	const showComparison = !! previousRange;
 
 	return (
@@ -64,6 +68,7 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 						{ registeredReaders && (
 							<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
 						) }
+						{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
 					</>
 				) : (
 					<>
@@ -75,6 +80,7 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 						{ registeredReaders && (
 							<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
 						) }
+						{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
 						<CompositionSection current={ current } previous={ previous } />
 						<TrafficSourcesSection current={ current } previous={ previous } />
 						<GeographicSection current={ current } previous={ previous } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Tests for the Audience NewsletterValueSection (NEWS-2603 Phase 3): the modeled
+ * newsletter-subscriber value card's computable / not-computable rendering.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import NewsletterValueSection from './NewsletterValueSection';
+
+describe( 'Audience NewsletterValueSection', () => {
+	it( 'renders the modeled value when computable', () => {
+		render( <NewsletterValueSection value={ { value: 27.3, computable: true, denominator: 1200 } } /> );
+		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders an em-dash with explanatory copy when not computable', () => {
+		render( <NewsletterValueSection value={ { value: 0, computable: false, denominator: 0 } } /> );
+		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not enough newsletter or supporter history to model yet.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
@@ -25,4 +25,10 @@ describe( 'Audience NewsletterValueSection', () => {
 		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough newsletter or supporter history to model yet.' ) ).toBeInTheDocument();
 	} );
+
+	it( 'suppresses the insufficient-history copy when the payload carries an error', () => {
+		render( <NewsletterValueSection value={ { value: 0, computable: false, error: 'Hub unavailable' } } /> );
+		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
@@ -1,0 +1,57 @@
+/**
+ * Audience › Newsletter subscriber value (NEWS-2603 Phase 3).
+ *
+ * A single at-a-glance card: the modeled 3-year reader-revenue value of a
+ * newsletter subscriber — the expected value across the subscription and
+ * donation conversion paths (newsletter→paid conversion rate × 3-year supporter
+ * CLV, summed). Sourced from local Woo + the hub conversion rates, so — like
+ * Registered readers — it is GA4-independent and renders in both AudienceTab
+ * branches, including under the connect banner. A window-independent snapshot.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { MetricPayload } from '../../../api/audience';
+import MetricCard from '../../components/MetricCard';
+import SectionHeading from '../../components/SectionHeading';
+
+export interface NewsletterValueSectionProps {
+	value: MetricPayload | null | undefined;
+}
+
+const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
+	// Usable when the server could model it (either revenue path computable).
+	const amount = value && value.computable !== false && typeof value.value === 'number' ? value.value : null;
+
+	return (
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-newsletter-value">
+			<SectionHeading
+				id="newspack-insights-audience-newsletter-value"
+				title={ __( 'Newsletter subscriber value', 'newspack-plugin' ) }
+				description={ __( 'What your newsletter audience is worth as future reader revenue.', 'newspack-plugin' ) }
+			/>
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-2">
+				<MetricCard
+					label={ __( 'Value per newsletter subscriber', 'newspack-plugin' ) }
+					value={ amount ?? 0 }
+					format="currency"
+					notComputableMessage={
+						amount === null ? __( 'Not enough newsletter or supporter history to model yet.', 'newspack-plugin' ) : undefined
+					}
+					description={ __(
+						'Modeled 3-year reader revenue per newsletter signup, across subscriptions and donations. An estimate.',
+						'newspack-plugin'
+					) }
+				/>
+			</div>
+		</section>
+	);
+};
+
+export default NewsletterValueSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { MetricPayload } from '../../../api/audience';
+import type { MetricPayload } from '../../components/metrics';
 import MetricCard from '../../components/MetricCard';
 import SectionHeading from '../../components/SectionHeading';
 
@@ -28,6 +28,10 @@ export interface NewsletterValueSectionProps {
 const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 	// Usable when the server could model it (either revenue path computable).
 	const amount = value && value.computable !== false && typeof value.value === 'number' ? value.value : null;
+	// A hub failure or a no-WooCommerce setup is not the same as "insufficient
+	// history" — surface those distinctly so the em-dash copy isn't misleading.
+	const hasError = !! value?.error;
+	const notConfigured = !! value?.not_configured;
 
 	return (
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-newsletter-value">
@@ -36,13 +40,17 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 				title={ __( 'Newsletter subscriber value', 'newspack-plugin' ) }
 				description={ __( 'What your newsletter audience is worth as future reader revenue.', 'newspack-plugin' ) }
 			/>
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-2">
+			<div className="newspack-insights__metric-grid">
 				<MetricCard
 					label={ __( 'Value per newsletter subscriber', 'newspack-plugin' ) }
 					value={ amount ?? 0 }
 					format="currency"
+					error={ value?.error }
+					notConfigured={ notConfigured }
 					notComputableMessage={
-						amount === null ? __( 'Not enough newsletter or supporter history to model yet.', 'newspack-plugin' ) : undefined
+						amount === null && ! hasError && ! notConfigured
+							? __( 'Not enough newsletter or supporter history to model yet.', 'newspack-plugin' )
+							: undefined
 					}
 					description={ __(
 						'Modeled 3-year reader revenue per newsletter signup, across subscriptions and donations. An estimate.',


### PR DESCRIPTION
## Summary

**NEWS-2603 Phase 3** — the modeled **3-year value of a newsletter subscriber** as an at-a-glance card on the **Audience** tab, per the Reader Revenue Development "Newsletter CLV" worksheet.

```
value per newsletter signup = Σ over paths [ P(convert within 12mo of signup) × 3-year supporter CLV ]
                            = nl→sub rate × subscriber CLV  +  nl→donation rate × donor CLV
```

Expected value is additive across the subscription and donation paths by linearity (fine even where a reader takes both). A path contributes only when **both** its conversion rate and its CLV are computable; the card is computable if either path contributed, else an em-dash.

## Changes

- `Conversion_Metric::get_newsletter_subscriber_value_3yr( $start, $end )` — reuses the class's existing injected `Subscribers_Metric` / `Donors_Metric` collaborators for the two CLVs and its own newsletter→paid rate methods; short-circuits (no hub calls) when WooCommerce is inactive.
- Audience REST `build_response` attaches `newsletter_subscriber_value` at top level next to `registered_readers` (GA4-independent — renders in both the normal and connect-banner branches).
- New `NewsletterValueSection` (dedicated section — a revenue estimate, distinct from the wp_users count section); wired into both `AudienceTab` branches.
- Audience fixture + `AudienceResponse` type + the section test.

## Testing

- JS: 4 audience suites / 12 tests green (incl. the new section — computable + em-dash).
- eslint + root-PHPCS clean; `php -l` clean.
- **Verified live on localhost** via `wp eval`: the combiner returns `$20.98` (7% × $299.74 subscriber path; donor path correctly skipped — the dev site has no recurring donors). Fixture shows `$27.30` on the tab.

## Notes for review

- **Modeling choice:** sums both revenue paths for a single "expected value per signup." Could instead show only the dominant path or split into two cards.