### PR TITLE
fix(lint): add root prettier config so pre-commit uses custom rules

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,17 @@
+/**
+ * Workspace-root Prettier config.
+ *
+ * Re-exports the shared Newspack config (printWidth 150, arrowParens 'avoid',
+ * wp-prettier parenSpacing) so tools that resolve Prettier config relative to
+ * the *repo root* pick up the custom rules — most importantly the husky
+ * pre-commit hook, which runs ESLint with cwd = workspace root.
+ *
+ * Without this file, `@wordpress/eslint-plugin` bakes Prettier options into its
+ * `prettier/prettier` rule via a cwd-based `cosmiconfig( 'prettier' ).search()`
+ * at config-load time. Run from the repo root that search finds no config and
+ * silently falls back to the upstream `@wordpress/prettier-config` defaults
+ * (printWidth 80), so the hook demands argument wrapping that the real
+ * 150-width config allows. Each package's own `.prettierrc.js` re-exports the
+ * same shared config; this makes the root behave identically. See NPPM-290.
+ */
+module.exports = require( 'newspack-scripts/config/prettier.config.js' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up fix for the pre-commit lint gate added in #299 (NPPM-290, Phase 1).

**Symptom:** the pre-commit hook throws spurious `prettier/prettier` errors that
try to wrap function arguments onto separate lines, even when the line is
comfortably within our house `printWidth` of 150. It behaves as if it never sees
our custom Prettier rules. `n build` / `npm run lint:js` and CI's per-package
lint do **not** flag the same code.

**Root cause:** `@wordpress/eslint-plugin/configs/recommended.js` bakes the
Prettier options into its `prettier/prettier` rule at config-load time via a
**cwd-based** search:

```js
const localPrettierConfig = cosmiconfigSync( 'prettier' ).search() || {};
const defaultPrettierConfig = require( '@wordpress/prettier-config' ); // printWidth 80
const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
'prettier/prettier': [ 'error', prettierConfig ],
```

`cosmiconfig.search()` walks up from `process.cwd()`, **not** from the file being
linted. Our custom rules (`printWidth: 150`, `arrowParens: 'avoid'`) live in each
package's `.prettierrc.js` (which re-exports `newspack-scripts/config/prettier.config.js`).

- Run from **inside a package** (normal `n build`) → finds that package's
  `.prettierrc.js` → **printWidth 150**. ✅
- Run from the **workspace root** (the #299 `lint-staged` hook runs
  `bin/precommit-eslint.sh` → `eslint` with cwd = repo root) → finds **no** config
  at the root → falls back to `@wordpress/prettier-config` defaults
  (**printWidth 80**, `arrowParens: 'always'`). ❌

The workspace root had no Prettier config, so the hook silently linted at width 80.

**Fix:** add a workspace-root `.prettierrc.js` that re-exports the same shared
config. All 13 packages already re-export it, so this makes the root behave
identically, and it also covers `super-cool-ad-inserter` (which ships no
`.prettierrc.js` of its own). One file, no dependency or lockfile changes.

### How to test the changes in this Pull Request:

1. `pnpm install` at the workspace root.
2. In a plugin's `src/`, add a JS file with a valid call whose single line is
   between 80 and 150 chars, e.g.:
   ```js
   const format = ( a, b, c, d ) => [ a, b, c, d ].join( ', ' );
   export const value = format( 'alphaValue', 'betaValue', 'gammaValue', 'deltaValue' );
   ```
3. `git add` it and `git commit`. **Before** this PR the commit is blocked with a
   `prettier/prettier` "wrap arguments onto separate lines" error; **with** this
   PR the commit passes.
4. Sanity check the gate still blocks real errors: commit `export const bad=1;`
   → still blocked.

### Verification performed

- Reproduced the width-80 fallback from the repo root and confirmed width-150
  from inside a package (`cosmiconfig` cwd search).
- End-to-end through the real husky + `lint-staged` path: a correctly-150-formatted
  file now **passes** the hook (exit 0); a genuinely misformatted file is still
  **blocked** (exit 1).

Part of [NPPM-290](https://linear.app/a8c/issue/NPPM-290/theme-linting-php-and-css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
