### PR TITLE
perf(insights): harden timeout-prone subscription + donor storage queries

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-subscribers-metric.php
@@ -295,6 +295,20 @@ class Subscribers_Metric {
 		$arpu = $arr / $active;
 
 		// 12-month retention annualized from churn (no subscriber cohort series).
+		//
+		// TODO (follow-up, not this fix): get_churned_subscribers_in_window()
+		// returns a bare `int` (Storage_Interface contract), and its result is
+		// also transient-cached in Subscribers_Metric::cached() before it gets
+		// here. A DB failure inside $wpdb->get_var() surfaces as `null`, which
+		// casts to 0 — indistinguishable from a legitimate "zero churn" and, once
+		// cached, invisible to this method entirely. That silently computes
+		// r = 1.0 (no churn) and reports an INFLATED CLV as `computable: true`.
+		// Cleanly fixing this needs either (a) widening the storage contract to
+		// signal failure (e.g. return null, or a {value, ok} shape) across every
+		// implementation and call site, or (b) checking $wpdb->last_error at the
+		// storage boundary and threading that through the cache layer. Both are
+		// broader, riskier changes than this perf fix's scope — flagging as a
+		// recommended follow-up rather than forcing it in here.
 		$year_ago = \DateTimeImmutable::createFromInterface( $end )->sub( new \DateInterval( 'P365D' ) );
 		$churned  = $this->get_churned_subscribers_in_window( $year_ago, $end );
 		$r        = 1.0 - ( $churned / $active );

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -579,11 +579,18 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 		unset( $end ); // included in cache key by orchestrator; SQL uses NOW for the "still active" check.
 
-		// Subscriptions active at :start (subscription start <= :start
-		// AND not cancelled before :start). The CTE yields one row per
-		// (customer, subscription) pair.
-		$active_at_start_sql = $wpdb->prepare(
-			"SELECT DISTINCT o.customer_id, o.id AS subscription_id, o.status
+		// Subscriptions active at :start (subscription start <= :start AND
+		// not cancelled before :start). The active-at-start cohort used to
+		// be pulled into a PHP array and serialized back into an
+		// `o.customer_id IN ($customer_list)` filter for the numerator query —
+		// slow, and a `max_allowed_packet` "MySQL server has gone away"
+		// trigger on large cohorts. Prepared once with the :start bound
+		// baked in as a literal, then reused (already-escaped) as a derived
+		// table by both the denominator COUNT and the numerator JOIN below —
+		// nesting a second prepare() around an interpolated %s-bearing
+		// string would double-escape / mis-count placeholders.
+		$active_at_start_cte = $wpdb->prepare(
+			"SELECT DISTINCT o.customer_id
 			FROM {$prefix}wc_orders o
 			JOIN {$prefix}wc_orders_meta start_meta
 				ON start_meta.order_id = o.id AND start_meta.meta_key = '_schedule_start'
@@ -606,18 +613,9 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 			$this->fmt( $start ),
 			$this->fmt( $start )
 		);
-		$rows = $wpdb->get_results( $active_at_start_sql, ARRAY_A );
-		if ( empty( $rows ) ) {
-			return [
-				'value'       => 0.0,
-				'computable'  => false,
-				'denominator' => 0,
-			];
-		}
 
 		// Denominator: distinct customers who were active at start.
-		$customers_active_at_start = array_unique( array_map( 'intval', array_column( $rows, 'customer_id' ) ) );
-		$denominator               = count( $customers_active_at_start );
+		$denominator = (int) $wpdb->get_var( "SELECT COUNT(*) FROM ({$active_at_start_cte}) AS active_at_start" );
 		if ( 0 === $denominator ) {
 			return [
 				'value'       => 0.0,
@@ -628,17 +626,16 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 
 		// Numerator: those customers who still have at least one
 		// active donation subscription right now.
-		$customer_list = $this->id_list( $customers_active_at_start );
-		$numerator_sql = "SELECT COUNT(DISTINCT o.customer_id)
-			FROM {$prefix}wc_orders o
+		$numerator_sql = "SELECT COUNT(DISTINCT active_at_start.customer_id)
+			FROM ({$active_at_start_cte}) AS active_at_start
+			JOIN {$prefix}wc_orders o ON o.customer_id = active_at_start.customer_id
 			JOIN {$prefix}woocommerce_order_items oi
 				ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
 			JOIN {$prefix}woocommerce_order_itemmeta oim
 				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 			WHERE o.type = 'shop_subscription'
 			  AND o.status = 'wc-active'
-			  AND oim.meta_value IN ($donations)
-			  AND o.customer_id IN ($customer_list)";
+			  AND oim.meta_value IN ($donations)";
 		$numerator     = (int) $wpdb->get_var( $numerator_sql );
 
 		return [

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -305,6 +305,15 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Tab 6 churn pattern scoped to donation products: customers whose
+	 * donation subscriptions cancelled/expired in window AND who currently
+	 * have no active donation subscription. Cancelled/expired side
+	 * pre-aggregated to DISTINCT customer_ids and LEFT-JOINed against the
+	 * DISTINCT active-donation-subscriber customer_ids (also pre-aggregated),
+	 * keeping only rows where the active side is NULL — an anti-join, not a
+	 * correlated `NOT IN (subquery)` (MySQL's slowest anti-join form). Same
+	 * approach as {@see HPOS_Storage::get_churned_subscribers_in_window()}.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return int
@@ -314,12 +323,9 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Tab 6 churn pattern scoped to donation products: customers
-		// whose donation subscriptions cancelled/expired in window AND
-		// who currently have no active donation subscription.
 		$sql = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT cancellations.customer_id) FROM (
-				SELECT o.customer_id
+				SELECT DISTINCT o.customer_id
 				FROM {$prefix}wc_orders o
 				JOIN {$prefix}wc_orders_meta om
 					ON om.order_id = o.id AND om.meta_key = '_schedule_cancelled'
@@ -333,7 +339,7 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				  AND om.meta_value BETWEEN %s AND %s
 				  AND om.meta_value != ''
 			) AS cancellations
-			WHERE cancellations.customer_id NOT IN (
+			LEFT JOIN (
 				SELECT DISTINCT o2.customer_id
 				FROM {$prefix}wc_orders o2
 				JOIN {$prefix}woocommerce_order_items oi2
@@ -343,7 +349,8 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				WHERE o2.type = 'shop_subscription'
 				  AND o2.status = 'wc-active'
 				  AND oim2.meta_value IN ($donations)
-			)",
+			) AS active ON active.customer_id = cancellations.customer_id
+			WHERE active.customer_id IS NULL",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -757,7 +757,11 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 		// product row, so SUM(lapsed_donors_in_window) across rows can
 		// exceed the scorecard. In Newspack's typical data shape a
 		// donor only has one recurring donation, so this reconciles
-		// cleanly in practice.
+		// cleanly in practice. The active-subscriber exclusion is a LEFT
+		// JOIN anti-join (`active.customer_id IS NULL`) against a
+		// pre-aggregated DISTINCT active-donation-subscriber derived table,
+		// not a correlated `NOT IN (subquery)` (MySQL's slowest anti-join
+		// form) — same approach as {@see self::get_lapsed_donors_in_window()}.
 		$lapsed_sql = $wpdb->prepare(
 			"SELECT
 				pv.ID AS variation_id,
@@ -780,12 +784,7 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 			LEFT JOIN {$prefix}posts pp ON pp.ID = pv.post_parent
 			LEFT JOIN {$prefix}postmeta period_meta
 				ON period_meta.post_id = pv.ID AND period_meta.meta_key = '_subscription_period'
-			WHERE o.type = 'shop_subscription'
-			  AND o.status IN ('wc-cancelled', 'wc-expired')
-			  AND pid_meta.meta_value IN ($donations)
-			  AND cm.meta_value BETWEEN %s AND %s
-			  AND cm.meta_value != ''
-			  AND o.customer_id NOT IN (
+			LEFT JOIN (
 				SELECT DISTINCT o2.customer_id
 				FROM {$prefix}wc_orders o2
 				JOIN {$prefix}woocommerce_order_items oi2
@@ -795,7 +794,13 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				WHERE o2.type = 'shop_subscription'
 				  AND o2.status = 'wc-active'
 				  AND oim2.meta_value IN ($donations)
-			  )
+			) AS active ON active.customer_id = o.customer_id
+			WHERE o.type = 'shop_subscription'
+			  AND o.status IN ('wc-cancelled', 'wc-expired')
+			  AND pid_meta.meta_value IN ($donations)
+			  AND cm.meta_value BETWEEN %s AND %s
+			  AND cm.meta_value != ''
+			  AND active.customer_id IS NULL
 			GROUP BY pv.ID, pv.post_title, pv.post_parent, parent_name, sub_period",
 			$this->fmt( $start ),
 			$this->fmt( $end )

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-donors-storage.php
@@ -468,6 +468,15 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * The prior-window lapsed cohort used to be pulled into a PHP array and
+	 * serialized back into an `o.customer_id IN ($lapsed_list)` filter for the
+	 * "recovered" query — slow, and a `max_allowed_packet` risk on large
+	 * cohorts. Now computed as a single reusable derived table (`lapsed`,
+	 * itself an anti-join against active donation subscribers — see
+	 * {@see self::get_lapsed_donors_in_window()}) that both the denominator
+	 * COUNT and the numerator's JOIN read from directly, eliminating the PHP
+	 * round trip entirely.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return float
@@ -487,11 +496,15 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 
 		// Lapsed-in-prior cohort (same shape as get_lapsed_donors_in_window
-		// but with explicit prior window bounds rather than current window).
-		$lapsed_sql = $wpdb->prepare(
+		// but with explicit prior window bounds rather than current window),
+		// reused by both the denominator and numerator queries below.
+		// Prepared once with the prior-window bounds baked in as literals;
+		// nesting a second prepare() around an interpolated %s-bearing string
+		// would double-escape / mis-count placeholders.
+		$lapsed_cte = $wpdb->prepare(
 			"SELECT DISTINCT cancellations.customer_id
 			FROM (
-				SELECT o.customer_id
+				SELECT DISTINCT o.customer_id
 				FROM {$prefix}wc_orders o
 				JOIN {$prefix}wc_orders_meta om
 					ON om.order_id = o.id AND om.meta_key = '_schedule_cancelled'
@@ -505,7 +518,7 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				  AND om.meta_value BETWEEN %s AND %s
 				  AND om.meta_value != ''
 			) AS cancellations
-			WHERE cancellations.customer_id NOT IN (
+			LEFT JOIN (
 				SELECT DISTINCT o2.customer_id
 				FROM {$prefix}wc_orders o2
 				JOIN {$prefix}woocommerce_order_items oi2
@@ -515,33 +528,32 @@ class HPOS_Donors_Storage implements Donors_Storage_Interface {
 				WHERE o2.type = 'shop_subscription'
 				  AND o2.status = 'wc-active'
 				  AND oim2.meta_value IN ($donations)
-			)",
+			) AS active ON active.customer_id = cancellations.customer_id
+			WHERE active.customer_id IS NULL",
 			$prior_start_iso,
 			$prior_end_iso
 		);
 
-		$lapsed_customer_ids = $wpdb->get_col( $lapsed_sql );
-		if ( empty( $lapsed_customer_ids ) ) {
+		$lapsed_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM ({$lapsed_cte}) AS lapsed" );
+		if ( 0 === $lapsed_count ) {
 			return [
 				'value'       => 0.0,
 				'computable'  => false,
 				'denominator' => 0,
 			];
 		}
-		$lapsed_count = count( $lapsed_customer_ids );
-		$lapsed_list  = $this->id_list( array_map( 'intval', $lapsed_customer_ids ) );
 
 		// Of the lapsed cohort, who made a NEW completed donation order
 		// in the current window.
 		$recovered_sql = $wpdb->prepare(
-			"SELECT COUNT(DISTINCT o.customer_id)
-			FROM {$prefix}wc_orders o
+			"SELECT COUNT(DISTINCT lapsed.customer_id)
+			FROM ({$lapsed_cte}) AS lapsed
+			JOIN {$prefix}wc_orders o ON o.customer_id = lapsed.customer_id
 			JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o.id
 			WHERE o.type = 'shop_order'
 			  AND o.status IN ('wc-completed', 'wc-processing')
 			  AND o.date_created_gmt BETWEEN %s AND %s
-			  AND opl.product_id IN ($donations)
-			  AND o.customer_id IN ($lapsed_list)",
+			  AND opl.product_id IN ($donations)",
 			$current_start_iso,
 			$current_end_iso
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1222,6 +1222,13 @@ class HPOS_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * The non-donation filter is pre-aggregated to DISTINCT order_ids in a
+	 * derived table and INNER-JOINed against `o.id`, instead of an `o.id IN
+	 * (SELECT DISTINCT ...)` semi-join subquery — the DISTINCT is preserved
+	 * (so a subscription with multiple non-donation line items still counts
+	 * once) but MySQL builds the set once rather than re-evaluating it as part
+	 * of the outer scan.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
@@ -1231,9 +1238,6 @@ class HPOS_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// DISTINCT id-subselect on the non-donation filter so a sub with
-		// multiple line items doesn't get counted multiple times under the
-		// same reason.
 		$sql = $wpdb->prepare(
 			"SELECT
 				COALESCE(om.meta_value, 'unknown') AS cancellation_reason,
@@ -1243,16 +1247,16 @@ class HPOS_Storage implements Storage_Interface {
 				ON om.order_id = o.id AND om.meta_key = 'newspack_subscriptions_cancellation_reason'
 			JOIN {$prefix}wc_orders_meta sch
 				ON sch.order_id = o.id AND sch.meta_key = '_schedule_cancelled'
-			WHERE o.type = 'shop_subscription'
-			  AND o.status IN ('wc-cancelled', 'wc-expired')
-			  AND o.id IN (
+			INNER JOIN (
 				SELECT DISTINCT oi.order_id
 				FROM {$prefix}woocommerce_order_items oi
 				JOIN {$prefix}woocommerce_order_itemmeta oim
 					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 				WHERE oi.order_item_type = 'line_item'
 				  AND oim.meta_value NOT IN ($donations)
-			  )
+			) AS non_donation_orders ON non_donation_orders.order_id = o.id
+			WHERE o.type = 'shop_subscription'
+			  AND o.status IN ('wc-cancelled', 'wc-expired')
 			  AND sch.meta_value BETWEEN %s AND %s
 			GROUP BY cancellation_reason
 			ORDER BY count DESC",

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1331,6 +1331,36 @@ class HPOS_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Same inner aggregate as get_new_subscribers_in_window() (first
+	 * non-donation _schedule_start per customer), filtered to the window.
+	 * Guest orders (customer_id = 0) are excluded: a guest has no user account
+	 * to match against BQ registration events.
+	 *
+	 * Source meta lives on the PARENT shop_order (the subscription's initial
+	 * checkout order), NOT on the shop_subscription row itself. Each
+	 * subscription's parent_order_id in {prefix}wc_orders points to the
+	 * initial shop_order; we read _gate_post_id / _memberships_content_gate /
+	 * _newspack_popup_id from that parent order's meta.
+	 *
+	 * `first_sub_parent` pre-aggregates, per (customer_id, first_start) pair,
+	 * the parent_order_id of that first subscription — `MIN(parent_order_id)`
+	 * deterministically resolves the rare case of two subscriptions tying on
+	 * the same customer + start timestamp (the original's `LIMIT 1` with no
+	 * ORDER BY picked "any one" of the tied rows just as arbitrarily). Gate /
+	 * legacy-gate / popup meta are each pre-aggregated to one row per order_id
+	 * (`MIN(meta_value)` guards against an order carrying more than one
+	 * non-empty value for the same key, mirroring the original's `LIMIT 1`)
+	 * and LEFT-JOINed on that resolved parent id, instead of three correlated
+	 * per-row subqueries that each re-execute the whole 4-table join on every
+	 * outer row.
+	 *
+	 * gate_post_id: first non-empty _gate_post_id on the parent order, falling
+	 * back to legacy _memberships_content_gate (both NOT IN ('','0')).
+	 * popup_id: non-empty _newspack_popup_id on the parent order. A LEFT JOIN
+	 * miss (no parent order / no meta) still yields '' via COALESCE, exactly
+	 * as the original — the metric layer falls those records to the BQ
+	 * temporal matcher (unchanged behaviour).
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array<int, array{customer_id:int, ts:int}>
@@ -1340,88 +1370,12 @@ class HPOS_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Same inner aggregate as get_new_subscribers_in_window() (first
-		// non-donation _schedule_start per customer), filtered to the window.
-		// Guest orders (customer_id = 0) are excluded: a guest has no user
-		// account to match against BQ registration events.
-		//
-		// Source meta lives on the PARENT shop_order (the subscription's initial
-		// checkout order), NOT on the shop_subscription row itself. Each
-		// subscription's parent_order_id in {prefix}wc_orders points to the
-		// initial shop_order; we read _gate_post_id / _memberships_content_gate
-		// / _newspack_popup_id from that parent order's meta.
-		//
-		// To identify the first subscription per customer in the window we pick
-		// the subscription whose _schedule_start = the customer's MIN. Correlated
-		// subqueries (MySQL 5.7-safe, no window functions) then read meta from
-		// that first subscription's parent order. LIMIT 1 resolves same-timestamp
-		// ties (two subscriptions sharing the same MIN _schedule_start): any one
-		// tied first-subscription's parent order meta is used — the signal is a
-		// soft fallback, not an exact ID.
-		//
-		// gate_post_id: first non-empty _gate_post_id on the parent order,
-		// falling back to legacy _memberships_content_gate (both
-		// NOT IN ('','0')).
-		// popup_id:     non-empty _newspack_popup_id on the parent order.
-		// No parent order / no meta → '' for that column; the metric layer falls
-		// those records to the BQ temporal matcher (unchanged behaviour).
 		$sql = $wpdb->prepare(
 			"SELECT
 				first_subs.customer_id,
 				first_subs.first_start,
-				COALESCE((
-					SELECT om_gate.meta_value
-					FROM {$prefix}wc_orders o_sub
-					JOIN {$prefix}wc_orders_meta om_start_s
-						ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
-					JOIN {$prefix}wc_orders_meta om_gate
-						ON om_gate.order_id = o_sub.parent_order_id AND om_gate.meta_key = '_gate_post_id'
-					JOIN {$prefix}woocommerce_order_items oi_s
-						ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim_s
-						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
-					WHERE o_sub.type = 'shop_subscription'
-					  AND o_sub.customer_id = first_subs.customer_id
-					  AND oim_s.meta_value NOT IN ($donations)
-					  AND om_start_s.meta_value = first_subs.first_start
-					  AND om_gate.meta_value NOT IN ('', '0')
-					LIMIT 1
-				), (
-					SELECT om_legacy.meta_value
-					FROM {$prefix}wc_orders o_sub
-					JOIN {$prefix}wc_orders_meta om_start_s
-						ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
-					JOIN {$prefix}wc_orders_meta om_legacy
-						ON om_legacy.order_id = o_sub.parent_order_id AND om_legacy.meta_key = '_memberships_content_gate'
-					JOIN {$prefix}woocommerce_order_items oi_s
-						ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim_s
-						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
-					WHERE o_sub.type = 'shop_subscription'
-					  AND o_sub.customer_id = first_subs.customer_id
-					  AND oim_s.meta_value NOT IN ($donations)
-					  AND om_start_s.meta_value = first_subs.first_start
-					  AND om_legacy.meta_value NOT IN ('', '0')
-					LIMIT 1
-				), '') AS gate_post_id,
-				COALESCE((
-					SELECT om_popup.meta_value
-					FROM {$prefix}wc_orders o_sub
-					JOIN {$prefix}wc_orders_meta om_start_s
-						ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
-					JOIN {$prefix}wc_orders_meta om_popup
-						ON om_popup.order_id = o_sub.parent_order_id AND om_popup.meta_key = '_newspack_popup_id'
-					JOIN {$prefix}woocommerce_order_items oi_s
-						ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim_s
-						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
-					WHERE o_sub.type = 'shop_subscription'
-					  AND o_sub.customer_id = first_subs.customer_id
-					  AND oim_s.meta_value NOT IN ($donations)
-					  AND om_start_s.meta_value = first_subs.first_start
-					  AND om_popup.meta_value NOT IN ('', '0')
-					LIMIT 1
-				), '') AS popup_id
+				COALESCE(gate.gate_post_id, legacy_gate.gate_post_id, '') AS gate_post_id,
+				COALESCE(popup.popup_id, '') AS popup_id
 			FROM (
 				SELECT o.customer_id, MIN(om.meta_value) AS first_start
 				FROM {$prefix}wc_orders o
@@ -1437,6 +1391,42 @@ class HPOS_Storage implements Storage_Interface {
 				  AND om.meta_value != ''
 				GROUP BY o.customer_id
 			) AS first_subs
+			LEFT JOIN (
+				SELECT
+					o_sub.customer_id,
+					om_start_s.meta_value AS first_start,
+					MIN(o_sub.parent_order_id) AS parent_id
+				FROM {$prefix}wc_orders o_sub
+				JOIN {$prefix}wc_orders_meta om_start_s
+					ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi_s
+					ON oi_s.order_id = o_sub.id AND oi_s.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim_s
+					ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+				WHERE o_sub.type = 'shop_subscription'
+				  AND oim_s.meta_value NOT IN ($donations)
+				GROUP BY o_sub.customer_id, om_start_s.meta_value
+			) AS first_sub_parent
+				ON first_sub_parent.customer_id = first_subs.customer_id
+				AND first_sub_parent.first_start = first_subs.first_start
+			LEFT JOIN (
+				SELECT order_id, MIN(meta_value) AS gate_post_id
+				FROM {$prefix}wc_orders_meta
+				WHERE meta_key = '_gate_post_id' AND meta_value NOT IN ('', '0')
+				GROUP BY order_id
+			) AS gate ON gate.order_id = first_sub_parent.parent_id
+			LEFT JOIN (
+				SELECT order_id, MIN(meta_value) AS gate_post_id
+				FROM {$prefix}wc_orders_meta
+				WHERE meta_key = '_memberships_content_gate' AND meta_value NOT IN ('', '0')
+				GROUP BY order_id
+			) AS legacy_gate ON legacy_gate.order_id = first_sub_parent.parent_id
+			LEFT JOIN (
+				SELECT order_id, MIN(meta_value) AS popup_id
+				FROM {$prefix}wc_orders_meta
+				WHERE meta_key = '_newspack_popup_id' AND meta_value NOT IN ('', '0')
+				GROUP BY order_id
+			) AS popup ON popup.order_id = first_sub_parent.parent_id
 			WHERE first_subs.first_start BETWEEN %s AND %s",
 			$this->fmt( $start ),
 			$this->fmt( $end )

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -222,6 +222,17 @@ class HPOS_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Customers whose non-donation subscriptions cancelled/expired in window
+	 * AND who have no remaining active non-donation subscriptions. Cancelled/
+	 * expired side pre-aggregated to DISTINCT customer_ids and LEFT-JOINed
+	 * against the DISTINCT active-subscriber customer_ids (also pre-aggregated),
+	 * keeping only rows where the active side is NULL — an anti-join, not a
+	 * correlated `NOT IN (subquery)` (MySQL's slowest anti-join form). Same
+	 * approach as {@see self::get_winback_subscribers_in_window()}. DISTINCT on
+	 * both derived tables prevents JOIN fan-out from the line-item join.
+	 * `wc_orders.customer_id` is a native column, so unlike the legacy backend
+	 * no `_customer_user` postmeta join is needed on either side.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return int
@@ -231,11 +242,9 @@ class HPOS_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Customers whose non-donation subscriptions cancelled/expired in
-		// window AND who have no remaining active non-donation subscriptions.
 		$sql = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT cancellations.customer_id) FROM (
-				SELECT o.customer_id
+				SELECT DISTINCT o.customer_id
 				FROM {$prefix}wc_orders o
 				JOIN {$prefix}wc_orders_meta om
 					ON om.order_id = o.id AND om.meta_key = '_schedule_cancelled'
@@ -249,7 +258,7 @@ class HPOS_Storage implements Storage_Interface {
 				  AND om.meta_value BETWEEN %s AND %s
 				  AND om.meta_value != ''
 			) AS cancellations
-			WHERE cancellations.customer_id NOT IN (
+			LEFT JOIN (
 				SELECT DISTINCT o2.customer_id
 				FROM {$prefix}wc_orders o2
 				JOIN {$prefix}woocommerce_order_items oi2
@@ -259,7 +268,8 @@ class HPOS_Storage implements Storage_Interface {
 				WHERE o2.type = 'shop_subscription'
 				  AND o2.status = 'wc-active'
 				  AND oim2.meta_value NOT IN ($donations)
-			)",
+			) AS active ON active.customer_id = cancellations.customer_id
+			WHERE active.customer_id IS NULL",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1130,6 +1130,34 @@ class HPOS_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Base population: registered readers. The canonical Newspack signal is
+	 * the `np_reader` user meta written at reader registration time. As a
+	 * non-strict fallback we also include users in the 'subscriber' or
+	 * 'customer' roles even when np_reader is absent — mirroring
+	 * Reader_Activation::is_user_reader( $user, strict=false ). Admins and
+	 * editors are excluded (the default restricted_roles set).
+	 *
+	 * Phase-A approximation (M1): hardcodes 'subscriber'/'customer' as reader
+	 * roles and 'administrator'/'editor' as restricted roles — does NOT honor
+	 * the filterable newspack_reader_user_roles / newspack_reader_restricted_roles
+	 * hooks, so sites with custom reader roles may see a slightly off count
+	 * (acceptable upper-bound for Phase A; adjust in a later iteration).
+	 *
+	 * Exclusion sets: (a) users with ≥1 active non-donation subscription today;
+	 * (b) users who completed a donation order in the trailing 365 days. Both
+	 * are pre-aggregated to DISTINCT customer_ids and LEFT-JOINed against
+	 * `u.ID`, keeping only rows where both sides are NULL — an anti-join, not a
+	 * correlated `NOT IN (subquery)` (MySQL's slowest anti-join form). Same
+	 * approach as {@see self::get_churned_subscribers_in_window()}. The
+	 * base-population / restricted-role checks stay as correlated `EXISTS` —
+	 * each is a single indexed lookup on `usermeta.user_id`, not a multi-join
+	 * subquery, so they are not a timeout risk.
+	 *
+	 * Phase-A approximation: the "no BQ-tracked activity in 90 days"
+	 * refinement that distinguishes truly stale readers from recently-active
+	 * non-converters is deferred to Phase B (requires the BQ event export).
+	 * This count is an upper bound, not an exact match for the BQ definition.
+	 *
 	 * @return int
 	 */
 	public function get_stale_registered_users(): int {
@@ -1137,28 +1165,28 @@ class HPOS_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Base population: registered readers. The canonical Newspack signal is
-		// the `np_reader` user meta written at reader registration time. As a
-		// non-strict fallback we also include users in the 'subscriber' or
-		// 'customer' roles even when np_reader is absent — mirroring
-		// Reader_Activation::is_user_reader( $user, strict=false ). Admins and
-		// editors are excluded (the default restricted_roles set).
-		//
-		// Phase-A approximation (M1): hardcodes 'subscriber'/'customer' as reader
-		// roles and 'administrator'/'editor' as restricted roles — does NOT honor
-		// the filterable newspack_reader_user_roles / newspack_reader_restricted_roles
-		// hooks, so sites with custom reader roles may see a slightly off count
-		// (acceptable upper-bound for Phase A; adjust in a later iteration).
-		//
-		// Exclusion sub-queries: (a) users with ≥1 active non-donation subscription
-		// today; (b) users who completed a donation order in the trailing 365 days.
-		//
-		// Phase-A approximation: the "no BQ-tracked activity in 90 days"
-		// refinement that distinguishes truly stale readers from recently-active
-		// non-converters is deferred to Phase B (requires the BQ event export).
-		// This count is an upper bound, not an exact match for the BQ definition.
 		$sql = "SELECT COUNT(DISTINCT u.ID)
 			FROM {$prefix}users u
+			LEFT JOIN (
+				SELECT DISTINCT o.customer_id
+				FROM {$prefix}wc_orders o
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE o.type = 'shop_subscription'
+				  AND o.status = 'wc-active'
+				  AND oim.meta_value NOT IN ($donations)
+			) AS active_subscribers ON active_subscribers.customer_id = u.ID
+			LEFT JOIN (
+				SELECT DISTINCT o2.customer_id
+				FROM {$prefix}wc_orders o2
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o2.id
+				WHERE o2.type = 'shop_order'
+				  AND o2.status IN ('wc-completed', 'wc-processing')
+				  AND o2.date_created_gmt >= DATE_SUB(NOW(), INTERVAL 365 DAY)
+				  AND opl.product_id IN ($donations)
+			) AS recent_donors ON recent_donors.customer_id = u.ID
 			WHERE (
 				EXISTS (
 					SELECT 1 FROM {$prefix}usermeta um
@@ -1185,26 +1213,8 @@ class HPOS_Storage implements Storage_Interface {
 					OR um3.meta_value LIKE '%\"editor\"%'
 				  )
 			)
-			AND u.ID NOT IN (
-				SELECT DISTINCT o.customer_id
-				FROM {$prefix}wc_orders o
-				JOIN {$prefix}woocommerce_order_items oi
-					ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
-				JOIN {$prefix}woocommerce_order_itemmeta oim
-					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
-				WHERE o.type = 'shop_subscription'
-				  AND o.status = 'wc-active'
-				  AND oim.meta_value NOT IN ($donations)
-			)
-			AND u.ID NOT IN (
-				SELECT DISTINCT o2.customer_id
-				FROM {$prefix}wc_orders o2
-				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = o2.id
-				WHERE o2.type = 'shop_order'
-				  AND o2.status IN ('wc-completed', 'wc-processing')
-				  AND o2.date_created_gmt >= DATE_SUB(NOW(), INTERVAL 365 DAY)
-				  AND opl.product_id IN ($donations)
-			)";
+			AND active_subscribers.customer_id IS NULL
+			AND recent_donors.customer_id IS NULL";
 
 		return (int) $wpdb->get_var( $sql );
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1346,24 +1346,32 @@ class HPOS_Storage implements Storage_Interface {
 	 * initial shop_order; we read _gate_post_id / _memberships_content_gate /
 	 * _newspack_popup_id from that parent order's meta.
 	 *
-	 * `first_sub_parent` pre-aggregates, per (customer_id, first_start) pair,
-	 * the parent_order_id of that first subscription — `MIN(parent_order_id)`
-	 * deterministically resolves the rare case of two subscriptions tying on
-	 * the same customer + start timestamp (the original's `LIMIT 1` with no
-	 * ORDER BY picked "any one" of the tied rows just as arbitrarily). Gate /
+	 * `first_sub_parents` pre-aggregates, per (customer_id, first_start) pair,
+	 * the FULL SET of parent_order_id values across ALL of that pair's tied
+	 * first subscriptions (not just the lowest one) — two subscriptions can
+	 * tie on the same customer + start timestamp with DIFFERENT parent
+	 * orders, and only one of those parents may carry the gate/popup meta.
+	 * Collapsing to `MIN(parent_order_id)` before the meta lookup (as an
+	 * earlier version of this query did) can silently lose that attribution
+	 * when the lowest-id parent happens to be the meta-less one. Gate /
 	 * legacy-gate / popup meta are each pre-aggregated to one row per order_id
 	 * (`MIN(meta_value)` guards against an order carrying more than one
-	 * non-empty value for the same key, mirroring the original's `LIMIT 1`)
-	 * and LEFT-JOINed on that resolved parent id, instead of three correlated
-	 * per-row subqueries that each re-execute the whole 4-table join on every
-	 * outer row.
+	 * non-empty value for the same key) and LEFT-JOINed onto the full
+	 * parent-id set, then re-aggregated with `MIN(meta_value)` per
+	 * (customer_id, first_start) — an arbitrary but deterministic pick among
+	 * the tied siblings that DO carry the meta, mirroring the original
+	 * correlated-subquery version's `LIMIT 1` (no ORDER BY) semantics of "any
+	 * one" of the tied rows. This avoids the three correlated per-row
+	 * subqueries that each re-execute the whole 4-table join on every outer
+	 * row.
 	 *
-	 * gate_post_id: first non-empty _gate_post_id on the parent order, falling
-	 * back to legacy _memberships_content_gate (both NOT IN ('','0')).
-	 * popup_id: non-empty _newspack_popup_id on the parent order. A LEFT JOIN
-	 * miss (no parent order / no meta) still yields '' via COALESCE, exactly
-	 * as the original — the metric layer falls those records to the BQ
-	 * temporal matcher (unchanged behaviour).
+	 * gate_post_id: first non-empty _gate_post_id across the tied parent
+	 * orders, falling back to legacy _memberships_content_gate (both
+	 * NOT IN ('','0')).
+	 * popup_id: non-empty _newspack_popup_id across the tied parent orders. A
+	 * miss across every tied parent (no parent order / no meta) still yields
+	 * '' via COALESCE, exactly as the original — the metric layer falls those
+	 * records to the BQ temporal matcher (unchanged behaviour).
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -1378,8 +1386,12 @@ class HPOS_Storage implements Storage_Interface {
 			"SELECT
 				first_subs.customer_id,
 				first_subs.first_start,
-				COALESCE(gate.gate_post_id, legacy_gate.gate_post_id, '') AS gate_post_id,
-				COALESCE(popup.popup_id, '') AS popup_id
+				COALESCE(
+					MIN(CASE WHEN gate.meta_value IS NOT NULL THEN gate.meta_value END),
+					MIN(CASE WHEN legacy_gate.meta_value IS NOT NULL THEN legacy_gate.meta_value END),
+					''
+				) AS gate_post_id,
+				COALESCE(MIN(CASE WHEN popup.meta_value IS NOT NULL THEN popup.meta_value END), '') AS popup_id
 			FROM (
 				SELECT o.customer_id, MIN(om.meta_value) AS first_start
 				FROM {$prefix}wc_orders o
@@ -1396,10 +1408,10 @@ class HPOS_Storage implements Storage_Interface {
 				GROUP BY o.customer_id
 			) AS first_subs
 			LEFT JOIN (
-				SELECT
+				SELECT DISTINCT
 					o_sub.customer_id,
 					om_start_s.meta_value AS first_start,
-					MIN(o_sub.parent_order_id) AS parent_id
+					o_sub.parent_order_id AS parent_id
 				FROM {$prefix}wc_orders o_sub
 				JOIN {$prefix}wc_orders_meta om_start_s
 					ON om_start_s.order_id = o_sub.id AND om_start_s.meta_key = '_schedule_start'
@@ -1409,29 +1421,23 @@ class HPOS_Storage implements Storage_Interface {
 					ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
 				WHERE o_sub.type = 'shop_subscription'
 				  AND oim_s.meta_value NOT IN ($donations)
-				GROUP BY o_sub.customer_id, om_start_s.meta_value
-			) AS first_sub_parent
-				ON first_sub_parent.customer_id = first_subs.customer_id
-				AND first_sub_parent.first_start = first_subs.first_start
-			LEFT JOIN (
-				SELECT order_id, MIN(meta_value) AS gate_post_id
-				FROM {$prefix}wc_orders_meta
-				WHERE meta_key = '_gate_post_id' AND meta_value NOT IN ('', '0')
-				GROUP BY order_id
-			) AS gate ON gate.order_id = first_sub_parent.parent_id
-			LEFT JOIN (
-				SELECT order_id, MIN(meta_value) AS gate_post_id
-				FROM {$prefix}wc_orders_meta
-				WHERE meta_key = '_memberships_content_gate' AND meta_value NOT IN ('', '0')
-				GROUP BY order_id
-			) AS legacy_gate ON legacy_gate.order_id = first_sub_parent.parent_id
-			LEFT JOIN (
-				SELECT order_id, MIN(meta_value) AS popup_id
-				FROM {$prefix}wc_orders_meta
-				WHERE meta_key = '_newspack_popup_id' AND meta_value NOT IN ('', '0')
-				GROUP BY order_id
-			) AS popup ON popup.order_id = first_sub_parent.parent_id
-			WHERE first_subs.first_start BETWEEN %s AND %s",
+			) AS first_sub_parents
+				ON first_sub_parents.customer_id = first_subs.customer_id
+				AND first_sub_parents.first_start = first_subs.first_start
+			LEFT JOIN {$prefix}wc_orders_meta gate
+				ON gate.order_id = first_sub_parents.parent_id
+				AND gate.meta_key = '_gate_post_id'
+				AND gate.meta_value NOT IN ('', '0')
+			LEFT JOIN {$prefix}wc_orders_meta legacy_gate
+				ON legacy_gate.order_id = first_sub_parents.parent_id
+				AND legacy_gate.meta_key = '_memberships_content_gate'
+				AND legacy_gate.meta_value NOT IN ('', '0')
+			LEFT JOIN {$prefix}wc_orders_meta popup
+				ON popup.order_id = first_sub_parents.parent_id
+				AND popup.meta_key = '_newspack_popup_id'
+				AND popup.meta_value NOT IN ('', '0')
+			WHERE first_subs.first_start BETWEEN %s AND %s
+			GROUP BY first_subs.customer_id, first_subs.first_start",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-hpos-storage.php
@@ -1712,6 +1712,19 @@ class HPOS_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Cohort membership (first-ever non-donation subscription start within the
+	 * trailing 365 days) is pre-aggregated to one row per customer_id in the
+	 * `cohort` derived table and INNER-JOINed against the outer subscription
+	 * scan, instead of a correlated `customer_id IN (SELECT ... GROUP BY ...
+	 * HAVING ...)` semi-join subquery — the INNER JOIN lets MySQL build the
+	 * cohort set once rather than re-evaluating it as part of a full outer
+	 * scan. Mirrors the first-start definition in
+	 * get_first_subscription_order_dates(). MIN(meta_value) is a lexical
+	 * comparison; _schedule_start is zero-padded `Y-m-d H:i:s`, so lexical
+	 * order == chronological order. The outer scan is otherwise unchanged: it
+	 * still returns every non-donation subscription belonging to a cohort
+	 * member, not just the qualifying first one.
+	 *
 	 * @return array<int, array{customer_id:int, start:string, cancelled:?string, end:?string}>
 	 */
 	public function get_new_subscriber_cohort_intervals(): array {
@@ -1724,13 +1737,6 @@ class HPOS_Storage implements Storage_Interface {
 		// Upper bound excludes subscriptions with a future _schedule_start (scheduled/pending).
 		$now = gmdate( 'Y-m-d H:i:s', ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->getTimestamp() );
 
-		// Inner subquery: customers whose earliest non-donation subscription
-		// start is within the window (the cohort). Mirrors the first-start
-		// definition in get_first_subscription_order_dates(). MIN(meta_value)
-		// is a lexical comparison; _schedule_start is zero-padded `Y-m-d H:i:s`,
-		// so lexical order == chronological order.
-		// Outer query: every non-donation subscription of those customers, with
-		// its start/cancelled/end schedule meta.
 		$sql = $wpdb->prepare(
 			"SELECT o.customer_id,
 				sm.meta_value AS sched_start,
@@ -1747,28 +1753,26 @@ class HPOS_Storage implements Storage_Interface {
 				ON oi.order_id = o.id AND oi.order_item_type = 'line_item'
 			JOIN {$prefix}woocommerce_order_itemmeta oim
 				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+			INNER JOIN (
+				SELECT o2.customer_id, MIN(sm2.meta_value) AS first_start
+				FROM {$prefix}wc_orders o2
+				JOIN {$prefix}wc_orders_meta sm2
+					ON sm2.order_id = o2.id AND sm2.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi2
+					ON oi2.order_id = o2.id AND oi2.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim2
+					ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
+				WHERE o2.type = 'shop_subscription'
+				  AND o2.customer_id > 0 -- exclude guest subscriptions
+				  AND oim2.meta_value NOT IN ($donations)
+				  AND sm2.meta_value != ''
+				GROUP BY o2.customer_id
+				HAVING first_start >= %s AND first_start <= %s
+			) AS cohort ON cohort.customer_id = o.customer_id
 			WHERE o.type = 'shop_subscription'
 			  AND o.customer_id > 0 -- exclude guest subscriptions (mirrors get_new_subscriber_records_in_window)
 			  AND oim.meta_value NOT IN ($donations)
-			  AND sm.meta_value != ''
-			  AND o.customer_id IN (
-				SELECT cohort.customer_id FROM (
-					SELECT o2.customer_id, MIN(sm2.meta_value) AS first_start
-					FROM {$prefix}wc_orders o2
-					JOIN {$prefix}wc_orders_meta sm2
-						ON sm2.order_id = o2.id AND sm2.meta_key = '_schedule_start'
-					JOIN {$prefix}woocommerce_order_items oi2
-						ON oi2.order_id = o2.id AND oi2.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim2
-						ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
-					WHERE o2.type = 'shop_subscription'
-					  AND o2.customer_id > 0 -- exclude guest subscriptions
-					  AND oim2.meta_value NOT IN ($donations)
-					  AND sm2.meta_value != ''
-					GROUP BY o2.customer_id
-					HAVING first_start >= %s AND first_start <= %s
-				) cohort
-			  )",
+			  AND sm.meta_value != ''",
 			$cutoff,
 			$now
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -574,8 +574,17 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		$donations = $this->id_list( $this->donation_product_ids );
 		unset( $end ); // cache key only; SQL uses NOW for the "still active" check.
 
-		$active_at_start_sql = $wpdb->prepare(
-			"SELECT DISTINCT cust.meta_value AS customer_id, p.ID AS subscription_id, p.post_status
+		// The active-at-start cohort used to be pulled into a PHP array and
+		// serialized back into a `CAST(... AS UNSIGNED) IN ($customer_list)`
+		// filter for the numerator query — slow, and a `max_allowed_packet`
+		// "MySQL server has gone away" trigger on large cohorts. Prepared once
+		// with the :start bound baked in as a literal, then reused
+		// (already-escaped) as a derived table by both the denominator COUNT
+		// and the numerator JOIN below — nesting a second prepare() around an
+		// interpolated %s-bearing string would double-escape / mis-count
+		// placeholders.
+		$active_at_start_cte = $wpdb->prepare(
+			"SELECT DISTINCT CAST(cust.meta_value AS UNSIGNED) AS customer_id
 			FROM {$prefix}posts p
 			JOIN {$prefix}postmeta cust
 				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
@@ -600,17 +609,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 			$this->fmt( $start ),
 			$this->fmt( $start )
 		);
-		$rows = $wpdb->get_results( $active_at_start_sql, ARRAY_A );
-		if ( empty( $rows ) ) {
-			return [
-				'value'       => 0.0,
-				'computable'  => false,
-				'denominator' => 0,
-			];
-		}
 
-		$customers_active_at_start = array_unique( array_map( 'intval', array_column( $rows, 'customer_id' ) ) );
-		$denominator               = count( $customers_active_at_start );
+		$denominator = (int) $wpdb->get_var( "SELECT COUNT(*) FROM ({$active_at_start_cte}) AS active_at_start" );
 		if ( 0 === $denominator ) {
 			return [
 				'value'       => 0.0,
@@ -619,19 +619,18 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 			];
 		}
 
-		$customer_list = $this->id_list( $customers_active_at_start );
-		$numerator_sql = "SELECT COUNT(DISTINCT cust.meta_value)
-			FROM {$prefix}posts p
+		$numerator_sql = "SELECT COUNT(DISTINCT active_at_start.customer_id)
+			FROM ({$active_at_start_cte}) AS active_at_start
 			JOIN {$prefix}postmeta cust
-				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				ON CAST(cust.meta_value AS UNSIGNED) = active_at_start.customer_id AND cust.meta_key = '_customer_user'
+			JOIN {$prefix}posts p ON p.ID = cust.post_id
 			JOIN {$prefix}woocommerce_order_items oi
 				ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
 			JOIN {$prefix}woocommerce_order_itemmeta oim
 				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 			WHERE p.post_type = 'shop_subscription'
 			  AND p.post_status = 'wc-active'
-			  AND oim.meta_value IN ($donations)
-			  AND CAST(cust.meta_value AS UNSIGNED) IN ($customer_list)";
+			  AND oim.meta_value IN ($donations)";
 		$numerator     = (int) $wpdb->get_var( $numerator_sql );
 
 		return [

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -302,6 +302,14 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Cancelled/expired side pre-aggregated to DISTINCT customer_ids and
+	 * LEFT-JOINed against the DISTINCT active-donation-subscriber customer_ids
+	 * (also pre-aggregated), keeping only rows where the active side is NULL —
+	 * an anti-join, not a correlated `NOT IN (subquery)` (MySQL's slowest
+	 * anti-join form). Same approach as
+	 * {@see Legacy_Storage::get_churned_subscribers_in_window()}. DISTINCT on
+	 * both derived tables prevents JOIN fan-out from the line-item join.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return int
@@ -313,7 +321,7 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 
 		$sql = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT cancellations.customer_id) FROM (
-				SELECT cust.meta_value AS customer_id
+				SELECT DISTINCT cust.meta_value AS customer_id
 				FROM {$prefix}posts p
 				JOIN {$prefix}postmeta cust
 					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
@@ -329,8 +337,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				  AND cancelled.meta_value BETWEEN %s AND %s
 				  AND cancelled.meta_value != ''
 			) AS cancellations
-			WHERE cancellations.customer_id NOT IN (
-				SELECT DISTINCT cust2.meta_value
+			LEFT JOIN (
+				SELECT DISTINCT cust2.meta_value AS customer_id
 				FROM {$prefix}posts p2
 				JOIN {$prefix}postmeta cust2
 					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
@@ -341,7 +349,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				WHERE p2.post_type = 'shop_subscription'
 				  AND p2.post_status = 'wc-active'
 				  AND oim2.meta_value IN ($donations)
-			)",
+			) AS active ON active.customer_id = cancellations.customer_id
+			WHERE active.customer_id IS NULL",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -724,7 +724,11 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		$subs_rows = $wpdb->get_results( $subs_sql, ARRAY_A );
 
 		// Lapsed-donors pass: per-tier bucket of the {@see get_lapsed_donors_in_window}
-		// scorecard cohort. See HPOS variant for the over-count note.
+		// scorecard cohort. See HPOS variant for the over-count note. The
+		// active-subscriber exclusion is a LEFT JOIN anti-join (`active.customer_id
+		// IS NULL`) against a pre-aggregated DISTINCT active-donation-subscriber
+		// derived table, not a correlated `NOT IN (subquery)` (MySQL's slowest
+		// anti-join form) — same approach as {@see self::get_lapsed_donors_in_window()}.
 		$lapsed_sql = $wpdb->prepare(
 			"SELECT
 				pv.ID AS variation_id,
@@ -749,13 +753,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 			LEFT JOIN {$prefix}posts pp ON pp.ID = pv.post_parent
 			LEFT JOIN {$prefix}postmeta period_meta
 				ON period_meta.post_id = pv.ID AND period_meta.meta_key = '_subscription_period'
-			WHERE p.post_type = 'shop_subscription'
-			  AND p.post_status IN ('wc-cancelled', 'wc-expired')
-			  AND pid_meta.meta_value IN ($donations)
-			  AND cancelled.meta_value BETWEEN %s AND %s
-			  AND cancelled.meta_value != ''
-			  AND cust.meta_value NOT IN (
-				SELECT DISTINCT cust2.meta_value
+			LEFT JOIN (
+				SELECT DISTINCT cust2.meta_value AS customer_id
 				FROM {$prefix}posts p2
 				JOIN {$prefix}postmeta cust2
 					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
@@ -766,7 +765,13 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				WHERE p2.post_type = 'shop_subscription'
 				  AND p2.post_status = 'wc-active'
 				  AND oim2.meta_value IN ($donations)
-			  )
+			) AS active ON active.customer_id = cust.meta_value
+			WHERE p.post_type = 'shop_subscription'
+			  AND p.post_status IN ('wc-cancelled', 'wc-expired')
+			  AND pid_meta.meta_value IN ($donations)
+			  AND cancelled.meta_value BETWEEN %s AND %s
+			  AND cancelled.meta_value != ''
+			  AND active.customer_id IS NULL
 			GROUP BY pv.ID, pv.post_title, pv.post_parent, parent_name, sub_period",
 			$this->fmt( $start ),
 			$this->fmt( $end )

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-donors-storage.php
@@ -462,6 +462,15 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * The prior-window lapsed cohort used to be pulled into a PHP array and
+	 * serialized back into a `CAST(... AS UNSIGNED) IN ($lapsed_list)` filter
+	 * for the "recovered" query — slow, and a `max_allowed_packet` risk on
+	 * large cohorts. Now computed as a single reusable derived table
+	 * (`lapsed`, itself an anti-join against active donation subscribers —
+	 * see {@see self::get_lapsed_donors_in_window()}) that both the
+	 * denominator COUNT and the numerator's INNER JOIN read from directly,
+	 * eliminating the PHP round trip entirely.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return float
@@ -479,10 +488,14 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		$lapsed_sql = $wpdb->prepare(
+		// Prepared once with the prior-window bounds baked in as literals, then
+		// reused (already-escaped) as a derived table by both queries below —
+		// nesting a second prepare() around an interpolated %s-bearing string
+		// would double-escape / mis-count placeholders.
+		$lapsed_cte = $wpdb->prepare(
 			"SELECT DISTINCT cancellations.customer_id
 			FROM (
-				SELECT cust.meta_value AS customer_id
+				SELECT DISTINCT cust.meta_value AS customer_id
 				FROM {$prefix}posts p
 				JOIN {$prefix}postmeta cust
 					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
@@ -498,8 +511,8 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				  AND cancelled.meta_value BETWEEN %s AND %s
 				  AND cancelled.meta_value != ''
 			) AS cancellations
-			WHERE cancellations.customer_id NOT IN (
-				SELECT DISTINCT cust2.meta_value
+			LEFT JOIN (
+				SELECT DISTINCT cust2.meta_value AS customer_id
 				FROM {$prefix}posts p2
 				JOIN {$prefix}postmeta cust2
 					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
@@ -510,33 +523,32 @@ class Legacy_Donors_Storage implements Donors_Storage_Interface {
 				WHERE p2.post_type = 'shop_subscription'
 				  AND p2.post_status = 'wc-active'
 				  AND oim2.meta_value IN ($donations)
-			)",
+			) AS active ON active.customer_id = cancellations.customer_id
+			WHERE active.customer_id IS NULL",
 			$prior_start_iso,
 			$prior_end_iso
 		);
 
-		$lapsed_customer_ids = $wpdb->get_col( $lapsed_sql );
-		if ( empty( $lapsed_customer_ids ) ) {
+		$lapsed_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM ({$lapsed_cte}) AS lapsed" );
+		if ( 0 === $lapsed_count ) {
 			return [
 				'value'       => 0.0,
 				'computable'  => false,
 				'denominator' => 0,
 			];
 		}
-		$lapsed_count = count( $lapsed_customer_ids );
-		$lapsed_list  = $this->id_list( array_map( 'intval', $lapsed_customer_ids ) );
 
 		$recovered_sql = $wpdb->prepare(
-			"SELECT COUNT(DISTINCT cust.meta_value)
-			FROM {$prefix}posts p
+			"SELECT COUNT(DISTINCT lapsed.customer_id)
+			FROM ({$lapsed_cte}) AS lapsed
 			JOIN {$prefix}postmeta cust
-				ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				ON CAST(cust.meta_value AS UNSIGNED) = lapsed.customer_id AND cust.meta_key = '_customer_user'
+			JOIN {$prefix}posts p ON p.ID = cust.post_id
 			JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p.ID
 			WHERE p.post_type = 'shop_order'
 			  AND p.post_status IN ('wc-completed', 'wc-processing')
 			  AND p.post_date_gmt BETWEEN %s AND %s
-			  AND opl.product_id IN ($donations)
-			  AND CAST(cust.meta_value AS UNSIGNED) IN ($lapsed_list)",
+			  AND opl.product_id IN ($donations)",
 			$current_start_iso,
 			$current_end_iso
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1264,20 +1264,26 @@ class Legacy_Storage implements Storage_Interface {
 	 *
 	 * Source meta lives on the PARENT shop_order (post_parent of the
 	 * shop_subscription post), NOT on the shop_subscription post itself.
-	 * `first_sub_parent` pre-aggregates, per (customer_id, first_start) pair,
-	 * the post_parent of that first subscription — `MIN(post_parent)`
-	 * deterministically resolves the rare case of two subscriptions tying on
-	 * the same customer + start timestamp (the original's `LIMIT 1` with no
-	 * ORDER BY picked "any one" of the tied rows just as arbitrarily). Gate /
-	 * legacy-gate / popup meta are each pre-aggregated to one row per post_id
-	 * (`MIN(meta_value)` guards against a post carrying more than one non-empty
-	 * value for the same key, mirroring the original's `LIMIT 1`) and
-	 * LEFT-JOINed on that resolved parent id, instead of three correlated
-	 * per-row subqueries that each re-execute the whole 4-table join on every
-	 * outer row. A LEFT JOIN miss (no such meta on the parent order, or no
-	 * parent order at all) still yields '' via COALESCE, exactly as the
-	 * original — a customer with no gate/popup attribution still appears in
-	 * the result set.
+	 * `first_sub_parents` pre-aggregates, per (customer_id, first_start) pair,
+	 * the FULL SET of post_parent ids across ALL of that pair's tied first
+	 * subscriptions (not just the lowest one) — two subscriptions can tie on
+	 * the same customer + start timestamp with DIFFERENT parent orders, and
+	 * only one of those parents may carry the gate/popup meta. Collapsing to
+	 * `MIN(post_parent)` before the meta lookup (as an earlier version of
+	 * this query did) can silently lose that attribution when the
+	 * lowest-id parent happens to be the meta-less one. Gate / legacy-gate /
+	 * popup meta are each pre-aggregated to one row per post_id (`MIN(meta_value)`
+	 * guards against a post carrying more than one non-empty value for the
+	 * same key) and LEFT-JOINed onto the full parent-id set, then re-aggregated
+	 * with `MIN(meta_value)` per (customer_id, first_start) — an arbitrary but
+	 * deterministic pick among the tied siblings that DO carry the meta,
+	 * mirroring the original correlated-subquery version's `LIMIT 1` (no
+	 * ORDER BY) semantics of "any one" of the tied rows. This avoids the three
+	 * correlated per-row subqueries that each re-execute the whole 4-table join
+	 * on every outer row. A miss across every tied parent (no such meta on any
+	 * of them, or no parent order at all) still yields '' via COALESCE, exactly
+	 * as the original — a customer with no gate/popup attribution still
+	 * appears in the result set.
 	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
@@ -1292,8 +1298,12 @@ class Legacy_Storage implements Storage_Interface {
 			"SELECT
 				first_subs.customer_id,
 				first_subs.first_start,
-				COALESCE(gate.gate_post_id, legacy_gate.gate_post_id, '') AS gate_post_id,
-				COALESCE(popup.popup_id, '') AS popup_id
+				COALESCE(
+					MIN(CASE WHEN gate.meta_value IS NOT NULL THEN gate.meta_value END),
+					MIN(CASE WHEN legacy_gate.meta_value IS NOT NULL THEN legacy_gate.meta_value END),
+					''
+				) AS gate_post_id,
+				COALESCE(MIN(CASE WHEN popup.meta_value IS NOT NULL THEN popup.meta_value END), '') AS popup_id
 			FROM (
 				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
 				FROM {$prefix}posts p
@@ -1312,10 +1322,10 @@ class Legacy_Storage implements Storage_Interface {
 				GROUP BY CAST(cust.meta_value AS UNSIGNED)
 			) AS first_subs
 			LEFT JOIN (
-				SELECT
+				SELECT DISTINCT
 					CAST(cust_s.meta_value AS UNSIGNED) AS customer_id,
 					start_s.meta_value AS first_start,
-					MIN(p_sub.post_parent) AS parent_id
+					p_sub.post_parent AS parent_id
 				FROM {$prefix}posts p_sub
 				JOIN {$prefix}postmeta cust_s
 					ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
@@ -1327,29 +1337,23 @@ class Legacy_Storage implements Storage_Interface {
 					ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
 				WHERE p_sub.post_type = 'shop_subscription'
 				  AND oim_s.meta_value NOT IN ($donations)
-				GROUP BY CAST(cust_s.meta_value AS UNSIGNED), start_s.meta_value
-			) AS first_sub_parent
-				ON first_sub_parent.customer_id = first_subs.customer_id
-				AND first_sub_parent.first_start = first_subs.first_start
-			LEFT JOIN (
-				SELECT post_id, MIN(meta_value) AS gate_post_id
-				FROM {$prefix}postmeta
-				WHERE meta_key = '_gate_post_id' AND meta_value NOT IN ('', '0')
-				GROUP BY post_id
-			) AS gate ON gate.post_id = first_sub_parent.parent_id
-			LEFT JOIN (
-				SELECT post_id, MIN(meta_value) AS gate_post_id
-				FROM {$prefix}postmeta
-				WHERE meta_key = '_memberships_content_gate' AND meta_value NOT IN ('', '0')
-				GROUP BY post_id
-			) AS legacy_gate ON legacy_gate.post_id = first_sub_parent.parent_id
-			LEFT JOIN (
-				SELECT post_id, MIN(meta_value) AS popup_id
-				FROM {$prefix}postmeta
-				WHERE meta_key = '_newspack_popup_id' AND meta_value NOT IN ('', '0')
-				GROUP BY post_id
-			) AS popup ON popup.post_id = first_sub_parent.parent_id
-			WHERE first_subs.first_start BETWEEN %s AND %s",
+			) AS first_sub_parents
+				ON first_sub_parents.customer_id = first_subs.customer_id
+				AND first_sub_parents.first_start = first_subs.first_start
+			LEFT JOIN {$prefix}postmeta gate
+				ON gate.post_id = first_sub_parents.parent_id
+				AND gate.meta_key = '_gate_post_id'
+				AND gate.meta_value NOT IN ('', '0')
+			LEFT JOIN {$prefix}postmeta legacy_gate
+				ON legacy_gate.post_id = first_sub_parents.parent_id
+				AND legacy_gate.meta_key = '_memberships_content_gate'
+				AND legacy_gate.meta_value NOT IN ('', '0')
+			LEFT JOIN {$prefix}postmeta popup
+				ON popup.post_id = first_sub_parents.parent_id
+				AND popup.meta_key = '_newspack_popup_id'
+				AND popup.meta_value NOT IN ('', '0')
+			WHERE first_subs.first_start BETWEEN %s AND %s
+			GROUP BY first_subs.customer_id, first_subs.first_start",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -243,6 +243,14 @@ class Legacy_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Cancelled/expired side pre-aggregated to DISTINCT customer_ids and
+	 * LEFT-JOINed against the DISTINCT active-subscriber customer_ids (also
+	 * pre-aggregated), keeping only rows where the active side is NULL — an
+	 * anti-join, not a correlated `NOT IN (subquery)` (MySQL's slowest anti-join
+	 * form) and not the unindexed `BETWEEN` string range scan's only filter.
+	 * Same approach as {@see self::get_winback_subscribers_in_window()}. DISTINCT
+	 * on both derived tables prevents JOIN fan-out from the line-item join.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return int
@@ -254,7 +262,7 @@ class Legacy_Storage implements Storage_Interface {
 
 		$sql = $wpdb->prepare(
 			"SELECT COUNT(DISTINCT cancellations.customer_id) FROM (
-				SELECT cust.meta_value AS customer_id
+				SELECT DISTINCT cust.meta_value AS customer_id
 				FROM {$prefix}posts p
 				JOIN {$prefix}postmeta cust
 					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
@@ -270,8 +278,8 @@ class Legacy_Storage implements Storage_Interface {
 				  AND cancelled.meta_value BETWEEN %s AND %s
 				  AND cancelled.meta_value != ''
 			) AS cancellations
-			WHERE cancellations.customer_id NOT IN (
-				SELECT DISTINCT cust2.meta_value
+			LEFT JOIN (
+				SELECT DISTINCT cust2.meta_value AS customer_id
 				FROM {$prefix}posts p2
 				JOIN {$prefix}postmeta cust2
 					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
@@ -282,7 +290,8 @@ class Legacy_Storage implements Storage_Interface {
 				WHERE p2.post_type = 'shop_subscription'
 				  AND p2.post_status = 'wc-active'
 				  AND oim2.meta_value NOT IN ($donations)
-			)",
+			) AS active ON active.customer_id = cancellations.customer_id
+			WHERE active.customer_id IS NULL",
 			$this->fmt( $start ),
 			$this->fmt( $end )
 		);

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1143,6 +1143,13 @@ class Legacy_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * The non-donation filter is pre-aggregated to DISTINCT order_ids in a
+	 * derived table and INNER-JOINed against `p.ID`, instead of a `p.ID IN
+	 * (SELECT DISTINCT ...)` semi-join subquery — the DISTINCT is preserved
+	 * (so a subscription with multiple non-donation line items still counts
+	 * once) but MySQL builds the set once rather than re-evaluating it as part
+	 * of the outer scan.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array
@@ -1152,9 +1159,6 @@ class Legacy_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// DISTINCT id-subselect on the non-donation filter so a sub with
-		// multiple line items doesn't get counted multiple times under the
-		// same reason.
 		$sql = $wpdb->prepare(
 			"SELECT
 				COALESCE(reason.meta_value, 'unknown') AS cancellation_reason,
@@ -1164,16 +1168,16 @@ class Legacy_Storage implements Storage_Interface {
 				ON reason.post_id = p.ID AND reason.meta_key = 'newspack_subscriptions_cancellation_reason'
 			JOIN {$prefix}postmeta cancelled
 				ON cancelled.post_id = p.ID AND cancelled.meta_key = '_schedule_cancelled'
-			WHERE p.post_type = 'shop_subscription'
-			  AND p.post_status IN ('wc-cancelled', 'wc-expired')
-			  AND p.ID IN (
+			INNER JOIN (
 				SELECT DISTINCT oi.order_id
 				FROM {$prefix}woocommerce_order_items oi
 				JOIN {$prefix}woocommerce_order_itemmeta oim
 					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
 				WHERE oi.order_item_type = 'line_item'
 				  AND oim.meta_value NOT IN ($donations)
-			  )
+			) AS non_donation_orders ON non_donation_orders.order_id = p.ID
+			WHERE p.post_type = 'shop_subscription'
+			  AND p.post_status IN ('wc-cancelled', 'wc-expired')
 			  AND cancelled.meta_value BETWEEN %s AND %s
 			GROUP BY cancellation_reason
 			ORDER BY count DESC",

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1254,6 +1254,27 @@ class Legacy_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Legacy CPT equivalent of HPOS get_new_subscriber_records_in_window().
+	 * Guest orders (blank _customer_user → 0 when cast) are excluded from
+	 * source attribution — see the HPOS variant for the rationale.
+	 *
+	 * Source meta lives on the PARENT shop_order (post_parent of the
+	 * shop_subscription post), NOT on the shop_subscription post itself.
+	 * `first_sub_parent` pre-aggregates, per (customer_id, first_start) pair,
+	 * the post_parent of that first subscription — `MIN(post_parent)`
+	 * deterministically resolves the rare case of two subscriptions tying on
+	 * the same customer + start timestamp (the original's `LIMIT 1` with no
+	 * ORDER BY picked "any one" of the tied rows just as arbitrarily). Gate /
+	 * legacy-gate / popup meta are each pre-aggregated to one row per post_id
+	 * (`MIN(meta_value)` guards against a post carrying more than one non-empty
+	 * value for the same key, mirroring the original's `LIMIT 1`) and
+	 * LEFT-JOINed on that resolved parent id, instead of three correlated
+	 * per-row subqueries that each re-execute the whole 4-table join on every
+	 * outer row. A LEFT JOIN miss (no such meta on the parent order, or no
+	 * parent order at all) still yields '' via COALESCE, exactly as the
+	 * original — a customer with no gate/popup attribution still appears in
+	 * the result set.
+	 *
 	 * @param DateTimeInterface $start Window start.
 	 * @param DateTimeInterface $end   Window end.
 	 * @return array<int, array{customer_id:int, ts:int}>
@@ -1263,79 +1284,12 @@ class Legacy_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Legacy CPT equivalent of HPOS get_new_subscriber_records_in_window().
-		// Guest orders (blank _customer_user → 0 when cast) are excluded from
-		// source attribution — see the HPOS variant for the rationale.
-		//
-		// Source meta lives on the PARENT shop_order (post_parent of the
-		// shop_subscription post), NOT on the shop_subscription post itself.
-		// Correlated subqueries (MySQL 5.7-safe) read _gate_post_id /
-		// _memberships_content_gate / _newspack_popup_id from {prefix}postmeta
-		// WHERE post_id = p_sub.post_parent. LIMIT 1 resolves same-timestamp
-		// ties — any one tied first-subscription's parent-order meta is used.
 		$sql = $wpdb->prepare(
 			"SELECT
 				first_subs.customer_id,
 				first_subs.first_start,
-				COALESCE((
-					SELECT pm_gate.meta_value
-					FROM {$prefix}posts p_sub
-					JOIN {$prefix}postmeta cust_s
-						ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
-					JOIN {$prefix}postmeta start_s
-						ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
-					JOIN {$prefix}postmeta pm_gate
-						ON pm_gate.post_id = p_sub.post_parent AND pm_gate.meta_key = '_gate_post_id'
-					JOIN {$prefix}woocommerce_order_items oi_s
-						ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim_s
-						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
-					WHERE p_sub.post_type = 'shop_subscription'
-					  AND CAST(cust_s.meta_value AS UNSIGNED) = first_subs.customer_id
-					  AND oim_s.meta_value NOT IN ($donations)
-					  AND start_s.meta_value = first_subs.first_start
-					  AND pm_gate.meta_value NOT IN ('', '0')
-					LIMIT 1
-				), (
-					SELECT pm_legacy.meta_value
-					FROM {$prefix}posts p_sub
-					JOIN {$prefix}postmeta cust_s
-						ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
-					JOIN {$prefix}postmeta start_s
-						ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
-					JOIN {$prefix}postmeta pm_legacy
-						ON pm_legacy.post_id = p_sub.post_parent AND pm_legacy.meta_key = '_memberships_content_gate'
-					JOIN {$prefix}woocommerce_order_items oi_s
-						ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim_s
-						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
-					WHERE p_sub.post_type = 'shop_subscription'
-					  AND CAST(cust_s.meta_value AS UNSIGNED) = first_subs.customer_id
-					  AND oim_s.meta_value NOT IN ($donations)
-					  AND start_s.meta_value = first_subs.first_start
-					  AND pm_legacy.meta_value NOT IN ('', '0')
-					LIMIT 1
-				), '') AS gate_post_id,
-				COALESCE((
-					SELECT pm_popup.meta_value
-					FROM {$prefix}posts p_sub
-					JOIN {$prefix}postmeta cust_s
-						ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
-					JOIN {$prefix}postmeta start_s
-						ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
-					JOIN {$prefix}postmeta pm_popup
-						ON pm_popup.post_id = p_sub.post_parent AND pm_popup.meta_key = '_newspack_popup_id'
-					JOIN {$prefix}woocommerce_order_items oi_s
-						ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim_s
-						ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
-					WHERE p_sub.post_type = 'shop_subscription'
-					  AND CAST(cust_s.meta_value AS UNSIGNED) = first_subs.customer_id
-					  AND oim_s.meta_value NOT IN ($donations)
-					  AND start_s.meta_value = first_subs.first_start
-					  AND pm_popup.meta_value NOT IN ('', '0')
-					LIMIT 1
-				), '') AS popup_id
+				COALESCE(gate.gate_post_id, legacy_gate.gate_post_id, '') AS gate_post_id,
+				COALESCE(popup.popup_id, '') AS popup_id
 			FROM (
 				SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id, MIN(start.meta_value) AS first_start
 				FROM {$prefix}posts p
@@ -1353,6 +1307,44 @@ class Legacy_Storage implements Storage_Interface {
 				  AND start.meta_value != ''
 				GROUP BY CAST(cust.meta_value AS UNSIGNED)
 			) AS first_subs
+			LEFT JOIN (
+				SELECT
+					CAST(cust_s.meta_value AS UNSIGNED) AS customer_id,
+					start_s.meta_value AS first_start,
+					MIN(p_sub.post_parent) AS parent_id
+				FROM {$prefix}posts p_sub
+				JOIN {$prefix}postmeta cust_s
+					ON cust_s.post_id = p_sub.ID AND cust_s.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta start_s
+					ON start_s.post_id = p_sub.ID AND start_s.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi_s
+					ON oi_s.order_id = p_sub.ID AND oi_s.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim_s
+					ON oim_s.order_item_id = oi_s.order_item_id AND oim_s.meta_key = '_product_id'
+				WHERE p_sub.post_type = 'shop_subscription'
+				  AND oim_s.meta_value NOT IN ($donations)
+				GROUP BY CAST(cust_s.meta_value AS UNSIGNED), start_s.meta_value
+			) AS first_sub_parent
+				ON first_sub_parent.customer_id = first_subs.customer_id
+				AND first_sub_parent.first_start = first_subs.first_start
+			LEFT JOIN (
+				SELECT post_id, MIN(meta_value) AS gate_post_id
+				FROM {$prefix}postmeta
+				WHERE meta_key = '_gate_post_id' AND meta_value NOT IN ('', '0')
+				GROUP BY post_id
+			) AS gate ON gate.post_id = first_sub_parent.parent_id
+			LEFT JOIN (
+				SELECT post_id, MIN(meta_value) AS gate_post_id
+				FROM {$prefix}postmeta
+				WHERE meta_key = '_memberships_content_gate' AND meta_value NOT IN ('', '0')
+				GROUP BY post_id
+			) AS legacy_gate ON legacy_gate.post_id = first_sub_parent.parent_id
+			LEFT JOIN (
+				SELECT post_id, MIN(meta_value) AS popup_id
+				FROM {$prefix}postmeta
+				WHERE meta_key = '_newspack_popup_id' AND meta_value NOT IN ('', '0')
+				GROUP BY post_id
+			) AS popup ON popup.post_id = first_sub_parent.parent_id
 			WHERE first_subs.first_start BETWEEN %s AND %s",
 			$this->fmt( $start ),
 			$this->fmt( $end )

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1054,6 +1054,22 @@ class Legacy_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Mirrors HPOS_Storage::get_stale_registered_users(). Base population and
+	 * exclusion logic are identical — the only difference is using
+	 * posts/postmeta for donation orders instead of wc_orders/wc_orders_meta,
+	 * and wc_order_product_lookup (cross-backend) for the product filter. See
+	 * the HPOS variant for the full Phase-A approximation rationale.
+	 *
+	 * Both exclusion sets (active non-donation subscribers; trailing-365-day
+	 * donors) are pre-aggregated to DISTINCT customer_ids and LEFT-JOINed
+	 * against `u.ID`, keeping only rows where both sides are NULL — an
+	 * anti-join, not a correlated `NOT IN (subquery)` (MySQL's slowest
+	 * anti-join form). Same approach as
+	 * {@see self::get_churned_subscribers_in_window()}. The base-population /
+	 * restricted-role checks stay as correlated `EXISTS` — each is a single
+	 * indexed lookup on `usermeta.user_id`, not a multi-join subquery, so they
+	 * are not a timeout risk.
+	 *
 	 * @return int
 	 */
 	public function get_stale_registered_users(): int {
@@ -1061,12 +1077,6 @@ class Legacy_Storage implements Storage_Interface {
 		$prefix    = $wpdb->prefix;
 		$donations = $this->id_list( $this->donation_product_ids );
 
-		// Mirrors HPOS_Storage::get_stale_registered_users(). Base population and
-		// exclusion logic are identical — the only difference is using
-		// posts/postmeta for donation orders instead of wc_orders/wc_orders_meta,
-		// and wc_order_product_lookup (cross-backend) for the product filter.
-		// See the HPOS variant for the full Phase-A approximation rationale.
-		//
 		// Phase-A approximation (M1): hardcodes 'subscriber'/'customer' as reader
 		// roles and 'administrator'/'editor' as restricted roles — does NOT honor
 		// the filterable newspack_reader_user_roles / newspack_reader_restricted_roles
@@ -1074,6 +1084,30 @@ class Legacy_Storage implements Storage_Interface {
 		// (acceptable upper-bound for Phase A; adjust in a later iteration).
 		$sql = "SELECT COUNT(DISTINCT u.ID)
 			FROM {$prefix}users u
+			LEFT JOIN (
+				SELECT DISTINCT CAST(cust.meta_value AS UNSIGNED) AS customer_id
+				FROM {$prefix}posts p
+				JOIN {$prefix}postmeta cust
+					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
+				JOIN {$prefix}woocommerce_order_items oi
+					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim
+					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+				WHERE p.post_type = 'shop_subscription'
+				  AND p.post_status = 'wc-active'
+				  AND oim.meta_value NOT IN ($donations)
+			) AS active_subscribers ON active_subscribers.customer_id = u.ID
+			LEFT JOIN (
+				SELECT DISTINCT CAST(cust2.meta_value AS UNSIGNED) AS customer_id
+				FROM {$prefix}posts p2
+				JOIN {$prefix}postmeta cust2
+					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
+				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p2.ID
+				WHERE p2.post_type = 'shop_order'
+				  AND p2.post_status IN ('wc-completed', 'wc-processing')
+				  AND p2.post_date_gmt >= DATE_SUB(NOW(), INTERVAL 365 DAY)
+				  AND opl.product_id IN ($donations)
+			) AS recent_donors ON recent_donors.customer_id = u.ID
 			WHERE (
 				EXISTS (
 					SELECT 1 FROM {$prefix}usermeta um
@@ -1100,30 +1134,8 @@ class Legacy_Storage implements Storage_Interface {
 					OR um3.meta_value LIKE '%\"editor\"%'
 				  )
 			)
-			AND u.ID NOT IN (
-				SELECT DISTINCT CAST(cust.meta_value AS UNSIGNED)
-				FROM {$prefix}posts p
-				JOIN {$prefix}postmeta cust
-					ON cust.post_id = p.ID AND cust.meta_key = '_customer_user'
-				JOIN {$prefix}woocommerce_order_items oi
-					ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
-				JOIN {$prefix}woocommerce_order_itemmeta oim
-					ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
-				WHERE p.post_type = 'shop_subscription'
-				  AND p.post_status = 'wc-active'
-				  AND oim.meta_value NOT IN ($donations)
-			)
-			AND u.ID NOT IN (
-				SELECT DISTINCT CAST(cust2.meta_value AS UNSIGNED)
-				FROM {$prefix}posts p2
-				JOIN {$prefix}postmeta cust2
-					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
-				JOIN {$prefix}wc_order_product_lookup opl ON opl.order_id = p2.ID
-				WHERE p2.post_type = 'shop_order'
-				  AND p2.post_status IN ('wc-completed', 'wc-processing')
-				  AND p2.post_date_gmt >= DATE_SUB(NOW(), INTERVAL 365 DAY)
-				  AND opl.product_id IN ($donations)
-			)";
+			AND active_subscribers.customer_id IS NULL
+			AND recent_donors.customer_id IS NULL";
 
 		return (int) $wpdb->get_var( $sql );
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/storage/class-legacy-storage.php
@@ -1635,6 +1635,20 @@ class Legacy_Storage implements Storage_Interface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Legacy CPT equivalent of HPOS_Storage::get_new_subscriber_cohort_intervals().
+	 * _customer_user is cast to UNSIGNED (stored as a string) to align with the
+	 * other list-scoped legacy queries.
+	 *
+	 * Cohort membership (first-ever non-donation subscription start within the
+	 * trailing 365 days) is pre-aggregated to one row per customer_id in the
+	 * `cohort` derived table and INNER-JOINed against the outer subscription
+	 * scan, instead of a correlated `customer_id IN (SELECT ... GROUP BY ...
+	 * HAVING ...)` semi-join subquery — the INNER JOIN lets MySQL build the
+	 * cohort set once rather than re-evaluating it as part of a full outer
+	 * scan. The outer scan is otherwise unchanged: it still returns every
+	 * non-donation subscription belonging to a cohort member, not just the
+	 * qualifying first one.
+	 *
 	 * @return array<int, array{customer_id:int, start:string, cancelled:?string, end:?string}>
 	 */
 	public function get_new_subscriber_cohort_intervals(): array {
@@ -1646,9 +1660,6 @@ class Legacy_Storage implements Storage_Interface {
 		// Upper bound excludes subscriptions with a future _schedule_start (scheduled/pending).
 		$now = gmdate( 'Y-m-d H:i:s', ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->getTimestamp() );
 
-		// Legacy CPT equivalent of HPOS_Storage::get_new_subscriber_cohort_intervals().
-		// _customer_user is cast to UNSIGNED (stored as a string) to align with the
-		// other list-scoped legacy queries.
 		$sql = $wpdb->prepare(
 			"SELECT CAST(cust.meta_value AS UNSIGNED) AS customer_id,
 				sm.meta_value AS sched_start,
@@ -1667,30 +1678,28 @@ class Legacy_Storage implements Storage_Interface {
 				ON oi.order_id = p.ID AND oi.order_item_type = 'line_item'
 			JOIN {$prefix}woocommerce_order_itemmeta oim
 				ON oim.order_item_id = oi.order_item_id AND oim.meta_key = '_product_id'
+			INNER JOIN (
+				SELECT CAST(cust2.meta_value AS UNSIGNED) AS customer_id, MIN(sm2.meta_value) AS first_start
+				FROM {$prefix}posts p2
+				JOIN {$prefix}postmeta cust2
+					ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
+				JOIN {$prefix}postmeta sm2
+					ON sm2.post_id = p2.ID AND sm2.meta_key = '_schedule_start'
+				JOIN {$prefix}woocommerce_order_items oi2
+					ON oi2.order_id = p2.ID AND oi2.order_item_type = 'line_item'
+				JOIN {$prefix}woocommerce_order_itemmeta oim2
+					ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
+				WHERE p2.post_type = 'shop_subscription'
+				  AND CAST(cust2.meta_value AS UNSIGNED) > 0 -- exclude guest subscriptions
+				  AND oim2.meta_value NOT IN ($donations)
+				  AND sm2.meta_value != ''
+				GROUP BY CAST(cust2.meta_value AS UNSIGNED)
+				HAVING first_start >= %s AND first_start <= %s
+			) AS cohort ON cohort.customer_id = CAST(cust.meta_value AS UNSIGNED)
 			WHERE p.post_type = 'shop_subscription'
 			  AND CAST(cust.meta_value AS UNSIGNED) > 0 -- exclude guest subscriptions (mirrors get_new_subscriber_records_in_window)
 			  AND oim.meta_value NOT IN ($donations)
-			  AND sm.meta_value != ''
-			  AND CAST(cust.meta_value AS UNSIGNED) IN (
-				SELECT cohort.customer_id FROM (
-					SELECT CAST(cust2.meta_value AS UNSIGNED) AS customer_id, MIN(sm2.meta_value) AS first_start
-					FROM {$prefix}posts p2
-					JOIN {$prefix}postmeta cust2
-						ON cust2.post_id = p2.ID AND cust2.meta_key = '_customer_user'
-					JOIN {$prefix}postmeta sm2
-						ON sm2.post_id = p2.ID AND sm2.meta_key = '_schedule_start'
-					JOIN {$prefix}woocommerce_order_items oi2
-						ON oi2.order_id = p2.ID AND oi2.order_item_type = 'line_item'
-					JOIN {$prefix}woocommerce_order_itemmeta oim2
-						ON oim2.order_item_id = oi2.order_item_id AND oim2.meta_key = '_product_id'
-					WHERE p2.post_type = 'shop_subscription'
-					  AND CAST(cust2.meta_value AS UNSIGNED) > 0 -- exclude guest subscriptions
-					  AND oim2.meta_value NOT IN ($donations)
-					  AND sm2.meta_value != ''
-					GROUP BY CAST(cust2.meta_value AS UNSIGNED)
-					HAVING first_start >= %s AND first_start <= %s
-				) cohort
-			  )",
+			  AND sm.meta_value != ''",
 			$cutoff,
 			$now
 		);

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-cancellation-reasons-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-cancellation-reasons-query.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * DB-backed characterization test for get_cancellation_reasons() (perf fix).
+ *
+ * The storage implementation restricts to non-donation subscriptions via
+ * `p.ID IN (SELECT DISTINCT oi.order_id FROM ... WHERE oim.meta_value NOT IN
+ * (donations))` — a semi-join subquery flagged for timeout risk on large
+ * subscriptions datasets.
+ *
+ * This test pins the query's OUTPUT (cancellation_reason => count buckets)
+ * against a small, deliberately adversarial fixture set BEFORE the query is
+ * rewritten as a pre-aggregated INNER JOIN semi-join. It must pass unchanged
+ * on the OLD query (baseline) and again on the NEW query (equivalence proof)
+ * — especially the crux case: a subscription with MULTIPLE non-donation line
+ * items must still be counted ONCE (the DISTINCT in the original subquery
+ * guards against this; the rewrite's derived table must too).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_cancellation_reasons().
+ *
+ * @group insights
+ */
+class Test_Cancellation_Reasons_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id, excluded from the cancellation-reason population.
+	 */
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id.
+	 */
+	const SUB_PRODUCT_ID = 555001;
+
+	/**
+	 * A second non-donation subscription product id (for the multi-line-item case).
+	 */
+	const SUB_PRODUCT_ID_2 = 555002;
+
+	/**
+	 * Stand up the WC order + line-item tables once.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to exclude the
+	 * donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function storage_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * Set the `newspack_subscriptions_cancellation_reason` meta on a
+	 * subscription, in the given backend.
+	 *
+	 * @param string $backend Backend key.
+	 * @param int    $sub_id  Subscription id.
+	 * @param string $reason  Reason value.
+	 * @return void
+	 */
+	private function set_reason( string $backend, int $sub_id, string $reason ): void {
+		if ( 'hpos' === $backend ) {
+			global $wpdb;
+			$wpdb->insert(
+				"{$wpdb->prefix}wc_orders_meta",
+				[
+					'order_id'   => $sub_id,
+					'meta_key'   => 'newspack_subscriptions_cancellation_reason',
+					'meta_value' => $reason,
+				]
+			);
+		} else {
+			add_post_meta( $sub_id, 'newspack_subscriptions_cancellation_reason', $reason );
+		}
+	}
+
+	/**
+	 * The window: brackets the "in window" fixture dates while excluding the
+	 * "outside window" fixture dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-30 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Find a reason bucket's count by reason string.
+	 *
+	 * @param array<int, array{cancellation_reason:string, count:int}> $rows   Result set.
+	 * @param string                                                   $reason Reason to find.
+	 * @return int|null
+	 */
+	private function count_for( array $rows, string $reason ): ?int {
+		foreach ( $rows as $row ) {
+			if ( $row['cancellation_reason'] === $reason ) {
+				return $row['count'];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Case A: a cancelled subscription in the window with a reason meta is
+	 * bucketed under that reason.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_reason_bucket_counts_cancelled_subscription_in_window( string $backend ): void {
+		$base      = 92000 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$sub_id = $this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => $base + 1,
+				'customer_id'        => 601,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->set_reason( $backend, $sub_id, 'too_expensive' );
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_cancellation_reasons( $start, $end );
+
+		$this->assertSame( 1, $this->count_for( $rows, 'too_expensive' ) );
+	}
+
+	/**
+	 * Case B: a cancelled subscription with NO reason meta is bucketed as
+	 * 'unknown'.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_missing_reason_bucketed_as_unknown( string $backend ): void {
+		$base      = 92100 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => $base + 1,
+				'customer_id'        => 602,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-expired',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_cancellation_reasons( $start, $end );
+
+		$this->assertSame( 1, $this->count_for( $rows, 'unknown' ) );
+	}
+
+	/**
+	 * Case C: a cancelled subscription OUTSIDE the window is excluded.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_cancellation_outside_window_excluded( string $backend ): void {
+		$base       = 92200 + ( 'hpos' === $backend ? 500 : 0 );
+		$out_window = gmdate( 'Y-m-d H:i:s', strtotime( '-90 days' ) );
+
+		$sub_id = $this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => $base + 1,
+				'customer_id'        => 603,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $out_window,
+			]
+		);
+		$this->set_reason( $backend, $sub_id, 'out_of_window_reason' );
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_cancellation_reasons( $start, $end );
+
+		$this->assertNull( $this->count_for( $rows, 'out_of_window_reason' ) );
+	}
+
+	/**
+	 * Case D: a cancelled DONATION-product subscription in window is excluded.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donation_cancellation_excluded( string $backend ): void {
+		$base      = 92300 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$sub_id = $this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => $base + 1,
+				'customer_id'        => 604,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->set_reason( $backend, $sub_id, 'donation_reason' );
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_cancellation_reasons( $start, $end );
+
+		$this->assertNull( $this->count_for( $rows, 'donation_reason' ) );
+	}
+
+	/**
+	 * Case E: multiple cancelled subscriptions sharing the same reason are
+	 * summed under one bucket.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_multiple_subscriptions_same_reason_summed( string $backend ): void {
+		$base      = 92400 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		foreach ( [ 605, 606, 607 ] as $i => $customer_id ) {
+			$sub_id = $this->insert_subscription(
+				$backend,
+				[
+					'order_id'           => $base + 1 + $i,
+					'customer_id'        => $customer_id,
+					'product_id'         => self::SUB_PRODUCT_ID,
+					'status'             => 'wc-cancelled',
+					'schedule_cancelled' => $in_window,
+				]
+			);
+			$this->set_reason( $backend, $sub_id, 'switched_provider' );
+		}
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_cancellation_reasons( $start, $end );
+
+		$this->assertSame( 3, $this->count_for( $rows, 'switched_provider' ) );
+	}
+
+	/**
+	 * Crux case: a subscription with TWO non-donation line items must be
+	 * counted ONCE, not twice — the original's `DISTINCT oi.order_id` in the
+	 * semi-join subquery guards against this; the rewrite's pre-aggregated
+	 * derived table must preserve that DISTINCT.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_subscription_with_multiple_line_items_counted_once( string $backend ): void {
+		$base      = 92500 + ( 'hpos' === $backend ? 500 : 0 );
+		$order_id  = $base + 1;
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$sub_id = $this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => $order_id,
+				'customer_id'        => 608,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		// Add a SECOND non-donation line item to the same subscription order.
+		$this->insert_subscription_line_item( $sub_id, self::SUB_PRODUCT_ID_2 );
+		$this->set_reason( $backend, $sub_id, 'multi_item_reason' );
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_cancellation_reasons( $start, $end );
+
+		$this->assertSame(
+			1,
+			$this->count_for( $rows, 'multi_item_reason' ),
+			'A subscription with multiple non-donation line items must be counted once, not once per line item.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-churned-subscribers-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-churned-subscribers-query.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * DB-backed characterization test for get_churned_subscribers_in_window()
+ * (churn-query perf fix).
+ *
+ * On www.richlandsource.com's large legacy WooCommerce subscriptions dataset,
+ * a manual Audience-tab refresh timed out inside this query: the storage
+ * implementation used `customer_id NOT IN (SELECT ... multi-join subquery)`
+ * for the active-subscriber exclusion — MySQL's slowest anti-join form — plus
+ * an unindexed BETWEEN string range scan on the schedule-cancelled meta.
+ *
+ * This test pins the query's OUTPUT (the churned-customer count) against a
+ * small, deliberately adversarial fixture set BEFORE the query is rewritten
+ * as a pre-aggregated LEFT JOIN anti-join (mirroring the proven
+ * get_winback_subscribers_in_window() pattern in both storage backends). It
+ * must pass unchanged on the OLD query (baseline) and again on the NEW query
+ * (equivalence proof) — especially case B, the customer who both churned in
+ * the window AND holds a separate active subscription, which is the exact
+ * scenario the anti-join must continue to exclude.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_churned_subscribers_in_window().
+ *
+ * @group insights
+ */
+class Test_Churned_Subscribers_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id, excluded from the churn count via the NOT IN list.
+	 */
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id.
+	 */
+	const SUB_PRODUCT_ID = 555001;
+
+	/**
+	 * Stand up the WC order + line-item tables once (InnoDB → per-test inserts
+	 * roll back via the surrounding transaction).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to exclude the
+	 * donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function storage_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * The churn window: brackets the "in window" fixture dates while excluding
+	 * the "outside window" fixture dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-30 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Seed the four anchor cases (A–D) described in the fix plan:
+	 *
+	 *   A: cancelled/expired sub, `_schedule_cancelled` INSIDE the window, no
+	 *      active sub for that customer → COUNTED as churned.
+	 *   B: cancelled sub in window AND an active subscription for the SAME
+	 *      customer (different order) → NOT counted. This is the crux case:
+	 *      it is exactly what the anti-join must continue to exclude.
+	 *   C: cancelled sub, `_schedule_cancelled` OUTSIDE the window → not counted.
+	 *   D: cancelled sub in window, but on a DONATION product id → excluded.
+	 *
+	 * Only case A should be counted, so the assertion is `assertSame( 1, ... )`.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return void
+	 */
+	private function seed_anchor_cases( string $backend ): void {
+		$in_window  = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$out_window = gmdate( 'Y-m-d H:i:s', strtotime( '-90 days' ) );
+
+		// Case A: churned in window, no active sub. customer_id 101.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 7001,
+				'customer_id'        => 101,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+
+		// Case B: churned in window (customer 102) AND has a separate active sub
+		// (customer 102) — must NOT be counted as churned.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 7002,
+				'customer_id'        => 102,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 7003,
+				'customer_id' => 102,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		// Case C: cancelled but OUTSIDE the window. customer_id 103.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 7004,
+				'customer_id'        => 103,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-expired',
+				'schedule_cancelled' => $out_window,
+			]
+		);
+
+		// Case D: cancelled in window, but on the DONATION product. customer_id 104.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 7005,
+				'customer_id'        => 104,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+	}
+
+	/**
+	 * The characterization assertion: only case A (customer 101) is counted as
+	 * churned. This must pass BOTH before and after the anti-join rewrite —
+	 * that is the equivalence proof required before shipping the perf fix.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_churned_count_excludes_active_and_out_of_window_and_donation( string $backend ): void {
+		$this->seed_anchor_cases( $backend );
+		[ $start, $end ] = $this->window();
+
+		$count = $this->storage_for( $backend )->get_churned_subscribers_in_window( $start, $end );
+
+		$this->assertSame(
+			1,
+			$count,
+			'Only case A (churned in window, no active sub) should count. ' .
+			'Case B (churned in window but also active) must be excluded — the crux ' .
+			'case the anti-join rewrite must preserve. Cases C (out of window) and D ' .
+			'(donation product) must also be excluded.'
+		);
+	}
+
+	/**
+	 * Isolate case B on its own (no other fixtures) to pin the exact crux
+	 * scenario independent of the combined-count test above: a customer who
+	 * both churned inside the window and holds a separate active subscription
+	 * must contribute 0 to the churn count.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_customer_with_active_sub_is_never_counted_as_churned( string $backend ): void {
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 8001,
+				'customer_id'        => 202,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 8002,
+				'customer_id' => 202,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$count            = $this->storage_for( $backend )->get_churned_subscribers_in_window( $start, $end );
+
+		$this->assertSame( 0, $count, 'A customer with a remaining active subscription is never "churned".' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donations-by-tier-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-donations-by-tier-query.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * DB-backed characterization test for get_donations_by_tier()
+ * (donor-query perf fix).
+ *
+ * `get_donations_by_tier()` runs 3 passes of wide joins. Pass 2 (lapsed
+ * donors per tier) used a `cust.meta_value NOT IN (SELECT ... multi-join
+ * subquery)` for the active-subscriber exclusion — MySQL's slowest
+ * anti-join form, plus an unindexed `_schedule_cancelled` range scan. Pass
+ * 3 already uses a pre-aggregated (non-correlated) derived table for
+ * first-donation-date, so it is untouched by this fix.
+ *
+ * This test pins the query's OUTPUT (the per-product tier rows) against a
+ * small, deliberately adversarial fixture set BEFORE Pass 2 is rewritten
+ * as a pre-aggregated LEFT JOIN anti-join (mirroring
+ * get_lapsed_donors_in_window()). It must pass unchanged on the OLD query
+ * (baseline) and again on the NEW query (equivalence proof) — especially
+ * the crux case: a donor who cancelled a donation subscription for a given
+ * product INSIDE the window but holds a SEPARATE active donation
+ * subscription, which must be excluded from that product's
+ * `lapsed_donors_in_window` count.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Donors_Storage;
+use Newspack\Insights\Legacy_Donors_Storage;
+use Newspack\Insights\Donors_Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_donations_by_tier().
+ *
+ * @group insights
+ */
+class Test_Donations_By_Tier_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Simple (non-variable) donation product A — a real `wp_posts` row is
+	 * required because the tier SQL JOINs `{$prefix}posts pv ON pv.ID = ...`.
+	 */
+	const PRODUCT_A_ID = 999401;
+
+	/**
+	 * Simple (non-variable) donation product B, used to prove Pass 2 buckets
+	 * lapsed donors per-product, not globally.
+	 */
+	const PRODUCT_B_ID = 999402;
+
+	/**
+	 * Stand up the WC order + line-item tables once (InnoDB → per-test inserts
+	 * roll back via the surrounding transaction).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Create the real `wp_posts` rows the tier SQL's `pv` JOIN requires for
+	 * each simple donation product, once per test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		foreach ( [ self::PRODUCT_A_ID, self::PRODUCT_B_ID ] as $product_id ) {
+			wp_insert_post(
+				[
+					'import_id'   => $product_id,
+					'post_type'   => 'product',
+					'post_status' => 'publish',
+					'post_title'  => 'Donation Product ' . $product_id,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to both donation
+	 * products.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Donors_Storage_Interface
+	 */
+	private function storage_for( string $backend ): Donors_Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Donors_Storage( [ self::PRODUCT_A_ID, self::PRODUCT_B_ID ] )
+			: new Legacy_Donors_Storage( [ self::PRODUCT_A_ID, self::PRODUCT_B_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * The window: brackets the "in window" fixture dates while excluding the
+	 * "outside window" fixture dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-30 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Find the tier row for a given (effective) product id — since neither
+	 * fixture product here is a variation, `variation_id` === the product id.
+	 *
+	 * @param array $rows   get_donations_by_tier() output.
+	 * @param int   $prod_id Product id to find.
+	 * @return array|null
+	 */
+	private function find_row( array $rows, int $prod_id ): ?array {
+		foreach ( $rows as $row ) {
+			if ( (int) $row['product_id'] === $prod_id ) {
+				return $row;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The crux case: a donor who cancelled a donation subscription for
+	 * PRODUCT_A inside the window, but holds a SEPARATE active donation
+	 * subscription (for PRODUCT_A too — the exclusion is per the
+	 * scorecard's global "any active donation sub" cohort, not
+	 * per-product), must be excluded from PRODUCT_A's
+	 * `lapsed_donors_in_window`. A second donor who cancelled PRODUCT_B
+	 * with no active sub anywhere IS counted for PRODUCT_B — proving the
+	 * bucketing stays per-product while the exclusion cohort is preserved.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_lapsed_bucket_excludes_donor_with_active_sub( string $backend ): void {
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		// Donor 501: cancelled PRODUCT_A in window AND has a separate active
+		// PRODUCT_A sub — must NOT be counted as lapsed for PRODUCT_A.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 95001,
+				'customer_id'        => 501,
+				'product_id'         => self::PRODUCT_A_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 95002,
+				'customer_id' => 501,
+				'product_id'  => self::PRODUCT_A_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		// Donor 502: cancelled PRODUCT_B in window, no active sub anywhere —
+		// counted as lapsed for PRODUCT_B.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 95003,
+				'customer_id'        => 502,
+				'product_id'         => self::PRODUCT_B_ID,
+				'status'             => 'wc-expired',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_donations_by_tier( $start, $end );
+
+		$row_a = $this->find_row( $rows, self::PRODUCT_A_ID );
+		$row_b = $this->find_row( $rows, self::PRODUCT_B_ID );
+
+		$this->assertNotNull( $row_a, 'PRODUCT_A must appear (it has an active_recurring_donor).' );
+		$this->assertSame(
+			0,
+			$row_a['lapsed_donors_in_window'],
+			'Donor 501 has an active donation sub and must be excluded from the lapsed bucket — the crux case.'
+		);
+
+		$this->assertNotNull( $row_b, 'PRODUCT_B must appear (it has a lapsed donor).' );
+		$this->assertSame(
+			1,
+			$row_b['lapsed_donors_in_window'],
+			'Donor 502 genuinely lapsed with no active sub anywhere and must be counted for PRODUCT_B.'
+		);
+	}
+
+	/**
+	 * Isolate the crux case on its own product (no cross-product fixtures)
+	 * to pin the exact scenario independent of the bucketing test above.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donor_with_active_sub_never_counted_as_lapsed_for_any_product( string $backend ): void {
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 96001,
+				'customer_id'        => 601,
+				'product_id'         => self::PRODUCT_A_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 96002,
+				'customer_id' => 601,
+				'product_id'  => self::PRODUCT_A_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$rows             = $this->storage_for( $backend )->get_donations_by_tier( $start, $end );
+		$row_a            = $this->find_row( $rows, self::PRODUCT_A_ID );
+
+		$this->assertNotNull( $row_a );
+		$this->assertSame( 0, $row_a['lapsed_donors_in_window'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-lapsed-donor-recovery-rate-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-lapsed-donor-recovery-rate-query.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * DB-backed characterization test for get_lapsed_donor_recovery_rate()
+ * (donor-query perf fix).
+ *
+ * `get_lapsed_donor_recovery_rate()` used a `NOT IN (subquery)` anti-join
+ * for the active-donation-subscriber exclusion (MySQL's slowest anti-join
+ * form) PLUS a PHP round trip: it pulled the entire prior-window lapsed
+ * cohort into a PHP array and serialized it back into a
+ * `CAST(cust.meta_value AS UNSIGNED) IN ($lapsed_list)` filter for the
+ * "recovered" query — slow and a `max_allowed_packet` risk on large
+ * cohorts.
+ *
+ * This test pins the query's OUTPUT (value/computable/denominator) against
+ * a small, deliberately adversarial fixture set BEFORE the query is
+ * rewritten to compute the lapsed cohort as an in-SQL derived table
+ * (anti-join for exclusion, semi-join/derived-table for the recovered-in
+ * check) instead of a PHP-built id list. It must pass unchanged on the OLD
+ * query (baseline) and again on the NEW query (equivalence proof) —
+ * especially:
+ *   - a donor who lapsed in the PRIOR window but holds a separate active
+ *     donation sub (must never enter the lapsed cohort — the anti-join
+ *     crux case), and
+ *   - a donor who lapsed in the prior window and DID make a new donation
+ *     order inside the CURRENT window (the "recovered" numerator case).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+use Newspack\Insights\HPOS_Donors_Storage;
+use Newspack\Insights\Legacy_Donors_Storage;
+use Newspack\Insights\Donors_Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_lapsed_donor_recovery_rate().
+ *
+ * @group insights
+ */
+class Test_Lapsed_Donor_Recovery_Rate_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id — the only product id these donor queries scope to.
+	 */
+	const DONATION_PRODUCT_ID = 999201;
+
+	/**
+	 * Stand up the WC order + line-item tables once (InnoDB → per-test inserts
+	 * roll back via the surrounding transaction).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to the donation
+	 * product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Donors_Storage_Interface
+	 */
+	private function storage_for( string $backend ): Donors_Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Donors_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Donors_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * Insert a shop_order row (used for the "recovered" donation order) into
+	 * the given backend, with `customer_id` set. Neither `insert_hpos_order()`
+	 * nor `insert_legacy_order()` persists a customer id on a plain shop_order
+	 * (only the subscription helpers do), so this wires it up directly: HPOS
+	 * via `wc_orders.customer_id`, legacy via `_customer_user` postmeta —
+	 * same approach as {@see Test_Stale_Registered_Users_Query::insert_order()}.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait); `customer_id` required.
+	 * @return int The created order id.
+	 */
+	private function insert_order( string $backend, array $args ): int {
+		global $wpdb;
+		$order_id = 'hpos' === $backend
+			? $this->insert_hpos_order( $args )
+			: $this->insert_legacy_order( $args );
+
+		if ( 'hpos' === $backend ) {
+			$wpdb->update( "{$wpdb->prefix}wc_orders", [ 'customer_id' => (int) $args['customer_id'] ], [ 'id' => $order_id ] );
+		} else {
+			add_post_meta( $order_id, '_customer_user', (string) $args['customer_id'] );
+		}
+		return $order_id;
+	}
+
+	/**
+	 * Current window: [-30 days, +1 day]. The prior window (computed by the
+	 * method under test) is the same-length window immediately preceding it.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function current_window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-30 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * A date safely inside the prior window (roughly -61 days, well before
+	 * the current window's -30 day start).
+	 *
+	 * @return string Y-m-d H:i:s (UTC).
+	 */
+	private function prior_window_date(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '-61 days' ) );
+	}
+
+	/**
+	 * A date inside the current window (used for the "recovered" order).
+	 *
+	 * @return string Y-m-d H:i:s (UTC).
+	 */
+	private function current_window_date(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+	}
+
+	/**
+	 * Crux case: a donor who lapsed in the PRIOR window but holds a SEPARATE
+	 * active donation subscription must never enter the lapsed cohort at
+	 * all — denominator must exclude them, and recovery must be computable
+	 * only from genuinely lapsed donors.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donor_with_active_sub_excluded_from_lapsed_cohort( string $backend ): void {
+		// Donor 301: cancelled a donation sub in the prior window, but ALSO
+		// has a separate active donation sub — never "lapsed".
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 81001,
+				'customer_id'        => 301,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $this->prior_window_date(),
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 81002,
+				'customer_id' => 301,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		[ $start, $end ] = $this->current_window();
+		$result           = $this->storage_for( $backend )->get_lapsed_donor_recovery_rate( $start, $end );
+
+		$this->assertFalse(
+			$result['computable'],
+			'Donor 301 has an active donation sub and must never enter the lapsed cohort; ' .
+			'with no other lapsed donors, the cohort is empty and the rate is not computable.'
+		);
+		$this->assertSame( 0, $result['denominator'], 'The lapsed cohort must exclude a donor with an active donation sub.' );
+	}
+
+	/**
+	 * The recovery-rate numerator: a donor who lapsed in the prior window
+	 * (no active sub) and placed a NEW completed donation order inside the
+	 * CURRENT window counts as "recovered". A second lapsed donor who did
+	 * NOT donate again in the current window keeps the denominator at 2 and
+	 * the rate at 0.5.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_recovery_rate_counts_new_current_window_donation( string $backend ): void {
+		// Donor 302: lapsed in prior window, no active sub, DONATES again in
+		// the current window → recovered.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 82001,
+				'customer_id'        => 302,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $this->prior_window_date(),
+			]
+		);
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'    => 82002,
+				'customer_id' => 302,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-completed',
+				'date'        => $this->current_window_date(),
+			]
+		);
+
+		// Donor 303: lapsed in prior window, no active sub, does NOT donate
+		// again → not recovered, but still in the denominator.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 82003,
+				'customer_id'        => 303,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-expired',
+				'schedule_cancelled' => $this->prior_window_date(),
+			]
+		);
+
+		[ $start, $end ] = $this->current_window();
+		$result           = $this->storage_for( $backend )->get_lapsed_donor_recovery_rate( $start, $end );
+
+		$this->assertTrue( $result['computable'], 'Two genuinely lapsed donors form a computable cohort.' );
+		$this->assertSame( 2, $result['denominator'], 'Both donor 302 and 303 are in the lapsed cohort.' );
+		$this->assertEqualsWithDelta( 0.5, $result['value'], 0.0001, 'Only donor 302 (1 of 2) recovered.' );
+	}
+
+	/**
+	 * No lapsed cohort at all → not computable, denominator 0, value 0.0.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_no_lapsed_cohort_is_not_computable( string $backend ): void {
+		[ $start, $end ] = $this->current_window();
+		$result           = $this->storage_for( $backend )->get_lapsed_donor_recovery_rate( $start, $end );
+
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 0, $result['denominator'] );
+		$this->assertSame( 0.0, $result['value'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-lapsed-donors-in-window-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-lapsed-donors-in-window-query.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * DB-backed characterization test for get_lapsed_donors_in_window()
+ * (donor-query perf fix).
+ *
+ * The Donors tab's `get_lapsed_donors_in_window()` used
+ * `customer_id NOT IN (SELECT ... multi-join subquery)` for the
+ * active-donation-subscriber exclusion — MySQL's slowest anti-join form,
+ * a timeout risk on large legacy WooCommerce subscriptions datasets. This
+ * test pins the query's OUTPUT (the lapsed-donor count) against a small,
+ * deliberately adversarial fixture set BEFORE the query is rewritten as a
+ * pre-aggregated LEFT JOIN anti-join (mirroring
+ * get_churned_subscribers_in_window()). It must pass unchanged on the OLD
+ * query (baseline) and again on the NEW query (equivalence proof) —
+ * especially case B, the donor who both lapsed in the window AND holds a
+ * separate active donation subscription, which is the exact scenario the
+ * anti-join must continue to exclude.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Donors_Storage;
+use Newspack\Insights\Legacy_Donors_Storage;
+use Newspack\Insights\Donors_Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_lapsed_donors_in_window().
+ *
+ * @group insights
+ */
+class Test_Lapsed_Donors_In_Window_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id — the only product id these donor queries scope to.
+	 */
+	const DONATION_PRODUCT_ID = 999101;
+
+	/**
+	 * A different (non-donation) subscription product id, used to prove the
+	 * donation product_id filter is preserved.
+	 */
+	const OTHER_SUB_PRODUCT_ID = 555101;
+
+	/**
+	 * Stand up the WC order + line-item tables once (InnoDB → per-test inserts
+	 * roll back via the surrounding transaction).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to the donation
+	 * product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Donors_Storage_Interface
+	 */
+	private function storage_for( string $backend ): Donors_Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Donors_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Donors_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * The window: brackets the "in window" fixture dates while excluding the
+	 * "outside window" fixture dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-30 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Seed the four anchor cases (A–D):
+	 *
+	 *   A: donation sub cancelled/expired, `_schedule_cancelled` INSIDE the
+	 *      window, no active donation sub for that customer → COUNTED.
+	 *   B: donation sub cancelled in window AND a separate active donation
+	 *      sub for the SAME customer → NOT counted. This is the crux case —
+	 *      exactly what the anti-join must continue to exclude.
+	 *   C: donation sub cancelled, `_schedule_cancelled` OUTSIDE the window
+	 *      → not counted.
+	 *   D: cancelled in window, but on a non-donation product id → excluded
+	 *      by the product_id filter, not counted.
+	 *
+	 * Only case A should be counted, so the assertion is `assertSame( 1, ... )`.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return void
+	 */
+	private function seed_anchor_cases( string $backend ): void {
+		$in_window  = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$out_window = gmdate( 'Y-m-d H:i:s', strtotime( '-90 days' ) );
+
+		// Case A: lapsed in window, no active donation sub. customer_id 101.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 71001,
+				'customer_id'        => 101,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+
+		// Case B: lapsed in window (customer 102) AND has a separate active
+		// donation sub (customer 102) — must NOT be counted as lapsed.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 71002,
+				'customer_id'        => 102,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 71003,
+				'customer_id' => 102,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		// Case C: cancelled but OUTSIDE the window. customer_id 103.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 71004,
+				'customer_id'        => 103,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-expired',
+				'schedule_cancelled' => $out_window,
+			]
+		);
+
+		// Case D: cancelled in window, but on a non-donation product. customer_id 104.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 71005,
+				'customer_id'        => 104,
+				'product_id'         => self::OTHER_SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+	}
+
+	/**
+	 * The characterization assertion: only case A (customer 101) is counted
+	 * as lapsed. This must pass BOTH before and after the anti-join rewrite.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_lapsed_count_excludes_active_and_out_of_window_and_other_product( string $backend ): void {
+		$this->seed_anchor_cases( $backend );
+		[ $start, $end ] = $this->window();
+
+		$count = $this->storage_for( $backend )->get_lapsed_donors_in_window( $start, $end );
+
+		$this->assertSame(
+			1,
+			$count,
+			'Only case A (lapsed in window, no active donation sub) should count. ' .
+			'Case B (lapsed in window but also active) must be excluded — the crux ' .
+			'case the anti-join rewrite must preserve. Cases C (out of window) and D ' .
+			'(non-donation product) must also be excluded.'
+		);
+	}
+
+	/**
+	 * Isolate case B on its own (no other fixtures) to pin the exact crux
+	 * scenario independent of the combined-count test above: a donor who
+	 * both lapsed inside the window and holds a separate active donation
+	 * subscription must contribute 0 to the lapsed count.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donor_with_active_donation_sub_is_never_counted_as_lapsed( string $backend ): void {
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 72001,
+				'customer_id'        => 202,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_cancelled' => $in_window,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 72002,
+				'customer_id' => 202,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$count            = $this->storage_for( $backend )->get_lapsed_donors_in_window( $start, $end );
+
+		$this->assertSame( 0, $count, 'A donor with a remaining active donation subscription is never "lapsed".' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-new-subscriber-cohort-intervals-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-new-subscriber-cohort-intervals-query.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * DB-backed characterization test for get_new_subscriber_cohort_intervals()
+ * (perf fix).
+ *
+ * The storage implementation determines cohort membership via
+ * `customer_id IN (SELECT cohort.customer_id FROM (... GROUP BY ... HAVING
+ * ...) cohort)` — a semi-join subquery pattern flagged for timeout risk on
+ * large subscriptions datasets (full outer scan + a two-pass evaluation of
+ * the cohort subquery).
+ *
+ * This test pins the query's OUTPUT (one row per customer+subscription for
+ * every trailing-365-day cohort member) against a small, deliberately
+ * adversarial fixture set BEFORE the query is rewritten as a pre-aggregated
+ * INNER JOIN semi-join. It must pass unchanged on the OLD query (baseline)
+ * and again on the NEW query (equivalence proof) — especially the
+ * multi-subscription case (a cohort customer's SECOND subscription must also
+ * be returned, not just their first) and the out-of-window exclusion (a
+ * customer whose first-ever subscription predates the 365-day cutoff must be
+ * excluded even if they have a LATER subscription that falls inside it).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_new_subscriber_cohort_intervals().
+ *
+ * @group insights
+ */
+class Test_New_Subscriber_Cohort_Intervals_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id, excluded from the cohort population.
+	 */
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id.
+	 */
+	const SUB_PRODUCT_ID = 555001;
+
+	/**
+	 * Stand up the WC order + line-item tables once.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to exclude the
+	 * donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function storage_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * Rows for a given customer_id from a
+	 * get_new_subscriber_cohort_intervals() result set.
+	 *
+	 * @param array<int, array<string, mixed>> $rows        Result set.
+	 * @param int                              $customer_id Customer id to find.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function rows_for( array $rows, int $customer_id ): array {
+		return array_values( array_filter( $rows, static fn( $row ) => $row['customer_id'] === $customer_id ) );
+	}
+
+	/**
+	 * Case A: customer whose first-ever subscription starts INSIDE the
+	 * trailing 365 days is a cohort member — their subscription row is
+	 * returned with start/cancelled/end.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_customer_with_recent_first_subscription_is_in_cohort( string $backend ): void {
+		$base      = 91000 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_365    = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
+		$customer_id = 501;
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 1,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_365,
+			]
+		);
+
+		$rows = $this->storage_for( $backend )->get_new_subscriber_cohort_intervals();
+		$mine = $this->rows_for( $rows, $customer_id );
+
+		$this->assertCount( 1, $mine );
+		$this->assertSame( $in_365, $mine[0]['start'] );
+		$this->assertNull( $mine[0]['cancelled'] );
+		$this->assertNull( $mine[0]['end'] );
+	}
+
+	/**
+	 * Crux case: a customer whose first-ever subscription predates the
+	 * trailing 365-day cutoff must be excluded from the cohort ENTIRELY, even
+	 * though they have a LATER subscription that falls inside the window —
+	 * cohort membership is keyed on the customer's first-ever start, not any
+	 * qualifying subscription.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_customer_with_old_first_subscription_excluded_despite_later_one_in_window( string $backend ): void {
+		$base        = 91100 + ( 'hpos' === $backend ? 500 : 0 );
+		$too_old     = gmdate( 'Y-m-d H:i:s', strtotime( '-400 days' ) );
+		$in_365      = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
+		$customer_id = 502;
+
+		// First-ever subscription, predates the 365-day cutoff.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 1,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-cancelled',
+				'schedule_start' => $too_old,
+			]
+		);
+		// A second subscription, inside the window.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 2,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_365,
+			]
+		);
+
+		$rows = $this->storage_for( $backend )->get_new_subscriber_cohort_intervals();
+		$mine = $this->rows_for( $rows, $customer_id );
+
+		$this->assertCount( 0, $mine, 'Cohort membership is keyed on the FIRST-EVER subscription start, not any qualifying one.' );
+	}
+
+	/**
+	 * Case: a customer whose first-ever subscription start is in the FUTURE
+	 * (beyond "now") is excluded — the upper bound guards against
+	 * scheduled/pending subscriptions.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_customer_with_future_first_subscription_excluded( string $backend ): void {
+		$base        = 91200 + ( 'hpos' === $backend ? 500 : 0 );
+		$future      = gmdate( 'Y-m-d H:i:s', strtotime( '+10 days' ) );
+		$customer_id = 503;
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 1,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $future,
+			]
+		);
+
+		$rows = $this->storage_for( $backend )->get_new_subscriber_cohort_intervals();
+		$mine = $this->rows_for( $rows, $customer_id );
+
+		$this->assertCount( 0, $mine, 'A first subscription scheduled in the future must not count as a cohort member yet.' );
+	}
+
+	/**
+	 * Donation-product subscriptions never establish cohort membership.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donation_subscription_does_not_establish_cohort_membership( string $backend ): void {
+		$base        = 91300 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_365      = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
+		$customer_id = 504;
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 1,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::DONATION_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_365,
+			]
+		);
+
+		$rows = $this->storage_for( $backend )->get_new_subscriber_cohort_intervals();
+		$mine = $this->rows_for( $rows, $customer_id );
+
+		$this->assertCount( 0, $mine );
+	}
+
+	/**
+	 * Guest subscriptions (customer_id = 0) are excluded.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_guest_subscription_excluded( string $backend ): void {
+		$base      = 91400 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_365    = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 1,
+				'customer_id'    => 0,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_365,
+			]
+		);
+
+		$rows = $this->storage_for( $backend )->get_new_subscriber_cohort_intervals();
+		$mine = $this->rows_for( $rows, 0 );
+
+		$this->assertCount( 0, $mine );
+	}
+
+	/**
+	 * Crux case: multiplicity. A cohort customer with TWO non-donation
+	 * subscriptions (both inside history) must have BOTH rows returned, not
+	 * just their first — the outer query returns every subscription of cohort
+	 * members, not just the qualifying one.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_cohort_customer_with_two_subscriptions_returns_both_rows( string $backend ): void {
+		$base        = 91500 + ( 'hpos' === $backend ? 500 : 0 );
+		$first_start = gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) );
+		$second_start = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 505;
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => $base + 1,
+				'customer_id'        => $customer_id,
+				'product_id'         => self::SUB_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_start'     => $first_start,
+				'schedule_cancelled' => $second_start,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 2,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $second_start,
+			]
+		);
+
+		$rows = $this->storage_for( $backend )->get_new_subscriber_cohort_intervals();
+		$mine = $this->rows_for( $rows, $customer_id );
+
+		$this->assertCount( 2, $mine, 'Both subscriptions of a cohort member must be returned, not just the qualifying first one.' );
+
+		$starts = array_column( $mine, 'start' );
+		sort( $starts );
+		$this->assertSame( [ $first_start, $second_start ], $starts );
+
+		// The first (cancelled) row must carry its cancelled date; the second (active) row's cancelled/end stay null.
+		foreach ( $mine as $row ) {
+			if ( $row['start'] === $first_start ) {
+				$this->assertSame( $second_start, $row['cancelled'] );
+			} else {
+				$this->assertNull( $row['cancelled'] );
+			}
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-new-subscriber-records-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-new-subscriber-records-query.php
@@ -1,0 +1,589 @@
+<?php
+/**
+ * DB-backed characterization test for get_new_subscriber_records_in_window()
+ * (perf fix).
+ *
+ * The storage implementation resolves gate_post_id / popup_id attribution via
+ * 3 correlated scalar subqueries per first-subscription row, each a 4-table
+ * join (posts/postmeta × order_items × itemmeta) filtered by
+ * `customer_id = first_subs.customer_id AND start = first_subs.first_start`
+ * — HIGH timeout risk on large subscriptions datasets, since the correlation
+ * re-executes the whole join for every row in the outer result.
+ *
+ * This test pins the query's OUTPUT (customer_id, ts, gate_post_id, popup_id
+ * per new-subscriber record) against a small, deliberately adversarial
+ * fixture set BEFORE the query is rewritten as pre-aggregated LEFT JOINs. It
+ * must pass unchanged on the OLD query (baseline) and again on the NEW query
+ * (equivalence proof) — especially the NULL-preservation case (a customer
+ * with no gate/popup attribution must still appear, with '' for both) and the
+ * gate-precedence case (_gate_post_id wins over the legacy
+ * _memberships_content_gate fallback when both are present).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_new_subscriber_records_in_window().
+ *
+ * @group insights
+ */
+class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id, excluded from the new-subscriber population.
+	 */
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id.
+	 */
+	const SUB_PRODUCT_ID = 555001;
+
+	/**
+	 * Stand up the WC order + line-item tables once.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to exclude the
+	 * donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function storage_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a parent shop_order carrying gate/popup/legacy-gate meta, into
+	 * the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait): `order_id`,
+	 *                        `gate_ids`, `popup_ids`, and `legacy_gate_id`
+	 *                        (maps to `_memberships_content_gate`, not natively
+	 *                        supported by the trait's `insert_*_order()`).
+	 * @return int The created order id.
+	 */
+	private function insert_parent_order( string $backend, array $args ): int {
+		global $wpdb;
+		$order_id = 'hpos' === $backend
+			? $this->insert_hpos_order( $args )
+			: $this->insert_legacy_order( $args );
+
+		if ( isset( $args['legacy_gate_id'] ) ) {
+			if ( 'hpos' === $backend ) {
+				$wpdb->insert(
+					"{$wpdb->prefix}wc_orders_meta",
+					[
+						'order_id'   => $order_id,
+						'meta_key'   => '_memberships_content_gate',
+						'meta_value' => $args['legacy_gate_id'],
+					]
+				);
+			} else {
+				add_post_meta( $order_id, '_memberships_content_gate', $args['legacy_gate_id'] );
+			}
+		}
+		return $order_id;
+	}
+
+	/**
+	 * Insert a shop_subscription row (optionally parented to an initiating
+	 * order) into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * The window: brackets the "in window" fixture dates while excluding the
+	 * "outside window" fixture dates.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-30 days', $tz ), new DateTimeImmutable( '+1 day', $tz ) ];
+	}
+
+	/**
+	 * Find a record by customer_id in a get_new_subscriber_records_in_window()
+	 * result set.
+	 *
+	 * @param array<int, array<string, mixed>> $records Result set.
+	 * @param int                              $customer_id Customer id to find.
+	 * @return array<string, mixed>|null
+	 */
+	private function find_record( array $records, int $customer_id ): ?array {
+		foreach ( $records as $record ) {
+			if ( $record['customer_id'] === $customer_id ) {
+				return $record;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Isolated case: customer with a `_gate_post_id` on the parent order gets
+	 * gate_post_id populated and popup_id blank.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_gate_attributed_first_subscriber_is_recorded( string $backend ): void {
+		$base       = 81000 + ( 'hpos' === $backend ? 500 : 0 );
+		$order_id   = $base + 1;
+		$sub_id     = $base + 2;
+		$in_window  = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 301;
+
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $order_id,
+				'customer_id' => $customer_id,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'gate_ids'    => [ 4001 ],
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $sub_id,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $order_id,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+		$record           = $this->find_record( $records, $customer_id );
+
+		$this->assertNotNull( $record, 'Customer with a gate-attributed first subscription must be recorded.' );
+		$this->assertSame( '4001', $record['gate_post_id'] );
+		$this->assertSame( '', $record['popup_id'] );
+	}
+
+	/**
+	 * Isolated case: customer with a `_newspack_popup_id` on the parent order
+	 * gets popup_id populated and gate_post_id blank.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_popup_attributed_first_subscriber_is_recorded( string $backend ): void {
+		$base        = 81100 + ( 'hpos' === $backend ? 500 : 0 );
+		$order_id    = $base + 1;
+		$sub_id      = $base + 2;
+		$in_window   = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 302;
+
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $order_id,
+				'customer_id' => $customer_id,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'popup_ids'   => [ 5001 ],
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $sub_id,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $order_id,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+		$record           = $this->find_record( $records, $customer_id );
+
+		$this->assertNotNull( $record, 'Customer with a popup-attributed first subscription must be recorded.' );
+		$this->assertSame( '', $record['gate_post_id'] );
+		$this->assertSame( '5001', $record['popup_id'] );
+	}
+
+	/**
+	 * Crux case: customer with NO gate/popup attribution on the parent order
+	 * must still be recorded (NULL-preservation), with both fields blank —
+	 * not silently dropped by the rewrite's LEFT JOINs.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_unattributed_first_subscriber_still_recorded_with_blank_attribution( string $backend ): void {
+		$base        = 81200 + ( 'hpos' === $backend ? 500 : 0 );
+		$order_id    = $base + 1;
+		$sub_id      = $base + 2;
+		$in_window   = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 303;
+
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $order_id,
+				'customer_id' => $customer_id,
+				'product_id'  => self::SUB_PRODUCT_ID,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $sub_id,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $order_id,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+		$record           = $this->find_record( $records, $customer_id );
+
+		$this->assertNotNull( $record, 'A customer with no gate/popup attribution must still appear in the result set.' );
+		$this->assertSame( '', $record['gate_post_id'], 'No attribution must yield blank, not a dropped/null row.' );
+		$this->assertSame( '', $record['popup_id'] );
+	}
+
+	/**
+	 * Crux case: gate precedence. When BOTH `_gate_post_id` and the legacy
+	 * `_memberships_content_gate` are present on the parent order,
+	 * `_gate_post_id` must win.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_gate_post_id_takes_precedence_over_legacy_gate( string $backend ): void {
+		$base        = 81300 + ( 'hpos' === $backend ? 500 : 0 );
+		$order_id    = $base + 1;
+		$sub_id      = $base + 2;
+		$in_window   = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 304;
+
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'       => $order_id,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'gate_ids'       => [ 4002 ],
+				'legacy_gate_id' => 4999,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $sub_id,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $order_id,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+		$record           = $this->find_record( $records, $customer_id );
+
+		$this->assertNotNull( $record );
+		$this->assertSame( '4002', $record['gate_post_id'], '_gate_post_id must take precedence over the legacy _memberships_content_gate.' );
+	}
+
+	/**
+	 * Crux case: legacy gate fallback. When ONLY the legacy
+	 * `_memberships_content_gate` is present (no `_gate_post_id`), it must be
+	 * used as the gate_post_id.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_legacy_gate_used_as_fallback_when_gate_post_id_absent( string $backend ): void {
+		$base        = 81400 + ( 'hpos' === $backend ? 500 : 0 );
+		$order_id    = $base + 1;
+		$sub_id      = $base + 2;
+		$in_window   = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 305;
+
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'       => $order_id,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'legacy_gate_id' => 4998,
+			]
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $sub_id,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $order_id,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+		$record           = $this->find_record( $records, $customer_id );
+
+		$this->assertNotNull( $record );
+		$this->assertSame( '4998', $record['gate_post_id'] );
+	}
+
+	/**
+	 * Guest subscriptions (customer_id = 0) are excluded entirely.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_guest_subscription_excluded( string $backend ): void {
+		$base      = 81500 + ( 'hpos' === $backend ? 500 : 0 );
+		$sub_id    = $base + 1;
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $sub_id,
+				'customer_id'    => 0,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_window,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+
+		$this->assertNull( $this->find_record( $records, 0 ), 'Guest (customer_id = 0) subscriptions must be excluded.' );
+	}
+
+	/**
+	 * Only the customer's FIRST-EVER subscription start counts; a later
+	 * subscription start inside the window for a customer whose true first
+	 * subscription predates the window must NOT re-trigger inclusion.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_only_first_ever_subscription_counts_not_a_later_one_in_window( string $backend ): void {
+		$base         = 81600 + ( 'hpos' === $backend ? 500 : 0 );
+		$first_sub_id = $base + 1;
+		$second_sub_id = $base + 2;
+		$out_window   = gmdate( 'Y-m-d H:i:s', strtotime( '-90 days' ) );
+		$in_window    = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id  = 306;
+
+		// First-ever subscription, OUTSIDE the window.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $first_sub_id,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-cancelled',
+				'schedule_start' => $out_window,
+			]
+		);
+		// A SECOND subscription (e.g. a resubscribe), inside the window.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $second_sub_id,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_window,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+
+		$this->assertNull(
+			$this->find_record( $records, $customer_id ),
+			'A customer whose FIRST-EVER subscription predates the window must be excluded, even if a later subscription falls inside it.'
+		);
+	}
+
+	/**
+	 * Donation-product subscriptions are excluded from the new-subscriber
+	 * population entirely.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_donation_subscription_excluded( string $backend ): void {
+		$base      = 81700 + ( 'hpos' === $backend ? 500 : 0 );
+		$sub_id    = $base + 1;
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 307;
+
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $sub_id,
+				'customer_id'    => $customer_id,
+				'product_id'     => self::DONATION_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_window,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+
+		$this->assertNull( $this->find_record( $records, $customer_id ), 'Donation-product subscriptions must be excluded.' );
+	}
+
+	/**
+	 * Combined scenario: run all the anchor cases together in one fixture set
+	 * and assert the full result set — proving the rewrite doesn't cross-
+	 * contaminate attribution between customers when multiple derived-table
+	 * joins are active simultaneously.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_combined_anchor_cases_produce_expected_record_set( string $backend ): void {
+		$in_window = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$base      = 81800 + ( 'hpos' === $backend ? 500 : 0 );
+
+		// Gate-attributed customer 401.
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $base + 1,
+				'customer_id' => 401,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'gate_ids'    => [ 9001 ],
+			] 
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $base + 2,
+				'customer_id'     => 401,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $base + 1,
+			] 
+		);
+
+		// Popup-attributed customer 402.
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $base + 3,
+				'customer_id' => 402,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'popup_ids'   => [ 9002 ],
+			] 
+		);
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $base + 4,
+				'customer_id'     => 402,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $base + 3,
+			] 
+		);
+
+		// Unattributed customer 403 (no parent order meta at all — organic).
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => $base + 5,
+				'customer_id'    => 403,
+				'product_id'     => self::SUB_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $in_window,
+			] 
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+
+		$this->assertCount( 3, $records, 'Exactly the three seeded customers must be present.' );
+
+		$rec401 = $this->find_record( $records, 401 );
+		$rec402 = $this->find_record( $records, 402 );
+		$rec403 = $this->find_record( $records, 403 );
+
+		$this->assertSame( '9001', $rec401['gate_post_id'] );
+		$this->assertSame( '', $rec401['popup_id'] );
+
+		$this->assertSame( '', $rec402['gate_post_id'] );
+		$this->assertSame( '9002', $rec402['popup_id'] );
+
+		$this->assertSame( '', $rec403['gate_post_id'] );
+		$this->assertSame( '', $rec403['popup_id'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-new-subscriber-records-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-new-subscriber-records-query.php
@@ -500,6 +500,79 @@ class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Crux case: tied first subscriptions (same customer, same
+	 * `_schedule_start`) with DIFFERENT parent orders — the lower-id parent
+	 * order carries NO gate/popup meta, but the tied sibling's (higher-id)
+	 * parent order DOES carry `_gate_post_id`. Attribution must be recovered
+	 * from the tied sibling rather than lost because the resolver collapsed
+	 * to the lowest parent id before the meta lookup.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_tied_first_subscriptions_recover_attribution_from_sibling_parent( string $backend ): void {
+		$base        = 81900 + ( 'hpos' === $backend ? 500 : 0 );
+		$in_window   = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$customer_id = 501;
+
+		// Lower-id parent order: NO gate/popup meta at all.
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $base + 1,
+				'customer_id' => $customer_id,
+				'product_id'  => self::SUB_PRODUCT_ID,
+			]
+		);
+		// Its subscription — tied first-start, lower-id parent.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $base + 2,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $base + 1,
+			]
+		);
+
+		// Higher-id parent order: HAS `_gate_post_id`.
+		$this->insert_parent_order(
+			$backend,
+			[
+				'order_id'    => $base + 3,
+				'customer_id' => $customer_id,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'gate_ids'    => [ 7001 ],
+			]
+		);
+		// Its subscription — the SAME tied first-start, higher-id parent.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'        => $base + 4,
+				'customer_id'     => $customer_id,
+				'product_id'      => self::SUB_PRODUCT_ID,
+				'status'          => 'wc-active',
+				'schedule_start'  => $in_window,
+				'parent_order_id' => $base + 3,
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$records          = $this->storage_for( $backend )->get_new_subscriber_records_in_window( $start, $end );
+		$record           = $this->find_record( $records, $customer_id );
+
+		$this->assertNotNull( $record, 'Customer with tied first subscriptions must still be recorded.' );
+		$this->assertSame(
+			'7001',
+			$record['gate_post_id'],
+			'Attribution must be recovered from the tied sibling parent order, not lost because the MIN(parent) resolver picked the meta-less lower-id parent.'
+		);
+	}
+
+	/**
 	 * Combined scenario: run all the anchor cases together in one fixture set
 	 * and assert the full result set — proving the rewrite doesn't cross-
 	 * contaminate attribution between customers when multiple derived-table
@@ -520,7 +593,7 @@ class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
 				'customer_id' => 401,
 				'product_id'  => self::SUB_PRODUCT_ID,
 				'gate_ids'    => [ 9001 ],
-			] 
+			]
 		);
 		$this->insert_subscription(
 			$backend,
@@ -531,7 +604,7 @@ class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
 				'status'          => 'wc-active',
 				'schedule_start'  => $in_window,
 				'parent_order_id' => $base + 1,
-			] 
+			]
 		);
 
 		// Popup-attributed customer 402.
@@ -542,7 +615,7 @@ class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
 				'customer_id' => 402,
 				'product_id'  => self::SUB_PRODUCT_ID,
 				'popup_ids'   => [ 9002 ],
-			] 
+			]
 		);
 		$this->insert_subscription(
 			$backend,
@@ -553,7 +626,7 @@ class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
 				'status'          => 'wc-active',
 				'schedule_start'  => $in_window,
 				'parent_order_id' => $base + 3,
-			] 
+			]
 		);
 
 		// Unattributed customer 403 (no parent order meta at all — organic).
@@ -565,7 +638,7 @@ class Test_New_Subscriber_Records_Query extends WP_UnitTestCase {
 				'product_id'     => self::SUB_PRODUCT_ID,
 				'status'         => 'wc-active',
 				'schedule_start' => $in_window,
-			] 
+			]
 		);
 
 		[ $start, $end ] = $this->window();

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-recurring-donor-retention-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-recurring-donor-retention-query.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * DB-backed characterization test for get_recurring_donor_retention()
+ * (donor-query perf fix — HIGHEST PRIORITY, feeds the Donors-tab CLV card).
+ *
+ * `get_recurring_donor_retention()` ran a first query, pulled EVERY
+ * active-at-start donor into a PHP array, then serialized them back into
+ * `CAST(cust.meta_value AS UNSIGNED) IN ($customer_list)` for a second
+ * query — slow, AND a `max_allowed_packet` "MySQL server has gone away"
+ * trigger on large active-at-start cohorts.
+ *
+ * This test pins the query's OUTPUT (value/computable/denominator) against
+ * a small, deliberately adversarial fixture set BEFORE the query is
+ * rewritten to compute the active-at-start cohort as an in-SQL derived
+ * table joined directly into the numerator query, eliminating the PHP
+ * round trip. It must pass unchanged on the OLD query (baseline) and again
+ * on the NEW query (equivalence proof) — especially:
+ *
+ *   - the `_schedule_cancelled = '0'` WCS "not cancelled" sentinel (must
+ *     count as active-at-start, not excluded),
+ *   - a donor active at start whose subscription is cancelled by NOW
+ *     (excluded from the numerator, but stays in the denominator), and
+ *   - a donor whose subscription started AFTER the window start (excluded
+ *     entirely — not active-at-start).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+use Newspack\Insights\HPOS_Donors_Storage;
+use Newspack\Insights\Legacy_Donors_Storage;
+use Newspack\Insights\Donors_Storage_Interface;
+use DateTimeImmutable;
+use DateTimeZone;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_recurring_donor_retention().
+ *
+ * @group insights
+ */
+class Test_Recurring_Donor_Retention_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id — the only product id these donor queries scope to.
+	 */
+	const DONATION_PRODUCT_ID = 999301;
+
+	/**
+	 * Stand up the WC order + line-item tables once (InnoDB → per-test inserts
+	 * roll back via the surrounding transaction).
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to the donation
+	 * product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Donors_Storage_Interface
+	 */
+	private function storage_for( string $backend ): Donors_Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Donors_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Donors_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * Window start: 365 days ago (mirrors the CLV card's 12-month cohort).
+	 * "End" only disambiguates the cache key — the "still active" check
+	 * anchors on NOW, not on end, per the interface docblock.
+	 *
+	 * @return DateTimeImmutable[] [ start, end ]
+	 */
+	private function window(): array {
+		$tz = new DateTimeZone( 'UTC' );
+		return [ new DateTimeImmutable( '-365 days', $tz ), new DateTimeImmutable( 'now', $tz ) ];
+	}
+
+	/**
+	 * A schedule_start date safely before the window start (well in the past).
+	 *
+	 * @return string Y-m-d H:i:s (UTC).
+	 */
+	private function before_start_date(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '-400 days' ) );
+	}
+
+	/**
+	 * A schedule_start date AFTER the window start (should be excluded from
+	 * the active-at-start cohort).
+	 *
+	 * @return string Y-m-d H:i:s (UTC).
+	 */
+	private function after_start_date(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+	}
+
+	/**
+	 * A schedule_cancelled date in the FUTURE relative to start (still
+	 * "active at start" per the interface: cancelled meta empty/null/'0'/>
+	 * start all count as active-at-start).
+	 *
+	 * @return string Y-m-d H:i:s (UTC).
+	 */
+	private function future_cancel_date(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '+300 days' ) );
+	}
+
+	/**
+	 * A schedule_cancelled date BEFORE the window start (not active at
+	 * start — cancelled before the cohort was measured).
+	 *
+	 * @return string Y-m-d H:i:s (UTC).
+	 */
+	private function past_cancel_date(): string {
+		return gmdate( 'Y-m-d H:i:s', strtotime( '-380 days' ) );
+	}
+
+	/**
+	 * Crux case A: the WCS `'0'` "not cancelled" sentinel must count as
+	 * active-at-start, not be excluded by a naive falsy check.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_schedule_cancelled_zero_sentinel_counts_as_active_at_start( string $backend ): void {
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 91001,
+				'customer_id'        => 401,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-active',
+				'schedule_start'     => $this->before_start_date(),
+				'schedule_cancelled' => '0',
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$result           = $this->storage_for( $backend )->get_recurring_donor_retention( $start, $end );
+
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 1, $result['denominator'], "The '0' sentinel must count as active-at-start, not excluded." );
+		$this->assertEqualsWithDelta( 1.0, $result['value'], 0.0001, 'Still wc-active now → retained.' );
+	}
+
+	/**
+	 * Crux case B: a donor active at start whose subscription is cancelled
+	 * by NOW must be excluded from the numerator but remain in the
+	 * denominator — this is the exact active-at-start vs still-active-now
+	 * distinction the in-SQL rewrite must preserve.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_active_at_start_but_since_cancelled_lowers_retention( string $backend ): void {
+		// Donor 402: active at start, still wc-active now → retained.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => 92001,
+				'customer_id'    => 402,
+				'product_id'     => self::DONATION_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $this->before_start_date(),
+			]
+		);
+
+		// Donor 403: active at start (cancel date is in the future relative
+		// to start), but the subscription's CURRENT status is wc-cancelled —
+		// no longer active now → excluded from numerator, stays in denominator.
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 92002,
+				'customer_id'        => 403,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-cancelled',
+				'schedule_start'     => $this->before_start_date(),
+				'schedule_cancelled' => $this->future_cancel_date(),
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$result           = $this->storage_for( $backend )->get_recurring_donor_retention( $start, $end );
+
+		$this->assertTrue( $result['computable'] );
+		$this->assertSame( 2, $result['denominator'], 'Both donors were active-at-start.' );
+		$this->assertEqualsWithDelta( 0.5, $result['value'], 0.0001, 'Only donor 402 (1 of 2) is still active now.' );
+	}
+
+	/**
+	 * Crux case C: a subscription that started AFTER the window start must
+	 * never enter the active-at-start cohort at all.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_subscription_started_after_window_excluded( string $backend ): void {
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'       => 93001,
+				'customer_id'    => 404,
+				'product_id'     => self::DONATION_PRODUCT_ID,
+				'status'         => 'wc-active',
+				'schedule_start' => $this->after_start_date(),
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$result           = $this->storage_for( $backend )->get_recurring_donor_retention( $start, $end );
+
+		$this->assertFalse( $result['computable'], 'A subscription starting after the window start never enters the cohort.' );
+		$this->assertSame( 0, $result['denominator'] );
+	}
+
+	/**
+	 * Crux case D: a subscription cancelled BEFORE the window start was not
+	 * active at start and must not enter the cohort either.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_subscription_cancelled_before_window_excluded( string $backend ): void {
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'           => 94001,
+				'customer_id'        => 405,
+				'product_id'         => self::DONATION_PRODUCT_ID,
+				'status'             => 'wc-expired',
+				'schedule_start'     => $this->before_start_date(),
+				'schedule_cancelled' => $this->past_cancel_date(),
+			]
+		);
+
+		[ $start, $end ] = $this->window();
+		$result           = $this->storage_for( $backend )->get_recurring_donor_retention( $start, $end );
+
+		$this->assertFalse( $result['computable'], 'A subscription cancelled before window start was not active at start.' );
+		$this->assertSame( 0, $result['denominator'] );
+	}
+
+	/**
+	 * No active-at-start cohort at all → not computable.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_no_cohort_is_not_computable( string $backend ): void {
+		[ $start, $end ] = $this->window();
+		$result           = $this->storage_for( $backend )->get_recurring_donor_retention( $start, $end );
+
+		$this->assertFalse( $result['computable'] );
+		$this->assertSame( 0, $result['denominator'] );
+		$this->assertSame( 0.0, $result['value'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-stale-registered-users-query.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-stale-registered-users-query.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * DB-backed characterization test for get_stale_registered_users() (perf fix).
+ *
+ * The storage implementation combines 3 correlated `EXISTS` subqueries (base
+ * population + admin/editor exclusion) with 2 `NOT IN (SELECT ... multi-join
+ * subquery)` exclusions (active non-donation subscribers; trailing-365-day
+ * donors) — all HIGH timeout risk on large usermeta/subscription datasets.
+ *
+ * This test pins the query's OUTPUT (the stale-reader count) against a small,
+ * deliberately adversarial fixture set BEFORE the query is rewritten as
+ * pre-aggregated LEFT JOIN anti-joins. It must pass unchanged on the OLD
+ * query (baseline) and again on the NEW query (equivalence proof).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+
+use Newspack\Insights\HPOS_Storage;
+use Newspack\Insights\Legacy_Storage;
+use Newspack\Insights\Storage_Interface;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/trait-insights-woo-order-fixtures.php';
+
+/**
+ * Characterization test for get_stale_registered_users().
+ *
+ * @group insights
+ */
+class Test_Stale_Registered_Users_Query extends WP_UnitTestCase {
+
+	use Insights_Woo_Order_Fixtures;
+
+	/**
+	 * Donation product id, excluded from the subscriber exclusion / matched by
+	 * the donation exclusion.
+	 */
+	const DONATION_PRODUCT_ID = 999001;
+
+	/**
+	 * Non-donation subscription product id.
+	 */
+	const SUB_PRODUCT_ID = 555001;
+
+	/**
+	 * Stand up the WC order + line-item tables once.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::create_woo_order_tables();
+	}
+
+	/**
+	 * Drop the integration tables after the class.
+	 */
+	public static function tearDownAfterClass(): void {
+		self::drop_woo_order_tables();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Both storage backends. Every test runs against legacy AND HPOS.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function backends(): array {
+		return [
+			'legacy' => [ 'legacy' ],
+			'hpos'   => [ 'hpos' ],
+		];
+	}
+
+	/**
+	 * The storage instance under test for a backend, scoped to exclude the
+	 * donation product.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return Storage_Interface
+	 */
+	private function storage_for( string $backend ): Storage_Interface {
+		return 'hpos' === $backend
+			? new HPOS_Storage( [ self::DONATION_PRODUCT_ID ] )
+			: new Legacy_Storage( [ self::DONATION_PRODUCT_ID ] );
+	}
+
+	/**
+	 * Insert a shop_subscription row into the given backend.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Subscription spec (see the fixtures trait).
+	 * @return int The created subscription id.
+	 */
+	private function insert_subscription( string $backend, array $args ): int {
+		return 'hpos' === $backend
+			? $this->insert_hpos_subscription( $args )
+			: $this->insert_legacy_subscription( $args );
+	}
+
+	/**
+	 * Insert a shop_order row (used for the donation-order exclusion) into the
+	 * given backend, with `customer_id` set for the stale-reader exclusion
+	 * query. Neither `insert_hpos_order()` nor `insert_legacy_order()` persists
+	 * a customer id on a plain shop_order (only the subscription helpers do),
+	 * so this wires it up directly: HPOS via `wc_orders.customer_id`, legacy
+	 * via `_customer_user` postmeta.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @param array  $args    Order spec (see the fixtures trait); `customer_id` required.
+	 * @return int The created order id.
+	 */
+	private function insert_order( string $backend, array $args ): int {
+		global $wpdb;
+		$order_id = 'hpos' === $backend
+			? $this->insert_hpos_order( $args )
+			: $this->insert_legacy_order( $args );
+
+		if ( 'hpos' === $backend ) {
+			$wpdb->update( "{$wpdb->prefix}wc_orders", [ 'customer_id' => (int) $args['customer_id'] ], [ 'id' => $order_id ] );
+		} else {
+			add_post_meta( $order_id, '_customer_user', (string) $args['customer_id'] );
+		}
+		return $order_id;
+	}
+
+	/**
+	 * Create a WordPress user with the given roles and optional np_reader meta.
+	 *
+	 * @param string      $login      Unique login.
+	 * @param string[]    $roles      Roles to set (first is primary via wp_insert_user; extras via add_role).
+	 * @param string|null $np_reader  Value for the np_reader user meta (null = do not set).
+	 * @return int The created user id.
+	 */
+	private function make_user( string $login, array $roles, ?string $np_reader = '1' ): int {
+		$user_id = wp_insert_user(
+			[
+				'user_login' => $login,
+				'user_pass'  => wp_generate_password(),
+				'user_email' => $login . '@example.com',
+				'role'       => $roles[0] ?? 'subscriber',
+			]
+		);
+		$this->assertIsInt( $user_id, "Failed to create user {$login}" );
+		$user = new \WP_User( $user_id );
+		foreach ( array_slice( $roles, 1 ) as $extra_role ) {
+			$user->add_role( $extra_role );
+		}
+		if ( null !== $np_reader ) {
+			update_user_meta( $user_id, 'np_reader', $np_reader );
+		}
+		return $user_id;
+	}
+
+	/**
+	 * Seed the anchor cases described in the fix plan:
+	 *
+	 *   A: np_reader user, no active sub, no donation ever → COUNTED as stale.
+	 *   B: np_reader user WITH an active non-donation subscription → NOT counted.
+	 *   C: np_reader user with a completed donation order INSIDE the trailing
+	 *      365 days → NOT counted.
+	 *   D: np_reader user with a completed donation order OUTSIDE the trailing
+	 *      365 days (400 days ago) → COUNTED (donation exclusion is time-bound;
+	 *      the crux case the anti-join rewrite must preserve, since a naive
+	 *      unbounded exclusion would wrongly drop this user).
+	 *   E: no np_reader meta, but 'subscriber' role → COUNTED (fallback path).
+	 *   F: np_reader user who is ALSO an administrator → NOT counted (admin/
+	 *      editor exclusion overrides reader status).
+	 *   G: plain user, no np_reader meta, 'editor' role (not subscriber/customer)
+	 *      → NOT counted (fails base population — editor isn't a reader role,
+	 *      and the restricted-role exclusion is moot since it never entered
+	 *      the base population).
+	 *
+	 * Only A, D, and E should count => 3.
+	 *
+	 * @param string $backend 'legacy' | 'hpos'.
+	 * @return void
+	 */
+	private function seed_anchor_cases( string $backend ): void {
+		$in_365      = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) );
+		$outside_365 = gmdate( 'Y-m-d H:i:s', strtotime( '-400 days' ) );
+
+		// Case A: stale reader, no sub, no donation.
+		$this->make_user( "stale_a_{$backend}", [ 'subscriber' ] );
+
+		// Case B: reader with an active non-donation subscription.
+		$user_b = $this->make_user( "active_b_{$backend}", [ 'subscriber' ] );
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 71001 + ( 'hpos' === $backend ? 1 : 0 ),
+				'customer_id' => $user_b,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		// Case C: reader with a recent (in-window) completed donation order.
+		$user_c = $this->make_user( "donor_c_{$backend}", [ 'subscriber' ] );
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'    => 71003 + ( 'hpos' === $backend ? 1 : 0 ),
+				'customer_id' => $user_c,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-completed',
+				'date'        => $in_365,
+			]
+		);
+
+		// Case D: reader with a completed donation order OUTSIDE the trailing
+		// 365-day window — must still count as stale (crux case).
+		$user_d = $this->make_user( "donor_d_{$backend}", [ 'subscriber' ] );
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'    => 71005 + ( 'hpos' === $backend ? 1 : 0 ),
+				'customer_id' => $user_d,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-completed',
+				'date'        => $outside_365,
+			]
+		);
+
+		// Case E: no np_reader meta, but 'subscriber' role (fallback path).
+		$this->make_user( "fallback_e_{$backend}", [ 'subscriber' ], null );
+
+		// Case F: np_reader user who is ALSO an administrator.
+		$this->make_user( "admin_f_{$backend}", [ 'subscriber', 'administrator' ] );
+
+		// Case G: plain editor, no np_reader meta, not subscriber/customer role.
+		$this->make_user( "editor_g_{$backend}", [ 'editor' ], null );
+	}
+
+	/**
+	 * The characterization assertion: only cases A, D, E count as stale (3).
+	 * Must pass BOTH before and after the anti-join rewrite.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_stale_count_excludes_active_subs_and_recent_donors( string $backend ): void {
+		$this->seed_anchor_cases( $backend );
+
+		$count = $this->storage_for( $backend )->get_stale_registered_users();
+
+		$this->assertSame(
+			3,
+			$count,
+			'Only cases A (stale, no activity), D (donation outside 365d window), and E ' .
+			'(fallback subscriber role, no np_reader meta) should count. Case B (active sub) ' .
+			'and case C (donation inside 365d) must be excluded. Case D is the crux case: the ' .
+			'donation exclusion is time-bound, not unbounded — a customer with only an OLD ' .
+			'donation is still stale today.'
+		);
+	}
+
+	/**
+	 * Isolate case D on its own (no other fixtures) to pin the exact crux
+	 * scenario independent of the combined-count test above: a reader whose
+	 * only donation order falls OUTSIDE the trailing 365-day window must
+	 * still be counted as stale.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_reader_with_old_donation_outside_window_is_still_stale( string $backend ): void {
+		$outside_365 = gmdate( 'Y-m-d H:i:s', strtotime( '-400 days' ) );
+		$user_id     = $this->make_user( "isolated_d_{$backend}", [ 'subscriber' ] );
+		$order_id    = 72001 + ( 'hpos' === $backend ? 1 : 0 );
+
+		$this->insert_order(
+			$backend,
+			[
+				'order_id'    => $order_id,
+				'customer_id' => $user_id,
+				'product_id'  => self::DONATION_PRODUCT_ID,
+				'status'      => 'wc-completed',
+				'date'        => $outside_365,
+			]
+		);
+
+		$count = $this->storage_for( $backend )->get_stale_registered_users();
+
+		$this->assertSame( 1, $count, 'A reader whose only donation is outside the trailing 365 days is still stale.' );
+	}
+
+	/**
+	 * Isolate case B on its own: a reader with a remaining active non-donation
+	 * subscription must never be counted as stale.
+	 *
+	 * @dataProvider backends
+	 * @param string $backend Backend key.
+	 */
+	public function test_reader_with_active_subscription_is_never_stale( string $backend ): void {
+		$user_id = $this->make_user( "isolated_b_{$backend}", [ 'subscriber' ] );
+		$this->insert_subscription(
+			$backend,
+			[
+				'order_id'    => 73001 + ( 'hpos' === $backend ? 1 : 0 ),
+				'customer_id' => $user_id,
+				'product_id'  => self::SUB_PRODUCT_ID,
+				'status'      => 'wc-active',
+			]
+		);
+
+		$count = $this->storage_for( $backend )->get_stale_registered_users();
+
+		$this->assertSame( 0, $count, 'A reader with a remaining active subscription is never "stale".' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
@@ -44,7 +44,7 @@ trait Insights_Woo_Order_Fixtures {
 		global $wpdb;
 		$p = $wpdb->prefix;
 		// HPOS authoritative store.
-		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders ( id BIGINT UNSIGNED NOT NULL PRIMARY KEY, status VARCHAR(20) NULL, type VARCHAR(20) NULL, date_created_gmt DATETIME NULL, total_amount DECIMAL(26,8) NULL, customer_id BIGINT UNSIGNED NULL ) ENGINE=InnoDB" );
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders ( id BIGINT UNSIGNED NOT NULL PRIMARY KEY, status VARCHAR(20) NULL, type VARCHAR(20) NULL, date_created_gmt DATETIME NULL, total_amount DECIMAL(26,8) NULL, customer_id BIGINT UNSIGNED NULL, parent_order_id BIGINT UNSIGNED NULL ) ENGINE=InnoDB" );
 		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders_meta ( id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, order_id BIGINT UNSIGNED NULL, meta_key VARCHAR(255) NULL, meta_value LONGTEXT NULL, KEY order_id ( order_id ) ) ENGINE=InnoDB" );
 		// Product lookup (both backends maintain this).
 		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_order_product_lookup ( order_id BIGINT UNSIGNED NOT NULL, product_id BIGINT UNSIGNED NOT NULL, PRIMARY KEY ( order_id, product_id ) ) ENGINE=InnoDB" );
@@ -243,7 +243,11 @@ trait Insights_Woo_Order_Fixtures {
 	 *                    `product_id` (required), `status` (post_status, e.g.
 	 *                    'wc-cancelled' / 'wc-expired' / 'wc-active'),
 	 *                    `schedule_cancelled` (optional 'Y-m-d H:i:s'),
-	 *                    `schedule_start` (optional 'Y-m-d H:i:s').
+	 *                    `schedule_start` (optional 'Y-m-d H:i:s'),
+	 *                    `parent_order_id` (optional int — sets `post_parent` to
+	 *                    the initiating shop_order id, the shape
+	 *                    {@see Legacy_Storage::get_new_subscriber_records_in_window()}
+	 *                    reads gate/popup attribution meta from).
 	 * @return int The created subscription's post ID.
 	 */
 	protected function insert_legacy_subscription( array $args ): int {
@@ -254,6 +258,7 @@ trait Insights_Woo_Order_Fixtures {
 				'post_type'   => 'shop_subscription',
 				'post_status' => $args['status'],
 				'post_title'  => 'Subscription',
+				'post_parent' => (int) ( $args['parent_order_id'] ?? 0 ),
 			]
 		);
 		add_post_meta( $order_id, '_customer_user', (string) $args['customer_id'] );
@@ -273,7 +278,11 @@ trait Insights_Woo_Order_Fixtures {
 	 * the exact shape {@see HPOS_Storage::get_churned_subscribers_in_window()}
 	 * and its winback counterpart query.
 	 *
-	 * @param array $args Same shape as {@see insert_legacy_subscription()}.
+	 * @param array $args Same shape as {@see insert_legacy_subscription()};
+	 *                    `parent_order_id` (optional int) sets `parent_order_id`
+	 *                    on `wc_orders`, the shape
+	 *                    {@see HPOS_Storage::get_new_subscriber_records_in_window()}
+	 *                    reads gate/popup attribution meta from.
 	 * @return int The order ID.
 	 */
 	protected function insert_hpos_subscription( array $args ): int {
@@ -289,6 +298,7 @@ trait Insights_Woo_Order_Fixtures {
 				'date_created_gmt' => $args['date'] ?? $this->default_order_date_gmt(),
 				'total_amount'     => $args['total'] ?? 0,
 				'customer_id'      => (int) $args['customer_id'],
+				'parent_order_id'  => (int) ( $args['parent_order_id'] ?? 0 ),
 			]
 		);
 		if ( isset( $args['schedule_cancelled'] ) ) {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/trait-insights-woo-order-fixtures.php
@@ -44,10 +44,15 @@ trait Insights_Woo_Order_Fixtures {
 		global $wpdb;
 		$p = $wpdb->prefix;
 		// HPOS authoritative store.
-		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders ( id BIGINT UNSIGNED NOT NULL PRIMARY KEY, status VARCHAR(20) NULL, type VARCHAR(20) NULL, date_created_gmt DATETIME NULL, total_amount DECIMAL(26,8) NULL ) ENGINE=InnoDB" );
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders ( id BIGINT UNSIGNED NOT NULL PRIMARY KEY, status VARCHAR(20) NULL, type VARCHAR(20) NULL, date_created_gmt DATETIME NULL, total_amount DECIMAL(26,8) NULL, customer_id BIGINT UNSIGNED NULL ) ENGINE=InnoDB" );
 		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_orders_meta ( id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, order_id BIGINT UNSIGNED NULL, meta_key VARCHAR(255) NULL, meta_value LONGTEXT NULL, KEY order_id ( order_id ) ) ENGINE=InnoDB" );
 		// Product lookup (both backends maintain this).
 		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}wc_order_product_lookup ( order_id BIGINT UNSIGNED NOT NULL, product_id BIGINT UNSIGNED NOT NULL, PRIMARY KEY ( order_id, product_id ) ) ENGINE=InnoDB" );
+		// Line-item tables — shared by both backends (not HPOS-specific). Needed by
+		// subscription queries (churn/winback/performance), which JOIN through these
+		// rather than the shop_order-only analytics lookup (see class docblocks).
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}woocommerce_order_items ( order_item_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, order_item_name TEXT NOT NULL, order_item_type VARCHAR(200) NOT NULL DEFAULT '', order_id BIGINT UNSIGNED NOT NULL, KEY order_id ( order_id ) ) ENGINE=InnoDB" );
+		$wpdb->query( "CREATE TABLE IF NOT EXISTS {$p}woocommerce_order_itemmeta ( meta_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, order_item_id BIGINT UNSIGNED NOT NULL, meta_key VARCHAR(255) NULL, meta_value LONGTEXT NULL, KEY order_item_id ( order_item_id ) ) ENGINE=InnoDB" );
 	}
 
 	/**
@@ -61,6 +66,8 @@ trait Insights_Woo_Order_Fixtures {
 		$wpdb->query( "DROP TABLE IF EXISTS {$p}wc_orders" );
 		$wpdb->query( "DROP TABLE IF EXISTS {$p}wc_orders_meta" );
 		$wpdb->query( "DROP TABLE IF EXISTS {$p}wc_order_product_lookup" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$p}woocommerce_order_items" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$p}woocommerce_order_itemmeta" );
 	}
 
 	/**
@@ -192,6 +199,119 @@ trait Insights_Woo_Order_Fixtures {
 				]
 			);
 		}
+		return $order_id;
+	}
+
+	/**
+	 * Insert a `shop_subscription` line item (order_item + `_product_id` itemmeta)
+	 * against an already-created order row (legacy `posts` or HPOS `wc_orders`).
+	 * Shared by both backends — the line-item tables are backend-agnostic.
+	 *
+	 * @param int $order_id   The subscription's order/post id.
+	 * @param int $product_id Line-item product id.
+	 * @return void
+	 */
+	private function insert_subscription_line_item( int $order_id, int $product_id ): void {
+		global $wpdb;
+		$p = $wpdb->prefix;
+		$wpdb->insert(
+			"{$p}woocommerce_order_items",
+			[
+				'order_item_name' => 'Subscription',
+				'order_item_type' => 'line_item',
+				'order_id'        => $order_id,
+			]
+		);
+		$order_item_id = (int) $wpdb->insert_id;
+		$wpdb->insert(
+			"{$p}woocommerce_order_itemmeta",
+			[
+				'order_item_id' => $order_item_id,
+				'meta_key'      => '_product_id',
+				'meta_value'    => $product_id,
+			]
+		);
+	}
+
+	/**
+	 * Insert a legacy (posts/postmeta) `shop_subscription`, with its customer,
+	 * line item, and optional `_schedule_cancelled` / `_schedule_start` meta —
+	 * the exact shape {@see Legacy_Storage::get_churned_subscribers_in_window()}
+	 * and its winback counterpart query.
+	 *
+	 * @param array $args Spec: `order_id` (required), `customer_id` (required),
+	 *                    `product_id` (required), `status` (post_status, e.g.
+	 *                    'wc-cancelled' / 'wc-expired' / 'wc-active'),
+	 *                    `schedule_cancelled` (optional 'Y-m-d H:i:s'),
+	 *                    `schedule_start` (optional 'Y-m-d H:i:s').
+	 * @return int The created subscription's post ID.
+	 */
+	protected function insert_legacy_subscription( array $args ): int {
+		global $wpdb;
+		$order_id = wp_insert_post(
+			[
+				'import_id'   => (int) $args['order_id'],
+				'post_type'   => 'shop_subscription',
+				'post_status' => $args['status'],
+				'post_title'  => 'Subscription',
+			]
+		);
+		add_post_meta( $order_id, '_customer_user', (string) $args['customer_id'] );
+		if ( isset( $args['schedule_cancelled'] ) ) {
+			add_post_meta( $order_id, '_schedule_cancelled', $args['schedule_cancelled'] );
+		}
+		if ( isset( $args['schedule_start'] ) ) {
+			add_post_meta( $order_id, '_schedule_start', $args['schedule_start'] );
+		}
+		$this->insert_subscription_line_item( (int) $order_id, (int) $args['product_id'] );
+		return (int) $order_id;
+	}
+
+	/**
+	 * Insert an HPOS (`wc_orders`) `shop_subscription`, with its customer_id,
+	 * line item, and optional `_schedule_cancelled` / `_schedule_start` meta —
+	 * the exact shape {@see HPOS_Storage::get_churned_subscribers_in_window()}
+	 * and its winback counterpart query.
+	 *
+	 * @param array $args Same shape as {@see insert_legacy_subscription()}.
+	 * @return int The order ID.
+	 */
+	protected function insert_hpos_subscription( array $args ): int {
+		global $wpdb;
+		$p        = $wpdb->prefix;
+		$order_id = (int) $args['order_id'];
+		$wpdb->insert(
+			"{$p}wc_orders",
+			[
+				'id'               => $order_id,
+				'status'           => $args['status'],
+				'type'             => 'shop_subscription',
+				'date_created_gmt' => $args['date'] ?? $this->default_order_date_gmt(),
+				'total_amount'     => $args['total'] ?? 0,
+				'customer_id'      => (int) $args['customer_id'],
+			]
+		);
+		if ( isset( $args['schedule_cancelled'] ) ) {
+			$wpdb->insert(
+				"{$p}wc_orders_meta",
+				[
+					'order_id'   => $order_id,
+					'meta_key'   => '_schedule_cancelled',
+					'meta_value' => $args['schedule_cancelled'],
+				]
+			);
+		}
+		if ( isset( $args['schedule_start'] ) ) {
+			$wpdb->insert(
+				"{$p}wc_orders_meta",
+				[
+					'order_id'   => $order_id,
+					'meta_key'   => '_schedule_start',
+					'meta_value' => $args['schedule_start'],
+				]
+			);
+		}
+		$this->insert_subscription_line_item( $order_id, (int) $args['product_id'] );
 		return $order_id;
 	}
 }


### PR DESCRIPTION
## What

Hardens **9 timeout-prone SQL queries** in the Insights consumer storage layer (subscription + donor, both Legacy and HPOS backends) that could kill the DB connection (`MySQL server has gone away`) on large publishers. Each is a semantics-preserving rewrite from a correlated / `NOT IN (subquery)` / PHP-built `IN ($big_list)` pattern to a **pre-aggregated `LEFT JOIN` anti-/semi-join**, mirroring the already-optimized `get_winback_subscribers_in_window`.

Base: `feat/insights-rsm`.

## Why

On a live publisher site, a manual "Refresh now" of the **Audience** tab (30-day) failed with `MySQL server has gone away` on `get_churned_subscribers_in_window` (a 1-year churn scan, run synchronously in the REST request). Root cause: `NOT IN (multi-join subquery)` + an unindexed `_schedule_cancelled` range scan.

Investigating why the three new NEWS-2603 newsletter metrics (Audience "value per newsletter subscriber", Subscribers "newsletter→subscription", Donors "newsletter→donation") were all blank revealed the real blast radius: **all three tabs compute a supporter/donor CLV inside `build_response`**, and each CLV depends on a heavy churn/retention query. When that query times out it aborts the *entire* tab refresh → nothing caches → every card on the tab goes blank, including the newsletter ones. A sweep then found the same risk pattern in **9 queries** across the subscription and (previously un-audited) donor storage classes.

## The queries (both backends each)

**Subscription storage** (`class-legacy-storage.php` / `class-hpos-storage.php`):
- `get_churned_subscribers_in_window` — `NOT IN` → anti-join
- `get_stale_registered_users` — 3× `EXISTS` + 2× `NOT IN` → anti-joins
- `get_new_subscriber_records_in_window` — 3 correlated attribution subqueries → pre-aggregated `LEFT JOIN`s (attribution meta lives on the parent `shop_order`; NULL-preservation + gate precedence preserved)
- `get_new_subscriber_cohort_intervals` — `IN (SELECT cohort)` → `INNER JOIN`
- `get_cancellation_reasons` — `IN (SELECT DISTINCT)` → `INNER JOIN`

**Donor storage** (`class-legacy-donors-storage.php` / `class-hpos-donors-storage.php`):
- `get_recurring_donor_retention` — eliminated a PHP round-trip that serialized *every active-at-start donor* into `CAST(...) IN ($list)` (slow **and** a `max_allowed_packet` "gone away" trigger); now a single reused in-SQL derived table
- `get_donations_by_tier` — Pass-2 `NOT IN` → anti-join
- `get_lapsed_donor_recovery_rate` — `NOT IN` + PHP-built `IN ($lapsed_list)` → anti-join + in-SQL cohort
- `get_lapsed_donors_in_window` — `NOT IN` → anti-join

## Approach & guarantees

- **These are refactors — output must not change.** Every query got a **new DB-backed characterization test** (data-provided over both backends) that pins the semantically-tricky case (churned-but-active excluded; NULL-preserving attribution; active-at-start cohort boundary; WCS `'0'` cancel sentinel; per-tier bucketing; etc.). Each test was run against the **unmodified** query first (baseline), then re-run after the rewrite (equivalence proof).
- Range scans on `meta_value` are inherent and left as-is — the win is eliminating the correlated/`NOT IN`/large-`IN` work.
- A couple of queries the sweeps flagged were **correctly left untouched** after inspection (`get_subscription_tenure_distribution` — a documented 1:N contract, not a subquery problem; `get_donations_by_tier` Pass 3 — already non-correlated).

## Follow-ups (noted, not in this PR)

- `get_upcoming_donation_renewals_30d` / `get_upcoming_donation_cancellations_30d` — `meta_value` range scans whose real fix is a **postmeta index** (a schema change, out of scope for a query-rewrite PR).
- `get_supporter_clv_3yr` still treats a churn-query DB failure as `0` (→ inflated CLV shown as computable). A TODO (`540d24306`) recommends widening the storage contract to signal failure. The perf fixes make the failure far less likely, but don't formally close it.

## Testing

- `n test-php --group insights` → **768 tests / 2839 assertions, all green** (up from 696 baseline; +72 new).
- Host PHPCS clean on all touched files.
- Not yet verified live — deploying to a large publisher site and re-running the Audience/Subscribers/Donors 30-day refresh is the real acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
