### PR TITLE
feat(insights): Tab 8 cross-system RPM + impressions/session scorecards

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -56,6 +56,7 @@ class Insights_Section_Advertising {
 	 */
 	private static function load_dependencies(): void {
 		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'derived/class-cross-system-metrics.php';
 		include_once $base . 'metrics/class-advertising-metric.php';
 		include_once $base . 'api/class-advertising-rest-controller.php';
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/derived/class-cross-system-metrics.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/derived/class-cross-system-metrics.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Newspack Insights — Cross-system derived metrics (NPPD-1675).
+ *
+ * The first Insights metrics that join data across two orchestrators. RPM and
+ * average impressions per session both divide a GAM-backed Advertising figure
+ * (revenue, impressions) by a GA4-backed Audience figure (sessions); neither is
+ * computable from GAM alone. This module is the single seam where those joins
+ * live, so future cross-system metrics (revenue per article, conversion rate per
+ * impression, …) have an established home rather than every orchestrator learning
+ * every other orchestrator's API (the N×M coupling of "Option A").
+ *
+ * Division of labour with the Advertising orchestrator (NPPD-1675, Option B, at
+ * the read layer):
+ *   - The Advertising volume/revenue payloads are passed IN by the caller
+ *     ({@see \Newspack\Insights\Advertising_Metric::read_window()}), read from the
+ *     GAM cache. This module never triggers a GAM report — those are async jobs
+ *     that must never run in a web request.
+ *   - Sessions are fetched HERE, fresh, from the Audience orchestrator
+ *     ({@see \Newspack\Insights\Audience_Metric::get_total_sessions()}, 15-minute
+ *     BigQuery cache). Fetching at the read layer — rather than baking sessions
+ *     into Advertising's day-long GAM cache — keeps the sessions denominator from
+ *     lagging a full day behind (the cache-TTL mismatch flagged in the ticket's
+ *     pre-flight).
+ *
+ * Date/timezone parity (pre-flight 2): both orchestrators take the same `Y-m-d`
+ * window strings in the site timezone ({@see wp_timezone()}), so the window
+ * boundaries align. The underlying data timezones differ (GAM reports in the ad
+ * network's timezone; GA4 sessions in the property's), a sub-window-boundary skew
+ * on already day-lagged figures — documented, normalized silently for v1.
+ *
+ * Payload shapes mirror the orchestrators:
+ *   scalar  : { value, computable, type: currency|decimal, numerator, denominator }
+ *   overlay : { value: null, computable: false, overlay: { type: data_unavailable } }
+ * The overlay (rather than a `computable: false` scalar) is deliberate: a non-rate
+ * scalar with `computable: false` renders a literal `0` in the UI, which would
+ * misread "we couldn't get sessions" as "your RPM is $0". The data-unavailable
+ * overlay is the same treatment the Viewability scorecard uses.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\Derived;
+
+use Newspack\Insights\Audience_Metric;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Cross-system derived metrics (Advertising × Audience).
+ */
+final class Cross_System_Metrics {
+
+	/**
+	 * RPM — revenue per thousand sessions: `( revenue / sessions ) * 1000`.
+	 * Cross-publisher-comparable in a way total revenue isn't.
+	 *
+	 * @param array    $revenue_payload Advertising `total_revenue` MetricCard payload
+	 *                                  ({ value, computable, … }) for the window.
+	 * @param int|null $sessions        Total sessions for the same window, or null
+	 *                                  when the Audience orchestrator is unavailable.
+	 * @return array MetricCard payload (currency), or the data-unavailable overlay.
+	 */
+	public static function rpm( array $revenue_payload, ?int $sessions ): array {
+		$revenue = self::source_value( $revenue_payload );
+		if ( null === $revenue || null === $sessions || $sessions <= 0 ) {
+			return self::unavailable();
+		}
+		return [
+			'value'       => ( $revenue / $sessions ) * 1000,
+			'computable'  => true,
+			'type'        => 'currency',
+			'numerator'   => $revenue,
+			'denominator' => $sessions,
+		];
+	}
+
+	/**
+	 * Average impressions per session — `impressions / sessions`. An inventory
+	 * saturation signal: how many ads the typical visit sees. Displayed as a whole
+	 * number (`count` format) — a single decimal reads as false precision on a
+	 * ~3-per-session figure — while the raw ratio is preserved so period deltas
+	 * stay exact.
+	 *
+	 * @param array    $impressions_payload Advertising `total_impressions` MetricCard
+	 *                                      payload ({ value, computable, … }).
+	 * @param int|null $sessions            Total sessions for the same window, or null.
+	 * @return array MetricCard payload (count), or the data-unavailable overlay.
+	 */
+	public static function avg_impressions_per_session( array $impressions_payload, ?int $sessions ): array {
+		$impressions = self::source_value( $impressions_payload );
+		if ( null === $impressions || null === $sessions || $sessions <= 0 ) {
+			return self::unavailable();
+		}
+		return [
+			'value'       => $impressions / $sessions,
+			'computable'  => true,
+			'type'        => 'count',
+			'numerator'   => (int) $impressions,
+			'denominator' => $sessions,
+		];
+	}
+
+	/**
+	 * Total sessions for a window from the Audience (GA4/BigQuery) orchestrator.
+	 * The cross-orchestrator bridge — the one place the Advertising read path
+	 * reaches into Audience. Returns null (not 0) when sessions can't be
+	 * established, so callers render "data unavailable" rather than a misleading
+	 * zero-denominator result.
+	 *
+	 * @param string $start_date Inclusive window start, YYYY-MM-DD (site timezone).
+	 * @param string $end_date   Inclusive window end, YYYY-MM-DD (site timezone).
+	 * @return int|null Total sessions, or null when unavailable.
+	 */
+	public static function sessions_for_window( string $start_date, string $end_date ): ?int {
+		if ( ! class_exists( Audience_Metric::class ) ) {
+			return null;
+		}
+		return Audience_Metric::get_total_sessions( $start_date, $end_date );
+	}
+
+	/**
+	 * Extract the numeric value from a source MetricCard payload, but only when it
+	 * carries a real number — a computable payload with no error/overlay. Guards
+	 * the joins against dividing an errored or unavailable source into a plausible-
+	 * looking but meaningless derived value.
+	 *
+	 * @param array $payload Source MetricCard payload.
+	 * @return float|null The value, or null when the source can't contribute one.
+	 */
+	private static function source_value( array $payload ): ?float {
+		if ( empty( $payload['computable'] ) || isset( $payload['error'] ) || isset( $payload['overlay'] ) ) {
+			return null;
+		}
+		$value = $payload['value'] ?? null;
+		return is_numeric( $value ) ? (float) $value : null;
+	}
+
+	/**
+	 * Data-unavailable payload: a derived metric that couldn't be joined because a
+	 * source was missing (Audience uncached/outage, or an errored Advertising
+	 * volume metric). Rendered as the "data unavailable" overlay, not a zero.
+	 *
+	 * @return array
+	 */
+	private static function unavailable(): array {
+		return [
+			'value'      => null,
+			'computable' => false,
+			'overlay'    => [ 'type' => 'data_unavailable' ],
+		];
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -44,48 +44,61 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 	$metrics = function ( float $scale, string $window_variant ): array {
 		if ( 'zero' === $window_variant ) {
 			return [
-				'total_impressions'      => [
+				// Cross-system scorecards (NPPD-1675) can't be joined in a no-activity
+				// window (no sessions to divide by); the section collapses to its empty
+				// state anyway, but keep the metric keys present as data-unavailable.
+				'rpm'                         => [
+					'value'      => null,
+					'computable' => false,
+					'overlay'    => [ 'type' => 'data_unavailable' ],
+				],
+				'avg_impressions_per_session' => [
+					'value'      => null,
+					'computable' => false,
+					'overlay'    => [ 'type' => 'data_unavailable' ],
+				],
+				'total_impressions'           => [
 					'value'      => 0,
 					'computable' => true,
 					'type'       => 'count',
 				],
-				'total_revenue'          => [
+				'total_revenue'               => [
 					'value'      => 0.0,
 					'computable' => true,
 					'type'       => 'currency',
 				],
-				'avg_ecpm'               => [
+				'avg_ecpm'                    => [
 					'value'       => 0.0,
 					'computable'  => false,
 					'type'        => 'currency',
 					'numerator'   => 0.0,
 					'denominator' => 0,
 				],
-				'fill_rate'              => [
+				'fill_rate'                   => [
 					'value'       => 0.0,
 					'computable'  => false,
 					'type'        => 'rate',
 					'numerator'   => 0,
 					'denominator' => 0,
 				],
-				'viewability_rate'       => [
+				'viewability_rate'            => [
 					'value'       => 0.0,
 					'computable'  => false,
 					'type'        => 'rate',
 					'numerator'   => 0,
 					'denominator' => 0,
 				],
-				'direct_vs_programmatic' => [
+				'direct_vs_programmatic'      => [
 					'rows'       => [],
 					'computable' => false,
 					'type'       => 'breakdown',
 				],
-				'top_ad_units'           => [
+				'top_ad_units'                => [
 					'rows'       => [],
 					'computable' => false,
 					'type'       => 'table',
 				],
-				'top_advertisers'        => [
+				'top_advertisers'             => [
 					'rows'       => [],
 					'computable' => false,
 					'type'       => 'table',
@@ -97,47 +110,66 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 			// Impressions running, zero revenue — exercises the ReachRevenue per-card
 			// no-revenue treatment on the Total Revenue card.
 			$no_rev_impressions = (int) round( 2400000 * $scale );
+			$no_rev_sessions    = 800000;
 			return [
-				'total_impressions'      => [
+				// Derived scorecards still compute: RPM is a genuine $0.00 (no revenue),
+				// while impressions-per-session stays meaningful.
+				'rpm'                         => \Newspack\Insights\Derived\Cross_System_Metrics::rpm(
+					[
+						'value'      => 0.0,
+						'computable' => true,
+						'type'       => 'currency',
+					],
+					$no_rev_sessions
+				),
+				'avg_impressions_per_session' => \Newspack\Insights\Derived\Cross_System_Metrics::avg_impressions_per_session(
+					[
+						'value'      => $no_rev_impressions,
+						'computable' => true,
+						'type'       => 'count',
+					],
+					$no_rev_sessions
+				),
+				'total_impressions'           => [
 					'value'      => $no_rev_impressions,
 					'computable' => true,
 					'type'       => 'count',
 				],
-				'total_revenue'          => [
+				'total_revenue'               => [
 					'value'      => 0.0,
 					'computable' => true,
 					'type'       => 'currency',
 				],
-				'avg_ecpm'               => [
+				'avg_ecpm'                    => [
 					'value'       => 0.0,
 					'computable'  => false,
 					'type'        => 'currency',
 					'numerator'   => 0.0,
 					'denominator' => 0,
 				],
-				'fill_rate'              => [
+				'fill_rate'                   => [
 					'value'       => 0.0,
 					'computable'  => false,
 					'type'        => 'rate',
 					'numerator'   => 0,
 					'denominator' => 0,
 				],
-				'viewability_rate'       => [
+				'viewability_rate'            => [
 					'value'      => null,
 					'computable' => false,
 					'overlay'    => [ 'type' => 'data_unavailable' ],
 				],
-				'direct_vs_programmatic' => [
+				'direct_vs_programmatic'      => [
 					'rows'       => [],
 					'computable' => false,
 					'type'       => 'breakdown',
 				],
-				'top_ad_units'           => [
+				'top_ad_units'                => [
 					'rows'       => [],
 					'computable' => false,
 					'type'       => 'table',
 				],
-				'top_advertisers'        => [
+				'top_advertisers'             => [
 					'rows'       => [],
 					'computable' => false,
 					'type'       => 'table',
@@ -149,6 +181,11 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		$coded       = (int) round( $impressions * 0.87 );
 		$revenue     = round( 4200.0 * $scale, 2 );
 		$ecpm        = $coded > 0 ? round( ( $revenue / $coded ) * 1000, 2 ) : 0.0;
+		// Mock sessions (NPPD-1675): 800k against 2.4M impressions / $4,200 revenue →
+		// 3.0 ads per session and $5.25 RPM. Held FLAT across windows (not scaled)
+		// so the comparison window — whose volume/revenue scale down — produces a
+		// visible RPM / ads-per-session delta ("revenue grew on flat traffic").
+		$sessions = 800000;
 
 		$viewability = 'no_viewability' === $window_variant
 			? [
@@ -191,32 +228,50 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		}
 
 		return [
-			'total_impressions'      => [
+			// Cross-system derived scorecards (NPPD-1675), computed through the real
+			// join so the fixture and production render identically.
+			'rpm'                         => \Newspack\Insights\Derived\Cross_System_Metrics::rpm(
+				[
+					'value'      => $revenue,
+					'computable' => true,
+					'type'       => 'currency',
+				],
+				$sessions
+			),
+			'avg_impressions_per_session' => \Newspack\Insights\Derived\Cross_System_Metrics::avg_impressions_per_session(
+				[
+					'value'      => $impressions,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				$sessions
+			),
+			'total_impressions'           => [
 				'value'      => $impressions,
 				'computable' => true,
 				'type'       => 'count',
 			],
-			'total_revenue'          => [
+			'total_revenue'               => [
 				'value'      => $revenue,
 				'computable' => true,
 				'type'       => 'currency',
 			],
-			'avg_ecpm'               => [
+			'avg_ecpm'                    => [
 				'value'       => $ecpm,
 				'computable'  => true,
 				'type'        => 'currency',
 				'numerator'   => $revenue,
 				'denominator' => $coded,
 			],
-			'fill_rate'              => [
+			'fill_rate'                   => [
 				'value'       => 0.87,
 				'computable'  => true,
 				'type'        => 'rate',
 				'numerator'   => $coded,
 				'denominator' => $impressions,
 			],
-			'viewability_rate'       => $viewability,
-			'direct_vs_programmatic' => [
+			'viewability_rate'            => $viewability,
+			'direct_vs_programmatic'      => [
 				'rows'       => [
 					[
 						'label'       => 'direct',
@@ -242,12 +297,12 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 				'computable' => true,
 				'type'       => 'breakdown',
 			],
-			'top_ad_units'           => [
+			'top_ad_units'                => [
 				'rows'       => $ad_units,
 				'computable' => true,
 				'type'       => 'table',
 			],
-			'top_advertisers'        => [
+			'top_advertisers'             => [
 				'rows'       => $advertisers,
 				'computable' => true,
 				'type'       => 'table',

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -40,6 +40,7 @@ namespace Newspack\Insights;
 use Newspack\Insights\GAM\Client;
 use Newspack\Insights\GAM\Report_Query;
 use Newspack\Insights\GAM\Report_Job_Status;
+use Newspack\Insights\Derived\Cross_System_Metrics;
 use Newspack\Logger;
 
 defined( 'ABSPATH' ) || exit;
@@ -334,6 +335,27 @@ class Advertising_Metric {
 		$rev     = $metrics['total_revenue'] ?? [];
 		if ( ! empty( $imp['computable'] ) && ! empty( $rev['computable'] ) ) {
 			$window['has_window_activity'] = self::window_activity_signal( (int) ( $imp['value'] ?? 0 ), (float) ( $rev['value'] ?? 0 ) );
+		}
+
+		// Cross-system derived scorecards (NPPD-1675): RPM and avg impressions per
+		// session join this window's GAM revenue/impressions (already resolved, from
+		// the cache above) with GA4 sessions fetched fresh from the Audience
+		// orchestrator. Computed HERE at the read layer — not baked into the day-long
+		// GAM cache in compute_window() — so the sessions denominator tracks Audience's
+		// 15-minute cache rather than lagging up to a day. Skipped on a loading/empty
+		// window (that branch returned above); each derived metric degrades to a
+		// data-unavailable overlay on its own when sessions or its source is missing.
+		if ( ! empty( $metrics ) ) {
+			$sessions = Cross_System_Metrics::sessions_for_window( $start_date, $end_date );
+
+			$window['metrics']['rpm'] = Cross_System_Metrics::rpm(
+				$metrics['total_revenue'] ?? [],
+				$sessions
+			);
+			$window['metrics']['avg_impressions_per_session'] = Cross_System_Metrics::avg_impressions_per_session(
+				$metrics['total_impressions'] ?? [],
+				$sessions
+			);
 		}
 
 		return $window;

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -487,6 +487,96 @@ final class Audience_Metric {
 		];
 	}
 
+	/**
+	 * Total sessions for a window via BigQuery (NPPD-1675 precursor). The GA4 side
+	 * of the cross-system RPM / avg-impressions-per-session joins. Reuses the
+	 * existing `audience_avg_sessions_per_reader` catalog query — it already
+	 * returns a `sessions` total alongside `active_readers` — so no new BigQuery
+	 * catalog entry (and no hub-side change) is needed to expose sessions.
+	 *
+	 * `computable` is false on a proxy outage or an empty result set, so the
+	 * caller can distinguish "sessions unavailable" from a genuine zero.
+	 *
+	 * @param BigQuery_Proxy_Client $proxy Proxy client.
+	 * @param \DateTimeInterface    $start Window start.
+	 * @param \DateTimeInterface    $end   Window end.
+	 * @return array Scalar count payload { value, computable, type: count[, error] }.
+	 */
+	public static function total_sessions_via_bq( BigQuery_Proxy_Client $proxy, \DateTimeInterface $start, \DateTimeInterface $end ): array {
+		$rows = $proxy->query( 'audience_avg_sessions_per_reader', $start, $end );
+		if ( is_wp_error( $rows ) ) {
+			return [
+				'value'      => 0,
+				'computable' => false,
+				'type'       => 'count',
+				'error'      => $rows->get_error_message(),
+			];
+		}
+		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! isset( $rows[0]['sessions'] ) ) {
+			return [
+				'value'      => 0,
+				'computable' => false,
+				'type'       => 'count',
+			];
+		}
+		return [
+			'value'      => (int) $rows[0]['sessions'],
+			'computable' => true,
+			'type'       => 'count',
+		];
+	}
+
+	/**
+	 * Total sessions for a window as a plain integer, for cross-system consumers
+	 * (NPPD-1675). Callable server-side from another orchestrator without going
+	 * through the Audience REST endpoint. Independently cached (15 minutes, its own
+	 * transient) so it never triggers the full Audience window computation — the
+	 * Advertising tab needs only this one figure, not all 19 Audience metrics.
+	 *
+	 * Returns null when sessions can't be established (no GA4 property, proxy
+	 * outage, empty result). Unavailable results are NOT cached, so a transient
+	 * outage clears on the next request rather than suppressing RPM for the full
+	 * TTL. A `newspack_insights_pre_total_sessions` filter can short-circuit the
+	 * BigQuery call (used by tests and available as a production override).
+	 *
+	 * @param string $start_date Inclusive window start, YYYY-MM-DD (site timezone).
+	 * @param string $end_date   Inclusive window end, YYYY-MM-DD (site timezone).
+	 * @return int|null Total sessions, or null when unavailable.
+	 */
+	public static function get_total_sessions( string $start_date, string $end_date ): ?int {
+		/**
+		 * Short-circuit the sessions lookup. Return a non-null value to bypass the
+		 * BigQuery call entirely (tests inject a known count; production may override).
+		 *
+		 * @param int|null $pre        Pre-computed sessions, or null to run the query.
+		 * @param string   $start_date Window start, YYYY-MM-DD.
+		 * @param string   $end_date   Window end, YYYY-MM-DD.
+		 */
+		$pre = apply_filters( 'newspack_insights_pre_total_sessions', null, $start_date, $end_date );
+		if ( null !== $pre ) {
+			return is_numeric( $pre ) ? (int) $pre : null;
+		}
+
+		$cache_key = self::CACHE_KEY_PREFIX . 'sessions:' . md5( self::resolve_property_id() . '|' . $start_date . '|' . $end_date );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (int) $cached;
+		}
+
+		$payload = self::total_sessions_via_bq(
+			new BigQuery_Proxy_Client(),
+			new \DateTimeImmutable( $start_date ),
+			new \DateTimeImmutable( $end_date )
+		);
+		if ( empty( $payload['computable'] ) ) {
+			return null;
+		}
+
+		$sessions = (int) $payload['value'];
+		set_transient( $cache_key, $sessions, self::CACHE_TTL );
+		return $sessions;
+	}
+
 	/*
 	===================================================================
 	 * BigQuery breakdown / table / timeseries methods (NPPD-1729 Task B2)

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
@@ -134,7 +134,7 @@ describe( 'AdvertisingTab', () => {
 		render( <AdvertisingTab range={ range } previousRange={ null } /> );
 
 		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
-		expect( screen.getByText( '2,400,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument(); // 7-digit impressions abbreviate (NPPD-1684)
 		expect( screen.getByText( '$4,200' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Sidebar' ) ).toBeInTheDocument();
 		// Viewability degrades to the data-unavailable note.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
@@ -21,6 +21,10 @@ import type { InsightsWindow } from '../../../api/advertising';
 const metrics = ( over: InsightsWindow = {} ): InsightsWindow => ( {
 	total_impressions: { value: 2400000, computable: true, type: 'count' },
 	total_revenue: { value: 4200, computable: true, type: 'currency' },
+	// Cross-system derived scorecards (NPPD-1675): 4200 / 800k * 1000 = $5.25 RPM,
+	// 2.4M / 800k = 3 impressions per session (whole-number `count`).
+	rpm: { value: 5.25, computable: true, type: 'currency', numerator: 4200, denominator: 800000 },
+	avg_impressions_per_session: { value: 3.0, computable: true, type: 'count', numerator: 2400000, denominator: 800000 },
 	direct_vs_programmatic: {
 		type: 'breakdown',
 		computable: true,
@@ -63,8 +67,9 @@ describe( 'ReachRevenueSection empty states', () => {
 		const { container } = render( <ReachRevenueSection current={ current } previous={ previous } hasWindowActivity /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		// Real impressions count still shown — section not collapsed.
-		expect( screen.getByText( '2,400,000' ) ).toBeInTheDocument();
+		// Real impressions count still shown — section not collapsed. The card value
+		// abbreviates at 7 digits (2.4M); the no-revenue secondary line stays full.
+		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument();
 		expect( screen.getByText( '2,400,000 impressions, but no revenue this timeframe' ) ).toBeInTheDocument();
 
 		const cardByLabel = ( label: string ) =>
@@ -94,7 +99,49 @@ describe( 'ReachRevenueSection empty states', () => {
 		const { container } = render( <ReachRevenueSection current={ metrics() } previous={ null } hasWindowActivity /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( cardValueByLabel( container, 'Total Impressions' ) ).toBe( '2,400,000' );
+		// 7-digit impressions abbreviate to the millions tier (NPPD-1684 rule).
+		expect( cardValueByLabel( container, 'Total Impressions' ) ).toBe( '2.4M' );
 		expect( screen.getByText( 'Total Revenue' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'ReachRevenueSection cross-system scorecards (NPPD-1675)', () => {
+	it( 'renders RPM (currency, cents) and impressions per session (whole number)', () => {
+		const { container } = render( <ReachRevenueSection current={ metrics() } previous={ null } hasWindowActivity /> );
+
+		expect( screen.getByText( 'RPM' ) ).toBeInTheDocument();
+		expect( cardValueByLabel( container, 'RPM' ) ).toBe( '$5.25' );
+
+		expect( screen.getByText( 'Impressions per session' ) ).toBeInTheDocument();
+		expect( cardValueByLabel( container, 'Impressions per session' ) ).toBe( '3' );
+	} );
+
+	it( 'shows period deltas on the derived scorecards under comparison', () => {
+		const previous = metrics( {
+			rpm: { value: 5.0, computable: true, type: 'currency', numerator: 4000, denominator: 800000 },
+			avg_impressions_per_session: { value: 2.5, computable: true, type: 'count', numerator: 2000000, denominator: 800000 },
+		} );
+		const { container } = render( <ReachRevenueSection current={ metrics() } previous={ previous } hasWindowActivity /> );
+
+		const deltaByLabel = ( label: string ) =>
+			Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
+				.find( el => el.textContent === label )
+				?.closest( '.newspack-insights__metric-card' )
+				?.querySelector( '.newspack-insights__metric-card-delta' );
+
+		expect( deltaByLabel( 'RPM' ) ).not.toBeNull();
+		expect( deltaByLabel( 'Impressions per session' ) ).not.toBeNull();
+	} );
+
+	it( 'renders the data-unavailable overlay when sessions are missing', () => {
+		const current = metrics( {
+			rpm: { value: null, computable: false, overlay: { type: 'data_unavailable' } },
+			avg_impressions_per_session: { value: null, computable: false, overlay: { type: 'data_unavailable' } },
+		} );
+		const { container } = render( <ReachRevenueSection current={ current } previous={ null } hasWindowActivity /> );
+
+		// The RPM label still renders; its value is not a misleading zero.
+		expect( screen.getByText( 'RPM' ) ).toBeInTheDocument();
+		expect( cardValueByLabel( container, 'RPM' ) ).not.toBe( '$0.00' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -1,9 +1,12 @@
 /**
- * Advertising › Reach & revenue (NPPD-1618, Section 1; empty states NPPD-1697).
+ * Advertising › Reach & revenue (NPPD-1618, Section 1; empty states NPPD-1697;
+ * cross-system scorecards NPPD-1675).
  *
  * Headline scorecards for the period: impressions served, revenue earned, and
- * the revenue mix (direct share). Three equal-width cards, matching the
- * Inventory performance row's sizing.
+ * two cross-system derived cards — RPM (revenue per 1,000 sessions) and
+ * impressions per session — that join the GAM figures with GA4 sessions. Those
+ * four sit in a --cols-4 row; the revenue mix (direct share) sits in its own row
+ * below, keeping the same card width.
  *
  * Empty states (NPPD-1697), mirroring Donors (NPPD-1696) / Subscribers
  * (NPPD-1695):
@@ -84,7 +87,10 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 	return (
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
 			<SectionHeading id="newspack-insights-advertising-reach-revenue" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+			{ /* Row 1: the four headline scorecards. Volume + revenue (raw), then the
+			     two cross-system derived cards (NPPD-1675) — RPM and impressions per
+			     session — which join GAM figures with GA4 sessions. */ }
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
 				<Scorecard
 					label={ __( 'Total Impressions', 'newspack-plugin' ) }
 					description={ __( 'Total ad impressions served on your site in this timeframe.', 'newspack-plugin' ) }
@@ -113,6 +119,22 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 						previous={ previous?.total_revenue }
 					/>
 				) }
+				<Scorecard
+					label={ __( 'RPM', 'newspack-plugin' ) }
+					description={ __( 'Revenue per 1,000 sessions', 'newspack-plugin' ) }
+					current={ current.rpm }
+					previous={ previous?.rpm }
+				/>
+				<Scorecard
+					label={ __( 'Impressions per session', 'newspack-plugin' ) }
+					description={ __( 'Avg ad impressions each session', 'newspack-plugin' ) }
+					current={ current.avg_impressions_per_session }
+					previous={ previous?.avg_impressions_per_session }
+				/>
+			</div>
+			{ /* Row 2: revenue mix sits below the headline scorecards, keeping the same
+			     card width as the row above. */ }
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
 				<RevenueMixCard payload={ current.direct_vs_programmatic } />
 			</div>
 		</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/sections.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/sections.test.tsx
@@ -47,7 +47,7 @@ describe( 'Advertising sections', () => {
 	it( 'ReachRevenueSection shows impressions, revenue, and the revenue-mix card', () => {
 		render( <ReachRevenueSection current={ metrics } previous={ null } /> );
 		expect( screen.getByText( 'Total Impressions' ) ).toBeInTheDocument();
-		expect( screen.getByText( '2,400,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument(); // 7-digit impressions abbreviate (NPPD-1684)
 		expect( screen.getByText( '$4,200' ) ).toBeInTheDocument();
 		// Definitional descriptions fill the third slot (no short caption).
 		expect( screen.getByText( 'Total ad impressions served on your site in this timeframe.' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -24,7 +24,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Card } from '../../../../../packages/components/src';
-import { formatCurrency, formatDecimal, formatDuration, formatNumber, formatPercent, formatDelta, deltaTone } from './format';
+import { formatCurrency, formatCount, formatDecimal, formatDuration, formatNumber, formatPercent, formatDelta, deltaTone } from './format';
 import MetricNote from './MetricNote';
 
 export type MetricFormat = 'number' | 'currency' | 'percent' | 'decimal' | 'duration';
@@ -262,14 +262,16 @@ const MetricCard = ( props: MetricCardProps ) => {
 			  ).trim()
 			: null;
 
-	// Currency formats once, yielding both the display string and (when
-	// abbreviated, e.g. "$1.2M") the full-value title; other formats go through
-	// formatValue.
-	const currency = format === 'currency' ? formatCurrency( value ) : null;
-	const valueText = currency ? currency.display : formatValue( value, format );
+	// Currency and large counts format once, yielding both the display string and
+	// (when abbreviated, e.g. "$1.2M" / "2.4M") the full-value title; other formats
+	// go through formatValue. Counts share the currency millions tier so a 7+ digit
+	// impressions total abbreviates instead of overflowing the card (NPPD-1684).
+	const tiered =
+		format === 'currency' ? formatCurrency( value ) : format === 'number' ? formatCount( value ) : null;
+	const valueText = tiered ? tiered.display : formatValue( value, format );
 	// Explicit `valueTitle` wins; `||` (not `??`) so an empty string isn't treated
 	// as an override and still falls back to the formatter-derived full value.
-	const valueTooltip = valueTitle || currency?.title || undefined;
+	const valueTooltip = valueTitle || tiered?.title || undefined;
 
 	// Hero content: a count-fallback string, the em-dash null glyph (matched to
 	// the Performance by gate table's null cell — same glyph + aria-label), or

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -24,7 +24,17 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Card } from '../../../../../packages/components/src';
-import { formatCurrency, formatCount, formatDecimal, formatDuration, formatNumber, formatPercent, formatDelta, deltaTone } from './format';
+import {
+	formatCurrency,
+	formatCount,
+	formatDecimal,
+	formatDuration,
+	formatNumber,
+	formatPercent,
+	formatDelta,
+	deltaTone,
+	type FormattedCurrency,
+} from './format';
 import MetricNote from './MetricNote';
 
 export type MetricFormat = 'number' | 'currency' | 'percent' | 'decimal' | 'duration';
@@ -115,8 +125,9 @@ export interface MetricCardProps {
 	notComputableMessage?: string;
 }
 
-// Currency is handled by the caller (it needs both display + title from one
-// formatCurrency call); every other format maps to a plain string here.
+// Currency and large counts are handled by the caller (they need both a display
+// string and a full-value title from one call); every other format maps to a
+// plain string here.
 const formatValue = ( v: number, fmt: MetricFormat ): string => {
 	switch ( fmt ) {
 		case 'percent':
@@ -128,6 +139,20 @@ const formatValue = ( v: number, fmt: MetricFormat ): string => {
 		default:
 			return formatNumber( v );
 	}
+};
+
+// The two tiered formats: currency and count both yield a { display, title }
+// pair (title = the full value when the display is abbreviated to "$1.2M" /
+// "2.4M"). Other formats have no tier and return null so the caller falls back
+// to formatValue.
+const tieredFormat = ( v: number, fmt: MetricFormat ): FormattedCurrency | null => {
+	if ( fmt === 'currency' ) {
+		return formatCurrency( v );
+	}
+	if ( fmt === 'number' ) {
+		return formatCount( v );
+	}
+	return null;
 };
 
 // Em-dash null glyph (U+2014). Matches the "Not applicable" treatment in the
@@ -266,8 +291,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 	// (when abbreviated, e.g. "$1.2M" / "2.4M") the full-value title; other formats
 	// go through formatValue. Counts share the currency millions tier so a 7+ digit
 	// impressions total abbreviates instead of overflowing the card (NPPD-1684).
-	const tiered =
-		format === 'currency' ? formatCurrency( value ) : format === 'number' ? formatCount( value ) : null;
+	const tiered = tieredFormat( value, format );
 	const valueText = tiered ? tiered.display : formatValue( value, format );
 	// Explicit `valueTitle` wins; `||` (not `??`) so an empty string isn't treated
 	// as an override and still falls back to the formatter-derived full value.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.test.ts
@@ -7,7 +7,7 @@
 /**
  * Internal dependencies
  */
-import { formatCurrency, formatPercent } from './format';
+import { formatCount, formatCurrency, formatPercent } from './format';
 
 describe( 'formatCurrency', () => {
 	it( 'keeps cents below $1,000', () => {
@@ -42,6 +42,31 @@ describe( 'formatCurrency', () => {
 
 	it( 'renders zero with cents and no title', () => {
 		expect( formatCurrency( 0 ) ).toEqual( { display: '$0.00', title: null } );
+	} );
+} );
+
+describe( 'formatCount', () => {
+	it( 'renders below 1M in full with thousands separators and no title', () => {
+		expect( formatCount( 98765 ) ).toEqual( { display: '98,765', title: null } );
+	} );
+
+	it( 'rounds a fractional value to a whole number (impressions-per-session case)', () => {
+		expect( formatCount( 3.4 ) ).toEqual( { display: '3', title: null } );
+	} );
+
+	it( 'abbreviates 1M+ to the millions tier and carries the full value as a title', () => {
+		expect( formatCount( 2400000 ) ).toEqual( { display: '2.4M', title: '2,400,000' } );
+	} );
+
+	it( 'treats exactly 1,000,000 as the abbreviated tier', () => {
+		// Trailing ".0" varies by ICU version ("1M" vs "1.0M"); assert the invariants.
+		const result = formatCount( 1000000 );
+		expect( result.display ).toMatch( /^1(\.0)?M$/ );
+		expect( result.title ).toBe( '1,000,000' );
+	} );
+
+	it( 'renders zero as 0 with no title', () => {
+		expect( formatCount( 0 ) ).toEqual( { display: '0', title: null } );
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
@@ -45,6 +45,11 @@ const USD_COMPACT = new Intl.NumberFormat( undefined, {
 	maximumFractionDigits: 1,
 } );
 
+const NUMBER_COMPACT = new Intl.NumberFormat( undefined, {
+	notation: 'compact',
+	maximumFractionDigits: 1,
+} );
+
 const percentFormatter = new Intl.NumberFormat( undefined, {
 	style: 'percent',
 	maximumFractionDigits: 1,
@@ -100,6 +105,24 @@ export const formatCurrency = ( value: number ): FormattedCurrency => {
 	return {
 		display: USD_COMPACT.format( value ),
 		title: USD_WITH_CENTS.format( value ),
+	};
+};
+
+/**
+ * Tiered count: `< 1M` renders in full with thousands separators; `>= 1M`
+ * abbreviates (e.g. "2.4M") and carries the full value as `title` for a tooltip.
+ * Mirrors {@see formatCurrency}'s millions tier (NPPD-1684) so large counts —
+ * ad impressions especially — don't overflow a scorecard at 7+ digits. Shares
+ * `FormattedCurrency`'s `{ display, title }` shape so MetricCard treats an
+ * abbreviated count exactly like an abbreviated amount.
+ */
+export const formatCount = ( value: number ): FormattedCurrency => {
+	if ( Math.abs( value ) < 1_000_000 ) {
+		return { display: numberFormatter.format( value ), title: null };
+	}
+	return {
+		display: NUMBER_COMPACT.format( value ),
+		title: numberFormatter.format( value ),
 	};
 };
 

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -376,7 +376,7 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 		$this->assertSame( ( 4200.0 / 800000 ) * 1000, $window['metrics']['rpm']['value'] );
 
 		$this->assertArrayHasKey( 'avg_impressions_per_session', $window['metrics'] );
-		$this->assertSame( 2400000 / 800000, $window['metrics']['avg_impressions_per_session']['value'] );
+		$this->assertSame( 3.0, $window['metrics']['avg_impressions_per_session']['value'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -332,6 +332,66 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Injects the cross-system derived scorecards (NPPD-1675) onto a resolved
+	 * window via read_window(): RPM and avg impressions per session, joining the
+	 * cached GAM volume/revenue with GA4 sessions (fed here via the filter).
+	 */
+	public function test_read_window_injects_cross_system_metrics() {
+		add_filter( 'newspack_insights_pre_total_sessions', [ $this, 'return_fixed_sessions' ], 10, 3 );
+
+		$start = '2026-01-01';
+		$end   = '2026-01-31';
+		$key   = $this->invoke( 'cache_key', [ $start, $end ] );
+		set_transient(
+			$key,
+			[
+				'computed_at' => time(),
+				'payload'     => [
+					'window'  => [
+						'start' => $start,
+						'end'   => $end,
+					],
+					'metrics' => [
+						'total_impressions' => [
+							'value'      => 2400000,
+							'computable' => true,
+							'type'       => 'count',
+						],
+						'total_revenue'     => [
+							'value'      => 4200.0,
+							'computable' => true,
+							'type'       => 'currency',
+						],
+					],
+				],
+			]
+		);
+
+		$window = $this->invoke( 'read_window', [ $start, $end ] );
+		delete_transient( $key );
+		remove_filter( 'newspack_insights_pre_total_sessions', [ $this, 'return_fixed_sessions' ], 10 );
+
+		$this->assertArrayHasKey( 'rpm', $window['metrics'] );
+		$this->assertTrue( $window['metrics']['rpm']['computable'] );
+		$this->assertSame( ( 4200.0 / 800000 ) * 1000, $window['metrics']['rpm']['value'] );
+
+		$this->assertArrayHasKey( 'avg_impressions_per_session', $window['metrics'] );
+		$this->assertSame( 2400000 / 800000, $window['metrics']['avg_impressions_per_session']['value'] );
+	}
+
+	/**
+	 * Filter callback: a known session count for the cross-system injection test.
+	 *
+	 * @param int|null $pre        Incoming value.
+	 * @param string   $start_date Window start.
+	 * @param string   $end_date   Window end.
+	 * @return int
+	 */
+	public function return_fixed_sessions( $pre, $start_date, $end_date ): int {
+		return 800000;
+	}
+
+	/**
 	 * Prior period is the contiguous, equal-length preceding window.
 	 */
 	public function test_prior_period() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-metric.php
@@ -320,6 +320,69 @@ class Test_Audience_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reads the `sessions` total off the reused avg-sessions-per-reader query
+	 * (NPPD-1675 precursor).
+	 */
+	public function test_total_sessions_via_bq_reads_sessions() {
+		$proxy = $this->makeProxyReturning(
+			'audience_avg_sessions_per_reader',
+			[
+				[
+					'sessions'       => 6000,
+					'active_readers' => 2000,
+				],
+			]
+		);
+		$out = Audience_Metric::total_sessions_via_bq( $proxy, new \DateTimeImmutable( '2026-01-01' ), new \DateTimeImmutable( '2026-01-31' ) );
+		$this->assertSame( 6000, $out['value'] );
+		$this->assertTrue( $out['computable'] );
+		$this->assertSame( 'count', $out['type'] );
+	}
+
+	/**
+	 * Surfaces a proxy outage as computable=false, so the consumer can render
+	 * "data unavailable" rather than a zero denominator.
+	 */
+	public function test_total_sessions_via_bq_outage_not_computable() {
+		$proxy = $this->makeProxyError();
+		$out   = Audience_Metric::total_sessions_via_bq( $proxy, new \DateTimeImmutable( '2026-01-01' ), new \DateTimeImmutable( '2026-01-31' ) );
+		$this->assertFalse( $out['computable'] );
+		$this->assertArrayHasKey( 'error', $out );
+	}
+
+	/**
+	 * Returns not-computable when the query yields no rows.
+	 */
+	public function test_total_sessions_via_bq_empty_not_computable() {
+		$proxy = $this->makeProxyReturning( 'audience_avg_sessions_per_reader', [] );
+		$out   = Audience_Metric::total_sessions_via_bq( $proxy, new \DateTimeImmutable( '2026-01-01' ), new \DateTimeImmutable( '2026-01-31' ) );
+		$this->assertFalse( $out['computable'] );
+	}
+
+	/**
+	 * Honors the pre-filter short-circuit (the cross-system seam), returning the
+	 * injected count without a BigQuery call.
+	 */
+	public function test_get_total_sessions_pre_filter_short_circuits() {
+		add_filter( 'newspack_insights_pre_total_sessions', [ $this, 'return_fixed_sessions' ], 10, 3 );
+		$sessions = Audience_Metric::get_total_sessions( '2026-01-01', '2026-01-31' );
+		remove_filter( 'newspack_insights_pre_total_sessions', [ $this, 'return_fixed_sessions' ], 10 );
+		$this->assertSame( 42000, $sessions );
+	}
+
+	/**
+	 * Filter callback: a known session count for the short-circuit test.
+	 *
+	 * @param int|null $pre        Incoming value.
+	 * @param string   $start_date Window start.
+	 * @param string   $end_date   Window end.
+	 * @return int
+	 */
+	public function return_fixed_sessions( $pre, $start_date, $end_date ): int {
+		return 42000;
+	}
+
+	/**
 	 * Tests that proxy_scalar returns computable=false when the column is absent.
 	 */
 	public function test_active_readers_via_bq_missing_column_not_computable() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-cross-system-metrics.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-cross-system-metrics.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Test Cross_System_Metrics (NPPD-1675).
+ *
+ * The first Insights metrics that join two orchestrators: RPM and average
+ * impressions per session divide a GAM figure by GA4 sessions. The join math is
+ * pure and tested directly; the sessions bridge is exercised through the
+ * `newspack_insights_pre_total_sessions` short-circuit filter so no BigQuery call
+ * is made.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Derived\Cross_System_Metrics;
+use WP_UnitTestCase;
+
+/**
+ * Cross_System_Metrics test class.
+ *
+ * @group insights
+ */
+class Test_Cross_System_Metrics extends WP_UnitTestCase {
+
+	/**
+	 * A computable revenue payload for reuse.
+	 *
+	 * @param float $value Revenue.
+	 * @return array
+	 */
+	private function revenue( float $value ): array {
+		return [
+			'value'      => $value,
+			'computable' => true,
+			'type'       => 'currency',
+		];
+	}
+
+	/**
+	 * A computable impressions payload for reuse.
+	 *
+	 * @param int $value Impressions.
+	 * @return array
+	 */
+	private function impressions( int $value ): array {
+		return [
+			'value'      => $value,
+			'computable' => true,
+			'type'       => 'count',
+		];
+	}
+
+	/**
+	 * RPM is revenue per thousand sessions, with revenue/sessions carried through
+	 * as numerator/denominator.
+	 */
+	public function test_rpm_computes() {
+		$out = Cross_System_Metrics::rpm( $this->revenue( 4200.0 ), 800000 );
+		$this->assertTrue( $out['computable'] );
+		$this->assertSame( 'currency', $out['type'] );
+		$this->assertSame( ( 4200.0 / 800000 ) * 1000, $out['value'] );
+		$this->assertSame( 4200.0, $out['numerator'] );
+		$this->assertSame( 800000, $out['denominator'] );
+	}
+
+	/**
+	 * Zero revenue is a genuine $0.00 RPM (not "unavailable") — the join succeeded,
+	 * the numerator is simply zero.
+	 */
+	public function test_rpm_zero_revenue_is_computable_zero() {
+		$out = Cross_System_Metrics::rpm( $this->revenue( 0.0 ), 800000 );
+		$this->assertTrue( $out['computable'] );
+		$this->assertSame( 0.0, $out['value'] );
+	}
+
+	/**
+	 * Average impressions per session divides impressions by sessions. Typed as a
+	 * whole-number `count` for display; the raw ratio is preserved as `value`.
+	 */
+	public function test_avg_impressions_per_session_computes() {
+		$out = Cross_System_Metrics::avg_impressions_per_session( $this->impressions( 2400000 ), 800000 );
+		$this->assertTrue( $out['computable'] );
+		$this->assertSame( 'count', $out['type'] );
+		$this->assertSame( 2400000 / 800000, $out['value'] );
+		$this->assertSame( 2400000, $out['numerator'] );
+		$this->assertSame( 800000, $out['denominator'] );
+	}
+
+	/**
+	 * Null sessions (Audience unavailable) → data-unavailable overlay on both, not a
+	 * misleading zero.
+	 *
+	 * @dataProvider provide_unavailable_sessions
+	 * @param int|null $sessions Session count under test.
+	 */
+	public function test_missing_sessions_is_data_unavailable( $sessions ) {
+		$rpm = Cross_System_Metrics::rpm( $this->revenue( 4200.0 ), $sessions );
+		$avg = Cross_System_Metrics::avg_impressions_per_session( $this->impressions( 2400000 ), $sessions );
+
+		foreach ( [ $rpm, $avg ] as $out ) {
+			$this->assertFalse( $out['computable'] );
+			$this->assertNull( $out['value'] );
+			$this->assertSame( 'data_unavailable', $out['overlay']['type'] );
+		}
+	}
+
+	/**
+	 * Null (outage), zero, and negative sessions all fail closed to the overlay:
+	 * there is no meaningful per-session figure without a positive denominator.
+	 *
+	 * @return array
+	 */
+	public function provide_unavailable_sessions(): array {
+		return [
+			'null'     => [ null ],
+			'zero'     => [ 0 ],
+			'negative' => [ -5 ],
+		];
+	}
+
+	/**
+	 * A non-computable / errored / overlaid source metric can't seed a derived
+	 * value — the derived metric is data-unavailable rather than dividing garbage.
+	 *
+	 * @dataProvider provide_unusable_sources
+	 * @param array $source A source payload that shouldn't contribute a value.
+	 */
+	public function test_unusable_source_is_data_unavailable( array $source ) {
+		$out = Cross_System_Metrics::rpm( $source, 800000 );
+		$this->assertFalse( $out['computable'] );
+		$this->assertSame( 'data_unavailable', $out['overlay']['type'] );
+	}
+
+	/**
+	 * Sources the join must refuse: not computable, carrying an error, carrying an
+	 * overlay, or a non-numeric value.
+	 *
+	 * @return array
+	 */
+	public function provide_unusable_sources(): array {
+		return [
+			'not computable' => [
+				[
+					'value'      => 4200.0,
+					'computable' => false,
+				],
+			],
+			'errored'        => [
+				[
+					'value'      => null,
+					'computable' => false,
+					'error'      => 'boom',
+				],
+			],
+			'overlaid'       => [
+				[
+					'value'      => null,
+					'computable' => false,
+					'overlay'    => [ 'type' => 'data_unavailable' ],
+				],
+			],
+			'non-numeric'    => [
+				[
+					'value'      => null,
+					'computable' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * The sessions bridge delegates to the Audience orchestrator; the short-circuit
+	 * filter proves it is wired without touching BigQuery.
+	 */
+	public function test_sessions_for_window_bridges_to_audience() {
+		add_filter( 'newspack_insights_pre_total_sessions', [ $this, 'return_fixed_sessions' ], 10, 3 );
+		$sessions = Cross_System_Metrics::sessions_for_window( '2026-01-01', '2026-01-31' );
+		remove_filter( 'newspack_insights_pre_total_sessions', [ $this, 'return_fixed_sessions' ], 10 );
+
+		$this->assertSame( 800000, $sessions );
+	}
+
+	/**
+	 * Filter callback: a known session count for the bridge test.
+	 *
+	 * @param int|null $pre        Incoming value.
+	 * @param string   $start_date Window start.
+	 * @param string   $end_date   Window end.
+	 * @return int
+	 */
+	public function return_fixed_sessions( $pre, $start_date, $end_date ): int {
+		return 800000;
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-cross-system-metrics.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-cross-system-metrics.php
@@ -82,7 +82,9 @@ class Test_Cross_System_Metrics extends WP_UnitTestCase {
 		$out = Cross_System_Metrics::avg_impressions_per_session( $this->impressions( 2400000 ), 800000 );
 		$this->assertTrue( $out['computable'] );
 		$this->assertSame( 'count', $out['type'] );
-		$this->assertSame( 2400000 / 800000, $out['value'] );
+		// Value is the raw float ratio (3.0), not the int the whole-number display
+		// implies — impressions is divided as a float so deltas stay exact.
+		$this->assertSame( 3.0, $out['value'] );
 		$this->assertSame( 2400000, $out['numerator'] );
 		$this->assertSame( 800000, $out['denominator'] );
 	}


### PR DESCRIPTION
## Summary

Adds the first **cross-system** metrics in Insights (NPPD-1675): two new scorecards in the Advertising tab's **Reach & revenue** section that join GAM (Advertising) with GA4 sessions (Audience).

- **RPM** — `(total_revenue / total_sessions) * 1000`, displayed as currency ("$2.15").
- **Impressions per session** — `total_impressions / total_sessions`, displayed as a whole number ("3").

Linear: [NPPD-1675](https://linear.app/a8c/issue/NPPD-1675)

## Pre-flight (per the ticket)

- **PF1 — sessions exposure:** `Audience_Metric` didn't expose total sessions. Added `Audience_Metric::get_total_sessions()` (+ `total_sessions_via_bq()`), **reusing** the existing `audience_avg_sessions_per_reader` BigQuery query's `sessions` column — no new BQ catalog entry, no hub change. Independently cached (15 min).
- **PF2 — date/timezone parity:** both orchestrators take the same `Y-m-d` site-timezone window boundaries. Underlying data timezones differ (GAM network vs GA4 property) — a sub-boundary skew on already day-lagged data, documented and normalized silently for v1.
- **PF3 — architecture:** **Option B (shared module), joined at the read layer.**

## Architecture decision

A shared module `\Newspack\Insights\Derived\Cross_System_Metrics` owns the join math (`rpm()`, `avg_impressions_per_session()`) and the one cross-orchestrator reach (`sessions_for_window()` → Audience). It's invoked from `Advertising_Metric::read_window()` — the request/read layer — **not** from the background GAM refresh (`compute_window`).

Why the read layer and not `compute_window`: Advertising's GAM cache TTL is a **full day** (`CACHE_HARD_TTL`) while Audience sessions is **15 min**. Baking sessions into the day-long GAM payload would stale the RPM denominator by up to a day. Computing at the read layer keeps sessions fresh and keeps the async GAM job decoupled from the Audience orchestrator. This establishes the pattern for future cross-system metrics (revenue per article, conversion rate per impression, …) — one shared module rather than N×M orchestrator coupling.

Missing source (uncached sessions, errored volume metric, zero sessions) → `data_unavailable` overlay, not a misleading `$0`/`0`.

## Also in this PR

- **Large-count abbreviation.** Added a tiered `formatCount()` mirroring the existing `formatCurrency` rule (≥1M → "2.4M" with the full value in a tooltip) and wired it into `MetricCard`'s count path, so a 7-digit Total Impressions no longer overflows the card. Shared rule; impressions is the only count large enough to trigger it in practice.

## Testing

- New `Cross_System_Metrics` PHPUnit suite (pure joins, missing-data, sessions bridge), Audience `total_sessions_via_bq` / `get_total_sessions` tests, and an Advertising `read_window` integration test.
- JS: `format` (formatCount), `ReachRevenueSection` (4 scorecards + deltas + overlay), `MetricCard`, `AdvertisingTab`, `sections`.
- **Full JS suite green (91 suites / 741 tests)** locally; PHPCS clean against the workspace-root standard. Verified live on localhost in fixture mode.

## Notes / open questions carried from the ticket

- Timezone mismatch is normalized silently for v1; surfacing a UI caveat (info icon) is a possible v1.x follow-up.
