### PR TITLE
refactor(insights): newsletter ads full-width tables + left-align toggle

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.test.tsx
@@ -139,7 +139,7 @@ describe( 'NewsletterAdsTab', () => {
 		expect( screen.getAllByText( 'Requires the latest Newspack Newsletters plugin.' ).length ).toBeGreaterThan( 0 );
 		// The timeframe-scoped sections stay withheld…
 		expect( screen.queryByText( 'Performance trend' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Top performers' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top ads' ) ).not.toBeInTheDocument();
 		// …and the absent has_window_activity signal must NOT collapse the
 		// Overview into the empty state (the lifetime cards carry the signal).
 		expect( document.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
@@ -165,7 +165,8 @@ describe( 'NewsletterAdsTab', () => {
 		// …and every section still renders.
 		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top performers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top ads' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Ad performance by newsletter' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders all sections with values when ready', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -285,6 +285,11 @@
 	// "See more" / "See less" toggle below an expandable MetricTable.
 	&__table-toggle {
 		display: inline-block;
+		// Hug the start when the toggle is a direct flex child (e.g. a full-width
+		// table rendered straight into a flex-column section) — otherwise it
+		// stretches full width and the button's default centered text drifts to
+		// the middle. A no-op where the toggle isn't a flex item.
+		align-self: flex-start;
 		margin-top: 8px;
 		padding: 0;
 		background: transparent;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
@@ -1,11 +1,12 @@
 /**
- * Newsletter Ads › Top performers (NPPD-1861).
+ * Newsletter Ads › performance tables (NPPD-1861).
  *
- * Mirrors Advertising's TopPerformersSection exactly: MetricTable (static, not
- * sortable) with Top ads and Top advertisers side by side (collapsed to 5 rows
- * behind "See more"), and the per-newsletter breakdown full-width below.
- * MetricTable renders null cells (CTR/revenue without impressions or price) as
- * the em-dash natively — never a misleading 0% / $0.00.
+ * Three MetricTables (static, not sortable), each rendered as its own
+ * full-width H2 section — Top ads, Top advertisers, and Ad performance by
+ * newsletter — collapsed to 5 rows behind "See more". Ad titles and advertiser
+ * names run long, so a side-by-side pair truncated badly. MetricTable renders
+ * null cells (CTR/revenue without impressions or price) as the em-dash
+ * natively — never a misleading 0% / $0.00.
  */
 
 /**
@@ -45,66 +46,57 @@ const withDisplayDates = ( payload?: MetricPayload ): MetricPayload | undefined 
 };
 
 const TablesSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-performers">
-		<SectionHeading
-			id="newspack-insights-newsletter-ads-top-performers"
-			title={ __( 'Top performers', 'newspack-plugin' ) }
-			description={ __( 'Which ads, advertisers, and newsletters drive your results in the selected timeframe.', 'newspack-plugin' ) }
-		/>
-		<div className="newspack-insights__table-grid newspack-insights__table-grid--cols-2">
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Top ads', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.top_ads }
-					emptyMessage={ __( 'No ad data in this timeframe.', 'newspack-plugin' ) }
-					expandable
-					defaultRowLimit={ 5 }
-					columns={ [
-						{ key: 'title', label: __( 'Ad', 'newspack-plugin' ) },
-						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-					] }
-				/>
-			</div>
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Top advertisers', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.top_advertisers }
-					emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
-					expandable
-					defaultRowLimit={ 5 }
-					columns={ [
-						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
-						{ key: 'ads', label: __( 'Ads', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-					] }
-				/>
-			</div>
-		</div>
-		<div className="newspack-insights__table-grid">
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Ad performance by newsletter', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ withDisplayDates( current.by_newsletter ) }
-					emptyMessage={ __( 'No newsletters carried ads in this timeframe.', 'newspack-plugin' ) }
-					expandable
-					defaultRowLimit={ 5 }
-					columns={ [
-						{ key: 'title', label: __( 'Newsletter', 'newspack-plugin' ) },
-						{ key: 'sent_date', label: __( 'Sent date', 'newspack-plugin' ) },
-						{ key: 'ads', label: __( 'Ads carried', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					] }
-				/>
-			</div>
-		</div>
-	</section>
+	<>
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-ads">
+			<SectionHeading id="newspack-insights-newsletter-ads-top-ads" title={ __( 'Top ads', 'newspack-plugin' ) } />
+			<MetricTable
+				payload={ current.top_ads }
+				emptyMessage={ __( 'No ad data in this timeframe.', 'newspack-plugin' ) }
+				expandable
+				defaultRowLimit={ 5 }
+				columns={ [
+					{ key: 'title', label: __( 'Ad', 'newspack-plugin' ) },
+					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+				] }
+			/>
+		</section>
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-advertisers">
+			<SectionHeading id="newspack-insights-newsletter-ads-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
+			<MetricTable
+				payload={ current.top_advertisers }
+				emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
+				expandable
+				defaultRowLimit={ 5 }
+				columns={ [
+					{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+					{ key: 'ads', label: __( 'Ads', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+				] }
+			/>
+		</section>
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-by-newsletter">
+			<SectionHeading id="newspack-insights-newsletter-ads-by-newsletter" title={ __( 'Ad performance by newsletter', 'newspack-plugin' ) } />
+			<MetricTable
+				payload={ withDisplayDates( current.by_newsletter ) }
+				emptyMessage={ __( 'No newsletters carried ads in this timeframe.', 'newspack-plugin' ) }
+				expandable
+				defaultRowLimit={ 5 }
+				columns={ [
+					{ key: 'title', label: __( 'Newsletter', 'newspack-plugin' ) },
+					{ key: 'sent_date', label: __( 'Sent date', 'newspack-plugin' ) },
+					{ key: 'ads', label: __( 'Ads carried', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+				] }
+			/>
+		</section>
+	</>
 );
 
 export default TablesSection;


### PR DESCRIPTION
Follow-up to NPPD-1861 (#548, merged) — applies the same table-layout styling the Advertising tab got in #550 to the Newsletter Ads tab, which merged before those tweaks existed.

## Changes (3 files, styling only)
- **Top ads / Top advertisers / Ad performance by newsletter** each become their own full-width **H2 section** (was `cols-2` side-by-side under a "Top performers" umbrella heading, now dropped) — ad titles and advertiser names run long, so the side-by-side pair truncated badly.
- **`table-toggle { align-self: flex-start }`** — the "See more" toggle was stretching full-width and centering its label when it became a direct flex child of a section. No-op where the toggle isn't a flex item (other tabs unaffected).
- Test assertions updated (`Top performers` → `Top ads` / `Ad performance by newsletter`).

## Test plan
Full jest 773 green; eslint + stylelint clean; verified live in fixture mode (three full-width H2 sections, all three See-more toggles flush left).