### PR TITLE
feat(content-gate): dynamic product button for content banners

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -1459,6 +1459,45 @@ class Content_Gate {
 	}
 
 	/**
+	 * Get product IDs required to access a given post.
+	 *
+	 * Checks the content gate's custom access rules for subscription products.
+	 * Other restriction strategies (e.g. Memberships) can provide additional
+	 * product IDs via the 'newspack_gate_access_product_ids' filter.
+	 *
+	 * @param int $post_id Optional post ID. Defaults to current post.
+	 *
+	 * @return int[] Array of unique product IDs, or empty array if none found.
+	 */
+	public static function get_gate_access_product_ids( $post_id = null ) {
+		$gate_id = self::get_gate_post_id( $post_id );
+		if ( ! $gate_id ) {
+			/**
+			 * Filter the product IDs required to access a restricted post.
+			 *
+			 * @param int[] $product_ids Array of product IDs.
+			 * @param int   $post_id     The post ID.
+			 */
+			return apply_filters( 'newspack_gate_access_product_ids', [], $post_id ?? get_the_ID() );
+		}
+		$custom_access = self::get_custom_access_settings( $gate_id );
+		$product_ids   = [];
+		if ( ! empty( $custom_access['active'] ) && ! empty( $custom_access['access_rules'] ) ) {
+			foreach ( $custom_access['access_rules'] as $group ) {
+				foreach ( $group as $rule ) {
+					if ( 'subscription' === ( $rule['slug'] ?? '' ) && ! empty( $rule['value'] ) ) {
+						$product_ids = array_merge( $product_ids, array_map( 'intval', (array) $rule['value'] ) );
+					}
+				}
+			}
+		}
+		$product_ids = array_values( array_unique( array_filter( $product_ids ) ) );
+
+		/** This filter is documented above. */
+		return apply_filters( 'newspack_gate_access_product_ids', $product_ids, $post_id ?? get_the_ID() );
+	}
+
+	/**
 	 * Get an array of tier-eligible subscription product options, formatted for select controls.
 	 *
 	 * @return array Array of subscription product options.

--- a/plugins/newspack-plugin/includes/content-gate/class-metering-countdown.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering-countdown.php
@@ -36,15 +36,13 @@ class Metering_Countdown {
 	 * @return array Default countdown settings.
 	 */
 	public static function get_default_settings() {
-		$primary_product = Subscriptions_Tiers::get_primary_subscription_tier_product();
 		return [
-			'enabled'        => false,
-			'style'          => 'light',
-			'cta_label'      => __( 'Subscribe now and get unlimited access.', 'newspack-plugin' ),
-			'button_label'   => __( 'Subscribe now', 'newspack-plugin' ),
-			'cta_type'       => 'product',
-			'cta_product_id' => $primary_product ? $primary_product->get_id() : 0,
-			'cta_url'        => '',
+			'enabled'      => false,
+			'style'        => 'light',
+			'cta_label'    => __( 'Subscribe now and get unlimited access.', 'newspack-plugin' ),
+			'button_label' => __( 'Subscribe now', 'newspack-plugin' ),
+			'cta_type'     => 'product',
+			'cta_url'      => '',
 		];
 	}
 
