### PR TITLE
fix(content-gate): preserve gate_layout_id when editing gate settings

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.test.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CustomAccess from './custom-access';
+
+jest.mock( './metering', () => () => null );
+jest.mock( './access-rules', () => ( { onChange } ) => (
+	<button data-testid="set-rules" onClick={ () => onChange( [ { name: 'active_subscription' } ] ) } />
+) );
+
+describe( 'CustomAccess gate settings', () => {
+	it( 'preserves fields it does not manage (gate_layout_id) when rules change', () => {
+		const onChange = jest.fn();
+		const customAccess = {
+			active: true,
+			metering: { enabled: false },
+			access_rules: [],
+			gate_layout_id: 456,
+		};
+
+		render( <CustomAccess customAccess={ customAccess } onChange={ onChange } isNewsletter /> );
+
+		fireEvent.click( screen.getByTestId( 'set-rules' ) );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( { access_rules: [ [ { name: 'active_subscription' } ] ], gate_layout_id: 456 } )
+		);
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.tsx
@@ -22,10 +22,10 @@ export default function CustomAccess( { customAccess, onChange, isNewsletter = f
 
 	const handleChange = useCallback(
 		( value: Partial< CustomAccess > ) => {
+			// Spread the full object so fields this screen doesn't manage
+			// (e.g. gate_layout_id) survive the update and the next save.
 			onChange( {
-				active: customAccess.active,
-				metering: customAccess.metering,
-				access_rules: customAccess.access_rules,
+				...customAccess,
 				...value,
 			} );
 		},

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/registration.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/registration.test.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Registration from './registration';
+
+jest.mock( '../../../../../../packages/components/src', () => ( {
+	ActionCard: () => null,
+} ) );
+jest.mock( './metering', () => () => null );
+
+describe( 'Registration gate settings', () => {
+	it( 'preserves fields it does not manage (gate_layout_id) when a setting changes', () => {
+		const onChange = jest.fn();
+		const registration = {
+			active: true,
+			metering: { enabled: false },
+			require_verification: false,
+			gate_layout_id: 123,
+		};
+
+		render( <Registration registration={ registration } onChange={ onChange } isNewsletter /> );
+
+		fireEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( expect.objectContaining( { require_verification: true, gate_layout_id: 123 } ) );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/registration.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/registration.tsx
@@ -21,10 +21,10 @@ interface RegistrationProps {
 export default function Registration( { registration, onChange, isNewsletter = false }: RegistrationProps ) {
 	const handleChange = useCallback(
 		( value: Partial< Registration > ) => {
+			// Spread the full object so fields this screen doesn't manage
+			// (e.g. gate_layout_id) survive the update and the next save.
 			onChange( {
-				active: registration.active,
-				metering: registration.metering,
-				require_verification: registration.require_verification,
+				...registration,
 				...value,
 			} );
 		},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `custom-access` and `registration` gate-edit screens each rebuilt the object they pass to `onChange` from an explicit whitelist of fields (`active`, `metering`, `access_rules` / `require_verification`), then spread the new `value` on top. Any field the screen doesn't manage - notably `gate_layout_id` - was silently dropped from every save made through that screen, since it was never in the whitelist to begin with.

Fix: spread the full incoming object first, then overlay `value`, so unmanaged fields survive unchanged.

### How to test the changes in this Pull Request:

1. In the Audience wizard, create/edit a content gate and assign it a layout (`gate_layout_id` gets set).
2. Open the gate's Custom Access or Registration settings and change any managed field (e.g. toggle "Require verification", or add an access rule).
3. Save, then reload the gate settings - confirm the assigned layout is still attached (previously it would be cleared).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?