### PR TITLE
feat(subscribers): add subscriptions demo prototype

### DIFF
--- a/packages/components/src/footer/index.js
+++ b/packages/components/src/footer/index.js
@@ -17,6 +17,7 @@ const Footer = ( { simple = undefined } ) => {
 	const {
 		components_demo: componentsDemo = false,
 		subscribers_demo: subscribersDemo = false,
+		subscriptions_demo: subscriptionsDemo = false,
 		support = false,
 		setup_wizard: setupWizard = false,
 		reset_url: resetUrl = false,
@@ -52,6 +53,12 @@ const Footer = ( { simple = undefined } ) => {
 		footerElements.push( {
 			label: __( 'Subscribers Demo', 'newspack-plugin' ),
 			url: subscribersDemo,
+		} );
+	}
+	if ( subscriptionsDemo ) {
+		footerElements.push( {
+			label: __( 'Subscriptions Demo', 'newspack-plugin' ),
+			url: subscriptionsDemo,
 		} );
 	}
 	if ( setupWizard ) {

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -177,6 +177,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-subscribers-demo.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-subscriptions-demo.php';
 
 		// Listings Wizard.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-listings-wizard.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -42,7 +42,10 @@ class Wizards {
 	public static function init_wizards() {
 		self::$wizards = [
 			'components-demo'         => new Components_Demo(),
-			...( Newspack::is_debug_mode() ? [ 'subscribers-demo' => new Subscribers_Demo() ] : [] ),
+			...( Newspack::is_debug_mode() ? [
+				'subscribers-demo'   => new Subscribers_Demo(),
+				'subscriptions-demo' => new Subscriptions_Demo(),
+			] : [] ),
 			// v2 Information Architecture.
 			'newspack-dashboard'      => new Newspack_Dashboard(),
 			'setup'                   => new Setup_Wizard(),

--- a/plugins/newspack-plugin/includes/wizards/class-subscriptions-demo.php
+++ b/plugins/newspack-plugin/includes/wizards/class-subscriptions-demo.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Newspack Subscriptions Demo.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Subscriptions demo wizard.
+ */
+class Subscriptions_Demo extends Wizard {
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-subscriptions-demo';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool
+	 */
+	protected $hidden = true;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $args Optional arguments.
+	 */
+	public function __construct( $args = [] ) {
+		parent::__construct( $args );
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return esc_html__( 'Subscriptions demo', 'newspack' );
+	}
+
+	/**
+	 * Register REST endpoints.
+	 */
+	public function register_api_endpoints() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/avatars',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'api_get_avatars' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'emails' => [
+						'type'     => 'array',
+						'required' => true,
+						'items'    => [ 'type' => 'string' ],
+					],
+					'size'   => [
+						'type'              => 'integer',
+						'default'           => 64,
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Resolve avatar URLs for a set of emails via core get_avatar_url(), which
+	 * honors the Settings → Discussion avatar options and any avatar plugin.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
+	 */
+	public function api_get_avatars( $request ) {
+		if ( ! get_option( 'show_avatars', true ) ) {
+			return rest_ensure_response( [ 'show' => false ] );
+		}
+		// Callers request 2x their render size so avatars stay crisp on high-DPR
+		// displays (list: 32px → 64, profile: 64px → 128).
+		$size    = $request->get_param( 'size' );
+		$avatars = [];
+		foreach ( $request->get_param( 'emails' ) as $email ) {
+			$avatars[ $email ] = get_avatar_url( $email, [ 'size' => $size ] );
+		}
+		return rest_ensure_response(
+			[
+				'show'    => true,
+				'avatars' => $avatars,
+			]
+		);
+	}
+
+	/**
+	 * Enqueue Subscriptions Demo scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
+			return;
+		}
+
+		$asset = include NEWSPACK_ABSPATH . 'dist/subscriptionsDemo.asset.php';
+
+		wp_enqueue_script(
+			'newspack-subscriptions-demo',
+			Newspack::plugin_url() . '/dist/subscriptionsDemo.js',
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
+
+		// Mirror the publisher's configurable group/team label so the prototype
+		// stays consistent with the Audience → Setup "Group labels" override.
+		$group_label_singular = class_exists( '\Newspack\Group_Subscription' )
+			? \Newspack\Group_Subscription::get_label( 'singular' )
+			: __( 'Group', 'newspack' );
+		$group_label_plural = class_exists( '\Newspack\Group_Subscription' )
+			? \Newspack\Group_Subscription::get_label( 'plural' )
+			: __( 'Groups', 'newspack' );
+
+		// Mirror the site's WooCommerce currency presentation so amounts render in
+		// the publisher's currency rather than a hardcoded "$".
+		$currency = [
+			'symbol'   => function_exists( 'get_woocommerce_currency_symbol' ) ? html_entity_decode( get_woocommerce_currency_symbol() ) : '$',
+			'position' => function_exists( 'get_option' ) ? (string) get_option( 'woocommerce_currency_pos', 'left' ) : 'left',
+		];
+
+		wp_add_inline_script(
+			'newspack-subscriptions-demo',
+			'window.newspackSubscribersDemo = ' . wp_json_encode(
+				[
+					'groupLabel'       => $group_label_singular,
+					'groupLabelPlural' => $group_label_plural,
+					'currency'         => $currency,
+					// Drives the column layout synchronously; the avatar URLs
+					// themselves come from the /avatars REST endpoint.
+					'showAvatars'      => (bool) get_option( 'show_avatars', true ),
+					// Newsletters shown before the "View more" toggle. Defaults to
+					// 4; override per-site with the NEWSPACK_SUBSCRIBERS_DEMO_NEWSLETTERS_LIMIT
+					// wp-config constant if a publisher finds the list too long.
+					'newslettersLimit' => defined( 'NEWSPACK_SUBSCRIBERS_DEMO_NEWSLETTERS_LIMIT' )
+						? (int) NEWSPACK_SUBSCRIBERS_DEMO_NEWSLETTERS_LIMIT
+						: 4,
+					// Cancelled subscriptions shown before the "View more" toggle when a
+					// reader has no active or on-hold plan. Defaults to 1; override with
+					// the NEWSPACK_SUBSCRIBERS_DEMO_CANCELLED_LIMIT wp-config constant.
+					'cancelledLimit'   => defined( 'NEWSPACK_SUBSCRIBERS_DEMO_CANCELLED_LIMIT' )
+						? (int) NEWSPACK_SUBSCRIBERS_DEMO_CANCELLED_LIMIT
+						: 1,
+				]
+			) . ';',
+			'before'
+		);
+
+		wp_enqueue_style(
+			'newspack-subscriptions-demo',
+			Newspack::plugin_url() . '/dist/subscriptionsDemo.css',
+			[ 'wp-components' ],
+			NEWSPACK_PLUGIN_VERSION
+		);
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/class-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-wizard.php
@@ -192,6 +192,7 @@ abstract class Wizard {
 		if ( Newspack::is_debug_mode() && current_user_can( 'manage_options' ) ) {
 			$urls['components_demo']  = esc_url( admin_url( 'admin.php?page=newspack-components-demo' ) );
 			$urls['subscribers_demo'] = esc_url( admin_url( 'admin.php?page=newspack-subscribers-demo' ) );
+			$urls['subscriptions_demo'] = esc_url( admin_url( 'admin.php?page=newspack-subscriptions-demo' ) );
 			$urls['setup_wizard']     = esc_url( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 			$urls['reset_url']       = esc_url(
 				add_query_arg(

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberList.jsx
@@ -204,9 +204,10 @@ export default function SubscriberList() {
 			},
 			{
 				// Filter-only (not in DEFAULT_VIEW.fields): backs the subscription
-				// "View subscribers" deep-link. Unlike `plans` above, this only
-				// counts live (active/on-hold) holders, matching the subscriber
-				// count shown on the Subscriptions list.
+				// "View subscribers" deep-link. Unlike `plans` above, this matches
+				// only the holders the Subscriptions list counts: live (active/
+				// on-hold) individual subscriptions, and — for group subscriptions —
+				// the owner alone (one per group), not covered members/managers.
 				id: 'livePlans',
 				label: __( 'Subscription (live)', 'newspack-plugin' ),
 				elements: [ ...ALL_PLAN_NAMES, ...ALL_GROUP_PLAN_NAMES ].map( n => ( {
@@ -216,7 +217,7 @@ export default function SubscriberList() {
 				filterBy: { operators: [ 'isAny' ] },
 				getValue: ( { item } ) =>
 					planEntries( item, groupsBySubscriber[ item.id ] )
-						.filter( e => e.status === 'active' || e.status === 'on-hold' )
+						.filter( e => ( e.status === 'active' || e.status === 'on-hold' ) && ( e.role === null || e.role === 'owner' ) )
 						.map( e => e.plan ),
 				enableSorting: false,
 			},

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberList.jsx
@@ -17,7 +17,7 @@ import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '
  */
 import { Badge, DataViews, Router, Waiting } from '../../../../packages/components/src';
 import './style.scss';
-import { fmtRelative, fmtDate } from '../format';
+import { fmtRelative, fmtDate, fmtCurrency } from '../format';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { SUBSCRIBERS, DIGITAL_PLANS, PRINT_PLANS, ALL_TAGS, NEWSLETTERS } from '../data/mock-subscribers';
@@ -25,7 +25,7 @@ import { getAllGroups, ALL_GROUP_PLAN_NAMES, ROLE_LABELS } from '../data/mock-gr
 import { GROUP_LABEL } from '../labels';
 import { STATUS_LABELS, STATUS_BADGE_LEVEL, STATUS_RANK, displayStatuses } from '../status';
 
-const { useHistory } = Router;
+const { useHistory, useLocation } = Router;
 
 // Every subscription a subscriber has, group and individual alike: cohorts they
 // own or belong to (tagged by role) plus their own individual subscriptions.
@@ -65,13 +65,17 @@ const subscriberStatuses = ( item, groupEntries ) =>
 
 const ALL_PLAN_NAMES = [ ...DIGITAL_PLANS, ...PRINT_PLANS ].map( p => p.name );
 
+// Lifetime spend: sum of the reader's order amounts. Covered group members with
+// no orders of their own total zero.
+const totalSpent = subscriber => ( subscriber.orders || [] ).reduce( ( sum, order ) => sum + ( order.amount || 0 ), 0 );
+
 const DEFAULT_VIEW = {
 	type: 'table',
 	page: 1,
 	perPage: 20,
 	sort: { field: 'memberSince', direction: 'desc' },
 	search: '',
-	fields: [ 'status', 'plans', 'lastPayment', 'memberSince' ],
+	fields: [ 'status', 'plans', 'lastPayment', 'totalSpent', 'memberSince' ],
 	filters: [],
 	layout: {},
 	titleField: 'name',
@@ -79,7 +83,13 @@ const DEFAULT_VIEW = {
 
 export default function SubscriberList() {
 	const history = useHistory();
-	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const location = useLocation();
+	// A "subscription" query param (from a subscription's "View subscribers"
+	// link) opens the list pre-filtered to that subscription's subscribers.
+	const [ view, setView ] = useState( () => {
+		const subscription = new URLSearchParams( location.search ).get( 'subscription' );
+		return subscription ? { ...DEFAULT_VIEW, filters: [ { field: 'plans', operator: 'isAny', value: [ subscription ] } ] } : DEFAULT_VIEW;
+	} );
 
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
@@ -235,6 +245,16 @@ export default function SubscriberList() {
 						<div className="newspack-subscribers-demo__muted">{ fmtRelative( item.memberSince ) }</div>
 					</div>
 				),
+			},
+			{
+				id: 'totalSpent',
+				label: __( 'Total spent', 'newspack-plugin' ),
+				getValue: ( { item } ) => totalSpent( item ),
+				render: ( { item } ) => {
+					const spent = totalSpent( item );
+					return <span>{ spent > 0 ? fmtCurrency( spent ) : '—' }</span>;
+				},
+				enableSorting: true,
 			},
 			{
 				id: 'lastSeen',

--- a/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribersDemo/screens/SubscriberList.jsx
@@ -88,7 +88,7 @@ export default function SubscriberList() {
 	// link) opens the list pre-filtered to that subscription's subscribers.
 	const [ view, setView ] = useState( () => {
 		const subscription = new URLSearchParams( location.search ).get( 'subscription' );
-		return subscription ? { ...DEFAULT_VIEW, filters: [ { field: 'plans', operator: 'isAny', value: [ subscription ] } ] } : DEFAULT_VIEW;
+		return subscription ? { ...DEFAULT_VIEW, filters: [ { field: 'livePlans', operator: 'isAny', value: [ subscription ] } ] } : DEFAULT_VIEW;
 	} );
 
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
@@ -200,6 +200,24 @@ export default function SubscriberList() {
 						</VStack>
 					);
 				},
+				enableSorting: false,
+			},
+			{
+				// Filter-only (not in DEFAULT_VIEW.fields): backs the subscription
+				// "View subscribers" deep-link. Unlike `plans` above, this only
+				// counts live (active/on-hold) holders, matching the subscriber
+				// count shown on the Subscriptions list.
+				id: 'livePlans',
+				label: __( 'Subscription (live)', 'newspack-plugin' ),
+				elements: [ ...ALL_PLAN_NAMES, ...ALL_GROUP_PLAN_NAMES ].map( n => ( {
+					value: n,
+					label: n,
+				} ) ),
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) =>
+					planEntries( item, groupsBySubscriber[ item.id ] )
+						.filter( e => e.status === 'active' || e.status === 'on-hold' )
+						.map( e => e.plan ),
 				enableSorting: false,
 			},
 			{

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/README.md
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/README.md
@@ -1,0 +1,81 @@
+> This folder is the subscriptions/commerce twin of `../subscribersDemo`. It shares that demo's mock dataset (people and plans are re-exported from `../subscribersDemo/data`) and layers on only the subscription-commerce surface.
+
+# Subscriptions Demo
+
+A design prototype for subscription and subscriber-discount management, shipped for
+internal review. It is a **hidden wizard** (not in the admin menu) with mock data,
+reachable at `admin.php?page=newspack-subscriptions-demo` **when the site is in
+Newspack debug mode**.
+
+Two tabs, both full-width DataViews lists. There is **no subscription detail
+view** — the list is the overview, and per-row actions do the rest (an earlier
+full-page/drawer detail was explored and dropped; see the design notes).
+
+- **Subscriptions** (`/`, `screens/SubscriptionList.jsx`) — one row per
+  subscription (digital, print, team): Status, Price, Billing, Subscribers,
+  Total Sales, Total Revenue. Each row's kebab offers:
+  - **View subscribers** — deep-links to the Subscribers demo, pre-filtered to
+    this subscription (`admin.php?page=newspack-subscribers-demo#/?subscription=…`).
+  - **Add subscriber discount** — opens the discount editor pre-scoped to this
+    subscription (audience locked, picker hidden).
+  - **View in WooCommerce** — opens the products screen, pre-searched by name.
+- **Subscriber discounts** (`/discounts`, `screens/DiscountList.jsx`) — one row
+  per discount rule: which subscription's subscribers get what off which store
+  products. Subscription, Discount, Applies to, Status, Created. Row actions
+  (Edit / Pause·Resume / Delete) and header actions (Add discount, Settings).
+
+## The discount model
+
+A subscriber discount says *"subscribers of subscription **X** get $/% off store
+products **Y**."* Its **audience** is a subscription (a WooCommerce subscription
+product); its **target** is a set of store products (all products / a category /
+specific products, with exclusions). In a real build the membership oracle is
+`Access_Rules::has_active_subscription( $user_id, $product_ids )` and the price is
+applied via WooCommerce price filters.
+
+## Structure
+
+```
+subscriptionsDemo/
+├── index.js                Entry point: mounts the Wizard with the two tabbed sections.
+├── screens/
+│   ├── SubscriptionList.jsx  Subscriptions list + row actions.
+│   ├── DiscountList.jsx      Subscriber-discounts list.
+│   └── style.scss
+├── flows/                  Modals (all drawer/dialog chrome shared via __sub-detail-*).
+│   ├── DiscountRuleFlow.jsx     The discount editor (right-edge drawer).
+│   ├── DiscountSettingsFlow.jsx Global discount settings.
+│   └── ConfirmFlow.jsx          Shared confirm scaffold (pause/resume/delete).
+├── data/                   The prototype↔production seam (see below).
+├── format.js               Currency / date formatting.
+└── labels.js               Publisher-configurable group label.
+```
+
+The PHP side is a single class,
+`includes/wizards/class-subscriptions-demo.php`: the wizard scaffold, debug-mode
+gating, localized config, and the `POST …/avatars` endpoint.
+
+## Data (`data/`)
+
+People and plan data have a **single source of truth: the Subscribers demo.**
+
+| File | Role |
+|------|------|
+| `mock-subscribers.js` | Re-exports `SUBSCRIBERS` and the plan definitions from `../../subscribersDemo/data/mock-subscribers`, layering on the plan-level commercial extras (`status`, `totalSales`, `totalRevenue`). |
+| `mock-groups.js` | Re-exports the Subscribers demo's group dataset, layering the same extras onto `TEAM_PLANS`. |
+| `mock-discounts.js` | Subscriber-discount rules + presentation helpers (`discountLabel`, `targetingLabel`, `subscriberPrice`, …). Specific to this demo. |
+| `mock-catalog.js` | The store products/categories a discount can target. Specific to this demo. |
+| `plan-stats.js` | Pure roll-ups over the shared stores into per-subscription figures (`getAllPlans`, `getPlanStats`, `getSubscribersForPlan`). |
+| `storage.js` | `localStorage` persistence for demo edits (discount rules/settings). |
+
+Because the people/plan records are shared, a subscription's subscriber count
+here matches the Subscribers demo list that "View subscribers" links into.
+
+## Known prototype shortcuts
+
+- **`localStorage` persistence** is per-browser; a `DATA_VERSION` bump in
+  `data/storage.js` wipes it (no migration).
+- `@wordpress/components` is externalized to `wp.components` at runtime, so verify
+  any newer export against the live bundle, not just the build.
+- DataViews sorts filters alphabetically by label; there is no per-filter order
+  knob short of `isPrimary` (which also pins a filter always-visible).

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-catalog.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-catalog.js
@@ -1,0 +1,51 @@
+/**
+ * Mock store catalog for the Subscriptions Demo — shaped like a real
+ * news publisher's storefront (books, events, courses), entirely separate from
+ * the subscription products that grant site access.
+ */
+
+export const CATEGORIES = [ 'Books', 'Events', 'Courses' ];
+
+export const PRODUCTS = [
+	{ id: 'prod_book_v1', name: 'Centennial History, Vol. 1', price: 450, category: 'Books' },
+	{ id: 'prod_book_v2', name: 'Centennial History, Vol. 2', price: 450, category: 'Books' },
+	{ id: 'prod_book_v3', name: 'Centennial History, Vol. 3', price: 450, category: 'Books' },
+	{ id: 'prod_book_city', name: 'City at Dawn: A Portrait', price: 450, category: 'Books' },
+	{ id: 'prod_book_recipes', name: 'Recipes from the Archive', price: 450, category: 'Books' },
+	{
+		id: 'prod_album',
+		name: 'Anniversary Photo Album',
+		price: 520,
+		category: 'Books',
+		variations: [
+			{ id: 'prod_album_hard', name: 'Hardcover', price: 520 },
+			{ id: 'prod_album_soft', name: 'Paperback', price: 380 },
+		],
+	},
+	{ id: 'prod_talk_quarter', name: 'Guided Talk: The Old Quarter', price: 120, category: 'Events' },
+	{ id: 'prod_talk_newsroom', name: 'Guided Talk: Inside the Newsroom', price: 120, category: 'Events' },
+	{ id: 'prod_gala', name: 'Annual Gala Ticket', price: 250, category: 'Events' },
+	{ id: 'prod_photo_walk', name: 'Photography Walk', price: 85, category: 'Events' },
+	{ id: 'prod_course_journalism', name: 'Diploma: Narrative Journalism', price: 2900, category: 'Courses' },
+	{ id: 'prod_course_photo', name: 'Diploma: Documentary Photography', price: 3400, category: 'Courses' },
+	{ id: 'prod_course_writing', name: 'Short Course: Feature Writing', price: 950, category: 'Courses' },
+];
+
+// Variations are addressable too, so exclusion lists and previews can target them.
+const BY_ID = {};
+PRODUCTS.forEach( p => {
+	BY_ID[ p.id ] = p;
+	( p.variations || [] ).forEach( v => {
+		BY_ID[ v.id ] = { ...v, name: `${ p.name } — ${ v.name }`, category: p.category, parentId: p.id };
+	} );
+} );
+
+export const getProductById = id => BY_ID[ id ] || null;
+
+export const searchProducts = term => {
+	const q = ( term || '' ).trim().toLowerCase();
+	if ( ! q ) {
+		return PRODUCTS;
+	}
+	return PRODUCTS.filter( p => p.name.toLowerCase().includes( q ) );
+};

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.js
@@ -143,7 +143,7 @@ export function setDiscountActive( id, active ) {
 
 // ---- Global settings. ----
 
-const DEFAULT_SETTINGS = { applyOnSale: false, overlap: 'best' };
+const DEFAULT_SETTINGS = { applyOnSale: false, applyAtCheckout: false, overlap: 'best' };
 
 export const getDiscountSettings = () => ( { ...DEFAULT_SETTINGS, ...readStore( SETTINGS_KEY ) } );
 

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.js
@@ -1,0 +1,213 @@
+/**
+ * Mock subscriber product-discount rules for the Subscriptions Demo.
+ *
+ * Mirrors the storage pattern of mock-groups: a static seed plus a
+ * localStorage override store, so demo mutations survive a refresh.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { STORAGE_PREFIX, readStore, writeStore } from './storage';
+import { PRODUCTS, getProductById } from './mock-catalog';
+import { TEAM_PLANS } from './mock-groups';
+import { fmtCurrency } from '../format';
+
+const DISCOUNTS_KEY = STORAGE_PREFIX + 'discounts';
+const SETTINGS_KEY = STORAGE_PREFIX + 'discount-settings';
+
+// Seeded to exercise every list state: Yucatan-style fixed amount on a
+// hand-picked product list, a category rule, an all-store rule, a paused
+// rule, and a rule with an exclusion.
+const SEED = [
+	{
+		id: 'disc_books',
+		audience: 'Supporter Annual',
+		type: 'fixed',
+		amount: 51,
+		targeting: 'products',
+		productIds: [ 'prod_book_v1', 'prod_book_v2', 'prod_book_v3', 'prod_book_city', 'prod_book_recipes' ],
+		category: null,
+		excludedIds: [],
+		active: true,
+		createdAt: '2026-04-02',
+	},
+	{
+		id: 'disc_books_cat',
+		audience: 'Yearly Digital',
+		type: 'percent',
+		amount: 10,
+		targeting: 'category',
+		productIds: [],
+		category: 'Books',
+		excludedIds: [],
+		active: true,
+		createdAt: '2026-04-18',
+	},
+	{
+		id: 'disc_all',
+		audience: 'Supporter Annual',
+		type: 'percent',
+		amount: 5,
+		targeting: 'all',
+		productIds: [],
+		category: null,
+		excludedIds: [],
+		active: true,
+		createdAt: '2026-05-11',
+	},
+	{
+		id: 'disc_gala',
+		audience: 'Monthly Digital',
+		type: 'fixed',
+		amount: 20,
+		targeting: 'products',
+		productIds: [ 'prod_gala' ],
+		category: null,
+		excludedIds: [],
+		active: false,
+		createdAt: '2026-05-30',
+	},
+	{
+		id: 'disc_team_courses',
+		audience: TEAM_PLANS[ 0 ].name,
+		type: 'percent',
+		amount: 15,
+		targeting: 'category',
+		productIds: [],
+		category: 'Courses',
+		excludedIds: [ 'prod_course_photo' ],
+		active: true,
+		createdAt: '2026-06-09',
+	},
+];
+
+// ---- Storage: seed + overrides (mirrors mock-groups). ----
+
+function readOverrides() {
+	return readStore( DISCOUNTS_KEY );
+}
+
+export function getAllDiscounts() {
+	const overrides = readOverrides();
+	const rules = SEED.map( rule => ( overrides[ rule.id ] === 'deleted' ? null : { ...rule, ...( overrides[ rule.id ] || {} ) } ) ).filter(
+		Boolean
+	);
+	Object.keys( overrides ).forEach( id => {
+		if ( ! SEED.some( rule => rule.id === id ) && overrides[ id ] !== 'deleted' ) {
+			rules.push( overrides[ id ] );
+		}
+	} );
+	return rules.sort( ( a, b ) => ( b.createdAt || '' ).localeCompare( a.createdAt || '' ) );
+}
+
+export const getDiscountById = id => getAllDiscounts().find( rule => rule.id === id ) || null;
+
+export function saveDiscount( rule ) {
+	const overrides = readOverrides();
+	const saved = {
+		productIds: [],
+		category: null,
+		excludedIds: [],
+		active: true,
+		...rule,
+		id: rule.id || 'disc_new_' + Date.now(),
+		createdAt: rule.createdAt || new Date().toISOString().slice( 0, 10 ),
+	};
+	overrides[ saved.id ] = saved;
+	writeStore( DISCOUNTS_KEY, overrides );
+	return saved;
+}
+
+export function deleteDiscount( id ) {
+	const overrides = readOverrides();
+	if ( SEED.some( rule => rule.id === id ) ) {
+		overrides[ id ] = 'deleted';
+	} else {
+		delete overrides[ id ];
+	}
+	writeStore( DISCOUNTS_KEY, overrides );
+}
+
+export function setDiscountActive( id, active ) {
+	const rule = getDiscountById( id );
+	if ( rule ) {
+		saveDiscount( { ...rule, active } );
+	}
+}
+
+// ---- Global settings. ----
+
+const DEFAULT_SETTINGS = { applyOnSale: false, overlap: 'best' };
+
+export const getDiscountSettings = () => ( { ...DEFAULT_SETTINGS, ...readStore( SETTINGS_KEY ) } );
+
+export const saveDiscountSettings = settings => writeStore( SETTINGS_KEY, { ...getDiscountSettings(), ...settings } );
+
+// ---- Presentation helpers. ----
+
+export function subscriberPrice( price, rule ) {
+	const value = rule.type === 'percent' ? price * ( 1 - rule.amount / 100 ) : price - rule.amount;
+	return Math.max( 0, Math.round( value * 100 ) / 100 );
+}
+
+export function productsForRule( rule ) {
+	let matches;
+	if ( rule.targeting === 'products' ) {
+		matches = ( rule.productIds || [] ).map( getProductById ).filter( Boolean );
+	} else {
+		matches = PRODUCTS.filter( p => rule.targeting === 'all' || p.category === rule.category );
+	}
+	// A variable product is sold through its variations, so previews and
+	// exclusions operate on those instead of the parent.
+	const expanded = matches.flatMap( p => ( ( p.variations || [] ).length ? p.variations.map( v => getProductById( v.id ) ) : [ p ] ) );
+	const excluded = new Set( rule.excludedIds || [] );
+	return expanded.filter( p => ! excluded.has( p.id ) && ! excluded.has( p.parentId ) );
+}
+
+export function discountLabel( rule ) {
+	if ( rule.type === 'percent' ) {
+		// translators: %s: percentage number.
+		return sprintf( __( '%s%%', 'newspack-plugin' ), rule.amount );
+	}
+	return fmtCurrency( rule.amount );
+}
+
+export function targetingBaseLabel( rule ) {
+	if ( rule.targeting === 'all' ) {
+		return __( 'All products', 'newspack-plugin' );
+	}
+	if ( rule.targeting === 'category' ) {
+		// translators: %s: product category name.
+		return sprintf( __( '%s category', 'newspack-plugin' ), rule.category );
+	}
+	const count = ( rule.productIds || [] ).length;
+	// translators: %d: number of products.
+	return sprintf( _n( '%d product', '%d products', count, 'newspack-plugin' ), count );
+}
+
+export function excludedLabel( rule ) {
+	const excluded = ( rule.excludedIds || [] ).length;
+	if ( ! excluded ) {
+		return '';
+	}
+	// translators: %d: number of excluded products.
+	return sprintf( __( '%d excluded', 'newspack-plugin' ), excluded );
+}
+
+export function targetingLabel( rule ) {
+	const base = targetingBaseLabel( rule );
+	const excluded = excludedLabel( rule );
+	if ( excluded ) {
+		// translators: %1$s: targeting label, %2$s: excluded products label.
+		return sprintf( __( '%1$s · %2$s', 'newspack-plugin' ), base, excluded );
+	}
+	return base;
+}
+
+export const benefitsForPlans = planNames => getAllDiscounts().filter( rule => rule.active && ( planNames || [] ).includes( rule.audience ) );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.test.js
@@ -1,0 +1,112 @@
+/**
+ * Internal dependencies.
+ */
+import { CATEGORIES, PRODUCTS, getProductById } from './mock-catalog';
+import {
+	getAllDiscounts,
+	getDiscountById,
+	saveDiscount,
+	deleteDiscount,
+	setDiscountActive,
+	getDiscountSettings,
+	saveDiscountSettings,
+	subscriberPrice,
+	discountLabel,
+	targetingLabel,
+	productsForRule,
+	benefitsForPlans,
+} from './mock-discounts';
+import { ALL_PLANS } from './mock-subscribers';
+import { TEAM_PLANS } from './mock-groups';
+
+const PLAN_NAMES = [ ...ALL_PLANS, ...TEAM_PLANS ].map( p => p.name );
+
+beforeEach( () => window.localStorage.clear() );
+
+describe( 'mock catalog', () => {
+	it( 'has valid categories and at least one variable product', () => {
+		PRODUCTS.forEach( p => expect( CATEGORIES ).toContain( p.category ) );
+		expect( PRODUCTS.some( p => ( p.variations || [] ).length > 1 ) ).toBe( true );
+	} );
+} );
+
+describe( 'seeded discount rules', () => {
+	it( 'reference real plans, products and categories', () => {
+		getAllDiscounts().forEach( rule => {
+			expect( PLAN_NAMES ).toContain( rule.audience );
+			( rule.productIds || [] ).forEach( id => expect( getProductById( id ) ).toBeTruthy() );
+			( rule.excludedIds || [] ).forEach( id => expect( getProductById( id ) ).toBeTruthy() );
+			if ( rule.targeting === 'category' ) {
+				expect( CATEGORIES ).toContain( rule.category );
+			}
+		} );
+	} );
+
+	it( 'cover every list state: yucatan-style, category, all-store, paused, exclusion', () => {
+		const rules = getAllDiscounts();
+		expect( rules.some( r => r.type === 'fixed' && r.targeting === 'products' && r.productIds.length >= 5 ) ).toBe( true );
+		expect( rules.some( r => r.targeting === 'category' ) ).toBe( true );
+		expect( rules.some( r => r.targeting === 'all' ) ).toBe( true );
+		expect( rules.some( r => ! r.active ) ).toBe( true );
+		expect( rules.some( r => ( r.excludedIds || [] ).length > 0 ) ).toBe( true );
+	} );
+} );
+
+describe( 'pricing helpers', () => {
+	it( 'computes fixed and percent subscriber prices, never negative', () => {
+		expect( subscriberPrice( 450, { type: 'fixed', amount: 51 } ) ).toBe( 399 );
+		expect( subscriberPrice( 100, { type: 'percent', amount: 10 } ) ).toBe( 90 );
+		expect( subscriberPrice( 30, { type: 'fixed', amount: 51 } ) ).toBe( 0 );
+	} );
+
+	it( 'expands variations and removes exclusions in productsForRule', () => {
+		const variable = PRODUCTS.find( p => ( p.variations || [] ).length > 1 );
+		const all = productsForRule( { targeting: 'all', excludedIds: [], productIds: [] } );
+		expect( all.some( e => e.id === variable.variations[ 0 ].id ) ).toBe( true );
+		expect( all.some( e => e.id === variable.id ) ).toBe( false );
+		const excluded = productsForRule( { targeting: 'all', excludedIds: [ PRODUCTS[ 0 ].id ], productIds: [] } );
+		expect( excluded.some( e => e.id === PRODUCTS[ 0 ].id ) ).toBe( false );
+	} );
+
+	it( 'labels discounts and targeting', () => {
+		expect( discountLabel( { type: 'percent', amount: 10 } ) ).toBe( '10%' );
+		expect( targetingLabel( { targeting: 'all', excludedIds: [], productIds: [] } ) ).toBe( 'All products' );
+		expect( targetingLabel( { targeting: 'products', productIds: [ 'a', 'b' ], excludedIds: [] } ) ).toBe( '2 products' );
+	} );
+} );
+
+describe( 'storage-backed mutations', () => {
+	it( 'persists save, toggle and delete via localStorage overrides', () => {
+		const rule = saveDiscount( {
+			audience: ALL_PLANS[ 0 ].name,
+			type: 'fixed',
+			amount: 5,
+			targeting: 'all',
+			productIds: [],
+			category: null,
+			excludedIds: [],
+			active: true,
+		} );
+		expect( getDiscountById( rule.id ) ).toBeTruthy();
+		setDiscountActive( rule.id, false );
+		expect( getDiscountById( rule.id ).active ).toBe( false );
+		deleteDiscount( rule.id );
+		expect( getDiscountById( rule.id ) ).toBeFalsy();
+	} );
+
+	it( 'round-trips settings', () => {
+		expect( getDiscountSettings() ).toEqual( { applyOnSale: false, overlap: 'best' } );
+		saveDiscountSettings( { applyOnSale: true, overlap: 'combine' } );
+		expect( getDiscountSettings() ).toEqual( { applyOnSale: true, overlap: 'combine' } );
+	} );
+} );
+
+describe( 'benefits', () => {
+	it( 'returns only active rules matching the given plan names', () => {
+		const teamRule = getAllDiscounts().find( r => TEAM_PLANS.some( p => p.name === r.audience ) );
+		expect( teamRule ).toBeTruthy();
+		const benefits = benefitsForPlans( [ teamRule.audience ] );
+		expect( benefits ).toContainEqual( expect.objectContaining( { id: teamRule.id } ) );
+		benefits.forEach( r => expect( r.active ).toBe( true ) );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.test.js
@@ -95,9 +95,9 @@ describe( 'storage-backed mutations', () => {
 	} );
 
 	it( 'round-trips settings', () => {
-		expect( getDiscountSettings() ).toEqual( { applyOnSale: false, overlap: 'best' } );
-		saveDiscountSettings( { applyOnSale: true, overlap: 'combine' } );
-		expect( getDiscountSettings() ).toEqual( { applyOnSale: true, overlap: 'combine' } );
+		expect( getDiscountSettings() ).toEqual( { applyOnSale: false, applyAtCheckout: false, overlap: 'best' } );
+		saveDiscountSettings( { applyOnSale: true, applyAtCheckout: true, overlap: 'combine' } );
+		expect( getDiscountSettings() ).toEqual( { applyOnSale: true, applyAtCheckout: true, overlap: 'combine' } );
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-groups.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-groups.js
@@ -1,0 +1,62 @@
+/**
+ * Subscriptions demo — group & team-plan data.
+ *
+ * Re-exports the Subscribers demo's group dataset verbatim (single source of
+ * truth for people and groups), layering on the team-plan commercial extras
+ * the subscription views need (status, total sales, total revenue).
+ */
+
+/**
+ * Internal dependencies.
+ */
+import { TEAM_PLANS as BASE_TEAM_PLANS } from '../../subscribersDemo/data/mock-groups';
+
+export {
+	getPlanOptions,
+	GROUP_STATUS_LABELS,
+	GROUP_STATUS_BADGE_LEVEL,
+	ROLE_LABELS,
+	ROLE_RANK,
+	GROUPS,
+	ALL_GROUP_PLAN_NAMES,
+	seatsUsed,
+	seatsAvailable,
+	isGroupFull,
+	reservedSeats,
+	isInviteExpired,
+	hasActiveInviteLink,
+	inviteCapacity,
+	isGroupActive,
+	isGroupManageable,
+	hasSeatRequest,
+	canRequestSeats,
+	requestSeatIncrease,
+	applySeatIncrease,
+	sendSeatUpgradeLink,
+	paySeatUpgrade,
+	clearSeatRequest,
+	setMemberRole,
+	getStoredGroup,
+	setStoredGroup,
+	getGroupById,
+	getAllGroups,
+	createGroup,
+	getGroupsForSubscriber,
+	getInvitableSubscribers,
+	getMemberSubscriber,
+	addMembersByEmail,
+	getGroupOwnerName,
+	getGroupLabel,
+} from '../../subscribersDemo/data/mock-groups';
+
+// Per-team-subscription commercial extras keyed by name, merged onto the shared
+// team-plan definitions. Defaults keep any unlisted plan active with zero sales.
+const TEAM_EXTRAS = {
+	'Team Monthly': { status: 'active', totalSales: 22, totalRevenue: 14800 },
+	'Team Yearly': { status: 'active', totalSales: 12, totalRevenue: 19000 },
+	'Education Annual': { status: 'active', totalSales: 8, totalRevenue: 32000 },
+};
+
+const withExtras = plan => ( { status: 'active', totalSales: 0, totalRevenue: 0, ...plan, ...TEAM_EXTRAS[ plan.name ] } );
+
+export const TEAM_PLANS = BASE_TEAM_PLANS.map( withExtras );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-groups.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-groups.test.js
@@ -1,0 +1,97 @@
+/**
+ * Internal dependencies.
+ */
+import {
+	requestSeatIncrease,
+	applySeatIncrease,
+	sendSeatUpgradeLink,
+	paySeatUpgrade,
+	clearSeatRequest,
+	hasSeatRequest,
+	canRequestSeats,
+	setMemberRole,
+	GROUPS,
+} from './mock-groups';
+
+const baseGroup = () => ( {
+	id: 'grp_test',
+	status: 'active',
+	seatLimit: 10,
+	members: [ { subscriberId: 's1', role: 'owner', joinedAt: '2026-01-01' } ],
+	invites: [],
+	seatRequest: null,
+} );
+
+describe( 'seat request helpers', () => {
+	it( 'requestSeatIncrease records a pending request without changing the limit', () => {
+		const next = requestSeatIncrease( baseGroup(), 15 );
+		expect( next.seatLimit ).toBe( 10 );
+		expect( next.seatRequest.target ).toBe( 15 );
+		expect( next.seatRequest.status ).toBe( 'pending' );
+		expect( next.seatRequest.requestedAt ).toMatch( /^\d{4}-\d{2}-\d{2}$/ );
+	} );
+
+	it( 'applySeatIncrease raises the limit and clears the request', () => {
+		const next = applySeatIncrease( requestSeatIncrease( baseGroup(), 15 ), 15 );
+		expect( next.seatLimit ).toBe( 15 );
+		expect( next.seatRequest ).toBeNull();
+	} );
+
+	it( 'sendSeatUpgradeLink stores amount and awaiting-payment without changing the limit', () => {
+		const next = sendSeatUpgradeLink( requestSeatIncrease( baseGroup(), 15 ), 15, 50 );
+		expect( next.seatLimit ).toBe( 10 );
+		expect( next.seatRequest.status ).toBe( 'awaiting-payment' );
+		expect( next.seatRequest.amount ).toBe( 50 );
+		expect( next.seatRequest.target ).toBe( 15 );
+		expect( next.seatRequest.linkSentAt ).toMatch( /^\d{4}-\d{2}-\d{2}$/ );
+	} );
+
+	it( 'paySeatUpgrade applies the awaiting-payment target and clears the request', () => {
+		const awaiting = sendSeatUpgradeLink( requestSeatIncrease( baseGroup(), 15 ), 15, 50 );
+		const next = paySeatUpgrade( awaiting );
+		expect( next.seatLimit ).toBe( 15 );
+		expect( next.seatRequest ).toBeNull();
+	} );
+
+	it( 'clearSeatRequest drops the request with no seat change', () => {
+		const next = clearSeatRequest( requestSeatIncrease( baseGroup(), 15 ) );
+		expect( next.seatLimit ).toBe( 10 );
+		expect( next.seatRequest ).toBeNull();
+	} );
+
+	it( 'canRequestSeats is false when a request already exists or the group is inactive', () => {
+		expect( canRequestSeats( baseGroup() ) ).toBe( true );
+		expect( canRequestSeats( requestSeatIncrease( baseGroup(), 15 ) ) ).toBe( false );
+		expect( hasSeatRequest( requestSeatIncrease( baseGroup(), 15 ) ) ).toBe( true );
+		expect( canRequestSeats( { ...baseGroup(), status: 'on-hold' } ) ).toBe( false );
+	} );
+} );
+
+describe( 'manager role helpers', () => {
+	const managedGroup = () => ( {
+		...baseGroup(),
+		ownerId: 's1',
+		members: [
+			{ subscriberId: 's1', role: 'owner', joinedAt: '2026-01-01' },
+			{ subscriberId: 's2', role: 'member', joinedAt: '2026-02-01' },
+		],
+	} );
+
+	it( 'setMemberRole promotes a member to manager and demotes back', () => {
+		const promoted = setMemberRole( managedGroup(), 's2', 'manager' );
+		expect( promoted.members.find( m => m.subscriberId === 's2' ).role ).toBe( 'manager' );
+		const demoted = setMemberRole( promoted, 's2', 'member' );
+		expect( demoted.members.find( m => m.subscriberId === 's2' ).role ).toBe( 'member' );
+	} );
+
+	it( 'setMemberRole never re-roles the owner', () => {
+		const group = managedGroup();
+		expect( setMemberRole( group, 's1', 'manager' ) ).toBe( group );
+	} );
+
+	it( 'seeds managers who are group members and never the owner', () => {
+		const withManagers = GROUPS.filter( g => ( g.members || [] ).some( m => m.role === 'manager' ) );
+		expect( withManagers.map( g => g.id ) ).toEqual( expect.arrayContaining( [ 'grp_acme', 'grp_riverside', 'grp_northside' ] ) );
+		withManagers.forEach( g => g.members.filter( m => m.role === 'manager' ).forEach( m => expect( m.subscriberId ).not.toBe( g.ownerId ) ) );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-subscribers.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-subscribers.js
@@ -1,0 +1,51 @@
+/**
+ * Subscriptions demo — subscriber & plan data.
+ *
+ * People and plan definitions have a single source of truth: the Subscribers
+ * demo. This module re-exports that dataset verbatim and layers on the
+ * plan-level commercial extras the subscription views need (status, total
+ * sales, total revenue). One shared dataset means a subscription's subscriber
+ * count here matches the Subscribers demo list the "View subscribers" link
+ * deep-links into.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import { DIGITAL_PLANS as BASE_DIGITAL_PLANS, PRINT_PLANS as BASE_PRINT_PLANS } from '../../subscribersDemo/data/mock-subscribers';
+
+export {
+	SUBSCRIBERS,
+	ALL_TAGS,
+	KNOWN_TAGS,
+	NEWSLETTERS,
+	getSubscriberById,
+	getSubscriberByEmail,
+	getStoredNotes,
+	setStoredNotes,
+	getStoredTags,
+	setStoredTags,
+	getStoredNewsletters,
+	setStoredNewsletters,
+	getStoredSubscriber,
+	setStoredSubscriber,
+	plusCadenceIso,
+	minusCadenceIso,
+} from '../../subscribersDemo/data/mock-subscribers';
+
+// Per-subscription commercial extras keyed by name, merged onto the shared plan
+// definitions. Defaults keep any unlisted plan active with zero sales.
+const PLAN_EXTRAS = {
+	'Monthly Digital': { status: 'active', totalSales: 320, totalRevenue: 18400 },
+	'Yearly Digital': { status: 'active', totalSales: 145, totalRevenue: 21200 },
+	'Student Monthly': { status: 'active', totalSales: 210, totalRevenue: 4900 },
+	'Supporter Annual': { status: 'active', totalSales: 60, totalRevenue: 22500 },
+	'Monthly Print': { status: 'active', totalSales: 95, totalRevenue: 8600 },
+	'Yearly Print': { status: 'retired', totalSales: 30, totalRevenue: 6300 },
+};
+
+const withExtras = plan => ( { status: 'active', totalSales: 0, totalRevenue: 0, ...plan, ...PLAN_EXTRAS[ plan.name ] } );
+
+export const DIGITAL_PLANS = BASE_DIGITAL_PLANS.map( withExtras );
+export const PRINT_PLANS = BASE_PRINT_PLANS.map( withExtras );
+export const ALL_PLANS = [ ...DIGITAL_PLANS, ...PRINT_PLANS ];

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/plan-stats.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/plan-stats.js
@@ -1,0 +1,138 @@
+/**
+ * Plan-stats: pure derivations over the existing mock stores.
+ *
+ * Rolls up the subscribers, groups and discounts stores into per-plan figures
+ * for the plan-centric views. No new storage — every number here is computed
+ * from the same seeded/overridden data the list screens already read.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import { SUBSCRIBERS, DIGITAL_PLANS, PRINT_PLANS } from './mock-subscribers';
+import { TEAM_PLANS, getAllGroups, seatsUsed } from './mock-groups';
+import { getAllDiscounts } from './mock-discounts';
+
+// A subscription/group still counts toward a plan's live figures while active
+// or on-hold; cancelled is churned and drops out.
+const LIVE_STATUSES = [ 'active', 'on-hold' ];
+
+function slugify( name ) {
+	return String( name )
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /^-+|-+$/g, '' );
+}
+
+function planEntry( plan, family ) {
+	return {
+		id: slugify( plan.name ),
+		name: plan.name,
+		family,
+		cadence: plan.cadence,
+		amount: plan.amount,
+		access: plan.access ?? null,
+		status: plan.status ?? 'active',
+		totalSales: plan.totalSales ?? 0,
+		totalRevenue: plan.totalRevenue ?? 0,
+	};
+}
+
+// Stable base order within each family: monthly before yearly (unknowns last),
+// then cheapest-first. The list screen re-sorts by the active column, so this
+// is just a sensible default when subscriptions share a sort key.
+const CADENCE_RANK = { monthly: 0, yearly: 1, annual: 1 };
+const byCadenceThenPrice = ( a, b ) => {
+	const ra = CADENCE_RANK[ String( a.cadence ).toLowerCase() ] ?? 2;
+	const rb = CADENCE_RANK[ String( b.cadence ).toLowerCase() ] ?? 2;
+	return ra !== rb ? ra - rb : ( a.amount || 0 ) - ( b.amount || 0 );
+};
+
+export function getAllPlans() {
+	return [
+		...DIGITAL_PLANS.map( p => planEntry( p, 'digital' ) ).sort( byCadenceThenPrice ),
+		...PRINT_PLANS.map( p => planEntry( p, 'print' ) ).sort( byCadenceThenPrice ),
+		...TEAM_PLANS.map( p => planEntry( p, 'team' ) ).sort( byCadenceThenPrice ),
+	];
+}
+
+export function getPlanById( id ) {
+	return getAllPlans().find( p => p.id === id ) || null;
+}
+
+// Live subscriptions a subscriber holds on the given plan (usually zero or one,
+// but a resubscribe can leave more than one row for the same plan name).
+function liveSubscriptionsForPlan( subscriber, planName ) {
+	return ( subscriber.subscriptions || [] ).filter( sub => sub.plan === planName && LIVE_STATUSES.includes( sub.status ) );
+}
+
+// Live groups on the given team plan.
+function liveGroupsForPlan( planName ) {
+	return getAllGroups().filter( group => group.plan === planName && LIVE_STATUSES.includes( group.status ) );
+}
+
+function activeDiscountsForPlan( planName ) {
+	return getAllDiscounts().filter( rule => rule.active && rule.audience === planName ).length;
+}
+
+/**
+ * Live individual holders of a digital/print plan, newest-first by that
+ * subscription's startDate (the latest, if a subscriber somehow carries more
+ * than one live row for the same plan).
+ *
+ * @param {string} planName Plan name.
+ * @return {Object[]} Subscriber records.
+ */
+export function getSubscribersForPlan( planName ) {
+	return SUBSCRIBERS.map( subscriber => {
+		const liveSubs = liveSubscriptionsForPlan( subscriber, planName );
+		if ( ! liveSubs.length ) {
+			return null;
+		}
+		const latestStart = liveSubs
+			.map( sub => sub.startDate )
+			.sort()
+			.pop();
+		return { subscriber, latestStart };
+	} )
+		.filter( Boolean )
+		.sort( ( a, b ) => b.latestStart.localeCompare( a.latestStart ) )
+		.map( entry => entry.subscriber );
+}
+
+/**
+ * Live groups on a team plan.
+ *
+ * @param {string} planName Plan name.
+ * @return {Object[]} Group records.
+ */
+export function getGroupsForPlan( planName ) {
+	return liveGroupsForPlan( planName );
+}
+
+/**
+ * Roll-up stats for a single plan by name.
+ *
+ * @param {string} planName Plan name.
+ * @return {{individuals: (number|null), groups: (number|null), members: (number|null), discounts: number}} Stats.
+ */
+export function getPlanStats( planName ) {
+	const isTeamPlan = TEAM_PLANS.some( p => p.name === planName );
+
+	if ( isTeamPlan ) {
+		const groups = liveGroupsForPlan( planName );
+		return {
+			individuals: null,
+			groups: groups.length,
+			members: groups.reduce( ( sum, group ) => sum + seatsUsed( group ), 0 ),
+			discounts: activeDiscountsForPlan( planName ),
+		};
+	}
+
+	return {
+		individuals: getSubscribersForPlan( planName ).length,
+		groups: null,
+		members: null,
+		discounts: activeDiscountsForPlan( planName ),
+	};
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/plan-stats.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/plan-stats.test.js
@@ -1,0 +1,146 @@
+/**
+ * Internal dependencies.
+ */
+import { getAllPlans, getPlanById, getPlanStats, getSubscribersForPlan, getGroupsForPlan } from './plan-stats';
+import { SUBSCRIBERS, DIGITAL_PLANS, PRINT_PLANS } from './mock-subscribers';
+import { TEAM_PLANS, getAllGroups, seatsUsed } from './mock-groups';
+import { getAllDiscounts } from './mock-discounts';
+
+const LIVE_STATUSES = [ 'active', 'on-hold' ];
+
+beforeEach( () => window.localStorage.clear() );
+
+describe( 'getAllPlans', () => {
+	it( 'includes every plan from the three family arrays exactly once, with the right family', () => {
+		const all = getAllPlans();
+		expect( all ).toHaveLength( DIGITAL_PLANS.length + PRINT_PLANS.length + TEAM_PLANS.length );
+
+		DIGITAL_PLANS.forEach( p => {
+			const matches = all.filter( e => e.name === p.name );
+			expect( matches ).toHaveLength( 1 );
+			expect( matches[ 0 ].family ).toBe( 'digital' );
+		} );
+		PRINT_PLANS.forEach( p => {
+			const matches = all.filter( e => e.name === p.name );
+			expect( matches ).toHaveLength( 1 );
+			expect( matches[ 0 ].family ).toBe( 'print' );
+		} );
+		TEAM_PLANS.forEach( p => {
+			const matches = all.filter( e => e.name === p.name );
+			expect( matches ).toHaveLength( 1 );
+			expect( matches[ 0 ].family ).toBe( 'team' );
+		} );
+	} );
+
+	it( 'has unique, slugified ids (lowercase, non-alphanumerics collapsed to a single hyphen, trimmed)', () => {
+		const all = getAllPlans();
+		const ids = all.map( p => p.id );
+		expect( new Set( ids ).size ).toBe( ids.length );
+		all.forEach( p => {
+			expect( p.id ).toBe( p.id.toLowerCase() );
+			expect( p.id ).not.toMatch( /[^a-z0-9-]/ );
+			expect( p.id ).not.toMatch( /^-|-$/ );
+			expect( p.id ).not.toMatch( /--/ );
+		} );
+	} );
+} );
+
+describe( 'getPlanById', () => {
+	it( 'resolves a plan by its slugified id', () => {
+		const plan = getAllPlans()[ 0 ];
+		expect( getPlanById( plan.id ) ).toEqual( plan );
+	} );
+
+	it( 'returns null for an unknown id', () => {
+		expect( getPlanById( 'not-a-real-plan' ) ).toBeNull();
+	} );
+} );
+
+describe( 'getPlanStats for a digital plan', () => {
+	const planName = 'Supporter Annual';
+
+	it( 'counts live holders derived from the subscribers fixture, with groups/members null', () => {
+		const expectedIndividuals = SUBSCRIBERS.filter( s =>
+			( s.subscriptions || [] ).some( sub => sub.plan === planName && LIVE_STATUSES.includes( sub.status ) )
+		).length;
+
+		const stats = getPlanStats( planName );
+		expect( stats.individuals ).toBe( expectedIndividuals );
+		expect( stats.groups ).toBeNull();
+		expect( stats.members ).toBeNull();
+	} );
+
+	it( 'counts active seeded discount rules targeting the plan', () => {
+		const expectedDiscounts = getAllDiscounts().filter( rule => rule.active && rule.audience === planName ).length;
+		// Structurally guaranteed by the seed (disc_books and disc_all both target
+		// Supporter Annual and are active).
+		expect( expectedDiscounts ).toBeGreaterThanOrEqual( 1 );
+		expect( getPlanStats( planName ).discounts ).toBe( expectedDiscounts );
+	} );
+} );
+
+describe( 'getPlanStats for a team plan', () => {
+	const planName = 'Team Monthly';
+
+	it( 'returns null individuals and groups/members agreeing with getAllGroups()', () => {
+		const liveGroups = getAllGroups().filter( g => g.plan === planName && LIVE_STATUSES.includes( g.status ) );
+		const expectedMembers = liveGroups.reduce( ( sum, g ) => sum + seatsUsed( g ), 0 );
+
+		const stats = getPlanStats( planName );
+		expect( stats.individuals ).toBeNull();
+		expect( stats.groups ).toBe( liveGroups.length );
+		expect( stats.members ).toBe( expectedMembers );
+	} );
+} );
+
+describe( 'getSubscribersForPlan', () => {
+	const planName = 'Monthly Digital';
+
+	it( 'returns only live holders, each actually holding the plan, newest-first by that subscription startDate', () => {
+		const result = getSubscribersForPlan( planName );
+		expect( result.length ).toBeGreaterThan( 0 );
+
+		const latestLiveStart = subscriber => {
+			const liveSubs = ( subscriber.subscriptions || [] ).filter( sub => sub.plan === planName && LIVE_STATUSES.includes( sub.status ) );
+			expect( liveSubs.length ).toBeGreaterThan( 0 );
+			return liveSubs
+				.map( sub => sub.startDate )
+				.sort()
+				.pop();
+		};
+
+		const starts = result.map( latestLiveStart );
+		const sortedDesc = [ ...starts ].sort( ( a, b ) => b.localeCompare( a ) );
+		expect( starts ).toEqual( sortedDesc );
+
+		expect( result ).toHaveLength( getPlanStats( planName ).individuals );
+	} );
+
+	it( 'excludes a subscriber whose only subscription on the plan is cancelled', () => {
+		// Oscar Rivera (id '4') holds a cancelled Monthly Digital subscription only.
+		const oscar = SUBSCRIBERS.find( s => s.id === '4' );
+		expect( oscar.subscriptions.some( sub => sub.plan === planName && sub.status === 'cancelled' ) ).toBe( true );
+		expect( getSubscribersForPlan( planName ).some( s => s.id === '4' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getGroupsForPlan', () => {
+	it( "returns only that plan's live groups, matching getAllGroups()", () => {
+		const planName = 'Team Yearly';
+		const expected = getAllGroups().filter( g => g.plan === planName && LIVE_STATUSES.includes( g.status ) );
+
+		const result = getGroupsForPlan( planName );
+		result.forEach( g => {
+			expect( g.plan ).toBe( planName );
+			expect( LIVE_STATUSES ).toContain( g.status );
+		} );
+		expect( result.map( g => g.id ).sort() ).toEqual( expected.map( g => g.id ).sort() );
+	} );
+
+	it( 'excludes a cancelled group on the plan', () => {
+		// grp_oldpress (Jane Chen) is a cancelled Team Monthly group.
+		const cancelled = getAllGroups().find( g => g.id === 'grp_oldpress' );
+		expect( cancelled.status ).toBe( 'cancelled' );
+		expect( getGroupsForPlan( 'Team Monthly' ).some( g => g.id === 'grp_oldpress' ) ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/storage.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/storage.js
@@ -1,0 +1,49 @@
+// PROTOTYPE ONLY: demo mutations (notes, tags, newsletters, group and subscriber
+// overrides) are persisted to the current admin's localStorage so they survive a
+// refresh during a demo. Everything lives under a shared prefix so a single version
+// check can invalidate it all at once.
+export const STORAGE_PREFIX = 'newspack-subscriptions-demo:';
+
+// Bump this whenever the seeded mock data changes shape or content. On the next load
+// a mismatch wipes every stored override so the new seed surfaces instead of being
+// masked by stale localStorage from a previous build. Reset to '1' for the
+// subscriptions demo's own storage namespace (transplanted from the discounts demo).
+const DATA_VERSION = '1';
+const VERSION_STORAGE_KEY = STORAGE_PREFIX + 'data-version';
+
+export function readStore( key ) {
+	try {
+		return JSON.parse( window.localStorage.getItem( key ) ) || {};
+	} catch ( e ) {
+		return {};
+	}
+}
+
+export function writeStore( key, store ) {
+	try {
+		window.localStorage.setItem( key, JSON.stringify( store ) );
+	} catch ( e ) {
+		// Storage quota or disabled — fail silently in the prototype.
+	}
+}
+
+// Clears every stored demo override when the data version has changed. Called once at
+// app init, before any screen reads from localStorage.
+export function purgeStaleStorage() {
+	try {
+		if ( window.localStorage.getItem( VERSION_STORAGE_KEY ) === DATA_VERSION ) {
+			return;
+		}
+		const keys = [];
+		for ( let i = 0; i < window.localStorage.length; i++ ) {
+			const key = window.localStorage.key( i );
+			if ( key && key.startsWith( STORAGE_PREFIX ) ) {
+				keys.push( key );
+			}
+		}
+		keys.forEach( key => window.localStorage.removeItem( key ) );
+		window.localStorage.setItem( VERSION_STORAGE_KEY, DATA_VERSION );
+	} catch ( e ) {
+		// Storage disabled — nothing to purge.
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/ConfirmFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/ConfirmFlow.jsx
@@ -1,0 +1,37 @@
+/**
+ * Shared confirmation modal for the simple single-action flows (cancel invite,
+ * disable link, remove member, make owner, regenerate link, resend invite).
+ *
+ * Encapsulates the small-modal scaffold — title, body text, and a tertiary
+ * Cancel + primary Confirm button pair — so each flow only supplies its copy and
+ * the action to run on confirm.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Modal } from '../../../../packages/components/src';
+
+export default function ConfirmFlow( { title, children, cancelLabel, confirmLabel, isDestructive = false, busy = false, onCancel, onConfirm } ) {
+	return (
+		<Modal title={ title } onRequestClose={ onCancel } size="small">
+			<VStack spacing={ 4 }>
+				<p className="newspack-subscribers-demo__modal-text">{ children }</p>
+				<HStack spacing={ 2 } justify="flex-end">
+					<Button variant="tertiary" size="compact" disabled={ busy } onClick={ onCancel }>
+						{ cancelLabel || __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+					<Button variant="primary" size="compact" isDestructive={ isDestructive } isBusy={ busy } disabled={ busy } onClick={ onConfirm }>
+						{ confirmLabel }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
@@ -113,7 +113,14 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 		amount: rule.amount ?? 0,
 	} );
 	const isDirty = JSON.stringify( draft ) !== JSON.stringify( initial );
-	const isValid = draft.amount > 0 && ( targeting !== 'products' || productIds.length > 0 );
+	// A valid amount is finite and positive; a percentage can't exceed 100. Save
+	// stays disabled (and saveDiscount never runs) until the amount clears these.
+	const amountValue = Number( amountInput );
+	const isValid =
+		Number.isFinite( amountValue ) &&
+		amountValue > 0 &&
+		( type !== 'percent' || amountValue <= 100 ) &&
+		( targeting !== 'products' || productIds.length > 0 );
 	const canSave = isDirty && isValid;
 
 	const onSave = () => {

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
@@ -83,7 +83,20 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 		setExcludedIds( names.map( name => scopeProducts.find( p => p.name === name )?.id ).filter( Boolean ) );
 	};
 
-	const draft = ruleShape( { audience, targeting, productIds, category, excludedIds, type, amount: Number( amountInput ) || 0 } );
+	// Drop exclusions no longer in scope (e.g. left over after switching targeting
+	// or category) so the saved rule and its "N excluded" label never count
+	// products the editor isn't showing.
+	const scopedExcludedIds = excludedIds.filter( id => scopeProducts.some( p => p.id === id ) );
+
+	const draft = ruleShape( {
+		audience,
+		targeting,
+		productIds,
+		category,
+		excludedIds: scopedExcludedIds,
+		type,
+		amount: Number( amountInput ) || 0,
+	} );
 	const products = productsForRule( draft );
 
 	const onAmountChange = value => setAmountInput( value );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
@@ -1,0 +1,289 @@
+/**
+ * Discount rule editor — two-step "who and what, then how much" flow for
+ * adding or editing a subscriber product-discount rule. `rule` is `{}` for a new
+ * rule or an existing rule object to edit. Mirrors AddSubscriptionFlow's
+ * method → details shape via the shared useTwoStep/StepButtons scaffolding.
+ */
+
+import { useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	FormTokenField,
+	RadioControl,
+	TextControl,
+} from '@wordpress/components';
+import { close } from '@wordpress/icons';
+import { Button, Modal, SelectControl } from '../../../../packages/components/src';
+import { CATEGORIES, PRODUCTS, getProductById } from '../data/mock-catalog';
+import { saveDiscount, subscriberPrice, productsForRule } from '../data/mock-discounts';
+import { DIGITAL_PLANS, PRINT_PLANS } from '../data/mock-subscribers';
+import { TEAM_PLANS } from '../data/mock-groups';
+import { GROUP_LABEL } from '../labels';
+import { fmtCurrency } from '../format';
+import ConfirmFlow from './ConfirmFlow';
+
+// Every subscription, in list order. Group (team) subscriptions are tagged
+// "(Group)" — matching how the Subscribers demo marks them — while individual
+// ones show a plain name.
+const ALL_PLANS = [ ...DIGITAL_PLANS, ...PRINT_PLANS, ...TEAM_PLANS ];
+const isGroupPlan = name => TEAM_PLANS.some( p => p.name === name );
+const planLabel = name => ( isGroupPlan( name ) ? `${ name } (${ GROUP_LABEL })` : name );
+
+// The saved shape of a rule's targeting/amount, normalized so a mode switch
+// before saving doesn't persist stale ids. Shared by the draft and the "has it
+// changed?" comparison.
+function ruleShape( { audience, targeting, productIds, category, excludedIds, type, amount } ) {
+	return {
+		audience,
+		targeting,
+		productIds: targeting === 'products' ? productIds : [],
+		category: targeting === 'category' ? category : null,
+		excludedIds: targeting === 'products' ? [] : excludedIds,
+		type,
+		amount,
+	};
+}
+
+export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
+	const isEdit = Boolean( rule.id );
+	// Adding from a subscription's row pre-scopes the audience: lock it in and
+	// drop the picker, since the subscription is already chosen.
+	const isScopedAdd = ! isEdit && Boolean( rule.audience );
+
+	const [ audience, setAudience ] = useState( rule.audience || ALL_PLANS[ 0 ].name );
+	const [ targeting, setTargeting ] = useState( rule.targeting || 'products' );
+	const [ productIds, setProductIds ] = useState( rule.productIds || [] );
+	const [ category, setCategory ] = useState( rule.category || CATEGORIES[ 0 ] );
+	const [ excludedIds, setExcludedIds ] = useState( rule.excludedIds || [] );
+	const [ type, setType ] = useState( rule.type || 'fixed' );
+	// Amount and subscriber price are linked but each holds its own raw input
+	// string, so typing intermediate states ("", "12.") is never rewritten;
+	// only the counterpart field recomputes.
+	const [ amountInput, setAmountInput ] = useState( rule.amount !== undefined && rule.amount !== null ? String( rule.amount ) : '' );
+	const [ busy, setBusy ] = useState( false );
+	const [ confirmDiscard, setConfirmDiscard ] = useState( false );
+
+	const onProductsChange = names => {
+		setProductIds( names.map( name => PRODUCTS.find( p => p.name === name )?.id ).filter( Boolean ) );
+	};
+
+	// Products currently in scope with no exclusions applied yet, so the
+	// exclusion picker only ever offers what could actually be excluded.
+	const scopeProducts = productsForRule( { targeting, productIds, category, excludedIds: [] } );
+
+	const onExcludedChange = names => {
+		setExcludedIds( names.map( name => scopeProducts.find( p => p.name === name )?.id ).filter( Boolean ) );
+	};
+
+	const draft = ruleShape( { audience, targeting, productIds, category, excludedIds, type, amount: Number( amountInput ) || 0 } );
+	const products = productsForRule( draft );
+
+	const onAmountChange = value => setAmountInput( value );
+
+	// What the rule looked like when the editor opened; Save stays disabled until
+	// the draft differs from it (and is valid), so a no-op edit can't be saved.
+	const initial = ruleShape( {
+		audience: rule.audience || ALL_PLANS[ 0 ].name,
+		targeting: rule.targeting || 'products',
+		productIds: rule.productIds || [],
+		category: rule.category || CATEGORIES[ 0 ],
+		excludedIds: rule.excludedIds || [],
+		type: rule.type || 'fixed',
+		amount: rule.amount ?? 0,
+	} );
+	const isDirty = JSON.stringify( draft ) !== JSON.stringify( initial );
+	const isValid = draft.amount > 0 && ( targeting !== 'products' || productIds.length > 0 );
+	const canSave = isDirty && isValid;
+
+	const onSave = () => {
+		setBusy( true );
+		setTimeout( () => {
+			saveDiscount( { ...rule, ...draft } );
+			onSaved( rule.id ? __( 'Discount updated.', 'newspack-plugin' ) : __( 'Discount added.', 'newspack-plugin' ) );
+		}, 700 );
+	};
+
+	// Guard an unsaved close behind a discard confirmation.
+	const attemptClose = () => ( isDirty ? setConfirmDiscard( true ) : onClose() );
+
+	const previewRows = products.slice( 0, 8 );
+	const extra = products.length - previewRows.length;
+
+	let title = __( 'Add discount', 'newspack-plugin' );
+	if ( isEdit ) {
+		title = __( 'Edit discount', 'newspack-plugin' );
+	} else if ( isScopedAdd ) {
+		title = sprintf(
+			// translators: %s: subscription name, e.g. "Education Annual (Group)".
+			__( 'Add subscriber discount to %s', 'newspack-plugin' ),
+			planLabel( rule.audience )
+		);
+	}
+
+	const content = (
+		<VStack spacing={ 4 } className="newspack-subscribers-demo__flow">
+			{ ! isScopedAdd && (
+				<SelectControl
+					label={ __( 'Subscription', 'newspack-plugin' ) }
+					help={ __( 'Subscribers of this subscription get the discount.', 'newspack-plugin' ) }
+					value={ audience }
+					options={ ALL_PLANS.map( p => ( { label: planLabel( p.name ), value: p.name } ) ) }
+					onChange={ setAudience }
+					__next40pxDefaultSize
+				/>
+			) }
+			<RadioControl
+				label={ __( 'Applies to', 'newspack-plugin' ) }
+				help={ __( 'Choose which store products this discount applies to.', 'newspack-plugin' ) }
+				selected={ targeting }
+				onChange={ setTargeting }
+				options={ [
+					{ value: 'products', label: __( 'Specific products', 'newspack-plugin' ) },
+					{ value: 'category', label: __( 'Category', 'newspack-plugin' ) },
+					{ value: 'all', label: __( 'All products', 'newspack-plugin' ) },
+				] }
+			/>
+			{ targeting === 'products' && (
+				<FormTokenField
+					label={ __( 'Products', 'newspack-plugin' ) }
+					value={ productIds.map( id => getProductById( id )?.name ).filter( Boolean ) }
+					suggestions={ PRODUCTS.map( p => p.name ) }
+					onChange={ onProductsChange }
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+			{ targeting === 'category' && (
+				<SelectControl
+					label={ __( 'Category', 'newspack-plugin' ) }
+					help={ __( 'Subscribers get the discount on every product in this category.', 'newspack-plugin' ) }
+					value={ category }
+					options={ CATEGORIES.map( c => ( { label: c, value: c } ) ) }
+					onChange={ setCategory }
+					__next40pxDefaultSize
+				/>
+			) }
+			{ targeting !== 'products' && (
+				<FormTokenField
+					label={ __( 'Excluded products', 'newspack-plugin' ) }
+					value={ excludedIds.map( id => scopeProducts.find( p => p.id === id )?.name ).filter( Boolean ) }
+					suggestions={ scopeProducts.map( p => p.name ) }
+					onChange={ onExcludedChange }
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+			<ToggleGroupControl
+				label={ __( 'Discount type', 'newspack-plugin' ) }
+				value={ type }
+				onChange={ setType }
+				isBlock
+				__nextHasNoMarginBottom
+			>
+				<ToggleGroupControlOption value="fixed" label={ __( 'Fixed amount', 'newspack-plugin' ) } />
+				<ToggleGroupControlOption value="percent" label={ __( 'Percentage', 'newspack-plugin' ) } />
+			</ToggleGroupControl>
+			<TextControl
+				type="number"
+				label={ type === 'percent' ? __( 'Percentage off', 'newspack-plugin' ) : __( 'Amount off', 'newspack-plugin' ) }
+				help={
+					type === 'percent'
+						? __( 'The percentage subscribers save on each product.', 'newspack-plugin' )
+						: __( 'The amount subscribers save on each product.', 'newspack-plugin' )
+				}
+				value={ amountInput }
+				onChange={ onAmountChange }
+			/>
+			{ products.length > 0 && (
+				<table className="newspack-subscribers-demo__discount-preview">
+					<thead>
+						<tr>
+							<th>{ __( 'Product', 'newspack-plugin' ) }</th>
+							<th>{ __( 'Price', 'newspack-plugin' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ previewRows.map( p => {
+							const discounted = subscriberPrice( p.price, draft );
+							return (
+								<tr key={ p.id }>
+									<td>{ p.name }</td>
+									<td>
+										{ discounted < p.price ? (
+											<>
+												<del>{ fmtCurrency( p.price ) }</del> { fmtCurrency( discounted ) }
+											</>
+										) : (
+											fmtCurrency( p.price )
+										) }
+									</td>
+								</tr>
+							);
+						} ) }
+						{ extra > 0 && (
+							<tr className="newspack-subscribers-demo__discount-preview-more">
+								<td colSpan={ 2 }>
+									{ sprintf(
+										// translators: %d: number of additional matching products not shown in the preview.
+										_n( '…and %d more product', '…and %d more products', extra, 'newspack-plugin' ),
+										extra
+									) }
+								</td>
+							</tr>
+						) }
+					</tbody>
+				</table>
+			) }
+		</VStack>
+	);
+	const footer = (
+		<HStack spacing={ 2 } justify="flex-end">
+			<Button variant="secondary" onClick={ attemptClose }>
+				{ __( 'Cancel', 'newspack-plugin' ) }
+			</Button>
+			<Button variant="primary" isBusy={ busy } disabled={ busy || ! canSave } onClick={ onSave }>
+				{ __( 'Save', 'newspack-plugin' ) }
+			</Button>
+		</HStack>
+	);
+
+	return (
+		<>
+			<Modal
+				__experimentalHideHeader
+				size="small"
+				onRequestClose={ attemptClose }
+				className="newspack-subscribers-demo__sub-detail-modal newspack-subscribers-demo__sub-detail-modal--form"
+				overlayClassName="newspack-subscribers-demo__sub-detail-overlay"
+			>
+				<HStack className="newspack-subscribers-demo__sub-detail-header" spacing={ 2 } alignment="center">
+					<h2 className="newspack-subscribers-demo__sub-detail-title">{ title }</h2>
+					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } onClick={ attemptClose } />
+				</HStack>
+				<div className="newspack-subscribers-demo__sub-detail-content">{ content }</div>
+				<div className="newspack-subscribers-demo__sub-detail-footer">{ footer }</div>
+			</Modal>
+			{ confirmDiscard && (
+				<ConfirmFlow
+					title={ __( 'Discard changes?', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Discard changes', 'newspack-plugin' ) }
+					isDestructive
+					onCancel={ () => setConfirmDiscard( false ) }
+					onConfirm={ onClose }
+				>
+					{ __( 'You have unsaved changes that will be lost.', 'newspack-plugin' ) }
+				</ConfirmFlow>
+			) }
+		</>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
@@ -111,8 +111,19 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 		}, 700 );
 	};
 
-	// Guard an unsaved close behind a discard confirmation.
-	const attemptClose = () => ( isDirty ? setConfirmDiscard( true ) : onClose() );
+	// Guard an unsaved close behind a discard confirmation. Blocked while busy so
+	// a discard during the in-flight save's 700ms timeout can't unmount the flow
+	// out from under the pending saveDiscount()/onSaved() call.
+	const attemptClose = () => {
+		if ( busy ) {
+			return;
+		}
+		if ( isDirty ) {
+			setConfirmDiscard( true );
+		} else {
+			onClose();
+		}
+	};
 
 	const previewRows = products.slice( 0, 8 );
 	const extra = products.length - previewRows.length;
@@ -248,7 +259,7 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 	);
 	const footer = (
 		<HStack spacing={ 2 } justify="flex-end">
-			<Button variant="secondary" onClick={ attemptClose }>
+			<Button variant="secondary" disabled={ busy } onClick={ attemptClose }>
 				{ __( 'Cancel', 'newspack-plugin' ) }
 			</Button>
 			<Button variant="primary" isBusy={ busy } disabled={ busy || ! canSave } onClick={ onSave }>
@@ -268,7 +279,7 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 			>
 				<HStack className="newspack-subscribers-demo__sub-detail-header" spacing={ 2 } alignment="center">
 					<h2 className="newspack-subscribers-demo__sub-detail-title">{ title }</h2>
-					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } onClick={ attemptClose } />
+					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } disabled={ busy } onClick={ attemptClose } />
 				</HStack>
 				<div className="newspack-subscribers-demo__sub-detail-content">{ content }</div>
 				<div className="newspack-subscribers-demo__sub-detail-footer">{ footer }</div>

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountSettingsFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountSettingsFlow.jsx
@@ -25,34 +25,44 @@ export default function DiscountSettingsFlow( { onClose, onSaved } ) {
 
 	return (
 		<Modal title={ __( 'Discount settings', 'newspack-plugin' ) } onRequestClose={ onClose } size="small">
-			<VStack spacing={ 4 }>
-				<RadioControl
-					label={ __( 'Overlapping discounts', 'newspack-plugin' ) }
-					help={ __( 'What happens when more than one discount applies to the same product.', 'newspack-plugin' ) }
-					selected={ draft.overlap }
-					options={ [
-						{ label: __( 'Apply the best discount only', 'newspack-plugin' ), value: 'best' },
-						{ label: __( 'Combine discounts', 'newspack-plugin' ), value: 'combine' },
-					] }
-					onChange={ overlap => setDraft( { ...draft, overlap } ) }
-				/>
-				<ToggleControl
-					label={ __( 'Apply on top of sale prices', 'newspack-plugin' ) }
-					help={ __( 'Subscribers get their discount even on products that are already on sale.', 'newspack-plugin' ) }
-					checked={ draft.applyOnSale }
-					onChange={ applyOnSale => setDraft( { ...draft, applyOnSale } ) }
-					__nextHasNoMarginBottom
-				/>
-				<ToggleControl
-					label={ __( 'Apply discounts at checkout', 'newspack-plugin' ) }
-					help={ __(
-						'Give readers their subscriber prices as soon as a subscription is in their cart, before they’ve completed the purchase.',
-						'newspack-plugin'
-					) }
-					checked={ draft.applyAtCheckout }
-					onChange={ applyAtCheckout => setDraft( { ...draft, applyAtCheckout } ) }
-					__nextHasNoMarginBottom
-				/>
+			<VStack spacing={ 6 }>
+				<VStack spacing={ 4 }>
+					<h3 className="newspack-subscribers-demo__settings-group-title">
+						{ __( 'Combining discounts', 'newspack-plugin' ) }
+					</h3>
+					<RadioControl
+						label={ __( 'Overlapping discounts', 'newspack-plugin' ) }
+						help={ __( 'What happens when more than one discount applies to the same product.', 'newspack-plugin' ) }
+						selected={ draft.overlap }
+						options={ [
+							{ label: __( 'Apply the best discount only', 'newspack-plugin' ), value: 'best' },
+							{ label: __( 'Combine discounts', 'newspack-plugin' ), value: 'combine' },
+						] }
+						onChange={ overlap => setDraft( { ...draft, overlap } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Apply on top of sale prices', 'newspack-plugin' ) }
+						help={ __( 'Subscribers get their discount even on products that are already on sale.', 'newspack-plugin' ) }
+						checked={ draft.applyOnSale }
+						onChange={ applyOnSale => setDraft( { ...draft, applyOnSale } ) }
+						__nextHasNoMarginBottom
+					/>
+				</VStack>
+				<VStack spacing={ 4 }>
+					<h3 className="newspack-subscribers-demo__settings-group-title">
+						{ __( 'Timing', 'newspack-plugin' ) }
+					</h3>
+					<ToggleControl
+						label={ __( 'Apply discounts at checkout', 'newspack-plugin' ) }
+						help={ __(
+							'Give readers their subscriber prices as soon as a subscription is in their cart, before they’ve completed the purchase.',
+							'newspack-plugin'
+						) }
+						checked={ draft.applyAtCheckout }
+						onChange={ applyAtCheckout => setDraft( { ...draft, applyAtCheckout } ) }
+						__nextHasNoMarginBottom
+					/>
+				</VStack>
 				<HStack spacing={ 2 } justify="flex-end">
 					<Button variant="tertiary" size="compact" onClick={ onClose }>
 						{ __( 'Cancel', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountSettingsFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountSettingsFlow.jsx
@@ -1,0 +1,56 @@
+/**
+ * Flow — Global discount settings: whether subscriber discounts stack on top of
+ * sale prices, and how overlapping discounts on the same product resolve.
+ */
+
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	RadioControl,
+	ToggleControl,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { Button, Modal } from '../../../../packages/components/src';
+import { getDiscountSettings, saveDiscountSettings } from '../data/mock-discounts';
+
+export default function DiscountSettingsFlow( { onClose, onSaved } ) {
+	const [ draft, setDraft ] = useState( getDiscountSettings );
+
+	const onSave = () => {
+		saveDiscountSettings( draft );
+		onSaved( __( 'Discount settings saved.', 'newspack-plugin' ) );
+	};
+
+	return (
+		<Modal title={ __( 'Discount settings', 'newspack-plugin' ) } onRequestClose={ onClose } size="small">
+			<VStack spacing={ 4 }>
+				<RadioControl
+					label={ __( 'Overlapping discounts', 'newspack-plugin' ) }
+					help={ __( 'What happens when more than one discount applies to the same product.', 'newspack-plugin' ) }
+					selected={ draft.overlap }
+					options={ [
+						{ label: __( 'Apply the best discount only', 'newspack-plugin' ), value: 'best' },
+						{ label: __( 'Combine discounts', 'newspack-plugin' ), value: 'combine' },
+					] }
+					onChange={ overlap => setDraft( { ...draft, overlap } ) }
+				/>
+				<ToggleControl
+					label={ __( 'Apply on top of sale prices', 'newspack-plugin' ) }
+					help={ __( 'Subscribers get their discount even on products that are already on sale.', 'newspack-plugin' ) }
+					checked={ draft.applyOnSale }
+					onChange={ applyOnSale => setDraft( { ...draft, applyOnSale } ) }
+					__nextHasNoMarginBottom
+				/>
+				<HStack spacing={ 2 } justify="flex-end">
+					<Button variant="tertiary" size="compact" onClick={ onClose }>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+					<Button variant="primary" size="compact" onClick={ onSave }>
+						{ __( 'Save', 'newspack-plugin' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountSettingsFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountSettingsFlow.jsx
@@ -1,6 +1,7 @@
 /**
  * Flow — Global discount settings: whether subscriber discounts stack on top of
- * sale prices, and how overlapping discounts on the same product resolve.
+ * sale prices, how overlapping discounts on the same product resolve, and
+ * whether discounts kick in while the subscription is still in the cart.
  */
 
 import { useState } from '@wordpress/element';
@@ -40,6 +41,16 @@ export default function DiscountSettingsFlow( { onClose, onSaved } ) {
 					help={ __( 'Subscribers get their discount even on products that are already on sale.', 'newspack-plugin' ) }
 					checked={ draft.applyOnSale }
 					onChange={ applyOnSale => setDraft( { ...draft, applyOnSale } ) }
+					__nextHasNoMarginBottom
+				/>
+				<ToggleControl
+					label={ __( 'Apply discounts at checkout', 'newspack-plugin' ) }
+					help={ __(
+						'Give readers their subscriber prices as soon as a subscription is in their cart, before they’ve completed the purchase.',
+						'newspack-plugin'
+					) }
+					checked={ draft.applyAtCheckout }
+					onChange={ applyAtCheckout => setDraft( { ...draft, applyAtCheckout } ) }
 					__nextHasNoMarginBottom
 				/>
 				<HStack spacing={ 2 } justify="flex-end">

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/format.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/format.js
@@ -1,0 +1,49 @@
+/**
+ * Shared formatting helpers for the Subscribers Demo wizard.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { gmdateI18n, getSettings, humanTimeDiff } from '@wordpress/date';
+
+// "2 days ago" — defers to core's localized relative-time formatting (the same
+// helper wp-admin uses) rather than a bespoke ladder.
+export const fmtRelative = date => ( date ? humanTimeDiff( date ) : '' );
+
+// Calendar-date presentation, using the publisher's WordPress date format. The
+// wizard stores dates as date-only strings (YYYY-MM-DD) with no time or zone, so
+// they are anchored at UTC midnight and formatted in UTC: this keeps the shown
+// day stable no matter the viewer's timezone (a browser ahead of the site's zone
+// would otherwise roll a bare date back to the previous day).
+export const fmtDate = value => {
+	if ( ! value ) {
+		return '';
+	}
+	const anchored = /^\d{4}-\d{2}-\d{2}$/.test( value ) ? `${ value }T00:00:00+00:00` : value;
+	return gmdateI18n( getSettings().formats.date, anchored );
+};
+
+// Currency presentation, mirroring the publisher's WooCommerce settings when
+// localized onto window by the wizard PHP (symbol + position); defaults to a
+// left-positioned "$" with two decimals.
+const currencyCfg = ( ( typeof window !== 'undefined' && window.newspackSubscribersDemo ) || {} ).currency || {};
+const CURRENCY_SYMBOL = currencyCfg.symbol || '$';
+const CURRENCY_POSITION = currencyCfg.position || 'left';
+
+export const fmtCurrency = amount => {
+	const formatted = Number( amount || 0 ).toLocaleString( undefined, {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	} );
+	switch ( CURRENCY_POSITION ) {
+		case 'right':
+			return `${ formatted }${ CURRENCY_SYMBOL }`;
+		case 'right_space':
+			return `${ formatted } ${ CURRENCY_SYMBOL }`;
+		case 'left_space':
+			return `${ CURRENCY_SYMBOL } ${ formatted }`;
+		default:
+			return `${ CURRENCY_SYMBOL }${ formatted }`;
+	}
+};

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/index.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/index.js
@@ -1,0 +1,53 @@
+import '../../shared/js/public-path';
+
+/**
+ * Subscriptions Demo — subscriptions/commerce twin of the Subscribers Demo
+ * people-first subscriber management prototype, transplanted from the
+ * discounts demo (PR #544).
+ *
+ * Entry point: mounts a Wizard with two visible tabs — Subscriptions (plan
+ * list) and Discounts — plus hidden plan-detail, subscriber-profile, and
+ * group-detail routes reached by row click.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { render } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { Wizard } from '../../../packages/components/src';
+import SubscriptionList from './screens/SubscriptionList';
+import DiscountList from './screens/DiscountList';
+import { purgeStaleStorage } from './data/storage';
+
+function SubscribersDemoApp() {
+	return (
+		<Wizard
+			headerText={ __( 'Audience Management', 'newspack-plugin' ) }
+			sections={ [
+				{
+					label: __( 'Subscriptions', 'newspack-plugin' ),
+					path: '/',
+					exact: true,
+					fullWidth: true,
+					render: SubscriptionList,
+				},
+				{
+					label: __( 'Subscriber discounts', 'newspack-plugin' ),
+					path: '/discounts',
+					exact: true,
+					fullWidth: true,
+					render: DiscountList,
+				},
+			] }
+		/>
+	);
+}
+
+purgeStaleStorage();
+
+render( <SubscribersDemoApp />, document.getElementById( 'newspack-subscriptions-demo' ) );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/labels.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/labels.js
@@ -1,0 +1,17 @@
+/**
+ * Publisher-configurable group/team label.
+ *
+ * Mirrors the Audience → Setup "Group labels" override
+ * (newspack_group_subscription_label_singular / _plural options, surfaced by
+ * Group_Subscription::get_label), localized onto window by the wizard's PHP
+ * enqueue. Falls back to the default "Group" / "Groups" when unset.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+const cfg = ( typeof window !== 'undefined' && window.newspackSubscribersDemo ) || {};
+
+export const GROUP_LABEL = cfg.groupLabel || __( 'Group', 'newspack-plugin' );
+export const GROUP_LABEL_PLURAL = cfg.groupLabelPlural || __( 'Groups', 'newspack-plugin' );
+export const GROUP_LABEL_LOWER = GROUP_LABEL.toLowerCase();
+export const GROUP_LABEL_PLURAL_LOWER = GROUP_LABEL_PLURAL.toLowerCase();

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/DiscountList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/DiscountList.jsx
@@ -1,0 +1,309 @@
+/* eslint-disable @wordpress/i18n-translator-comments */
+/**
+ * L0 — Discounts list (DataViews, full-width).
+ *
+ * Admin-facing list of subscriber product-discount rules: which plan gets what
+ * off which products. Mirrors SubscriptionList's list idioms.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import {
+	Snackbar,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Badge, Button, DataViews } from '../../../../packages/components/src';
+import './style.scss';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import {
+	getAllDiscounts,
+	deleteDiscount,
+	setDiscountActive,
+	discountLabel,
+	targetingLabel,
+	targetingBaseLabel,
+	excludedLabel,
+} from '../data/mock-discounts';
+import { getAllPlans } from '../data/plan-stats';
+import { fmtDate } from '../format';
+import ConfirmFlow from '../flows/ConfirmFlow';
+import DiscountRuleFlow from '../flows/DiscountRuleFlow';
+import DiscountSettingsFlow from '../flows/DiscountSettingsFlow';
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'createdAt', direction: 'desc' },
+	search: '',
+	fields: [ 'status', 'discount', 'appliesTo', 'createdAt' ],
+	filters: [],
+	layout: {},
+	titleField: 'audience',
+};
+
+export default function DiscountList() {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	// Unlike groups, rules mutate in place on this screen (pause/resume/delete
+	// are direct storage writes), so re-reading the store is enough to refresh.
+	const [ rules, setRules ] = useState( () => getAllDiscounts() );
+	const refresh = () => setRules( getAllDiscounts() );
+
+	const [ editorRule, setEditorRule ] = useState( null );
+	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const [ confirmAction, setConfirmAction ] = useState( null );
+	const [ snackbar, setSnackbar ] = useState( null );
+
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	const closeConfirm = () => setConfirmAction( null );
+
+	const applyPauseResume = () => {
+		const { item, kind } = confirmAction;
+		setDiscountActive( item.id, kind === 'resume' );
+		refresh();
+		setSnackbar( { message: kind === 'resume' ? __( 'Discount resumed.', 'newspack-plugin' ) : __( 'Discount paused.', 'newspack-plugin' ) } );
+		closeConfirm();
+	};
+
+	const applyDelete = () => {
+		deleteDiscount( confirmAction.item.id );
+		refresh();
+		setSnackbar( { message: __( 'Discount deleted.', 'newspack-plugin' ) } );
+		closeConfirm();
+	};
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'audience',
+				label: __( 'Subscription', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				elements: getAllPlans().map( plan => ( { value: plan.name, label: plan.name } ) ),
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) => item.audience,
+				render: ( { item } ) => <span>{ item.audience }</span>,
+				enableSorting: true,
+			},
+			{
+				id: 'discount',
+				label: __( 'Discount', 'newspack-plugin' ),
+				getValue: ( { item } ) => discountLabel( item ),
+				render: ( { item } ) => <span>{ discountLabel( item ) }</span>,
+				enableSorting: false,
+			},
+			{
+				id: 'appliesTo',
+				label: __( 'Applies to', 'newspack-plugin' ),
+				getValue: ( { item } ) => targetingLabel( item ),
+				render: ( { item } ) => {
+					const excluded = excludedLabel( item );
+					return (
+						<VStack spacing={ 0 } alignment="flex-start" expanded={ false }>
+							<span>{ targetingBaseLabel( item ) }</span>
+							{ excluded && <span className="newspack-subscribers-demo__muted">{ excluded }</span> }
+						</VStack>
+					);
+				},
+				enableSorting: false,
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				elements: [
+					{ value: 'active', label: __( 'Active', 'newspack-plugin' ) },
+					{ value: 'paused', label: __( 'Paused', 'newspack-plugin' ) },
+				],
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) => ( item.active ? 'active' : 'paused' ),
+				render: ( { item } ) => (
+					<Badge
+						level={ item.active ? 'success' : 'default' }
+						text={ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Paused', 'newspack-plugin' ) }
+					/>
+				),
+			},
+			{
+				id: 'createdAt',
+				label: __( 'Created', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.createdAt,
+				render: ( { item } ) => <span>{ fmtDate( item.createdAt ) }</span>,
+				enableSorting: true,
+			},
+		],
+		[]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'newspack-plugin' ),
+				callback: items => setEditorRule( items[ 0 ] ),
+			},
+			{
+				id: 'toggle-active',
+				label: items => ( items[ 0 ].active ? __( 'Pause', 'newspack-plugin' ) : __( 'Resume', 'newspack-plugin' ) ),
+				callback: items => setConfirmAction( { kind: items[ 0 ].active ? 'pause' : 'resume', item: items[ 0 ] } ),
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'newspack-plugin' ),
+				isDestructive: true,
+				callback: items => setConfirmAction( { kind: 'delete', item: items[ 0 ] } ),
+			},
+		],
+		[]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( rules, view, fields ), [ rules, view, fields ] );
+
+	// Whole-row click → edit (DataViews only wires up the title cell).
+	const onRowClick = event => {
+		if ( event.target.closest( 'a, button, input, label, [role="button"], [role="checkbox"]' ) ) {
+			return;
+		}
+		const row = event.target.closest( 'tbody tr.dataviews-view-table__row' );
+		if ( ! row ) {
+			return;
+		}
+		const index = Array.from( row.parentNode.children ).indexOf( row );
+		const item = processedData[ index ];
+		if ( item ) {
+			setEditorRule( item );
+		}
+	};
+
+	const total = paginationInfo?.totalItems ?? 0;
+
+	// Surface the rule count in the header breadcrumb, e.g. "/ Discounts (5)".
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: (
+				<>
+					{ __( 'Subscriber discounts', 'newspack-plugin' ) }{ ' ' }
+					<span
+						className="newspack-subscribers-demo__header-count"
+						aria-label={ sprintf( _n( '%d discount total', '%d discounts total', total, 'newspack-plugin' ), total ) }
+					>
+						{ `(${ total.toLocaleString() })` }
+					</span>
+				</>
+			),
+			actions: [
+				{
+					type: 'primary',
+					label: __( 'Add discount', 'newspack-plugin' ),
+					action: () => setEditorRule( {} ),
+				},
+			],
+		} );
+	}, [ setHeaderData, total ] );
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div className="newspack-subscribers-demo__clickable-rows" onClick={ onRowClick }>
+			<DataViews
+				data={ processedData }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ { table: {} } }
+				getItemId={ item => item.id }
+				onClickItem={ item => setEditorRule( item ) }
+				search
+				header={
+					<Button variant="secondary" size="compact" onClick={ () => setSettingsOpen( true ) }>
+						{ __( 'Settings', 'newspack-plugin' ) }
+					</Button>
+				}
+			/>
+
+			{ editorRule !== null && (
+				<DiscountRuleFlow
+					rule={ editorRule }
+					onClose={ () => setEditorRule( null ) }
+					onSaved={ message => {
+						refresh();
+						setEditorRule( null );
+						setSnackbar( { message } );
+					} }
+				/>
+			) }
+
+			{ settingsOpen && (
+				<DiscountSettingsFlow
+					onClose={ () => setSettingsOpen( false ) }
+					onSaved={ message => {
+						setSettingsOpen( false );
+						setSnackbar( { message } );
+					} }
+				/>
+			) }
+
+			{ confirmAction?.kind === 'pause' && (
+				<ConfirmFlow
+					title={ __( 'Pause discount', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Pause discount', 'newspack-plugin' ) }
+					onCancel={ closeConfirm }
+					onConfirm={ applyPauseResume }
+				>
+					{ sprintf(
+						__( 'Pause the %1$s discount for %2$s? Subscribers stop getting the discount until you resume it.', 'newspack-plugin' ),
+						discountLabel( confirmAction.item ),
+						confirmAction.item.audience
+					) }
+				</ConfirmFlow>
+			) }
+
+			{ confirmAction?.kind === 'resume' && (
+				<ConfirmFlow
+					title={ __( 'Resume discount', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Resume discount', 'newspack-plugin' ) }
+					onCancel={ closeConfirm }
+					onConfirm={ applyPauseResume }
+				>
+					{ sprintf(
+						__( 'Resume the %1$s discount for %2$s? Subscribers start getting the discount again immediately.', 'newspack-plugin' ),
+						discountLabel( confirmAction.item ),
+						confirmAction.item.audience
+					) }
+				</ConfirmFlow>
+			) }
+
+			{ confirmAction?.kind === 'delete' && (
+				<ConfirmFlow
+					title={ __( 'Delete discount', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Delete discount', 'newspack-plugin' ) }
+					isDestructive
+					onCancel={ closeConfirm }
+					onConfirm={ applyDelete }
+				>
+					{ sprintf(
+						__( 'Delete the %1$s discount for %2$s? Subscribers stop getting the discount immediately.', 'newspack-plugin' ),
+						discountLabel( confirmAction.item ),
+						confirmAction.item.audience
+					) }
+				</ConfirmFlow>
+			) }
+
+			{ snackbar && (
+				<div className="newspack-subscribers-demo__snackbar">
+					<Snackbar onRemove={ () => setSnackbar( null ) }>{ snackbar.message }</Snackbar>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/DiscountList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/DiscountList.jsx
@@ -22,7 +22,8 @@ import {
 /**
  * Internal dependencies.
  */
-import { Badge, Button, DataViews } from '../../../../packages/components/src';
+import { Badge, Button, DataViews, Router } from '../../../../packages/components/src';
+import EmptyDiscounts from './EmptyDiscounts';
 import './style.scss';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import {
@@ -35,6 +36,8 @@ import {
 	excludedLabel,
 } from '../data/mock-discounts';
 import { getAllPlans } from '../data/plan-stats';
+import { TEAM_PLANS } from '../data/mock-groups';
+import { GROUP_LABEL } from '../labels';
 import { fmtDate } from '../format';
 import ConfirmFlow from '../flows/ConfirmFlow';
 import DiscountRuleFlow from '../flows/DiscountRuleFlow';
@@ -52,7 +55,17 @@ const DEFAULT_VIEW = {
 	titleField: 'audience',
 };
 
+const { useLocation } = Router;
+
+// Group (team) subscriptions are tagged "(Group)" — matching the editor and the
+// Subscribers demo — while individual ones show a plain name.
+const planLabel = name => ( TEAM_PLANS.some( p => p.name === name ) ? `${ name } (${ GROUP_LABEL })` : name );
+
 export default function DiscountList() {
+	// `?empty=1` on the discounts tab forces the onboarding for demos/screenshots
+	// without touching stored rules (nothing to restore afterwards).
+	const previewEmpty = new URLSearchParams( useLocation().search ).get( 'empty' ) !== null;
+
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	// Unlike groups, rules mutate in place on this screen (pause/resume/delete
 	// are direct storage writes), so re-reading the store is enough to refresh.
@@ -89,10 +102,10 @@ export default function DiscountList() {
 				id: 'audience',
 				label: __( 'Subscription', 'newspack-plugin' ),
 				enableGlobalSearch: true,
-				elements: getAllPlans().map( plan => ( { value: plan.name, label: plan.name } ) ),
+				elements: getAllPlans().map( plan => ( { value: plan.name, label: planLabel( plan.name ) } ) ),
 				filterBy: { operators: [ 'isAny' ] },
 				getValue: ( { item } ) => item.audience,
-				render: ( { item } ) => <span>{ item.audience }</span>,
+				render: ( { item } ) => <span>{ planLabel( item.audience ) }</span>,
 				enableSorting: true,
 			},
 			{
@@ -184,7 +197,10 @@ export default function DiscountList() {
 		}
 	};
 
-	const total = paginationInfo?.totalItems ?? 0;
+	// Onboarding shows for a genuinely empty store (or the preview param), but a
+	// search/filter that returns nothing keeps the normal DataViews "No results".
+	const isEmpty = previewEmpty || rules.length === 0;
+	const total = previewEmpty ? 0 : paginationInfo?.totalItems ?? 0;
 
 	// Surface the rule count in the header breadcrumb, e.g. "/ Discounts (5)".
 	useEffect( () => {
@@ -200,36 +216,43 @@ export default function DiscountList() {
 					</span>
 				</>
 			),
-			actions: [
-				{
-					type: 'primary',
-					label: __( 'Add discount', 'newspack-plugin' ),
-					action: () => setEditorRule( {} ),
-				},
-			],
+			// When empty, the onboarding owns the CTA — don't duplicate it in the header.
+			actions: isEmpty
+				? []
+				: [
+						{
+							type: 'primary',
+							label: __( 'Add discount', 'newspack-plugin' ),
+							action: () => setEditorRule( {} ),
+						},
+				  ],
 		} );
-	}, [ setHeaderData, total ] );
+	}, [ setHeaderData, total, isEmpty ] );
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
 		<div className="newspack-subscribers-demo__clickable-rows" onClick={ onRowClick }>
-			<DataViews
-				data={ processedData }
-				fields={ fields }
-				view={ view }
-				onChangeView={ setView }
-				actions={ actions }
-				paginationInfo={ paginationInfo }
-				defaultLayouts={ { table: {} } }
-				getItemId={ item => item.id }
-				onClickItem={ item => setEditorRule( item ) }
-				search
-				header={
-					<Button variant="secondary" size="compact" onClick={ () => setSettingsOpen( true ) }>
-						{ __( 'Settings', 'newspack-plugin' ) }
-					</Button>
-				}
-			/>
+			{ isEmpty ? (
+				<EmptyDiscounts onAdd={ () => setEditorRule( {} ) } />
+			) : (
+				<DataViews
+					data={ processedData }
+					fields={ fields }
+					view={ view }
+					onChangeView={ setView }
+					actions={ actions }
+					paginationInfo={ paginationInfo }
+					defaultLayouts={ { table: {} } }
+					getItemId={ item => item.id }
+					onClickItem={ item => setEditorRule( item ) }
+					search
+					header={
+						<Button variant="secondary" size="compact" onClick={ () => setSettingsOpen( true ) }>
+							{ __( 'Settings', 'newspack-plugin' ) }
+						</Button>
+					}
+				/>
+			) }
 
 			{ editorRule !== null && (
 				<DiscountRuleFlow

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/EmptyDiscounts.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/EmptyDiscounts.jsx
@@ -1,0 +1,52 @@
+/**
+ * L0 — Discounts empty state (onboarding).
+ *
+ * Shown when there are no discount rules: a genuinely empty store, or the
+ * `?empty=1` preview param on the discounts tab. Mirrors the audience
+ * institutions onboarding so it reads as part of the design system.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { percent } from '@wordpress/icons';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Grid, SectionHeader } from '../../../../packages/components/src';
+
+export default function EmptyDiscounts( { onAdd } ) {
+	return (
+		<div
+			style={ {
+				margin: '0 auto',
+				maxWidth: 'calc(var(--newspack-wizard-section-space) * 2 + var(--newspack-wizard-section-width))',
+				padding: '0 var(--newspack-wizard-section-space) 0',
+			} }
+		>
+			<Grid columns={ 4 } noMargin>
+				<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+					<SectionHeader
+						icon={ percent }
+						title={ __( 'Get started with subscriber discounts', 'newspack-plugin' ) }
+						description={ __(
+							'Offer subscribers a discount on store products. Create your first rule to choose which plan gets what off which products.',
+							'newspack-plugin'
+						) }
+						pageHeader
+						noMargin
+					/>
+					<HStack alignment="center">
+						<Button variant="primary" onClick={ onAdd }>
+							{ __( 'Add discount', 'newspack-plugin' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</Grid>
+		</div>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/SubscriptionList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/SubscriptionList.jsx
@@ -1,0 +1,293 @@
+/**
+ * L0 — Subscription list (DataViews, full-width).
+ *
+ * Admin-facing list of every subscription plan (digital, print, team). Each
+ * row rolls up live counts from the subscriber/group/discount stores via
+ * getPlanStats. The list is the whole view; per-row actions handle the rest
+ * (view subscribers, add a subscriber discount, open in WooCommerce).
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { Snackbar } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Badge, DataViews } from '../../../../packages/components/src';
+import { fmtCurrency } from '../format';
+import './style.scss';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import { getAllPlans, getPlanStats } from '../data/plan-stats';
+import { GROUP_LABEL } from '../labels';
+import DiscountRuleFlow from '../flows/DiscountRuleFlow';
+
+// Product status labels; retired plans are no longer sold but keep existing
+// subscribers.
+const STATUS_LABELS = {
+	active: __( 'Active', 'newspack-plugin' ),
+	retired: __( 'Retired', 'newspack-plugin' ),
+};
+
+const STATUS_BADGE_LEVEL = {
+	active: 'success',
+	retired: 'error',
+};
+
+// A group subscription is still one subscription, held by its owner, so the
+// subscriber count is the number of owners (one per group) — seats/members are
+// not counted here. The column header already says "Subscribers", so cells show
+// just the number.
+const subscribersCount = ( plan, stats ) => ( plan.family === 'team' ? stats.groups || 0 : stats.individuals || 0 );
+
+// "3 active" or a dash when the plan has no active discount rules targeting it.
+const discountsText = stats =>
+	stats.discounts > 0
+		? sprintf(
+				// translators: %d: number of active discount rules targeting this plan.
+				_n( '%d active', '%d active', stats.discounts, 'newspack-plugin' ),
+				stats.discounts
+		  )
+		: '—';
+
+// Deep-link into the Subscribers demo, pre-filtered to this subscription.
+function subscribersLink( planName ) {
+	const base = ( window.newspack_urls && window.newspack_urls.subscribers_demo ) || '';
+	return `${ base }#/?subscription=${ encodeURIComponent( planName ) }`;
+}
+
+// Open the WooCommerce products screen, pre-searched for this subscription.
+function openWooCommerce( planName ) {
+	const site = ( window.newspack_urls && window.newspack_urls.site ) || '';
+	window.open( `${ site }/wp-admin/edit.php?post_type=product&s=${ encodeURIComponent( planName ) }`, '_blank', 'noopener,noreferrer' );
+}
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'name', direction: 'asc' },
+	search: '',
+	// 'type' is intentionally omitted from the columns — it lives as a filter
+	// only; group subscriptions are marked inline in the name (see below).
+	// 'discounts' is defined as a field (so the Has/No discounts filter and the
+	// optional column stay available) but is left out of the default columns.
+	fields: [ 'status', 'amount', 'cadence', 'subscribers', 'sales', 'revenue' ],
+	filters: [],
+	layout: {},
+	titleField: 'name',
+};
+
+export default function SubscriptionList() {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const [ editorRule, setEditorRule ] = useState( null );
+	const [ snackbar, setSnackbar ] = useState( null );
+
+	const plans = useMemo( () => getAllPlans(), [] );
+
+	// Status only earns a column/filter when at least one subscription is not
+	// active (e.g. a retired plan with legacy subscribers). If everything is
+	// active the column carries no information, so it's dropped entirely.
+	const showStatus = useMemo( () => plans.some( plan => ( plan.status ?? 'active' ) !== 'active' ), [ plans ] );
+
+	const [ view, setView ] = useState( () => ( {
+		...DEFAULT_VIEW,
+		fields: showStatus ? DEFAULT_VIEW.fields : DEFAULT_VIEW.fields.filter( field => field !== 'status' ),
+	} ) );
+
+	const statsByPlan = useMemo( () => {
+		const byName = {};
+		plans.forEach( plan => {
+			byName[ plan.name ] = getPlanStats( plan.name );
+		} );
+		return byName;
+	}, [ plans ] );
+
+	const fields = useMemo(
+		() =>
+			[
+				{
+					id: 'name',
+					label: __( 'Subscription', 'newspack-plugin' ),
+					enableGlobalSearch: true,
+					getValue: ( { item } ) => item.name,
+					// Group subscriptions are marked inline (with the publisher's own
+					// group label) since Type is a filter-only field.
+					render: ( { item } ) => <span>{ item.family === 'team' ? `${ item.name } (${ GROUP_LABEL })` : item.name }</span>,
+					enableSorting: true,
+				},
+				{
+					// Filter-only: not in the visible columns (see DEFAULT_VIEW.fields).
+					id: 'type',
+					label: __( 'Type', 'newspack-plugin' ),
+					elements: [
+						{ value: 'individual', label: __( 'Individual', 'newspack-plugin' ) },
+						{ value: 'group', label: GROUP_LABEL },
+					],
+					filterBy: { operators: [ 'isAny' ] },
+					// Return the stable key (not the label) so the isAny filter matches.
+					getValue: ( { item } ) => ( item.family === 'team' ? 'group' : 'individual' ),
+					enableSorting: false,
+				},
+				{
+					id: 'status',
+					label: __( 'Status', 'newspack-plugin' ),
+					elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+					filterBy: { operators: [ 'isAny' ] },
+					getValue: ( { item } ) => item.status,
+					render: ( { item } ) => (
+						<Badge level={ STATUS_BADGE_LEVEL[ item.status ] || 'default' } text={ STATUS_LABELS[ item.status ] || item.status } />
+					),
+					enableSorting: true,
+				},
+				{
+					id: 'amount',
+					label: __( 'Price', 'newspack-plugin' ),
+					getValue: ( { item } ) => item.amount,
+					render: ( { item } ) => <span>{ fmtCurrency( item.amount ) }</span>,
+					enableSorting: true,
+				},
+				{
+					id: 'cadence',
+					label: __( 'Billing', 'newspack-plugin' ),
+					elements: [
+						{ value: 'Monthly', label: __( 'Monthly', 'newspack-plugin' ) },
+						{ value: 'Yearly', label: __( 'Yearly', 'newspack-plugin' ) },
+					],
+					filterBy: { operators: [ 'isAny' ] },
+					getValue: ( { item } ) => item.cadence,
+					render: ( { item } ) => <span>{ item.cadence }</span>,
+					enableSorting: true,
+				},
+				{
+					id: 'subscribers',
+					label: __( 'Subscribers', 'newspack-plugin' ),
+					getValue: ( { item } ) => subscribersCount( item, statsByPlan[ item.name ] ),
+					render: ( { item } ) => <span>{ subscribersCount( item, statsByPlan[ item.name ] ).toLocaleString() }</span>,
+					enableSorting: true,
+				},
+				{
+					id: 'sales',
+					label: __( 'Total Sales', 'newspack-plugin' ),
+					getValue: ( { item } ) => item.totalSales || 0,
+					render: ( { item } ) => <span>{ ( item.totalSales || 0 ).toLocaleString() }</span>,
+					enableSorting: true,
+				},
+				{
+					id: 'revenue',
+					label: __( 'Total Revenue', 'newspack-plugin' ),
+					getValue: ( { item } ) => item.totalRevenue || 0,
+					render: ( { item } ) => <span>{ fmtCurrency( item.totalRevenue || 0 ) }</span>,
+					enableSorting: true,
+				},
+				{
+					id: 'discounts',
+					label: __( 'Discounts', 'newspack-plugin' ),
+					elements: [
+						{ value: 'has', label: __( 'Has discounts', 'newspack-plugin' ) },
+						{ value: 'none', label: __( 'No discounts', 'newspack-plugin' ) },
+					],
+					filterBy: { operators: [ 'isAny' ] },
+					// Filter on presence, not the formatted "N active" string.
+					getValue: ( { item } ) => ( statsByPlan[ item.name ]?.discounts > 0 ? 'has' : 'none' ),
+					render: ( { item } ) => <span>{ discountsText( statsByPlan[ item.name ] ) }</span>,
+					enableSorting: false,
+				},
+			].filter( field => field.id !== 'status' || showStatus ),
+		[ statsByPlan, showStatus ]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'view-subscribers',
+				label: __( 'View subscribers', 'newspack-plugin' ),
+				callback: items => {
+					window.location.href = subscribersLink( items[ 0 ].name );
+				},
+			},
+			{
+				id: 'add-discount',
+				label: __( 'Add subscriber discount', 'newspack-plugin' ),
+				callback: items => setEditorRule( { audience: items[ 0 ].name } ),
+			},
+			{
+				id: 'view-in-woocommerce',
+				label: __( 'View in WooCommerce', 'newspack-plugin' ),
+				callback: items => openWooCommerce( items[ 0 ].name ),
+			},
+		],
+		[]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( plans, view, fields ), [ plans, view, fields ] );
+
+	const total = paginationInfo?.totalItems ?? 0;
+
+	// Surface the plan count in the header breadcrumb, e.g. "/ Subscriptions (9)".
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: (
+				<>
+					{ __( 'Subscriptions', 'newspack-plugin' ) }{ ' ' }
+					<span
+						className="newspack-subscribers-demo__header-count"
+						aria-label={ sprintf(
+							// translators: %s: number of subscription plans.
+							__( '%s subscription plans total', 'newspack-plugin' ),
+							total.toLocaleString()
+						) }
+					>
+						{ `(${ total.toLocaleString() })` }
+					</span>
+				</>
+			),
+			actions: [
+				{
+					type: 'more',
+					label: __( 'View in WooCommerce', 'newspack-plugin' ),
+					action: () => {
+						const site = ( window.newspack_urls && window.newspack_urls.site ) || '';
+						window.open( `${ site }/wp-admin/edit.php?post_type=product`, '_blank', 'noopener,noreferrer' );
+					},
+				},
+			],
+		} );
+	}, [ setHeaderData, total ] );
+
+	return (
+		<>
+			<DataViews
+				data={ processedData }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ { table: {} } }
+				getItemId={ item => item.id }
+				search
+			/>
+			{ editorRule !== null && (
+				<DiscountRuleFlow
+					rule={ editorRule }
+					onClose={ () => setEditorRule( null ) }
+					onSaved={ message => {
+						setEditorRule( null );
+						setSnackbar( { message } );
+					} }
+				/>
+			) }
+			{ snackbar && (
+				<div className="newspack-subscribers-demo__snackbar">
+					<Snackbar onRemove={ () => setSnackbar( null ) }>{ snackbar.message }</Snackbar>
+				</div>
+			) }
+		</>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/SubscriptionList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/SubscriptionList.jsx
@@ -87,6 +87,10 @@ export default function SubscriptionList() {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ editorRule, setEditorRule ] = useState( null );
 	const [ snackbar, setSnackbar ] = useState( null );
+	// Bumped after a discount is saved so statsByPlan (below) re-reads
+	// getPlanStats(), which pulls discount rules from localStorage and isn't
+	// otherwise reflected in the `plans` dependency.
+	const [ statsRevision, setStatsRevision ] = useState( 0 );
 
 	const plans = useMemo( () => getAllPlans(), [] );
 
@@ -106,7 +110,7 @@ export default function SubscriptionList() {
 			byName[ plan.name ] = getPlanStats( plan.name );
 		} );
 		return byName;
-	}, [ plans ] );
+	}, [ plans, statsRevision ] );
 
 	const fields = useMemo(
 		() =>
@@ -280,6 +284,7 @@ export default function SubscriptionList() {
 					onSaved={ message => {
 						setEditorRule( null );
 						setSnackbar( { message } );
+						setStatsRevision( n => n + 1 );
 					} }
 				/>
 			) }

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/style.scss
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/style.scss
@@ -183,6 +183,14 @@
 	margin-block: wp-vars.$grid-unit-30 wp-vars.$grid-unit-15;
 }
 
+// Group heading inside the settings modal: one step up from the 13px control
+// labels beneath it, without competing with the modal title.
+.newspack-subscribers-demo__settings-group-title {
+	font-size: wp-vars.$font-size-large;
+	font-weight: wp-vars.$font-weight-medium;
+	margin: 0;
+}
+
 // Seat count beside the "Members" heading: same size/line-height as the title,
 // lighter weight and gray so it reads as secondary.
 .newspack-subscribers-demo__seat-count {

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/style.scss
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/style.scss
@@ -1,0 +1,530 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/breakpoints" as wp-breakpoints;
+
+.newspack-wizard__header .newspack-section-header p {
+	white-space: pre-line !important;
+}
+
+.newspack-subscribers-demo__snackbar {
+	bottom: wp-vars.$grid-unit-15;
+	left: 50%;
+	position: fixed;
+	transform: translateX( -50% );
+	z-index: 100000;
+}
+
+.newspack-subscribers-demo__card-icon {
+	width: wp-vars.$grid-unit-40;
+	height: auto;
+	display: block;
+}
+
+// Active, non-default payment cards keep their status badge but hide it: it
+// reserves the badge's (taller-than-text) height so promoting a card to default
+// doesn't shift the row. Hidden from view and, via aria-hidden, screen readers.
+.newspack-subscribers-demo__badge-placeholder {
+	visibility: hidden;
+}
+
+.newspack-subscribers-demo__email,
+.newspack-subscribers-demo__muted {
+	color: wp-colors.$gray-700;
+	font-size: wp-vars.$helptext-font-size;
+	line-height: wp-vars.$default-line-height;
+	font-weight: normal;
+}
+
+.newspack-subscribers-demo__header-count {
+	color: wp-colors.$gray-700;
+	font-weight: normal;
+}
+
+// Center the loading spinner in the content area while data resolves.
+.newspack-subscribers-demo__loading {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	min-height: 50vh;
+}
+
+// Whole-row click affordance for the subscriber list.
+.newspack-subscribers-demo__clickable-rows {
+	.dataviews-view-table tbody tr.dataviews-view-table__row {
+		cursor: pointer;
+
+		&:hover {
+			background: rgba( wp-colors.$gray-100, 0.5 );
+		}
+	}
+}
+
+.newspack-subscribers-demo__avatar {
+	width: wp-vars.$grid-unit-40;
+	height: wp-vars.$grid-unit-40;
+	border-radius: 50%;
+	flex-shrink: 0;
+	object-fit: cover;
+	background: wp-colors.$gray-100;
+}
+
+// Profile header avatar, portaled into the wizard section header, top-right.
+.newspack-wizard__section-header.newspack-subscribers-demo__has-avatar {
+	position: relative;
+}
+
+.newspack-subscribers-demo__profile-avatar {
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: wp-vars.$grid-unit-80;
+	height: wp-vars.$grid-unit-80;
+	border-radius: 50%;
+	object-fit: cover;
+	background: wp-colors.$gray-100;
+}
+
+// Spinner placeholder shown in the avatar circle until the URL resolves.
+.newspack-subscribers-demo__profile-avatar--loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+// Full-width notices hosted below the wizard header/tabs (inserted as the first
+// child of .newspack-wizard__main), spanning wider than the content column.
+.newspack-subscribers-demo__notices:not(:empty) {
+	margin-bottom: wp-vars.$grid-unit-20;
+}
+
+// Modal flow body: rely on the stack's gap for vertical rhythm, so reset the
+// default top/bottom margins on its direct children (paragraphs, controls).
+.newspack-subscribers-demo__flow > * {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.newspack-subscribers-demo__notices-inner {
+	background: wp-colors.$gray-300;
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	padding-bottom: 1px;
+
+	.components-notice {
+		margin: 0;
+	}
+}
+
+// Clickable summary row (Subscription detail's Subscribers row): plain Cards
+// rather than a DataViews table, so the whole card is one button.
+.newspack-subscribers-demo__holder-row-button {
+	background: none;
+	border: 0;
+	cursor: pointer;
+	display: block;
+	text-align: left;
+	width: 100%;
+
+	&:hover {
+		background: rgba( wp-colors.$gray-100, 0.5 );
+	}
+
+	&:focus-visible {
+		outline: var( --wp-admin-border-width-focus, 1.5px ) solid var( --wp-admin-theme-color );
+		outline-offset: 2px;
+	}
+}
+
+// Contained loading placeholder for an embedded row list (unlike
+// __loading's full-height variant used for a whole screen).
+.newspack-subscribers-demo__row-loading {
+	display: flex;
+	justify-content: center;
+	padding: wp-vars.$grid-unit-30 0;
+}
+
+// Inline name button rendered as plain dark text, matching the un-linked
+// names in the Subscribers/Groups lists. Used for table row names.
+.newspack-subscribers-demo__rowlink {
+	background: none;
+	border: 0;
+	color: wp-colors.$gray-900;
+	cursor: pointer;
+	padding: 0;
+	text-align: left;
+
+	&:hover {
+		color: var( --wp-admin-theme-color );
+	}
+
+	&:focus-visible {
+		outline: var( --wp-admin-border-width-focus, 1.5px ) solid var( --wp-admin-theme-color );
+		outline-offset: 2px;
+	}
+}
+
+// Custom section header row: heading (+ light-gray seat count) on the left,
+// actions on the right. Matches the SectionHeader title type scale.
+.newspack-subscribers-demo__section-head {
+	margin-block: wp-vars.$grid-unit-30 wp-vars.$grid-unit-15;
+}
+
+.newspack-subscribers-demo__section-title {
+	font-size: wp-vars.$font-size-x-large;
+	font-weight: wp-vars.$font-weight-medium;
+	line-height: wp-vars.$font-line-height-x-large;
+	margin: 0;
+}
+
+// A standalone section heading (no surrounding flex row) carries both classes;
+// this beats section-title's margin reset so section-head's block spacing applies.
+.newspack-subscribers-demo__section-title.newspack-subscribers-demo__section-head {
+	margin-block: wp-vars.$grid-unit-30 wp-vars.$grid-unit-15;
+}
+
+// Seat count beside the "Members" heading: same size/line-height as the title,
+// lighter weight and gray so it reads as secondary.
+.newspack-subscribers-demo__seat-count {
+	color: wp-colors.$gray-700;
+	font-size: wp-vars.$font-size-x-large;
+	font-weight: normal;
+	line-height: wp-vars.$font-line-height-x-large;
+}
+
+.newspack-subscribers-demo__note-card.newspack-card--core {
+	background-color: wp-colors.$gray-100;
+	overflow: hidden;
+
+	.components-card__body,
+	.newspack-card--core__body {
+		background-color: transparent;
+	}
+}
+
+.newspack-subscribers-demo__profile {
+	.components-notice__actions {
+		margin-top: wp-vars.$grid-unit-15;
+
+		.components-button {
+			height: wp-vars.$grid-unit-40;
+			line-height: 1;
+			margin-left: 0;
+			margin-right: 0;
+			padding: 0 wp-vars.$grid-unit-15;
+		}
+	}
+
+	.components-card__header,
+	.newspack-card--core__header {
+		padding: wp-vars.$grid-unit-20;
+	}
+	// The Dropdown wrapper ships as inline-block, whose line box is ~0.2px taller
+	// than the button; flex collapses it to the button's exact height. Pinning the
+	// flex basis keeps it from shrinking below the button when the row is tight.
+	.newspack-subscribers-demo__card-menu {
+		display: flex;
+		flex: 0 0 wp-vars.$button-size-compact;
+	}
+	// The compact kebab is taller than the header's text row, so pull it in by
+	// half the difference to keep the card header at its text-only height.
+	.newspack-subscribers-demo__card-menu-toggle {
+		$kebab-pull: calc( ( 20px - #{wp-vars.$button-size-compact} ) / 2 );
+
+		margin-top: $kebab-pull;
+		margin-bottom: $kebab-pull;
+	}
+	// A group card's title doubles as a link to the group page; keep it looking
+	// like the heading and only reveal the link affordance on hover/focus.
+	.newspack-subscribers-demo__card-title-link.components-button.is-link {
+		color: inherit;
+		font: inherit;
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			color: var(--wp-admin-theme-color);
+		}
+	}
+	.components-card__body,
+	.newspack-card--core__body {
+		padding: wp-vars.$grid-unit-20;
+
+		> * {
+			margin: 0 !important;
+			padding: 0 !important;
+		}
+	}
+}
+
+// DataViews ships its search input and footer page-select as `.components-base-control`,
+// which adds `margin-bottom: 16px`. That throws their parent HStacks out of vertical
+// alignment with the buttons next to them. Drop the bottom margin so the toolbar and
+// footer collapse to a single line.
+.dataviews-wrapper {
+	.dataviews__search .components-base-control,
+	.dataviews-pagination .components-base-control {
+		margin-bottom: 0;
+	}
+}
+
+.newspack-subscribers-demo__orders-wrapper {
+	.dataviews-view-table {
+		tr td:first-child,
+		tr th:first-child {
+			padding-left: wp-vars.$grid-unit-15 !important;
+		}
+		tr td:last-child,
+		tr th:last-child {
+			padding-right: wp-vars.$grid-unit-15 !important;
+		}
+		tr:hover {
+			background: rgba( wp-colors.$gray-100, 0.5 );
+		}
+	}
+}
+
+.newspack-subscribers-demo__profile {
+	// Inline (non-full-width) DataViews inherit a -48px horizontal bleed from the
+	// wizard content style; cancel it so the member/invitation tables align with
+	// the rest of the section.
+	.newspack-dataviews {
+		margin-left: 0 !important;
+		margin-right: 0 !important;
+	}
+
+	// Tighten the default 48px edge padding on the group detail tables.
+	.dataviews-view-table {
+		tr td:first-child,
+		tr th:first-child {
+			padding-left: wp-vars.$grid-unit-15 !important;
+		}
+		tr td:last-child,
+		tr th:last-child {
+			padding-right: wp-vars.$grid-unit-15 !important;
+		}
+	}
+
+	// The footer ships its own 48px horizontal padding; tighten it to match the
+	// table cells so the pagination and bulk-action bar line up with the content.
+	.dataviews-footer {
+		padding-left: wp-vars.$grid-unit-15 !important;
+		padding-right: wp-vars.$grid-unit-15 !important;
+	}
+
+	// These fixed profile tables have no search or actions, so drop the now-empty
+	// DataViews view-actions toolbar. Column-header sorting still works. The
+	// members table opts back in below, since it has search.
+	.dataviews__view-actions {
+		display: none;
+	}
+}
+
+// The members table enables search, so restore its view-actions toolbar (hidden
+// for the other fixed profile tables above) and drop its horizontal padding so
+// the search field lines up with the table edge.
+.newspack-subscribers-demo__members-dataviews .dataviews__view-actions {
+	display: flex;
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.newspack-subscribers-demo__modal-text {
+	margin: 0;
+}
+
+.newspack-subscribers-demo__nowrap {
+	white-space: nowrap;
+}
+
+// "View subscription" drawer: a read-only, right-edge slide-in panel that
+// mirrors the newsletters quick-edit look. Built on @wordpress/components Modal
+// with custom overlay/frame classes so it anchors to the right instead of
+// rendering centered.
+.newspack-subscribers-demo__sub-detail-overlay {
+	align-items: stretch;
+	justify-content: flex-end;
+	padding: 0;
+}
+
+.components-modal__frame.newspack-subscribers-demo__sub-detail-modal {
+	animation: 0.2s ease-out forwards newspack-subscribers-demo__sub-detail-slide-in;
+	border-radius: 0;
+	box-shadow: -1px 0 16px rgb( 0 0 0 / 8% );
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	margin: 0;
+	max-height: 100vh;
+	width: 350px;
+
+	@media ( max-width: wp-breakpoints.$break-small ) {
+		width: 100vw;
+	}
+
+	// Drop the modal's built-in content padding so the header/content classes
+	// below own the spacing (matching the newsletters quick-edit), and let the
+	// inner wrappers flex so the content area scrolls within the full height.
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+	}
+
+	.components-modal__children-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+	}
+}
+
+// Form-flow variant of the right drawer (the discount editor). The width comes
+// from the Modal `size` prop (e.g. size="medium"); this only releases the fixed
+// width the read-only "view subscription" drawer sets so the size prop applies.
+.components-modal__frame.newspack-subscribers-demo__sub-detail-modal--form {
+	width: 100%;
+}
+
+@keyframes newspack-subscribers-demo__sub-detail-slide-in {
+	from {
+		transform: translateX( 100% );
+	}
+
+	to {
+		transform: translateX( 0 );
+	}
+}
+
+@keyframes newspack-subscribers-demo__sub-detail-slide-out {
+	from {
+		transform: translateX( 0 );
+	}
+
+	to {
+		transform: translateX( 100% );
+	}
+}
+
+// Mirror the slide-in with a slide-out on close. @wp/components' Modal adds
+// `is-animating-out` and keeps the panel mounted until an animationend fires
+// (which bubbles up from the frame), so animating the frame is enough. Suppress
+// the overlay's default disappear animation so the motion stays a slide, not a
+// fade. The compound selector outweighs the base frame rule in the cascade.
+.components-modal__screen-overlay.newspack-subscribers-demo__sub-detail-overlay.is-animating-out {
+	animation: none;
+}
+
+.components-modal__screen-overlay.newspack-subscribers-demo__sub-detail-overlay.is-animating-out .components-modal__frame {
+	animation: 0.2s ease-in forwards newspack-subscribers-demo__sub-detail-slide-out;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.newspack-subscribers-demo__sub-detail-overlay,
+	.components-modal__frame.newspack-subscribers-demo__sub-detail-modal,
+	.components-modal__screen-overlay.newspack-subscribers-demo__sub-detail-overlay.is-animating-out .components-modal__frame {
+		animation: none;
+	}
+}
+
+.newspack-subscribers-demo__sub-detail-header {
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-30 wp-vars.$grid-unit-30 0;
+}
+
+.newspack-subscribers-demo__sub-detail-title {
+	flex: 1;
+	font-size: inherit;
+	font-weight: wp-vars.$font-weight-medium;
+	margin: 0;
+}
+
+.newspack-subscribers-demo__sub-detail-content {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	padding: wp-vars.$grid-unit-30;
+	padding-bottom: 0;
+}
+
+// Match the WordPress control label (e.g. TextControl): 11px, medium weight,
+// uppercase, gray-900.
+.newspack-subscribers-demo__sub-detail-label {
+	color: wp-colors.$gray-900;
+	font-size: wp-vars.$font-size-x-small;
+	font-weight: wp-vars.$font-weight-medium;
+	text-transform: uppercase;
+}
+
+.newspack-subscribers-demo__sub-detail-value {
+	// The Badge ships display: block, so it would stretch to the full row width
+	// here; keep it hugging its label (e.g. the status pill).
+	.newspack-badge {
+		display: inline-block;
+	}
+}
+
+// Pinned action bar at the bottom of the drawer: the same subscription CTAs as
+// the person-profile group card. Mirrors the newspack-newsletters quick-edit
+// footer (white, sticky, no divider, buttons split 50/50).
+.newspack-subscribers-demo__sub-detail-footer {
+	background: wp-colors.$white;
+	bottom: 0;
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-20 wp-vars.$grid-unit-30;
+	position: sticky;
+	z-index: 1;
+
+	.components-button {
+		flex: 1;
+		justify-content: center;
+	}
+}
+
+// Labeled label/value rows on the subscription and payment-method cards,
+// reusing the quick-edit drawer's label style.
+.newspack-subscribers-demo__card-row {
+	display: flex;
+	flex-direction: column;
+	gap: wp-vars.$grid-unit-05;
+}
+
+.newspack-subscribers-demo__card-label {
+	color: wp-colors.$gray-900;
+	font-size: wp-vars.$font-size-x-small;
+	font-weight: wp-vars.$font-weight-medium;
+	text-transform: uppercase;
+}
+
+// Live preview table in the discount rule editor: the member price for each
+// product in scope (original struck through), capped with a muted "…and N more"
+// row. Styled to read like the DataViews admin tables.
+.newspack-subscribers-demo__discount-preview {
+	border-collapse: collapse;
+	width: 100%;
+
+	th,
+	td {
+		border-bottom: 1px solid wp-colors.$gray-100;
+		padding: wp-vars.$grid-unit-15 0;
+		text-align: left;
+	}
+
+	// Match the WordPress control label (e.g. TextControl): 11px, medium, uppercase.
+	th {
+		color: wp-colors.$gray-900;
+		font-size: wp-vars.$font-size-x-small;
+		font-weight: wp-vars.$font-weight-medium;
+		text-transform: uppercase;
+	}
+
+	// Price column reads as secondary next to the product name.
+	td:nth-child( 2 ) {
+		color: wp-colors.$gray-700;
+		font-weight: normal;
+	}
+
+	.newspack-subscribers-demo__discount-preview-more td {
+		color: wp-colors.$gray-700;
+		font-style: italic;
+	}
+}


### PR DESCRIPTION
> [!WARNING]
> **Do not merge.** Design-exploration sandbox layered on the prototype PR #295. It targets `feat/subscribers-demo-prototype`, not `main`. Supersedes #544.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The commerce twin of the subscribers demo, exploring the admin UX for [NPPD-1794: Implement WCM product discount functionality](https://linear.app/a8c/issue/NPPD-1794/implement-wcm-product-discount-functionality) and the [AC Product Discount user stories](https://linear.app/a8c/document/ac-product-discount-user-stories-4389131fa2e3). It is a hidden, mock-data prototype reachable at `admin.php?page=newspack-subscriptions-demo` in Newspack debug mode, beside the untouched `newspack-subscribers-demo`.

The information architecture this models ("2 and 2"): the product gets two independent surfaces rather than one four-tab page. **Subscribers / Groups** (the existing demo) is people management. **Subscriptions / Subscriber discounts** (this demo) is commerce configuration: what you sell and what it grants. Discounts stopped reading as ambiguous once their sibling was subscriptions rather than people — the insight that superseded #544's shape.

What the demo now presents:

- **Subscriptions** — a list of every subscription (Status, Price, Billing, Subscribers, Total Sales, Total Revenue). The list is the whole overview; there is no separate detail view. Each row's actions handle the rest: **View subscribers** (deep-links to the Subscribers demo pre-filtered to that subscription), **Add subscriber discount** (opens the editor pre-scoped to that subscription), and **View in WooCommerce**.
- **Subscriber discounts** — a list of discount rules ("subscribers of subscription X get $/% off store products Y"), with a products-first editor showing a live discounted-price preview, and a global settings modal (on-sale stacking, best-vs-combine overlap).
- **One shared dataset.** People and plans have a single source of truth: the subscriptions demo re-exports the subscribers demo's data and layers on only the commercial extras (status, sales, revenue). So a subscription's subscriber count matches the pre-filtered list "View subscribers" opens.

The `subscribersDemo` folder is untouched apart from a new Total-spent column and a `?subscription=` filter param that lets the subscriptions demo deep-link into it. Labels that overlap between the two surfaces will be publisher-customizable in the real product.

Relates to NPPD-1794.

### How to test the changes in this Pull Request:

1. In Newspack debug mode, open `admin.php?page=newspack-subscriptions-demo`.
2. **Subscriptions tab:** confirm one row per subscription with Status, Price, Billing, Subscribers, Total Sales, Total Revenue; exercise search, sort, and the Type / Billing / Status / Discounts filters.
3. On a row, open the **⋮ actions** menu:
   - **View subscribers** → the Subscribers demo opens pre-filtered to that subscription; confirm the filtered count matches the row's Subscribers value.
   - **Add subscriber discount** → the editor opens with the subscription locked in (no picker) and the title "Add subscriber discount to \<name\> (Group)" for team subscriptions; save and confirm the rule appears on the Subscriber discounts tab.
   - **View in WooCommerce** → the WooCommerce products screen opens in a new tab, pre-searched by name.
4. **Subscriber discounts tab:** add, edit, pause/resume, and delete a rule. In the editor, confirm the subscription dropdown shows plain names with a `(Group)` tag for team subscriptions (no family prefix), the products-first targeting, and the live discounted-price preview. Open **Settings** and confirm the on-sale stacking and overlap options.
5. Confirm the **empty state** on a subscription with no discounts (the "Get started with subscriber discounts" onboarding).
6. Open `admin.php?page=newspack-subscribers-demo` and confirm it is unchanged except the new **Total spent** column, and that arriving via a `?subscription=` link pre-applies the subscription filter.
7. Confirm the two demos keep separate `localStorage` state while reading the same seeded people/plans.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? (jest: 30 suites / 292 tests green; eslint clean; `pnpm build` emits `dist/subscriptionsDemo.{js,css,asset.php}`.)