@@ -84,9 +82,6 @@ class Metering_Countdown {
 			return $default_settings[ $key ];
 		}
 		if ( $key === 'cta_type' && ! in_array( $value, [ 'product', 'url' ], true ) ) {
-			return $default_settings[ $key ];
-		}
-		if ( $key === 'cta_product_id' && ! is_numeric( $value ) ) {
 			return $default_settings[ $key ];
 		}
 		if ( $key === 'cta_url' ) {
@@ -160,9 +155,6 @@ class Metering_Countdown {
 	 * Print the subscribe button.
 	 */
 	public static function print_subscribe_button() {
-		if ( ! class_exists( 'Newspack_Blocks' ) || ! class_exists( 'Newspack_Blocks\Modal_Checkout' ) || ! class_exists( 'Newspack_Blocks\Modal_Checkout\Checkout_Data' ) || ! function_exists( 'wc_get_product' ) ) {
-			return;
-		}
 		$settings     = self::get_settings();
 		$button_label = $settings['button_label'];
 		$button_class = 'dark' === $settings['style'] ? 'newspack-ui__button--primary-light' : 'newspack-ui__button--accent';
@@ -178,26 +170,11 @@ class Metering_Countdown {
 			}
 		}
 
-		// If CTA type is 'product', try a modal checkout using the primary subscription tier product.
 		if ( $cta_type === 'product' ) {
-			$product_id = self::get_settings( 'cta_product_id' );
-			$product    = function_exists( 'wc_get_product' ) ? \wc_get_product( $product_id ) : null;
-			if ( ! $product ) {
-				return;
+			$product_ids = Content_Gate::get_gate_access_product_ids();
+			if ( ! empty( $product_ids ) ) {
+				Subscriptions_Tiers::render_checkout_button( $product_ids, $button_label, $button_class );
 			}
-			\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product->get_id() );
-			\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
-			$checkout_data = \Newspack_Blocks\Modal_Checkout\Checkout_Data::get_checkout_data( $product );
-			?>
-			<div class="wp-block-newspack-blocks-checkout-button">
-				<form data-checkout="<?php echo esc_attr( wp_json_encode( $checkout_data ) ); ?>" target="newspack_modal_checkout_iframe">
-					<input type="hidden" name="newspack_checkout" value="1" />
-					<input type="hidden" name="modal_checkout" value="1" />
-					<input type="hidden" name="product_id" value="<?php echo esc_attr( $product->get_id() ); ?>" />
-					<button type="submit" class="newspack-ui__button newspack-ui__button--x-small <?php echo esc_attr( $button_class ); ?>"><?php echo esc_html( $button_label ); ?></button>
-				</form>
-			</div>
-			<?php
 		}
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting-cta.php
+++ b/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting-cta.php
@@ -82,33 +82,6 @@ class Content_Gifting_CTA {
 	}
 
 	/**
-	 * Get CTA product ID. Used if the CTA type is `product`.
-	 * Defaults to the primary subscription tier product, if available.
-	 *
-	 * @return int The CTA product ID.
-	 */
-	public static function get_cta_product_id() {
-		$primary_product = Subscriptions_Tiers::get_primary_subscription_tier_product();
-		$product_id = get_option( 'newspack_content_gifting_cta_product_id', $primary_product ? $primary_product->get_id() : 0 );
-		return $product_id;
-	}
-
-	/**
-	 * Set CTA product IDs.
-	 *
-	 * @param int $product_id The CTA product ID.
-	 *
-	 * @return void
-	 */
-	public static function set_cta_product_id( $product_id ) {
-		if ( function_exists( 'wc_get_product' ) && ! \wc_get_product( $product_id ) ) {
-			$primary_product = Subscriptions_Tiers::get_primary_subscription_tier_product();
-			$product_id = $primary_product ? $primary_product->get_id() : 0;
-		}
-		update_option( 'newspack_content_gifting_cta_product_id', (int) $product_id );
-	}
-
-	/**
 	 * Get CTA url.  Used if the CTA type is `url`.
 	 *
 	 * @return string The CTA url.
@@ -152,9 +125,6 @@ class Content_Gifting_CTA {
 	 * Print the subscribe button.
 	 */
 	public static function print_subscribe_button() {
-		if ( ! class_exists( 'Newspack_Blocks' ) || ! class_exists( 'Newspack_Blocks\Modal_Checkout' ) || ! class_exists( 'Newspack_Blocks\Modal_Checkout\Checkout_Data' ) || ! function_exists( 'wc_get_product' ) ) {
-			return;
-		}
 		$button_label = self::get_button_label();
 		$button_class = 'dark' === self::get_style() ? 'newspack-ui__button--primary-light' : 'newspack-ui__button--accent';
 
@@ -169,26 +139,11 @@ class Content_Gifting_CTA {
 			}
 		}
 
-		// If CTA type is 'product', try a modal checkout using the primary subscription tier product.
 		if ( $cta_type === 'product' ) {
-			$product_id = self::get_cta_product_id();
-			$product    = function_exists( 'wc_get_product' ) ? \wc_get_product( $product_id ) : null;
-			if ( ! $product ) {
-				return;
+			$product_ids = Content_Gate::get_gate_access_product_ids();
+			if ( ! empty( $product_ids ) ) {
+				Subscriptions_Tiers::render_checkout_button( $product_ids, $button_label, $button_class );
 			}
-			\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product_id );
-			\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
-			$checkout_data = \Newspack_Blocks\Modal_Checkout\Checkout_Data::get_checkout_data( $product );
-			?>
-			<div class="wp-block-newspack-blocks-checkout-button">
-				<form data-checkout="<?php echo esc_attr( wp_json_encode( $checkout_data ) ); ?>" target="newspack_modal_checkout_iframe">
-					<input type="hidden" name="newspack_checkout" value="1" />
-					<input type="hidden" name="modal_checkout" value="1" />
-					<input type="hidden" name="product_id" value="<?php echo esc_attr( $product_id ); ?>" />
-					<button type="submit" class="newspack-ui__button newspack-ui__button--x-small <?php echo esc_attr( $button_class ); ?>"><?php echo esc_html( $button_label ); ?></button>
-				</form>
-			</div>
-			<?php
 		}
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
@@ -213,7 +213,6 @@ class Content_Gifting {
 			'cta_label'            => Content_Gifting_CTA::get_cta_label(),
 			'button_label'         => Content_Gifting_CTA::get_button_label(),
 			'cta_type'             => Content_Gifting_CTA::get_cta_type(),
-			'cta_product_id'       => Content_Gifting_CTA::get_cta_product_id(),
 			'cta_url'              => Content_Gifting_CTA::get_cta_url(),
 			'style'                => Content_Gifting_CTA::get_style(),
 		];

--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
@@ -42,6 +42,7 @@ class Memberships {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ], 9 ); // Render before gate layout editor.
 		add_filter( 'newspack_post_has_restrictions', [ __CLASS__, 'post_has_restrictions' ], 10, 2 );
 		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'is_post_restricted' ], 10, 2 );
+		add_filter( 'newspack_gate_access_product_ids', [ __CLASS__, 'filter_gate_access_product_ids' ], 10, 2 );
 
 		// Handle restriction when using metering.
 		add_action( 'wp', [ __CLASS__, 'handle_metering_restriction' ], 5 ); // Before Woo Memberships' restriction handler, which was lowered to 9 in 1.27.2.
@@ -448,6 +449,32 @@ class Memberships {
 			}
 		}
 		return $plans;
