### PR TITLE
chore(insights): match regwall/paywall terminology to Access Control UI

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
@@ -27,13 +27,13 @@ describe( 'EmptyMetricSection', () => {
 		const { container } = render(
 			<EmptyMetricSection
 				title="Paid reader conversion"
-				caption="How effectively paid access gate gates convert visitors."
+				caption="How effectively paid access gates convert visitors."
 				state="no_opportunity"
 				body="No paid access gate attempts in this window."
 			/>
 		);
 		expect( container ).toHaveTextContent( 'Paid reader conversion' );
-		expect( container ).toHaveTextContent( 'How effectively paid access gate gates convert visitors.' );
+		expect( container ).toHaveTextContent( 'How effectively paid access gates convert visitors.' );
 		expect( container ).toHaveTextContent( 'No paid access gate attempts in this window.' );
 	} );
 
@@ -41,7 +41,7 @@ describe( 'EmptyMetricSection', () => {
 		const { container } = render(
 			<EmptyMetricSection title="Free reader conversion" state="no_opportunity" body="No registration impressions." />
 		);
-		expect( container ).not.toHaveTextContent( 'How effectively paid access gate gates convert visitors.' );
+		expect( container ).not.toHaveTextContent( 'How effectively paid access gates convert visitors.' );
 	} );
 
 	it.each( [ 'no_opportunity', 'no_conversions', 'configuration_missing' ] as const )( 'exposes the %s state via the data attribute', state => {
@@ -57,7 +57,12 @@ describe( 'EmptyMetricSection', () => {
 	describe( '{N} interpolation', () => {
 		it( 'substitutes {N} with the localized signalCount when provided', () => {
 			const { container } = render(
-				<EmptyMetricSection title="Section" state="no_conversions" body="Your paid access gate reached {N} readers." signalCount={ 1234567 } />
+				<EmptyMetricSection
+					title="Section"
+					state="no_conversions"
+					body="Your paid access gate reached {N} readers."
+					signalCount={ 1234567 }
+				/>
 			);
 			expect( container ).toHaveTextContent( 'Your paid access gate reached 1,234,567 readers.' );
 		} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
@@ -27,21 +27,21 @@ describe( 'EmptyMetricSection', () => {
 		const { container } = render(
 			<EmptyMetricSection
 				title="Paid reader conversion"
-				caption="How effectively paywall gates convert visitors."
+				caption="How effectively paid access gate gates convert visitors."
 				state="no_opportunity"
-				body="No paywall attempts in this window."
+				body="No paid access gate attempts in this window."
 			/>
 		);
 		expect( container ).toHaveTextContent( 'Paid reader conversion' );
-		expect( container ).toHaveTextContent( 'How effectively paywall gates convert visitors.' );
-		expect( container ).toHaveTextContent( 'No paywall attempts in this window.' );
+		expect( container ).toHaveTextContent( 'How effectively paid access gate gates convert visitors.' );
+		expect( container ).toHaveTextContent( 'No paid access gate attempts in this window.' );
 	} );
 
 	it( 'omits the caption when none is passed', () => {
 		const { container } = render(
 			<EmptyMetricSection title="Free reader conversion" state="no_opportunity" body="No registration impressions." />
 		);
-		expect( container ).not.toHaveTextContent( 'How effectively paywall gates convert visitors.' );
+		expect( container ).not.toHaveTextContent( 'How effectively paid access gate gates convert visitors.' );
 	} );
 
 	it.each( [ 'no_opportunity', 'no_conversions', 'configuration_missing' ] as const )( 'exposes the %s state via the data attribute', state => {
@@ -57,9 +57,9 @@ describe( 'EmptyMetricSection', () => {
 	describe( '{N} interpolation', () => {
 		it( 'substitutes {N} with the localized signalCount when provided', () => {
 			const { container } = render(
-				<EmptyMetricSection title="Section" state="no_conversions" body="Your paywall reached {N} readers." signalCount={ 1234567 } />
+				<EmptyMetricSection title="Section" state="no_conversions" body="Your paid access gate reached {N} readers." signalCount={ 1234567 } />
 			);
-			expect( container ).toHaveTextContent( 'Your paywall reached 1,234,567 readers.' );
+			expect( container ).toHaveTextContent( 'Your paid access gate reached 1,234,567 readers.' );
 		} );
 
 		it( 'handles signalCount={0} gracefully', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -43,13 +43,13 @@ describe( 'MetricCard value tooltip', () => {
 } );
 
 describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
-	const PAYWALL = { attemptsLabel: 'paywall attempts', conversionsLabel: 'conversions' };
+	const PAYWALL = { attemptsLabel: 'paid access gate attempts', conversionsLabel: 'conversions' };
 
 	describe( 'rate card (format="percent")', () => {
 		it( 'renders "0 of N" (count, no % suffix) when numerator is 0 and denominator > 0', () => {
 			render(
 				<MetricCard
-					label="Paywall conversion (Direct)"
+					label="Paid access gate conversion (Direct)"
 					value={ 0 }
 					format="percent"
 					zeroFallback={ { numerator: 0, denominator: 17, ...PAYWALL } }
@@ -65,10 +65,10 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 			expect( screen.getByText( '0 of 1,234,567' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the em-dash + "No paywall attempts in this timeframe" when denominator is 0', () => {
+		it( 'renders the em-dash + "No paid access gate attempts in this timeframe" when denominator is 0', () => {
 			render( <MetricCard label="Rate" value={ 0 } format="percent" zeroFallback={ { numerator: 0, denominator: 0, ...PAYWALL } } /> );
 			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
-			expect( screen.getByText( 'No paywall attempts in this timeframe' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No paid access gate attempts in this timeframe' ) ).toBeInTheDocument();
 		} );
 
 		it( 'falls through to the normal percentage when numerator and denominator are both positive', () => {
@@ -82,7 +82,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 		it( 'renders "0 conversions" when conversions are 0 and attempts > 0', () => {
 			render(
 				<MetricCard
-					label="Total paywall revenue (Direct)"
+					label="Total paid access gate revenue (Direct)"
 					value={ 0 }
 					format="currency"
 					zeroFallback={ { numerator: 0, denominator: 17, currencyRole: 'total', ...PAYWALL } }
@@ -92,7 +92,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 			expect( screen.queryByText( '$0.00' ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'renders the em-dash + "No paywall attempts in this timeframe" when attempts are 0', () => {
+		it( 'renders the em-dash + "No paid access gate attempts in this timeframe" when attempts are 0', () => {
 			render(
 				<MetricCard
 					label="Total"
@@ -102,7 +102,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 				/>
 			);
 			expect( screen.getByLabelText( 'Not applicable' ) ).toHaveTextContent( '—' );
-			expect( screen.getByText( 'No paywall attempts in this timeframe' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No paid access gate attempts in this timeframe' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -110,7 +110,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 		it( 'renders the em-dash + "No conversions in this timeframe" when conversions are 0 but attempts > 0', () => {
 			render(
 				<MetricCard
-					label="Avg revenue per paywall conversion"
+					label="Avg revenue per paid access gate conversion"
 					value={ 0 }
 					format="currency"
 					zeroFallback={ { numerator: 0, denominator: 17, currencyRole: 'average', ...PAYWALL } }
@@ -120,7 +120,7 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 			expect( screen.getByText( 'No conversions in this timeframe' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders "No paywall attempts in this timeframe" when attempts are 0', () => {
+		it( 'renders "No paid access gate attempts in this timeframe" when attempts are 0', () => {
 			render(
 				<MetricCard
 					label="Avg"
@@ -129,14 +129,14 @@ describe( 'MetricCard zeroFallback (NPPD-1694)', () => {
 					zeroFallback={ { numerator: 0, denominator: 0, currencyRole: 'average', ...PAYWALL } }
 				/>
 			);
-			expect( screen.getByText( 'No paywall attempts in this timeframe' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No paid access gate attempts in this timeframe' ) ).toBeInTheDocument();
 		} );
 	} );
 
 	it( 'renders a custom plural opportunity label', () => {
 		render(
 			<MetricCard
-				label="Regwall conversion"
+				label="Registered access gate conversion"
 				value={ 0 }
 				format="percent"
 				zeroFallback={ { numerator: 0, denominator: 0, attemptsLabel: 'registration gate impressions' } }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.test.tsx
@@ -70,8 +70,8 @@ describe( 'FreeReaderConversionSection empty states (NPPD-1702)', () => {
 		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Regwall Conversion (Direct)' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Regwall Conversion (Influenced, 7d)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Registered access gate Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Registered access gate Conversion (Influenced, 7d)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders no_opportunity when the fields are present and impressions === 0', () => {
@@ -82,7 +82,7 @@ describe( 'FreeReaderConversionSection empty states (NPPD-1702)', () => {
 		// Body asserted on the container — the Notice's speak() duplicates it into a
 		// global live-region, so a screen-level text query would match twice.
 		expect( container ).toHaveTextContent( 'No registration gate impressions in this timeframe' );
-		expect( screen.queryByText( 'Regwall Conversion (Direct)' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Registered access gate Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders no_conversions with the impressions count interpolated when impressions > 0 and registrations === 0', () => {
@@ -94,7 +94,7 @@ describe( 'FreeReaderConversionSection empty states (NPPD-1702)', () => {
 		expect( container ).toHaveTextContent( 'Your registration gates reached 14,000 readers' );
 		// 7-day attribution window in the Free copy (NOT 14 — that's the Paid side).
 		expect( container ).toHaveTextContent( 'within the 7-day attribution window' );
-		expect( screen.queryByText( 'Regwall Conversion (Direct)' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Registered access gate Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the two scorecards (no empty state) when the section has data', () => {
@@ -107,8 +107,8 @@ describe( 'FreeReaderConversionSection empty states (NPPD-1702)', () => {
 		const { container } = render( <FreeReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Regwall Conversion (Direct)' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Regwall Conversion (Influenced, 7d)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Registered access gate Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Registered access gate Conversion (Influenced, 7d)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'applies the per-card count fallback inside a normal section render', () => {
@@ -138,6 +138,6 @@ describe( 'FreeReaderConversionSection empty states (NPPD-1702)', () => {
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( container ).not.toHaveTextContent( 'No registration gate impressions in this timeframe' );
-		expect( screen.getByText( 'Regwall Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Registered access gate Conversion (Direct)' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
@@ -109,7 +109,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--pair">
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
-						label: __( 'Regwall Conversion (Direct)', 'newspack-plugin' ),
+						label: __( 'Registered access gate Conversion (Direct)', 'newspack-plugin' ),
 						description: __(
 							'Sessions with a registration after a registration gate impression ÷ sessions with a registration gate impression',
 							'newspack-plugin'
@@ -129,7 +129,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				/>
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
-						label: __( 'Regwall Conversion (Influenced, 7d)', 'newspack-plugin' ),
+						label: __( 'Registered access gate Conversion (Influenced, 7d)', 'newspack-plugin' ),
 						description: __(
 							'Registrants whose registration followed a registration-gate view in a prior session within 7 days ÷ all new registrations',
 							'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.test.tsx
@@ -51,15 +51,15 @@ const makeWindow = ( over: Partial< GatesWindow > = {} ): GatesWindow => ( {
 } );
 
 describe( 'PaidReaderConversionSection empty states', () => {
-	it( 'renders no_opportunity when there are no paywall impressions', () => {
+	it( 'renders no_opportunity when there are no paid access gate impressions', () => {
 		const current = makeWindow( { paywall_impressions_total: 0, paywall_conversions_total: 0 } );
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Body is asserted on the container — the Notice's speak() duplicates it into a
 		// global live-region, so a screen-level text query would match twice.
-		expect( container ).toHaveTextContent( 'No paywall impressions in this timeframe' );
-		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'No paid access gate impressions in this timeframe' );
+		expect( screen.queryByText( 'Paid access gate Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders no_conversions with the impression count interpolated when impressions > 0 and conversions = 0', () => {
@@ -67,8 +67,8 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state="no_conversions"]' ) ).toBeInTheDocument();
-		expect( container ).toHaveTextContent( 'Your paywall was shown 17 times' );
-		expect( screen.queryByText( 'Paywall Conversion (Direct)' ) ).not.toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'Your paid access gate was shown 17 times' );
+		expect( screen.queryByText( 'Paid access gate Conversion (Direct)' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the four scorecards (no empty state) when the section has data', () => {
@@ -83,13 +83,13 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Total Paywall Revenue (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Paid access gate Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total Paid access gate Revenue (Direct)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does NOT show an empty state when the Direct scalar errored — renders the scorecards instead', () => {
 		// An errored Direct query leaves paywall_impressions_total at 0 (null denominator).
-		// That must not be mistaken for a genuine "no paywall impressions" empty state — the
+		// That must not be mistaken for a genuine "no paid access gate impressions" empty state — the
 		// cards should render so the errored one surfaces its own error treatment.
 		const current = makeWindow( {
 			paywall_impressions_total: 0,
@@ -99,8 +99,8 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		const { container } = render( <PaidReaderConversionSection current={ current } previous={ null } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( container ).not.toHaveTextContent( 'No paywall impressions in this timeframe' );
-		expect( screen.getByText( 'Paywall Conversion (Direct)' ) ).toBeInTheDocument();
+		expect( container ).not.toHaveTextContent( 'No paid access gate impressions in this timeframe' );
+		expect( screen.getByText( 'Paid access gate Conversion (Direct)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does NOT show an empty state when the Influenced scalar errored — renders the scorecards instead', () => {
@@ -118,9 +118,9 @@ describe( 'PaidReaderConversionSection empty states', () => {
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		// Assert on the container, not `screen`: the Notice's speak() leaves the
 		// no_conversions copy in a global live-region from an earlier test.
-		expect( container ).not.toHaveTextContent( 'No paywall conversions in this timeframe' );
+		expect( container ).not.toHaveTextContent( 'No paid access gate conversions in this timeframe' );
 		// Scorecards render; the errored Influenced card shows the shared error note.
-		expect( screen.getByText( 'Paywall Conversion (Influenced, 14d)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Paid access gate Conversion (Influenced, 14d)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'applies the per-card count fallback inside a normal section render', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -37,7 +37,7 @@ const HEADING_ID = 'newspack-insights-gates-paid-heading';
 const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversionSectionProps ) => {
 	const title = __( 'Paid reader conversion', 'newspack-plugin' );
 	const caption = __(
-		'How effectively paid access gate gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paid access gate impression. Influenced counts subscriptions that happened in a later session within 14 days of a paid access gate impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
+		'How effectively paid access gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paid access gate impression. Influenced counts subscriptions that happened in a later session within 14 days of a paid access gate impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
 		'newspack-plugin'
 	);
 	const impressionsLabel = __( 'paid access gate impressions', 'newspack-plugin' );
@@ -66,7 +66,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				caption={ caption }
 				state="no_opportunity"
 				body={ __(
-					'No paid access gate impressions in this timeframe. Your paid access gate gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
+					'No paid access gate impressions in this timeframe. Your paid access gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
 					'newspack-plugin'
 				) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -3,11 +3,11 @@
  *
  * Four scorecards in a single row covering paywall-gate conversion
  * (Direct attribution, Influenced 14-day lookback) plus revenue
- * from same-session paywall conversions.
+ * from same-session paid access gate conversions.
  *
  * When the section would render as a row of zeros it swaps the grid for a
  * single `<EmptyMetricSection>` (detection stays here, not in the orchestrator):
- *   - no paywall impressions in the window → `no_opportunity`
+ *   - no paid access gate impressions in the window → `no_opportunity`
  *   - impressions but no conversions       → `no_conversions` (with the impression count)
  *   - otherwise the four scorecards, each carrying its count fallback so an
  *     individual zero card reads as "0 of N" / "0 conversions" rather than 0%/$0.
@@ -37,12 +37,12 @@ const HEADING_ID = 'newspack-insights-gates-paid-heading';
 const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversionSectionProps ) => {
 	const title = __( 'Paid reader conversion', 'newspack-plugin' );
 	const caption = __(
-		'How effectively paywall gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paywall impression. Influenced counts subscriptions that happened in a later session within 14 days of a paywall impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
+		'How effectively paid access gate gates convert visitors into paying subscribers. Direct counts subscriptions that happened in the same session as a paid access gate impression. Influenced counts subscriptions that happened in a later session within 14 days of a paid access gate impression. Revenue is computed from actual Woo orders, not gate-event amounts.',
 		'newspack-plugin'
 	);
-	const impressionsLabel = __( 'paywall impressions', 'newspack-plugin' );
+	const impressionsLabel = __( 'paid access gate impressions', 'newspack-plugin' );
 	// The Influenced rate is converter-denominated (NPPD-1764): its denominator is all
-	// new subscribers in the window, not paywall impressions.
+	// new subscribers in the window, not paid access gate impressions.
 	const subscribersLabel = __( 'subscribers', 'newspack-plugin' );
 	const conversionsLabel = __( 'conversions', 'newspack-plugin' );
 
@@ -54,7 +54,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 	// coercing the totals to 0. A zero total is only a *genuine* empty state when
 	// both source metrics actually computed; if either errored we fall through to
 	// the scorecards so each card surfaces its own error treatment rather than a
-	// misleading "no paywall impressions" / "no conversions" empty state. (Direct and
+	// misleading "no paid access gate impressions" / "no conversions" empty state. (Direct and
 	// Influenced are separate queries and can fail independently.)
 	const dataKnown = current.paywall_conversion_direct.state !== 'error' && current.paywall_conversion_influenced_14d.state !== 'error';
 
@@ -66,7 +66,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				caption={ caption }
 				state="no_opportunity"
 				body={ __(
-					'No paywall impressions in this timeframe. Your paywall gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
+					'No paid access gate impressions in this timeframe. Your paid access gate gates may not be reaching readers — could be a placement question, a frequency question, or simply that the timeframe doesn’t include enough traffic. See the per-gate breakdown below for configuration details.',
 					'newspack-plugin'
 				) }
 			/>
@@ -80,7 +80,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				state="no_conversions"
 				signalCount={ impressions }
 				body={ __(
-					'No paywall conversions in this timeframe. Your paywall was shown {N} times, but none led to a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
+					'No paid access gate conversions in this timeframe. Your paid access gate was shown {N} times, but none led to a paid subscription within the 14-day attribution window. Worth a look at your checkout flow or pricing. See the per-gate breakdown below.',
 					'newspack-plugin'
 				) }
 			/>
@@ -93,9 +93,9 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 			<div className="newspack-insights__metric-grid">
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
-						label: __( 'Paywall Conversion (Direct)', 'newspack-plugin' ),
+						label: __( 'Paid access gate Conversion (Direct)', 'newspack-plugin' ),
 						description: __(
-							'Sessions with a subscription after a paywall impression ÷ sessions with a paywall impression',
+							'Sessions with a subscription after a paid access gate impression ÷ sessions with a paid access gate impression',
 							'newspack-plugin'
 						),
 						current: current.paywall_conversion_direct,
@@ -109,9 +109,9 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				/>
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
-						label: __( 'Paywall Conversion (Influenced, 14d)', 'newspack-plugin' ),
+						label: __( 'Paid access gate Conversion (Influenced, 14d)', 'newspack-plugin' ),
 						description: __(
-							'Subscribers whose conversion followed a paywall exposure in a prior session within 14 days ÷ all new subscribers',
+							'Subscribers whose conversion followed a paid access gate exposure in a prior session within 14 days ÷ all new subscribers',
 							'newspack-plugin'
 						),
 						current: current.paywall_conversion_influenced_14d,
@@ -125,9 +125,9 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				/>
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
-						label: __( 'Total Paywall Revenue (Direct)', 'newspack-plugin' ),
+						label: __( 'Total Paid access gate Revenue (Direct)', 'newspack-plugin' ),
 						description: __(
-							'Sum of Woo order totals from subscriptions completed in the same session as a paywall impression',
+							'Sum of Woo order totals from subscriptions completed in the same session as a paid access gate impression',
 							'newspack-plugin'
 						),
 						current: current.total_paywall_revenue_direct,
@@ -136,7 +136,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						// impressions come from the section total — but only when the Direct
 						// scalar computed. Otherwise `impressions` is an unreliable 0, so pass
 						// undefined and let the card render its own value/error treatment
-						// instead of a misleading "No paywall impressions".
+						// instead of a misleading "No paid access gate impressions".
 						zeroFallback: {
 							numerator: current.total_paywall_revenue_direct.denominator ?? undefined,
 							denominator: dataKnown ? impressions : undefined,
@@ -148,8 +148,8 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				/>
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
-						label: __( 'Avg Revenue per Paywall Conversion', 'newspack-plugin' ),
-						description: __( 'Total paywall revenue ÷ paywall conversions', 'newspack-plugin' ),
+						label: __( 'Avg Revenue per Paid access gate Conversion', 'newspack-plugin' ),
+						description: __( 'Total paid access gate revenue ÷ paid access gate conversions', 'newspack-plugin' ),
 						current: current.avg_revenue_per_paywall_conversion,
 						previous: previous?.avg_revenue_per_paywall_conversion,
 						zeroFallback: {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for PerformanceByGateSection (NPPD-1686): the per-gate paywall columns
+ * Tests for PerformanceByGateSection (NPPD-1686): the per-gate paid access gate columns
  * surface true conversions (count + rate), with an em-dash for a non-paywall-capable
  * (regwall-only) gate — replacing the old engagement-intent attempt columns.
  */
@@ -32,13 +32,13 @@ const table = ( rows: GatesPerformanceRow[] ): GatesPerformanceTable => ( {
 	rows,
 } );
 
-describe( 'PerformanceByGateSection paywall conversion columns', () => {
+describe( 'PerformanceByGateSection paid access gate conversion columns', () => {
 	it( 'renders the conversion column headers, not the old attempt columns', () => {
 		render( <PerformanceByGateSection data={ table( [] ) } /> );
-		expect( screen.getByText( 'Paywall conversions' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Paywall conversion rate' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Paywall attempts' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Paywall attempt rate' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Paid access gate conversions' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Paid access gate conversion rate' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Paid access gate attempts' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Paid access gate attempt rate' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows the count + rate for a paywall-capable gate', () => {
@@ -59,13 +59,13 @@ describe( 'PerformanceByGateSection paywall conversion columns', () => {
 		expect( screen.getByText( '1%' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders an em-dash for a regwall-only gate (null paywall columns)', () => {
+	it( 'renders an em-dash for a regwall-only gate (null paid access gate columns)', () => {
 		render(
 			<PerformanceByGateSection
 				data={ table( [
 					row( {
 						gate_post_id: 88,
-						gate_name: 'Regwall only',
+						gate_name: 'Registered access gate only',
 						impressions: 3000,
 						registrations: 150,
 						regwall_conversion_rate: 0.07,
@@ -75,7 +75,7 @@ describe( 'PerformanceByGateSection paywall conversion columns', () => {
 				] ) }
 			/>
 		);
-		// Exactly the two paywall cells render the N/A em-dash (regwall rate is 7%).
+		// Exactly the two paid access gate cells render the N/A em-dash (regwall rate is 7%).
 		expect( screen.getAllByText( '—' ) ).toHaveLength( 2 );
 	} );
 
@@ -88,7 +88,7 @@ describe( 'PerformanceByGateSection paywall conversion columns', () => {
 						gate_name: 'Member paywall',
 						impressions: 5000,
 						registrations: 12, // distinct value so "0" uniquely identifies paywall_conversions
-						regwall_conversion_rate: 0.07, // non-null so the only em-dash candidates are paywall cells
+						regwall_conversion_rate: 0.07, // non-null so the only em-dash candidates are paid access gate cells
 						paywall_conversions: 0,
 						paywall_conversion_rate: 0,
 					} ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
@@ -7,7 +7,7 @@
  * click, ASC on second click; the gate-name column starts ASC).
  *
  * Null cells (em-dash) always sort to the bottom regardless of
- * direction — a gate without a registration block has no Regwall
+ * direction — a gate without a registration block has no Registered access gate
  * conversion rate to compare, so a "—" should never claim the top of
  * an ascending sort.
  *
@@ -153,9 +153,9 @@ const PerformanceByGateSection = ( { data }: PerformanceByGateSectionProps ) => 
 		{ key: 'impressions', label: __( 'Impressions', 'newspack-plugin' ), numeric: true },
 		{ key: 'unique_viewers', label: __( 'Unique viewers', 'newspack-plugin' ), numeric: true },
 		{ key: 'registrations', label: __( 'Registrations', 'newspack-plugin' ), numeric: true },
-		{ key: 'regwall_conversion_rate', label: __( 'Regwall conversion rate', 'newspack-plugin' ), numeric: true },
-		{ key: 'paywall_conversions', label: __( 'Paywall conversions', 'newspack-plugin' ), numeric: true },
-		{ key: 'paywall_conversion_rate', label: __( 'Paywall conversion rate', 'newspack-plugin' ), numeric: true },
+		{ key: 'regwall_conversion_rate', label: __( 'Registered access gate conversion rate', 'newspack-plugin' ), numeric: true },
+		{ key: 'paywall_conversions', label: __( 'Paid access gate conversions', 'newspack-plugin' ), numeric: true },
+		{ key: 'paywall_conversion_rate', label: __( 'Paid access gate conversion rate', 'newspack-plugin' ), numeric: true },
 	];
 
 	const [ sortKey, setSortKey ] = useState< SortKey >( 'impressions' );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/scalarToCard.test.ts
@@ -23,7 +23,7 @@ const scalar = ( overrides: Partial< GatesScalarMetric > = {} ): GatesScalarMetr
 describe( 'gates scalarToMetricCardProps — data_missing routing', () => {
 	it( 'returns dataMissing:true (no value) when populated and data_missing is true', () => {
 		const props = scalarToMetricCardProps( {
-			label: 'Paywall Conversion (Direct)',
+			label: 'Paid access gate Conversion (Direct)',
 			description: 'd',
 			current: scalar( { data_missing: true } ),
 		} );
@@ -34,7 +34,7 @@ describe( 'gates scalarToMetricCardProps — data_missing routing', () => {
 	it( 'returns the normal value mapping when populated and data_missing is false', () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const props: any = scalarToMetricCardProps( {
-			label: 'Paywall Conversion (Direct)',
+			label: 'Paid access gate Conversion (Direct)',
 			description: 'd',
 			current: scalar( { data_missing: false } ),
 		} );
@@ -44,7 +44,7 @@ describe( 'gates scalarToMetricCardProps — data_missing routing', () => {
 
 	it( 'lets the error treatment win over data_missing', () => {
 		const props = scalarToMetricCardProps( {
-			label: 'Paywall Conversion (Direct)',
+			label: 'Paid access gate Conversion (Direct)',
 			description: 'd',
 			current: scalar( { state: 'error', data_missing: true, error_message: 'BQ down' } ),
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates mentions of "regwall" and "paywall" across Insights UIs to match the terminology used in other Access Control UI ("registered access" and "paid access" gates).

### How to test the changes in this Pull Request:

No functional changes, purely cosmetic.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
