### PR TITLE
fix(audience): avoid [object Object] in segment summary

### DIFF
--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -33,7 +33,7 @@ type DraggableItemAction = {
 type DraggableItem = {
 	id: string | number;
 	title: string;
-	description?: string;
+	description?: React.ReactNode;
 	badgeLevel: 'default' | 'success' | 'info' | 'warning' | 'error';
 	badgeText: string;
 	toggleChecked?: boolean;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -185,7 +185,23 @@ export const segmentDescription = segment => {
 		}
 	}
 
-	return descriptionMessages.join( ' | ' );
+	if ( ! descriptionMessages.length ) {
+		return null;
+	}
+
+	// Criteria messages can be React elements (some `criteriaMessage` filters resolve
+	// their labels asynchronously). Interleave the separators as nodes instead of
+	// `.join( ' | ' )`, which would coerce those elements to the string "[object Object]".
+	return (
+		<Fragment>
+			{ descriptionMessages.map( ( message, index ) => (
+				<Fragment key={ index }>
+					{ index > 0 && ' | ' }
+					{ message }
+				</Fragment>
+			) ) }
+		</Fragment>
+	);
 };
 
 const getFavoriteCategoryNamesFn = async favoriteCategories => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -18,10 +18,11 @@ import { render, waitFor } from '@testing-library/react';
  */
 import apiFetch from '@wordpress/api-fetch';
 
-jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 // `utils.js` captures `window.newspackAudienceCampaigns.criteria` at module-load
-// time, so the global must be set before the module is required.
+// time, so the global must be set before the module is loaded (see the dynamic
+// import in `beforeAll`).
 const CRITERIA = [
 	{
 		id: 'newsletter',
@@ -43,12 +44,12 @@ const CRITERIA = [
 describe( 'segmentDescription', () => {
 	let segmentDescription;
 
-	beforeAll( () => {
+	beforeAll( async () => {
 		window.newspackAudienceCampaigns = {
 			api: '/newspack/v1/wizard/newspack-audience-campaigns',
 			criteria: CRITERIA,
 		};
-		( { segmentDescription } = require( './utils' ) );
+		( { segmentDescription } = await import( './utils' ) );
 	} );
 
 	it( 'renders an element-valued criteria message as a label, not "[object Object]"', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests for the campaigns wizard utils.
+ *
+ * Regression coverage for NPPD-1852: a segment summary rendered the literal
+ * string "[object Object]" when a criteria message resolved to a React element
+ * (e.g. the async-resolved "Not subscribed to: <list>" label). `segmentDescription`
+ * must return renderable React nodes, not a `.join( ' | ' )`-ed string that would
+ * coerce those elements to "[object Object]".
+ */
+
+/**
+ * External dependencies
+ */
+import { render, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
+
+// `utils.js` captures `window.newspackAudienceCampaigns.criteria` at module-load
+// time, so the global must be set before the module is required.
+const CRITERIA = [
+	{
+		id: 'newsletter',
+		category: 'newsletter',
+		name: 'Newsletter',
+		options: [
+			{ label: 'Subscribers and non-subscribers', value: '' },
+			{ label: 'Subscribers', value: 'subscribers' },
+			{ label: 'Non-subscribers', value: 'non-subscribers' },
+		],
+	},
+	{
+		id: 'not_subscribed_lists',
+		category: 'newsletter',
+		name: 'Newsletter',
+	},
+];
+
+describe( 'segmentDescription', () => {
+	let segmentDescription;
+
+	beforeAll( () => {
+		window.newspackAudienceCampaigns = {
+			api: '/newspack/v1/wizard/newspack-audience-campaigns',
+			criteria: CRITERIA,
+		};
+		( { segmentDescription } = require( './utils' ) );
+	} );
+
+	it( 'renders an element-valued criteria message as a label, not "[object Object]"', async () => {
+		apiFetch.mockResolvedValue( [ { id: 1, name: 'Weekly Digest' } ] );
+
+		const segment = {
+			configuration: { is_disabled: false },
+			criteria: [
+				{ criteria_id: 'newsletter', value: 'non-subscribers' },
+				{ criteria_id: 'not_subscribed_lists', value: [ 1 ] },
+			],
+		};
+
+		const { container } = render( <div>{ segmentDescription( segment ) }</div> );
+
+		// The plain-string criterion still renders.
+		expect( container.textContent ).toContain( 'Newsletter: Non-subscribers' );
+		// Regression: the element-valued criterion must not stringify to "[object Object]".
+		expect( container.textContent ).not.toContain( '[object Object]' );
+		// Once the list names resolve, it renders the human-readable label.
+		await waitFor( () => expect( container.textContent ).toContain( 'Not subscribed to:' ) );
+		await waitFor( () => expect( container.textContent ).toContain( 'Weekly Digest' ) );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In **Audience → Campaigns**, a segment's summary line could display the literal text `[object Object]` in place of a criterion whose label is resolved asynchronously — newsletter lists (subscribed / not subscribed), WooCommerce subscriptions, memberships, and favorite categories. This restores those criteria to their human-readable labels (e.g. `Not subscribed to: Weekly Digest`) in both the **Segments** list and the **Campaigns** segment-group view.

Those criteria render as small React components (they fetch the list/product/plan names on demand). The segment-summary builder was flattening every criterion into a single string with `Array.join()`, which coerces a React element to the string `[object Object]`. The summary is now assembled as React nodes so those elements render normally, while plain-string criteria are unchanged.

This is a regression from the campaigns wizard light UI refresh (#4588), which replaced the previous node-based rendering with a joined string. Cosmetic / display only — segment matching itself was never affected.

Closes NPPD-1852.

### How to test the changes in this Pull Request:

1. In `wp-admin`, go to **Audience → Campaigns → Segments** and add or edit a segment.
2. Under **Newsletters**, set **Newsletter** to `Non-subscribers`, and pick at least one list for **Not subscribed to** (or **Subscribed to**). Save.
3. Back on the **Segments** list, confirm the summary reads e.g. `Newsletter: Non-subscribers | Not subscribed to: <List name>` — **not** `[object Object]`.
4. Repeat for the other asynchronously-resolved criteria and confirm each shows a readable label rather than `[object Object]`:
   - **Reader Revenue → Has / Does not have active subscription(s)** (WooCommerce subscription products)
   - **Reader Revenue → Has / Does not have active membership(s)** (membership plans)
   - **Reader Engagement → Favorite Categories**
5. Open **Audience → Campaigns** (the campaigns screen) and confirm the same segments render their labels correctly in the grouped segment descriptions.
6. Delete a list/subscription/plan referenced by a segment and confirm the summary shows its `Deleted …` label (not `[object Object]`).
7. Confirm plain-string criteria are unchanged (e.g. **Articles read**, **Referrer sources**, and any integration criteria such as dynamic-pricing "Has available deal").

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? Added a `segmentDescription` regression test asserting an async, element-valued criterion renders a label instead of `[object Object]`.
* [ ] Have you successfully run tests with your changes locally? Not run locally (this worktree has no installed dependencies); the new JS test runs in CI on this PR.
