### PR TITLE
fix(insights): newsletter cards show error state, not "insufficient history"

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -73,6 +73,8 @@ export interface DonorsRateValue {
 	value: number;
 	computable: boolean;
 	denominator: number;
+	/** `'error'` when the hub proxy failed — distinct from a genuine non-computable (insufficient-data) result. */
+	state?: string;
 }
 
 export interface DonorsTierVariationRow extends BillingNature {

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -73,8 +73,8 @@ export interface DonorsRateValue {
 	value: number;
 	computable: boolean;
 	denominator: number;
-	/** `'error'` when the hub proxy failed — distinct from a genuine non-computable (insufficient-data) result. */
-	state?: string;
+	/** `'error'` when the hub proxy failed — distinct from `'populated'` (a real result, computable or not). */
+	state?: 'error' | 'populated';
 }
 
 export interface DonorsTierVariationRow extends BillingNature {

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -29,6 +29,8 @@ export interface SubscribersRateValue {
 	value: number;
 	computable: boolean;
 	denominator: number;
+	/** `'error'` when the hub proxy failed — distinct from a genuine non-computable (insufficient-data) result. */
+	state?: string;
 }
 
 export interface SubscribersClassification {

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -29,8 +29,8 @@ export interface SubscribersRateValue {
 	value: number;
 	computable: boolean;
 	denominator: number;
-	/** `'error'` when the hub proxy failed — distinct from a genuine non-computable (insufficient-data) result. */
-	state?: string;
+	/** `'error'` when the hub proxy failed — distinct from `'populated'` (a real result, computable or not). */
+	state?: 'error' | 'populated';
 }
 
 export interface SubscribersClassification {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
@@ -53,6 +53,8 @@ describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
 			/>
 		);
 		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		// The card enters MetricCard's shared error-note state, not the em-dash/value path.
+		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
@@ -45,4 +45,14 @@ describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
 		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough newsletter signups with a full year of history yet.' ) ).toBeInTheDocument();
 	} );
+
+	it( 'shows an error state (not the insufficient-history copy) when the hub proxy failed', () => {
+		render(
+			<ScorecardSection
+				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'error' } } ) }
+			/>
+		);
+		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -84,11 +84,10 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				format="percent"
 				// A hub proxy failure is an error state, not "insufficient history" —
 				// surface it distinctly so a transient/hub issue doesn't read as "no data yet".
-				error={
-					snapshot.newsletter_conversion.state === 'error'
-						? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' )
-						: undefined
-				}
+				// MetricCard only needs a truthy `error` to switch to its shared
+				// "Data temporarily unavailable." note; the string isn't shown, so pass the
+				// state sentinel rather than a translatable string that never renders.
+				error={ snapshot.newsletter_conversion.state === 'error' ? snapshot.newsletter_conversion.state : undefined }
 				notComputableMessage={
 					! snapshot.newsletter_conversion.computable && snapshot.newsletter_conversion.state !== 'error'
 						? __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -82,10 +82,17 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				label={ __( 'Newsletter → donation', 'newspack-plugin' ) }
 				value={ snapshot.newsletter_conversion.value }
 				format="percent"
+				// A hub proxy failure is an error state, not "insufficient history" —
+				// surface it distinctly so a transient/hub issue doesn't read as "no data yet".
+				error={
+					snapshot.newsletter_conversion.state === 'error'
+						? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' )
+						: undefined
+				}
 				notComputableMessage={
-					snapshot.newsletter_conversion.computable
-						? undefined
-						: __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
+					! snapshot.newsletter_conversion.computable && snapshot.newsletter_conversion.state !== 'error'
+						? __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
+						: undefined
 				}
 				description={ __( 'Share of newsletter signups who became a donor within 12 months.', 'newspack-plugin' ) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
@@ -45,4 +45,14 @@ describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
 		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough newsletter signups with a full year of history yet.' ) ).toBeInTheDocument();
 	} );
+
+	it( 'shows an error state (not the insufficient-history copy) when the hub proxy failed', () => {
+		render(
+			<ScorecardSection
+				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'error' } } ) }
+			/>
+		);
+		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
@@ -53,6 +53,8 @@ describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
 			/>
 		);
 		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		// The card enters MetricCard's shared error-note state, not the em-dash/value path.
+		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -79,11 +79,10 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				format="percent"
 				// A hub proxy failure is an error state, not "insufficient history" —
 				// surface it distinctly so a transient/hub issue doesn't read as "no data yet".
-				error={
-					snapshot.newsletter_conversion.state === 'error'
-						? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' )
-						: undefined
-				}
+				// MetricCard only needs a truthy `error` to switch to its shared
+				// "Data temporarily unavailable." note; the string isn't shown, so pass the
+				// state sentinel rather than a translatable string that never renders.
+				error={ snapshot.newsletter_conversion.state === 'error' ? snapshot.newsletter_conversion.state : undefined }
 				notComputableMessage={
 					! snapshot.newsletter_conversion.computable && snapshot.newsletter_conversion.state !== 'error'
 						? __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -77,10 +77,17 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				label={ __( 'Newsletter → subscription', 'newspack-plugin' ) }
 				value={ snapshot.newsletter_conversion.value }
 				format="percent"
+				// A hub proxy failure is an error state, not "insufficient history" —
+				// surface it distinctly so a transient/hub issue doesn't read as "no data yet".
+				error={
+					snapshot.newsletter_conversion.state === 'error'
+						? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' )
+						: undefined
+				}
 				notComputableMessage={
-					snapshot.newsletter_conversion.computable
-						? undefined
-						: __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
+					! snapshot.newsletter_conversion.computable && snapshot.newsletter_conversion.state !== 'error'
+						? __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
+						: undefined
 				}
 				description={ __( 'Share of newsletter signups who became a paid subscriber within 12 months.', 'newspack-plugin' ) }
 			/>


### PR DESCRIPTION
## Problem

**Richland Source** sees the Subscribers "Newsletter → subscription" card showing *"Not enough newsletter signups with a full year of history yet."* — but that's **inaccurate**. The exact hub query against their BigQuery export (property `400107557`) returns:

- **9,082** mature-cohort newsletter signups, **31** conversions → a real **0.34%** rate.

The card is non-computable because the **hub** returns `bigquery_query_invalid_args: Invalid query_name: conversion_journey_newsletter_to_subscription` (the hub-side query builders aren't deployed to production yet — see the tracking ticket). The Phase-1 card collapsed **every** non-computable result — including a hub proxy **error** — into the single "insufficient history" message.

## Fix

Surface the proxy error state distinctly: when `newsletter_conversion.state === 'error'`, the card renders MetricCard's error note instead of the "insufficient history" copy. The "not enough signups" message is now shown only for a genuine non-computable (no error). This mirrors the same distinction already made on the Phase-3 Audience card (#519).

- `SubscribersRateValue` / `DonorsRateValue` expose the optional `state` field (already present in the JSON from `error_scalar`).
- Both Subscribers & Donors "at a glance" newsletter cards gate `error` vs `notComputableMessage` on `state`.
- +error-state test on each scorecard suite (8/8 green).

## Notes

- This is a **UI-resilience** fix — it stops the mislabeling. The underlying Richland issue (hub queries not deployed) is tracked separately.
- eslint + build clean; 8 ScorecardSection tests pass.