### PR TITLE
feat(plugin): My Account group management for owner, manager, member

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -600,11 +600,13 @@ class Group_Subscription_MyAccount {
 	}
 
 	/**
-	 * Handle the make/remove manager form submission (owner-only).
+	 * Handle the make/remove manager form submission.
 	 *
-	 * An instant action with no confirm step, mirroring the admin prototype:
-	 * promote/demote stays with the person who owns the billing, so managers
-	 * cannot change peer roles.
+	 * Gated to the subscription owner — or a store admin acting on the owner's
+	 * behalf (the admin-side parity from DSGNEWS-184). An instant action with
+	 * no confirm step, mirroring the admin prototype: promote/demote stays
+	 * with the person who owns the billing, so managers cannot change peer
+	 * roles.
 	 */
 	public static function handle_set_manager_role() {
 		check_admin_referer( self::SET_MANAGER_ROLE_NONCE_ACTION );
@@ -627,13 +629,13 @@ class Group_Subscription_MyAccount {
 		}
 		self::verify_manageable( $subscription_id, $redirect_url, 'members' );
 
-		$member_id = filter_input( INPUT_POST, 'member_id', FILTER_VALIDATE_INT ) ?? 0;
+		$member_id = absint( filter_input( INPUT_POST, 'member_id', FILTER_VALIDATE_INT ) );
 		$role      = 'manager' === filter_input( INPUT_POST, 'role', FILTER_SANITIZE_SPECIAL_CHARS ) ? 'manager' : 'member';
 		$result    = 'manager' === $role
 			? Group_Subscription::add_manager( $subscription, $member_id )
 			: Group_Subscription::remove_manager( $subscription, $member_id );
 
-		$member = get_userdata( (int) $member_id );
+		$member = get_userdata( $member_id );
 		$name   = $member ? newspack_get_user_display_label( $member ) : __( 'This member', 'newspack-plugin' );
 
 		self::redirect(

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -49,6 +49,11 @@ class Group_Subscription_MyAccount {
 	const REQUEST_SEATS_NONCE_ACTION = 'newspack_group_subscription_request_seats';
 
 	/**
+	 * Nonce action for the make/remove manager forms.
+	 */
+	const SET_MANAGER_ROLE_NONCE_ACTION = 'newspack_group_subscription_set_manager_role';
+
+	/**
 	 * Register hooks for the My Account group subscription UI.
 	 */
 	public static function init() {
@@ -65,6 +70,7 @@ class Group_Subscription_MyAccount {
 		add_action( 'admin_post_' . self::REMOVE_MEMBER_NONCE_ACTION, [ __CLASS__, 'handle_remove_member' ] );
 		add_action( 'admin_post_' . self::LEAVE_GROUP_NONCE_ACTION, [ __CLASS__, 'handle_leave_group' ] );
 		add_action( 'admin_post_' . self::REQUEST_SEATS_NONCE_ACTION, [ __CLASS__, 'handle_request_seats' ] );
+		add_action( 'admin_post_' . self::SET_MANAGER_ROLE_NONCE_ACTION, [ __CLASS__, 'handle_set_manager_role' ] );
 	}
 
 	/**
@@ -590,6 +596,55 @@ class Group_Subscription_MyAccount {
 				$member_label,
 				Group_Subscription::get_label_lower( 'singular' )
 			)
+		);
+	}
+
+	/**
+	 * Handle the make/remove manager form submission (owner-only).
+	 *
+	 * An instant action with no confirm step, mirroring the admin prototype:
+	 * promote/demote stays with the person who owns the billing, so managers
+	 * cannot change peer roles.
+	 */
+	public static function handle_set_manager_role() {
+		check_admin_referer( self::SET_MANAGER_ROLE_NONCE_ACTION );
+		[ $subscription_id, $redirect_url ] = self::get_subscription_context();
+
+		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription_id );
+		$is_owner     = $subscription && get_current_user_id() === (int) $subscription->get_user_id();
+		if ( ! $subscription || ( ! $is_owner && ! current_user_can( 'manage_woocommerce' ) ) ) {
+			$error_message = sprintf(
+				/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+				__( 'Only the owner can change who manages this %s.', 'newspack-plugin' ),
+				Group_Subscription::get_label_lower( 'singular' )
+			);
+			self::redirect(
+				new \WP_Error( 'newspack_group_subscription_role_permission', $error_message ),
+				$redirect_url,
+				'members',
+				$error_message
+			);
+		}
+		self::verify_manageable( $subscription_id, $redirect_url, 'members' );
+
+		$member_id = filter_input( INPUT_POST, 'member_id', FILTER_VALIDATE_INT ) ?? 0;
+		$role      = 'manager' === filter_input( INPUT_POST, 'role', FILTER_SANITIZE_SPECIAL_CHARS ) ? 'manager' : 'member';
+		$result    = 'manager' === $role
+			? Group_Subscription::add_manager( $subscription, $member_id )
+			: Group_Subscription::remove_manager( $subscription, $member_id );
+
+		$member = get_userdata( (int) $member_id );
+		$name   = $member ? newspack_get_user_display_label( $member ) : __( 'This member', 'newspack-plugin' );
+
+		self::redirect(
+			$result,
+			$redirect_url,
+			'members',
+			'manager' === $role
+				/* translators: %s: member display name. */
+				? sprintf( __( '%s is now a manager.', 'newspack-plugin' ), $name )
+				/* translators: %s: member display name. */
+				: sprintf( __( '%s is no longer a manager.', 'newspack-plugin' ), $name )
 		);
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -25,6 +25,13 @@ class Group_Subscription {
 	const GROUP_SUBSCRIPTION_JOINED_META_KEY_PREFIX = '_newspack_group_subscription_joined_';
 
 	/**
+	 * Per-manager user meta key. Repeatable, with the subscription ID as the
+	 * value — mirroring the membership storage above. The owner is never
+	 * stored: ownership implies management.
+	 */
+	const GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY = '_newspack_group_subscription_manager';
+
+	/**
 	 * Build the per-subscription joined-at user_meta key.
 	 *
 	 * @param int $subscription_id Subscription ID.
@@ -107,7 +114,7 @@ class Group_Subscription {
 	 * @param string    $meta_key  Meta key.
 	 */
 	public static function maybe_reset_cache_on_user_meta( $meta_ids, $object_id, $meta_key ) {
-		if ( self::GROUP_SUBSCRIPTION_USER_META_KEY === $meta_key ) {
+		if ( in_array( $meta_key, [ self::GROUP_SUBSCRIPTION_USER_META_KEY, self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY ], true ) ) {
 			self::reset_cache();
 		}
 	}
@@ -168,15 +175,83 @@ class Group_Subscription {
 	 */
 	public static function get_managers( $subscription ) {
 		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		$managers     = [ $subscription ? $subscription->get_user_id() : 0 ];
+		if ( $subscription ) {
+			$stored = \get_users(
+				[
+					'fields'     => [ 'ID' ],
+					'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						[
+							'key'   => self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY,
+							'value' => $subscription->get_id(),
+						],
+					],
+				]
+			);
+			foreach ( $stored as $user ) {
+				$managers[] = (int) $user->ID;
+			}
+			$managers = array_values( array_unique( $managers ) );
+		}
 
 		/**
 		 * Filter the managers of a group subscription.
-		 * Currently this is only the subscription owner.
 		 *
 		 * @param int[] $member_ids The group manager user IDs.
 		 * @param WC_Subscription $subscription The subscription object.
 		 */
-		return apply_filters( 'newspack_group_subscription_managers', [ $subscription ? $subscription->get_user_id() : 0 ], $subscription );
+		return apply_filters( 'newspack_group_subscription_managers', $managers, $subscription );
+	}
+
+	/**
+	 * Promote a group member to manager.
+	 *
+	 * Only an existing member qualifies, and the owner is never stored —
+	 * ownership implies management. Storage mirrors membership: a repeatable
+	 * user meta with the subscription ID as the value.
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 * @param int                  $user_id      The member user ID.
+	 *
+	 * @return true|\WP_Error True on success.
+	 */
+	public static function add_manager( $subscription, $user_id ) {
+		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		$user_id      = absint( $user_id );
+		if ( ! self::is_group_subscription( $subscription ) ) {
+			return new \WP_Error( 'newspack_group_subscription_add_manager', __( 'Subscription not found.', 'newspack-plugin' ), [ 'status' => 404 ] );
+		}
+		if ( $user_id === (int) $subscription->get_user_id() ) {
+			return new \WP_Error( 'newspack_group_subscription_add_manager', __( 'The owner already manages this subscription.', 'newspack-plugin' ), [ 'status' => 400 ] );
+		}
+		if ( ! self::user_is_member( $user_id, $subscription ) ) {
+			return new \WP_Error( 'newspack_group_subscription_add_manager', __( 'Only an existing member can be made a manager.', 'newspack-plugin' ), [ 'status' => 400 ] );
+		}
+		if ( ! in_array( $user_id, self::get_managers( $subscription ), true ) ) {
+			\add_user_meta( $user_id, self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY, $subscription->get_id() );
+		}
+		return true;
+	}
+
+	/**
+	 * Demote a manager back to a regular member.
+	 *
+	 * @param \WC_Subscription|int $subscription The subscription object or ID.
+	 * @param int                  $user_id      The manager user ID.
+	 *
+	 * @return true|\WP_Error True on success.
+	 */
+	public static function remove_manager( $subscription, $user_id ) {
+		$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription );
+		$user_id      = absint( $user_id );
+		if ( ! self::is_group_subscription( $subscription ) ) {
+			return new \WP_Error( 'newspack_group_subscription_remove_manager', __( 'Subscription not found.', 'newspack-plugin' ), [ 'status' => 404 ] );
+		}
+		if ( $user_id === (int) $subscription->get_user_id() ) {
+			return new \WP_Error( 'newspack_group_subscription_remove_manager', __( 'The owner cannot be demoted.', 'newspack-plugin' ), [ 'status' => 400 ] );
+		}
+		\delete_user_meta( $user_id, self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY, $subscription->get_id() );
+		return true;
 	}
 
 	/**
@@ -217,6 +292,31 @@ class Group_Subscription {
 				continue;
 			}
 			$managed[] = $ids_only ? $sub->get_id() : $sub;
+		}
+
+		// Subscriptions the user manages without owning (a promoted manager),
+		// read from their own manager meta — the reverse of get_managers().
+		$have_ids = array_map(
+			function ( $sub ) {
+				return $sub instanceof \WC_Subscription ? $sub->get_id() : (int) $sub;
+			},
+			$managed
+		);
+		$manager_of = array_map( 'absint', (array) \get_user_meta( $user_id, self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY, false ) );
+		foreach ( $manager_of as $managed_id ) {
+			if ( in_array( $managed_id, $have_ids, true ) ) {
+				continue;
+			}
+			$sub = WooCommerce_Subscriptions::sanitize_subscription( $managed_id );
+			if ( ! $sub instanceof \WC_Subscription ) {
+				continue;
+			}
+			$settings = Group_Subscription_Settings::get_subscription_settings( $sub );
+			if ( empty( $settings['enabled'] ) ) {
+				continue;
+			}
+			$managed[]  = $ids_only ? $sub->get_id() : $sub;
+			$have_ids[] = $managed_id;
 		}
 
 		/**
@@ -302,6 +402,8 @@ class Group_Subscription {
 			}
 			if ( \delete_user_meta( $member_id, self::GROUP_SUBSCRIPTION_USER_META_KEY, $subscription->get_id() ) ) {
 				\delete_user_meta( $member_id, self::get_member_joined_meta_key( $subscription->get_id() ) );
+				// Leaving the group also ends any manager role — no orphaned managers.
+				\delete_user_meta( $member_id, self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY, $subscription->get_id() );
 				$members_removed[ $member_id ] = [
 					'email' => \get_userdata( $member_id )->user_email,
 					'url'   => \get_edit_user_link( $member_id ),

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -179,8 +179,9 @@ class Group_Subscription {
 		if ( $subscription ) {
 			$stored = \get_users(
 				[
-					'fields'     => [ 'ID' ],
-					'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'fields'      => [ 'ID' ],
+					'count_total' => false,
+					'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						[
 							'key'   => self::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY,
 							'value' => $subscription->get_id(),

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -38,6 +38,8 @@ $invite_link          = Group_Subscription_Invite::get_link_invite( $subscriptio
 $invite_link_url      = $invite_link ? Group_Subscription_Invite::get_link_invite_url( $subscription->get_id(), $current_user_id, $invite_link['key'] ) : '';
 $is_at_limit         = $member_limit > 0 && ( count( $members ) + count( $pending_invites ) ) >= $member_limit;
 $is_manageable       = Group_Subscription_MyAccount::is_subscription_manageable( $subscription );
+// Role changes (and touching peer managers) are the owner's call; a manager only manages plain members.
+$viewer_is_owner     = $current_user_id === (int) $subscription->get_user_id();
 $is_active           = Group_Subscription_MyAccount::is_subscription_active( $subscription );
 $active_tab          = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_unslash( $_GET['activeTab'] ) ) ) ? 'invites' : 'members'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $group_label_lower   = Group_Subscription::get_label_lower( 'singular' );
@@ -156,14 +158,20 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 			<tr>
 				<td data-title="<?php esc_attr_e( 'Name', 'newspack-plugin' ); ?>">
 					<strong><?php echo esc_html( newspack_get_user_display_label( $user ) ); ?></strong>
-					<?php if ( $is_owner ) : ?>
+					<?php if ( $user_id === $current_user_id ) : ?>
 						<?php esc_html_e( ' (you)', 'newspack-plugin' ); ?>
 					<?php endif; ?>
 				</td>
 				<td data-title="<?php esc_attr_e( 'Email', 'newspack-plugin' ); ?>"><a href="mailto:<?php echo esc_attr( sanitize_email( $user->user_email ) ); ?>"><?php echo esc_html( sanitize_email( $user->user_email ) ); ?></a></td>
 				<td data-title="<?php esc_attr_e( 'Role', 'newspack-plugin' ); ?>"><?php echo esc_html( $member_role ); ?></td>
-				<td class="newspack-my-account__group_subscription__members--actions order-actions <?php echo esc_attr( $is_manager ? 'newspack-my-account__group_subscription__members--actions--manager' : '' ); ?>">
-					<?php if ( ! $is_manager && $is_manageable ) : ?>
+				<td class="newspack-my-account__group_subscription__members--actions order-actions">
+					<?php
+					// The owner's row has no actions. A manager row is only actionable by
+					// the owner (peer managers are off limits); a manager viewing manages
+					// plain members only.
+					$show_row_actions = ! $is_owner && $is_manageable && ( $viewer_is_owner || ! $is_manager );
+					?>
+					<?php if ( $show_row_actions ) : ?>
 					<div class="newspack-ui__dropdown">
 						<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--small newspack-ui__dropdown__toggle newspack-ui__button--icon">
 							<?php Newspack_UI_Icons::print_svg( 'more' ); ?>
@@ -171,6 +179,20 @@ $is_completely_empty = empty( $members ) && empty( $all_invites );
 						</button>
 							<div class="newspack-ui__dropdown__content">
 								<ul>
+									<?php if ( $viewer_is_owner ) : ?>
+									<li>
+										<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+											<input type="hidden" name="action" value="newspack_group_subscription_set_manager_role">
+											<input type="hidden" name="subscription_id" value="<?php echo esc_attr( $subscription->get_id() ); ?>">
+											<input type="hidden" name="member_id" value="<?php echo esc_attr( $user->ID ); ?>">
+											<input type="hidden" name="role" value="<?php echo esc_attr( $is_manager ? 'member' : 'manager' ); ?>">
+											<?php wp_nonce_field( Group_Subscription_MyAccount::SET_MANAGER_ROLE_NONCE_ACTION ); ?>
+											<button type="submit" class="newspack-ui__button newspack-ui__button--ghost">
+												<?php echo esc_html( $is_manager ? __( 'Remove manager', 'newspack-plugin' ) : __( 'Make manager', 'newspack-plugin' ) ); ?>
+											</button>
+										</form>
+									</li>
+									<?php endif; ?>
 									<li>
 										<button
 											type="button"

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
@@ -69,9 +69,11 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 		</div>
 		<div class="newspack-my-account__subscription--actions">
 			<div class="newspack-my-account__subscription--actions-container">
-				<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--secondary">
-					<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
-				</a>
+				<?php if ( $user_id === (int) $subscription->get_user_id() ) : // Billing is the owner's surface; a manager never sees it. ?>
+					<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--secondary">
+						<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
+					</a>
+				<?php endif; ?>
 				<?php if ( $is_active && ! $is_completely_empty ) : ?>
 					<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
 						<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__dropdown__toggle">

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-managers.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-managers.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Tests for Group_Subscription manager storage (DSGNEWS-184 / NPPD-1815).
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ */
+
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * Test the manager role data layer: promote/demote, reverse lookups, and the
+ * membership-removal cleanup.
+ */
+class Test_Group_Subscription_Managers extends WP_UnitTestCase {
+
+	/**
+	 * User IDs to clean up.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = [];
+
+	/**
+	 * Include WC mocks.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		Group_Subscription::reset_cache();
+	}
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tear_down() {
+		global $subscriptions_database;
+		$subscriptions_database = [];
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a reader user (member fixture).
+	 *
+	 * @return int User ID.
+	 */
+	private function create_reader(): int {
+		$user_id = wp_insert_user(
+			[
+				'user_login' => 'user-' . wp_generate_password( 6, false ),
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'user-' . wp_generate_password( 6, false ) . '@test.com',
+				'role'       => 'subscriber',
+			]
+		);
+		$this->assertNotWPError( $user_id, 'Fixture user creation should succeed.' );
+		$this->user_ids[] = $user_id;
+		update_user_meta( $user_id, '_newspack_reader', true );
+		return $user_id;
+	}
+
+	/**
+	 * Create an active, group-enabled subscription owned by $owner_id.
+	 *
+	 * @param int $owner_id Owner user ID.
+	 * @return WC_Subscription
+	 */
+	private function create_group_subscription( int $owner_id ) {
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $owner_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		return $subscription;
+	}
+
+	/**
+	 * Promoting an existing member via add_manager(): get_managers() returns
+	 * the owner plus the manager, and user_is_manager() flips to true.
+	 */
+	public function test_add_manager_promotes_a_member() {
+		$owner_id     = $this->create_reader();
+		$member_id    = $this->create_reader();
+		$subscription = $this->create_group_subscription( $owner_id );
+		Group_Subscription::update_members( $subscription, [ $member_id ] );
+
+		$this->assertFalse( Group_Subscription::user_is_manager( $member_id, $subscription ), 'A plain member is not a manager.' );
+
+		$result = Group_Subscription::add_manager( $subscription, $member_id );
+
+		$this->assertTrue( $result, 'Promoting a member should succeed.' );
+		$this->assertEqualsCanonicalizing( [ $owner_id, $member_id ], Group_Subscription::get_managers( $subscription ), 'Managers are the owner plus the promoted member.' );
+		$this->assertTrue( Group_Subscription::user_is_manager( $member_id, $subscription ), 'The promoted member is a manager.' );
+	}
+
+	/**
+	 * The owner (implicit manager) and non-members are rejected by add_manager().
+	 */
+	public function test_add_manager_rejects_owner_and_non_members() {
+		$owner_id     = $this->create_reader();
+		$outsider_id  = $this->create_reader();
+		$subscription = $this->create_group_subscription( $owner_id );
+
+		$this->assertWPError( Group_Subscription::add_manager( $subscription, $owner_id ), 'The owner cannot be stored as a manager.' );
+		$this->assertWPError( Group_Subscription::add_manager( $subscription, $outsider_id ), 'A non-member cannot be made a manager.' );
+		$this->assertSame( [ $owner_id ], Group_Subscription::get_managers( $subscription ), 'Managers remain owner-only.' );
+	}
+
+	/**
+	 * Demoting via remove_manager() returns the manager to a plain member; the
+	 * owner is protected.
+	 */
+	public function test_remove_manager_demotes() {
+		$owner_id     = $this->create_reader();
+		$member_id    = $this->create_reader();
+		$subscription = $this->create_group_subscription( $owner_id );
+		Group_Subscription::update_members( $subscription, [ $member_id ] );
+		Group_Subscription::add_manager( $subscription, $member_id );
+
+		$this->assertTrue( Group_Subscription::remove_manager( $subscription, $member_id ), 'Demoting a manager should succeed.' );
+		$this->assertSame( [ $owner_id ], Group_Subscription::get_managers( $subscription ), 'Managers are back to owner-only.' );
+		$this->assertTrue( Group_Subscription::user_is_member( $member_id, $subscription ), 'The demoted manager remains a member.' );
+		$this->assertWPError( Group_Subscription::remove_manager( $subscription, $owner_id ), 'The owner cannot be demoted.' );
+	}
+
+	/**
+	 * Removing a member from the group clears their manager meta too.
+	 */
+	public function test_removing_a_member_clears_their_manager_role() {
+		$owner_id     = $this->create_reader();
+		$member_id    = $this->create_reader();
+		$subscription = $this->create_group_subscription( $owner_id );
+		Group_Subscription::update_members( $subscription, [ $member_id ] );
+		Group_Subscription::add_manager( $subscription, $member_id );
+
+		Group_Subscription::update_members( $subscription, [], [ $member_id ] );
+
+		$this->assertSame( [ $owner_id ], Group_Subscription::get_managers( $subscription ), 'Leaving the group ends the manager role.' );
+		$this->assertEmpty(
+			get_user_meta( $member_id, Group_Subscription::GROUP_SUBSCRIPTION_MANAGER_USER_META_KEY, false ),
+			'No orphaned manager meta remains.'
+		);
+	}
+
+	/**
+	 * A promoted manager's managed-subscriptions lookup includes the group they
+	 * manage without owning — this is what lights up their My Account access.
+	 */
+	public function test_managed_subscriptions_include_manager_of_groups() {
+		$owner_id     = $this->create_reader();
+		$member_id    = $this->create_reader();
+		$subscription = $this->create_group_subscription( $owner_id );
+		Group_Subscription::update_members( $subscription, [ $member_id ] );
+
+		Group_Subscription::reset_cache();
+		$this->assertNotContains( $subscription->get_id(), Group_Subscription::get_managed_subscriptions_for_user( $member_id, true ), 'A plain member manages nothing.' );
+
+		Group_Subscription::add_manager( $subscription, $member_id );
+
+		$this->assertContains( $subscription->get_id(), Group_Subscription::get_managed_subscriptions_for_user( $member_id, true ), 'A promoted manager manages the group.' );
+
+		Group_Subscription::remove_manager( $subscription, $member_id );
+
+		$this->assertNotContains( $subscription->get_id(), Group_Subscription::get_managed_subscriptions_for_user( $member_id, true ), 'A demoted manager loses the group.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Stacked on #539** (bases on its branch, so the two fold together on the prototype branch). Where #539 designs the admin side with mock data, this makes the manager role real on the front end: My Account now has three distinct experiences for a group's **owner**, **managers**, and **members**.

- **Storage (real, not mock):** managers are stored as repeatable user meta (`_newspack_group_subscription_manager`, value = subscription ID), exactly mirroring how membership is stored. `get_managers()` returns owner + stored managers (existing filter preserved), `add_manager()` / `remove_manager()` guard the owner and non-members, and removing a member from the group clears their manager role with it. The implementation ticket (NPPD-1753) inherits this data layer instead of rebuilding it.
- **Owner:** the members-panel kebab becomes role-aware — member rows get **Make manager** / Remove member; manager rows (which previously had no actions at all) get **Remove manager** / Remove member. Role changes are instant form POSTs to a new owner-gated `admin-post` handler, landing back with "{Name} is now a manager." — no confirm modal, matching the admin prototype decision.
- **Manager:** `get_managed_subscriptions_for_user()` now includes manager-of subscriptions, which lights up the Group nav entry, multi-group picker, and page access with zero template work (every existing handler already gates on `user_is_manager()`). They get the full management view — invite menu, invite links, seat count, **Request more seats** — but the **View subscription** button is hidden: billing is the owner's surface. Their kebab appears only on plain member rows (Remove member); peer managers are off limits.
- **Member:** unchanged — view-only subscription, no group page access. The "(you)" row marker now follows the current user rather than being owner-only.

Design decisions recorded on NPPD-1815: owner-only promote/demote, billing hidden (not disabled) for managers, instant role changes, everyone joins as a member.

Part of DSGNEWS-184.

https://github.com/user-attachments/assets/a157dac0-617e-4b1b-86fb-1dddb669f6f2

### How to test the changes in this Pull Request:

1. As a group owner (e.g. `eleanor.whitfield` / group `/my-account/group/2931/`), open a member row's kebab: **Make manager** applies instantly and redirects back with "{Name} is now a manager."; the row's role reads Manager.
2. The manager row's kebab now offers **Remove manager** and **Remove member**; the owner row has none.
3. Log in as the promoted manager: the Group entry appears in My Account, and the group page renders with the invite menu, seat count, and **Request more seats** — but no **View subscription** button in the header.
4. As the manager, verify kebabs appear only on plain member rows (Remove member only) — not on the owner, other managers, or your own row — and that "(you)" marks your row.
5. Invite by email, copy/regenerate/disable the invite link, and remove a member as the manager — all existing handlers work (they were already `user_is_manager()`-gated).
6. As the owner, **Remove manager** demotes back; as anyone else, POSTing the role-change action is rejected ("Only the owner can change who manages this group.").
7. Remove a manager from the group entirely (Remove member): their manager role is cleared with the membership.
8. Run `n test-php --group WooCommerce_Subscriptions_Integration` — 44 tests pass, including the new manager storage suite.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?