### PR TITLE
feat(insights): Newsletter Ads tab (NPPD-1861)

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -182,6 +182,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-subscribers.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-donors.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-advertising.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-section-newsletter-ads.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/class-insights-feedback.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/gam/class-report-job-status.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/insights/gam/class-report-query.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -100,6 +100,7 @@ class Wizards {
 			Insights_Section_Subscribers::init();
 			Insights_Section_Donors::init();
 			Insights_Section_Advertising::init();
+			Insights_Section_Newsletter_Ads::init();
 			Insights_Feedback::init();
 		}
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-newsletter-ads-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-newsletter-ads-rest-controller.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Newspack Insights — Newsletter Ads REST controller (NPPD-1861).
+ *
+ * Endpoints: `GET /newspack-insights/v1/newsletter-ads` and
+ * `POST /newspack-insights/v1/newsletter-ads/refresh`. Same date-arg
+ * validation, permission check, and date parsing conventions as the other
+ * Insights controllers (shared via {@see Insights_REST_Trait}).
+ *
+ * Response shape:
+ *   current  — Newsletter Ads envelope for the requested window
+ *              (is_tab_visible, is_report_ready, readiness_issues,
+ *              data_as_of, metrics, has_window_activity).
+ *   previous — same for the comparison window, or null.
+ *
+ * Data comes from {@see Newsletter_Ads_Metric}, which computes synchronously
+ * from local SQL (ads CPT meta + the newsletters ad-stats table) behind a
+ * short transient cache.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Newsletter Ads REST controller.
+ */
+class Newsletter_Ads_REST_Controller extends WP_REST_Controller {
+
+	use Cached_Controller_Trait;
+	use Insights_REST_Trait;
+
+	/**
+	 * Shared Insights namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newspack-insights/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'newsletter-ads';
+
+	/**
+	 * Cache source classification for this controller. Local SQL (ads CPT
+	 * meta + the newsletters stats table) — no external API or BigQuery.
+	 *
+	 * @return string
+	 */
+	protected function cache_source(): string {
+		return Cache::SOURCE_LOCAL;
+	}
+
+	/**
+	 * Tab slug used as the cache namespace.
+	 *
+	 * @return string
+	 */
+	protected function tab_slug(): string {
+		return 'newsletter_ads';
+	}
+
+	/**
+	 * Register the Newsletter Ads routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_newsletter_ads_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/refresh',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'refresh_newsletter_ads_data' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * GET handler.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function get_newsletter_ads_data( WP_REST_Request $request ) {
+		$parsed = $this->parse_window_args( $request );
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+		[ $start, $end, $compare_start, $compare_end ] = $parsed;
+
+		// Dev smoke-test path: serve canned fixture data so the UI renders
+		// without the newsletters plugin. The optional _fixture_state param
+		// selects a render path (see dev-notes.md). Never enable in production.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			$compare  = $compare_start && $compare_end;
+			$variant  = (string) ( $request->get_param( '_fixture_state' ) ?? 'populated' );
+			$response = rest_ensure_response(
+				[
+					'cache' => [
+						'source'         => Cache::SOURCE_LOCAL,
+						'computed_at'    => gmdate( 'Y-m-d\TH:i:s\Z' ),
+						'cooldown_until' => null,
+					],
+					'data'  => Newsletter_Ads_Metric::get_fixture( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), $compare, $variant ),
+				]
+			);
+			$response->header( 'Cache-Control', 'no-store, private' );
+			return $response;
+		}
+
+		return $this->cached_response( $request, $start, $end, $compare_start, $compare_end );
+	}
+
+	/**
+	 * POST /newsletter-ads/refresh handler — bypass cache and recompute.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function refresh_newsletter_ads_data( WP_REST_Request $request ) {
+		// Fixture mode: delegate to GET so refresh is a no-op cache bypass.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			return $this->get_newsletter_ads_data( $request );
+		}
+		$parsed = $this->parse_window_args( $request );
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+		[ $start, $end, $compare_start, $compare_end ] = $parsed;
+
+		return $this->refresh_response( $request, $start, $end, $compare_start, $compare_end );
+	}
+
+	/**
+	 * Base-window payload (no comparison) — satisfies the
+	 * {@see Cached_Controller_Trait} contract. Like Advertising, this
+	 * controller is NOT registered for the daily pre-warm: the metric layer's
+	 * own transient makes recomputes cheap.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array
+	 */
+	public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		return $this->build_response( $start, $end, null, null );
+	}
+
+	/**
+	 * Assemble the top-level response.
+	 *
+	 * @param DateTimeImmutable      $start         Current window start.
+	 * @param DateTimeImmutable      $end           Current window end.
+	 * @param DateTimeImmutable|null $compare_start Prior window start.
+	 * @param DateTimeImmutable|null $compare_end   Prior window end.
+	 * @return array
+	 */
+	private function build_response(
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		?DateTimeImmutable $compare_start,
+		?DateTimeImmutable $compare_end
+	): array {
+		$response = [
+			'current'  => Newsletter_Ads_Metric::get_all( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), false ),
+			'previous' => null,
+		];
+		if ( $compare_start && $compare_end ) {
+			$response['previous'] = Newsletter_Ads_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );
+		}
+		return $response;
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-newsletter-ads.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-newsletter-ads.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Newspack Insights — Newsletter Ads section (NPPD-1861).
+ *
+ * Newsletter Ads tab scope: performance of newsletter ads sold and served
+ * through newspack-newsletters — lifetime tracking counters, windowed
+ * impressions/clicks from the dated ad-stats table, flat-over-flight revenue
+ * proration, and per-ad / per-advertiser / per-newsletter breakdowns.
+ *
+ * The data layer registers from {@see self::register_hooks()} via
+ * {@see \Newspack\Insights\Newsletter_Ads_REST_Controller} and
+ * {@see \Newspack\Insights\Newsletter_Ads_Metric}. Everything computes
+ * synchronously from local SQL — no Action Scheduler refresh (unlike
+ * Advertising's GAM jobs). Every newsletters-plugin touch inside the data
+ * layer is defensively guarded, so this section is safe to init even when
+ * newspack-newsletters is inactive.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\Insights\Newsletter_Ads_REST_Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newsletter Ads section.
+ */
+class Insights_Section_Newsletter_Ads {
+
+	/**
+	 * Display label for this tab. Must match the React tab label.
+	 *
+	 * @var string
+	 */
+	const SECTION_NAME = 'Newsletter Ads';
+
+	/**
+	 * Initialize. Loads the Newsletter Ads data layer and registers its REST
+	 * routes. No-op unless the Insights flag is enabled.
+	 */
+	public static function init() {
+		if ( ! Insights_Wizard::is_enabled() ) {
+			return;
+		}
+		self::load_dependencies();
+		self::register_hooks();
+	}
+
+	/**
+	 * Include the Newsletter Ads PHP files (metric orchestrator + REST
+	 * controller), matching the per-section include convention.
+	 *
+	 * @return void
+	 */
+	private static function load_dependencies(): void {
+		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
+		include_once $base . 'metrics/class-newsletter-ads-metric.php';
+		include_once $base . 'api/class-newsletter-ads-rest-controller.php';
+	}
+
+	/**
+	 * Register the Newsletter Ads REST routes.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new Newsletter_Ads_REST_Controller();
+				$controller->register_routes();
+			}
+		);
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -404,6 +404,23 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
+	 * Whether the Newsletter Ads (NPPD-1861) nav entry should render: the
+	 * newsletter ads CPT exists and the site has at least one published ad
+	 * (transient-cached in the orchestrator), or fixture mode is on so the tab
+	 * is testable without the newsletters plugin. Class-guarded so a boot-order
+	 * hiccup (section not loaded) degrades to a hidden tab, never a fatal.
+	 *
+	 * @return bool
+	 */
+	private static function is_newsletter_ads_tab_visible(): bool {
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			return true;
+		}
+		return class_exists( '\Newspack\Insights\Newsletter_Ads_Metric' )
+			&& \Newspack\Insights\Newsletter_Ads_Metric::is_tab_visible();
+	}
+
+	/**
 	 * Build the boot config consumed by the React entry.
 	 *
 	 * @return array
@@ -434,14 +451,17 @@ class Insights_Wizard extends Wizard {
 			// gated to the preview constant NEWSPACK_INSIGHTS_GATES_PREVIEW while
 			// Phase 1 (placeholder data) is being validated.
 			'tabs'                => [
-				'audience'    => true,
-				'engagement'  => true,
-				'conversion'  => true,
-				'gates'       => self::is_gates_preview_enabled(),
-				'prompts'     => true,
-				'subscribers' => true,
-				'donors'      => self::has_donation_activity(),
-				'advertising' => self::is_advertising_tab_visible(),
+				'audience'       => true,
+				'engagement'     => true,
+				'conversion'     => true,
+				'gates'          => self::is_gates_preview_enabled(),
+				'prompts'        => true,
+				'subscribers'    => true,
+				'donors'         => self::has_donation_activity(),
+				'advertising'    => self::is_advertising_tab_visible(),
+				// Newsletter Ads (NPPD-1861): shown when the site has published
+				// newsletter ads (or fixture mode). See is_newsletter_ads_tab_visible().
+				'newsletter_ads' => self::is_newsletter_ads_tab_visible(),
 			],
 			'defaultDateRange'    => [
 				'preset' => 'last-30',

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/newsletter-ads-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/newsletter-ads-fixture.php
@@ -1,0 +1,533 @@
+<?php
+/**
+ * Newspack Insights — Newsletter Ads fixture (NPPD-1861).
+ *
+ * Returns a callable that produces a realistic, date-relative Newsletter Ads
+ * payload for UI smoke testing without the newsletters plugin. The shape
+ * matches the live REST response — `{ current, previous }`, where each is the
+ * {@see \Newspack\Insights\Newsletter_Ads_Metric::get_all()} envelope (and
+ * `previous` is null without comparison). Served by the REST controller when
+ * NEWSPACK_INSIGHTS_FIXTURE_MODE is on.
+ *
+ * Variants (via the `_fixture_state` query param):
+ *   populated      — full scorecards + tables + daily series.
+ *   zero           — zero-activity window: scorecards 0, tables empty
+ *                    (has_window_activity false).
+ *   not_ready      — is_report_ready false + the stats-missing issue;
+ *                    lifetime metrics still populated, timeframe metrics
+ *                    non-computable.
+ *   no_impressions — clicks > 0 but impressions 0 (pixel tracking disabled):
+ *                    ctr / ecpm / lifetime_ctr non-computable, tables ranked
+ *                    by clicks, tracking-disabled readiness issue present.
+ *
+ * No 'loading' variant — this tab computes synchronously (is_loading is
+ * always false).
+ *
+ * All dates are computed at runtime so the fixture never goes stale. All
+ * advertiser / ad / newsletter names are deliberately generic and fictional.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return function ( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated' ): array {
+	$tz         = wp_timezone();
+	$today      = new DateTimeImmutable( 'today', $tz );
+	$data_as_of = $today->format( 'Y-m-d' );
+
+	// Obviously-fake advertisers and ads (never real business or publisher names).
+	$catalog = [
+		[
+			'advertiser' => 'Hometown Hardware',
+			'title'      => 'Hometown Hardware — Spring Sale',
+			'weight'     => 10,
+		],
+		[
+			'advertiser' => 'Riverside Cafe',
+			'title'      => 'Riverside Cafe — Weekend Brunch',
+			'weight'     => 8,
+		],
+		[
+			'advertiser' => 'Maple Street Books',
+			'title'      => 'Maple Street Books — Author Night',
+			'weight'     => 7,
+		],
+		[
+			'advertiser' => 'Sunrise Bakery',
+			'title'      => 'Sunrise Bakery — Fresh Daily',
+			'weight'     => 5,
+		],
+		[
+			'advertiser' => 'Valley Bike Shop',
+			'title'      => 'Valley Bike Shop — Tune-Up Special',
+			'weight'     => 4,
+		],
+		[
+			'advertiser' => 'Bluebird Florist',
+			'title'      => 'Bluebird Florist — Mothers Day',
+			'weight'     => 3,
+		],
+		[
+			'advertiser' => '',
+			'title'      => 'House Promo — Membership Drive',
+			'weight'     => 2,
+		],
+	];
+
+	/**
+	 * Build a single window's metric set, scaled so comparison windows can
+	 * differ and produce both positive and negative deltas.
+	 *
+	 * @param float  $scale          Multiplier applied to the baseline numbers.
+	 * @param string $window_variant Variant for this window.
+	 * @return array
+	 */
+	$metrics = function ( float $scale, string $window_variant ) use ( $catalog, $start_date, $end_date, $tz ): array {
+		$no_impressions = 'no_impressions' === $window_variant;
+		$zero           = 'zero' === $window_variant;
+
+		// Lifetime counters (meta) — always present, even on a zero window.
+		$lifetime_impressions = $no_impressions ? 0 : 1850000;
+		$lifetime_clicks      = 24800;
+		$lifetime             = [
+			'lifetime_impressions' => [
+				'value'      => $lifetime_impressions,
+				'computable' => true,
+				'type'       => 'count',
+			],
+			'lifetime_clicks'      => [
+				'value'      => $lifetime_clicks,
+				'computable' => true,
+				'type'       => 'count',
+			],
+			'lifetime_ctr'         => [
+				'value'       => $lifetime_impressions > 0 ? round( $lifetime_clicks / $lifetime_impressions, 4 ) : 0.0,
+				'computable'  => $lifetime_impressions > 0,
+				'type'        => 'rate',
+				'numerator'   => $lifetime_clicks,
+				'denominator' => $lifetime_impressions,
+			],
+		];
+
+		if ( $zero ) {
+			return array_merge(
+				$lifetime,
+				[
+					'total_impressions'    => [
+						'value'      => 0,
+						'computable' => true,
+						'type'       => 'count',
+					],
+					'total_clicks'         => [
+						'value'      => 0,
+						'computable' => true,
+						'type'       => 'count',
+					],
+					'ctr'                  => [
+						'value'       => 0.0,
+						'computable'  => false,
+						'type'        => 'rate',
+						'numerator'   => 0,
+						'denominator' => 0,
+					],
+					'total_revenue'        => [
+						'value'      => 0.0,
+						'computable' => true,
+						'type'       => 'currency',
+					],
+					'revenue_excluded_ads' => [
+						'value'      => 0,
+						'computable' => true,
+						'type'       => 'count',
+					],
+					'ecpm'                 => [
+						'value'       => 0.0,
+						'computable'  => false,
+						'type'        => 'currency',
+						'numerator'   => 0.0,
+						'denominator' => 0,
+					],
+					'active_ads'           => [
+						'value'      => 0,
+						'computable' => true,
+						'type'       => 'count',
+					],
+					'performance_by_day'   => [
+						'rows'       => [],
+						'computable' => false,
+						'type'       => 'timeseries',
+					],
+					'top_ads'              => [
+						'rows'       => [],
+						'computable' => false,
+						'type'       => 'table',
+					],
+					'top_advertisers'      => [
+						'rows'       => [],
+						'computable' => false,
+						'type'       => 'table',
+					],
+					'by_newsletter'        => [
+						'rows'       => [],
+						'computable' => false,
+						'type'       => 'table',
+					],
+				]
+			);
+		}
+
+		$impressions = $no_impressions ? 0 : (int) round( 96000 * $scale );
+		$clicks      = (int) round( 1440 * $scale );
+		$revenue     = round( 1260.0 * $scale, 2 );
+		$total_w     = (float) array_sum( array_column( $catalog, 'weight' ) );
+
+		// Per-ad rows spread across the catalog by weight.
+		$ad_rows = [];
+		foreach ( $catalog as $i => $entry ) {
+			$share    = $entry['weight'] / $total_w;
+			$ad_imp   = (int) round( $impressions * $share );
+			$ad_click = (int) round( $clicks * $share );
+			// The house promo carries no price → excluded from revenue.
+			$ad_rev    = '' === $entry['advertiser'] ? null : round( $revenue * $share, 2 );
+			$ad_rows[] = [
+				'ad_id'       => 9000 + $i,
+				'title'       => $entry['title'],
+				'advertiser'  => $entry['advertiser'],
+				'impressions' => $ad_imp,
+				'clicks'      => $ad_click,
+				'ctr'         => $ad_imp > 0 ? round( $ad_click / $ad_imp, 4 ) : null,
+				'revenue'     => $ad_rev,
+			];
+		}
+
+		$advertiser_rows = [];
+		foreach ( $ad_rows as $row ) {
+			$name = '' !== $row['advertiser'] ? $row['advertiser'] : __( '(no advertiser)', 'newspack-plugin' );
+			if ( ! isset( $advertiser_rows[ $name ] ) ) {
+				$advertiser_rows[ $name ] = [
+					'advertiser'  => $name,
+					'ads'         => 0,
+					'impressions' => 0,
+					'clicks'      => 0,
+					'revenue'     => null,
+				];
+			}
+			++$advertiser_rows[ $name ]['ads'];
+			$advertiser_rows[ $name ]['impressions'] += $row['impressions'];
+			$advertiser_rows[ $name ]['clicks']      += $row['clicks'];
+			if ( null !== $row['revenue'] ) {
+				$advertiser_rows[ $name ]['revenue'] = round( ( $advertiser_rows[ $name ]['revenue'] ?? 0.0 ) + $row['revenue'], 2 );
+			}
+		}
+		$advertiser_rows = array_values( $advertiser_rows );
+		foreach ( $advertiser_rows as $i => $row ) {
+			$advertiser_rows[ $i ]['ctr'] = $row['impressions'] > 0 ? round( $row['clicks'] / $row['impressions'], 4 ) : null;
+		}
+
+		// By-newsletter rows: weekly sends across the window, date-relative.
+		$newsletter_rows = [];
+		try {
+			$day = new DateTimeImmutable( $end_date, $tz );
+		} catch ( Exception $e ) {
+			$day = new DateTimeImmutable( 'today', $tz );
+		}
+		for ( $i = 0; $i < 6; $i++ ) {
+			$sent   = $day->modify( '-' . ( $i * 7 ) . ' days' );
+			$factor = ( 6 - $i ) / 6;
+			$nl_imp = (int) round( ( $impressions / 8 ) * $factor );
+			$nl_clk = (int) round( ( $clicks / 8 ) * $factor );
+			$newsletter_rows[] = [
+				'newsletter_id' => 7000 + $i,
+				'title'         => sprintf( 'Weekly Roundup — %s', $sent->format( 'M j' ) ),
+				'sent_date'     => $sent->format( 'Y-m-d' ),
+				'ads'           => 3,
+				'impressions'   => $nl_imp,
+				'clicks'        => $nl_clk,
+				'ctr'           => $nl_imp > 0 ? round( $nl_clk / $nl_imp, 4 ) : null,
+			];
+		}
+
+		// Rank like the live orchestrator: by impressions, falling back to
+		// clicks when nothing recorded an impression (pixel disabled).
+		$rank = function ( array $rows ) use ( $no_impressions ): array {
+			$by = $no_impressions ? 'clicks' : 'impressions';
+			usort(
+				$rows,
+				function ( $a, $b ) use ( $by ) {
+					return ( $b[ $by ] ?? 0 ) <=> ( $a[ $by ] ?? 0 );
+				}
+			);
+			return array_slice( $rows, 0, 10 );
+		};
+
+		return array_merge(
+			$lifetime,
+			[
+				'total_impressions'    => [
+					'value'      => $impressions,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'total_clicks'         => [
+					'value'      => $clicks,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'ctr'                  => [
+					'value'       => $impressions > 0 ? round( $clicks / $impressions, 4 ) : 0.0,
+					'computable'  => $impressions > 0,
+					'type'        => 'rate',
+					'numerator'   => $clicks,
+					'denominator' => $impressions,
+				],
+				'total_revenue'        => [
+					'value'      => $revenue,
+					'computable' => true,
+					'type'       => 'currency',
+				],
+				'revenue_excluded_ads' => [
+					'value'      => 1,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'ecpm'                 => [
+					'value'       => $impressions > 0 ? round( ( $revenue / $impressions ) * 1000, 2 ) : 0.0,
+					'computable'  => $revenue > 0 && $impressions > 0,
+					'type'        => 'currency',
+					'numerator'   => $revenue,
+					'denominator' => $impressions,
+				],
+				'active_ads'           => [
+					'value'      => count( $catalog ),
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'performance_by_day'   => [
+					'rows'       => [],
+					'computable' => true,
+					'type'       => 'timeseries',
+				],
+				'top_ads'              => [
+					'rows'       => $rank( $ad_rows ),
+					'computable' => true,
+					'type'       => 'table',
+				],
+				'top_advertisers'      => [
+					'rows'       => $rank( $advertiser_rows ),
+					'computable' => true,
+					'type'       => 'table',
+				],
+				'by_newsletter'        => [
+					'rows'       => $rank( $newsletter_rows ),
+					'computable' => true,
+					'type'       => 'table',
+				],
+			]
+		);
+	};
+
+	// Daily impressions/clicks series across the requested window, computed
+	// date-relative so the fixture never goes stale. Slight midweek lift
+	// (newsletters send on weekdays) and an upward drift; capped at 92 days.
+	$daily_series = function ( string $from, string $to, float $scale, bool $no_impressions ) use ( $tz ): array {
+		try {
+			$day = new DateTimeImmutable( $from, $tz );
+			$end = new DateTimeImmutable( $to, $tz );
+		} catch ( Exception $e ) {
+			return [];
+		}
+		$rows = [];
+		$i    = 0;
+		while ( $day <= $end && $i < 92 ) {
+			$is_send_day = in_array( (int) $day->format( 'N' ), [ 2, 4 ], true ) ? 2.4 : 0.7;
+			$trend       = 1 + ( $i * 0.01 );
+			$wobble      = 1 + ( ( $i % 5 ) - 2 ) * 0.05;
+			$factor      = $scale * $trend * $is_send_day * $wobble;
+			$rows[]      = [
+				'date'        => $day->format( 'Y-m-d' ),
+				'impressions' => $no_impressions ? 0 : (int) round( 3200 * $factor ),
+				'clicks'      => (int) round( 48 * $factor ),
+			];
+			$day = $day->modify( '+1 day' );
+			++$i;
+		}
+		return $rows;
+	};
+
+	/**
+	 * Assemble a window envelope for a variant.
+	 *
+	 * @param string $from           Window start.
+	 * @param string $to             Window end.
+	 * @param float  $scale          Baseline multiplier.
+	 * @param string $window_variant Variant for this window.
+	 * @return array
+	 */
+	$envelope = function ( string $from, string $to, float $scale, string $window_variant ) use ( $metrics, $daily_series, $data_as_of ): array {
+		$window_metrics = $metrics( $scale, $window_variant );
+		if ( 'zero' !== $window_variant ) {
+			$window_metrics['performance_by_day'] = [
+				'rows'       => $daily_series( $from, $to, $scale, 'no_impressions' === $window_variant ),
+				'computable' => true,
+				'type'       => 'timeseries',
+			];
+		}
+
+		$issues = [];
+		if ( 'no_impressions' === $window_variant ) {
+			// The real shape of "click tracking on, pixel off": the informational
+			// tracking-disabled issue accompanies the zero-impression figures.
+			$issues[] = [
+				'code'            => 'newsletter_ads_tracking_disabled',
+				'message'         => __( 'Newsletter open tracking (the tracking pixel) is disabled, so ad impressions are not recorded. Enable it in Newsletters settings to measure impressions.', 'newspack-plugin' ),
+				'remediation_url' => '',
+			];
+		}
+
+		$out = [
+			'window'           => [
+				'start' => $from,
+				'end'   => $to,
+			],
+			'is_tab_visible'   => true,
+			'is_report_ready'  => true,
+			'readiness_issues' => $issues,
+			'data_as_of'       => $data_as_of,
+			'is_loading'       => false,
+			'metrics'          => $window_metrics,
+		];
+
+		// Mirror the live derivation: set only when the window volume metrics
+		// are computable.
+		$imp = $window_metrics['total_impressions'] ?? [];
+		$clk = $window_metrics['total_clicks'] ?? [];
+		if ( ! empty( $imp['computable'] ) && ! empty( $clk['computable'] ) ) {
+			$out['has_window_activity'] = ( (int) ( $imp['value'] ?? 0 ) ) > 0 || ( (int) ( $clk['value'] ?? 0 ) ) > 0;
+		}
+
+		return $out;
+	};
+
+	// Not-ready render path: tab visible (ads exist), stats table missing —
+	// lifetime metrics real, timeframe metrics non-computable.
+	if ( 'not_ready' === $variant ) {
+		$lifetime_impressions = 1850000;
+		$lifetime_clicks      = 24800;
+		$count_na             = [
+			'value'      => 0,
+			'computable' => false,
+			'type'       => 'count',
+		];
+		$not_ready            = [
+			'window'           => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			'is_tab_visible'   => true,
+			'is_report_ready'  => false,
+			'readiness_issues' => [
+				[
+					'code'            => 'newsletter_ads_stats_missing',
+					'message'         => __( 'Newsletter ad statistics require the latest Newspack Newsletters plugin.', 'newspack-plugin' ),
+					'remediation_url' => '',
+				],
+			],
+			'data_as_of'       => $data_as_of,
+			'is_loading'       => false,
+			'metrics'          => [
+				'lifetime_impressions' => [
+					'value'      => $lifetime_impressions,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'lifetime_clicks'      => [
+					'value'      => $lifetime_clicks,
+					'computable' => true,
+					'type'       => 'count',
+				],
+				'lifetime_ctr'         => [
+					'value'       => round( $lifetime_clicks / $lifetime_impressions, 4 ),
+					'computable'  => true,
+					'type'        => 'rate',
+					'numerator'   => $lifetime_clicks,
+					'denominator' => $lifetime_impressions,
+				],
+				'total_impressions'    => $count_na,
+				'total_clicks'         => $count_na,
+				'ctr'                  => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'rate',
+					'numerator'   => 0,
+					'denominator' => 0,
+				],
+				'total_revenue'        => [
+					'value'      => 0.0,
+					'computable' => false,
+					'type'       => 'currency',
+				],
+				'revenue_excluded_ads' => $count_na,
+				'ecpm'                 => [
+					'value'       => 0.0,
+					'computable'  => false,
+					'type'        => 'currency',
+					'numerator'   => 0.0,
+					'denominator' => 0,
+				],
+				'active_ads'           => $count_na,
+				'performance_by_day'   => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'timeseries',
+				],
+				'top_ads'              => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+				'top_advertisers'      => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+				'by_newsletter'        => [
+					'rows'       => [],
+					'computable' => false,
+					'type'       => 'table',
+				],
+			],
+		];
+
+		return [
+			'current'  => $not_ready,
+			'previous' => null,
+		];
+	}
+
+	$current = $envelope( $start_date, $end_date, 1.0, $variant );
+
+	$previous = null;
+	if ( $compare ) {
+		// Comparison window = the immediately-preceding window of equal length.
+		try {
+			$start       = new DateTimeImmutable( $start_date, $tz );
+			$end         = new DateTimeImmutable( $end_date, $tz );
+			$length_days = (int) $start->diff( $end )->format( '%a' ) + 1;
+			$prior_end   = $start->modify( '-1 day' )->format( 'Y-m-d' );
+			$prior_start = $start->modify( '-' . $length_days . ' days' )->format( 'Y-m-d' );
+		} catch ( Exception $e ) {
+			$prior_start = $start_date;
+			$prior_end   = $end_date;
+		}
+
+		// 0.85 scale → current is higher on volume (positive deltas). The prior
+		// window always uses a non-empty variant so comparison deltas render.
+		$previous = $envelope( $prior_start, $prior_end, 0.85, 'zero' === $variant ? 'populated' : $variant );
+	}
+
+	return [
+		'current'  => $current,
+		'previous' => $previous,
+	];
+};

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-newsletter-ads-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-newsletter-ads-metric.php
@@ -1,0 +1,1035 @@
+<?php
+/**
+ * Newspack Insights — Newsletter Ads Metric orchestrator (NPPD-1861).
+ *
+ * Newsletter-ad performance from the newspack-newsletters plugin's data:
+ *   - Ads CPT (`newspack_nl_ads_cpt`) with per-ad meta: `start_date`,
+ *     `expiry_date` (flight dates), `price` (flat flight price, no currency),
+ *     and `tracking_impressions` / `tracking_clicks` (lifetime cumulative
+ *     counters).
+ *   - The dated stats table `{$wpdb->prefix}newspack_newsletters_ad_stats`
+ *     (one row per ad/newsletter/UTC day; `newsletter_id` 0 is the
+ *     unknown-source click sentinel), shipped by a newer newspack-newsletters
+ *     via {@see \Newspack_Newsletters\Tracking\Ad_Stats}.
+ *
+ * Every newsletters-plugin touch is defensively guarded (class_exists /
+ * post_type_exists / SHOW TABLES): missing pieces degrade to
+ * computable=false payloads, never fatals. Lifetime metrics come from the
+ * meta counters and work without the stats table; timeframe metrics need
+ * the table ({@see self::is_report_ready()}).
+ *
+ * Unlike GAM (async report jobs), everything here is cheap local SQL, so the
+ * tab computes SYNCHRONOUSLY in the request — no Action Scheduler, and
+ * `is_loading` is always false. The full window envelope is cached in a
+ * transient ({@see self::CACHE_KEY_PREFIX}).
+ *
+ * Revenue uses a FLAT-OVER-FLIGHT model: an ad's `price` covers its whole
+ * flight ([start_date, expiry_date], inclusive), so a window earns
+ * price / flight_days × overlapping_days. Ads missing price or either flight
+ * date are excluded from revenue (and surfaced via `revenue_excluded_ads`).
+ *
+ * Payload shapes mirror the Advertising orchestrator:
+ *   scalar : { value, computable, type: count|currency }
+ *   rate   : { value (0-1), computable, type: rate, numerator, denominator }
+ *   rows   : { rows: [...], computable, type: table|timeseries }
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newsletter Ads metric orchestrator.
+ *
+ * Not `final` (like {@see Advertising_Metric}): the newsletters-plugin
+ * seams ({@see self::ad_stats_class()}, {@see self::stats_table_exists()})
+ * are `protected` and called via `static::` so unit tests can subclass and
+ * simulate the plugin/table being absent.
+ */
+class Newsletter_Ads_Metric {
+
+	/**
+	 * Ads CPT registered by newspack-newsletters
+	 * ({@see \Newspack_Newsletters_Ads::CPT}). Mirrored as a local constant so
+	 * this class never hard-depends on the newsletters plugin being loaded.
+	 */
+	const ADS_CPT = 'newspack_nl_ads_cpt';
+
+	/**
+	 * Advertiser taxonomy registered by newspack-newsletters
+	 * ({@see \Newspack_Newsletters_Ads::ADVERTISER_TAX}).
+	 */
+	const ADVERTISER_TAX = 'newspack_nl_advertiser';
+
+	/**
+	 * The newsletters plugin's dated ad-stats reader. Only present on newer
+	 * newspack-newsletters builds; its absence means timeframe metrics can't
+	 * be computed ({@see self::is_report_ready()}).
+	 */
+	const AD_STATS_CLASS = 'Newspack_Newsletters\Tracking\Ad_Stats';
+
+	/**
+	 * The newsletters plugin's tracking settings surface, used to detect
+	 * whether the open-tracking pixel (the impressions source) is disabled.
+	 */
+	const TRACKING_ADMIN_CLASS = 'Newspack_Newsletters\Tracking\Admin';
+
+	/**
+	 * Unprefixed stats table name, used as a fallback when the Ad_Stats class
+	 * doesn't expose {@see \Newspack_Newsletters\Tracking\Ad_Stats::get_table_name()}.
+	 */
+	const STATS_TABLE_SUFFIX = 'newspack_newsletters_ad_stats';
+
+	/**
+	 * `newsletter_id` value the stats table uses for clicks whose source
+	 * newsletter is unknown. Excluded from the by-newsletter breakdown.
+	 */
+	const UNKNOWN_NEWSLETTER_SENTINEL = 0;
+
+	const CACHE_KEY_PREFIX = 'newspack_insights_newsletter_ads_v1:';
+
+	/**
+	 * Envelope cache TTL. Mirrors Advertising's CACHE_FRESH_TTL; because this
+	 * tab computes synchronously and cheaply there is no stale-while-revalidate
+	 * layer — the fresh TTL is simply the transient expiry.
+	 */
+	const CACHE_TTL = 15 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Cache key for the tab-visibility detection result (mirrors the Donors
+	 * `has_donation_activity()` transient pattern).
+	 */
+	const ADS_PRESENCE_TRANSIENT = 'newspack_insights_has_newsletter_ads';
+
+	/**
+	 * Row cap for the breakdown tables (top ads / advertisers / newsletters).
+	 */
+	const TABLE_ROW_LIMIT = 10;
+
+	/**
+	 * Per-request memo of the stats-table existence check (a SHOW TABLES
+	 * query), so a single request performs it at most once.
+	 *
+	 * @var bool|null
+	 */
+	private static $table_exists_memo = null;
+
+	/*
+	 * Visibility / readiness
+	 */
+
+	/**
+	 * Whether the Newsletter Ads tab should be visible: the ads CPT exists
+	 * (newsletters plugin active with ads enabled) AND the site has at least
+	 * one published ad. Cached for 24h; state transitions ("publisher created
+	 * their first newsletter ad") are rare, and tests / manual invalidation
+	 * can call {@see self::force_refresh_tab_visibility()}.
+	 *
+	 * @return bool
+	 */
+	public static function is_tab_visible(): bool {
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			return true;
+		}
+		$cached = get_transient( self::ADS_PRESENCE_TRANSIENT );
+		if ( 'yes' === $cached ) {
+			return true;
+		}
+		if ( 'no' === $cached ) {
+			return false;
+		}
+		$has_ads = self::compute_has_ads();
+		set_transient( self::ADS_PRESENCE_TRANSIENT, $has_ads ? 'yes' : 'no', DAY_IN_SECONDS );
+		return $has_ads;
+	}
+
+	/**
+	 * Force-recompute the ads-presence flag, bypassing and refreshing the
+	 * cache. Useful for tests and for the case where a publisher just
+	 * published their first ad.
+	 *
+	 * @return bool The freshly computed flag.
+	 */
+	public static function force_refresh_tab_visibility(): bool {
+		delete_transient( self::ADS_PRESENCE_TRANSIENT );
+		$has_ads = self::compute_has_ads();
+		set_transient( self::ADS_PRESENCE_TRANSIENT, $has_ads ? 'yes' : 'no', DAY_IN_SECONDS );
+		return $has_ads;
+	}
+
+	/**
+	 * Run the ads-presence check without consulting the cache.
+	 *
+	 * @return bool
+	 */
+	private static function compute_has_ads(): bool {
+		if ( ! post_type_exists( self::ADS_CPT ) ) {
+			return false;
+		}
+		$ids = get_posts(
+			[
+				'post_type'   => self::ADS_CPT,
+				'post_status' => 'publish',
+				'numberposts' => 1,
+				'fields'      => 'ids',
+			]
+		);
+		return ! empty( $ids );
+	}
+
+	/**
+	 * Whether timeframe (windowed) reporting is available: the newsletters
+	 * plugin ships the Ad_Stats reader AND its dated stats table actually
+	 * exists in the database. Lifetime metrics (meta counters) don't need
+	 * this and are computed regardless.
+	 *
+	 * @return bool
+	 */
+	public static function is_report_ready(): bool {
+		return null !== static::ad_stats_class() && static::stats_table_exists();
+	}
+
+	/**
+	 * Reset the per-request readiness memo. Mainly for tests; harmless in
+	 * production (each request starts fresh).
+	 *
+	 * @return void
+	 */
+	public static function reset_readiness_cache(): void {
+		self::$table_exists_memo = null;
+	}
+
+	/**
+	 * The newsletters plugin's Ad_Stats class name when it's loaded, else
+	 * null. A `protected` seam (called via `static::`) so tests can simulate
+	 * the plugin being absent without unloading classes.
+	 *
+	 * @return string|null
+	 */
+	protected static function ad_stats_class(): ?string {
+		return class_exists( self::AD_STATS_CLASS ) ? self::AD_STATS_CLASS : null;
+	}
+
+	/**
+	 * Whether the dated stats table exists (SHOW TABLES), memoized per
+	 * request. The class shipping without its table (e.g. migration not yet
+	 * run) must degrade cleanly rather than erroring on every query.
+	 *
+	 * @return bool
+	 */
+	protected static function stats_table_exists(): bool {
+		if ( null !== self::$table_exists_memo ) {
+			return self::$table_exists_memo;
+		}
+		global $wpdb;
+		$table = self::stats_table_name();
+		// Probe with a suppressed no-op SELECT rather than SHOW TABLES:
+		// $wpdb->query() returns false only on error (0 rows is fine), and —
+		// unlike SHOW TABLES — this also sees TEMPORARY tables, which is what
+		// CREATE TABLE becomes under the WP test framework's query rewrite.
+		$suppress = $wpdb->suppress_errors( true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->query( $wpdb->prepare( 'SELECT 1 FROM %i LIMIT 1', $table ) );
+		$wpdb->suppress_errors( $suppress );
+		self::$table_exists_memo = ( false !== $result );
+		return self::$table_exists_memo;
+	}
+
+	/**
+	 * Resolve the stats table name: prefer the newsletters plugin's own
+	 * accessor so a rename on their side can't strand us, falling back to the
+	 * documented `{$wpdb->prefix}newspack_newsletters_ad_stats`.
+	 *
+	 * @return string
+	 */
+	public static function stats_table_name(): string {
+		global $wpdb;
+		$class = static::ad_stats_class();
+		if ( null !== $class && is_callable( [ $class, 'get_table_name' ] ) ) {
+			$name = call_user_func( [ $class, 'get_table_name' ] );
+			if ( is_string( $name ) && '' !== $name ) {
+				return $name;
+			}
+		}
+		return $wpdb->prefix . self::STATS_TABLE_SUFFIX;
+	}
+
+	/**
+	 * Specific reasons reporting is limited, for the UI to render guidance.
+	 * Two independent issues:
+	 *  - `newsletter_ads_stats_missing` — the dated stats table isn't
+	 *    available (old newsletters plugin), so timeframe metrics can't run.
+	 *  - `newsletter_ads_tracking_disabled` — informational: the open-tracking
+	 *    pixel is off, so impressions aren't being recorded (clicks may still
+	 *    accrue). Present regardless of readiness.
+	 *
+	 * @return array<int,array<string,string>>
+	 */
+	public static function readiness_issues(): array {
+		$issues = [];
+		if ( ! static::is_report_ready() ) {
+			$issues[] = [
+				'code'            => 'newsletter_ads_stats_missing',
+				'message'         => __( 'Newsletter ad statistics require the latest Newspack Newsletters plugin.', 'newspack-plugin' ),
+				'remediation_url' => '',
+			];
+		}
+		if (
+			class_exists( self::TRACKING_ADMIN_CLASS )
+			&& method_exists( self::TRACKING_ADMIN_CLASS, 'is_tracking_pixel_enabled' )
+			&& ! call_user_func( [ self::TRACKING_ADMIN_CLASS, 'is_tracking_pixel_enabled' ] )
+		) {
+			$issues[] = [
+				'code'            => 'newsletter_ads_tracking_disabled',
+				'message'         => __( 'Newsletter open tracking (the tracking pixel) is disabled, so ad impressions are not recorded. Enable it in Newsletters settings to measure impressions.', 'newspack-plugin' ),
+				'remediation_url' => '',
+			];
+		}
+		return $issues;
+	}
+
+	/*
+	 * Public tab payload
+	 */
+
+	/**
+	 * Full Newsletter Ads payload for a window. Computes synchronously (cheap
+	 * local SQL — no Action Scheduler; `is_loading` always false) and caches
+	 * the full envelope in a transient.
+	 *
+	 * @param string $start_date YYYY-MM-DD (site timezone).
+	 * @param string $end_date   YYYY-MM-DD (site timezone).
+	 * @param bool   $compare    Whether to attach the prior-period payload.
+	 * @return array
+	 */
+	public static function get_all( string $start_date, string $end_date, bool $compare = false ): array {
+		$envelope = self::read_envelope( $start_date, $end_date );
+		if ( $compare ) {
+			[ $prior_start, $prior_end ] = self::prior_period( $start_date, $end_date );
+			$envelope['compare']         = self::read_envelope( $prior_start, $prior_end );
+		}
+		return $envelope;
+	}
+
+	/**
+	 * Realistic fixture payload for UI smoke testing without the newsletters
+	 * plugin. Served by the REST controller when NEWSPACK_INSIGHTS_FIXTURE_MODE
+	 * is on.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @param bool   $compare    Whether to attach the comparison payload.
+	 * @param string $variant    Render-path variant: populated|zero|not_ready|no_impressions.
+	 * @return array
+	 */
+	public static function get_fixture( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated' ): array {
+		$fixture = require NEWSPACK_ABSPATH . 'includes/wizards/insights/fixtures/newsletter-ads-fixture.php';
+		return $fixture( $start_date, $end_date, $compare, $variant );
+	}
+
+	/**
+	 * Derived empty-state signal: whether a resolved window saw any newsletter
+	 * ad activity. A pure function of the two window volume metrics, mirroring
+	 * the Advertising / Donors derivations. Set on the envelope only when the
+	 * window metrics are computable (report ready), so the React layer's
+	 * strict `=== false` check can't fire on a not-ready tab.
+	 *
+	 * @param int $impressions Total window impressions.
+	 * @param int $clicks      Total window clicks.
+	 * @return bool
+	 */
+	public static function window_activity_signal( int $impressions, int $clicks ): bool {
+		return $impressions > 0 || $clicks > 0;
+	}
+
+	/*
+	 * Envelope computation + cache
+	 */
+
+	/**
+	 * Read a window's envelope through the transient cache.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function read_envelope( string $start_date, string $end_date ): array {
+		$cache_disabled = defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) && NEWSPACK_INSIGHTS_CACHE_DISABLED;
+		$cache_key      = self::CACHE_KEY_PREFIX . $start_date . ':' . $end_date;
+		if ( ! $cache_disabled ) {
+			$cached = get_transient( $cache_key );
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
+		}
+		$envelope = self::compute_envelope( $start_date, $end_date );
+		if ( ! $cache_disabled ) {
+			set_transient( $cache_key, $envelope, self::CACHE_TTL );
+		}
+		return $envelope;
+	}
+
+	/**
+	 * Compute a full window envelope: lifetime metrics (meta counters, always
+	 * computed), timeframe metrics (stats table + flight-prorated revenue,
+	 * gated on {@see self::is_report_ready()}), and the activity signal.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array
+	 */
+	private static function compute_envelope( string $start_date, string $end_date ): array {
+		$is_ready = static::is_report_ready();
+		$ads      = self::get_published_ads();
+
+		$metrics = self::lifetime_metrics( $ads );
+
+		if ( $is_ready ) {
+			$metrics = array_merge( $metrics, self::window_metrics( $ads, $start_date, $end_date ) );
+		} else {
+			$metrics = array_merge( $metrics, self::not_ready_window_metrics() );
+		}
+
+		$envelope = [
+			'window'           => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			'is_tab_visible'   => static::is_tab_visible(),
+			'is_report_ready'  => $is_ready,
+			'readiness_issues' => static::readiness_issues(),
+			'data_as_of'       => ( new \DateTimeImmutable( 'now', wp_timezone() ) )->format( 'Y-m-d' ),
+			// This tab computes synchronously — never a background-loading state.
+			'is_loading'       => false,
+			'metrics'          => $metrics,
+		];
+
+		// Derived empty-state signal: only when the window volume metrics are
+		// computable (i.e. the stats table resolved), mirroring Advertising's
+		// read_window() derivation — absent otherwise so the UI's strict
+		// `=== false` empty-state check can't fire on a not-ready tab.
+		if ( ! empty( $metrics['total_impressions']['computable'] ) && ! empty( $metrics['total_clicks']['computable'] ) ) {
+			$envelope['has_window_activity'] = self::window_activity_signal(
+				(int) ( $metrics['total_impressions']['value'] ?? 0 ),
+				(int) ( $metrics['total_clicks']['value'] ?? 0 )
+			);
+		}
+
+		return $envelope;
+	}
+
+	/*
+	 * Lifetime metrics (meta counters — independent of the stats table)
+	 */
+
+	/**
+	 * Lifetime impressions / clicks / CTR from the per-ad cumulative meta
+	 * counters. These work on every newsletters build (no stats table
+	 * required). CTR is non-computable at zero impressions — the real case
+	 * of click tracking running with the pixel disabled must render n/a,
+	 * never 0%.
+	 *
+	 * @param array $ads Published-ad records ({@see self::get_published_ads()}).
+	 * @return array<string,array>
+	 */
+	private static function lifetime_metrics( array $ads ): array {
+		$impressions = 0;
+		$clicks      = 0;
+		foreach ( $ads as $ad ) {
+			$impressions += $ad['lifetime_impressions'];
+			$clicks      += $ad['lifetime_clicks'];
+		}
+		return [
+			'lifetime_impressions' => self::count_payload( $impressions ),
+			'lifetime_clicks'      => self::count_payload( $clicks ),
+			'lifetime_ctr'         => self::rate_payload( $clicks, $impressions ),
+		];
+	}
+
+	/*
+	 * Timeframe metrics (stats table + flat-over-flight revenue)
+	 */
+
+	/**
+	 * Compute every windowed metric. Only called when reporting is ready.
+	 *
+	 * @param array  $ads        Published-ad records.
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array<string,array>
+	 */
+	private static function window_metrics( array $ads, string $start_date, string $end_date ): array {
+		$totals  = self::query_window_totals( $start_date, $end_date );
+		$flights = self::flight_revenue( $ads, $start_date, $end_date );
+
+		$impressions = $totals['impressions'];
+		$clicks      = $totals['clicks'];
+		$revenue     = round( $flights['revenue'], 2 );
+
+		$per_ad_rows = self::query_per_ad_totals( $start_date, $end_date );
+
+		return [
+			'total_impressions'    => self::count_payload( $impressions ),
+			'total_clicks'         => self::count_payload( $clicks ),
+			'ctr'                  => self::rate_payload( $clicks, $impressions ),
+			'total_revenue'        => [
+				'value'      => $revenue,
+				'computable' => true,
+				'type'       => 'currency',
+			],
+			'revenue_excluded_ads' => self::count_payload( $flights['excluded'] ),
+			'ecpm'                 => [
+				'value'       => ( $revenue > 0 && $impressions > 0 ) ? round( ( $revenue / $impressions ) * 1000, 2 ) : 0.0,
+				'computable'  => $revenue > 0 && $impressions > 0,
+				'type'        => 'currency',
+				'numerator'   => $revenue,
+				'denominator' => $impressions,
+			],
+			'active_ads'           => self::count_payload( $flights['active'] ),
+			'performance_by_day'   => self::performance_by_day( $start_date, $end_date ),
+			'top_ads'              => self::top_ads( $per_ad_rows, $ads, $flights['per_ad'] ),
+			'top_advertisers'      => self::top_advertisers( $per_ad_rows, $ads, $flights['per_ad'] ),
+			'by_newsletter'        => self::by_newsletter( $start_date, $end_date ),
+		];
+	}
+
+	/**
+	 * The not-ready degradation: every windowed metric present but
+	 * computable=false, so the UI renders n/a cards instead of erroring
+	 * (lifetime metrics are still real).
+	 *
+	 * @return array<string,array>
+	 */
+	private static function not_ready_window_metrics(): array {
+		$count = [
+			'value'      => 0,
+			'computable' => false,
+			'type'       => 'count',
+		];
+		$currency = [
+			'value'      => 0.0,
+			'computable' => false,
+			'type'       => 'currency',
+		];
+		return [
+			'total_impressions'    => $count,
+			'total_clicks'         => $count,
+			'ctr'                  => [
+				'value'       => 0.0,
+				'computable'  => false,
+				'type'        => 'rate',
+				'numerator'   => 0,
+				'denominator' => 0,
+			],
+			'total_revenue'        => $currency,
+			'revenue_excluded_ads' => $count,
+			'ecpm'                 => [
+				'value'       => 0.0,
+				'computable'  => false,
+				'type'        => 'currency',
+				'numerator'   => 0.0,
+				'denominator' => 0,
+			],
+			'active_ads'           => $count,
+			'performance_by_day'   => [
+				'rows'       => [],
+				'computable' => false,
+				'type'       => 'timeseries',
+			],
+			'top_ads'              => [
+				'rows'       => [],
+				'computable' => false,
+				'type'       => 'table',
+			],
+			'top_advertisers'      => [
+				'rows'       => [],
+				'computable' => false,
+				'type'       => 'table',
+			],
+			'by_newsletter'        => [
+				'rows'       => [],
+				'computable' => false,
+				'type'       => 'table',
+			],
+		];
+	}
+
+	/**
+	 * Window impression/click totals from the stats table. Includes
+	 * unknown-source (sentinel) rows — totals reflect all recorded activity.
+	 *
+	 * @param string $start_date YYYY-MM-DD (UTC day, matching stat_date).
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array{impressions:int,clicks:int}
+	 */
+	private static function query_window_totals( string $start_date, string $end_date ): array {
+		global $wpdb;
+		$table = self::stats_table_name();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT COALESCE( SUM( impressions ), 0 ) AS impressions, COALESCE( SUM( clicks ), 0 ) AS clicks FROM {$table} WHERE stat_date BETWEEN %s AND %s",
+				$start_date,
+				$end_date
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+		return [
+			'impressions' => (int) ( $row['impressions'] ?? 0 ),
+			'clicks'      => (int) ( $row['clicks'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Daily impressions/clicks series from the stats table, chronological.
+	 * Zero-activity days are omitted (no zero-filling).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array Timeseries payload.
+	 */
+	private static function performance_by_day( string $start_date, string $end_date ): array {
+		global $wpdb;
+		$table = self::stats_table_name();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT stat_date, SUM( impressions ) AS impressions, SUM( clicks ) AS clicks FROM {$table} WHERE stat_date BETWEEN %s AND %s GROUP BY stat_date ORDER BY stat_date ASC",
+				$start_date,
+				$end_date
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+		$out = [];
+		foreach ( (array) $rows as $row ) {
+			$out[] = [
+				'date'        => (string) $row['stat_date'],
+				'impressions' => (int) $row['impressions'],
+				'clicks'      => (int) $row['clicks'],
+			];
+		}
+		return [
+			'rows'       => $out,
+			'computable' => ! empty( $out ),
+			'type'       => 'timeseries',
+		];
+	}
+
+	/**
+	 * Per-ad window totals from the stats table (all newsletters, sentinel
+	 * included — a click is the ad's regardless of source attribution).
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array<int,array{ad_id:int,impressions:int,clicks:int}>
+	 */
+	private static function query_per_ad_totals( string $start_date, string $end_date ): array {
+		global $wpdb;
+		$table = self::stats_table_name();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ad_id, SUM( impressions ) AS impressions, SUM( clicks ) AS clicks FROM {$table} WHERE stat_date BETWEEN %s AND %s GROUP BY ad_id",
+				$start_date,
+				$end_date
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+		$out = [];
+		foreach ( (array) $rows as $row ) {
+			$out[] = [
+				'ad_id'       => (int) $row['ad_id'],
+				'impressions' => (int) $row['impressions'],
+				'clicks'      => (int) $row['clicks'],
+			];
+		}
+		return $out;
+	}
+
+	/**
+	 * Top ads table: per-ad window stats enriched with title, advertiser, CTR
+	 * and the window's flat-over-flight revenue share. Top
+	 * {@see self::TABLE_ROW_LIMIT} by impressions, falling back to clicks when
+	 * no ad recorded an impression (pixel-disabled sites).
+	 *
+	 * @param array $per_ad_rows Per-ad stat rows ({@see self::query_per_ad_totals()}).
+	 * @param array $ads         Published-ad records keyed by ID.
+	 * @param array $per_ad_rev  Window revenue share keyed by ad ID.
+	 * @return array Table payload.
+	 */
+	private static function top_ads( array $per_ad_rows, array $ads, array $per_ad_rev ): array {
+		$out = [];
+		foreach ( $per_ad_rows as $row ) {
+			$ad_id = $row['ad_id'];
+			if ( isset( $ads[ $ad_id ] ) ) {
+				$title      = $ads[ $ad_id ]['title'];
+				$advertiser = $ads[ $ad_id ]['advertiser'];
+			} else {
+				// Stats can outlive the ad (unpublished/deleted).
+				$post       = get_post( $ad_id );
+				$title      = $post ? get_the_title( $post ) : __( '(deleted)', 'newspack-plugin' );
+				$advertiser = $post ? self::first_advertiser_name( $ad_id ) : '';
+			}
+			$out[] = [
+				'ad_id'       => $ad_id,
+				'title'       => $title,
+				'advertiser'  => $advertiser,
+				'impressions' => $row['impressions'],
+				'clicks'      => $row['clicks'],
+				'ctr'         => $row['impressions'] > 0 ? round( $row['clicks'] / $row['impressions'], 4 ) : null,
+				'revenue'     => isset( $per_ad_rev[ $ad_id ] ) ? round( $per_ad_rev[ $ad_id ], 2 ) : null,
+			];
+		}
+		return self::rank_table( $out );
+	}
+
+	/**
+	 * Top advertisers table: the per-ad window stats grouped by advertiser
+	 * term (first term per ad; ads without one grouped under a translated
+	 * "(no advertiser)" label).
+	 *
+	 * @param array $per_ad_rows Per-ad stat rows.
+	 * @param array $ads         Published-ad records keyed by ID.
+	 * @param array $per_ad_rev  Window revenue share keyed by ad ID.
+	 * @return array Table payload.
+	 */
+	private static function top_advertisers( array $per_ad_rows, array $ads, array $per_ad_rev ): array {
+		$no_advertiser = __( '(no advertiser)', 'newspack-plugin' );
+		$groups        = [];
+		foreach ( $per_ad_rows as $row ) {
+			$ad_id      = $row['ad_id'];
+			$advertiser = $ads[ $ad_id ]['advertiser'] ?? self::first_advertiser_name( $ad_id );
+			if ( '' === $advertiser ) {
+				$advertiser = $no_advertiser;
+			}
+			if ( ! isset( $groups[ $advertiser ] ) ) {
+				$groups[ $advertiser ] = [
+					'advertiser'  => $advertiser,
+					'ads'         => 0,
+					'impressions' => 0,
+					'clicks'      => 0,
+					'revenue'     => null,
+				];
+			}
+			++$groups[ $advertiser ]['ads'];
+			$groups[ $advertiser ]['impressions'] += $row['impressions'];
+			$groups[ $advertiser ]['clicks']      += $row['clicks'];
+			if ( isset( $per_ad_rev[ $ad_id ] ) ) {
+				$groups[ $advertiser ]['revenue'] = round( ( $groups[ $advertiser ]['revenue'] ?? 0.0 ) + $per_ad_rev[ $ad_id ], 2 );
+			}
+		}
+		$out = [];
+		foreach ( $groups as $group ) {
+			$group['ctr'] = $group['impressions'] > 0 ? round( $group['clicks'] / $group['impressions'], 4 ) : null;
+			$out[]        = $group;
+		}
+		return self::rank_table( $out );
+	}
+
+	/**
+	 * By-newsletter table: stats grouped by source newsletter, excluding the
+	 * unknown-source sentinel (`newsletter_id` 0 — clicks that couldn't be
+	 * attributed to a send). Top {@see self::TABLE_ROW_LIMIT} by impressions.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array Table payload.
+	 */
+	private static function by_newsletter( string $start_date, string $end_date ): array {
+		global $wpdb;
+		$table = self::stats_table_name();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT newsletter_id, COUNT( DISTINCT ad_id ) AS ads, SUM( impressions ) AS impressions, SUM( clicks ) AS clicks FROM {$table} WHERE stat_date BETWEEN %s AND %s AND newsletter_id != %d GROUP BY newsletter_id",
+				$start_date,
+				$end_date,
+				self::UNKNOWN_NEWSLETTER_SENTINEL
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+		$out = [];
+		foreach ( (array) $rows as $row ) {
+			$newsletter_id = (int) $row['newsletter_id'];
+			$post          = get_post( $newsletter_id );
+			$impressions   = (int) $row['impressions'];
+			$clicks        = (int) $row['clicks'];
+			$out[]         = [
+				'newsletter_id' => $newsletter_id,
+				'title'         => $post ? get_the_title( $post ) : __( '(deleted)', 'newspack-plugin' ),
+				'sent_date'     => $post ? mysql2date( 'Y-m-d', $post->post_date, false ) : '',
+				'ads'           => (int) $row['ads'],
+				'impressions'   => $impressions,
+				'clicks'        => $clicks,
+				'ctr'           => $impressions > 0 ? round( $clicks / $impressions, 4 ) : null,
+			];
+		}
+		return self::rank_table( $out );
+	}
+
+	/*
+	 * Flat-over-flight revenue model
+	 */
+
+	/**
+	 * Prorate each ad's flat flight price over the report window.
+	 *
+	 * For each published ad with `price` > 0 and a valid flight
+	 * (start_date <= expiry_date, both present): daily_rate = price /
+	 * flight_days (inclusive), and the window earns daily_rate × the number
+	 * of flight days overlapping [start, end].
+	 *
+	 * Ads whose flight overlaps the window but that are missing price or
+	 * either date are EXCLUDED from revenue and counted in `excluded` (the
+	 * `revenue_excluded_ads` honesty signal). `active` counts every published
+	 * ad whose flight overlaps the window under the lenient rule: a missing
+	 * expiry is open-ended, a missing start means already started.
+	 *
+	 * @param array  $ads        Published-ad records.
+	 * @param string $start_date Window start (YYYY-MM-DD).
+	 * @param string $end_date   Window end (YYYY-MM-DD).
+	 * @return array{revenue:float,excluded:int,active:int,per_ad:array<int,float>}
+	 */
+	private static function flight_revenue( array $ads, string $start_date, string $end_date ): array {
+		$revenue  = 0.0;
+		$excluded = 0;
+		$active   = 0;
+		$per_ad   = [];
+
+		foreach ( $ads as $ad ) {
+			$flight_start = $ad['flight_start'];
+			$flight_end   = $ad['flight_end'];
+
+			// Lenient overlap (for active_ads / exclusion counting): missing
+			// start = already started; missing expiry = open-ended.
+			$overlaps = ( null === $flight_start || $flight_start <= $end_date )
+				&& ( null === $flight_end || $flight_end >= $start_date );
+			if ( $overlaps ) {
+				++$active;
+			}
+
+			$revenue_eligible = null !== $ad['price'] && $ad['price'] > 0
+				&& null !== $flight_start && null !== $flight_end
+				&& $flight_end >= $flight_start;
+			if ( ! $revenue_eligible ) {
+				if ( $overlaps ) {
+					++$excluded;
+				}
+				continue;
+			}
+
+			// Strict flight ∩ window overlap, in inclusive days. Y-m-d strings
+			// compare correctly lexicographically.
+			$overlap_start = max( $flight_start, $start_date );
+			$overlap_end   = min( $flight_end, $end_date );
+			if ( $overlap_start > $overlap_end ) {
+				continue;
+			}
+			$flight_days  = self::days_inclusive( $flight_start, $flight_end );
+			$overlap_days = self::days_inclusive( $overlap_start, $overlap_end );
+			if ( $flight_days <= 0 ) {
+				continue;
+			}
+			$share = ( $ad['price'] / $flight_days ) * $overlap_days;
+
+			$per_ad[ $ad['id'] ] = $share;
+			$revenue            += $share;
+		}
+
+		return [
+			'revenue'  => $revenue,
+			'excluded' => $excluded,
+			'active'   => $active,
+			'per_ad'   => $per_ad,
+		];
+	}
+
+	/**
+	 * Inclusive day count between two Y-m-d dates (same day = 1).
+	 *
+	 * @param string $from YYYY-MM-DD.
+	 * @param string $to   YYYY-MM-DD (>= $from).
+	 * @return int
+	 */
+	private static function days_inclusive( string $from, string $to ): int {
+		try {
+			$a = new \DateTimeImmutable( $from );
+			$b = new \DateTimeImmutable( $to );
+		} catch ( \Exception $e ) {
+			return 0;
+		}
+		return (int) $a->diff( $b )->format( '%a' ) + 1;
+	}
+
+	/*
+	 * Ad records
+	 */
+
+	/**
+	 * Load every published ad's fields once: flight meta (normalized), price,
+	 * lifetime counters, title, and first advertiser term. Real catalogs run
+	 * into the hundreds of ads, so the post/meta/term caches are primed for
+	 * the full ID set up front — the per-ad reads in the loop then hit cache
+	 * instead of issuing ~7 queries per ad.
+	 *
+	 * @return array<int,array> Records keyed by ad ID.
+	 */
+	private static function get_published_ads(): array {
+		if ( ! post_type_exists( self::ADS_CPT ) ) {
+			return [];
+		}
+		$ids = get_posts(
+			[
+				'post_type'   => self::ADS_CPT,
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			]
+		);
+		if ( ! empty( $ids ) ) {
+			// One query each for posts (titles), meta, and terms.
+			_prime_post_caches( $ids, false, false );
+			update_meta_cache( 'post', $ids );
+			if ( taxonomy_exists( self::ADVERTISER_TAX ) ) {
+				update_object_term_cache( $ids, self::ADS_CPT );
+			}
+		}
+		$ads = [];
+		foreach ( $ids as $id ) {
+			$id    = (int) $id;
+			$price = get_post_meta( $id, 'price', true );
+			$ads[ $id ] = [
+				'id'                   => $id,
+				'title'                => get_the_title( $id ),
+				'advertiser'           => self::first_advertiser_name( $id ),
+				'price'                => is_numeric( $price ) ? (float) $price : null,
+				'flight_start'         => self::normalize_date_meta( get_post_meta( $id, 'start_date', true ) ),
+				'flight_end'           => self::normalize_date_meta( get_post_meta( $id, 'expiry_date', true ) ),
+				'lifetime_impressions' => (int) get_post_meta( $id, 'tracking_impressions', true ),
+				'lifetime_clicks'      => (int) get_post_meta( $id, 'tracking_clicks', true ),
+			];
+		}
+		return $ads;
+	}
+
+	/**
+	 * First advertiser term name for an ad, or '' (taxonomy guarded — the
+	 * newsletters plugin registers it).
+	 *
+	 * @param int $ad_id Ad post ID.
+	 * @return string
+	 */
+	private static function first_advertiser_name( int $ad_id ): string {
+		if ( ! taxonomy_exists( self::ADVERTISER_TAX ) ) {
+			return '';
+		}
+		$terms = get_the_terms( $ad_id, self::ADVERTISER_TAX );
+		if ( ! is_array( $terms ) || empty( $terms ) ) {
+			return '';
+		}
+		return (string) $terms[0]->name;
+	}
+
+	/**
+	 * Normalize a date meta value to Y-m-d, or null when empty/unparseable.
+	 *
+	 * @param mixed $raw Raw meta value.
+	 * @return string|null
+	 */
+	private static function normalize_date_meta( $raw ): ?string {
+		if ( ! is_string( $raw ) && ! is_numeric( $raw ) ) {
+			return null;
+		}
+		$raw = trim( (string) $raw );
+		if ( '' === $raw ) {
+			return null;
+		}
+		try {
+			return ( new \DateTimeImmutable( $raw ) )->format( 'Y-m-d' );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+	}
+
+	/*
+	 * Payload helpers
+	 */
+
+	/**
+	 * Scalar count payload.
+	 *
+	 * @param int $value Value.
+	 * @return array
+	 */
+	private static function count_payload( int $value ): array {
+		return [
+			'value'      => $value,
+			'computable' => true,
+			'type'       => 'count',
+		];
+	}
+
+	/**
+	 * Rate payload — non-computable at a zero denominator (renders n/a,
+	 * never a fake 0%).
+	 *
+	 * @param int $numerator   Numerator.
+	 * @param int $denominator Denominator.
+	 * @return array
+	 */
+	private static function rate_payload( int $numerator, int $denominator ): array {
+		return [
+			'value'       => $denominator > 0 ? round( $numerator / $denominator, 4 ) : 0.0,
+			'computable'  => $denominator > 0,
+			'type'        => 'rate',
+			'numerator'   => $numerator,
+			'denominator' => $denominator,
+		];
+	}
+
+	/**
+	 * Rank a table by impressions (desc), falling back to clicks when no row
+	 * recorded an impression (pixel-disabled sites still get a meaningful
+	 * ranking), capped to {@see self::TABLE_ROW_LIMIT}.
+	 *
+	 * @param array $rows Rows (each with impressions + clicks keys).
+	 * @return array Table payload.
+	 */
+	private static function rank_table( array $rows ): array {
+		$by = array_sum( array_column( $rows, 'impressions' ) ) > 0 ? 'impressions' : 'clicks';
+		usort(
+			$rows,
+			function ( $a, $b ) use ( $by ) {
+				return ( $b[ $by ] ?? 0 ) <=> ( $a[ $by ] ?? 0 );
+			}
+		);
+		$rows = array_slice( $rows, 0, self::TABLE_ROW_LIMIT );
+		return [
+			'rows'       => $rows,
+			'computable' => ! empty( $rows ),
+			'type'       => 'table',
+		];
+	}
+
+	/**
+	 * Immediately-preceding window of equal length.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string[] [ prior_start, prior_end ].
+	 */
+	private static function prior_period( string $start_date, string $end_date ): array {
+		$start       = new \DateTimeImmutable( $start_date );
+		$end         = new \DateTimeImmutable( $end_date );
+		$days        = (int) $start->diff( $end )->format( '%a' ) + 1;
+		$prior_end   = $start->modify( '-1 day' );
+		$prior_start = $prior_end->modify( '-' . ( $days - 1 ) . ' days' );
+		return [ $prior_start->format( 'Y-m-d' ), $prior_end->format( 'Y-m-d' ) ];
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/api/newsletter_ads.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/newsletter_ads.ts
@@ -1,0 +1,133 @@
+/**
+ * Newsletter Ads API client (NPPD-1861).
+ *
+ * Thin wrapper around `@wordpress/api-fetch` for the Newsletter Ads endpoint:
+ * `GET /newspack-insights/v1/newsletter-ads`. Mirrors {@see api/advertising}:
+ * the orchestrator returns the same rich per-window envelope — each of
+ * `current` / `previous` carries the visibility / readiness / data-lag signals
+ * alongside the keyed `metrics` map.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import type { MetricPayload } from '../tabs/components/metrics';
+import { type CachedEnvelope } from '../state/insightsCache';
+
+/** A window of metrics keyed by metric name. */
+export type InsightsWindow = Record< string, MetricPayload >;
+
+/** A single readiness reason from the orchestrator. */
+export interface ReadinessIssue {
+	code: string;
+	message: string;
+	remediation_url: string;
+}
+
+/** Row shape of the `top_ads` table payload. */
+export interface TopAdRow {
+	ad_id: string | number;
+	title: string;
+	advertiser: string;
+	impressions: number;
+	clicks: number;
+	ctr: number | null;
+	revenue: number | null;
+}
+
+/** Row shape of the `top_advertisers` table payload. */
+export interface TopAdvertiserRow {
+	advertiser: string;
+	ads: number;
+	impressions: number;
+	clicks: number;
+	ctr: number | null;
+	revenue: number | null;
+}
+
+/** Row shape of the `by_newsletter` table payload. */
+export interface ByNewsletterRow {
+	newsletter_id: string | number;
+	title: string;
+	sent_date: string;
+	ads: number;
+	impressions: number;
+	clicks: number;
+	ctr: number | null;
+}
+
+/**
+ * One window's full Newsletter Ads envelope (the orchestrator's `get_all()`
+ * shape). Same wrapper as Advertising: visibility and readiness are distinct
+ * signals; unlike Advertising, the lifetime counters (`lifetime_impressions` /
+ * `lifetime_clicks` / `lifetime_ctr`) resolve even when `is_report_ready` is
+ * false, so a not-ready tab still has an all-time story to tell.
+ */
+export interface NewsletterAdsWindow {
+	window?: { start: string; end: string };
+	is_tab_visible: boolean;
+	is_report_ready: boolean;
+	readiness_issues: ReadinessIssue[];
+	data_as_of?: string;
+	metrics: InsightsWindow;
+	/** Always false for newsletter ads (no async report); kept for envelope parity. */
+	is_loading?: boolean;
+	/**
+	 * Derived empty-state signal: `false` only on a resolved window with zero
+	 * timeframe ad activity. The OverviewSection reads `=== false` so an absent
+	 * value (loading / errored metric) never collapses the section.
+	 */
+	has_window_activity?: boolean;
+}
+
+export interface NewsletterAdsResponse {
+	current?: NewsletterAdsWindow;
+	previous?: NewsletterAdsWindow | null;
+}
+
+export interface InsightsQuery {
+	start: string;
+	end: string;
+	compare_start?: string;
+	compare_end?: string;
+}
+
+const ENDPOINT = '/newspack-insights/v1/newsletter-ads';
+
+const queryString = ( query: InsightsQuery ): string => {
+	const params = new URLSearchParams();
+	params.set( 'start', query.start );
+	params.set( 'end', query.end );
+	if ( query.compare_start && query.compare_end ) {
+		params.set( 'compare_start', query.compare_start );
+		params.set( 'compare_end', query.compare_end );
+	}
+	// Forward the `_fixture_state` URL param so fixture mode's render variants are
+	// reachable from the UI for smoke testing — matching the advertising tab. A
+	// no-op in production: the server ignores it unless
+	// NEWSPACK_INSIGHTS_FIXTURE_MODE is enabled.
+	if ( typeof window !== 'undefined' ) {
+		const fixtureState = new URLSearchParams( window.location.search ).get( '_fixture_state' );
+		if ( fixtureState ) {
+			params.set( '_fixture_state', fixtureState );
+		}
+	}
+	return params.toString();
+};
+
+export const fetchNewsletterAdsData = async ( query: InsightsQuery ): Promise< CachedEnvelope< NewsletterAdsResponse > > =>
+	apiFetch< CachedEnvelope< NewsletterAdsResponse > >( {
+		path: `${ ENDPOINT }?${ queryString( query ) }`,
+		method: 'GET',
+	} );
+
+export const refreshNewsletterAdsData = async ( query: InsightsQuery ): Promise< CachedEnvelope< NewsletterAdsResponse > > =>
+	apiFetch< CachedEnvelope< NewsletterAdsResponse > >( {
+		path: `${ ENDPOINT }/refresh?${ queryString( query ) }`,
+		method: 'POST',
+	} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -37,7 +37,7 @@ import useComparisonMode from '../state/useComparisonMode';
 import useDateRange, { type DateRange } from '../state/useDateRange';
 import { RefreshRegistryProvider } from '../state/refreshRegistry';
 
-export type TabKey = 'audience' | 'engagement' | 'conversion' | 'gates' | 'prompts' | 'subscribers' | 'donors' | 'advertising';
+export type TabKey = 'audience' | 'engagement' | 'conversion' | 'gates' | 'prompts' | 'subscribers' | 'donors' | 'advertising' | 'newsletter_ads';
 
 export interface TabDef {
 	key: TabKey;
@@ -61,6 +61,7 @@ export const ALL_TABS: TabDef[] = [
 	{ key: 'subscribers', label: __( 'Subscribers', 'newspack-plugin' ) },
 	{ key: 'donors', label: __( 'Donors', 'newspack-plugin' ) },
 	{ key: 'advertising', label: __( 'Advertising', 'newspack-plugin' ) },
+	{ key: 'newsletter_ads', label: __( 'Newsletter Ads', 'newspack-plugin' ) },
 ];
 
 export type TabVisibility = Record< TabKey, boolean >;
@@ -110,6 +111,7 @@ const PromptsTab = lazy( () => import( '../tabs/PromptsTab' ) );
 const SubscribersTab = lazy( () => import( '../tabs/SubscribersTab' ) );
 const DonorsTab = lazy( () => import( '../tabs/DonorsTab' ) );
 const AdvertisingTab = lazy( () => import( '../tabs/AdvertisingTab' ) );
+const NewsletterAdsTab = lazy( () => import( '../tabs/NewsletterAdsTab' ) );
 
 /**
  * Props every tab component receives. Exported so each tab module can
@@ -181,6 +183,8 @@ const renderTabComponent = ( tabKey: TabKey, sectionProps: TabSectionProps ): Re
 			return <DonorsTab { ...sectionProps } />;
 		case 'advertising':
 			return <AdvertisingTab { ...sectionProps } />;
+		case 'newsletter_ads':
+			return <NewsletterAdsTab { ...sectionProps } />;
 		default:
 			return null;
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/useNewsletterAdsData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/useNewsletterAdsData.ts
@@ -1,0 +1,70 @@
+/**
+ * useNewsletterAdsData (NPPD-1861).
+ *
+ * Thin reader over the module insightsCache, mirroring
+ * {@see useAdvertisingData}. The slot key embeds the date range + comparison
+ * window so cross-tab/date state stays coherent.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useSyncExternalStore } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+import { fetchNewsletterAdsData, refreshNewsletterAdsData, type NewsletterAdsResponse } from '../api/newsletter_ads';
+import { insightsCache, makeSlotKey } from '../state/insightsCache';
+import { useRegisterRefresh } from '../state/refreshRegistry';
+
+export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UseNewsletterAdsDataResult {
+	status: FetchStatus;
+	data: NewsletterAdsResponse | null;
+	error: string | null;
+	refetch: () => void;
+	computedAt: string | null;
+	source: 'bigquery' | 'external' | 'local' | null;
+	cooldownUntil: string | null;
+}
+
+const queryFrom = ( range: DateRange, previousRange: DateRange | null ) => ( {
+	start: range.start,
+	end: range.end,
+	compare_start: previousRange?.start,
+	compare_end: previousRange?.end,
+} );
+
+const useNewsletterAdsData = ( range: DateRange, previousRange: DateRange | null ): UseNewsletterAdsDataResult => {
+	const key = makeSlotKey( 'newsletter_ads', range, previousRange );
+
+	const slot = useSyncExternalStore(
+		listener => insightsCache.subscribe( key, listener ),
+		() => insightsCache.getSlot< NewsletterAdsResponse >( key )
+	);
+
+	useEffect( () => {
+		insightsCache.ensureFetched( key, () => fetchNewsletterAdsData( queryFrom( range, previousRange ) ) );
+	}, [ key, range.start, range.end, previousRange?.start, previousRange?.end ] );
+
+	const refetch = useCallback( () => {
+		insightsCache.refresh( key, () => refreshNewsletterAdsData( queryFrom( range, previousRange ) ) );
+	}, [ key, range.start, range.end, previousRange?.start, previousRange?.end ] );
+
+	useRegisterRefresh( 'newsletter_ads', refetch );
+
+	return {
+		status: slot.status,
+		data: slot.data,
+		error: slot.error,
+		refetch,
+		computedAt: slot.computedAt,
+		source: slot.source,
+		cooldownUntil: slot.cooldownUntil,
+	};
+};
+
+export default useNewsletterAdsData;

--- a/plugins/newspack-plugin/src/wizards/insights/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/index.tsx
@@ -28,6 +28,7 @@ const FALLBACK_CONFIG: InsightsBootConfig = {
 		subscribers: true,
 		donors: true,
 		advertising: true,
+		newsletter_ads: true,
 	},
 	defaultDateRange: ( () => {
 		const pad = ( n: number ) => String( n ).padStart( 2, '0' );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tab-level tests for NewsletterAdsTab (NPPD-1861): the visibility gate, the
+ * not-ready inline-notice behavior (lifetime section still renders — the
+ * deliberate divergence from AdvertisingTab), and the ready / error states.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import NewsletterAdsTab from './NewsletterAdsTab';
+import useNewsletterAdsData from '../hooks/useNewsletterAdsData';
+import type { DateRange } from '../state/useDateRange';
+import type { NewsletterAdsWindow } from '../api/newsletter_ads';
+
+jest.mock( '../hooks/useNewsletterAdsData' );
+
+const mockHook = useNewsletterAdsData as jest.Mock;
+const range = { start: '2026-06-01', end: '2026-06-30', preset: 'last-30' } as unknown as DateRange;
+
+const readyMetrics: NewsletterAdsWindow[ 'metrics' ] = {
+	lifetime_impressions: { value: 950000, computable: true, type: 'count' },
+	lifetime_clicks: { value: 12400, computable: true, type: 'count' },
+	lifetime_ctr: { value: 0.013, computable: true, type: 'rate', numerator: 12400, denominator: 950000 },
+	total_impressions: { value: 84000, computable: true, type: 'count' },
+	total_clicks: { value: 1200, computable: true, type: 'count' },
+	ctr: { value: 0.0143, computable: true, type: 'rate', numerator: 1200, denominator: 84000 },
+	total_revenue: { value: 4200, computable: true, type: 'currency' },
+	ecpm: { value: 50, computable: true, type: 'currency' },
+	active_ads: { value: 7, computable: true, type: 'count' },
+	revenue_excluded_ads: { value: 0, computable: true, type: 'count' },
+	performance_by_day: {
+		type: 'timeseries',
+		computable: true,
+		rows: [
+			{ date: '2026-06-01', impressions: 4000, clicks: 60 },
+			{ date: '2026-06-02', impressions: 4400, clicks: 66 },
+		],
+	},
+	top_ads: {
+		type: 'table',
+		computable: true,
+		rows: [ { ad_id: 12, title: 'Summer Sale', advertiser: 'Acme Hardware', impressions: 40000, clicks: 600, ctr: 0.015, revenue: 2100 } ],
+	},
+	top_advertisers: {
+		type: 'table',
+		computable: true,
+		rows: [ { advertiser: 'Acme Hardware', ads: 3, impressions: 60000, clicks: 800, ctr: 0.0133, revenue: 3000 } ],
+	},
+	by_newsletter: {
+		type: 'table',
+		computable: true,
+		rows: [ { newsletter_id: 991, title: 'Weekly Digest', sent_date: '2026-06-02', ads: 2, impressions: 8400, clicks: 120, ctr: 0.0143 } ],
+	},
+};
+
+const baseWindow = ( overrides: Partial< NewsletterAdsWindow > = {} ): NewsletterAdsWindow => ( {
+	is_tab_visible: true,
+	is_report_ready: true,
+	readiness_issues: [],
+	data_as_of: '2026-06-29',
+	has_window_activity: true,
+	is_loading: false,
+	metrics: readyMetrics,
+	...overrides,
+} );
+
+const mockData = ( current: NewsletterAdsWindow ) =>
+	mockHook.mockReturnValue( {
+		status: 'success',
+		data: { current, previous: null },
+		error: null,
+		refetch: () => {},
+		computedAt: null,
+		source: null,
+		cooldownUntil: null,
+	} );
+
+describe( 'NewsletterAdsTab', () => {
+	afterEach( () => {
+		mockHook.mockReset();
+	} );
+
+	it( 'renders nothing when the tab is not visible', () => {
+		mockData( baseWindow( { is_tab_visible: false } ) );
+		const { container } = render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'still renders the Overview (lifetime cards) with an inline notice when the report is not ready', () => {
+		// Mirror the real not-ready envelope: the orchestrator still emits every
+		// timeframe metric with `computable: false` (so the Overview renders N/A
+		// cards) and OMITS `has_window_activity` entirely.
+		const notReadyWindow = baseWindow( {
+			is_report_ready: false,
+			readiness_issues: [
+				{
+					code: 'newsletter_ads_stats_missing',
+					message: 'Newsletter ad statistics have not been recorded yet.',
+					remediation_url: 'http://example.test/newsletter-ads',
+				},
+			],
+			metrics: {
+				lifetime_impressions: { value: 950000, computable: true, type: 'count' },
+				lifetime_clicks: { value: 12400, computable: true, type: 'count' },
+				lifetime_ctr: { value: 0.013, computable: true, type: 'rate', numerator: 12400, denominator: 950000 },
+				total_impressions: { value: 0, computable: false, type: 'count' },
+				total_clicks: { value: 0, computable: false, type: 'count' },
+				ctr: { value: 0, computable: false, type: 'rate', numerator: 0, denominator: 0 },
+				total_revenue: { value: 0, computable: false, type: 'currency' },
+				ecpm: { value: 0, computable: false, type: 'currency' },
+				active_ads: { value: 0, computable: false, type: 'count' },
+				revenue_excluded_ads: { value: 0, computable: false, type: 'count' },
+				performance_by_day: { type: 'timeseries', computable: false, rows: [] },
+				top_ads: { type: 'table', computable: false, rows: [] },
+				top_advertisers: { type: 'table', computable: false, rows: [] },
+				by_newsletter: { type: 'table', computable: false, rows: [] },
+			},
+		} );
+		delete notReadyWindow.has_window_activity;
+		mockData( notReadyWindow );
+		render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+
+		// The inline notice carries the readiness issue…
+		expect( screen.getByText( 'Finish setting up newsletter ad tracking to see timeframe data' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter ad statistics have not been recorded yet.' ) ).toBeInTheDocument();
+		// …but — unlike AdvertisingTab — the tab body is NOT replaced: the Overview
+		// section renders with the all-time lifetime cards.
+		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'All-time impressions' ) ).toBeInTheDocument();
+		expect( screen.getByText( '950,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( '12,400' ) ).toBeInTheDocument();
+		// The non-computable timeframe cards render the em-dash treatment with the
+		// remediation copy — never fake zeros.
+		expect( screen.getAllByText( 'Requires the latest Newspack Newsletters plugin.' ).length ).toBeGreaterThan( 0 );
+		// The timeframe-scoped sections stay withheld…
+		expect( screen.queryByText( 'Performance trend' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top performers' ) ).not.toBeInTheDocument();
+		// …and the absent has_window_activity signal must NOT collapse the
+		// Overview into the empty state (the lifetime cards carry the signal).
+		expect( document.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the tracking-disabled issue as an informational notice without withholding any section', () => {
+		mockData(
+			baseWindow( {
+				readiness_issues: [
+					{
+						code: 'newsletter_ads_tracking_disabled',
+						message: 'Newsletter ad tracking is currently disabled.',
+						remediation_url: 'http://example.test/settings',
+					},
+				],
+			} )
+		);
+		render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'Newsletter ad tracking is currently disabled.' ) ).toBeInTheDocument();
+		// Not presented as a "finish connecting" blocker…
+		expect( screen.queryByText( 'Finish setting up newsletter ad tracking to see timeframe data' ) ).not.toBeInTheDocument();
+		// …and every section still renders.
+		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top performers' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders all sections with values when ready', () => {
+		mockData( baseWindow() );
+		render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+
+		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( '84,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$4,200' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Summer Sale' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Weekly Digest' ) ).toBeInTheDocument();
+		// No "About this data / data as of" callout: this tab reads local data
+		// with no lag, so the indicator was deliberately removed (NPPD-1861).
+		expect( screen.queryByText( /Data as of/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /About this data/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'collapses the Overview to no_opportunity on a resolved ready window with no activity', () => {
+		mockData(
+			baseWindow( {
+				has_window_activity: false,
+				metrics: {
+					...readyMetrics,
+					total_impressions: { value: 0, computable: true, type: 'count' },
+					total_clicks: { value: 0, computable: true, type: 'count' },
+				},
+			} )
+		);
+		const { container } = render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'No newsletter ad activity in this timeframe' );
+	} );
+
+	it( 'shows the error state with detail when the fetch fails', () => {
+		mockHook.mockReturnValue( {
+			status: 'error',
+			data: null,
+			error: 'HTTP 500',
+			refetch: () => {},
+			computedAt: null,
+			source: null,
+			cooldownUntil: null,
+		} );
+		render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+		expect( screen.getByText( 'Could not load newsletter ads data.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'HTTP 500' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the initial loading state before any data arrives', () => {
+		mockHook.mockReturnValue( {
+			status: 'loading',
+			data: null,
+			error: null,
+			refetch: () => {},
+			computedAt: null,
+			source: null,
+			cooldownUntil: null,
+		} );
+		render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
+		expect( screen.getByText( 'Loading…' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.tsx
@@ -1,0 +1,127 @@
+/**
+ * NewsletterAdsTab (NPPD-1861).
+ *
+ * Newsletter Ads tab. Fetches the newsletter-ads orchestrator endpoint and
+ * renders three sections. Lifecycle mirrors {@see AdvertisingTab} with one
+ * deliberate difference: `is_report_ready: false` does NOT replace the whole
+ * tab with a diagnostic. The lifetime counters (all-time impressions / clicks)
+ * resolve without the per-send stats table, so a not-ready tab still renders
+ * the Overview section — with an inline notice built from `readiness_issues` —
+ * and only the timeframe-scoped Trend / Tables sections are withheld.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Notice, Button } from '../../../../packages/components/src';
+import type { DateRange } from '../state/useDateRange';
+import useNewsletterAdsData from '../hooks/useNewsletterAdsData';
+import LastUpdated from '../components/LastUpdated';
+import TabStateView from './components/TabStateView';
+import FinishConnectingDiagnostic from './components/FinishConnectingDiagnostic';
+import OverviewSection from './newsletter_ads/sections/OverviewSection';
+import TrendSection from './newsletter_ads/sections/TrendSection';
+import TablesSection from './newsletter_ads/sections/TablesSection';
+
+import './newsletter_ads/newsletter-ads.scss';
+
+export interface NewsletterAdsTabProps {
+	range: DateRange;
+	previousRange: DateRange | null;
+}
+
+/**
+ * Informational-only readiness codes: surfaced as an info notice but never
+ * presented as a "finish connecting" blocker (they don't gate any section).
+ */
+const INFORMATIONAL_ISSUE_CODES = [ 'newsletter_ads_tracking_disabled' ];
+
+const NewsletterAdsTab = ( { range, previousRange }: NewsletterAdsTabProps ) => {
+	const { status, data, error } = useNewsletterAdsData( range, previousRange );
+	const current = data?.current;
+
+	// Tab visibility gate precedes the standard data lifecycle. Guarded by
+	// `current` (skipped on initial load) and by `status` so a fetch error still
+	// routes through TabStateView's error frame rather than being masked.
+	if ( status !== 'error' && current && ! current.is_tab_visible ) {
+		return null;
+	}
+
+	// Only surface comparison deltas when the toggle is on (previousRange set).
+	// Fixture mode returns a `previous` window unconditionally, so gate here.
+	const previous = previousRange ? data?.previous?.metrics ?? null : null;
+
+	const issues = current?.readiness_issues ?? [];
+	const infoIssues = issues.filter( issue => INFORMATIONAL_ISSUE_CODES.includes( issue.code ) );
+	const blockingIssues = issues.filter( issue => ! INFORMATIONAL_ISSUE_CODES.includes( issue.code ) );
+	const isReportReady = !! current?.is_report_ready;
+
+	return (
+		<TabStateView
+			status={ status }
+			hasData={ !! current }
+			error={ error }
+			errorLabel={ __( 'Could not load newsletter ads data.', 'newspack-plugin' ) }
+			className="newspack-insights__newsletter-ads-tab"
+		>
+			{ current && (
+				<>
+					{ /* No DataLagIndicator here: this tab reads local data with no lag,
+					     so an "About this data / data as of" callout is noise. */ }
+					{ /* Deliberate divergence from AdvertisingTab: readiness issues render as
+					     an INLINE notice above the Overview section instead of replacing the
+					     tab — the all-time cards below carry real signal without the stats
+					     table (e.g. `newsletter_ads_stats_missing`). */ }
+					{ ! isReportReady && blockingIssues.length > 0 && (
+						<FinishConnectingDiagnostic
+							heading={ __( 'Finish setting up newsletter ad tracking to see timeframe data', 'newspack-plugin' ) }
+							issues={ blockingIssues }
+						/>
+					) }
+					{ /* Informational notices (e.g. tracking disabled) — shown regardless of
+					     readiness, never gating a section. */ }
+					{ infoIssues.map( issue => (
+						<Notice key={ issue.code } className="newspack-insights__newsletter-ads-info-notice" noticeText={ issue.message }>
+							{ issue.remediation_url && (
+								<Button
+									variant="link"
+									href={ issue.remediation_url }
+									aria-label={ sprintf(
+										/* translators: %s: the readiness issue being remediated. */
+										__( 'Fix: %s', 'newspack-plugin' ),
+										issue.message
+									) }
+								>
+									{ __( 'Fix this →', 'newspack-plugin' ) }
+								</Button>
+							) }
+						</Notice>
+					) ) }
+					<OverviewSection
+						current={ current.metrics }
+						previous={ previous }
+						// The whole-section empty collapse only applies to a resolved report:
+						// while not ready, the lifetime cards must stay on screen, so the
+						// signal is withheld (undefined never collapses).
+						hasWindowActivity={ isReportReady ? current.has_window_activity : undefined }
+						lastUpdated={ <LastUpdated tab="newsletter_ads" range={ range } previousRange={ previousRange } /> }
+					/>
+					{ /* Timeframe-scoped sections need the stats table; withheld until ready. */ }
+					{ isReportReady && (
+						<>
+							<TrendSection current={ current.metrics } previous={ previous } />
+							<TablesSection current={ current.metrics } />
+						</>
+					) }
+				</>
+			) }
+		</TabStateView>
+	);
+};
+
+export default NewsletterAdsTab;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/advertising.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/advertising.scss
@@ -3,32 +3,14 @@
  *
  * Reuses the shared chart / table / grid / failure-state chrome from the
  * components partial (the `.newspack-insights__advertising-tab` wrapper gap is
- * defined there alongside audience/engagement). This file adds the two new
- * shared components introduced for Tab 8 — FinishConnectingDiagnostic and
- * DataLagIndicator — whose only consumer today is this tab.
+ * defined there alongside audience/engagement).
  */
 
 @use "../components/insights-charts";
 
-// "Finish connecting" diagnostic: chrome comes from the shared Notice component;
-// these rules only structure the itemized list of readiness issues inside it.
-.newspack-insights__finish-connecting {
-	&-list {
-		list-style: none;
-		margin: 8px 0 0;
-		padding: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	&-item {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 8px 16px;
-	}
-}
+// The "Finish connecting" diagnostic (FinishConnectingDiagnostic) styles moved
+// to the shared components/_insights-charts.scss partial when the Newsletter
+// Ads tab became its second consumer (NPPD-1861).
 
 // The data-lag note now renders via the shared `.newspack-insights__info-callout`
 // (components/_insights-charts.scss) — see DataLagIndicator / InfoCallout.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -796,10 +796,34 @@
 // butting against the previous one (NPPD-1649 fix #2).
 .newspack-insights__audience-tab,
 .newspack-insights__engagement-tab,
-.newspack-insights__advertising-tab {
+.newspack-insights__advertising-tab,
+.newspack-insights__newsletter-ads-tab {
 	display: flex;
 	flex-direction: column;
 	gap: 32px;
+}
+
+// "Finish connecting" diagnostic (FinishConnectingDiagnostic): chrome comes
+// from the shared Notice component; these rules only structure the itemized
+// list of readiness issues inside it. Shared by the Advertising and Newsletter
+// Ads tabs (moved here from advertising.scss when the second consumer arrived,
+// NPPD-1861).
+.newspack-insights__finish-connecting {
+	&-list {
+		list-style: none;
+		margin: 8px 0 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	&-item {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 8px 16px;
+	}
 }
 
 // Shared refetch chrome for every data tab (Audience, Engagement, Gates,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
@@ -125,13 +125,15 @@ export const payloadToCard = ( args: PayloadToCardArgs ): MetricCardProps | null
 	if ( current.not_configured ) {
 		return { label, description, notConfigured: true };
 	}
-	// Incalculable percentage (NEWS-2593): a populated rate with no population to
-	// divide from (`computable === false`, e.g. Completion Rate on a site that
-	// emits no scroll events) carries no signal. Render MetricCard's em-dash hero +
-	// explanatory line rather than a misleading `0%`. Scoped to rate format so
-	// count/currency/decimal good-zeros keep their real `0`. A generic fallback
-	// guarantees the em-dash even if a call site omits its per-metric copy.
-	if ( current.computable === false && current.type === 'rate' ) {
+	// Incalculable metric (NEWS-2593, NPPD-1861): a payload with
+	// `computable === false` carries no signal — render MetricCard's em-dash hero +
+	// explanatory line rather than a misleading `0%`/`$0.00`. Rates always get this
+	// treatment (with a generic fallback message, so a call site omitting its
+	// per-metric copy still avoids a fake `0%`). Other types (count/currency/
+	// decimal) get it only when the call site passes an explicit
+	// `notComputableMessage` — an intentional opt-in, so good-zeros on cards that
+	// never emit `computable: false` keep rendering their real `0`.
+	if ( current.computable === false && ( current.type === 'rate' || notComputableMessage ) ) {
 		return {
 			label,
 			description,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/newsletter-ads.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/newsletter-ads.scss
@@ -1,0 +1,12 @@
+/**
+ * Newsletter Ads tab (Tab 9, NPPD-1861) styles.
+ *
+ * No tab-specific rules yet — this file exists to pull the shared chart /
+ * table / grid / failure-state chrome into the tab's lazy-loaded chunk (tabs
+ * load their styles with their chunk, so relying on another tab having been
+ * visited first leaves this one unstyled on deep links). The
+ * `.newspack-insights__newsletter-ads-tab` wrapper gap and the
+ * FinishConnectingDiagnostic rules live in the partial.
+ */
+
+@use "../components/insights-charts";

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for the Newsletter Ads OverviewSection (NPPD-1861): scorecard render,
+ * the non-computable CTR em-dash treatment (never "0%"), the excluded-ads
+ * footnote, the delta-less lifetime cards, and the no_opportunity collapse.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import OverviewSection from './OverviewSection';
+import type { InsightsWindow } from '../../../api/newsletter_ads';
+const metrics = ( over: InsightsWindow = {} ): InsightsWindow => ( {
+	lifetime_impressions: { value: 950000, computable: true, type: 'count' },
+	lifetime_clicks: { value: 12400, computable: true, type: 'count' },
+	total_impressions: { value: 84000, computable: true, type: 'count' },
+	total_clicks: { value: 1200, computable: true, type: 'count' },
+	ctr: { value: 0.0143, computable: true, type: 'rate', numerator: 1200, denominator: 84000 },
+	total_revenue: { value: 4200, computable: true, type: 'currency' },
+	ecpm: { value: 50, computable: true, type: 'currency' },
+	active_ads: { value: 7, computable: true, type: 'count' },
+	revenue_excluded_ads: { value: 0, computable: true, type: 'count' },
+	...over,
+} );
+
+/** Locate a MetricCard by its label. */
+const cardByLabel = ( container: HTMLElement, label: string ) =>
+	Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
+		.find( el => el.textContent === label )
+		?.closest( '.newspack-insights__metric-card' );
+
+describe( 'OverviewSection', () => {
+	it( 'renders the timeframe scorecards and the all-time cards', () => {
+		const { container } = render( <OverviewSection current={ metrics() } previous={ null } hasWindowActivity /> );
+
+		expect( screen.getByText( 'Impressions' ) ).toBeInTheDocument();
+		expect( screen.getByText( '84,000' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Clicks' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$4,200' ) ).toBeInTheDocument();
+		expect( screen.getByText( '$50.00' ) ).toBeInTheDocument(); // eCPM keeps cents below $1K.
+		expect( screen.getByText( '1.4%' ) ).toBeInTheDocument(); // CTR as a percent.
+		// All-time cards, clearly labeled, values from the lifetime counters.
+		expect( cardByLabel( container, 'All-time impressions' ) ).toHaveTextContent( '950,000' );
+		expect( cardByLabel( container, 'All-time clicks' ) ).toHaveTextContent( '12,400' );
+	} );
+
+	it( 'never renders a delta on the lifetime cards, even under comparison', () => {
+		const previous = metrics( { total_impressions: { value: 70000, computable: true, type: 'count' } } );
+		const { container } = render( <OverviewSection current={ metrics() } previous={ previous } hasWindowActivity /> );
+
+		// The timeframe impressions card compares normally…
+		expect( cardByLabel( container, 'Impressions' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).not.toBeNull();
+		// …but the cumulative all-time cards never carry a delta.
+		expect( cardByLabel( container, 'All-time impressions' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+		expect( cardByLabel( container, 'All-time clicks' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+	} );
+
+	it( 'renders the em-dash treatment for a non-computable CTR — never 0%', () => {
+		const current = metrics( { ctr: { value: null, computable: false, type: 'rate', numerator: 0, denominator: 0 } } );
+		const { container } = render( <OverviewSection current={ current } previous={ null } hasWindowActivity /> );
+
+		const ctrCard = cardByLabel( container, 'CTR' );
+		expect( ctrCard ).toBeTruthy();
+		expect( ctrCard?.querySelector( '.newspack-insights__metric-card-na' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No impressions in this timeframe to calculate a click-through rate.' ) ).toBeInTheDocument();
+		expect( ctrCard ).not.toHaveTextContent( '0%' );
+	} );
+
+	it( 'renders the em-dash treatment for a non-computable eCPM — never $0.00', () => {
+		// The Austin-shaped window: clicks exist, impressions are zero, so the
+		// eCPM division is undefined. Currency cards opt in to the em-dash
+		// treatment via an explicit notComputableMessage (NPPD-1861).
+		const current = metrics( { ecpm: { value: 0, computable: false, type: 'currency' } } );
+		const { container } = render( <OverviewSection current={ current } previous={ null } hasWindowActivity /> );
+
+		const ecpmCard = cardByLabel( container, 'eCPM' );
+		expect( ecpmCard ).toBeTruthy();
+		expect( ecpmCard?.querySelector( '.newspack-insights__metric-card-na' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Requires both revenue and impressions in this timeframe to calculate.' ) ).toBeInTheDocument();
+		expect( ecpmCard ).not.toHaveTextContent( '$0.00' );
+	} );
+
+	it( 'shows the excluded-ads footnote when revenue_excluded_ads > 0', () => {
+		const current = metrics( { revenue_excluded_ads: { value: 3, computable: true, type: 'count' } } );
+		render( <OverviewSection current={ current } previous={ null } hasWindowActivity /> );
+
+		expect( screen.getByText( '3 ads excluded from revenue (missing price or flight dates)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the excluded-ads footnote at zero', () => {
+		render( <OverviewSection current={ metrics() } previous={ null } hasWindowActivity /> );
+		expect( screen.queryByText( /excluded from revenue/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'collapses to a no_opportunity EmptyMetricSection when hasWindowActivity is false', () => {
+		const { container } = render( <OverviewSection current={ metrics() } previous={ null } hasWindowActivity={ false } /> );
+
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'No newsletter ad activity in this timeframe' );
+		expect( screen.queryByText( '84,000' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does NOT collapse while the signal is absent (loading / not ready)', () => {
+		const { container } = render( <OverviewSection current={ metrics() } previous={ null } hasWindowActivity={ undefined } /> );
+		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '84,000' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
@@ -1,0 +1,163 @@
+/**
+ * Newsletter Ads › Overview (NPPD-1861).
+ *
+ * Headline scorecards: a timeframe row (impressions / clicks / CTR / revenue)
+ * and a second row mixing timeframe (eCPM, active ads) with the two clearly
+ * labeled all-time cards driven by the lifetime counters. The lifetime cards
+ * are cumulative, so they never carry a previous window or delta — a
+ * period-over-period arrow on an ever-growing counter would always read "up".
+ *
+ * Empty state mirrors Advertising's ReachRevenueSection (NPPD-1697): a
+ * whole-section `EmptyMetricSection` (`no_opportunity`) when the resolved
+ * report saw no timeframe ad activity (`hasWindowActivity === false`). The tab
+ * withholds the signal while the report isn't ready, so the all-time cards
+ * survive the not-ready state.
+ */
+
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { InsightsWindow } from '../../../api/newsletter_ads';
+import EmptyMetricSection from '../../components/EmptyMetricSection';
+import Scorecard from '../../components/Scorecard';
+import SectionHeading from '../../components/SectionHeading';
+
+export interface SectionProps {
+	current: InsightsWindow;
+	previous: InsightsWindow | null;
+	/**
+	 * Derived server signal: `false` only on a resolved window with zero
+	 * newsletter ad activity. Absent while loading, on an errored metric, or —
+	 * per the tab — while the report isn't ready (the all-time cards must stay).
+	 */
+	hasWindowActivity?: boolean;
+	lastUpdated?: ReactNode;
+}
+
+// Scope-neutral heading matching Advertising's ReachRevenueSection: this
+// section mixes timeframe cards with the two all-time cards, so a windowed
+// "In the last N days" heading would sit above cards it doesn't describe. The
+// page-level date picker carries the timeframe.
+const TITLE = __( 'Reach & revenue', 'newspack-plugin' );
+const CAPTION = __( 'Newsletter ad volume and revenue, plus all-time totals.', 'newspack-plugin' );
+// Timeframe metrics are non-computable only when dated ad tracking is
+// unavailable (the not-ready state) — mirror the diagnostic's remediation.
+const NOT_TRACKED_MESSAGE = __( 'Requires the latest Newspack Newsletters plugin.', 'newspack-plugin' );
+
+const OverviewSection = ( { current, previous, hasWindowActivity, lastUpdated }: SectionProps ) => {
+	// Whole-section empty: the report resolved with no ad activity. Strict
+	// `=== false` so the absent-while-loading / absent-on-error / not-ready
+	// cases fall through to the normal render.
+	if ( hasWindowActivity === false ) {
+		return (
+			<EmptyMetricSection
+				title={ TITLE }
+				caption={ CAPTION }
+				state="no_opportunity"
+				body={ __(
+					'No newsletter ad activity in this timeframe. Ad tracking is set up, but no impressions were recorded for this timeframe. Could be that no newsletters carrying ads were sent — worth expanding the date range or checking your ad placements.',
+					'newspack-plugin'
+				) }
+			/>
+		);
+	}
+
+	const excludedAds = current.revenue_excluded_ads?.computable ? current.revenue_excluded_ads?.value ?? 0 : 0;
+
+	return (
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-overview">
+			<SectionHeading id="newspack-insights-newsletter-ads-overview" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
+			{ /* Row 1: the four timeframe headline scorecards. */ }
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
+				<Scorecard
+					label={ __( 'Impressions', 'newspack-plugin' ) }
+					description={ __( 'How many times your ads were seen', 'newspack-plugin' ) }
+					current={ current.total_impressions }
+					previous={ previous?.total_impressions }
+					// Timeframe counts are non-computable only when dated tracking is
+					// unavailable (not-ready) — an em-dash there, not a fake 0.
+					notComputableMessage={ NOT_TRACKED_MESSAGE }
+				/>
+				<Scorecard
+					label={ __( 'Clicks', 'newspack-plugin' ) }
+					description={ __( 'How many times your ads were clicked', 'newspack-plugin' ) }
+					current={ current.total_clicks }
+					previous={ previous?.total_clicks }
+					notComputableMessage={ NOT_TRACKED_MESSAGE }
+				/>
+				<Scorecard
+					label={ __( 'CTR', 'newspack-plugin' ) }
+					description={ __( 'Clicks per impression', 'newspack-plugin' ) }
+					current={ current.ctr }
+					previous={ previous?.ctr }
+					// A non-computable rate renders the em-dash treatment — never "0%".
+					notComputableMessage={ __( 'No impressions in this timeframe to calculate a click-through rate.', 'newspack-plugin' ) }
+				/>
+				<Scorecard
+					label={ __( 'Revenue', 'newspack-plugin' ) }
+					description={ __( 'What your ads earned', 'newspack-plugin' ) }
+					current={ current.total_revenue }
+					previous={ previous?.total_revenue }
+					notComputableMessage={ NOT_TRACKED_MESSAGE }
+				/>
+			</div>
+			{ /* Row 2: remaining timeframe cards + the all-time lifetime counters.
+			     Lifetime cards deliberately pass no `previous` — they're cumulative,
+			     so a period delta is meaningless. */ }
+			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
+				<Scorecard
+					label={ __( 'eCPM', 'newspack-plugin' ) }
+					description={ __( 'Revenue per 1,000 impressions', 'newspack-plugin' ) }
+					current={ current.ecpm }
+					previous={ previous?.ecpm }
+					// eCPM is an undefined division without both revenue and impressions —
+					// em-dash, never a misleading "$0.00".
+					notComputableMessage={ __( 'Requires both revenue and impressions in this timeframe to calculate.', 'newspack-plugin' ) }
+				/>
+				<Scorecard
+					label={ __( 'Active ads', 'newspack-plugin' ) }
+					description={ __( 'Ads that ran in newsletters', 'newspack-plugin' ) }
+					current={ current.active_ads }
+					previous={ previous?.active_ads }
+					notComputableMessage={ NOT_TRACKED_MESSAGE }
+				/>
+				<Scorecard
+					label={ __( 'All-time impressions', 'newspack-plugin' ) }
+					description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
+					current={ current.lifetime_impressions }
+				/>
+				<Scorecard
+					label={ __( 'All-time clicks', 'newspack-plugin' ) }
+					description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
+					current={ current.lifetime_clicks }
+				/>
+			</div>
+			{ excludedAds > 0 && (
+				<p className="newspack-insights__table-footnote">
+					{ sprintf(
+						/* translators: %d: count of ads excluded from the revenue totals. */
+						_n(
+							'%d ad excluded from revenue (missing price or flight dates)',
+							'%d ads excluded from revenue (missing price or flight dates)',
+							excludedAds,
+							'newspack-plugin'
+						),
+						excludedAds
+					) }
+				</p>
+			) }
+		</section>
+	);
+};
+
+export default OverviewSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
@@ -1,0 +1,110 @@
+/**
+ * Newsletter Ads › Top performers (NPPD-1861).
+ *
+ * Mirrors Advertising's TopPerformersSection exactly: MetricTable (static, not
+ * sortable) with Top ads and Top advertisers side by side (collapsed to 5 rows
+ * behind "See more"), and the per-newsletter breakdown full-width below.
+ * MetricTable renders null cells (CTR/revenue without impressions or price) as
+ * the em-dash natively — never a misleading 0% / $0.00.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ByNewsletterRow, InsightsWindow } from '../../../api/newsletter_ads';
+import type { MetricPayload } from '../../components/metrics';
+import { formatShortDate } from '../../components/format';
+import MetricTable from '../../components/MetricTable';
+import SectionHeading from '../../components/SectionHeading';
+
+export interface SectionProps {
+	current: InsightsWindow;
+}
+
+/**
+ * Present the by-newsletter payload for display: sent_date arrives as
+ * 'YYYY-MM-DD' and MetricTable renders strings verbatim, so format it here
+ * (formatShortDate expects GA4's 'YYYYMMDD' — strip the separators).
+ */
+const withDisplayDates = ( payload?: MetricPayload ): MetricPayload | undefined => {
+	if ( ! payload || ! Array.isArray( payload.rows ) ) {
+		return payload;
+	}
+	return {
+		...payload,
+		rows: ( payload.rows as unknown as ByNewsletterRow[] ).map( row => ( {
+			...row,
+			sent_date: formatShortDate( row.sent_date.replace( /\D/g, '' ) ),
+		} ) ),
+	};
+};
+
+const TablesSection = ( { current }: SectionProps ) => (
+	<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-performers">
+		<SectionHeading
+			id="newspack-insights-newsletter-ads-top-performers"
+			title={ __( 'Top performers', 'newspack-plugin' ) }
+			description={ __( 'Which ads, advertisers, and newsletters drive your results in the selected timeframe.', 'newspack-plugin' ) }
+		/>
+		<div className="newspack-insights__table-grid newspack-insights__table-grid--cols-2">
+			<div>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top ads', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ current.top_ads }
+					emptyMessage={ __( 'No ad data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'title', label: __( 'Ad', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</div>
+			<div>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top advertisers', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ current.top_advertisers }
+					emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+						{ key: 'ads', label: __( 'Ads', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</div>
+		</div>
+		<div className="newspack-insights__table-grid">
+			<div>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Ad performance by newsletter', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ withDisplayDates( current.by_newsletter ) }
+					emptyMessage={ __( 'No newsletters carried ads in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'title', label: __( 'Newsletter', 'newspack-plugin' ) },
+						{ key: 'sent_date', label: __( 'Sent date', 'newspack-plugin' ) },
+						{ key: 'ads', label: __( 'Ads carried', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+					] }
+				/>
+			</div>
+		</div>
+	</section>
+);
+
+export default TablesSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Tests for the Newsletter Ads TrendSection (NPPD-1861): the split
+ * impressions/clicks ChartCards and the previous-period compare overlay.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import TrendSection from './TrendSection';
+import type { InsightsWindow } from '../../../api/newsletter_ads';
+
+const metrics = (): InsightsWindow => ( {
+	performance_by_day: {
+		type: 'timeseries',
+		computable: true,
+		rows: [
+			{ date: '2026-06-01', impressions: 3200, clicks: 48 },
+			{ date: '2026-06-02', impressions: 2800, clicks: 41 },
+			{ date: '2026-06-03', impressions: 3600, clicks: 55 },
+		],
+	},
+} );
+
+describe( 'TrendSection', () => {
+	it( 'renders impressions and clicks as two separate charts', () => {
+		const { container } = render( <TrendSection current={ metrics() } previous={ null } /> );
+
+		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Impressions' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Clicks' ) ).toBeInTheDocument();
+		// One series per chart without comparison → two line strokes total.
+		expect( container.querySelectorAll( '.newspack-insights__line-stroke' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'overlays the previous period on each chart when comparing', () => {
+		const { container } = render( <TrendSection current={ metrics() } previous={ metrics() } /> );
+
+		// Two series per chart with comparison → four line strokes total.
+		expect( container.querySelectorAll( '.newspack-insights__line-stroke' ) ).toHaveLength( 4 );
+		expect( screen.getAllByText( 'Previous period' ).length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
@@ -1,0 +1,65 @@
+/**
+ * Newsletter Ads › Performance trend (NPPD-1861).
+ *
+ * Impressions and Clicks as two side-by-side ChartCards (the shared
+ * chart-grid --cols-2 pattern, e.g. Audience's TimeTrendsSection) rather than
+ * two series on one chart: impressions run orders of magnitude above clicks,
+ * so a shared y-axis flattens the clicks series into an unreadable baseline.
+ * Splitting also restores previous-period compare parity with Advertising's
+ * RevenueTrendSection — each chart overlays "Previous period" when comparison
+ * is on, staying at two lines per chart. A zero-activity window falls through
+ * to LineChart's own empty state.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { InsightsWindow } from '../../../api/newsletter_ads';
+import ChartCard from '../../components/ChartCard';
+import SectionHeading from '../../components/SectionHeading';
+import LineChart from '../../components/LineChart';
+import { toSeries } from '../../components/metrics';
+import { formatShortDate } from '../../components/format';
+
+export interface SectionProps {
+	current: InsightsWindow;
+	previous: InsightsWindow | null;
+}
+
+// Rows carry 'YYYY-MM-DD' dates; formatShortDate expects GA4's 'YYYYMMDD'.
+// Strip all non-digits so any separator variation still yields the 8-digit form.
+const formatDateLabel = ( date: string ) => formatShortDate( date.replace( /\D/g, '' ) );
+
+/** Build the this-period series plus the previous-period overlay when comparing. */
+const buildSeries = ( current: InsightsWindow, previous: InsightsWindow | null, valueKey: 'impressions' | 'clicks' ) => {
+	const previousPoints = previous ? toSeries( previous.performance_by_day, 'date', valueKey ) : [];
+	return [
+		{ name: __( 'This period', 'newspack-plugin' ), points: toSeries( current.performance_by_day, 'date', valueKey ) },
+		...( previousPoints.length ? [ { name: __( 'Previous period', 'newspack-plugin' ), points: previousPoints } ] : [] ),
+	];
+};
+
+const TrendSection = ( { current, previous }: SectionProps ) => (
+	<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-trend">
+		<SectionHeading
+			id="newspack-insights-newsletter-ads-trend"
+			title={ __( 'Performance trend', 'newspack-plugin' ) }
+			description={ __( 'Daily impressions and clicks across the selected timeframe.', 'newspack-plugin' ) }
+		/>
+		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+			<ChartCard title={ __( 'Impressions', 'newspack-plugin' ) } payload={ current.performance_by_day }>
+				<LineChart series={ buildSeries( current, previous, 'impressions' ) } formatLabel={ formatDateLabel } />
+			</ChartCard>
+			<ChartCard title={ __( 'Clicks', 'newspack-plugin' ) } payload={ current.performance_by_day }>
+				<LineChart series={ buildSeries( current, previous, 'clicks' ) } formatLabel={ formatDateLabel } />
+			</ChartCard>
+		</div>
+	</section>
+);
+
+export default TrendSection;

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-newsletter-ads-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-newsletter-ads-metric.php
@@ -1,0 +1,431 @@
+<?php
+/**
+ * Test Newsletter_Ads_Metric (NPPD-1861).
+ *
+ * Covers tab visibility (ads-presence transient), report readiness (Ad_Stats
+ * class + stats table), the not-ready degradation of get_all() (timeframe
+ * metrics non-computable while lifetime metrics stay real), the lifetime CTR
+ * zero-impressions guard, the flat-over-flight revenue proration (including
+ * partial window overlap and exclusion counting), and the by-newsletter
+ * breakdown's unknown-source sentinel exclusion.
+ *
+ * The newsletters plugin is NOT loaded in this suite's bootstrap, so the
+ * tests pull in a minimal test double for
+ * `Newspack_Newsletters\Tracking\Ad_Stats` (doubles/class-ad-stats.php) and
+ * create the stats table directly, mimicking the documented schema. The
+ * "Ad_Stats class absent" leg is exercised through the orchestrator's
+ * protected `ad_stats_class()` seam
+ * (doubles/class-newsletter-ads-metric-no-stats.php), since a defined class
+ * can't be undefined.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Newsletter_Ads_Metric;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/doubles/class-ad-stats.php';
+require_once __DIR__ . '/doubles/class-newsletter-ads-metric-no-stats.php';
+
+/**
+ * Newsletter_Ads_Metric test class.
+ *
+ * @group insights
+ */
+class Test_Newsletter_Ads_Metric extends WP_UnitTestCase {
+
+	/**
+	 * Set up: register the ads CPT + advertiser taxonomy (the newsletters
+	 * plugin isn't loaded in this suite, and WP_UnitTestCase resets custom
+	 * post types between tests) and clear the orchestrator's caches.
+	 */
+	public function set_up() {
+		parent::set_up();
+		register_post_type( Newsletter_Ads_Metric::ADS_CPT, [ 'public' => false ] );
+		register_taxonomy( Newsletter_Ads_Metric::ADVERTISER_TAX, [ Newsletter_Ads_Metric::ADS_CPT ] );
+		Newsletter_Ads_Metric::reset_readiness_cache();
+		delete_transient( Newsletter_Ads_Metric::ADS_PRESENCE_TRANSIENT );
+	}
+
+	/**
+	 * Tear down: drop the stats table AFTER the parent's transaction
+	 * rollback (DDL would implicitly commit any pending test data) and
+	 * clear the orchestrator caches.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}newspack_newsletters_ad_stats" );
+		// phpcs:enable
+		Newsletter_Ads_Metric::reset_readiness_cache();
+		delete_transient( Newsletter_Ads_Metric::ADS_PRESENCE_TRANSIENT );
+	}
+
+	/*
+	 * Helpers
+	 */
+
+	/**
+	 * Create the dated stats table, mimicking the newsletters plugin's
+	 * documented schema, and reset the existence memo. Created FIRST in a
+	 * test (before factory data) so the DDL's implicit commit happens
+	 * before any rollback-able DML.
+	 */
+	private function create_stats_table(): void {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query(
+			"CREATE TABLE IF NOT EXISTS {$wpdb->prefix}newspack_newsletters_ad_stats (
+				ad_id BIGINT UNSIGNED NOT NULL,
+				newsletter_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+				stat_date DATE NOT NULL,
+				impressions INT UNSIGNED NOT NULL DEFAULT 0,
+				clicks INT UNSIGNED NOT NULL DEFAULT 0,
+				PRIMARY KEY (ad_id, newsletter_id, stat_date),
+				KEY stat_date (stat_date)
+			)"
+		);
+		// phpcs:enable
+		Newsletter_Ads_Metric::reset_readiness_cache();
+	}
+
+	/**
+	 * Insert a stats row directly.
+	 *
+	 * @param int    $ad_id         Ad post ID.
+	 * @param int    $newsletter_id Newsletter post ID (0 = unknown-source sentinel).
+	 * @param string $stat_date     Y-m-d (UTC day).
+	 * @param int    $impressions   Impressions.
+	 * @param int    $clicks        Clicks.
+	 */
+	private function insert_stat( int $ad_id, int $newsletter_id, string $stat_date, int $impressions, int $clicks ): void {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->insert(
+			$wpdb->prefix . 'newspack_newsletters_ad_stats',
+			[
+				'ad_id'         => $ad_id,
+				'newsletter_id' => $newsletter_id,
+				'stat_date'     => $stat_date,
+				'impressions'   => $impressions,
+				'clicks'        => $clicks,
+			],
+			[ '%d', '%d', '%s', '%d', '%d' ]
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Create a published newsletter ad with meta.
+	 *
+	 * @param string $title Ad title.
+	 * @param array  $meta  Meta key => value map (price, start_date, expiry_date, tracking_*).
+	 * @return int Ad post ID.
+	 */
+	private function create_ad( string $title, array $meta = [] ): int {
+		$ad_id = static::factory()->post->create(
+			[
+				'post_type'   => Newsletter_Ads_Metric::ADS_CPT,
+				'post_status' => 'publish',
+				'post_title'  => $title,
+			]
+		);
+		foreach ( $meta as $key => $value ) {
+			add_post_meta( $ad_id, $key, $value );
+		}
+		return $ad_id;
+	}
+
+	/**
+	 * Call get_all() with the window's envelope transient cleared first, so a
+	 * previous call in the same test (or the No_Stats subclass, which shares
+	 * the cache key) can't serve a stale envelope.
+	 *
+	 * @param string $orchestrator Orchestrator class to call.
+	 * @param string $start        Window start (Y-m-d).
+	 * @param string $end          Window end (Y-m-d).
+	 * @return array
+	 */
+	private function fresh_get_all( string $orchestrator, string $start, string $end ): array {
+		delete_transient( Newsletter_Ads_Metric::CACHE_KEY_PREFIX . $start . ':' . $end );
+		return call_user_func( [ $orchestrator, 'get_all' ], $start, $end );
+	}
+
+	/*
+	 * Visibility
+	 */
+
+	/**
+	 * No published ads → tab hidden. A draft ad doesn't count.
+	 */
+	public function test_tab_hidden_without_published_ads() {
+		$this->assertFalse( Newsletter_Ads_Metric::force_refresh_tab_visibility() );
+		$this->assertFalse( Newsletter_Ads_Metric::is_tab_visible() );
+
+		static::factory()->post->create(
+			[
+				'post_type'   => Newsletter_Ads_Metric::ADS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+		$this->assertFalse( Newsletter_Ads_Metric::force_refresh_tab_visibility(), 'A draft ad must not make the tab visible.' );
+	}
+
+	/**
+	 * A published ad makes the tab visible — but only after the 24h
+	 * presence transient is refreshed (force_refresh_tab_visibility()),
+	 * since state transitions are cached aggressively.
+	 */
+	public function test_tab_visible_with_published_ad_after_transient_reset() {
+		// Prime the cache in the no-ads state.
+		$this->assertFalse( Newsletter_Ads_Metric::is_tab_visible() );
+
+		$this->create_ad( 'Hometown Hardware — Spring Sale' );
+
+		// Still hidden: the 'no' result is transient-cached.
+		$this->assertFalse( Newsletter_Ads_Metric::is_tab_visible(), 'The cached no-ads result must be served until refreshed.' );
+
+		// Force refresh recomputes and re-primes the cache.
+		$this->assertTrue( Newsletter_Ads_Metric::force_refresh_tab_visibility() );
+		$this->assertTrue( Newsletter_Ads_Metric::is_tab_visible() );
+	}
+
+	/*
+	 * Readiness
+	 */
+
+	/**
+	 * Without the Ad_Stats class (old newsletters build — simulated via the
+	 * protected seam), reporting is not ready and the stats-missing issue
+	 * is surfaced.
+	 */
+	public function test_report_not_ready_when_ad_stats_class_absent() {
+		$this->create_stats_table();
+		$this->assertFalse( Newsletter_Ads_Metric_No_Stats::is_report_ready(), 'A present table must not make reporting ready without the Ad_Stats class.' );
+
+		$codes = array_column( Newsletter_Ads_Metric_No_Stats::readiness_issues(), 'code' );
+		$this->assertContains( 'newsletter_ads_stats_missing', $codes );
+	}
+
+	/**
+	 * With the Ad_Stats class (test double) present, readiness follows the
+	 * table's actual existence — memoized, so a reset is required between
+	 * checks.
+	 */
+	public function test_report_ready_follows_table_existence() {
+		// No table yet.
+		$this->assertFalse( Newsletter_Ads_Metric::is_report_ready() );
+
+		$this->create_stats_table();
+		$this->assertTrue( Newsletter_Ads_Metric::is_report_ready() );
+		$this->assertSame( [], array_column( Newsletter_Ads_Metric::readiness_issues(), 'code' ), 'A ready report must carry no stats-missing issue.' );
+	}
+
+	/*
+	 * get_all(): not-ready degradation + lifetime metrics
+	 */
+
+	/**
+	 * When reporting isn't ready, get_all() still returns the full
+	 * envelope: lifetime metrics computed from the meta counters, every
+	 * timeframe metric present but computable=false, no fatals, and no
+	 * has_window_activity key (so the UI's empty-state check can't fire).
+	 */
+	public function test_get_all_not_ready_degrades_timeframe_but_computes_lifetime() {
+		$this->create_ad(
+			'Riverside Cafe — Weekend Brunch',
+			[
+				'tracking_impressions' => 5000,
+				'tracking_clicks'      => 75,
+			]
+		);
+		$this->create_ad(
+			'Maple Street Books — Author Night',
+			[
+				'tracking_impressions' => 3000,
+				'tracking_clicks'      => 25,
+			]
+		);
+
+		$envelope = $this->fresh_get_all( Newsletter_Ads_Metric_No_Stats::class, '2026-06-01', '2026-06-30' );
+
+		$this->assertFalse( $envelope['is_report_ready'] );
+		$this->assertFalse( $envelope['is_loading'] );
+		$this->assertSame( '2026-06-01', $envelope['window']['start'] );
+		$this->assertSame( '2026-06-30', $envelope['window']['end'] );
+		$this->assertContains( 'newsletter_ads_stats_missing', array_column( $envelope['readiness_issues'], 'code' ) );
+		$this->assertArrayNotHasKey( 'has_window_activity', $envelope, 'The activity signal must be absent when window metrics are not computable.' );
+
+		$metrics = $envelope['metrics'];
+
+		// Lifetime metrics are real (meta counters need no stats table).
+		$this->assertSame( 8000, $metrics['lifetime_impressions']['value'] );
+		$this->assertTrue( $metrics['lifetime_impressions']['computable'] );
+		$this->assertSame( 100, $metrics['lifetime_clicks']['value'] );
+		$this->assertTrue( $metrics['lifetime_ctr']['computable'] );
+		$this->assertEqualsWithDelta( 100 / 8000, $metrics['lifetime_ctr']['value'], 0.0001 );
+
+		// Every timeframe metric is present but non-computable.
+		$timeframe_keys = [ 'total_impressions', 'total_clicks', 'ctr', 'total_revenue', 'revenue_excluded_ads', 'ecpm', 'active_ads', 'performance_by_day', 'top_ads', 'top_advertisers', 'by_newsletter' ];
+		foreach ( $timeframe_keys as $key ) {
+			$this->assertArrayHasKey( $key, $metrics );
+			$this->assertFalse( $metrics[ $key ]['computable'], "Timeframe metric '$key' must be non-computable when the stats table is unavailable." );
+		}
+	}
+
+	/**
+	 * Lifetime CTR at zero impressions (the real click-tracking-on /
+	 * pixel-off case) must be non-computable — n/a, never a fake 0%.
+	 */
+	public function test_lifetime_ctr_not_computable_at_zero_impressions() {
+		$this->create_ad(
+			'Sunrise Bakery — Fresh Daily',
+			[
+				'tracking_impressions' => 0,
+				'tracking_clicks'      => 40,
+			]
+		);
+
+		$envelope = $this->fresh_get_all( Newsletter_Ads_Metric_No_Stats::class, '2026-05-01', '2026-05-31' );
+		$metrics  = $envelope['metrics'];
+
+		$this->assertSame( 40, $metrics['lifetime_clicks']['value'] );
+		$this->assertSame( 0, $metrics['lifetime_impressions']['value'] );
+		$this->assertFalse( $metrics['lifetime_ctr']['computable'], 'CTR over zero impressions must be non-computable.' );
+	}
+
+	/*
+	 * Flat-over-flight revenue
+	 */
+
+	/**
+	 * Revenue prorates each ad's flat price over its flight, counting only
+	 * the days overlapping the window; ads missing price/dates are excluded
+	 * from revenue but counted in revenue_excluded_ads and active_ads.
+	 */
+	public function test_flat_over_flight_revenue_prorates_and_counts_exclusions() {
+		$this->create_stats_table();
+
+		// Fully inside the window: 30-day flight, $300 → all $300.
+		$this->create_ad(
+			'Hometown Hardware — Spring Sale',
+			[
+				'price'       => '300',
+				'start_date'  => '2026-06-01',
+				'expiry_date' => '2026-06-30',
+			]
+		);
+		// Partial overlap: 10-day flight at $10/day, 5 days in-window → $50.
+		$this->create_ad(
+			'Valley Bike Shop — Tune-Up Special',
+			[
+				'price'       => '100',
+				'start_date'  => '2026-05-27',
+				'expiry_date' => '2026-06-05',
+			]
+		);
+		// Overlapping flight but NO price → excluded from revenue, still active.
+		$this->create_ad(
+			'House Promo — Membership Drive',
+			[
+				'start_date'  => '2026-06-10',
+				'expiry_date' => '2026-06-20',
+			]
+		);
+		// Valid but entirely outside the window → contributes nothing, not active.
+		$this->create_ad(
+			'Bluebird Florist — Mothers Day',
+			[
+				'price'       => '500',
+				'start_date'  => '2026-07-10',
+				'expiry_date' => '2026-07-20',
+			]
+		);
+
+		$envelope = $this->fresh_get_all( Newsletter_Ads_Metric::class, '2026-06-01', '2026-06-30' );
+		$metrics  = $envelope['metrics'];
+
+		$this->assertTrue( $envelope['is_report_ready'] );
+		$this->assertTrue( $metrics['total_revenue']['computable'] );
+		$this->assertEqualsWithDelta( 350.0, $metrics['total_revenue']['value'], 0.001, 'Expected $300 (full flight) + $50 (5 of 10 flight days in-window).' );
+		$this->assertSame( 1, $metrics['revenue_excluded_ads']['value'], 'The price-less overlapping ad must be counted as excluded.' );
+		$this->assertSame( 3, $metrics['active_ads']['value'], 'Three flights overlap the window (the July flight does not).' );
+
+		// No stats rows: volume is a computable zero, eCPM is not computable,
+		// and the window is explicitly inactive.
+		$this->assertTrue( $metrics['total_impressions']['computable'] );
+		$this->assertSame( 0, $metrics['total_impressions']['value'] );
+		$this->assertFalse( $metrics['ecpm']['computable'] );
+		$this->assertFalse( $envelope['has_window_activity'] );
+	}
+
+	/*
+	 * Stats-table breakdowns
+	 */
+
+	/**
+	 * The by_newsletter table groups stats by source newsletter, EXCLUDING
+	 * the newsletter_id=0 unknown-source sentinel (whose clicks still count
+	 * toward window totals), counting DISTINCT ads per newsletter and
+	 * labeling deleted newsletters.
+	 */
+	public function test_by_newsletter_excludes_sentinel_rows() {
+		$this->create_stats_table();
+
+		$ad_a = $this->create_ad( 'Riverside Cafe — Weekend Brunch' );
+		$ad_b = $this->create_ad( 'Maple Street Books — Author Night' );
+		wp_insert_term( 'Riverside Cafe', Newsletter_Ads_Metric::ADVERTISER_TAX );
+		wp_set_object_terms( $ad_a, 'Riverside Cafe', Newsletter_Ads_Metric::ADVERTISER_TAX );
+
+		$newsletter_id = static::factory()->post->create(
+			[
+				'post_title' => 'Weekly Roundup',
+				'post_date'  => '2026-06-10 09:00:00',
+			]
+		);
+		$deleted_newsletter_id = 999999;
+
+		// Two ads in the real newsletter, one ad in a deleted one, plus
+		// unknown-source sentinel clicks.
+		$this->insert_stat( $ad_a, $newsletter_id, '2026-06-10', 1000, 20 );
+		$this->insert_stat( $ad_b, $newsletter_id, '2026-06-10', 800, 10 );
+		$this->insert_stat( $ad_a, $deleted_newsletter_id, '2026-06-12', 300, 5 );
+		$this->insert_stat( $ad_a, 0, '2026-06-13', 0, 7 );
+
+		$envelope = $this->fresh_get_all( Newsletter_Ads_Metric::class, '2026-06-01', '2026-06-30' );
+		$metrics  = $envelope['metrics'];
+
+		// Sentinel rows count toward totals.
+		$this->assertSame( 2100, $metrics['total_impressions']['value'] );
+		$this->assertSame( 42, $metrics['total_clicks']['value'] );
+		$this->assertTrue( $envelope['has_window_activity'] );
+
+		// But they never appear in the by-newsletter breakdown.
+		$rows = $metrics['by_newsletter']['rows'];
+		$this->assertCount( 2, $rows );
+		$this->assertNotContains( 0, array_column( $rows, 'newsletter_id' ), 'The unknown-source sentinel must be excluded.' );
+
+		$by_id = array_column( $rows, null, 'newsletter_id' );
+		$this->assertSame( 'Weekly Roundup', $by_id[ $newsletter_id ]['title'] );
+		$this->assertSame( '2026-06-10', $by_id[ $newsletter_id ]['sent_date'] );
+		$this->assertSame( 2, $by_id[ $newsletter_id ]['ads'], 'Distinct ads per newsletter.' );
+		$this->assertSame( 1800, $by_id[ $newsletter_id ]['impressions'] );
+		$this->assertSame( '(deleted)', $by_id[ $deleted_newsletter_id ]['title'], 'A missing newsletter post is labeled (deleted).' );
+
+		// top_ads reflects per-ad sums (sentinel included) with titles and
+		// the advertiser term.
+		$top_ads = $metrics['top_ads']['rows'];
+		$by_ad   = array_column( $top_ads, null, 'ad_id' );
+		$this->assertSame( 1300, $by_ad[ $ad_a ]['impressions'] );
+		$this->assertSame( 32, $by_ad[ $ad_a ]['clicks'] );
+		$this->assertSame( 'Riverside Cafe', $by_ad[ $ad_a ]['advertiser'] );
+		$this->assertSame( '', $by_ad[ $ad_b ]['advertiser'] );
+
+		// Daily series is chronological and skips zero-recorded days.
+		$days = array_column( $metrics['performance_by_day']['rows'], 'date' );
+		$this->assertSame( [ '2026-06-10', '2026-06-12', '2026-06-13' ], $days );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/doubles/class-ad-stats.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/doubles/class-ad-stats.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Test double for the newsletters plugin's Ad_Stats reader (NPPD-1861).
+ *
+ * The newsletters plugin is not loaded in this suite's bootstrap, so the
+ * Newsletter Ads metric tests ship this minimal stand-in — just enough
+ * surface for {@see \Newspack\Insights\Newsletter_Ads_Metric} (the
+ * class_exists readiness gate + get_table_name()). Guarded so it never
+ * shadows the real class if the plugin is ever added to the bootstrap.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+if ( ! class_exists( 'Newspack_Newsletters\Tracking\Ad_Stats' ) ) {
+	/**
+	 * Minimal Ad_Stats double.
+	 */
+	class Ad_Stats {
+		/**
+		 * Stats table name, matching the real class's contract.
+		 *
+		 * @return string
+		 */
+		public static function get_table_name() {
+			global $wpdb;
+			return $wpdb->prefix . 'newspack_newsletters_ad_stats';
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/doubles/class-newsletter-ads-metric-no-stats.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/doubles/class-newsletter-ads-metric-no-stats.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Newsletter_Ads_Metric subclass simulating an old newsletters build
+ * without the Ad_Stats class (NPPD-1861).
+ *
+ * A defined class can't be undefined, so the "Ad_Stats absent" readiness leg
+ * is exercised through the orchestrator's protected `ad_stats_class()` seam:
+ * this subclass returns null, making is_report_ready() false regardless of
+ * whether the stats table exists.
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Newsletter_Ads_Metric;
+
+/**
+ * Subclass with the Ad_Stats seam forced absent.
+ */
+class Newsletter_Ads_Metric_No_Stats extends Newsletter_Ads_Metric {
+	/**
+	 * Simulate the Ad_Stats class being absent.
+	 *
+	 * @return string|null
+	 */
+	protected static function ad_stats_class(): ?string {
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Newsletter Ads** tab (Tab 9) to Newspack Insights, surfacing performance of the Newspack Newsletters "Advertising" feature (`newspack_nl_ads_cpt`): impressions, clicks, CTR, revenue, eCPM, active ads, top ads / top advertisers / ad performance by newsletter, and a daily performance trend.

Ticket: NPPD-1861. Reference doc: `formulas/tab-9-newsletter-ads.md` in the insights docs repo (data model, every metric formula, decisions + dates).

## Data sources

- **Lifetime scorecards** (all-time impressions/clicks): the existing per-ad `tracking_impressions` / `tracking_clicks` meta counters — populated today on adopter sites.
- **Timeframe metrics**: the dated per-ad stats table `{prefix}newspack_newsletters_ad_stats` shipped by newspack-workspace#543 (newspack-newsletters, `release` line). Forward-only — no backfill exists; timeframe sections fill as data accrues post-deploy.
- **Revenue** is *flat-over-flight*: `price` is the flat booking price for the ad's `start_date`→`expiry_date` flight, recognized evenly per flight day and prorated to the report window. Ads missing price or either date are excluded from revenue but still counted — surfaced via a footnote (`revenue_excluded_ads`), never silently dropped.

## Conditional visibility & degradation

- **Tab is hidden entirely** (PHP boot config) unless the site has ≥1 published newsletter ad — a full-fleet sweep (2026-07-07) found ~70 sites / ~21% of the fleet qualify (~2,700 ads), so the other ~79% never see it. 24h-cached detection (Donors pattern).
- **Report-readiness** is separate: the stats table missing (older newsletters plugin) does NOT blank the tab — the lifetime cards still render, with an inline `FinishConnectingDiagnostic` notice; only the timeframe sections are withheld. Deliberate divergence from AdvertisingTab, covered by a regression test.
- **Honest non-computability**: CTR/eCPM render an em-dash with an explanation — never a fake `0%`/`$0.00`. Real case: sites with click tracking on but the open pixel disabled (verified in production) have clicks and no impressions. This opt-in em-dash treatment for non-rate cards extends the shared `payloadToCard` helper (also benefits existing audience/donors/subscribers call sites that already passed messages the helper ignored).

## Architecture (mirrors Tab 8 / established conventions)

- PHP: `Newsletter_Ads_Metric` orchestrator (synchronous — cheap local SQL, no Action Scheduler; standard envelope; transient cache `newspack_insights_newsletter_ads_v1:{start}:{end}`), REST controller at `/newspack-insights/v1/newsletter-ads` (+refresh), fixture with 4 variants (`populated` / `zero` / `not_ready` / `no_impressions`), boot-config wiring. Every newsletters-plugin touch is class/table-guarded; missing pieces degrade to non-computable, never fatal.
- React: tab registration, api client + hook, three sections. Tables are `MetricTable` (static) in Tab 8's Top Performers layout. Trend is **two side-by-side ChartCards (Impressions | Clicks)** — a shared y-axis flattens clicks into an unreadable baseline — each with a previous-period compare overlay. Per-tab SCSS chunk added (tabs lazy-load styles with their chunk; without it the tab renders unstyled on deep links). The `FinishConnectingDiagnostic` styles moved from `advertising.scss` to the shared partial now that it has two consumers.
- `by_newsletter` groups the stats table by source newsletter, excluding the `newsletter_id = 0` unknown-source click sentinel (old proxy links without `nid`). Per-issue grain; revenue allocation across issues deferred.

## Test plan

- PHPUnit: `Test_Newsletter_Ads_Metric` (8 tests — visibility gates + transient reset, readiness legs, envelope shape + not-ready degradation, lifetime CTR non-computability, flat-over-flight proration incl. partial overlap + exclusion counting, sentinel exclusion; uses an `Ad_Stats` test double + real-schema temp table). Full insights group: 700 tests green.
- Jest: tab (7) + OverviewSection (8) + TrendSection (2) tests; full suite 772 green. tsc + eslint + stylelint clean; root phpcs clean.
- Verified live in fixture mode on all four variants (deep-linked, compare on and off), zero console errors.

## Follow-ups (documented in the ticket / docs repo)

- Revenue-model refinements: no currency field on `price` (site-currency formatting is an approximation); flight-revenue allocation for the by-newsletter table.
- Next-steps strip entry once a monetization playbook page exists.