### PR TITLE
refactor(insights): remove per-tab preview/enabled flag gates

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/README.md
+++ b/plugins/newspack-plugin/includes/wizards/insights/README.md
@@ -11,7 +11,6 @@ All gated by PHP constants. The wizard registers nothing when `NEWSPACK_INSIGHTS
 | Constant | Effect |
 | --- | --- |
 | `NEWSPACK_INSIGHTS_ENABLED` | Master switch. When off, no admin page, no REST routes, no asset enqueue. |
-| `NEWSPACK_INSIGHTS_ADVERTISING_ENABLED` | Shows the Advertising (Tab 8) nav entry and activates its GAM-backed orchestrator. Also requires `NEWSPACK_INSIGHTS_ENABLED`. |
 | `NEWSPACK_INSIGHTS_FIXTURE_MODE` | REST controllers that wrap a metric with a `get_fixture()` method short-circuit to fixtures instead of live data. Used for UI smoke testing. (Conversion, Subscribers, and Donors don't implement fixtures today; see [Metric orchestrators](#metric-orchestrators-metricsclass--metricphp).) |
 | `NEWSPACK_INSIGHTS_CACHE_DISABLED` | Bypass the server-side transient cache entirely. Dev/debug only. |
 | `NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4`, `NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4` | Per-tab backend dispatch (default on). When off, the metric would route to the BigQuery proxy path — currently a stub until NPPD-1630. |
@@ -48,7 +47,7 @@ src/wizards/insights/               (frontend)
 
 ### Sections (`class-insights-section-*.php`)
 
-One per tab. Each section's `init()` is called from [`includes/class-wizards.php`](../../class-wizards.php) during wizard bootstrap. The section bails immediately when `Insights_Wizard::is_enabled()` is false; the Advertising section also gates on its per-tab enabled constant. When the gate passes, the section:
+One per tab. Each section's `init()` is called from [`includes/class-wizards.php`](../../class-wizards.php) during wizard bootstrap. The section bails immediately when `Insights_Wizard::is_enabled()` is false. When the gate passes, the section:
 
 1. Loads the tab's `metrics/class-*-metric.php` and `api/class-*-rest-controller.php` files.
 2. Registers the REST route on the `rest_api_init` hook.
@@ -85,7 +84,7 @@ Current tab status:
 | Prompts (5) | BigQuery | Conversion funnels. |
 | Subscribers (6) | Local Woo | Reads via [`storage/`](storage/). |
 | Donors (7) | Local Woo | Donation-scoped queries via the donors storage interface. |
-| Advertising (8) | GAM async SOAP | Polls async report jobs; gated by `NEWSPACK_INSIGHTS_ADVERTISING_ENABLED` and a runtime "GAM active" check. |
+| Advertising (8) | GAM async SOAP | Polls async report jobs; shown when GAM is the active ad provider (runtime "GAM active" check) or fixture mode is on. |
 
 ### Data clients
 

--- a/plugins/newspack-plugin/includes/wizards/insights/README.md
+++ b/plugins/newspack-plugin/includes/wizards/insights/README.md
@@ -11,7 +11,6 @@ All gated by PHP constants. The wizard registers nothing when `NEWSPACK_INSIGHTS
 | Constant | Effect |
 | --- | --- |
 | `NEWSPACK_INSIGHTS_ENABLED` | Master switch. When off, no admin page, no REST routes, no asset enqueue. |
