### PR TITLE
fix(insights): hide open kebab popover in print export

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/_print.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/_print.scss
@@ -65,6 +65,11 @@
 	// is useful provenance in a printed report.
 	.newspack-insights__header-controls,
 	.newspack-insights__refresh-menu,
+	// The open kebab menu renders in a Popover portaled to <body>, outside
+	// .newspack-insights, so the __refresh-menu selector above only hides the
+	// toggle. Hide the portaled popover too, or invoking Print from the open
+	// menu captures the menu list in the export.
+	.components-dropdown-menu__popover,
 	.newspack-insights__cooldown-notice,
 	.newspack-insights__tab-refreshing,
 	.newspack-insights__sortable-table-more {


### PR DESCRIPTION
### What & why

The Insights kebab (`RefreshMenu`) offers **Print / Save as PDF…**, which calls `window.print()`. The print stylesheet (`_print.scss`) hides the kebab via `.newspack-insights__refresh-menu` — but that class sits only on the DropdownMenu **toggle button**. When the menu is *open*, WordPress renders the menu list in a `Popover` **portaled to the end of `<body>`**, outside `.newspack-insights`, so the hide rule never reaches it.

Because you trigger the export from inside the open menu, WordPress's `onClose()` state update hasn't committed by the time `window.print()` fires synchronously — the popover is still in the DOM and gets captured in the print/PDF output (the floating menu box users were seeing in print preview).

This is a latent gap since the PDF export item was added (NPPD-1661, `8763e876c8`); adding **Export JSON…** just made the leftover menu box more noticeable. It is **not** caused by the JSON export code.

### Fix

Add the portaled popover class `.components-dropdown-menu__popover` to the existing `@media print` hide list. Timing-independent — the menu never prints whether or not React has unmounted it yet. Safe because the print stylesheet only loads on the Insights chunk.

### Testing

- Open the Insights kebab → **Print / Save as PDF…** → confirm the menu box is gone from the print preview.
- `Cmd/Ctrl+P` with the menu closed was already fine and still is.