### PR TITLE
chore(release): merge in release newspack@6.44.9

### DIFF
--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.44.9](https://github.com/Automattic/newspack-workspace/compare/newspack@6.44.8...newspack@6.44.9) (2026-07-06)
+
+
+### Bug Fixes
+
+* **reader-activation:** load RAS scripts after commons (NPPM-2951) ([#414](https://github.com/Automattic/newspack-workspace/issues/414)) ([d2dab16](https://github.com/Automattic/newspack-workspace/commit/d2dab162e8ff59c99b3b676ee13ca20bb3a79d96))
+
 ## newspack [6.44.8](https://github.com/Automattic/newspack-workspace/compare/newspack@6.44.7...newspack@6.44.8) (2026-07-06)
 
 

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -138,7 +138,11 @@ final class Reader_Activation {
 	 */
 	public static function enqueue_scripts() {
 		$authenticated_email = \is_user_logged_in() && self::is_user_reader( \wp_get_current_user() ) ? \wp_get_current_user()->user_email : '';
-		$script_dependencies = [];
+		// `newspack_commons` holds the shared (code-split) modules these scripts
+		// depend on at runtime, so it must load first. Declaring it as a dependency
+		// (combined with `defer` instead of `async` below) guarantees the load order
+		// even when an optimization plugin (e.g. Perfmatters) delays the scripts. See NPPM-2951.
+		$script_dependencies = [ 'newspack_commons' ];
 		$script_data         = [
 			'auth_intention_cookie'        => self::AUTH_INTENTION_COOKIE,
 			'cid_cookie'                   => NEWSPACK_CLIENT_ID_COOKIE_NAME,
@@ -173,7 +177,7 @@ final class Reader_Activation {
 			$script_dependencies,
 			NEWSPACK_PLUGIN_VERSION,
 			[
-				'strategy'  => 'async',
+				'strategy'  => 'defer',
 				'in_footer' => true,
 			]
 		);
@@ -182,7 +186,7 @@ final class Reader_Activation {
 			'newspack_ras_config',
 			$script_data
 		);
-		\wp_script_add_data( self::SCRIPT_HANDLE, 'async', true );
+		\wp_script_add_data( self::SCRIPT_HANDLE, 'defer', true );
 		\wp_script_add_data( self::SCRIPT_HANDLE, 'amp-plus', true );
 
 		/**
@@ -200,12 +204,12 @@ final class Reader_Activation {
 				[ self::SCRIPT_HANDLE ],
 				NEWSPACK_PLUGIN_VERSION,
 				[
-					'strategy'  => 'async',
+					'strategy'  => 'defer',
 					'in_footer' => true,
 				]
 			);
 			\wp_localize_script( self::AUTH_SCRIPT_HANDLE, 'newspack_reader_activation_labels', self::get_reader_activation_labels() );
-			\wp_script_add_data( self::AUTH_SCRIPT_HANDLE, 'async', true );
+			\wp_script_add_data( self::AUTH_SCRIPT_HANDLE, 'defer', true );
 			\wp_script_add_data( self::AUTH_SCRIPT_HANDLE, 'amp-plus', true );
 			\wp_enqueue_style(
 				self::AUTH_SCRIPT_HANDLE,
@@ -225,7 +229,7 @@ final class Reader_Activation {
 				[ self::SCRIPT_HANDLE ],
 				NEWSPACK_PLUGIN_VERSION,
 				[
-					'strategy'  => 'async',
+					'strategy'  => 'defer',
 					'in_footer' => true,
 				]
 			);
@@ -239,7 +243,7 @@ final class Reader_Activation {
 				]
 			);
 
-			\wp_script_add_data( self::NEWSLETTERS_SCRIPT_HANDLE, 'async', true );
+			\wp_script_add_data( self::NEWSLETTERS_SCRIPT_HANDLE, 'defer', true );
 			\wp_enqueue_style(
 				self::NEWSLETTERS_SCRIPT_HANDLE,
 				Newspack::plugin_url() . '/dist/newsletters-signup.css',

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.44.8
+ * Version: 6.44.9
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.44.8' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.44.9' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.44.8",
+	"version": "6.44.9",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/src/blocks/reader-registration/index.php
+++ b/plugins/newspack-plugin/src/blocks/reader-registration/index.php
@@ -69,9 +69,12 @@ function enqueue_scripts() {
 		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.js',
 		[ 'wp-polyfill', 'newspack-reader-activation' ],
 		NEWSPACK_PLUGIN_VERSION,
-		true
+		[
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		]
 	);
-	\wp_script_add_data( $handle, 'async', true );
+	\wp_script_add_data( $handle, 'defer', true );
 	\wp_script_add_data( $handle, 'amp-plus', true );
 	\wp_localize_script(
 		$handle,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Completes the `release` → `main` post-release branch sync that the [`Post-release branch sync` job](https://github.com/Automattic/newspack-workspace/actions/runs/28808628595) aborted on a merge conflict. The `alpha` sync in that run already succeeded and pushed; only the `main` merge failed.

The conflict was in `plugins/newspack-plugin/src/blocks/reader-registration/index.php` — two adjacent, independent changes git couldn't auto-separate:

| Change | `main` (#290) | `release`/`alpha` (NPPM-2951, #414) |
|---|---|---|
| Script version arg | `NEWSPACK_PLUGIN_VERSION` → `Newspack::asset_version(...)` (cache-busting) | unchanged |
| Script load strategy | unchanged (`true` / `async`) | `true` → `[ 'strategy' => 'defer', 'in_footer' => true ]` (load after `newspack_commons`) |

Resolved by combining both: keep `main`'s `asset_version()` call for the version arg, and `release`'s `defer` strategy array + `wp_script_add_data( $handle, 'defer', true )` for the load-order fix. Neither change conflicts semantically — they touch the same lines for unrelated reasons.

`class-reader-activation.php` auto-merged cleanly (verified: the merge carries forward the same `async` → `defer` change from NPPM-2951 alongside `main`'s independent additions in that file).

No `workspace:*` dep restoration was needed.

### How to test the changes in this Pull Request:

1. Confirm `origin/release` is fully an ancestor of this branch (`git merge-base --is-ancestor origin/release ci/post-release-sync-main`).
2. Confirm `reader-registration/index.php` retains both the `asset_version()` cache-busting call and the `defer` strategy/script-data pair.
3. `php -l` on the changed PHP files.
4. Merge with a **merge commit** (branch-sync, not squash) to keep `release` an ancestor of `main`.

### Other information:

Merge strategy must be **Create a merge commit** to preserve the release→main ancestry the post-release flow relies on.