### PR TITLE
fix(integrations): skip unconfigured integrations on deletion sync

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -308,7 +308,12 @@ class Contact_Sync extends Sync {
 		// shutdown queue refuses to re-push it for the rest of the request.
 		self::$deleted_emails[ $email ] = true;
 
-		$integrations = Integrations::get_active_integrations();
+		// Only act on integrations the admin has finished configuring. This path
+		// performs real I/O (delete_contact / flag-mode upserts) and schedules AS
+		// retries per integration, so it must use the same configured-only gate as
+		// the sync path to avoid deleting against, or retrying on, an integration
+		// whose external prerequisites are not set up.
+		$integrations = Integrations::get_active_configured_integrations();
 		$errors       = [];
 
 		// Build the flag-mode contact once. The timestamp uses the same format constant
@@ -800,6 +805,11 @@ class Contact_Sync extends Sync {
 		$integration = Integrations::get_integration( $integration_id );
 		if ( ! $integration ) {
 			Logger::log( sprintf( 'Integration "%s" not found on deletion retry %d.', $integration_id, $retry_count ), 'NEWSPACK-SYNC', 'error' );
+			return;
+		}
+
+		if ( ! $integration->is_set_up() ) {
+			static::log( sprintf( 'Integration "%s" no longer set up on deletion retry %d; aborting retry chain.', $integration_id, $retry_count ) );
 			return;
 		}
 

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-deletion-spy-integration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-deletion-spy-integration.php
@@ -41,6 +41,24 @@ class Deletion_Spy_Integration extends Integration {
 	public $push_result = true;
 
 	/**
+	 * Value returned by is_set_up(). Tests flip this to false to model an
+	 * enabled-but-unconfigured integration (e.g. an ESP whose provider was
+	 * deselected) and assert the deletion path skips it.
+	 *
+	 * @var bool
+	 */
+	public $is_set_up = true;
+
+	/**
+	 * Whether the integration's external prerequisites are configured.
+	 *
+	 * @return bool
+	 */
+	public function is_set_up() {
+		return $this->is_set_up;
+	}
+
+	/**
 	 * Register settings fields (test implementation).
 	 */
 	public function register_settings_fields() {

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-account-deletion.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-account-deletion.php
@@ -816,6 +816,77 @@ class Test_Account_Deletion extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An enabled integration whose external prerequisites are not configured
+	 * (is_set_up() === false) must be skipped by the deletion dispatcher, just
+	 * as the regular sync path skips it via get_active_configured_integrations().
+	 * Otherwise a deletion would perform I/O and schedule Action Scheduler retries
+	 * against an integration the admin never finished setting up.
+	 */
+	public function test_handle_account_deletion_skips_unconfigured_integration() {
+		$this->reset_integrations();
+		$spy            = new \Deletion_Spy_Integration( 'spy-unconfigured', 'Spy Unconfigured' );
+		$spy->is_set_up = false;
+		Integrations::register( $spy );
+		$spy->update_settings_field_value( 'sync_account_deletion', true );
+		$spy->update_settings_field_value( 'account_deletion_handling', 'delete' );
+		Integrations::enable( 'spy-unconfigured' );
+
+		\Newspack\Reader_Activation\Contact_Sync::handle_account_deletion(
+			'reader@example.com',
+			[
+				'email'    => 'reader@example.com',
+				'metadata' => [],
+			],
+			'TestContext'
+		);
+
+		$this->assertCount( 0, $spy->delete_calls, 'Unconfigured integration must not have delete_contact called.' );
+		$this->assertCount( 0, $spy->push_calls, 'Unconfigured integration must not have push_contact_data called.' );
+	}
+
+	/**
+	 * The deletion retry executor must abort the retry chain when the integration
+	 * is no longer set up, mirroring the guard in execute_integration_retry(). A
+	 * retry firing against an unconfigured integration would re-schedule itself
+	 * indefinitely instead of dropping cleanly.
+	 */
+	public function test_execute_deletion_retry_aborts_when_integration_not_set_up() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+		\as_unschedule_all_actions( \Newspack\Reader_Activation\Contact_Sync::RETRY_DELETION_HOOK );
+
+		$this->reset_integrations();
+		$spy            = new \Deletion_Spy_Integration( 'spy-retry-unconfigured', 'Spy Retry Unconfigured' );
+		$spy->is_set_up = false;
+		Integrations::register( $spy );
+		Integrations::enable( 'spy-retry-unconfigured' );
+
+		\Newspack\Reader_Activation\Contact_Sync::execute_deletion_retry(
+			[
+				'integration_id' => 'spy-retry-unconfigured',
+				'mode'           => 'delete',
+				'email'          => 'reader@example.com',
+				'contact'        => [],
+				'context'        => 'TestContext',
+				'retry_count'    => 1,
+			]
+		);
+
+		$this->assertCount( 0, $spy->delete_calls, 'Retry against an unconfigured integration must not call delete_contact.' );
+
+		$pending = \as_get_scheduled_actions(
+			[
+				'hook'   => \Newspack\Reader_Activation\Contact_Sync::RETRY_DELETION_HOOK,
+				'group'  => Integrations::get_action_group( 'spy-retry-unconfigured' ),
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertEmpty( $pending, 'Aborted retry chain must not schedule a further retry.' );
+	}
+
+	/**
 	 * In v1 metadata mode, Integration::prepare_contact() strips metadata keys that
 	 * are not registered in Sync\Metadata::get_keys() and enabled_outgoing_fields.
 	 * The dispatcher must re-inject account_deleted (with the integration's prefix)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Related PRs:**
- Legacy fix that introduced the deletion path: Automattic/newspack-plugin#4731 (`fix(integrations): sync reader-account deletion to ESP`)
- Workspace sync that landed it in the monorepo: #536 (`sync: land legacy trunk commits`)

The reader account-deletion → ESP sync path (added in Automattic/newspack-plugin#4731, landed via the legacy sync in #536) iterates `Integrations::get_active_integrations()` and, in its retry executor, has no readiness guard. Both bypass the configured-only contract the regular sync path adopted: `get_active_configured_integrations()`' docblock states that *"Iteration sites that perform real I/O on each integration (health checks, contact pushes, pulls, retries) MUST use this instead of `get_active_integrations()`"* to avoid acting on, or scheduling Action Scheduler retries for, an integration the admin has not finished setting up.

As a result, on an enabled integration whose external prerequisites are not set up (e.g. an ESP whose provider was deselected, or a transient config gap) with account-deletion sync turned on, `handle_account_deletion()` would call `delete_contact()` / flag-mode upserts and, on failure, schedule deletion retries that keep firing against an unconfigured provider – the exact failure mode the configured-only gate exists to prevent.

This aligns the deletion path with the sync path:

- `handle_account_deletion()` now iterates `get_active_configured_integrations()`.
- `execute_deletion_retry()` now aborts the retry chain with an `is_set_up()` guard, mirroring `execute_integration_retry()`.

The two edits were authored on divergent branches (the deletion path in Automattic/newspack-plugin#4731 predated the configured-only contract on the monorepo side) and merged with no textual conflict, so the inconsistency was not surfaced as a conflict – it was flagged by the sync collision detector on #536 and confirmed as a latent gap, not a dropped fix.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-plugin && n test-php --group account-deletion` – all pass (25 tests).
2. Two new tests reproduce the bug (red without the fix): `test_handle_account_deletion_skips_unconfigured_integration` and `test_execute_deletion_retry_aborts_when_integration_not_set_up`. Both assert an enabled-but-not-set-up integration receives no `delete_contact()` call and schedules no retry.
3. Full plugin suite is green (1944 tests, 0 failures).

### Other information:

* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)