### PR TITLE
feat(newsletters): dated per-ad impression/click stats (NPPD-1861)

### DIFF
--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -690,6 +690,8 @@ final class Ads {
 			}
 			$impressions++;
 			update_post_meta( $ad_id, 'tracking_impressions', $impressions );
+			// Also record a dated row so impressions can be reported over a timeframe.
+			Tracking\Ad_Stats::record_impressions( $ad_id, $newsletter_id, 1 );
 		}
 	}
 
@@ -711,6 +713,8 @@ final class Ads {
 			}
 			$impressions += $views;
 			update_post_meta( $ad_id, 'tracking_impressions', $impressions );
+			// Also record a dated row so impressions can be reported over a timeframe.
+			Tracking\Ad_Stats::record_impressions( $ad_id, $newsletter_id, $views );
 		}
 	}
 

--- a/plugins/newspack-newsletters/includes/tracking/class-ad-stats.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-ad-stats.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Newspack Newsletters ad stats — dated per-ad impression/click rows.
+ *
+ * Each ad post already keeps a lifetime cumulative counter in its
+ * `tracking_impressions` / `tracking_clicks` meta. That's fine for the ad-list
+ * admin columns but can't answer timeframe-scoped questions ("impressions in the
+ * last 30 days"). This table records the same events bucketed by UTC day so
+ * reporting (e.g. Newspack Insights) can sum over an arbitrary date range.
+ *
+ * Rows are aggregated per (ad_id, newsletter_id, day) via an upsert rather than
+ * one row per event, to keep the table small under high impression volume.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Ad_Stats class.
+ */
+class Ad_Stats {
+	const TABLE_NAME           = 'newspack_newsletters_ad_stats';
+	const TABLE_VERSION        = '1.0';
+	const TABLE_VERSION_OPTION = '_newspack_newsletters_ad_stats_version';
+	const CRON_HOOK            = 'np_newsletters_ad_stats_cleanup';
+
+	/**
+	 * Fallback newsletter ID for click rows whose source newsletter is unknown
+	 * (e.g. links proxied before newsletter attribution shipped). Clicks with a
+	 * known newsletter share the real newsletter's row; impressions always carry
+	 * a real newsletter ID.
+	 */
+	const UNKNOWN_NEWSLETTER_ID = 0;
+
+	/**
+	 * How long to retain rows. ~25 months keeps year-over-year comparisons
+	 * intact while bounding table growth.
+	 */
+	const RETENTION_MONTHS = 25;
+
+	/**
+	 * Rows deleted per statement in cleanup(), and the max batches per run.
+	 * The batch keeps any single DELETE lock small; the loop (bounded by
+	 * MAX_BATCHES as a runaway guard) drains a backlog larger than one batch —
+	 * a high-send site with a big inventory can exceed BATCH expired rows/week.
+	 */
+	const CLEANUP_BATCH      = 1000;
+	const CLEANUP_MAX_BATCHES = 1000;
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init() {
+		register_activation_hook( self::plugin_main_file(), [ __CLASS__, 'create_custom_table' ] );
+		add_action( 'init', [ __CLASS__, 'check_update_version' ] );
+		add_action( 'init', [ __CLASS__, 'cron_init' ] );
+		add_action( self::CRON_HOOK, [ __CLASS__, 'cleanup' ] );
+	}
+
+	/**
+	 * Absolute path to the plugin's main file, for the (de)activation hooks.
+	 *
+	 * `NEWSPACK_NEWSLETTERS_PLUGIN_FILE` is `plugin_dir_path()` — the plugin
+	 * directory, not a file — so passing it to register_(de)activation_hook()
+	 * computes the wrong `plugin_basename()` and the hooks never fire (which is
+	 * why the weekly cleanup cron would otherwise be orphaned on deactivation).
+	 *
+	 * @codeCoverageIgnore
+	 */
+	private static function plugin_main_file(): string {
+		return NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'newspack-newsletters.php';
+	}
+
+	/**
+	 * Schedule the periodic cleanup.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function cron_init() {
+		\register_deactivation_hook( self::plugin_main_file(), [ __CLASS__, 'cron_deactivate' ] );
+		if ( ! \wp_next_scheduled( self::CRON_HOOK ) ) {
+			\wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Clear the cleanup cron.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function cron_deactivate() {
+		\wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	/**
+	 * Get the custom table name.
+	 */
+	public static function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Create the table if it is missing or the version has changed.
+	 *
+	 * See: https://codex.wordpress.org/Creating_Tables_with_Plugins
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function check_update_version() {
+		if ( self::TABLE_VERSION !== \get_option( self::TABLE_VERSION_OPTION, false ) ) {
+			self::create_custom_table();
+			\update_option( self::TABLE_VERSION_OPTION, self::TABLE_VERSION );
+		}
+	}
+
+	/**
+	 * Create the custom DB table.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function create_custom_table() {
+		global $wpdb;
+		$table_name      = self::get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		// Columns: ad_id (newspack_nl_ads_cpt post), newsletter_id (source newsletter;
+		// always real for impressions, real for clicks when the proxy carried `nid`,
+		// 0 for clicks whose source newsletter is unknown — see UNKNOWN_NEWSLETTER_ID),
+		// stat_date (UTC day), and the impressions/clicks day counters.
+		// Note: no inline SQL comments below — dbDelta splits on ";", so a semicolon
+		// inside a comment would corrupt the statement.
+		$sql = "CREATE TABLE $table_name (
+			ad_id bigint(20) unsigned NOT NULL,
+			newsletter_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			stat_date date NOT NULL,
+			impressions int(11) unsigned NOT NULL DEFAULT 0,
+			clicks int(11) unsigned NOT NULL DEFAULT 0,
+			PRIMARY KEY  (ad_id, newsletter_id, stat_date),
+			KEY stat_date (stat_date)
+		) $charset_collate;";
+
+		// Run dbDelta unconditionally (not guarded on table existence): it creates
+		// the table when missing and applies ALTERs when the schema changes, so a
+		// TABLE_VERSION bump actually migrates the schema.
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Record impressions for an ad within a newsletter, bucketed by UTC day.
+	 *
+	 * @param int $ad_id         Ad post ID.
+	 * @param int $newsletter_id Newsletter post ID the impression came from.
+	 * @param int $count         Number of impressions to add (default 1).
+	 */
+	public static function record_impressions( $ad_id, $newsletter_id, $count = 1 ) {
+		self::increment( (int) $ad_id, (int) $newsletter_id, 'impressions', (int) $count );
+	}
+
+	/**
+	 * Record clicks for an ad, bucketed by UTC day.
+	 *
+	 * When the source newsletter is known, the click lands on the same
+	 * `(ad_id, newsletter_id, stat_date)` row as that newsletter's impressions.
+	 * When it isn't (e.g. links proxied before newsletter attribution shipped),
+	 * it falls back to the UNKNOWN_NEWSLETTER_ID sentinel.
+	 *
+	 * @param int $ad_id         Ad post ID.
+	 * @param int $newsletter_id Source newsletter post ID, or 0 if unknown.
+	 * @param int $count         Number of clicks to add (default 1).
+	 */
+	public static function record_clicks( $ad_id, $newsletter_id = self::UNKNOWN_NEWSLETTER_ID, $count = 1 ) {
+		$newsletter_id = $newsletter_id > 0 ? (int) $newsletter_id : self::UNKNOWN_NEWSLETTER_ID;
+		self::increment( (int) $ad_id, $newsletter_id, 'clicks', (int) $count );
+	}
+
+	/**
+	 * Upsert a daily counter for an ad.
+	 *
+	 * @param int    $ad_id         Ad post ID.
+	 * @param int    $newsletter_id Newsletter post ID (0 when not applicable).
+	 * @param string $field         Column to increment: 'impressions' or 'clicks'.
+	 * @param int    $count         Amount to add.
+	 */
+	private static function increment( $ad_id, $newsletter_id, $field, $count ) {
+		global $wpdb;
+
+		if ( $ad_id <= 0 || $count <= 0 ) {
+			return;
+		}
+
+		$table = self::get_table_name();
+		$date  = \current_time( 'Y-m-d', true ); // UTC day.
+
+		// A fully literal query per field keeps the column name out of any
+		// interpolation; only the two known fields are supported.
+		if ( 'impressions' === $field ) {
+			// Impressions must be attributed to a real newsletter. newsletter_id 0 is
+			// reserved as the click sentinel, so drop any impression that lacks one
+			// rather than merge it into (and corrupt) a click row.
+			if ( $newsletter_id <= 0 ) {
+				return;
+			}
+			$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					'INSERT INTO %i ( ad_id, newsletter_id, stat_date, impressions ) VALUES ( %d, %d, %s, %d )
+					ON DUPLICATE KEY UPDATE impressions = impressions + VALUES( impressions )',
+					$table,
+					$ad_id,
+					$newsletter_id,
+					$date,
+					$count
+				)
+			);
+		} elseif ( 'clicks' === $field ) {
+			$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					'INSERT INTO %i ( ad_id, newsletter_id, stat_date, clicks ) VALUES ( %d, %d, %s, %d )
+					ON DUPLICATE KEY UPDATE clicks = clicks + VALUES( clicks )',
+					$table,
+					$ad_id,
+					$newsletter_id,
+					$date,
+					$count
+				)
+			);
+		}
+	}
+
+	/**
+	 * Delete rows older than the retention window, in bounded batches.
+	 *
+	 * Loops CLEANUP_BATCH rows at a time until a batch deletes fewer than the
+	 * limit (backlog drained) — a single LIMITed DELETE could otherwise fall
+	 * permanently behind a high-send site that expires more than one batch of
+	 * rows per weekly run. CLEANUP_MAX_BATCHES caps the loop as a runaway guard;
+	 * whatever remains is drained on the next run.
+	 *
+	 * @return int Total rows deleted this run.
+	 */
+	public static function cleanup(): int {
+		global $wpdb;
+		$table   = self::get_table_name();
+		$deleted = 0;
+		for ( $batch = 0; $batch < self::CLEANUP_MAX_BATCHES; $batch++ ) {
+			$rows = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					// UTC_DATE() (not CURDATE()) to match how stat_date is written (UTC day),
+					// so retention isn't skewed by the DB server timezone.
+					'DELETE FROM %i WHERE stat_date < ( UTC_DATE() - INTERVAL %d MONTH ) LIMIT %d',
+					$table,
+					self::RETENTION_MONTHS,
+					self::CLEANUP_BATCH
+				)
+			);
+			// query() returns false on error (false < CLEANUP_BATCH → loop ends).
+			$deleted += (int) $rows;
+			if ( $rows < self::CLEANUP_BATCH ) {
+				break;
+			}
+		}
+		return $deleted;
+	}
+}
+Ad_Stats::init();

