### PR TITLE
feat(insights): Tab 8 revenue trend chart (daily revenue line chart) (NPPD-1674)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -441,10 +441,12 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 
 	$current_metrics = $metrics( 1.0, $variant );
 	// Revenue trend (NPPD-1674): a daily series across the window. Empty on the
-	// zero-activity variant so the chart renders its no-data state.
+	// revenue-less variants (zero, no_revenue) — both report $0 revenue, so the
+	// chart (current AND its compare overlay) stays coherent with the scorecards.
+	$revenueless                       = in_array( $variant, [ 'zero', 'no_revenue' ], true );
 	$current_metrics['revenue_by_day'] = [
-		'rows'       => 'zero' === $variant ? [] : $revenue_series( $start_date, $end_date, 1.0 ),
-		'computable' => 'zero' !== $variant,
+		'rows'       => $revenueless ? [] : $revenue_series( $start_date, $end_date, 1.0 ),
+		'computable' => ! $revenueless,
 		'type'       => 'timeseries',
 	];
 	if ( $is_network ) {
@@ -500,8 +502,8 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		$prev_from                      = $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start;
 		$prev_to                        = $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end;
 		$prev_metrics['revenue_by_day'] = [
-			'rows'       => $revenue_series( $prev_from, $prev_to, 0.85 ),
-			'computable' => true,
+			'rows'       => $revenueless ? [] : $revenue_series( $prev_from, $prev_to, 0.85 ),
+			'computable' => ! $revenueless,
 			'type'       => 'timeseries',
 		];
 		if ( $is_network ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -310,6 +310,33 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		];
 	};
 