-| `NEWSPACK_INSIGHTS_GATES_PREVIEW` | Shows the Gates (Tab 4) nav entry and activates its REST route. Requires `NEWSPACK_INSIGHTS_ENABLED` to be on as well — the section bails before either check otherwise. The two flags are kept separate so the Phase 1 preview can ship to a subset of Insights-enabled environments. |
 | `NEWSPACK_INSIGHTS_ADVERTISING_ENABLED` | Shows the Advertising (Tab 8) nav entry and activates its GAM-backed orchestrator. Also requires `NEWSPACK_INSIGHTS_ENABLED`. |
 | `NEWSPACK_INSIGHTS_FIXTURE_MODE` | REST controllers that wrap a metric with a `get_fixture()` method short-circuit to fixtures instead of live data. Used for UI smoke testing. (Conversion, Subscribers, and Donors don't implement fixtures today; see [Metric orchestrators](#metric-orchestrators-metricsclass--metricphp).) |
 | `NEWSPACK_INSIGHTS_CACHE_DISABLED` | Bypass the server-side transient cache entirely. Dev/debug only. |
@@ -49,7 +48,7 @@ src/wizards/insights/               (frontend)
 
 ### Sections (`class-insights-section-*.php`)
 
-One per tab. Each section's `init()` is called from [`includes/class-wizards.php`](../../class-wizards.php) during wizard bootstrap. The section bails immediately when `Insights_Wizard::is_enabled()` is false; Gates and Advertising sections also gate on their per-tab preview/enabled constants. When the gate passes, the section:
+One per tab. Each section's `init()` is called from [`includes/class-wizards.php`](../../class-wizards.php) during wizard bootstrap. The section bails immediately when `Insights_Wizard::is_enabled()` is false; the Advertising section also gates on its per-tab enabled constant. When the gate passes, the section:
 
 1. Loads the tab's `metrics/class-*-metric.php` and `api/class-*-rest-controller.php` files.
 2. Registers the REST route on the `rest_api_init` hook.
@@ -82,7 +81,7 @@ Current tab status:
 | Audience (1) | GA4 Data API | Default path; BQ v1.1 path is stubbed behind `NEWSPACK_INSIGHTS_AUDIENCE_USE_GA4`. |
 | Engagement (2) | GA4 Data API | Same dispatch pattern (`NEWSPACK_INSIGHTS_ENGAGEMENT_USE_GA4`). |
 | Conversion (3) | Inline placeholders | The metric returns synthetic payloads with `pending: true` per shape until NPPD-1630 Phase 2 lands. No BigQuery calls and no fixtures wired today. |
-| Gates (4) | BigQuery | Preview-flag gated. |
+| Gates (4) | BigQuery | Gate exposure, conversion funnel, per-gate breakdown. |
 | Prompts (5) | BigQuery | Conversion funnels. |
 | Subscribers (6) | Local Woo | Reads via [`storage/`](storage/). |
 | Donors (7) | Local Woo | Donation-scoped queries via the donors storage interface. |

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -9,9 +9,10 @@
  *
  * The data layer (REST route + Action Scheduler refresh) registers from
  * {@see self::register_hooks()} via {@see \Newspack\Insights\Advertising_REST_Controller}
- * and {@see \Newspack\Insights\Advertising_Metric}. It is gated behind both the
- * Insights flag and {@see Insights_Wizard::is_advertising_enabled()}, so the
- * entire stack stays dormant (and Tab 8 invisible) unless explicitly enabled.
+ * and {@see \Newspack\Insights\Advertising_Metric}. It is gated behind the
+ * Insights flag; tab visibility and whether any GAM report actually runs are
+ * governed at runtime by {@see \Newspack\Insights\Advertising_Metric::is_tab_visible()}
+ * (Google Ad Manager active), so the stack stays dormant on non-GAM sites.
  *
  * @package Newspack
  */
@@ -37,11 +38,12 @@ class Insights_Section_Advertising {
 
 	/**
 	 * Initialize. Loads the Tab 8 data layer and registers its REST route +
-	 * Action Scheduler refresh handler (NPPD-1663). No-op unless both the
-	 * Insights flag and the Advertising feature constant are enabled.
+	 * Action Scheduler refresh handler (NPPD-1663). No-op unless the Insights
+	 * flag is enabled; the GAM-active runtime check governs tab visibility and
+	 * whether any report actually runs.
 	 */
 	public static function init() {
-		if ( ! Insights_Wizard::is_enabled() || ! Insights_Wizard::is_advertising_enabled() ) {
+		if ( ! Insights_Wizard::is_enabled() ) {
 			return;
 		}
 		self::load_dependencies();

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -3,10 +3,8 @@
  * Newspack Insights — Gates section (NPPD-1604).
  *
  * Gates tab scope: gate exposure, free + paid reader conversion,
- * conversion-journey funnel, per-gate breakdown. Phase 1 ships the
- * full UI with placeholder data; Phase 2 (NPPD-1630) swaps the
- * underlying metric implementations to BigQuery via the Newspack
- * Manager query proxy.
+ * conversion-journey funnel, per-gate breakdown. Metrics are backed by
+ * BigQuery via the Newspack Manager query proxy (NPPD-1630).
  *
  * Visibility is gated by the standard {@see Insights_Wizard::is_enabled()}
  * flag — the `NEWSPACK_INSIGHTS_ENABLED` constant.

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-gates.php
@@ -8,10 +8,8 @@
  * underlying metric implementations to BigQuery via the Newspack
  * Manager query proxy.
  *
- * Visibility is gated by both the standard {@see Insights_Wizard::is_enabled()}
- * flag AND the additional {@see Insights_Wizard::is_gates_preview_enabled()}
- * constant — set `NEWSPACK_INSIGHTS_GATES_PREVIEW` to surface the
- * preview tab on a given environment.
+ * Visibility is gated by the standard {@see Insights_Wizard::is_enabled()}
+ * flag — the `NEWSPACK_INSIGHTS_ENABLED` constant.
  *
  * @package Newspack
  */
@@ -35,14 +33,10 @@ class Insights_Section_Gates {
 	const SECTION_NAME = 'Gates';
 
 	/**
-	 * Initialize. Bails early when either the parent Insights feature
-	 * flag or the Gates preview flag is off.
+	 * Initialize. Bails early when the Insights feature flag is off.
 	 */
 	public static function init() {
 		if ( ! Insights_Wizard::is_enabled() ) {
-			return;
-		}
-		if ( ! Insights_Wizard::is_gates_preview_enabled() ) {
 			return;
 		}
 		self::load_dependencies();
@@ -63,7 +57,7 @@ class Insights_Section_Gates {
 	/**
 	 * Register the Tab 4 REST route and warm the gates tab.
 	 *
-	 * Called only when NEWSPACK_INSIGHTS_GATES_PREVIEW is set (enforced by init()).
+	 * Called only when the Insights feature flag is enabled (enforced by init()).
 	 *
 	 * @return void
 	 */

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -82,34 +82,6 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
-	 * Whether the Gates preview tab (Tab 4 / NPPD-1604) is enabled
-	 * for this environment.
-	 *
-	 * Independent from {@see self::is_enabled()} so the preview can
-	 * be flipped on only where it's wanted (development, staging,
-	 * canary), separately from the broader Insights wizard rollout.
-	 * Once Phase 2 (NPPD-1630) lands and the tab is no longer a
-	 * placeholder, this gate can be retired in favor of the standard
-	 * Insights flag plus a runtime feature-detection check.
-	 *
-	 * @return bool True when the Gates preview should appear in the
-	 *              Insights tab nav and have its REST route active.
-	 */
-	public static function is_gates_preview_enabled(): bool {
-		/**
-		 * Enables the Gates tab preview (Phase 1, placeholder data).
-		 *
-		 * @constant NEWSPACK_INSIGHTS_GATES_PREVIEW
-		 * @type     bool
-		 * @default  Gates preview tab hidden
-		 * @status   draft
-		 *
-		 * @example define( 'NEWSPACK_INSIGHTS_GATES_PREVIEW', true );
-		 */
-		return defined( 'NEWSPACK_INSIGHTS_GATES_PREVIEW' ) && NEWSPACK_INSIGHTS_GATES_PREVIEW;
-	}
-
-	/**
 	 * Whether the Advertising tab (Tab 8 / NPPD-1663) is enabled for this
 	 * environment.
 	 *
@@ -448,13 +420,13 @@ class Insights_Wizard extends Wizard {
 			// donation products, then checks for an active donation subscription or
 			// a qualifying donation order in the trailing
 			// DONATION_ACTIVITY_WINDOW_DAYS window (cached for a day). Gates is
-			// gated to the preview constant NEWSPACK_INSIGHTS_GATES_PREVIEW while
-			// Phase 1 (placeholder data) is being validated.
+			// always shown (true) alongside the other BQ-backed tabs; it is
+			// governed solely by the Insights feature flag.
 			'tabs'                => [
 				'audience'       => true,
 				'engagement'     => true,
 				'conversion'     => true,
-				'gates'          => self::is_gates_preview_enabled(),
+				'gates'          => true,
 				'prompts'        => true,
 				'subscribers'    => true,
 				'donors'         => self::has_donation_activity(),

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -82,30 +82,6 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
-	 * Whether the Advertising tab (Tab 8 / NPPD-1663) is enabled for this
-	 * environment.
-	 *
-	 * Independent from {@see self::is_enabled()} so the GAM-backed Advertising
-	 * orchestrator (its REST route and Action Scheduler refresh) only registers
-	 * where wanted, separately from the broader Insights rollout.
-	 *
-	 * @return bool True when Tab 8's data layer should be active.
-	 */
-	public static function is_advertising_enabled(): bool {
-		/**
-		 * Enables the Advertising tab (Tab 8) GAM orchestrator.
-		 *
-		 * @constant NEWSPACK_INSIGHTS_ADVERTISING_ENABLED
-		 * @type     bool
-		 * @default  Advertising tab disabled
-		 * @status   draft
-		 *
-		 * @example define( 'NEWSPACK_INSIGHTS_ADVERTISING_ENABLED', true );
-		 */
-		return defined( 'NEWSPACK_INSIGHTS_ADVERTISING_ENABLED' ) && NEWSPACK_INSIGHTS_ADVERTISING_ENABLED;
-	}
-
-	/**
 	 * Globally disable the Insights cache for development / debugging.
 	 *
 	 * @constant NEWSPACK_INSIGHTS_CACHE_DISABLED
@@ -359,16 +335,13 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
-	 * Whether the Advertising (Tab 8) nav entry should render. Requires the
-	 * feature flag, plus either an active Google Ad Manager ad provider or
-	 * fixture mode (so the tab is testable without a GAM connection).
+	 * Whether the Advertising (Tab 8) nav entry should render. Shown when Google
+	 * Ad Manager is the active ad provider (runtime check), or when fixture mode
+	 * is on (so the tab is testable without a GAM connection).
 	 *
 	 * @return bool
 	 */
 	private static function is_advertising_tab_visible(): bool {
-		if ( ! self::is_advertising_enabled() ) {
-			return false;
-		}
 		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
 			return true;
 		}
@@ -409,10 +382,10 @@ class Insights_Wizard extends Wizard {
 			// are live BQ-backed tabs (data layers complete per NPPD-1729). They
 			// are always shown (true) — feature detection is handled at the metric
 			// level via the BQ proxy, not at tab-registration time. Advertising
-			// (Tab 8, NPPD-1618) has its own data layer: it shows when its feature
-			// flag is enabled AND either Google Ad Manager is the active ad provider
-			// (Advertising_Metric::is_tab_visible() === Client::is_gam_active()) or
-			// fixture mode is on for dev testing. See is_advertising_tab_visible().
+			// (Tab 8, NPPD-1618) has its own data layer: it shows when Google Ad
+			// Manager is the active ad provider (Advertising_Metric::is_tab_visible()
+			// === Client::is_gam_active()) or fixture mode is on for dev testing.
+			// See is_advertising_tab_visible().
 			// Subscribers stays all-on for now; Tab 6 visibility detection
 			// (non-donation subscription product presence) is a separate follow-up.
 			// Donors hides when there's no recent donation activity —


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Consolidates Insights tab gating onto the single `NEWSPACK_INSIGHTS_ENABLED` master flag by removing the two secondary per-tab feature-flag constants that were only needed while those tabs were previews:

- **`NEWSPACK_INSIGHTS_GATES_PREVIEW`** — the Gates tab (Tab 4) now behaves like the other BigQuery-backed tabs (Audience, Engagement, Conversion, Prompts): always shown when Insights is enabled. Its data layer is BigQuery-backed via the Newspack Manager query proxy (NPPD-1630), so the preview gate is no longer needed.
- **`NEWSPACK_INSIGHTS_ADVERTISING_ENABLED`** — the Advertising tab (Tab 8) is GAM-backed live data via the SOAP ReportService (NPPD-1662), not a preview. Its visibility is now governed solely by the existing runtime "GAM active" check (`Advertising_Metric::is_tab_visible()` → `Client::is_gam_active()`), plus fixture mode — the same runtime-detection pattern the Donors tab uses. The tab's REST route + Action Scheduler refresh handler now register whenever Insights is enabled, but stay dormant on non-GAM sites (`get_all()` short-circuits before any GAM work).

`NEWSPACK_INSIGHTS_FIXTURE_MODE` remains independent for mock/debug data. The Insights README and section docblocks are updated to drop both removed constants and the stale "Phase 1 placeholder data" language.

**Operational notes:**
- Because Gates is now registered with the pre-warm scheduler on every Insights-enabled site (previously only where the preview flag was set), the daily pre-warm fan-out enqueues ~5 additional (gates, window) Action Scheduler jobs per site. Intended; jobs are async, deduped (`as_has_scheduled_action`), retried with backoff, and short-circuited when not warmable.
- Removing `NEWSPACK_INSIGHTS_ADVERTISING_ENABLED` also removes it as a kill-switch: a GAM-active site that previously set the constant to `false` to hide Tab 8 will now show it (governed solely by the GAM-active check). This is the intended consolidation — no code contract depended on the old behavior.

### How to test the changes in this Pull Request:

1. On a site **without** `NEWSPACK_INSIGHTS_ENABLED` defined, confirm the Insights admin page and all tabs are absent (unchanged).
2. Define only `NEWSPACK_INSIGHTS_ENABLED` (`define( 'NEWSPACK_INSIGHTS_ENABLED', true );`); do **not** define `NEWSPACK_INSIGHTS_GATES_PREVIEW` or `NEWSPACK_INSIGHTS_ADVERTISING_ENABLED`.
3. Visit **Newspack → Insights**. Confirm the **Gates** tab now appears and loads its data without errors, and its REST route is registered (pre-warm runs for the `gates` tab).
4. On a site where **Google Ad Manager is the active ad provider**, confirm the **Advertising** tab appears and loads without errors.
5. On a site where **GAM is not active**, confirm the Advertising tab is hidden, and hitting `GET /newspack-insights/v1/advertising` directly schedules no GAM refresh job (the metric short-circuits).
6. Optionally set `NEWSPACK_INSIGHTS_FIXTURE_MODE` and confirm the Advertising tab appears with fixture data even without a GAM connection.
7. Verify no remaining references to either removed constant, and that defining them has no effect on tab visibility.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (N/A — removes two feature-flag gates; no logic to unit-test, and no existing test references either removed gate.)
* [ ] Have you successfully run tests with your changes locally? (Verified `php -l` + PHPCS clean on all touched PHP; full PHPUnit suite deferred to CI — this worktree isn't mounted in an isolated env.)