--- a/plugins/newspack-newsletters/includes/tracking/class-click.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-click.php
@@ -81,20 +81,24 @@ final class Click {
 	/**
 	 * Get proxied URL.
 	 *
-	 * @param int    $newsletter_id Newsletter ID.
+	 * @param int    $ad_id         Ad post ID (encoded as the tracked `id`).
 	 * @param string $url           Destination URL.
+	 * @param int    $newsletter_id Source newsletter post ID (encoded as `nid`), when known.
 	 *
 	 * @return string Proxied URL.
 	 */
-	public static function get_proxied_url( $newsletter_id, $url ) {
-		return add_query_arg(
-			[
-				'id'  => $newsletter_id,
-				'url' => urlencode( $url ),
-				'em'  => Utils::get_email_address_tag(),
-			],
-			self::get_tracking_url()
-		);
+	public static function get_proxied_url( $ad_id, $url, $newsletter_id = 0 ) {
+		$args = [
+			'id'  => $ad_id,
+			'url' => urlencode( $url ),
+			'em'  => Utils::get_email_address_tag(),
+		];
+		// Carry the source newsletter so the click can be attributed to it (the ad
+		// alone can't tell us which newsletter it was clicked from).
+		if ( $newsletter_id > 0 ) {
+			$args['nid'] = $newsletter_id;
+		}
+		return add_query_arg( $args, self::get_tracking_url() );
 	}
 
 	/**
@@ -116,37 +120,52 @@ final class Click {
 		if ( $post->post_type !== Ads::CPT ) {
 			return $url;
 		}
-		return self::get_proxied_url( $post->ID, $url );
+		// The renderer tracks the newsletter currently being rendered; capture it so
+		// the click can be attributed to the source newsletter. Guarded defensively.
+		$newsletter_id = 0;
+		if ( class_exists( '\Newspack_Newsletters_Renderer' ) && ! empty( \Newspack_Newsletters_Renderer::$newsletter_id ) ) {
+			$newsletter_id = (int) \Newspack_Newsletters_Renderer::$newsletter_id;
+		}
+		return self::get_proxied_url( $post->ID, $url, $newsletter_id );
 	}
 
 	/**
 	 * Track click.
 	 *
-	 * @param int    $newsletter_id Newsletter ID.
+	 * Only ad links are proxied, so the tracked id is the clicked ad's post ID.
+	 *
+	 * @param int    $ad_id         Clicked ad post ID.
 	 * @param string $email_address Email address.
 	 * @param string $url           Destination URL.
+	 * @param int    $newsletter_id Source newsletter post ID, when known (0 otherwise).
 	 *
 	 * @return void
 	 */
-	public static function track_click( $newsletter_id, $email_address, $url ) {
-		if ( ! $newsletter_id || ! $email_address || ! Admin::is_tracking_click_enabled() ) {
+	public static function track_click( $ad_id, $email_address, $url, $newsletter_id = 0 ) {
+		if ( ! $ad_id || ! $email_address || ! Admin::is_tracking_click_enabled() ) {
 			return;
 		}
 
-		$clicks = \get_post_meta( $newsletter_id, 'tracking_clicks', true );
+		$clicks = \get_post_meta( $ad_id, 'tracking_clicks', true );
 		if ( ! $clicks ) {
 			$clicks = 0;
 		}
 		$clicks++;
-		\update_post_meta( $newsletter_id, 'tracking_clicks', $clicks );
+		\update_post_meta( $ad_id, 'tracking_clicks', $clicks );
+
+		// Also record a dated row so clicks can be reported over a timeframe, attributed
+		// to the source newsletter when known (0 falls back to the click sentinel).
+		Ad_Stats::record_clicks( $ad_id, $newsletter_id, 1 );
 
 		/**
 		 * Fires when a click is tracked.
 		 *
-		 * @param int    $newsletter_id Newsletter ID.
+		 * @param int    $ad_id         Clicked ad post ID.
+		 * @param string $email_address Email address.
 		 * @param string $url           Destination URL.
+		 * @param int    $newsletter_id Source newsletter post ID, when known (0 otherwise).
 		 */
-		do_action( 'newspack_newsletters_tracking_click', $newsletter_id, $email_address, $url );
+		do_action( 'newspack_newsletters_tracking_click', $ad_id, $email_address, $url, $newsletter_id );
 	}
 
 	/**
@@ -160,7 +179,8 @@ final class Click {
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$newsletter_id = \intval( $_GET['id'] ?? 0 );
+		$ad_id         = \intval( $_GET['id'] ?? 0 );
+		$newsletter_id = \intval( $_GET['nid'] ?? 0 );
 		$email_address = \sanitize_email( $_GET['em'] ?? '' );
 		// We need to decode the URL before redirecting, as it may contain encoded characters.
 		$url = html_entity_decode( esc_url_raw( \wp_unslash( $_GET['url'] ?? '' ) ) );
@@ -170,10 +190,11 @@ final class Click {
 		// If the redirect URL does not point to the site, double-check it is actually a URL within the email.
 		$url_without_query_args = untrailingslashit( strtok( $url, '?' ) );
 		if ( false === strpos( $url_without_query_args, \get_site_url() ) ) {
-			$newsletter_content = (string) get_post_meta( $newsletter_id, 'newspack_email_html', true );
+			// The tracked id is the ad post; its rendered email HTML holds the link.
+			$ad_content = (string) get_post_meta( $ad_id, 'newspack_email_html', true );
 			if (
-				false === stripos( $newsletter_content, $url_without_query_args ) &&
-				false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) // URL might be encoded via a block pattern.
+				false === stripos( $ad_content, $url_without_query_args ) &&
+				false === stripos( $ad_content, urlencode( $url_without_query_args ) ) // URL might be encoded via a block pattern.
 			) {
 				\wp_die( 'Invalid URL', '', 400 );
 				exit;
@@ -201,7 +222,7 @@ final class Click {
 
 		// Don't track if the user is a logged-in editor or admin user.
 		if ( ! $is_admin_user ) {
-			self::track_click( $newsletter_id, $email_address, $url );
+			self::track_click( $ad_id, $email_address, $url, $newsletter_id );
 		}
 
 		if ( $with_redirect ) {

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -71,6 +71,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscription-attempts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/ads/class-ads.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-utils.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-ad-stats.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-pixel.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-click.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.php';

--- a/plugins/newspack-newsletters/tests/test-ad-stats.php
+++ b/plugins/newspack-newsletters/tests/test-ad-stats.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Test Ad_Stats — dated per-ad impression/click rows.
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack_Newsletters\Tracking\Ad_Stats;
+use Newspack_Newsletters\Tracking\Click;
+use Newspack_Newsletters\Ads;
+
+/**
+ * Ad_Stats test.
+ */
+class Ad_Stats_Test extends WP_UnitTestCase {
+	/**
+	 * Reset the table between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wpdb;
+		// Guarantee a clean, current-schema table for each test regardless of any
+		// persisted version option in the test database.
+		$table = Ad_Stats::get_table_name();
+		$wpdb->query( "DROP TABLE IF EXISTS $table" ); // phpcs:ignore
+		Ad_Stats::create_custom_table();
+	}
+
+	/**
+	 * Fetch a single stats row.
+	 *
+	 * @param int $ad_id         Ad post ID.
+	 * @param int $newsletter_id Newsletter post ID.
+	 *
+	 * @return object|null
+	 */
+	private function get_row( $ad_id, $newsletter_id ) {
+		global $wpdb;
+		return $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE ad_id = %d AND newsletter_id = %d AND stat_date = %s',
+				Ad_Stats::get_table_name(),
+				$ad_id,
+				$newsletter_id,
+				current_time( 'Y-m-d', true )
+			)
+		);
+	}
+
+	/**
+	 * The custom table version option is set.
+	 */
+	public function test_db_version() {
+		self::assertEquals( Ad_Stats::TABLE_VERSION, get_option( Ad_Stats::TABLE_VERSION_OPTION ) );
+	}
+
+	/**
+	 * Repeated impression records aggregate into a single daily row.
+	 */
+	public function test_record_impressions_aggregates_by_day() {
+		Ad_Stats::record_impressions( 111, 222, 1 );
+		Ad_Stats::record_impressions( 111, 222, 4 );
+
+		$row = $this->get_row( 111, 222 );
+		self::assertNotNull( $row );
+		self::assertEquals( 5, (int) $row->impressions );
+		self::assertEquals( 0, (int) $row->clicks );
+	}
+
+	/**
+	 * Repeated click records aggregate under the unknown-newsletter sentinel.
+	 */
+	public function test_record_clicks_aggregates_under_sentinel() {
+		Ad_Stats::record_clicks( 111 );
+		Ad_Stats::record_clicks( 111 );
+
+		$row = $this->get_row( 111, Ad_Stats::UNKNOWN_NEWSLETTER_ID );
+		self::assertNotNull( $row );
+		self::assertEquals( 2, (int) $row->clicks );
+		self::assertEquals( 0, (int) $row->impressions );
+	}
+
+	/**
+	 * A click with a known newsletter shares that newsletter's row, so
+	 * impressions and clicks coexist in one (ad_id, newsletter_id, day) row.
+	 */
+	public function test_click_with_newsletter_shares_impression_row() {
+		Ad_Stats::record_impressions( 111, 222, 3 );
+		Ad_Stats::record_clicks( 111, 222 );
+
+		$row = $this->get_row( 111, 222 );
+		self::assertNotNull( $row );
+		self::assertEquals( 3, (int) $row->impressions );
+		self::assertEquals( 1, (int) $row->clicks );
+
+		// No stray sentinel row was created.
+		self::assertNull( $this->get_row( 111, Ad_Stats::UNKNOWN_NEWSLETTER_ID ) );
+	}
+
+	/**
+	 * A click with an unknown newsletter falls back to the sentinel row and
+	 * stays separate from impressions.
+	 */
+	public function test_click_without_newsletter_uses_sentinel() {
+		Ad_Stats::record_impressions( 111, 222, 3 );
+		Ad_Stats::record_clicks( 111 );
+
+		$impression_row = $this->get_row( 111, 222 );
+		$click_row      = $this->get_row( 111, Ad_Stats::UNKNOWN_NEWSLETTER_ID );
+
+		self::assertEquals( 3, (int) $impression_row->impressions );
+		self::assertEquals( 0, (int) $impression_row->clicks );
+		self::assertEquals( 1, (int) $click_row->clicks );
+		self::assertEquals( 0, (int) $click_row->impressions );
+	}
+
+	/**
+	 * Invalid input is ignored (no row written).
+	 */
+	public function test_invalid_input_is_ignored() {
+		Ad_Stats::record_impressions( 0, 222, 1 );  // No ad ID.
+		Ad_Stats::record_impressions( 111, 222, 0 ); // Zero count.
+		Ad_Stats::record_impressions( 111, 0, 1 );   // No newsletter — would collide with the click sentinel.
+
+		global $wpdb;
+		$count = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . Ad_Stats::get_table_name() ); // phpcs:ignore
+		self::assertEquals( 0, $count );
+	}
+
+	/**
+	 * Ads::track_ad_impression writes a dated row alongside the lifetime counter.
+	 */
+	public function test_track_ad_impression_writes_dated_row() {
+		$ad_id         = $this->factory->post->create( [ 'post_type' => Ads::CPT ] );
+		$newsletter_id = $this->factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		update_post_meta( $newsletter_id, 'inserted_ads', [ $ad_id ] );
+
+		Ads::track_ad_impression( $newsletter_id, 'fake@email.com' );
+		Ads::bulk_track_ad_impression( $newsletter_id, 5 );
+
+		$row = $this->get_row( $ad_id, $newsletter_id );
+		self::assertNotNull( $row );
+		self::assertEquals( 6, (int) $row->impressions );
+	}
+
+	/**
+	 * A tracked ad-link click writes a dated click row keyed by the ad ID.
+	 */
+	public function test_handle_click_writes_dated_row() {
+		$content = "<!-- wp:paragraph -->\n<p><a href=\"https://google.com\">Link</a></p>\n<!-- /wp:paragraph -->";
+		$ad_id   = $this->factory->post->create(
+			[
+				'post_type'    => Ads::CPT,
+				'post_content' => $content,
+			]
+		);
+		update_post_meta( $ad_id, 'newspack_email_html', $content );
+
+		$_GET['np_newsletters_click'] = 1;
+		$_GET['id']                   = $ad_id;
+		$_GET['nid']                  = 222;
+		$_GET['em']                   = 'fake@email.com';
+		$_GET['url']                  = 'https://google.com';
+		Click::handle_click( false );
+
+		// The click is attributed to the source newsletter carried by `nid`.
+		$row = $this->get_row( $ad_id, 222 );
+		self::assertNotNull( $row );
+		self::assertEquals( 1, (int) $row->clicks );
+
+		unset( $_GET['np_newsletters_click'], $_GET['id'], $_GET['nid'], $_GET['em'], $_GET['url'] );
+	}
+
+	/**
+	 * A proxied ad link carries the current newsletter as `nid`.
+	 */
+	public function test_process_link_carries_newsletter_id() {
+		$ad_id = $this->factory->post->create( [ 'post_type' => Ads::CPT ] );
+		$ad    = get_post( $ad_id );
+
+		\Newspack_Newsletters_Renderer::$newsletter_id = 222;
+		$proxied = Click::process_link( 'https://google.com', 'https://google.com', $ad );
+		\Newspack_Newsletters_Renderer::$newsletter_id = null;
+
+		$args = [];
+		wp_parse_str( (string) wp_parse_url( $proxied, PHP_URL_QUERY ), $args );
+		self::assertEquals( $ad_id, (int) $args['id'] );
+		self::assertEquals( 222, (int) $args['nid'] );
+	}
+
+	/**
+	 * Cleanup deletes rows older than the retention window.
+	 */
+	public function test_cleanup_removes_old_rows() {
+		global $wpdb;
+		$table = Ad_Stats::get_table_name();
+
+		// A fresh row and a row well past the retention window.
+		Ad_Stats::record_impressions( 111, 222, 1 );
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table,
+			[
+				'ad_id'         => 999,
+				'newsletter_id' => 888,
+				'stat_date'     => gmdate( 'Y-m-d', strtotime( '-' . ( Ad_Stats::RETENTION_MONTHS + 1 ) . ' months' ) ),
+				'impressions'   => 1,
+			],
+			[ '%d', '%d', '%s', '%d' ]
+		);
+
+		self::assertEquals( 2, (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" ) ); // phpcs:ignore
+
+		$deleted = Ad_Stats::cleanup();
+
+		self::assertEquals( 1, $deleted );
+		self::assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" ) ); // phpcs:ignore
+		self::assertNotNull( $this->get_row( 111, 222 ) );
+	}
+
+	/**
+	 * A backlog larger than one delete batch is fully drained in a single run
+	 * (the loop keeps going until a batch clears fewer than CLEANUP_BATCH rows).
+	 */
+	public function test_cleanup_drains_multiple_batches() {
+		global $wpdb;
+		$table  = Ad_Stats::get_table_name();
+		$old    = gmdate( 'Y-m-d', strtotime( '-' . ( Ad_Stats::RETENTION_MONTHS + 1 ) . ' months' ) );
+		$total  = Ad_Stats::CLEANUP_BATCH + 5; // Just over one batch → forces a 2nd iteration.
+
+		// Bulk-insert expired rows with distinct (ad_id) so each is its own PK row.
+		$values = [];
+		for ( $i = 1; $i <= $total; $i++ ) {
+			$values[] = $wpdb->prepare( '(%d, %d, %s, %d, %d)', $i, 0, $old, 1, 0 );
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "INSERT INTO $table (ad_id, newsletter_id, stat_date, impressions, clicks) VALUES " . implode( ',', $values ) );
+		self::assertEquals( $total, (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" ) ); // phpcs:ignore
+
+		$deleted = Ad_Stats::cleanup();
+
+		self::assertEquals( $total, $deleted );
+		self::assertEquals( 0, (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" ) ); // phpcs:ignore
+	}
+}


### PR DESCRIPTION
## Why

Each newsletter ad already keeps a **lifetime cumulative** counter in its `tracking_impressions` / `tracking_clicks` post meta. That's fine for the ad-list admin columns but can't answer timeframe-scoped questions ("impressions in the last 30 days"), which is what reporting (Newspack Insights — NPPD-1861) needs. This adds dated per-ad rows alongside the existing counters, without changing them. Collection is forward-only (no backfill), so landing it starts the clock.

## What changed

- **New `Newspack_Newsletters\Tracking\Ad_Stats`** (`includes/tracking/class-ad-stats.php`) — a custom table `{prefix}newspack_newsletters_ad_stats` (dbDelta + version option + weekly cleanup cron, ~25-month retention, `UTC_DATE()`-aligned). Events are **aggregated per day** via upsert on `(ad_id, newsletter_id, stat_date)` rather than one row per event, to stay small under impression volume. `dbDelta()` runs unconditionally on version bump so future schema changes actually migrate.
- **Impressions** — `Ads::track_ad_impression` / `bulk_track_ad_impression` now also record a dated row, keyed to the real source newsletter. Impressions without a real newsletter ID are dropped rather than written (guards the click-sentinel row).
- **Clicks, with per-newsletter attribution** — `Click::track_click` now also records a dated row. Only ad links are proxied and the proxy encodes the **ad** post ID (`id`), so per-ad click attribution is deterministic at the proxy layer (no URL matching). Additionally, `process_link` now reads the newsletter being rendered from `Newspack_Newsletters_Renderer::$newsletter_id` and encodes it as **`nid`**, so clicks are attributed to the **source newsletter** too: a click with a known newsletter lands on the *same* `(ad_id, newsletter_id, day)` row as that newsletter's impressions. `newsletter_id = 0` remains only as a fallback for links proxied before this ships.
- **`Click` readability fixes** — the tracked id was named `$newsletter_id` throughout `Click` while actually being the ad's post ID; renamed to `$ad_id` in `get_proxied_url` / `track_click` / `handle_click` and corrected the `newspack_newsletters_tracking_click` action docblock. The action now passes the source newsletter ID as a **4th arg** (backward-compatible; no internal consumers).

## Notes / follow-ups

- Population is **site-dependent** in production (depends on the site's tracking/ESP config) — e.g. some sites record clicks but not impressions. Consumers must degrade gracefully (CTR uncomputable when a counter is absent).
- The lifetime `tracking_*` meta counters are intentionally left untouched; this is purely additive.
- Per-newsletter click attribution only applies to newsletters sent after this ships (older emails' proxy links carry no `nid` → sentinel fallback). Per-ad totals are unaffected either way.
- dbDelta gotcha handled: no inline SQL comments (dbDelta splits on `;`), two spaces after `PRIMARY KEY`.

## Test plan

- `tests/test-ad-stats.php` (10 tests) — table create, daily upsert aggregation, click-with-newsletter shares the impression row, sentinel fallback for unknown newsletter, invalid-input guards (incl. impression-without-newsletter), `Ads::track_ad_impression`/`bulk_track_ad_impression` wiring, `Click::handle_click` end-to-end with `nid`, `process_link` carries `nid`, retention cleanup.
- Existing `Newsletters_Tracking_Test` (8) and `Newsletter_Ads_Test` (5) suites still green.
- Root `phpcs.xml` clean on all changed files.