+	// Daily revenue series for the Revenue trend chart (NPPD-1674). One point per
+	// day across the window, with a slight upward drift and a weekend lift so the
+	// line has a readable shape. Date-relative (spans the requested window), capped
+	// at 92 days so a huge range stays sane.
+	$revenue_series = function ( string $from, string $to, float $scale ) use ( $tz ): array {
+		try {
+			$day = new DateTimeImmutable( $from, $tz );
+			$end = new DateTimeImmutable( $to, $tz );
+		} catch ( Exception $e ) {
+			return [];
+		}
+		$rows = [];
+		$i    = 0;
+		while ( $day <= $end && $i < 92 ) {
+			$is_weekend = (int) $day->format( 'N' ) >= 6 ? 1.35 : 1.0;
+			$trend      = 1 + ( $i * 0.01 );
+			$wobble     = 1 + ( ( $i % 5 ) - 2 ) * 0.06;
+			$rows[]     = [
+				'date'  => $day->format( 'Y-m-d' ),
+				'value' => round( 120.0 * $scale * $trend * $is_weekend * $wobble, 2 ),
+			];
+			$day = $day->modify( '+1 day' );
+			++$i;
+		}
+		return $rows;
+	};
+
 	// Not-ready render path: tab visible, reporting not ready, both issues.
 	if ( 'not_ready' === $variant ) {
 		$not_ready = [
@@ -364,7 +391,14 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 	}
 
 	$current_metrics = $metrics( 1.0, $variant );
-	$envelope        = [
+	// Revenue trend (NPPD-1674): a daily series across the window. Empty on the
+	// zero-activity variant so the chart renders its no-data state.
+	$current_metrics['revenue_by_day'] = [
+		'rows'       => 'zero' === $variant ? [] : $revenue_series( $start_date, $end_date, 1.0 ),
+		'computable' => 'zero' !== $variant,
+		'type'       => 'timeseries',
+	];
+	$envelope = [
 		'window'                      => [
 			'start' => $start_date,
 			'end'   => $end_date,
@@ -405,7 +439,15 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 		// per-row figures land lower, exercising both delta directions. The prior
 		// window always uses a non-empty variant so comparison deltas render.
 		$prev_metrics = $metrics( 0.85, 'zero' === $variant ? 'populated' : $variant );
-		$previous     = [
+		// Prior-period daily revenue (NPPD-1674): the dimmed overlay line under compare.
+		$prev_from                      = $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start;
+		$prev_to                        = $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end;
+		$prev_metrics['revenue_by_day'] = [
+			'rows'       => $revenue_series( $prev_from, $prev_to, 0.85 ),
+			'computable' => true,
+			'type'       => 'timeseries',
+		];
+		$previous = [
 			'window'                      => [
 				'start' => $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start,
 				'end'   => $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -93,6 +93,7 @@ class Advertising_Metric {
 	const DIM_LINE_ITEM_TYPE  = 'LINE_ITEM_TYPE';
 	const DIM_AD_UNIT_NAME    = 'AD_UNIT_NAME';
 	const DIM_ADVERTISER_NAME = 'ADVERTISER_NAME';
+	const DIM_DATE            = 'DATE';
 
 	const DIRECT_LINE_ITEM_TYPES       = [ 'SPONSORSHIP', 'STANDARD', 'BULK', 'PRICE_PRIORITY' ];
 	const PROGRAMMATIC_LINE_ITEM_TYPES = [ 'NETWORK', 'AD_EXCHANGE' ];
@@ -480,6 +481,7 @@ class Advertising_Metric {
 		return [
 			'total_impressions'      => self::total_impressions( $start_date, $end_date ),
 			'total_revenue'          => self::total_revenue( $start_date, $end_date ),
+			'revenue_by_day'         => self::revenue_by_day( $start_date, $end_date ),
 			'avg_ecpm'               => self::avg_ecpm( $start_date, $end_date ),
 			'fill_rate'              => self::fill_rate( $start_date, $end_date ),
 			'viewability_rate'       => self::viewability_rate( $start_date, $end_date ),
@@ -543,6 +545,57 @@ class Advertising_Metric {
 			'value'      => $revenue,
 			'computable' => true,
 			'type'       => 'currency',
+		];
+	}
+
+	/**
+	 * Revenue by day (NPPD-1674) — the window's revenue broken down by the GAM
+	 * `DATE` dimension for the trend line chart. Returns a timeseries payload of
+	 * `{ date: 'YYYY-MM-DD', value: <dollars> }` rows sorted chronologically
+	 * (GAM's row order isn't guaranteed), micros normalized at the boundary.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array
+	 */
+	public static function revenue_by_day( string $s, string $e ): array {
+		$rows = static::run_gam_report(
+			new Report_Query(
+				[
+					'dimensions' => [ self::DIM_DATE ],
+					'columns'    => [ self::COL_REVENUE ],
+					'start_date' => $s,
+					'end_date'   => $e,
+				]
+			)
+		);
+		if ( isset( $rows['error'] ) || isset( $rows['overlay'] ) ) {
+			return $rows;
+		}
+		$out = [];
+		foreach ( $rows['rows'] as $row ) {
+			// TODO(NPPD-1666): confirm the DATE dimension's CSV header + value format
+			// (assumed 'YYYY-MM-DD') against a live network.
+			$date = (string) self::cell( $row, self::DIM_DATE );
+			if ( '' === $date ) {
+				continue;
+			}
+			$out[] = [
+				'date'  => $date,
+				'value' => Client::normalize_currency_micros( self::cell_number( $row, self::COL_REVENUE ) ),
+			];
+		}
+		// GAM doesn't guarantee chronological order; sort so the line reads left→right.
+		usort(
+			$out,
+			function ( $a, $b ) {
+				return strcmp( $a['date'], $b['date'] );
+			}
+		);
+		return [
+			'rows'       => $out,
+			'computable' => ! empty( $out ),
+			'type'       => 'timeseries',
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -26,6 +26,7 @@ import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import DataLagIndicator from './components/DataLagIndicator';
 import FinishConnectingDiagnostic from './components/FinishConnectingDiagnostic';
 import ReachRevenueSection from './advertising/sections/ReachRevenueSection';
+import RevenueTrendSection from './advertising/sections/RevenueTrendSection';
 import InventoryPerformanceSection from './advertising/sections/InventoryPerformanceSection';
 import TopPerformersSection from './advertising/sections/TopPerformersSection';
 import './advertising/advertising.scss';
@@ -87,6 +88,7 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 						lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
 					/>
 					<InventoryPerformanceSection current={ current.metrics } previous={ previous } />
+					<RevenueTrendSection current={ current.metrics } previous={ previous } />
 					<TopPerformersSection current={ current.metrics } previous={ previous } />
 				</>
 			) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Tests for RevenueTrendSection (NPPD-1674): the daily-revenue line chart and
+ * its comparison overlay.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import RevenueTrendSection from './RevenueTrendSection';
+import type { InsightsWindow } from '../../../api/advertising';
+import type { MetricRow } from '../../components/metrics';
+
+const metrics = (
+	rows: MetricRow[] = [
+		{ date: '2026-06-01', value: 100 },
+		{ date: '2026-06-02', value: 120 },
+		{ date: '2026-06-03', value: 140 },
+	]
+): InsightsWindow => ( {
+	revenue_by_day: { type: 'timeseries', computable: true, rows },
+} );
+
+describe( 'RevenueTrendSection', () => {
+	it( 'renders the revenue trend section with a chart', () => {
+		const { container } = render( <RevenueTrendSection current={ metrics() } previous={ null } /> );
+
+		expect( screen.getByText( 'Revenue trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Daily revenue across the selected period.' ) ).toBeInTheDocument();
+		// One series → one line stroke.
+		expect( container.querySelectorAll( '.newspack-insights__line-stroke' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'overlays a second (prior-period) line under comparison', () => {
+		const previous = metrics( [
+			{ date: '2026-05-01', value: 80 },
+			{ date: '2026-05-02', value: 90 },
+			{ date: '2026-05-03', value: 95 },
+		] );
+		const { container } = render( <RevenueTrendSection current={ metrics() } previous={ previous } /> );
+
+		expect( container.querySelectorAll( '.newspack-insights__line-stroke' ) ).toHaveLength( 2 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
@@ -29,7 +29,8 @@ export interface SectionProps {
 }
 
 // GAM's DATE dimension is 'YYYY-MM-DD'; formatShortDate expects GA4's 'YYYYMMDD'.
-const formatDateLabel = ( date: string ) => formatShortDate( date.replace( /-/g, '' ) );
+// Strip all non-digits so any separator variation still yields the 8-digit form.
+const formatDateLabel = ( date: string ) => formatShortDate( date.replace( /\D/g, '' ) );
 const formatDollars = ( value: number ) => formatCurrency( value ).display;
 
 const RevenueTrendSection = ( { current, previous }: SectionProps ) => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
@@ -1,0 +1,62 @@
+/**
+ * Advertising › Revenue trend (NPPD-1674).
+ *
+ * A full-width daily-revenue line chart across the selected window — the shape
+ * behind the Reach & revenue scorecards. Under comparison, the prior period
+ * overlays as a second (recessive) line. Currency-formatted Y-axis + tooltip,
+ * date-formatted X-axis. Reuses the shared LineChart (NPPD-1649); a zero-revenue
+ * window falls through to LineChart's own empty state.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { InsightsWindow } from '../../../api/advertising';
+import ChartCard from '../../components/ChartCard';
+import SectionHeading from '../../components/SectionHeading';
+import LineChart from '../../components/LineChart';
+import { toSeries } from '../../components/metrics';
+import { formatCurrency, formatShortDate } from '../../components/format';
+
+export interface SectionProps {
+	current: InsightsWindow;
+	previous: InsightsWindow | null;
+}
+
+// GAM's DATE dimension is 'YYYY-MM-DD'; formatShortDate expects GA4's 'YYYYMMDD'.
+const formatDateLabel = ( date: string ) => formatShortDate( date.replace( /-/g, '' ) );
+const formatDollars = ( value: number ) => formatCurrency( value ).display;
+
+const RevenueTrendSection = ( { current, previous }: SectionProps ) => {
+	const currentPoints = toSeries( current.revenue_by_day, 'date', 'value' );
+	const previousPoints = previous ? toSeries( previous.revenue_by_day, 'date', 'value' ) : [];
+	const series = [
+		{ name: __( 'This period', 'newspack-plugin' ), points: currentPoints },
+		...( previousPoints.length ? [ { name: __( 'Previous period', 'newspack-plugin' ), points: previousPoints } ] : [] ),
+	];
+
+	return (
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-revenue-trend">
+			<SectionHeading
+				id="newspack-insights-advertising-revenue-trend"
+				title={ __( 'Revenue trend', 'newspack-plugin' ) }
+				description={ __( 'Daily revenue across the selected period.', 'newspack-plugin' ) }
+			/>
+			<ChartCard payload={ current.revenue_by_day }>
+				<LineChart
+					series={ series }
+					formatLabel={ formatDateLabel }
+					formatValue={ formatDollars }
+					yAxisLabel={ __( 'Revenue', 'newspack-plugin' ) }
+				/>
+			</ChartCard>
+		</section>
+	);
+};
+
+export default RevenueTrendSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ChartCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ChartCard.tsx
@@ -15,7 +15,11 @@ import MetricNote from './MetricNote';
 import type { MetricPayload } from './metrics';
 
 export interface ChartCardProps {
-	title: string;
+	/**
+	 * Chart heading. Optional: a single-chart section whose own SectionHeading
+	 * already names it (e.g. Revenue trend) omits this to avoid a duplicate title.
+	 */
+	title?: string;
 	/** Small temporal-scope subhead above the title (e.g. "Day to day"). */
 	subhead?: string;
 	caption?: string;
@@ -42,7 +46,7 @@ const ChartCard = ( { title, subhead, caption, payload, children }: ChartCardPro
 	return (
 		<div className="newspack-insights__chart-card">
 			{ subhead && <p className="newspack-insights__chart-card-subhead">{ subhead }</p> }
-			<h3 className="newspack-insights__chart-card-title">{ title }</h3>
+			{ title && <h3 className="newspack-insights__chart-card-title">{ title }</h3> }
 			{ caption && <p className="newspack-insights__chart-card-caption">{ caption }</p> }
 			{ body }
 		</div>

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -95,6 +95,46 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Revenue by day (NPPD-1674) sorts chronologically regardless of GAM's return
+	 * order and normalizes each day's revenue from micros.
+	 */
+	public function test_revenue_by_day_sorts_and_normalizes() {
+		$this->with_rows(
+			[
+				[
+					'DATE'                              => '2026-01-03',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => (string) ( 150 * 1000000 ),
+				],
+				[
+					'DATE'                              => '2026-01-01',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => (string) ( 100 * 1000000 ),
+				],
+				[
+					'DATE'                              => '2026-01-02',
+					'TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE' => (string) ( 120 * 1000000 ),
+				],
+			]
+		);
+		$payload = Insights_Advertising_Test_Metric::revenue_by_day( '2026-01-01', '2026-01-31' );
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertSame( 'timeseries', $payload['type'] );
+		$this->assertSame( [ '2026-01-01', '2026-01-02', '2026-01-03' ], array_column( $payload['rows'], 'date' ) );
+		$this->assertSame( 100.0, $payload['rows'][0]['value'] );
+		$this->assertSame( 150.0, $payload['rows'][2]['value'] );
+	}
+
+	/**
+	 * Revenue by day is not computable when the window has no daily rows.
+	 */
+	public function test_revenue_by_day_empty_not_computable() {
+		$this->with_rows( [] );
+		$payload = Insights_Advertising_Test_Metric::revenue_by_day( '2026-01-01', '2026-01-31' );
+		$this->assertFalse( $payload['computable'] );
+		$this->assertSame( [], $payload['rows'] );
+	}
+
+	/**
 	 * Average eCPM derives from normalized revenue and coded impressions.
 	 */
 	public function test_avg_ecpm() {


### PR DESCRIPTION
## Summary

Adds a **Revenue trend** section to the Insights Advertising tab (Tab 8): a full-width **daily-revenue line chart** across the selected window — closing the "is my ad revenue going up or down?" gap that the snapshot scorecards leave open. Under comparison, the prior period overlays as a dimmed second line.

Linear: [NPPD-1674](https://linear.app/a8c/issue/NPPD-1674)

## Pre-flight

- **`DATE` dimension** — `Report_Query` already takes arbitrary `dimensions`, so the daily breakdown is straightforward; the orchestrator sorts chronologically (GAM's row order isn't guaranteed).
- **Chart reuse** — the shared `LineChart` (NPPD-1649) is reused as-is: `series` for the compare overlay, `formatValue` for a **currency** Y-axis/tooltip, `formatLabel` for dates, built-in hover + empty state. No chart changes.

## What's included

- **`Advertising_Metric::revenue_by_day()`** — report dimensioned by `DATE` with `TOTAL_LINE_ITEM_LEVEL_ALL_REVENUE`; returns `{ date, value }` rows sorted chronologically, micros normalized. Runs in `compute_window` alongside the other metrics.
- **Fixture** — a date-relative daily series (slight upward drift + weekend lift) across the window + a prior-period overlay; empty on the `zero` state. Rides the existing `populated` state.
- **UI** — new `RevenueTrendSection` (SectionHeading + `ChartCard` + shared `LineChart`), placed **after** Inventory performance. Currency-formatted axis/tooltip; dimmed prior-period line under comparison.
- **`ChartCard` `title` made optional** (backward-compatible — all other callers still pass one) so a single-chart section whose SectionHeading already names it doesn't render a duplicate heading.

## Testing

- **PHP**: `revenue_by_day()` sorts chronologically regardless of GAM order + normalizes micros; empty-not-computable.
- **JS**: `RevenueTrendSection` renders one line (two under comparison). Full suite green (94 suites / 745).
- PHPCS / ESLint clean. Verified live on localhost in fixture mode (30-day series, prior overlay, graceful empty on `zero`).

## Caveat — NPPD-1666

The `DATE` enum and its exact CSV header/value format (`YYYY-MM-DD` assumed) are documented-not-verified against a live GAM run — `revenue_by_day` reads it defensively with a `TODO(NPPD-1666)`, same posture as the rest of Tab 8.