### PR TITLE
feat(insights): Tab 8 per-site breakdown for network publishers (NPPD-1671)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -319,6 +319,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 			],
 			'is_tab_visible'              => true,
 			'is_report_ready'             => false,
+			'is_network_member'           => false,
 			'readiness_issues'            => [
 				[
 					'code'            => 'oauth_scope_missing',
@@ -349,28 +350,84 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 	if ( 'loading' === $variant ) {
 		return [
 			'current'  => [
-				'window'           => [
+				'window'            => [
 					'start' => $start_date,
 					'end'   => $end_date,
 				],
-				'is_tab_visible'   => true,
-				'is_report_ready'  => true,
-				'readiness_issues' => [],
-				'metrics'          => [],
-				'is_loading'       => true,
+				'is_tab_visible'    => true,
+				'is_report_ready'   => true,
+				'is_network_member' => false,
+				'readiness_issues'  => [],
+				'metrics'           => [],
+				'is_loading'        => true,
 			],
 			'previous' => null,
 		];
 	}
 
+	// Per-site breakdown (NPPD-1671): the `network` fixture state flags the site as
+	// a network member and adds a top_sites table; every other state is a
+	// non-network publisher (is_network_member false, no top_sites).
+	$is_network = 'network' === $variant;
+	$site_rows  = function ( float $scale ): array {
+		$sites = [
+			[
+				'site'        => 'almanacnews.com',
+				'impressions' => 980000,
+				'revenue'     => 1720.0,
+			],
+			[
+				'site'        => 'paloaltoonline.com',
+				'impressions' => 760000,
+				'revenue'     => 1340.0,
+			],
+			[
+				'site'        => 'mv-voice.com',
+				'impressions' => 410000,
+				'revenue'     => 705.0,
+			],
+			[
+				'site'        => 'pleasantonweekly.com',
+				'impressions' => 190000,
+				'revenue'     => 300.0,
+			],
+			[
+				'site'        => 'livermorevine.com',
+				'impressions' => 95000,
+				'revenue'     => 138.0,
+			],
+		];
+		return array_map(
+			function ( $row ) use ( $scale ) {
+				$impressions = (int) round( $row['impressions'] * $scale );
+				$revenue     = round( $row['revenue'] * $scale, 2 );
+				return [
+					'site'        => $row['site'],
+					'impressions' => $impressions,
+					'revenue'     => $revenue,
+					'ecpm'        => $impressions > 0 ? round( ( $revenue / $impressions ) * 1000, 2 ) : 0.0,
+				];
+			},
+			$sites
+		);
+	};
+
 	$current_metrics = $metrics( 1.0, $variant );
-	$envelope        = [
+	if ( $is_network ) {
+		$current_metrics['top_sites'] = [
+			'rows'       => $site_rows( 1.0 ),
+			'computable' => true,
+			'type'       => 'table',
+		];
+	}
+	$envelope = [
 		'window'                      => [
 			'start' => $start_date,
 			'end'   => $end_date,
 		],
 		'is_tab_visible'              => true,
 		'is_report_ready'             => true,
+		'is_network_member'           => $is_network,
 		'readiness_issues'            => [],
 		'metrics'                     => $current_metrics,
 		'data_as_of'                  => $data_as_of,
@@ -405,13 +462,21 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		// per-row figures land lower, exercising both delta directions. The prior
 		// window always uses a non-empty variant so comparison deltas render.
 		$prev_metrics = $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant );
-		$previous     = [
+		if ( $is_network ) {
+			$prev_metrics['top_sites'] = [
+				'rows'       => $site_rows( 0.85 ),
+				'computable' => true,
+				'type'       => 'table',
+			];
+		}
+		$previous = [
 			'window'                      => [
 				'start' => $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start,
 				'end'   => $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end,
 			],
 			'is_tab_visible'              => true,
 			'is_report_ready'             => true,
+			'is_network_member'           => $is_network,
 			'readiness_issues'            => [],
 			'metrics'                     => $prev_metrics,
 			'data_as_of'                  => $data_as_of,

--- a/plugins/newspack-plugin/includes/wizards/insights/gam/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/gam/class-client.php
@@ -263,6 +263,21 @@ class Client {
 	 * @throws \RuntimeException If credentials or the library are unavailable.
 	 */
 	protected static function get_report_service( $network_code ) {
+		return ( new \Google\AdsApi\AdManager\v202602\ServiceFactory() )->createReportService( self::build_session( $network_code ) );
+	}
+
+	/**
+	 * Build a GAM API session bound to the network code, authenticated with the
+	 * publisher's OAuth credentials. Shared by the ReportService and the
+	 * CustomTargetingService (NPPD-1671) so both authenticate identically —
+	 * OAuth-only, never a service account.
+	 *
+	 * @param int $network_code The GAM network code.
+	 * @return \Google\AdsApi\AdManager\AdManagerSession
+	 *
+	 * @throws \RuntimeException If credentials or the library are unavailable.
+	 */
+	protected static function build_session( $network_code ) {
 		self::ensure_library_loaded();
 
 		$credentials = Google_Services_Connection::get_oauth2_credentials();
@@ -270,18 +285,51 @@ class Client {
 			throw new \RuntimeException( 'No Google OAuth credentials available for GAM reporting.' );
 		}
 
-		$config  = [
+		$config = [
 			'AD_MANAGER' => [
 				'applicationName' => self::APPLICATION_NAME,
 				'networkCode'     => (string) $network_code,
 			],
 		];
-		$session = ( new \Google\AdsApi\AdManager\AdManagerSessionBuilder() )
+		return ( new \Google\AdsApi\AdManager\AdManagerSessionBuilder() )
 			->from( new \Google\AdsApi\Common\Configuration( $config ) )
 			->withOAuth2Credential( $credentials )
 			->build();
+	}
 
-		return ( new \Google\AdsApi\AdManager\v202602\ServiceFactory() )->createReportService( $session );
+	/**
+	 * Resolve a reportable custom-dimension key by name to its GAM key ID
+	 * (NPPD-1671), for use as {@see Report_Query::$custom_dimension_key_ids}.
+	 * Queries the CustomTargetingService over the same OAuth session as reporting.
+	 * Returns null when the key doesn't exist (e.g. a non-network publisher, whose
+	 * GAM has no `site` dimension). SOAP-touching, so the orchestrator wraps calls
+	 * in a mockable seam.
+	 *
+	 * @param string $name         Custom targeting key name (e.g. 'site').
+	 * @param int    $network_code GAM network code.
+	 * @return int|null The key ID, or null when not found.
+	 *
+	 * @throws \RuntimeException On a (translated) API error.
+	 */
+	public static function resolve_custom_dimension_key_id( $name, $network_code ) {
+		// Key names are simple identifiers; hard-sanitize before it reaches the PQL.
+		$safe_name = preg_replace( '/[^a-z0-9_]/i', '', (string) $name );
+		if ( '' === $safe_name ) {
+			return null;
+		}
+		$service = ( new \Google\AdsApi\AdManager\v202602\ServiceFactory() )->createCustomTargetingService( self::build_session( $network_code ) );
+		try {
+			$statement = new \Google\AdsApi\AdManager\v202602\Statement(
+				"WHERE name = '" . $safe_name . "' AND status = 'ACTIVE'"
+			);
+			$results = $service->getCustomTargetingKeysByStatement( $statement )->getResults();
+		} catch ( \Exception $e ) {
+			throw self::friendly_api_error( $e ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- friendly_api_error() returns a RuntimeException with an already-escaped message.
+		}
+		if ( empty( $results ) ) {
+			return null;
+		}
+		return (int) $results[0]->getId();
 	}
 
 	/**
@@ -344,6 +392,11 @@ class Client {
 		$report_query = new \Google\AdsApi\AdManager\v202602\ReportQuery();
 		$report_query->setDimensions( $query->dimensions );
 		$report_query->setColumns( $query->columns );
+		// Custom-dimension breakdown (NPPD-1671): referencing the reportable key(s)
+		// by ID makes GAM emit one row per value (e.g. per network `site`).
+		if ( ! empty( $query->custom_dimension_key_ids ) ) {
+			$report_query->setCustomDimensionKeyIds( $query->custom_dimension_key_ids );
+		}
 		$report_query->setDateRangeType( $query->date_range_type );
 
 		if ( 'CUSTOM_DATE' === $query->date_range_type ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/gam/class-report-query.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/gam/class-report-query.php
@@ -34,6 +34,16 @@ class Report_Query {
 	public $columns = [];
 
 	/**
+	 * GAM custom-dimension key IDs to break the report down by (NPPD-1671). When
+	 * set, the `dimensions` list should include `CUSTOM_DIMENSION`; GAM then emits
+	 * one row per value of each referenced key. Used for the network `site`
+	 * breakdown — the reportable custom dimension newspack-network creates.
+	 *
+	 * @var int[]
+	 */
+	public $custom_dimension_key_ids = [];
+
+	/**
 	 * Optional PQL filter clause (the report's WHERE), or null.
 	 *
 	 * @var string|null
@@ -70,7 +80,7 @@ class Report_Query {
 	 *                    keyed by property name.
 	 */
 	public function __construct( array $args = [] ) {
-		$keys = [ 'dimensions', 'columns', 'pql_filter', 'start_date', 'end_date', 'date_range_type' ];
+		$keys = [ 'dimensions', 'columns', 'custom_dimension_key_ids', 'pql_filter', 'start_date', 'end_date', 'date_range_type' ];
 		foreach ( $keys as $key ) {
 			if ( array_key_exists( $key, $args ) ) {
 				$this->$key = $args[ $key ];
@@ -89,6 +99,7 @@ class Report_Query {
 				[
 					$this->dimensions,
 					$this->columns,
+					$this->custom_dimension_key_ids,
 					$this->pql_filter,
 					$this->start_date,
 					$this->end_date,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -90,9 +90,24 @@ class Advertising_Metric {
 	const COL_AV_VIEWABLE   = 'TOTAL_ACTIVE_VIEW_VIEWABLE_IMPRESSIONS';
 	const COL_AV_MEASURABLE = 'TOTAL_ACTIVE_VIEW_MEASURABLE_IMPRESSIONS';
 
-	const DIM_LINE_ITEM_TYPE  = 'LINE_ITEM_TYPE';
-	const DIM_AD_UNIT_NAME    = 'AD_UNIT_NAME';
-	const DIM_ADVERTISER_NAME = 'ADVERTISER_NAME';
+	const DIM_LINE_ITEM_TYPE   = 'LINE_ITEM_TYPE';
+	const DIM_AD_UNIT_NAME     = 'AD_UNIT_NAME';
+	const DIM_ADVERTISER_NAME  = 'ADVERTISER_NAME';
+	const DIM_CUSTOM_DIMENSION = 'CUSTOM_DIMENSION';
+
+	/**
+	 * The reportable custom-dimension key newspack-network creates for each site
+	 * in a Newspack Network (NPPD-1671). Its values are sanitized site URLs.
+	 */
+	const SITE_DIMENSION_KEY = 'site';
+
+	/**
+	 * Cache of the resolved `site` custom-dimension key ID (per network). Stable —
+	 * the dimension rarely changes — so a 1-day TTL keeps the CustomTargetingService
+	 * lookup off the per-window path. An empty-string entry caches "not found".
+	 */
+	const SITE_KEY_CACHE_PREFIX = 'newspack_insights_advertising_site_key:';
+	const SITE_KEY_CACHE_TTL    = DAY_IN_SECONDS;
 
 	const DIRECT_LINE_ITEM_TYPES       = [ 'SPONSORSHIP', 'STANDARD', 'BULK', 'PRICE_PRIORITY' ];
 	const PROGRAMMATIC_LINE_ITEM_TYPES = [ 'NETWORK', 'AD_EXCHANGE' ];
@@ -124,6 +139,20 @@ class Advertising_Metric {
 	 */
 	public static function is_tab_visible(): bool {
 		return Client::is_gam_active();
+	}
+
+	/**
+	 * Whether this site belongs to a Newspack Network (NPPD-1671). Gates the
+	 * per-site GAM breakdown: newspack-network creates a reportable `site` custom
+	 * dimension in the network's shared GAM, so any network site with GAM
+	 * connected (in practice the nodes, whose credentials carry network-level
+	 * reporting) can query impressions/revenue by site. Guarded so Insights never
+	 * hard-depends on newspack-network being active.
+	 *
+	 * @return bool
+	 */
+	public static function is_network_member(): bool {
+		return class_exists( '\Newspack_Network\Site_Role' ) && \Newspack_Network\Site_Role::has_role();
 	}
 
 	/**
@@ -233,13 +262,14 @@ class Advertising_Metric {
 	 */
 	public static function get_all( string $start_date, string $end_date, bool $compare = false ): array {
 		$envelope = [
-			'window'           => [
+			'window'            => [
 				'start' => $start_date,
 				'end'   => $end_date,
 			],
-			'is_tab_visible'   => self::is_tab_visible(),
-			'is_report_ready'  => self::is_report_ready(),
-			'readiness_issues' => self::readiness_issues(),
+			'is_tab_visible'    => self::is_tab_visible(),
+			'is_report_ready'   => self::is_report_ready(),
+			'is_network_member' => self::is_network_member(),
+			'readiness_issues'  => self::readiness_issues(),
 		];
 
 		// Not connected enough to report: return the envelope so the UI can show
@@ -477,7 +507,7 @@ class Advertising_Metric {
 	 * @return array<string,array> Keyed metric payloads.
 	 */
 	private static function compute_window( string $start_date, string $end_date ): array {
-		return [
+		$metrics = [
 			'total_impressions'      => self::total_impressions( $start_date, $end_date ),
 			'total_revenue'          => self::total_revenue( $start_date, $end_date ),
 			'avg_ecpm'               => self::avg_ecpm( $start_date, $end_date ),
@@ -487,6 +517,15 @@ class Advertising_Metric {
 			'top_ad_units'           => self::top_ad_units( $start_date, $end_date ),
 			'top_advertisers'        => self::top_advertisers( $start_date, $end_date ),
 		];
+
+		// Per-site breakdown (NPPD-1671): only for network members. The runner skips
+		// this GAM report entirely for non-members — even when reporting is otherwise
+		// ready — so a standalone publisher never pays for a `site` report it can't run.
+		if ( self::is_network_member() ) {
+			$metrics['top_sites'] = self::top_sites( $start_date, $end_date );
+		}
+
+		return $metrics;
 	}
 
 	/*
@@ -784,6 +823,105 @@ class Advertising_Metric {
 			];
 		}
 		return self::rank_table( $out, 'revenue', $limit );
+	}
+
+	/**
+	 * Performance by site (NPPD-1671) — impressions + revenue broken down by the
+	 * network `site` custom dimension. Resolves the reportable key ID first (cached),
+	 * then runs a report dimensioned by it. Returns an empty table when the site
+	 * has no `site` dimension (e.g. a network where it wasn't created), so the
+	 * section renders nothing rather than erroring.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function top_sites( string $s, string $e, int $limit = 25 ): array {
+		$key_id = static::resolve_site_key_id();
+		if ( null === $key_id ) {
+			return [
+				'rows'       => [],
+				'computable' => false,
+				'type'       => 'table',
+			];
+		}
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions'               => [ self::DIM_CUSTOM_DIMENSION ],
+					'custom_dimension_key_ids' => [ $key_id ],
+					'columns'                  => [ self::COL_IMPRESSIONS, self::COL_REVENUE ],
+					'start_date'               => $s,
+					'end_date'                 => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$out = [];
+		foreach ( $rows['rows'] as $row ) {
+			// The custom-dimension value column carries the sanitized site URL.
+			// TODO(NPPD-1666): confirm the exact CSV header for a custom-dimension
+			// report against a live network before GA.
+			$site = (string) self::cell( $row, self::DIM_CUSTOM_DIMENSION );
+			if ( '' === $site ) {
+				continue;
+			}
+			$impressions = (int) self::cell_number( $row, self::COL_IMPRESSIONS );
+			$revenue     = Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) );
+			$out[]       = [
+				'site'        => self::humanize_site( $site ),
+				'impressions' => $impressions,
+				'revenue'     => $revenue,
+				'ecpm'        => $impressions > 0 ? round( ( $revenue / $impressions ) * 1000, 2 ) : 0.0,
+			];
+		}
+		return self::rank_table( $out, 'revenue', $limit );
+	}
+
+	/**
+	 * Resolve the `site` custom-dimension key ID for the current network, cached
+	 * for a day (the dimension rarely changes) so the CustomTargetingService lookup
+	 * stays off the per-window path. An empty-string transient caches "not found".
+	 * A `protected` seam so tests inject a known ID without touching SOAP.
+	 *
+	 * @return int|null The key ID, or null when unavailable / not a network.
+	 */
+	protected static function resolve_site_key_id(): ?int {
+		$network_code = self::resolve_network_code();
+		if ( '' === $network_code ) {
+			return null;
+		}
+		$cache_key = self::SITE_KEY_CACHE_PREFIX . $network_code;
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return '' === $cached ? null : (int) $cached;
+		}
+		try {
+			$key_id = Client::resolve_custom_dimension_key_id( self::SITE_DIMENSION_KEY, (int) $network_code );
+		} catch ( \Exception $e ) {
+			Logger::error( $e->getMessage(), self::LOGGER_HEADER );
+			return null; // Transient outage — don't cache; retry next window.
+		}
+		set_transient( $cache_key, null === $key_id ? '' : (int) $key_id, self::SITE_KEY_CACHE_TTL );
+		return $key_id;
+	}
+
+	/**
+	 * Humanize a `site` dimension value (a sanitized site URL) to a bare domain
+	 * for the table label: "https://www.example.com" → "example.com".
+	 *
+	 * @param string $value The raw dimension value.
+	 * @return string
+	 */
+	private static function humanize_site( string $value ): string {
+		$host = wp_parse_url( $value, PHP_URL_HOST );
+		if ( ! $host ) {
+			$host = preg_replace( '#^https?://#', '', $value );
+		}
+		return (string) preg_replace( '#^www\.#', '', (string) $host );
 	}
 
 	/*

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -828,9 +828,9 @@ class Advertising_Metric {
 	/**
 	 * Performance by site (NPPD-1671) — impressions + revenue broken down by the
 	 * network `site` custom dimension. Resolves the reportable key ID first (cached),
-	 * then runs a report dimensioned by it. Returns an empty table when the site
-	 * has no `site` dimension (e.g. a network where it wasn't created), so the
-	 * section renders nothing rather than erroring.
+	 * then runs a report dimensioned by it. Returns an empty (non-computable) table
+	 * when the site has no `site` dimension (e.g. a network where it wasn't created);
+	 * the UI renders the section with its empty-state message rather than erroring.
 	 *
 	 * @param string $s     Start date.
 	 * @param string $e     End date.

--- a/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
@@ -37,6 +37,8 @@ export interface AdvertisingWindow {
 	window?: { start: string; end: string };
 	is_tab_visible: boolean;
 	is_report_ready: boolean;
+	/** Newspack Network member (NPPD-1671): gates the per-site breakdown (`metrics.top_sites`). */
+	is_network_member?: boolean;
 	readiness_issues: ReadinessIssue[];
 	data_as_of?: string;
 	has_estimated_data?: boolean;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
@@ -196,4 +196,28 @@ describe( 'AdvertisingTab', () => {
 		expect( screen.getByText( '20%' ) ).toBeInTheDocument();
 		expect( screen.getByText( '↑' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the per-site breakdown for network members (NPPD-1671)', () => {
+		mockData(
+			baseWindow( {
+				is_network_member: true,
+				metrics: {
+					top_sites: {
+						type: 'table',
+						computable: true,
+						rows: [ { site: 'almanacnews.com', impressions: 980000, revenue: 1720, ecpm: 1.76 } ],
+					},
+				},
+			} )
+		);
+		render( <AdvertisingTab range={ range } previousRange={ null } /> );
+		expect( screen.getByText( 'Performance by site' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'almanacnews.com' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the per-site breakdown for non-network publishers', () => {
+		mockData( baseWindow( { is_network_member: false } ) );
+		render( <AdvertisingTab range={ range } previousRange={ null } /> );
+		expect( screen.queryByText( 'Performance by site' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -27,6 +27,7 @@ import DataLagIndicator from './components/DataLagIndicator';
 import FinishConnectingDiagnostic from './components/FinishConnectingDiagnostic';
 import ReachRevenueSection from './advertising/sections/ReachRevenueSection';
 import InventoryPerformanceSection from './advertising/sections/InventoryPerformanceSection';
+import SitePerformanceSection from './advertising/sections/SitePerformanceSection';
 import TopPerformersSection from './advertising/sections/TopPerformersSection';
 import './advertising/advertising.scss';
 
@@ -87,6 +88,8 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 						lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
 					/>
 					<InventoryPerformanceSection current={ current.metrics } previous={ previous } />
+					{ /* Per-site breakdown (NPPD-1671): network members only; absent otherwise. */ }
+					{ current.is_network_member && <SitePerformanceSection current={ current.metrics } previous={ previous } /> }
 					<TopPerformersSection current={ current.metrics } previous={ previous } />
 				</>
 			) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Tests for SitePerformanceSection (NPPD-1671): the network-only per-site table.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import SitePerformanceSection from './SitePerformanceSection';
+import type { InsightsWindow } from '../../../api/advertising';
+
+const metrics = (): InsightsWindow => ( {
+	top_sites: {
+		type: 'table',
+		computable: true,
+		rows: [
+			{ site: 'almanacnews.com', impressions: 980000, revenue: 1720, ecpm: 1.76 },
+			{ site: 'mv-voice.com', impressions: 410000, revenue: 705, ecpm: 1.72 },
+		],
+	},
+} );
+
+describe( 'SitePerformanceSection', () => {
+	it( 'renders the per-site table with one row per network site', () => {
+		render( <SitePerformanceSection current={ metrics() } previous={ null } /> );
+
+		expect( screen.getByText( 'Performance by site' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'almanacnews.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'mv-voice.com' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
@@ -1,0 +1,49 @@
+/**
+ * Advertising › Performance by site (NPPD-1671).
+ *
+ * Network-only: a full-width table breaking impressions / revenue / eCPM down by
+ * the GAM `site` custom dimension newspack-network creates for each site in a
+ * Newspack Network. Rendered only for network members (AdvertisingTab gates on
+ * `is_network_member`); absent entirely for standalone publishers.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { InsightsWindow } from '../../../api/advertising';
+import MetricTable from '../../components/MetricTable';
+import SectionHeading from '../../components/SectionHeading';
+
+export interface SectionProps {
+	current: InsightsWindow;
+	previous: InsightsWindow | null;
+}
+
+const SitePerformanceSection = ( { current }: SectionProps ) => (
+	<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-site-performance">
+		<SectionHeading
+			id="newspack-insights-advertising-site-performance"
+			title={ __( 'Performance by site', 'newspack-plugin' ) }
+			description={ __( 'How each site in your network is performing.', 'newspack-plugin' ) }
+		/>
+		<MetricTable
+			payload={ current.top_sites }
+			emptyMessage={ __( 'No per-site data in this timeframe.', 'newspack-plugin' ) }
+			expandable
+			defaultRowLimit={ 10 }
+			columns={ [
+				{ key: 'site', label: __( 'Site', 'newspack-plugin' ) },
+				{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+				{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+				{ key: 'ecpm', label: __( 'eCPM', 'newspack-plugin' ), format: 'currency', align: 'right' },
+			] }
+		/>
+	</section>
+);
+
+export default SitePerformanceSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
@@ -36,6 +36,7 @@ const SitePerformanceSection = ( { current }: SectionProps ) => (
 			emptyMessage={ __( 'No per-site data in this timeframe.', 'newspack-plugin' ) }
 			expandable
 			defaultRowLimit={ 10 }
+			rowLimit={ 25 }
 			columns={ [
 				{ key: 'site', label: __( 'Site', 'newspack-plugin' ) },
 				{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -25,6 +25,13 @@ class Insights_Advertising_Test_Metric extends Advertising_Metric {
 	public static $next_report = [ 'rows' => [] ];
 
 	/**
+	 * The next resolve_site_key_id() result to return (NPPD-1671).
+	 *
+	 * @var int|null
+	 */
+	public static $next_site_key_id = 42;
+
+	/**
 	 * Override the GAM-touching seam with the injected result.
 	 *
 	 * @param Report_Query $query The query (ignored).
@@ -32,6 +39,15 @@ class Insights_Advertising_Test_Metric extends Advertising_Metric {
 	 */
 	protected static function run_gam_report( Report_Query $query ): array {
 		return self::$next_report;
+	}
+
+	/**
+	 * Override the CustomTargetingService-touching seam with the injected key ID.
+	 *
+	 * @return int|null
+	 */
+	protected static function resolve_site_key_id(): ?int {
+		return static::$next_site_key_id;
 	}
 }
 
@@ -59,7 +75,8 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	 * Reset the double between tests.
 	 */
 	public function tear_down() {
-		Insights_Advertising_Test_Metric::$next_report = [ 'rows' => [] ];
+		Insights_Advertising_Test_Metric::$next_report      = [ 'rows' => [] ];
+		Insights_Advertising_Test_Metric::$next_site_key_id = 42;
 		Advertising_Metric::reset_readiness_cache();
 		parent::tear_down();
 	}
@@ -255,6 +272,68 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 		$this->with_rows( $rows );
 		$payload = Insights_Advertising_Test_Metric::top_ad_units( '2026-01-01', '2026-01-31', 25 );
 		$this->assertCount( 25, $payload['rows'] );
+	}
+
+	/**
+	 * Per-site breakdown (NPPD-1671) humanizes the `site` URL to a domain,
+	 * normalizes revenue micros, derives eCPM, and ranks by revenue desc.
+	 */
+	public function test_top_sites_shapes_and_ranks_rows() {
+		$this->with_rows(
+			[
+				[
+					'CUSTOM_DIMENSION'                  => 'https://www.mv-voice.com',
+					'TOTAL_IMPRESSIONS'                 => '410000',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => (string) ( 705 * 1000000 ),
+				],
+				[
+					'CUSTOM_DIMENSION'                  => 'https://www.almanacnews.com',
+					'TOTAL_IMPRESSIONS'                 => '980000',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => (string) ( 1720 * 1000000 ),
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::top_sites( '2026-01-01', '2026-01-31', 25 );
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 'table', $payload['type'] );
+		$this->assertCount( 2, $payload['rows'] );
+
+		// Ranked by revenue desc → almanacnews (higher) first; URL humanized to domain.
+		$top = $payload['rows'][0];
+		$this->assertSame( 'almanacnews.com', $top['site'] );
+		$this->assertSame( 980000, $top['impressions'] );
+		$this->assertSame( 1720.0, $top['revenue'] );
+		$this->assertSame( round( ( 1720.0 / 980000 ) * 1000, 2 ), $top['ecpm'] );
+	}
+
+	/**
+	 * Returns an empty, non-computable table (and never runs a report) when the
+	 * `site` dimension can't be resolved — e.g. not a network member.
+	 */
+	public function test_top_sites_empty_when_dimension_unresolved() {
+		Insights_Advertising_Test_Metric::$next_site_key_id = null;
+		// A report result that WOULD shape into rows, to prove it isn't consulted.
+		$this->with_rows(
+			[
+				[
+					'CUSTOM_DIMENSION'  => 'https://x.com',
+					'TOTAL_IMPRESSIONS' => '5',
+				],
+			] 
+		);
+
+		$payload = Insights_Advertising_Test_Metric::top_sites( '2026-01-01', '2026-01-31', 25 );
+		$this->assertFalse( $payload['computable'] );
+		$this->assertSame( [], $payload['rows'] );
+	}
+
+	/**
+	 * Without newspack-network active (test env), the site is not a network member,
+	 * so the per-site breakdown stays gated off.
+	 */
+	public function test_is_network_member_false_without_network() {
+		$this->assertFalse( Advertising_Metric::is_network_member() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -320,7 +320,7 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 					'CUSTOM_DIMENSION'  => 'https://x.com',
 					'TOTAL_IMPRESSIONS' => '5',
 				],
-			] 
+			]
 		);
 
 		$payload = Insights_Advertising_Test_Metric::top_sites( '2026-01-01', '2026-01-31', 25 );


### PR DESCRIPTION
## Summary

Adds a **"Performance by site"** table to the Insights Advertising tab (Tab 8) for **Newspack Network** publishers — impressions / revenue / eCPM broken down by the reportable GAM `site` custom dimension that newspack-network creates for each site in a network.

Linear: [NPPD-1671](https://linear.app/a8c/issue/NPPD-1671)

## Pre-flight (live-validated against a real network)

- **`site` is reportable** ✅ — `newspack-network/includes/hub/class-newspack-ads-gam.php` creates the key with reportableType `CUSTOM_DIMENSION`; values are sanitized site URLs.
- **Detection** — `Newspack_Network\Site_Role::has_role()` (option `newspack_network_site_role`).
- **Topology** — validated against the Embarcadero Media Group network: the `site` dimension lives in the network's **shared GAM network**, and the nodes' GAM credentials carry **network-level reporting access**, so a node's `site`-dimensioned report returns the **whole network's** per-site breakdown. So the feature is **network member + GAM connected** (in practice, the nodes) — not hub-only.

## What's included

- **`Report_Query`** → `custom_dimension_key_ids`.
- **GAM `Client`** → extracted a shared OAuth `build_session()`; added `resolve_custom_dimension_key_id()` via the CustomTargetingService **over the OAuth session** (Insights is OAuth-only — never the service account); wired custom dimensions into the report job.
- **`Advertising_Metric`** → `is_network_member()`, `top_sites()` (rank by revenue, humanize the site URL to a domain, derive eCPM), a cached + mockable `resolve_site_key_id()` seam, `is_network_member` in the envelope, and `compute_window` running `top_sites` **only for members** (the runner skips it otherwise, so non-network publishers never pay for a report they can't use).
- **Fixture** → `_fixture_state=network`. **UI** → new full-width `SitePerformanceSection`, rendered by `AdvertisingTab` only for network members, after Inventory performance. Absent (no empty state) otherwise.

## Testing

- **PHP** (43): `top_sites()` shaping/ranking with mocked report + key-ID seams, empty-when-unresolved, `is_network_member()`.
- **JS** (746): `SitePerformanceSection` renders per-site rows; `AdvertisingTab` shows the section only for members.
- PHPCS / ESLint / tsc clean. Verified live in fixture mode on localhost.

## Caveat — NPPD-1666

The custom-dimension **SOAP query shape** and the exact **CSV column header** for the site value are built against documented v202602 enums and **not yet verified against a live GAM run** (my `top_sites` reads the value defensively with a `TODO(NPPD-1666)`). Data *existence* is confirmed (dimension in the shared network; network-level reporting); the *query shape* validation rides NPPD-1666, same posture as the rest of Tab 8.