+	}
+
+	/**
+	 * Filter the product IDs required to access a restricted post via
+	 * Membership plans.
+	 *
+	 * @param int[] $product_ids Array of product IDs.
+	 * @param int   $post_id     The post ID.
+	 *
+	 * @return int[] Filtered array of product IDs.
+	 */
+	public static function filter_gate_access_product_ids( $product_ids, $post_id ) {
+		if ( ! self::is_active() || ! empty( $product_ids ) ) {
+			return $product_ids;
+		}
+		$plan_ids = self::get_restricted_post_plans( $post_id );
+		if ( empty( $plan_ids ) ) {
+			return $product_ids;
+		}
+		foreach ( $plan_ids as $plan_id ) {
+			$plan = wc_memberships_get_membership_plan( $plan_id );
+			if ( $plan ) {
+				$product_ids = array_merge( $product_ids, $plan->get_product_ids() );
+			}
+		}
+		return array_values( array_unique( array_filter( $product_ids ) ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -14,6 +14,13 @@ defined( 'ABSPATH' ) || exit;
  */
 class Subscriptions_Tiers {
 	/**
+	 * Deferred tiers modals to render in wp_footer.
+	 *
+	 * @var array[]
+	 */
+	private static $deferred_modals = [];
+
+	/**
 	 * Switch subscription links rendered in the page.
 	 *
 	 * @var array
@@ -35,6 +42,7 @@ class Subscriptions_Tiers {
 
 		// Link-triggered modal rendering.
 		add_action( 'wp_footer', [ __CLASS__, 'print_modal' ] );
+		add_action( 'wp_footer', [ __CLASS__, 'render_deferred_modals' ], 100 );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 
 		// Unhook Upgrade/Downgrade switch direction text.
@@ -239,6 +247,72 @@ class Subscriptions_Tiers {
 	}
 
 	/**
+	 * Resolve products to their purchasable forms.
+	 *
+	 * Grouped products are expanded into their subscription children.
+	 * Variable subscriptions are expanded into their available variations.
+	 * Simple subscriptions and subscription variations are kept as-is.
+	 * Non-subscription and private products are excluded.
+	 *
+	 * @param (\WC_Product|int)[] $products Array of WC_Product objects or product IDs.
+	 *
+	 * @return \WC_Product[] Array of purchasable subscription products.
+	 */
+	public static function resolve_purchasable_products( $products ) {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return [];
+		}
+		$purchasable = [];
+		foreach ( $products as $product ) {
+			if ( is_int( $product ) ) {
+				$product = wc_get_product( $product );
+			}
+			if ( ! $product ) {
+				continue;
+			}
+			if ( ! $product->is_purchasable() ) {
+				continue;
+			}
+			// Expand grouped products into their purchasable children.
+			if ( $product->is_type( 'grouped' ) ) {
+				foreach ( $product->get_children() as $child_id ) {
+					$child = wc_get_product( $child_id );
+					if ( ! $child || ! $child->is_purchasable() ) {
+						continue;
+					}
+					// Expand variable subscriptions into their purchasable variations.
+					if ( $child->is_type( 'variable-subscription' ) ) {
+						foreach ( $child->get_available_variations() as $variation ) {
+							$variation_product = wc_get_product( $variation['variation_id'] );
+							if ( $variation_product && $variation_product->is_purchasable() ) {
+								$purchasable[] = $variation_product;
+							}
+						}
+					} elseif ( $child->is_type( 'subscription' ) ) {
+						$purchasable[] = $child;
+					}
+				}
+				continue;
+			}
+			if ( ! in_array( $product->get_type(), [ 'subscription', 'subscription_variation', 'variable-subscription' ], true ) ) {
+				continue;
+			}
+			// Expand variable subscriptions into their purchasable variations.
+			if ( $product->is_type( 'variable-subscription' ) ) {
+				foreach ( $product->get_available_variations() as $variation ) {
+					$variation_product = wc_get_product( $variation['variation_id'] );
+					if ( $variation_product && $variation_product->is_purchasable() ) {
+						$purchasable[] = $variation_product;
+					}
+				}
+			} else {
+				$purchasable[] = $product;
+			}
+		}
+		return array_values( $purchasable );
+	}
+
+	/**
 	 * Get the frequency of a product.
 	 *
 	 * @param \WC_Product $product Product object.
@@ -258,70 +332,23 @@ class Subscriptions_Tiers {
 	}
 
 	/**
-	 * Get tiered products by frequency given a grouped or
-	 * variable subscription product.
+	 * Get products organized by frequency.
 	 *
-	 * If no product is provided, it will use all
-	 * non-donation subscription products.
+	 * Takes an array of already-resolved purchasable products and groups
+	 * them by their subscription frequency.
 	 *
-	 * @param \WC_Product|null $product       Optional product.
-	 * @param bool|null        $sort_by_price Whether to sort by price.
+	 * @param \WC_Product[] $products      Array of purchasable product objects.
+	 * @param bool          $sort_by_price Whether to sort by price.
 	 *
-	 * @return array<string, \WC_Product[]> Product tiers by frequency.
+	 * @return array<string, \WC_Product[]> Products organized by frequency.
 	 */
-	public static function get_tiers_by_frequency( $product = null, $sort_by_price = null ) {
-		if ( ! function_exists( 'wc_get_products' ) || ! function_exists( 'wcs_user_has_subscription' ) ) {
-			return [];
-		}
-
-		if ( empty( $product ) ) {
-			$products = wc_get_products(
-				[
-					'type'  => [ 'subscription', 'variable-subscription' ],
-					'limit' => -1,
-				]
-			);
-			$sort_by_price = $sort_by_price ?? true;
-		} elseif ( $product->is_type( 'grouped' ) ) {
-			$products = $product->get_children();
-			$sort_by_price = $sort_by_price ?? false;
-		} elseif ( $product->is_type( 'variable' ) || $product->is_type( 'variable-subscription' ) || $product->is_type( 'subscription' ) ) {
-			$products = [ $product ];
-			$sort_by_price = $sort_by_price ?? true;
-		}
-
+	public static function get_products_by_frequency( $products, $sort_by_price = true ) {
 		if ( empty( $products ) ) {
 			return [];
 		}
 
-		$selected_products = [];
-
-		foreach ( $products as $product ) {
-			if ( is_int( $product ) ) {
-				$product = wc_get_product( $product );
-			}
-
-			if ( ! in_array( $product->get_type(), [ 'subscription', 'variable-subscription' ], true ) ) {
-				continue;
-			}
-
-			if ( $product->get_status() === 'private' ) {
-				continue;
-			}
-
-			// Extract the variations if it's a variable subscription product.
-			if ( $product->is_type( 'variable-subscription' ) ) {
-				$variations = $product->get_available_variations();
-				foreach ( $variations as $variation ) {
-					$selected_products[] = new \WC_Product_Variation( $variation['variation_id'] );
-				}
-			} else {
-				$selected_products[] = $product;
-			}
-		}
-
 		$products_by_frequency = [];
-		foreach ( $selected_products as $product ) {
+		foreach ( $products as $product ) {
 			$frequency = self::get_frequency( $product );
 			if ( ! $frequency ) {
 				continue;
@@ -330,18 +357,59 @@ class Subscriptions_Tiers {
 		}
 
 		if ( $sort_by_price ) {
-			foreach ( $products_by_frequency as $frequency => $products ) {
+			foreach ( $products_by_frequency as $frequency => $frequency_products ) {
 				usort(
-					$products,
+					$frequency_products,
 					function( $a, $b ) {
 						return intval( $a->get_price() ) <=> intval( $b->get_price() );
 					}
 				);
-				$products_by_frequency[ $frequency ] = $products;
+				$products_by_frequency[ $frequency ] = $frequency_products;
 			}
 		}
 
 		return $products_by_frequency;
+	}
+
+	/**
+	 * Get tiers by frequency given a grouped or variable subscription
+	 * product, or an array of products.
+	 *
+	 * If no product is provided, it will use all
+	 * non-donation subscription products.
+	 *
+	 * @param \WC_Product|\WC_Product[]|null $product       Optional product or array of products.
+	 * @param bool|null                      $sort_by_price Whether to sort by price.
+	 *
+	 * @return array<string, \WC_Product[]> Product tiers by frequency.
+	 */
+	public static function get_tiers( $product = null, $sort_by_price = null ) {
+		if ( ! function_exists( 'wc_get_products' ) || ! function_exists( 'wcs_user_has_subscription' ) ) {
+			return [];
+		}
+
+		$products = [];
+
+		if ( is_array( $product ) ) {
+			$products      = $product;
+			$sort_by_price = $sort_by_price ?? true;
+		} elseif ( empty( $product ) ) {
+			$products = wc_get_products(
+				[
+					'type'  => [ 'subscription', 'variable-subscription' ],
+					'limit' => -1,
+				]
+			);
+			$sort_by_price = $sort_by_price ?? true;
+		} elseif ( $product->is_type( 'grouped' ) ) {
+			$products      = [ $product ];
+			$sort_by_price = $sort_by_price ?? false;
+		} elseif ( $product->is_type( 'variable' ) || $product->is_type( 'variable-subscription' ) || $product->is_type( 'subscription' ) ) {
+			$products      = [ $product ];
+			$sort_by_price = $sort_by_price ?? true;
+		}
+
+		return self::get_products_by_frequency( self::resolve_purchasable_products( $products ), $sort_by_price ?? true );
 	}
 
 	/**
@@ -570,13 +638,13 @@ class Subscriptions_Tiers {
 	/**
 	 * Render subscription tiers form.
 	 *
-	 * @param \WC_Product $product      Optional product.
-	 * @param string|null $title        Optional title.
-	 * @param string|null $button_label Optional button label.
-	 * @param array|null  $switch_data  Switch subscription data or null.
+	 * @param \WC_Product|\WC_Product[]|null $product      Optional product, array of products, or null.
+	 * @param string|null                    $title        Optional title.
+	 * @param string|null                    $button_label Optional button label.
+	 * @param array|null                     $switch_data  Switch subscription data or null.
 	 */
 	public static function render_form( $product = null, $title = null, $button_label = null, $switch_data = null ) {
-		$tiers = self::get_tiers_by_frequency( $product );
+		$tiers = self::get_tiers( $product );
 		if ( empty( $tiers ) ) {
 			return;
 		}
@@ -591,11 +659,11 @@ class Subscriptions_Tiers {
 		if ( is_user_logged_in() ) {
 			$user_subscriptions = wcs_get_users_subscriptions( get_current_user_id() );
 			foreach ( $frequencies as $frequency ) {
-				foreach ( $tiers[ $frequency ] as $product ) {
+				foreach ( $tiers[ $frequency ] as $tier_product ) {
 					foreach ( $user_subscriptions as $subscription ) {
-						if ( $subscription->has_product( $product->get_id() ) && $subscription->has_status( 'active' ) ) {
+						if ( $subscription->has_product( $tier_product->get_id() ) && $subscription->has_status( 'active' ) ) {
 							$current_frequency = $frequency;
-							$current_product   = $product;
+							$current_product   = $tier_product;
 							$user_subscription = $subscription;
 							break 2;
 						}
@@ -642,9 +710,11 @@ class Subscriptions_Tiers {
 			}
 		}
 
+		// Derive data-product-id for the form (only for a single WC_Product).
+		$data_product_id    = ( $product && ! is_array( $product ) ) ? $product->get_id() : '';
 		$should_render_tabs = ! $is_single_tier || $is_nyp;
 		?>
-		<form class="newspack__subscription-tiers__form <?php echo esc_attr( $is_nyp ? 'nyp' : '' ); ?>" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-product-id="<?php echo esc_attr( $product ? $product->get_id() : '' ); ?>">
+		<form class="newspack__subscription-tiers__form <?php echo esc_attr( $is_nyp ? 'nyp' : '' ); ?>" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-product-id="<?php echo esc_attr( $data_product_id ); ?>">
 			<?php if ( $should_render_tabs ) : ?>
 				<div class="newspack-ui__segmented-control">
 					<?php
@@ -697,22 +767,89 @@ class Subscriptions_Tiers {
 	}
 
 	/**
+	 * Render a checkout button that opens a deferred tiers modal.
+	 *
+	 * The button is rendered inline and the modal is queued for rendering
+	 * in wp_footer at a late priority, outside any banner wrappers.
+	 *
+	 * @param int[]  $product_ids  Array of product IDs.
+	 * @param string $button_label Button label text.
+	 * @param string $button_class CSS class for the button.
+	 */
+	public static function render_checkout_button( $product_ids, $button_label, $button_class ) {
+		// Normalize product IDs so the modal ID is stable for the same set of products.
+		$product_ids = array_map( 'intval', (array) $product_ids );
+		$product_ids = array_values( array_unique( $product_ids ) );
+		sort( $product_ids, SORT_NUMERIC );
+
+		$modal_id = 'newspack-tiers-modal-' . md5( implode( '-', $product_ids ) );
+
+		// If modal is already queued, just render the button.
+		if ( isset( self::$deferred_modals[ $modal_id ] ) ) {
+			?>
+			<button type="button" class="newspack-ui__button newspack-ui__button--x-small <?php echo esc_attr( $button_class ); ?>" data-tiers-modal="<?php echo esc_attr( $modal_id ); ?>"><?php echo esc_html( $button_label ); ?></button>
+			<?php
+			return;
+		}
+
+		// Resolve purchasable products.
+		$products = self::resolve_purchasable_products( $product_ids );
+		if ( empty( $products ) ) {
+			return;
+		}
+
+		if ( ! class_exists( 'Newspack_Blocks' ) || ! class_exists( 'Newspack_Blocks\Modal_Checkout' ) ) {
+			return;
+		}
+		\Newspack_Blocks\Modal_Checkout::enqueue_modal();
+
+		// Queue the modal for deferred rendering.
+		self::$deferred_modals[ $modal_id ] = [
+			'products'     => $products,
+			'button_label' => $button_label,
+		];
+
+		// Render the CTA button that opens the modal.
+		?>
+		<button type="button" class="newspack-ui__button newspack-ui__button--x-small <?php echo esc_attr( $button_class ); ?>" data-tiers-modal="<?php echo esc_attr( $modal_id ); ?>"><?php echo esc_html( $button_label ); ?></button>
+		<?php
+	}
+
+	/**
+	 * Render all deferred tiers modals.
+	 *
+	 * Called on wp_footer at a late priority so modals are rendered
+	 * at the top level of the DOM, outside any banner wrappers.
+	 */
+	public static function render_deferred_modals() {
+		foreach ( self::$deferred_modals as $modal_id => $data ) {
+			self::render_modal( $data['products'], null, $data['button_label'], null, 'closed', $modal_id );
+		}
+		self::$deferred_modals = [];
+	}
+
+	/**
 	 * Render subscription tiers modal given a grouped or variable
-	 * subscription product.
+	 * subscription product, or an array of products.
 	 *
 	 * If no grouped or variable subscription product is provided,
 	 * all non-donation subscription products are rendered.
 	 *
-	 * @param \WC_Product|null $product       Optional product.
-	 * @param string|null      $title         Optional title.
-	 * @param string|null      $button_label  Optional button label.
-	 * @param array|null       $switch_data   Switch subscription data or null.
-	 * @param string           $initial_state Optional initial state.
+	 * @param \WC_Product|\WC_Product[]|null $product       Optional product, array of products, or null.
+	 * @param string|null                    $title         Optional title.
+	 * @param string|null                    $button_label  Optional button label.
+	 * @param array|null                     $switch_data   Switch subscription data or null.
+	 * @param string                         $initial_state Optional initial state.
+	 * @param string|null                    $modal_id      Optional HTML id attribute for the modal container.
 	 */
-	public static function render_modal( $product = null, $title = null, $button_label = null, $switch_data = null, $initial_state = 'closed' ) {
+	public static function render_modal( $product = null, $title = null, $button_label = null, $switch_data = null, $initial_state = 'closed', $modal_id = null ) {
 		$default_title = $switch_data ? __( 'Change Subscription', 'newspack-plugin' ) : __( 'Complete your transaction', 'newspack-plugin' );
+
+		// Derive data-product-id for the container (only for a single WC_Product).
+		$data_product_id      = ( $product && ! is_array( $product ) ) ? $product->get_id() : '';
+		$data_subscription_id = $switch_data ? $switch_data['subscription']->get_id() : '';
 		?>
-		<div class="newspack-ui newspack-ui__modal-container newspack__subscription-tiers" data-state="<?php echo esc_attr( $initial_state ); ?>" data-product-id="<?php echo esc_attr( $product ? $product->get_id() : '' ); ?>" data-subscription-id="<?php echo esc_attr( $switch_data ? $switch_data['subscription']->get_id() : '' ); ?>">
+		<div <?php echo $modal_id ? 'id="' . esc_attr( $modal_id ) . '"' : ''; ?> class="newspack-ui newspack-ui__modal-container newspack__subscription-tiers" data-state="<?php echo esc_attr( $initial_state ); ?>" data-product-id="<?php echo esc_attr( $data_product_id ); ?>" data-subscription-id="<?php echo esc_attr( $data_subscription_id ); ?>">
 			<div class="newspack-ui__modal-container__overlay"></div>
 			<div class="newspack-ui__modal newspack-ui__modal--small">
 				<header class="newspack-ui__modal__header">

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -199,9 +199,6 @@ class Audience_Content_Gates extends Wizard {
 					'cta_label'            => [
 						'type' => 'string',
 					],
-					'cta_product_id'       => [
-						'type' => 'integer',
-					],
 					'cta_type'             => [
 						'type' => 'string',
 					],
@@ -238,25 +235,22 @@ class Audience_Content_Gates extends Wizard {
 				'callback'            => [ $this, 'update_countdown_banner' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'button_label'   => [
+					'button_label' => [
 						'type' => 'string',
 					],
-					'cta_label'      => [
+					'cta_label'    => [
 						'type' => 'string',
 					],
-					'cta_product_id' => [
-						'type' => 'integer',
-					],
-					'cta_type'       => [
+					'cta_type'     => [
 						'type' => 'string',
 					],
-					'cta_url'        => [
+					'cta_url'      => [
 						'type' => 'string',
 					],
-					'enabled'        => [
+					'enabled'      => [
 						'type' => 'boolean',
 					],
-					'style'          => [
+					'style'        => [
 						'type' => 'string',
 					],
 				],
@@ -437,9 +431,6 @@ class Audience_Content_Gates extends Wizard {
 		}
 		if ( isset( $args['cta_type'] ) ) {
 			Content_Gifting_CTA::set_cta_type( sanitize_text_field( $args['cta_type'] ) );
-		}
-		if ( isset( $args['cta_product_id'] ) ) {
-			Content_Gifting_CTA::set_cta_product_id( (int) $args['cta_product_id'] );
 		}
 		if ( isset( $args['cta_url'] ) ) {
 			Content_Gifting_CTA::set_cta_url( sanitize_text_field( $args['cta_url'] ) );

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-wizard.php
@@ -714,9 +714,6 @@ class Audience_Wizard extends Wizard {
 			if ( isset( $args['content_gifting']['cta_type'] ) ) {
 				Content_Gifting_CTA::set_cta_type( sanitize_text_field( $args['content_gifting']['cta_type'] ) );
 			}
-			if ( isset( $args['content_gifting']['cta_product_id'] ) ) {
-				Content_Gifting_CTA::set_cta_product_id( (int) $args['content_gifting']['cta_product_id'] );
-			}
 			if ( isset( $args['content_gifting']['cta_url'] ) ) {
 				Content_Gifting_CTA::set_cta_url( sanitize_text_field( $args['content_gifting']['cta_url'] ) );
 			}

--- a/plugins/newspack-plugin/src/content-gate/content-banner.js
+++ b/plugins/newspack-plugin/src/content-gate/content-banner.js
@@ -36,6 +36,19 @@ domReady( () => {
 
 	setBodyOffset();
 
+	// Tiers modal buttons: open the corresponding modal when clicked.
+	const tiersButtons = document.querySelectorAll( '[data-tiers-modal]' );
+	[ ...tiersButtons ].forEach( button => {
+		button.addEventListener( 'click', ev => {
+			ev.preventDefault();
+			const modalId = button.getAttribute( 'data-tiers-modal' );
+			const tiersModal = document.getElementById( modalId );
+			if ( tiersModal ) {
+				tiersModal.setAttribute( 'data-state', 'open' );
+			}
+		} );
+	} );
+
 	// Countdown banner.
 	window.newspackRAS?.push( ras => {
 		const views = document.querySelector( '.newspack-countdown-banner__views' );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -47,7 +47,6 @@ const ContentGiftingSettings = () => {
 	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
-	const availableProducts = newspackAudience?.available_products || [];
 	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat() as string[];
 	const isDirty = useMemo( () => {
@@ -235,10 +234,11 @@ const ContentGiftingSettings = () => {
 					</ToggleGroupControl>
 					<ToggleGroupControl
 						label={ __( 'Subscribe button action', 'newspack-plugin' ) }
-						help={ __(
-							'Whether the subscribe button should start a product checkout or redirect to a landing page.',
-							'newspack-plugin'
-						) }
+						help={
+							( config?.content_gifting?.cta_type || 'product' ) === 'product'
+								? __( 'The product is automatically set by the content gate access rules.', 'newspack-plugin' )
+								: __( 'Redirect to a landing page.', 'newspack-plugin' )
+						}
 						value={ config?.content_gifting?.cta_type || 'product' }
 						onChange={ ( value: string ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_type: value } } ) }
 						isBlock
@@ -247,19 +247,6 @@ const ContentGiftingSettings = () => {
 						<ToggleGroupControlOption label={ __( 'Product', 'newspack-plugin' ) } value="product" />
 						<ToggleGroupControlOption label={ __( 'Landing page', 'newspack-plugin' ) } value="url" />
 					</ToggleGroupControl>
-					{ config?.content_gifting?.cta_type === 'product' && (
-						<SelectControl
-							label={ __( 'Subscribe button product', 'newspack-plugin' ) }
-							help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
-							options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
-							value={ config?.content_gifting?.cta_product_id || 0 }
-							suggestions={ availableProducts.map( o => o.label ) }
-							onChange={ ( value: number ) =>
-								setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_product_id: value } } )
-							}
-							__next40pxDefaultSize
-						/>
-					) }
 					{ config?.content_gifting?.cta_type === 'url' && (
 						<TextControl
 							label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
@@ -294,7 +281,7 @@ const ContentGiftingSettings = () => {
 											) }
 										</div>
 									</div>
-									{ ( ( config?.content_gifting?.cta_type === 'product' && config?.content_gifting?.cta_product_id ) ||
+									{ ( config?.content_gifting?.cta_type === 'product' ||
 										( config?.content_gifting?.cta_type === 'url' && config?.content_gifting?.cta_url ) ) && (
 										<button
 											className={ `newspack-ui__button newspack-ui__button--x-small ${

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -1,5 +1,3 @@
-/* global newspackAudience */
-
 /**
  * Metered Countdown settings page.
  */
@@ -23,7 +21,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Grid, Router, SectionHeader, SelectControl, TextControl, useConfirmDialog } from '../../../../../../packages/components/src';
+import { Grid, Router, SectionHeader, TextControl, useConfirmDialog } from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -37,7 +35,6 @@ const CountdownBannerSettings = () => {
 	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
-	const availableProducts = newspackAudience?.available_products || [];
 	const isDirty = useMemo( () => {
 		return (
 			config?.countdown_banner &&
@@ -171,10 +168,11 @@ const CountdownBannerSettings = () => {
 					</ToggleGroupControl>
 					<ToggleGroupControl
 						label={ __( 'Subscribe button action', 'newspack-plugin' ) }
-						help={ __(
-							'Whether the subscribe button should start a product checkout or redirect to a landing page.',
-							'newspack-plugin'
-						) }
+						help={
+							( config?.countdown_banner?.cta_type || 'product' ) === 'product'
+								? __( 'The product is automatically set by the content gate access rules.', 'newspack-plugin' )
+								: __( 'Redirect to a landing page.', 'newspack-plugin' )
+						}
 						value={ config?.countdown_banner?.cta_type || 'product' }
 						onChange={ ( value: string ) =>
 							setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_type: value } } )
@@ -185,19 +183,6 @@ const CountdownBannerSettings = () => {
 						<ToggleGroupControlOption label={ __( 'Product', 'newspack-plugin' ) } value="product" />
 						<ToggleGroupControlOption label={ __( 'Landing page', 'newspack-plugin' ) } value="url" />
 					</ToggleGroupControl>
-					{ config?.countdown_banner?.cta_type === 'product' && (
-						<SelectControl
-							label={ __( 'Subscribe button product', 'newspack-plugin' ) }
-							help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
-							options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
-							value={ config?.countdown_banner?.cta_product_id || 0 }
-							suggestions={ availableProducts.map( o => o.label ) }
-							onChange={ ( value: number ) =>
-								setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_product_id: value } } )
-							}
-							__next40pxDefaultSize
-						/>
-					) }
 					{ config?.countdown_banner?.cta_type === 'url' && (
 						<TextControl
 							label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
@@ -228,7 +213,7 @@ const CountdownBannerSettings = () => {
 											<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>.
 										</span>
 									</div>
-									{ ( ( config?.countdown_banner?.cta_type === 'product' && config?.countdown_banner?.cta_product_id ) ||
+									{ ( config?.countdown_banner?.cta_type === 'product' ||
 										( config?.countdown_banner?.cta_type === 'url' && config?.countdown_banner?.cta_url ) ) && (
 										<button
 											className={ `newspack-ui__button newspack-ui__button--x-small ${

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -131,7 +131,6 @@ type ContentGiftingConfig = {
 	cta_label: string;
 	button_label: string;
 	cta_type: string;
-	cta_product_id: number;
 	cta_url: string;
 };
 
@@ -142,7 +141,6 @@ type MeteringCountdownConfig = {
 	button_label: string;
 	cta_url: string;
 	cta_type: string;
-	cta_product_id: number;
 };
 
 type AdvancedSettingsConfig = {

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/content-gifting.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/content-gifting.js
@@ -17,8 +17,8 @@ import {
 import { ActionCard, Button, Grid, Notice, SelectControl, TextControl } from '../../../../../packages/components/src';
 
 export default function ContentGifting( { config, setConfig, updateConfig, noBorder = false } ) {
+	const ctaType = config.content_gifting?.cta_type || 'product';
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat();
-	const availableProducts = newspackAudience?.available_products || [];
 	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 
 	return (
@@ -118,11 +118,12 @@ export default function ContentGifting( { config, setConfig, updateConfig, noBor
 						</ToggleGroupControl>
 						<ToggleGroupControl
 							label={ __( 'Subscribe button action', 'newspack-plugin' ) }
-							help={ __(
-								'Whether the subscribe button should start a product checkout or redirect to a landing page.',
-								'newspack-plugin'
-							) }
-							value={ config.content_gifting.cta_type || 'product' }
+							help={
+								ctaType === 'product'
+									? __( 'The product is automatically set by the content gate access rules.', 'newspack-plugin' )
+									: __( 'Redirect to a landing page.', 'newspack-plugin' )
+							}
+							value={ ctaType }
 							onChange={ value => setConfig( { ...config, content_gifting: { ...config.content_gifting, cta_type: value } } ) }
 							isBlock
 							__next40pxDefaultSize
@@ -130,20 +131,7 @@ export default function ContentGifting( { config, setConfig, updateConfig, noBor
 							<ToggleGroupControlOption label={ __( 'Product', 'newspack-plugin' ) } value="product" />
 							<ToggleGroupControlOption label={ __( 'Landing page', 'newspack-plugin' ) } value="url" />
 						</ToggleGroupControl>
-						{ config.content_gifting.cta_type === 'product' && (
-							<SelectControl
-								label={ __( 'Subscribe button product', 'newspack-plugin' ) }
-								help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
-								options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
-								value={ config.content_gifting.cta_product_id }
-								suggestions={ availableProducts.map( o => o.label ) }
-								onChange={ value =>
-									setConfig( { ...config, content_gifting: { ...config.content_gifting, cta_product_id: value } } )
-								}
-								__next40pxDefaultSize
-							/>
-						) }
-						{ config.content_gifting.cta_type === 'url' && (
+						{ ctaType === 'url' && (
 							<TextControl
 								label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
 								help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
@@ -175,8 +163,7 @@ export default function ContentGifting( { config, setConfig, updateConfig, noBor
 														) }
 													</div>
 												</div>
-												{ ( ( config.content_gifting.cta_type === 'product' && config.content_gifting.cta_product_id ) ||
-													( config.content_gifting.cta_type === 'url' && config.content_gifting.cta_url ) ) && (
+												{ ( ctaType === 'product' || ( ctaType === 'url' && config.content_gifting.cta_url ) ) && (
 													<button
 														className={ `newspack-ui__button newspack-ui__button--x-small ${
 															( config.content_gifting.style || 'light' ) === 'dark'

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/countdown-banner.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/countdown-banner.js
@@ -1,5 +1,3 @@
-/* global newspackAudience */
-
 /**
  * WordPress dependencies
  */
@@ -12,10 +10,10 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 
-import { ActionCard, Button, Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
+import { ActionCard, Button, Grid, TextControl } from '../../../../../packages/components/src';
 
 export default function CountdownBanner( { config, setConfig, updateConfig, noBorder = false } ) {
-	const availableProducts = newspackAudience?.available_products || [];
+	const ctaType = config.countdown_banner?.cta_type || 'product';
 	return (
 		<ActionCard
 			title={ __( 'Metered Countdown', 'newspack-plugin' ) }
@@ -58,11 +56,12 @@ export default function CountdownBanner( { config, setConfig, updateConfig, noBo
 						</ToggleGroupControl>
 						<ToggleGroupControl
 							label={ __( 'Subscribe button action', 'newspack-plugin' ) }
-							help={ __(
-								'Whether the subscribe button should start a product checkout or redirect to a landing page.',
-								'newspack-plugin'
-							) }
-							value={ config.countdown_banner.cta_type || 'product' }
+							help={
+								ctaType === 'product'
+									? __( 'The product is automatically set by the content gate access rules.', 'newspack-plugin' )
+									: __( 'Redirect to a landing page.', 'newspack-plugin' )
+							}
+							value={ ctaType }
 							onChange={ value => setConfig( { ...config, countdown_banner: { ...config.countdown_banner, cta_type: value } } ) }
 							isBlock
 							__next40pxDefaultSize
@@ -70,20 +69,7 @@ export default function CountdownBanner( { config, setConfig, updateConfig, noBo
 							<ToggleGroupControlOption label={ __( 'Product', 'newspack-plugin' ) } value="product" />
 							<ToggleGroupControlOption label={ __( 'Landing page', 'newspack-plugin' ) } value="url" />
 						</ToggleGroupControl>
-						{ config.countdown_banner.cta_type === 'product' && (
-							<SelectControl
-								label={ __( 'Subscribe button product', 'newspack-plugin' ) }
-								help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
-								options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
-								value={ config.countdown_banner.cta_product_id }
-								suggestions={ availableProducts.map( o => o.label ) }
-								onChange={ value =>
-									setConfig( { ...config, countdown_banner: { ...config.countdown_banner, cta_product_id: value } } )
-								}
-								__next40pxDefaultSize
-							/>
-						) }
-						{ config.countdown_banner.cta_type === 'url' && (
+						{ ctaType === 'url' && (
 							<TextControl
 								label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
 								help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
@@ -113,8 +99,7 @@ export default function CountdownBanner( { config, setConfig, updateConfig, noBo
 														<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>.
 													</span>
 												</div>
-												{ ( ( config.countdown_banner.cta_type === 'product' && config.countdown_banner.cta_product_id ) ||
-													( config.countdown_banner.cta_type === 'url' && config.countdown_banner.cta_url ) ) && (
+												{ ( ctaType === 'product' || ( ctaType === 'url' && config.countdown_banner.cta_url ) ) && (
 													<button
 														className={ `newspack-ui__button newspack-ui__button--x-small ${
 															( config.countdown_banner.style || 'light' ) === 'dark'

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -1236,6 +1236,182 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertEquals( $grouped_rules, $settings['access_rules'], 'Grouped rules should be preserved' );
 	}
 
+	/**
+	 * Test get_gate_access_product_ids returns empty when no gate exists for the post.
+	 */
+	public function test_get_gate_access_product_ids_no_gate() {
+		$post_id = $this->factory->post->create( [ 'post_type' => 'page' ] );
+		$this->post_ids[] = $post_id;
+
+		$result = Content_Gate::get_gate_access_product_ids( $post_id );
+		$this->assertEmpty( $result, 'Should return empty array when no gate applies to the post' );
+	}
+
+	/**
+	 * Test get_gate_access_product_ids returns empty when custom access is inactive.
+	 */
+	public function test_get_gate_access_product_ids_inactive_custom_access() {
+		$gate_id = Content_Gate::create_gate( [ 'title' => 'Inactive Custom Access Gate' ] );
+		$this->gate_ids[] = $gate_id;
+
+		Content_Gate::update_custom_access_settings(
+			$gate_id,
+			[
+				'active'       => false,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ 100 ],
+						],
+					],
+				],
+			]
+		);
+
+		// Map the post to this gate.
+		$filter = function() use ( $gate_id ) {
+			return $gate_id;
+		};
+		add_filter( 'newspack_content_gate_post_id', $filter );
+
+		$result = Content_Gate::get_gate_access_product_ids( $this->post_ids[0] );
+		$this->assertEmpty( $result, 'Should return empty array when custom access is inactive' );
+
+		remove_filter( 'newspack_content_gate_post_id', $filter );
+	}
+
+	/**
+	 * Test get_gate_access_product_ids extracts subscription product IDs from access rules.
+	 */
+	public function test_get_gate_access_product_ids_extracts_subscriptions() {
+		$gate_id = Content_Gate::create_gate( [ 'title' => 'Subscription Gate' ] );
+		$this->gate_ids[] = $gate_id;
+
+		Content_Gate::update_custom_access_settings(
+			$gate_id,
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ 42, 43 ],
+						],
+					],
+				],
+			]
+		);
+
+		// Map the post to this gate.
+		$filter = function() use ( $gate_id ) {
+			return $gate_id;
+		};
+		add_filter( 'newspack_content_gate_post_id', $filter );
+
+		$result = Content_Gate::get_gate_access_product_ids( $this->post_ids[0] );
+		$this->assertEquals( [ 42, 43 ], $result, 'Should extract subscription product IDs from access rules' );
+
+		remove_filter( 'newspack_content_gate_post_id', $filter );
+	}
+
+	/**
+	 * Test get_gate_access_product_ids extracts from multiple groups and deduplicates.
+	 */
+	public function test_get_gate_access_product_ids_multiple_groups() {
+		$gate_id = Content_Gate::create_gate( [ 'title' => 'Multi Group Gate' ] );
+		$this->gate_ids[] = $gate_id;
+
+		Content_Gate::update_custom_access_settings(
+			$gate_id,
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ 10, 20 ],
+						],
+					],
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ 20, 30 ],
+						],
+					],
+				],
+			]
+		);
+
+		// Map the post to this gate.
+		$filter = function() use ( $gate_id ) {
+			return $gate_id;
+		};
+		add_filter( 'newspack_content_gate_post_id', $filter );
+
+		$result = Content_Gate::get_gate_access_product_ids( $this->post_ids[0] );
+		$this->assertCount( 3, $result, 'Should deduplicate product IDs across groups' );
+		$this->assertContains( 10, $result );
+		$this->assertContains( 20, $result );
+		$this->assertContains( 30, $result );
+
+		remove_filter( 'newspack_content_gate_post_id', $filter );
+	}
+
+	/**
+	 * Test get_gate_access_product_ids ignores non-subscription rules.
+	 */
+	public function test_get_gate_access_product_ids_ignores_non_subscription() {
+		$gate_id = Content_Gate::create_gate( [ 'title' => 'Mixed Rules Gate' ] );
+		$this->gate_ids[] = $gate_id;
+
+		Content_Gate::update_custom_access_settings(
+			$gate_id,
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'email_domain',
+							'value' => 'example.com',
+						],
+						[
+							'slug'  => 'subscription',
+							'value' => [ 55 ],
+						],
+					],
+				],
+			]
+		);
+
+		// Map the post to this gate.
+		$filter = function() use ( $gate_id ) {
+			return $gate_id;
+		};
+		add_filter( 'newspack_content_gate_post_id', $filter );
+
+		$result = Content_Gate::get_gate_access_product_ids( $this->post_ids[0] );
+		$this->assertEquals( [ 55 ], $result, 'Should only include subscription product IDs, not other rule types' );
+
+		remove_filter( 'newspack_content_gate_post_id', $filter );
+	}
+
+	/**
+	 * Test get_gate_access_product_ids filter augmentation.
+	 */
+	public function test_get_gate_access_product_ids_filter() {
+		$filter_callback = function( $product_ids, $post_id ) {
+			$product_ids[] = 999;
+			return $product_ids;
+		};
+		add_filter( 'newspack_gate_access_product_ids', $filter_callback, 10, 2 );
+
+		$result = Content_Gate::get_gate_access_product_ids( $this->post_ids[0] );
+		$this->assertContains( 999, $result, 'Filter should be able to add product IDs' );
+
+		remove_filter( 'newspack_gate_access_product_ids', $filter_callback, 10 );
+	}
+
 	// =========================================================================
 	// Newsletter content rule (added in feat/access-control-premium-newsletters)
 	// =========================================================================

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -1270,7 +1270,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		);
 
 		// Map the post to this gate.
-		$filter = function() use ( $gate_id ) {
+		$filter = function( $post_id ) use ( $gate_id ) {
 			return $gate_id;
 		};
 		add_filter( 'newspack_content_gate_post_id', $filter );
@@ -1304,7 +1304,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		);
 
 		// Map the post to this gate.
-		$filter = function() use ( $gate_id ) {
+		$filter = function( $post_id ) use ( $gate_id ) {
 			return $gate_id;
 		};
 		add_filter( 'newspack_content_gate_post_id', $filter );
@@ -1344,7 +1344,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		);
 
 		// Map the post to this gate.
-		$filter = function() use ( $gate_id ) {
+		$filter = function( $post_id ) use ( $gate_id ) {
 			return $gate_id;
 		};
 		add_filter( 'newspack_content_gate_post_id', $filter );
@@ -1385,7 +1385,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		);
 
 		// Map the post to this gate.
-		$filter = function() use ( $gate_id ) {
+		$filter = function( $post_id ) use ( $gate_id ) {
 			return $gate_id;
 		};
 		add_filter( 'newspack_content_gate_post_id', $filter );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Migrated from Automattic/newspack-plugin#4482 to the monorepo.

The content banner's subscribe button now dynamically resolves which products to offer based on the content gate's access rules, instead of requiring a manually selected product.

- Adds `Content_Gate::get_gate_access_product_ids()` to extract subscription product IDs from a gate's custom access rules, with a `newspack_gate_access_product_ids` filter for other restriction strategies to contribute product IDs.
- Adds Memberships integration via `filter_gate_access_product_ids` so membership plan products are included when no subscription rules exist.
- Refactors `Subscriptions_Tiers` to separate product resolution (`resolve_purchasable_products`) from frequency grouping (`get_products_by_frequency`), and adds support for receiving an array of products in `get_tiers()` and `render_form()`.
- Introduces `render_checkout_button()` and deferred modal rendering so tiers modals are output in `wp_footer` outside banner wrappers.
- Removes the manual `cta_product_id` setting from the countdown banner and content gifting CTA configuration — the product is now derived automatically from gate access rules.

Closes NPPD-1086.

### How to test the changes in this Pull Request:

1. Set up a content gate with metering and custom access rules that include a simple and a variable subscription.
2. Enable the metered countdown banner and set the subscribe button action to "Product".
3. Visit a gated post as a non-logged-in user and verify that the countdown banner appears with a subscribe button that opens a tiers modal with the correct subscription products from the gate's access rules.
4. Configure a content gate with multiple subscription products across multiple access rule groups — verify the tiers modal shows all unique products, properly grouped by frequency.
5. Enable WooCommerce Memberships and create a plan with the same restriction rules.
6. Verify the subscribe button resolves the membership plan's products.
7. Verify the subscribe button still works with the "Landing page" CTA type, redirecting to the configured URL.
8. Go to the Audience > Content Gates settings — verify the countdown banner and content gifting CTA settings no longer show a product selector when "Product" CTA type is selected, and instead show a help message that the product is automatically set by the access rules.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally? _(Migrated 1:1 from #4482; changes verified byte-identical to the source PR and `php -l` clean. Full PHPUnit suite to run in CI / an isolated env.)_
