### PR TITLE
feat(insights): consumer snapshot warming visibility

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -66,12 +66,16 @@ class Audience_REST_Controller extends WP_REST_Controller {
 	 * serving a stale tab-level envelope. Overrides the global default so only
 	 * the audience envelope is busted — other tabs keep their caches. v2 adds
 	 * the NEWS-2603 top-level `data_status` field (a stale v1 envelope would
-	 * lack it and the warming banner would never render).
+	 * lack it and the warming banner would never render). v3 adds `error_code`
+	 * to the core BigQuery-proxy metric error payloads AND changes how
+	 * `data_status` is derived (core-metric outages now flip it to
+	 * `incomplete`); a stale v2 window would keep serving the pre-fix
+	 * `data_status: 'complete'` and hide the outage banner until natural expiry.
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '2';
+		return '3';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -250,10 +250,6 @@ class Audience_REST_Controller extends WP_REST_Controller {
 			$response['previous'] = isset( $previous['tab_error'] ) ? null : $previous;
 		}
 
-		// NEWS-2603: top-level warming-aware status derived from every nested
-		// metric-scalar `state`, for the React banner to consume.
-		$response['data_status'] = Metric_Status::derive( $response );
-
 		return $response;
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -62,6 +62,19 @@ class Audience_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Bumped when the tab payload's shape changes so a deploy doesn't keep
+	 * serving a stale tab-level envelope. Overrides the global default so only
+	 * the audience envelope is busted — other tabs keep their caches. v2 adds
+	 * the NEWS-2603 top-level `data_status` field (a stale v1 envelope would
+	 * lack it and the warming banner would never render).
+	 *
+	 * @return string
+	 */
+	protected function cache_schema_version(): string {
+		return '2';
+	}
+
+	/**
 	 * Tab slug used as the cache namespace.
 	 *
 	 * @return string
@@ -236,6 +249,11 @@ class Audience_REST_Controller extends WP_REST_Controller {
 			$previous             = Audience_Metric::get_all( $compare_start->format( 'Y-m-d' ), $compare_end->format( 'Y-m-d' ), false );
 			$response['previous'] = isset( $previous['tab_error'] ) ? null : $previous;
 		}
+
+		// NEWS-2603: top-level warming-aware status derived from every nested
+		// metric-scalar `state`, for the React banner to consume.
+		$response['data_status'] = Metric_Status::derive( $response );
+
 		return $response;
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-donors-rest-controller.php
@@ -62,12 +62,13 @@ class Donors_REST_Controller extends WP_REST_Controller {
 	 * CACHE_PREFIX bump. Only the donors envelope is busted — other
 	 * (BigQuery-backed) tabs keep their caches. v4 adds the NEWS-2603 snapshot
 	 * fields `newsletter_conversion` and `supporter_clv_3yr` (a stale v3 envelope
-	 * would lack them and the cards would dereference `undefined`).
+	 * would lack them and the cards would dereference `undefined`); v5 adds the
+	 * NEWS-2603 top-level `data_status` field.
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '4';
+		return '5';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -74,12 +74,13 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 	 * merge + synthetic "(no variation)" row); v3 adds `winback_subscribers` to
 	 * each window payload; v4 adds the NEWS-2603 snapshot fields
 	 * `newsletter_conversion` and `supporter_clv_3yr` (a stale v3 envelope would
-	 * lack them and the cards would dereference `undefined`).
+	 * lack them and the cards would dereference `undefined`); v5 adds the
+	 * NEWS-2603 top-level `data_status` field.
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '4';
+		return '5';
 	}
 
 	/**
@@ -206,6 +207,10 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 		if ( $compare_start && $compare_end ) {
 			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end );
 		}
+
+		// NEWS-2603: top-level warming-aware status derived from every nested
+		// metric-scalar `state`, for the React banner to consume.
+		$response['data_status'] = Metric_Status::derive( $response );
 
 		return $response;
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-subscribers-rest-controller.php
@@ -208,10 +208,6 @@ class Subscribers_REST_Controller extends WP_REST_Controller {
 			$response['previous'] = $this->build_window( $metric, $compare_start, $compare_end );
 		}
 
-		// NEWS-2603: top-level warming-aware status derived from every nested
-		// metric-scalar `state`, for the React banner to consume.
-		$response['data_status'] = Metric_Status::derive( $response );
-
 		return $response;
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/trait-cached-controller.php
@@ -51,6 +51,30 @@ trait Cached_Controller_Trait {
 	abstract public function build_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array;
 
 	/**
+	 * Build a base window payload and stamp the NEWS-2603 top-level
+	 * `data_status` (`complete` | `warming` | `incomplete`) derived from every
+	 * nested metric-scalar `state`.
+	 *
+	 * Centralized here — on the single path every cached/refreshed/pre-warmed
+	 * current window flows through — rather than in each controller's
+	 * build_response(). Deriving it once makes it structurally impossible for a
+	 * tab to bump its schema version yet ship an envelope without `data_status`
+	 * (the omission that left the Donors banner, auto-refetch, and escalation
+	 * inert). It also feeds the cache's provisional-payload detection, so a
+	 * warming window gets the short TTL and skips the durable pools uniformly
+	 * across store(), refresh(), and the pre-warm path.
+	 *
+	 * @param DateTimeImmutable $start Window start.
+	 * @param DateTimeImmutable $end   Window end.
+	 * @return array The window payload with a top-level `data_status`.
+	 */
+	protected function status_stamped_window_payload( DateTimeImmutable $start, DateTimeImmutable $end ): array {
+		$payload                = $this->build_window_payload( $start, $end );
+		$payload['data_status'] = Metric_Status::derive( $payload );
+		return $payload;
+	}
+
+	/**
 	 * Build and durably store one pre-warmed base window. Uses the controller's
 	 * own tab/source/versioned key so the entry key-matches the GET read path.
 	 *
@@ -74,7 +98,7 @@ trait Cached_Controller_Trait {
 			$this->tab_slug(),
 			$this->cache_source(),
 			$key_parts,
-			$this->build_window_payload( $start, $end ),
+			$this->status_stamped_window_payload( $start, $end ),
 			[
 				'start' => $start->format( 'Y-m-d' ),
 				'end'   => $end->format( 'Y-m-d' ),
@@ -168,7 +192,7 @@ trait Cached_Controller_Trait {
 			$this->tab_slug(),
 			$this->cache_source(),
 			$this->base_key_parts( $start, $end ),
-			fn() => $this->build_window_payload( $start, $end ),
+			fn() => $this->status_stamped_window_payload( $start, $end ),
 			$this->window_map( $start, $end )
 		);
 
@@ -214,7 +238,7 @@ trait Cached_Controller_Trait {
 			$this->tab_slug(),
 			$this->cache_source(),
 			$this->base_key_parts( $start, $end ),
-			fn() => $this->build_window_payload( $start, $end ),
+			fn() => $this->status_stamped_window_payload( $start, $end ),
 			$this->window_map( $start, $end )
 		);
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-bigquery-proxy-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-bigquery-proxy-client.php
@@ -46,6 +46,17 @@ class BigQuery_Proxy_Client {
 	const REQUEST_TIMEOUT = 30;
 
 	/**
+	 * WP_Error code returned when the hub proxy isn't set up (Newspack Manager
+	 * not connected). This is a SETUP state, not a failed data fetch —
+	 * {@see \Newspack\Insights\Metric_Status::derive()} excludes it from the
+	 * envelope `data_status` so a never-connected hub doesn't trip the "last
+	 * data fetch didn't finish" warning banner.
+	 *
+	 * @var string
+	 */
+	const ERROR_NOT_CONFIGURED = 'bigquery_proxy_not_configured';
+
+	/**
 	 * Logger header so all BQ proxy failures land in one Logstash bucket.
 	 *
 	 * @var string
@@ -144,7 +155,7 @@ class BigQuery_Proxy_Client {
 	public function query( string $query_name, DateTimeInterface $start, DateTimeInterface $end ) {
 		if ( ! $this->is_configured() ) {
 			$error = new WP_Error(
-				'bigquery_proxy_not_configured',
+				self::ERROR_NOT_CONFIGURED,
 				__( 'Newspack Manager is not configured for BigQuery proxy calls.', 'newspack-plugin' )
 			);
 			$this->log_failure( $error, $query_name, $start, $end );

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -272,6 +272,15 @@ final class Cache {
 		if ( self::is_disabled() ) {
 			return $envelope;
 		}
+		// A provisional (warming) payload must never enter the durable pool: it
+		// is served as fresh for TTL_DURABLE_FRESH (~25h), which would cement a
+		// "still calculating" envelope long after the hub finished warming. Skip
+		// the write (the prewarm/refresh caller that produced it will recompute
+		// and persist a non-provisional payload on a later pass). Return the
+		// envelope so callers behave uniformly, exactly as the is_disabled() path.
+		if ( 'warming' === ( $payload['data_status'] ?? null ) ) {
+			return $envelope;
+		}
 		$store = [
 			'payload'     => $envelope['payload'],
 			'computed_at' => $envelope['computed_at'],
@@ -651,6 +660,14 @@ final class Cache {
 
 		$envelope = self::envelope( $payload, $source );
 
+		// A provisional (warming) refresh — the state the client's warming poll
+		// drives this method into — must behave like store()'s provisional path:
+		// short transient TTL and no durable/on-demand write-through, so the
+		// warming envelope isn't cemented as fresh (~25h) in a pool that the
+		// poll can't force past the BQ cooldown. The next recompute picks up the
+		// warmed value off the short transient.
+		$is_provisional = 'warming' === ( $payload['data_status'] ?? null );
+
 		if ( null !== $key ) {
 			$store = [
 				'payload'     => $envelope['payload'],
@@ -658,7 +675,7 @@ final class Cache {
 				'source'      => $envelope['source'],
 			];
 			// set_transient() overwrites in place — no need to delete_transient() first.
-			set_transient( $key, $store, self::ttl_for( $source ) );
+			set_transient( $key, $store, $is_provisional ? self::TTL_PROVISIONAL : self::ttl_for( $source ) );
 			if ( self::SOURCE_SNAPSHOT !== $source ) {
 				self::index_add( $tab, $key );
 			}
@@ -668,19 +685,22 @@ final class Cache {
 			// returns fresh data on the next request. Preset entries are synced in
 			// place; on-demand entries are synced or (for a windowed source with a
 			// supplied window) created — a refreshed custom range becomes durable.
-			$existing_durable = self::peek_durable( $tab, $source, $key_parts );
-			if ( null !== $existing_durable ) {
-				self::store_durable( $tab, $source, $key_parts, $envelope['payload'], $existing_durable['window'] );
-			}
-			$existing_ondemand = self::peek_ondemand( $tab, $source, $key_parts );
-			if ( null !== $existing_ondemand ) {
-				self::store_ondemand( $tab, $source, $key_parts, $envelope['payload'], $existing_ondemand['window'] );
-			} elseif (
-				null === $existing_durable &&
-				null !== $window &&
-				( self::SOURCE_EXTERNAL === $source || self::SOURCE_BIGQUERY === $source )
-			) {
-				self::store_ondemand( $tab, $source, $key_parts, $envelope['payload'], $window );
+			// Skipped entirely for a provisional payload (see above).
+			if ( ! $is_provisional ) {
+				$existing_durable = self::peek_durable( $tab, $source, $key_parts );
+				if ( null !== $existing_durable ) {
+					self::store_durable( $tab, $source, $key_parts, $envelope['payload'], $existing_durable['window'] );
+				}
+				$existing_ondemand = self::peek_ondemand( $tab, $source, $key_parts );
+				if ( null !== $existing_ondemand ) {
+					self::store_ondemand( $tab, $source, $key_parts, $envelope['payload'], $existing_ondemand['window'] );
+				} elseif (
+					null === $existing_durable &&
+					null !== $window &&
+					( self::SOURCE_EXTERNAL === $source || self::SOURCE_BIGQUERY === $source )
+				) {
+					self::store_ondemand( $tab, $source, $key_parts, $envelope['payload'], $window );
+				}
 			}
 		}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -40,6 +40,14 @@ final class Cache {
 	const BQ_COOLDOWN_SECONDS = 10 * MINUTE_IN_SECONDS;
 
 	/**
+	 * TTL for a provisional (warming) payload — one whose top-level
+	 * `data_status` is 'warming'. Short-lived so the next visit recomputes
+	 * soon and picks up the fully-warmed value, instead of serving the
+	 * provisional payload for the source's normal (much longer) TTL.
+	 */
+	const TTL_PROVISIONAL = 3 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Max number of transient keys retained per tab in the index. Older
 	 * entries are dropped FIFO when the cap is exceeded; the underlying
 	 * transients still expire naturally on their TTL — losing the index
@@ -146,18 +154,26 @@ final class Cache {
 		$payload  = (array) $compute();
 		$envelope = self::envelope( $payload, $source );
 
+		// A provisional (warming) payload gets a short TTL and is kept out of
+		// the on-demand durable pool, so the next visit recomputes soon and
+		// picks up the fully-warmed value rather than serving this provisional
+		// payload for the source's normal (much longer) TTL.
+		$is_provisional = is_array( $payload ) && ( 'warming' === ( $payload['data_status'] ?? null ) );
+
 		$store = [
 			'payload'     => $envelope['payload'],
 			'computed_at' => $envelope['computed_at'],
 			'source'      => $envelope['source'],
 		];
-		set_transient( self::transient_key( $tab, $key_parts ), $store, self::ttl_for( $source ) );
+		set_transient( self::transient_key( $tab, $key_parts ), $store, $is_provisional ? self::TTL_PROVISIONAL : self::ttl_for( $source ) );
 		if ( self::SOURCE_SNAPSHOT !== $source ) {
 			self::index_add( $tab, self::transient_key( $tab, $key_parts ) );
 		}
 
-		// Write-through / refresh the on-demand pool (same eligibility as the read).
-		if ( $ondemand_eligible ) {
+		// Write-through / refresh the on-demand pool (same eligibility as the
+		// read), skipped for a provisional payload so a warming value can't
+		// stick in the 25h-fresh on-demand pool.
+		if ( $ondemand_eligible && ! $is_provisional ) {
 			self::store_ondemand( $tab, $source, $key_parts, $envelope['payload'], $window );
 		}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -336,6 +336,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $column, $rows[0] ) ) {
@@ -387,6 +388,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( ! is_array( $rows ) ) {
@@ -465,6 +467,7 @@ final class Audience_Metric {
 				'numerator'   => 0,
 				'denominator' => 0,
 				'error'       => $rows->get_error_message(),
+				'error_code'  => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) ) {
@@ -510,6 +513,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => 'count',
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! isset( $rows[0]['sessions'] ) ) {
@@ -956,6 +960,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => 'rate',
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( 'returning_reader_rate', $rows[0] ) ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -350,6 +350,29 @@ final class Conversion_Metric {
 	}
 
 	/**
+	 * Warming payload for a snapshot scalar scorecard metric (NEWS-2603). The hub
+	 * returns this state when a snapshot cache miss is being backfilled by an
+	 * async refresh — a distinct, expected, transient condition, NOT an error and
+	 * NOT schema drift. Unlike error_scalar, no error_code/error_message is set;
+	 * unlike populated_scalar's data_missing branch, data_missing is always false.
+	 * The React layer reads `state` to render a "warming up" treatment rather than
+	 * a non-computable zero or an error.
+	 *
+	 * @param string $placeholder_type One of 'count', 'rate', 'currency', 'decimal'.
+	 * @return array
+	 */
+	private function warming_scalar( string $placeholder_type ): array {
+		return [
+			'state'            => 'warming',
+			'value'            => 0.0,
+			'computable'       => false,
+			'denominator'      => null,
+			'placeholder_type' => $placeholder_type,
+			'data_missing'     => false,
+		];
+	}
+
+	/**
 	 * Error payload for a collection metric (funnel / distribution / table).
 	 *
 	 * @param string    $rows_key Key holding the (empty) collection: 'stages'|'slices'|'points'|'groups'|'cohorts'|'rows'|'weeks'.
@@ -460,9 +483,13 @@ final class Conversion_Metric {
 		if ( is_wp_error( $rows ) ) {
 			return $this->error_scalar( 'rate', $rows );
 		}
-		if ( empty( $rows ) ) {
-			// No rows → empty window, legitimately no data.
-			return $this->populated_scalar( 0.0, false, null, 'rate' );
+		// Warming (NEWS-2603): the hub snapshot isn't built yet. A cache miss is
+		// signaled either by the explicit marker row, or — on a hub not yet
+		// updated to emit the marker — a bare [] result set. Distinct from a
+		// genuinely computed empty cohort, which always arrives as a real data
+		// row (e.g. newsletter_signups => 0), never as an empty result set.
+		if ( empty( $rows ) || ( isset( $rows[0]['__status'] ) && 'warming' === $rows[0]['__status'] ) ) {
+			return $this->warming_scalar( 'rate' );
 		}
 		if ( ! is_array( $rows[0] ) || ! array_key_exists( $rate_key, $rows[0] ) || ! array_key_exists( $denominator_key, $rows[0] ) ) {
 			// Row present but unusable → schema drift. Non-computable, flagged.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -88,6 +88,21 @@ final class Conversion_Metric {
 	const SNAPSHOT_KEY = 'cohorts';
 
 	/**
+	 * Hub query names whose result is a pre-warmed snapshot. For these — and
+	 * ONLY these — a bare `[]` from the proxy means "snapshot not built yet"
+	 * (warming), because a genuinely-empty cohort always arrives as a real data
+	 * row. The other influenced-rate queries that share
+	 * compute_influenced_rate_from_proxy() treat `[]` as a legitimately empty
+	 * window (see NEWS-2603).
+	 *
+	 * @var string[]
+	 */
+	const SNAPSHOT_QUERY_NAMES = [
+		'conversion_journey_newsletter_to_subscription',
+		'conversion_journey_newsletter_to_donation',
+	];
+
+	/**
 	 * Action Scheduler action name for a one-off cohort snapshot refresh
 	 * (triggered on cold-cache misses from the request path).
 	 *
@@ -484,12 +499,20 @@ final class Conversion_Metric {
 			return $this->error_scalar( 'rate', $rows );
 		}
 		// Warming (NEWS-2603): the hub snapshot isn't built yet. A cache miss is
-		// signaled either by the explicit marker row, or — on a hub not yet
-		// updated to emit the marker — a bare [] result set. Distinct from a
-		// genuinely computed empty cohort, which always arrives as a real data
-		// row (e.g. newsletter_signups => 0), never as an empty result set.
-		if ( empty( $rows ) || ( isset( $rows[0]['__status'] ) && 'warming' === $rows[0]['__status'] ) ) {
+		// signaled either by the explicit marker row (honored for any query), or
+		// — on a hub not yet updated to emit the marker — a bare [] result set.
+		// The bare-[] fallback is scoped to the snapshot queries ONLY: for those,
+		// a genuinely computed empty cohort always arrives as a real data row
+		// (e.g. newsletter_signups => 0), so [] means "not warmed yet". This same
+		// method also serves the live 14-day influenced-rate queries, where [] is
+		// a legitimately empty window — those keep the pre-existing zero behavior.
+		$is_marker = isset( $rows[0]['__status'] ) && 'warming' === $rows[0]['__status'];
+		if ( $is_marker || ( empty( $rows ) && in_array( $query_name, self::SNAPSHOT_QUERY_NAMES, true ) ) ) {
 			return $this->warming_scalar( 'rate' );
+		}
+		if ( empty( $rows ) ) {
+			// No rows on a non-snapshot query → empty window, legitimately no data.
+			return $this->populated_scalar( 0.0, false, null, 'rate' );
 		}
 		if ( ! is_array( $rows[0] ) || ! array_key_exists( $rate_key, $rows[0] ) || ! array_key_exists( $denominator_key, $rows[0] ) ) {
 			// Row present but unusable → schema drift. Non-computable, flagged.
@@ -1910,6 +1933,43 @@ final class Conversion_Metric {
 		$sub_clv  = $this->subscribers_metric->get_supporter_clv_3yr( $end );
 		$don_clv  = $this->donors_metric->get_supporter_clv_3yr( $end );
 
+		// Error precedence (NEWS-2603): a hub proxy failure on a rate query is the
+		// most actionable signal — surface it distinctly (not "insufficient
+		// history", which implies the publisher just needs to wait) even when the
+		// other path is computable or merely still warming up. Checked BEFORE the
+		// value computation so a partial failure is never masked by a value built
+		// from only the healthy path.
+		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
+			if ( isset( $rate['state'] ) && 'error' === $rate['state'] ) {
+				return [
+					'value'       => 0.0,
+					'computable'  => false,
+					'denominator' => 0,
+					'error'       => $rate['error_message'] ?? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' ),
+					'state'       => 'error',
+				];
+			}
+		}
+
+		// Warming precedence over a partial value (NEWS-2603): if either path's hub
+		// snapshot is still being backfilled, report warming rather than a value
+		// computed from only the ready path — a single-path value understates the
+		// modeled subscriber value and would render with no "still calculating"
+		// note. Only reached when neither path errored (error wins above).
+		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
+			if ( isset( $rate['state'] ) && 'warming' === $rate['state'] ) {
+				return [
+					'value'       => 0.0,
+					'computable'  => false,
+					'denominator' => 0,
+					'state'       => 'warming',
+				];
+			}
+		}
+
+		// Both contributing paths are settled (no error, no warming). Compute the
+		// value from whichever paths are computable — a genuinely empty path (e.g.
+		// insufficient history) simply contributes nothing.
 		$value      = 0.0;
 		$computable = false;
 		$signups    = 0;
@@ -1932,38 +1992,6 @@ final class Conversion_Metric {
 				'denominator' => $signups,
 				'state'       => 'populated',
 			];
-		}
-
-		// Not computable: a hub proxy failure on a rate query is an error state, not
-		// "insufficient history" — surface it distinctly so the card doesn't imply the
-		// publisher just needs to wait for data. Error takes precedence over warming
-		// (NEWS-2603): if either path outright failed, that's the more actionable
-		// signal even if the other path is merely still warming up.
-		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
-			if ( isset( $rate['state'] ) && 'error' === $rate['state'] ) {
-				return [
-					'value'       => 0.0,
-					'computable'  => false,
-					'denominator' => 0,
-					'error'       => $rate['error_message'] ?? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' ),
-					'state'       => 'error',
-				];
-			}
-		}
-
-		// Warming (NEWS-2603): the hub snapshot for at least one path is a cache
-		// miss being backfilled — a distinct, expected, transient condition, not
-		// an error and not "insufficient history" (which implies the publisher
-		// just needs more time/volume, not a rebuild already in progress).
-		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
-			if ( isset( $rate['state'] ) && 'warming' === $rate['state'] ) {
-				return [
-					'value'       => 0.0,
-					'computable'  => false,
-					'denominator' => 0,
-					'state'       => 'warming',
-				];
-			}
 		}
 
 		// Genuine insufficient-history state: neither path could be modeled yet.

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-conversion-metric.php
@@ -1887,18 +1887,21 @@ final class Conversion_Metric {
 	 *
 	 * @param DateTimeInterface $start Picker start (passed through to the rate queries).
 	 * @param DateTimeInterface $end   Report end date (the "now" anchor).
-	 * @return array{value: float, computable: bool, denominator: int}
+	 * @return array{value: float, computable: bool, denominator: int, state: string}
 	 */
 	public function get_newsletter_subscriber_value_3yr( DateTimeInterface $start, DateTimeInterface $end ): array {
 		// Both revenue paths need local Woo; no WooCommerce means there is no reader-
 		// revenue model to value — a "not configured" state, distinct from a site that
 		// has Woo but not yet enough history. Short-circuits before the hub calls.
+		// Deliberate non-applicability, not a data problem, so it counts as
+		// 'populated' for the envelope-level data_status (NEWS-2603).
 		if ( ! $this->woocommerce_active() ) {
 			return [
 				'value'          => 0.0,
 				'computable'     => false,
 				'denominator'    => 0,
 				'not_configured' => true,
+				'state'          => 'populated',
 			];
 		}
 
@@ -1927,12 +1930,15 @@ final class Conversion_Metric {
 				'value'       => round( $value, 2 ),
 				'computable'  => true,
 				'denominator' => $signups,
+				'state'       => 'populated',
 			];
 		}
 
 		// Not computable: a hub proxy failure on a rate query is an error state, not
 		// "insufficient history" — surface it distinctly so the card doesn't imply the
-		// publisher just needs to wait for data.
+		// publisher just needs to wait for data. Error takes precedence over warming
+		// (NEWS-2603): if either path outright failed, that's the more actionable
+		// signal even if the other path is merely still warming up.
 		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
 			if ( isset( $rate['state'] ) && 'error' === $rate['state'] ) {
 				return [
@@ -1940,6 +1946,22 @@ final class Conversion_Metric {
 					'computable'  => false,
 					'denominator' => 0,
 					'error'       => $rate['error_message'] ?? __( 'Newsletter conversion data is unavailable right now.', 'newspack-plugin' ),
+					'state'       => 'error',
+				];
+			}
+		}
+
+		// Warming (NEWS-2603): the hub snapshot for at least one path is a cache
+		// miss being backfilled — a distinct, expected, transient condition, not
+		// an error and not "insufficient history" (which implies the publisher
+		// just needs more time/volume, not a rebuild already in progress).
+		foreach ( [ $sub_rate, $don_rate ] as $rate ) {
+			if ( isset( $rate['state'] ) && 'warming' === $rate['state'] ) {
+				return [
+					'value'       => 0.0,
+					'computable'  => false,
+					'denominator' => 0,
+					'state'       => 'warming',
 				];
 			}
 		}
@@ -1949,6 +1971,7 @@ final class Conversion_Metric {
 			'value'       => 0.0,
 			'computable'  => false,
 			'denominator' => 0,
+			'state'       => 'populated',
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -217,6 +217,7 @@ final class Engagement_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $column, $rows[0] ) ) {
@@ -268,6 +269,7 @@ final class Engagement_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( ! is_array( $rows ) ) {
@@ -498,6 +500,7 @@ final class Engagement_Metric {
 				'computable' => false,
 				'type'       => 'table',
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( ! is_array( $rows ) ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Newspack Insights — envelope data_status deriver (NEWS-2603).
+ *
+ * Derives a top-level `data_status` for a tab's assembled REST response from
+ * the `state` carried by every metric-scalar node in the envelope (see
+ * {@see \Newspack\Insights\Conversion_Metric}'s `populated` / `warming` /
+ * `error` scalar states). The envelope-level vocabulary is intentionally
+ * distinct from the metric-scalar vocabulary: `data_status` is one of
+ * `complete` / `warming` / `incomplete`, never `populated` / `error`. A
+ * later React banner task consumes this field to decide whether to show a
+ * "still warming up" notice.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Pure derivation of the envelope-level data_status from nested metric states.
+ */
+class Metric_Status {
+
+	/**
+	 * Derive the envelope-level status from every metric-scalar `state` found
+	 * in the response, recursively. A node is treated as a metric scalar when
+	 * it is an array carrying a `state` key — its own children are not
+	 * descended into (the `state` key is the leaf signal); any other array is
+	 * walked further. Error takes precedence over warming: a single errored
+	 * metric makes the whole tab `incomplete` even if others are still
+	 * warming up.
+	 *
+	 * @param array $envelope Assembled tab response (or any sub-array of it).
+	 * @return string One of 'complete' | 'warming' | 'incomplete'.
+	 */
+	public static function derive( array $envelope ): string {
+		$has_warming = false;
+
+		foreach ( self::walk_states( $envelope ) as $state ) {
+			if ( 'error' === $state ) {
+				return 'incomplete';
+			}
+			if ( 'warming' === $state ) {
+				$has_warming = true;
+			}
+		}
+
+		return $has_warming ? 'warming' : 'complete';
+	}
+
+	/**
+	 * Yield every metric-scalar `state` value found by recursively walking
+	 * array children, without descending into a node once it's identified as
+	 * a metric scalar.
+	 *
+	 * @param array $node Current array node.
+	 * @return \Generator<string>
+	 */
+	private static function walk_states( array $node ) {
+		if ( array_key_exists( 'state', $node ) ) {
+			yield (string) $node['state'];
+			return;
+		}
+
+		foreach ( $node as $child ) {
+			if ( is_array( $child ) ) {
+				yield from self::walk_states( $child );
+			}
+		}
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
@@ -24,13 +24,11 @@ defined( 'ABSPATH' ) || exit;
 class Metric_Status {
 
 	/**
-	 * Derive the envelope-level status from every metric-scalar `state` found
-	 * in the response, recursively. A node is treated as a metric scalar when
-	 * it is an array carrying a `state` key — its own children are not
-	 * descended into (the `state` key is the leaf signal); any other array is
-	 * walked further. Error takes precedence over warming: a single errored
-	 * metric makes the whole tab `incomplete` even if others are still
-	 * warming up.
+	 * Derive the envelope-level status from every metric-scalar found in the
+	 * response, recursively. Each leaf metric resolves to one of `error` /
+	 * `warming` / `populated` (see {@see self::leaf_state()}); error takes
+	 * precedence over warming, so a single errored metric makes the whole tab
+	 * `incomplete` even if others are still warming up.
 	 *
 	 * @param array $envelope Assembled tab response (or any sub-array of it).
 	 * @return string One of 'complete' | 'warming' | 'incomplete'.
@@ -51,16 +49,22 @@ class Metric_Status {
 	}
 
 	/**
-	 * Yield every metric-scalar `state` value found by recursively walking
-	 * array children, without descending into a node once it's identified as
-	 * a metric scalar.
+	 * Yield the resolved state of every metric-scalar found by recursively
+	 * walking array children, without descending into a node once it's
+	 * identified as a metric scalar.
+	 *
+	 * A node is a metric-scalar leaf when it carries either a `state` key (the
+	 * three-state model, {@see \Newspack\Insights\Conversion_Metric}) or the
+	 * universal `computable` marker emitted by every metric shaper — including
+	 * the core BigQuery-proxy metrics (Audience's proxy_scalar/proxy_rows)
+	 * which predate the three-state model and never set a `state` key.
 	 *
 	 * @param array $node Current array node.
 	 * @return \Generator<string>
 	 */
 	private static function walk_states( array $node ) {
-		if ( array_key_exists( 'state', $node ) ) {
-			yield (string) $node['state'];
+		if ( array_key_exists( 'state', $node ) || array_key_exists( 'computable', $node ) ) {
+			yield self::leaf_state( $node );
 			return;
 		}
 
@@ -69,5 +73,40 @@ class Metric_Status {
 				yield from self::walk_states( $child );
 			}
 		}
+	}
+
+	/**
+	 * Resolve a single metric-scalar leaf to `error` | `warming` | `populated`.
+	 *
+	 * A hub/proxy failure surfaces either as an explicit `state` of `error`
+	 * (three-state metrics) or as a non-empty `error` message string alongside
+	 * `computable:false` (core BigQuery-proxy metrics, which predate the
+	 * three-state model). Either means the last data fetch for that metric
+	 * failed. A `computable:false` node with no error — an empty cohort, an
+	 * overlay, a not-configured metric — is NOT a failure and stays populated.
+	 *
+	 * The one legacy `error` explicitly excluded is the proxy's "not
+	 * configured" code: a never-connected hub is a setup state, not a failed
+	 * fetch, so it must not read as `incomplete`.
+	 *
+	 * @param array $node Metric-scalar leaf node.
+	 * @return string One of 'error' | 'warming' | 'populated'.
+	 */
+	private static function leaf_state( array $node ): string {
+		$is_error = ( isset( $node['state'] ) && 'error' === $node['state'] )
+			|| (
+				! empty( $node['error'] ) && is_string( $node['error'] )
+				&& BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED !== ( $node['error_code'] ?? null )
+			);
+
+		if ( $is_error ) {
+			return 'error';
+		}
+
+		if ( isset( $node['state'] ) && 'warming' === $node['state'] ) {
+			return 'warming';
+		}
+
+		return 'populated';
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
@@ -79,28 +79,33 @@ class Metric_Status {
 	 * Resolve a single metric-scalar leaf to `error` | `warming` | `populated`.
 	 *
 	 * A hub/proxy failure surfaces either as an explicit `state` of `error`
-	 * (three-state metrics) or as a non-empty `error` message string alongside
-	 * `computable:false` (core BigQuery-proxy metrics, which predate the
-	 * three-state model). Either means the last data fetch for that metric
-	 * failed. A `computable:false` node with no error — an empty cohort, an
-	 * overlay, a not-configured metric — is NOT a failure and stays populated.
+	 * (three-state metrics, via `Conversion_Metric::error_scalar()`) or as a
+	 * non-empty `error` message string alongside `computable:false` (core
+	 * BigQuery-proxy metrics, which predate the three-state model). Either means
+	 * the last data fetch for that metric failed. A `computable:false` node with
+	 * no error signal — an empty cohort or an overlay — is NOT a failure and
+	 * stays populated.
 	 *
-	 * The one legacy `error` explicitly excluded is the proxy's "not
-	 * configured" code: a never-connected hub is a setup state, not a failed
-	 * fetch, so it must not read as `incomplete`.
+	 * The one exception, applied to BOTH failure paths, is the proxy's "not
+	 * configured" `error_code`: a never-connected hub is a setup state, not a
+	 * failed fetch, so it must never read as `incomplete`. Both `error_scalar()`
+	 * and the core proxy shapers carry the WP_Error code as `error_code`.
 	 *
 	 * @param array $node Metric-scalar leaf node.
 	 * @return string One of 'error' | 'warming' | 'populated'.
 	 */
 	private static function leaf_state( array $node ): string {
-		$is_error = ( isset( $node['state'] ) && 'error' === $node['state'] )
-			|| (
-				! empty( $node['error'] ) && is_string( $node['error'] )
-				&& BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED !== ( $node['error_code'] ?? null )
-			);
+		// "Not configured" is a setup state, not a failed fetch — exclude it from
+		// both the three-state `state === 'error'` path and the legacy
+		// `error`-string path so a never-connected hub reads as complete on any tab.
+		$is_setup_not_configured = BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED === ( $node['error_code'] ?? null );
 
-		if ( $is_error ) {
-			return 'error';
+		if ( ! $is_setup_not_configured ) {
+			$is_error = ( isset( $node['state'] ) && 'error' === $node['state'] )
+				|| ( ! empty( $node['error'] ) && is_string( $node['error'] ) );
+			if ( $is_error ) {
+				return 'error';
+			}
 		}
 
 		if ( isset( $node['state'] ) && 'warming' === $node['state'] ) {

--- a/plugins/newspack-plugin/src/wizards/insights/api/audience.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/audience.ts
@@ -47,6 +47,8 @@ export interface AudienceResponse {
 	registered_readers?: RegisteredReaders;
 	/** Modeled 3-year value of a newsletter subscriber (NEWS-2603): expected reader revenue per newsletter signup. */
 	newsletter_subscriber_value?: MetricPayload;
+	/** Snapshot freshness (NEWS-2603): drives the top-of-tab TabStatusBanner. */
+	data_status?: 'complete' | 'warming' | 'incomplete';
 }
 
 export interface InsightsQuery {

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -165,6 +165,8 @@ export interface DonorsResponse {
 	snapshot: DonorsSnapshot;
 	current: DonorsWindow;
 	previous: DonorsWindow | null;
+	/** Snapshot freshness (NEWS-2603): drives the top-of-tab TabStatusBanner. */
+	data_status?: 'complete' | 'warming' | 'incomplete';
 }
 
 export interface DonorsQuery {

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -72,7 +72,8 @@ export interface BillingNature {
 export interface DonorsRateValue {
 	value: number;
 	computable: boolean;
-	denominator: number;
+	/** Null in the `'warming'` state (the backend's warming_scalar emits a null denominator). */
+	denominator: number | null;
 	/**
 	 * `'error'` when the hub proxy failed; `'warming'` when the hub snapshot is a
 	 * cache miss being backfilled (NEWS-2603, transient) — both distinct from

--- a/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/donors.ts
@@ -73,8 +73,12 @@ export interface DonorsRateValue {
 	value: number;
 	computable: boolean;
 	denominator: number;
-	/** `'error'` when the hub proxy failed — distinct from `'populated'` (a real result, computable or not). */
-	state?: 'error' | 'populated';
+	/**
+	 * `'error'` when the hub proxy failed; `'warming'` when the hub snapshot is a
+	 * cache miss being backfilled (NEWS-2603, transient) — both distinct from
+	 * `'populated'` (a real result, computable or not).
+	 */
+	state?: 'error' | 'warming' | 'populated';
 }
 
 export interface DonorsTierVariationRow extends BillingNature {

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -28,7 +28,8 @@ export type StorageBackend = 'hpos' | 'legacy';
 export interface SubscribersRateValue {
 	value: number;
 	computable: boolean;
-	denominator: number;
+	/** Null in the `'warming'` state (the backend's warming_scalar emits a null denominator). */
+	denominator: number | null;
 	/**
 	 * `'error'` when the hub proxy failed; `'warming'` when the hub snapshot is a
 	 * cache miss being backfilled (NEWS-2603, transient) — both distinct from

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -29,8 +29,12 @@ export interface SubscribersRateValue {
 	value: number;
 	computable: boolean;
 	denominator: number;
-	/** `'error'` when the hub proxy failed — distinct from `'populated'` (a real result, computable or not). */
-	state?: 'error' | 'populated';
+	/**
+	 * `'error'` when the hub proxy failed; `'warming'` when the hub snapshot is a
+	 * cache miss being backfilled (NEWS-2603, transient) — both distinct from
+	 * `'populated'` (a real result, computable or not).
+	 */
+	state?: 'error' | 'warming' | 'populated';
 }
 
 export interface SubscribersClassification {

--- a/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/subscribers.ts
@@ -158,6 +158,8 @@ export interface SubscribersResponse {
 	snapshot: SubscribersSnapshot;
 	current: SubscribersWindow;
 	previous: SubscribersWindow | null;
+	/** Snapshot freshness (NEWS-2603): drives the top-of-tab TabStatusBanner. */
+	data_status?: 'complete' | 'warming' | 'incomplete';
 }
 
 export interface SubscribersQuery {

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/useAudienceData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/useAudienceData.ts
@@ -17,6 +17,7 @@ import type { DateRange } from '../state/useDateRange';
 import { fetchAudienceData, refreshAudienceData, type AudienceResponse } from '../api/audience';
 import { insightsCache, makeSlotKey } from '../state/insightsCache';
 import { useRegisterRefresh } from '../state/refreshRegistry';
+import usePollWhileWarming from './usePollWhileWarming';
 
 export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -55,9 +56,11 @@ const useAudienceData = ( range: DateRange, previousRange: DateRange | null ): U
 
 	useRegisterRefresh( 'audience', refetch );
 
+	const polledData = usePollWhileWarming( key, slot.data, refetch );
+
 	return {
 		status: slot.status,
-		data: slot.data,
+		data: polledData,
 		error: slot.error,
 		refetch,
 		computedAt: slot.computedAt,

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/useDonorsData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/useDonorsData.ts
@@ -17,6 +17,7 @@ import type { DateRange } from '../state/useDateRange';
 import { fetchDonorsData, refreshDonorsData, type DonorsResponse } from '../api/donors';
 import { insightsCache, makeSlotKey } from '../state/insightsCache';
 import { useRegisterRefresh } from '../state/refreshRegistry';
+import usePollWhileWarming from './usePollWhileWarming';
 
 export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -55,9 +56,11 @@ const useDonorsData = ( range: DateRange, previousRange: DateRange | null ): Use
 
 	useRegisterRefresh( 'donors', refetch );
 
+	const polledData = usePollWhileWarming( key, slot.data, refetch );
+
 	return {
 		status: slot.status,
-		data: slot.data,
+		data: polledData,
 		error: slot.error,
 		refetch,
 		computedAt: slot.computedAt,

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/usePollWhileWarming.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/usePollWhileWarming.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import usePollWhileWarming, { POLL_INTERVAL_MS, MAX_POLL_ATTEMPTS } from './usePollWhileWarming';
+
+type Payload = { data_status?: 'complete' | 'warming' | 'incomplete' };
+
+describe( 'usePollWhileWarming', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'stops after exactly one extra fetch once the payload turns complete', () => {
+		const refetch = jest.fn();
+		const { result, rerender } = renderHook(
+			( { key, data }: { key: string; data: Payload | null } ) => usePollWhileWarming( key, data, refetch ),
+			{ initialProps: { key: 'k', data: { data_status: 'warming' } as Payload } }
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		} );
+
+		expect( refetch ).toHaveBeenCalledTimes( 1 );
+
+		// Store now returns a complete payload.
+		rerender( { key: 'k', data: { data_status: 'complete' } } );
+
+		act( () => {
+			jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		} );
+
+		expect( refetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current?.data_status ).toBe( 'complete' );
+	} );
+
+	it( 'escalates to incomplete and stops polling after the cap', () => {
+		const refetch = jest.fn();
+		const { result } = renderHook( () => usePollWhileWarming( 'k', { data_status: 'warming' } as Payload, refetch ) );
+
+		for ( let i = 0; i < MAX_POLL_ATTEMPTS; i++ ) {
+			act( () => {
+				jest.advanceTimersByTime( POLL_INTERVAL_MS );
+			} );
+		}
+
+		expect( refetch ).toHaveBeenCalledTimes( MAX_POLL_ATTEMPTS );
+		expect( result.current?.data_status ).toBe( 'incomplete' );
+
+		// No runaway: further time does not fire more fetches.
+		act( () => {
+			jest.advanceTimersByTime( POLL_INTERVAL_MS * 5 );
+		} );
+
+		expect( refetch ).toHaveBeenCalledTimes( MAX_POLL_ATTEMPTS );
+	} );
+
+	it( 'clears the timer on unmount', () => {
+		const refetch = jest.fn();
+		const { unmount } = renderHook( () => usePollWhileWarming( 'k', { data_status: 'warming' } as Payload, refetch ) );
+
+		unmount();
+
+		act( () => {
+			jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
+		} );
+
+		expect( refetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resets and resumes polling when the key changes', () => {
+		const refetch = jest.fn();
+		const { result, rerender } = renderHook(
+			( { key, data }: { key: string; data: Payload | null } ) => usePollWhileWarming( key, data, refetch ),
+			{ initialProps: { key: 'k1', data: { data_status: 'warming' } as Payload } }
+		);
+
+		// Escalate the first key.
+		for ( let i = 0; i < MAX_POLL_ATTEMPTS; i++ ) {
+			act( () => {
+				jest.advanceTimersByTime( POLL_INTERVAL_MS );
+			} );
+		}
+		expect( refetch ).toHaveBeenCalledTimes( MAX_POLL_ATTEMPTS );
+		expect( result.current?.data_status ).toBe( 'incomplete' );
+
+		// A new window/date range: fresh key, still warming.
+		rerender( { key: 'k2', data: { data_status: 'warming' } } );
+
+		// Not stuck escalated.
+		expect( result.current?.data_status ).toBe( 'warming' );
+
+		act( () => {
+			jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		} );
+
+		expect( refetch ).toHaveBeenCalledTimes( MAX_POLL_ATTEMPTS + 1 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/usePollWhileWarming.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/usePollWhileWarming.ts
@@ -1,0 +1,82 @@
+/**
+ * usePollWhileWarming (NEWS-2603).
+ *
+ * Shared poll used by the three insights tab hooks. While a tab payload's
+ * `data_status` is `warming` (the hub snapshot is still computing), this
+ * re-fetches quietly every ~20s so the warmed value fills in on its own.
+ * If it is STILL warming after a cap (~2 min), it escalates by overriding
+ * `data_status` to `incomplete` on a shallow copy — warming that never
+ * resolves is a genuine failure, so the soft banner becomes the warning
+ * banner. The store slot itself is never mutated.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+
+export const POLL_INTERVAL_MS = 20000; // ~20s between re-fetches.
+export const MAX_POLL_ATTEMPTS = 6; // ~2 min total, then escalate.
+
+type WithDataStatus = { data_status?: 'complete' | 'warming' | 'incomplete' };
+
+/**
+ * Poll while a payload is warming, escalating to `incomplete` at the cap.
+ *
+ * @param key     Slot key; changing it (new window/date range) resets the poll.
+ * @param data    The current tab payload from the store, or null.
+ * @param refetch Stable, unconditional re-fetch of the slot.
+ * @return The payload unchanged, or — once escalated — a shallow copy with
+ *         `data_status` set to `incomplete`.
+ */
+const usePollWhileWarming = < T extends WithDataStatus >( key: string, data: T | null, refetch: () => void ): T | null => {
+	const [ attempts, setAttempts ] = useState( 0 );
+	const [ escalated, setEscalated ] = useState( false );
+
+	const dataStatus = data?.data_status;
+
+	// A window/date-range change (new key) starts the poll fresh.
+	useEffect( () => {
+		setAttempts( 0 );
+		setEscalated( false );
+	}, [ key ] );
+
+	// Scheduling effect. `attempts` is intentionally state, not a ref: the
+	// payload stays `warming` across re-fetches, so a `dataStatus`-keyed effect
+	// would not re-fire on its own — the `attempts` change is what re-triggers
+	// scheduling after each poll tick.
+	useEffect( () => {
+		if ( dataStatus !== 'warming' ) {
+			// No longer warming: clear any accumulated poll state (guarded so we
+			// don't loop by setting an unchanged value).
+			if ( attempts !== 0 ) {
+				setAttempts( 0 );
+			}
+			if ( escalated ) {
+				setEscalated( false );
+			}
+			return;
+		}
+
+		if ( attempts >= MAX_POLL_ATTEMPTS ) {
+			// Warmed too long: escalate and stop polling until the key changes.
+			if ( ! escalated ) {
+				setEscalated( true );
+			}
+			return;
+		}
+
+		const id = setTimeout( () => {
+			setAttempts( a => a + 1 );
+			refetch();
+		}, POLL_INTERVAL_MS );
+
+		return () => clearTimeout( id );
+	}, [ key, dataStatus, attempts, escalated, refetch ] );
+
+	// Only escalate a copy; never touch the store slot. Returns the SAME `data`
+	// reference unless escalated, so warming/complete payloads don't re-render.
+	return useMemo( () => ( escalated && data ? { ...data, data_status: 'incomplete' } : data ), [ data, escalated ] );
+};
+
+export default usePollWhileWarming;

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/useSubscribersData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/useSubscribersData.ts
@@ -17,6 +17,7 @@ import type { DateRange } from '../state/useDateRange';
 import { fetchSubscribersData, refreshSubscribersData, type SubscribersResponse } from '../api/subscribers';
 import { insightsCache, makeSlotKey } from '../state/insightsCache';
 import { useRegisterRefresh } from '../state/refreshRegistry';
+import usePollWhileWarming from './usePollWhileWarming';
 
 export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -55,9 +56,11 @@ const useSubscribersData = ( range: DateRange, previousRange: DateRange | null )
 
 	useRegisterRefresh( 'subscribers', refetch );
 
+	const polledData = usePollWhileWarming( key, slot.data, refetch );
+
 	return {
 		status: slot.status,
-		data: slot.data,
+		data: polledData,
 		error: slot.error,
 		refetch,
 		computedAt: slot.computedAt,

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -20,6 +20,7 @@ import useAudienceData from '../hooks/useAudienceData';
 import LastUpdated from '../components/LastUpdated';
 import ConnectBanner from './components/ConnectBanner';
 import TabStateView from './components/TabStateView';
+import TabStatusBanner from './components/TabStatusBanner';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ReachSection from './audience/sections/ReachSection';
 import RegisteredReadersSection from './audience/sections/RegisteredReadersSection';
@@ -72,6 +73,7 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 					</>
 				) : (
 					<>
+						<TabStatusBanner status={ data.data_status } />
 						<ReachSection
 							current={ current }
 							previous={ previous }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -22,6 +22,7 @@ import type { DateRange } from '../state/useDateRange';
 import useDonorsData from '../hooks/useDonorsData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabStatusBanner from './components/TabStatusBanner';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ScorecardSection from './donors/ScorecardSection';
 import WindowedSection from './donors/WindowedSection';
@@ -49,6 +50,7 @@ const DonorsTab = ( { range, previousRange }: DonorsTabProps ) => {
 		>
 			{ data && (
 				<>
+					<TabStatusBanner status={ data.data_status } />
 					<ScorecardSection
 						snapshot={ data.snapshot }
 						lastUpdated={ <LastUpdated tab="donors" range={ range } previousRange={ previousRange } /> }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -26,6 +26,7 @@ import type { DateRange } from '../state/useDateRange';
 import useSubscribersData from '../hooks/useSubscribersData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabStatusBanner from './components/TabStatusBanner';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ScorecardSection from './subscribers/ScorecardSection';
 import WindowedSection from './subscribers/WindowedSection';
@@ -53,6 +54,7 @@ const SubscribersTab = ( { range, previousRange }: SubscribersTabProps ) => {
 		>
 			{ data && (
 				<>
+					<TabStatusBanner status={ data.data_status } />
 					<ScorecardSection
 						snapshot={ data.snapshot }
 						lastUpdated={ <LastUpdated tab="subscribers" range={ range } previousRange={ previousRange } /> }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
@@ -31,4 +31,11 @@ describe( 'Audience NewsletterValueSection', () => {
 		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'shows the warming note when the hub snapshot is still backfilling (NEWS-2603)', () => {
+		render( <NewsletterValueSection value={ { value: 0, computable: false, state: 'warming' } } /> );
+		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
@@ -32,6 +32,10 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 	// history" — surface those distinctly so the em-dash copy isn't misleading.
 	const hasError = !! value?.error;
 	const notConfigured = !! value?.not_configured;
+	// Hub snapshot cache miss being backfilled (NEWS-2603): a transient, expected
+	// condition — render the "still calculating" note, not the insufficient-
+	// history copy.
+	const warming = value?.state === 'warming';
 
 	return (
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-newsletter-value">
@@ -47,8 +51,9 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 					format="currency"
 					error={ value?.error }
 					notConfigured={ notConfigured }
+					warming={ warming }
 					notComputableMessage={
-						amount === null && ! hasError && ! notConfigured
+						amount === null && ! hasError && ! notConfigured && ! warming
 							? __( 'Not enough newsletter or supporter history to model yet.', 'newspack-plugin' )
 							: undefined
 					}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -210,6 +210,22 @@ describe( 'MetricCard notCapableMessage (NPPD-1720)', () => {
 	} );
 } );
 
+describe( 'MetricCard warming (NEWS-2603)', () => {
+	it( 'renders the "still calculating" note in place of the value', () => {
+		render( <MetricCard label="Newsletter → subscription" value={ 0 } format="percent" warming /> );
+		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
+		// Not the generic non-computable / em-dash note.
+		expect( screen.queryByLabelText( 'Not applicable' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Data temporarily unavailable.' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'yields to the error treatment (error wins over warming)', () => {
+		render( <MetricCard label="Newsletter → subscription" error="boom" warming /> );
+		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Still calculating — check back shortly.' ) ).not.toBeInTheDocument();
+	} );
+} );
+
 describe( 'MetricCard dataMissing', () => {
 	it( 'renders the data-missing note in place of the value', () => {
 		render( <MetricCard label="Influenced subscription rate" value={ 0 } format="percent" dataMissing /> );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -97,6 +97,13 @@ export interface MetricCardProps {
 	/** A present hub row was missing required column(s) — renders the data-missing note. */
 	dataMissing?: boolean;
 	/**
+	 * Hub snapshot cache miss being backfilled (NEWS-2603). Renders the shared
+	 * "Still calculating — check back shortly." note in place of the value.
+	 * Additive — every existing call site leaves it undefined, unchanged. Takes
+	 * precedence over the generic non-computable message but yields to `error`.
+	 */
+	warming?: boolean;
+	/**
 	 * Native tooltip for the value (e.g. the full amount behind an abbreviated
 	 * "$1.2M"). Overrides the title the currency formatter derives on its own.
 	 */
@@ -176,19 +183,26 @@ const MetricCard = ( props: MetricCardProps ) => {
 		error,
 		notConfigured,
 		dataMissing,
+		warming,
 		valueTitle,
 		zeroFallback,
 		notCapableMessage,
 		notComputableMessage,
 	} = props;
 
-	// Shared graceful-failure state (missing dimension / not configured / error / data missing).
-	if ( overlay || error || notConfigured || dataMissing ) {
+	// Shared graceful-failure state (missing dimension / not configured / error / data missing / warming).
+	if ( overlay || error || notConfigured || dataMissing || warming ) {
 		return (
 			<Card __experimentalCoreCard className="newspack-insights__metric-card newspack-insights__metric-card--note">
 				<div className="newspack-insights__metric-card-label">{ label }</div>
 				<div className="newspack-insights__metric-card-body">
-					<MetricNote overlay={ overlay } error={ !! error } notConfigured={ notConfigured } dataMissing={ dataMissing } />
+					<MetricNote
+						overlay={ overlay }
+						error={ !! error }
+						notConfigured={ notConfigured }
+						dataMissing={ dataMissing }
+						warming={ warming }
+					/>
 				</div>
 				{ description && <div className="newspack-insights__metric-card-description">{ description }</div> }
 			</Card>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricNote.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricNote.tsx
@@ -1,10 +1,15 @@
 /**
- * MetricNote (NPPD-1649).
+ * MetricNote (NPPD-1649, extended for NEWS-2603).
  *
  * Single graceful-failure treatment shared by scorecards, tables, and charts.
- * Three variants, one look: a small info glyph + muted sans-serif text (no
- * code-block styling). The custom-dimension parameter name keeps a `<code>`
- * inline, but the surrounding copy and the docs link are plain.
+ * One look across every variant: a small info glyph + muted sans-serif text
+ * (no code-block styling). The custom-dimension parameter name keeps a
+ * `<code>` inline, but the surrounding copy and the docs link are plain.
+ *
+ * Precedence when multiple flags are set: overlay(data_unavailable) →
+ * overlay(dimensions) → error → warming → notConfigured → dataMissing →
+ * generic. `error` is checked explicitly (rather than falling through to the
+ * generic branch) so a hard failure always wins over `warming`.
  */
 
 /**
@@ -30,9 +35,11 @@ export interface MetricNoteProps {
 	error?: boolean;
 	/** A present hub row was missing required column(s) — schema drift / bad deploy. */
 	dataMissing?: boolean;
+	/** Hub snapshot cache miss being backfilled (NEWS-2603) — transient, not an error. */
+	warming?: boolean;
 }
 
-const MetricNote = ( { overlay, notConfigured, dataMissing }: MetricNoteProps ) => {
+const MetricNote = ( { overlay, notConfigured, error, dataMissing, warming }: MetricNoteProps ) => {
 	let body: React.ReactNode;
 
 	if ( overlay && overlay.type === 'data_unavailable' ) {
@@ -49,6 +56,14 @@ const MetricNote = ( { overlay, notConfigured, dataMissing }: MetricNoteProps ) 
 				</a>
 			</>
 		);
+	} else if ( error ) {
+		// Explicit so a hard error always wins over `warming` below, even though
+		// both can theoretically be passed together.
+		body = __( 'Data temporarily unavailable.', 'newspack-plugin' );
+	} else if ( warming ) {
+		// Hub snapshot cache miss being backfilled (NEWS-2603): an honest "still
+		// calculating" note rather than a bare em-dash or the generic failure copy.
+		body = __( 'Still calculating — check back shortly.', 'newspack-plugin' );
 	} else if ( notConfigured ) {
 		body = __( 'Not configured for this site.', 'newspack-plugin' );
 	} else if ( dataMissing ) {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/TabStatusBanner.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/TabStatusBanner.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for TabStatusBanner (NEWS-2603): the two-tier top-of-tab status
+ * banner driven by the envelope's `data_status` field. Verifies that
+ * `complete` and `undefined` render nothing, `warming` renders the soft/info
+ * notice inside a polite live region, and `incomplete` renders the warning
+ * notice inside an assertive live region.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import TabStatusBanner from './TabStatusBanner';
+
+describe( 'TabStatusBanner', () => {
+	it( 'renders nothing when status is "complete"', () => {
+		const { container } = render( <TabStatusBanner status="complete" /> );
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'renders nothing when status is undefined', () => {
+		const { container } = render( <TabStatusBanner /> );
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'renders the soft/info notice with a polite live region when status is "warming"', () => {
+		render( <TabStatusBanner status="warming" /> );
+
+		expect( screen.getByText( 'Some metrics are still being calculated and will appear shortly.' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
+
+		// Info/soft variant: no warning class applied.
+		const notice = document.querySelector( '.newspack-notice' );
+		expect( notice ).not.toHaveClass( 'newspack-notice__is-warning' );
+		expect( notice ).not.toHaveClass( 'newspack-notice__is-error' );
+	} );
+
+	it( 'renders the warning notice with an assertive live region when status is "incomplete"', () => {
+		render( <TabStatusBanner status="incomplete" /> );
+
+		expect( screen.getByText( "The last data fetch didn't finish, so some figures may be missing or out of date." ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'alert' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
+
+		const notice = document.querySelector( '.newspack-notice' );
+		expect( notice ).toHaveClass( 'newspack-notice__is-warning' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/TabStatusBanner.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/TabStatusBanner.tsx
@@ -1,0 +1,59 @@
+/**
+ * TabStatusBanner (NEWS-2603).
+ *
+ * Two-tier top-of-tab status banner driven by the envelope's top-level
+ * `data_status` field (`complete | warming | incomplete`), set by the
+ * backend snapshot cache. `complete` (or the field being absent, e.g. on
+ * older cached payloads) renders nothing — the common case. `warming`
+ * renders a soft/info notice: the snapshot is mid-backfill and some
+ * metrics may still be catching up. `incomplete` renders a warning notice:
+ * the last fetch didn't finish, so some figures may be stale or missing.
+ * Backed by the shared Newspack `Notice` component, same as TabErrorBanner.
+ * The outer `<div role="status">` / `<div role="alert">` wrapper preserves
+ * live-region semantics (polite for warming, assertive for incomplete) so
+ * assistive tech announces the banner when it appears — the Newspack
+ * `Notice` component renders a plain `<div>` without a role.
+ *
+ * This component only renders whatever `data_status` currently says; it
+ * does not poll or escalate warming → incomplete over time (see Task 6).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Notice } from '../../../../../packages/components/src';
+
+export interface TabStatusBannerProps {
+	/** Envelope-level data freshness status; `complete`/absent renders nothing. */
+	status?: 'complete' | 'warming' | 'incomplete';
+}
+
+const TabStatusBanner = ( { status }: TabStatusBannerProps ) => {
+	if ( status === 'warming' ) {
+		return (
+			<div role="status">
+				<Notice noticeText={ __( 'Some metrics are still being calculated and will appear shortly.', 'newspack-plugin' ) } />
+			</div>
+		);
+	}
+
+	if ( status === 'incomplete' ) {
+		return (
+			<div role="alert">
+				<Notice
+					isWarning
+					noticeText={ __( "The last data fetch didn't finish, so some figures may be missing or out of date.", 'newspack-plugin' ) }
+				/>
+			</div>
+		);
+	}
+
+	return null;
+};
+
+export default TabStatusBanner;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.test.ts
@@ -95,6 +95,24 @@ describe( 'payloadToCard', () => {
 		expect( card ).not.toHaveProperty( 'notComputableMessage' );
 		expect( card?.value ).toBe( 0 );
 	} );
+
+	it( 'renders a warming metric as { warming: true }, not a value card (NEWS-2603)', () => {
+		const card = payloadToCard( {
+			label: 'Newsletter → subscription',
+			current: { state: 'warming', computable: false },
+		} );
+		expect( card ).toEqual( { label: 'Newsletter → subscription', description: undefined, warming: true } );
+		expect( card ).not.toHaveProperty( 'value' );
+	} );
+
+	it( 'lets a hard error win over a warming state', () => {
+		const card = payloadToCard( {
+			label: 'x',
+			current: { state: 'warming', computable: false, error: 'boom' },
+		} );
+		expect( card?.error ).toBe( 'boom' );
+		expect( card ).not.toHaveProperty( 'warming' );
+	} );
 } );
 
 describe( 'toSeries', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.ts
@@ -74,6 +74,14 @@ export interface MetricPayload {
 	not_configured?: boolean;
 	/** Cohort below its minimum-sessions floor: render the "needs data" state instead of a comparison. */
 	needs_data?: boolean;
+	/**
+	 * Metric lifecycle state (NEWS-2603). `'warming'` means the hub snapshot for
+	 * this metric is a cache miss being backfilled — a transient, expected
+	 * condition (distinct from `error` and from "insufficient history").
+	 * `payloadToCard` maps it to `warming: true` on MetricCard, below `error`
+	 * in precedence.
+	 */
+	state?: 'populated' | 'warming' | 'error';
 }
 
 const typeToFormat = ( type?: MetricPayloadType ): MetricFormat => {
@@ -121,6 +129,13 @@ export const payloadToCard = ( args: PayloadToCardArgs ): MetricCardProps | null
 	}
 	if ( current.error ) {
 		return { label, description, error: current.error };
+	}
+	// Warming (NEWS-2603): the hub snapshot is a cache miss being backfilled —
+	// checked after `error` (a hard failure is more actionable than "still
+	// calculating") and before not_configured / not-computable, so a warming
+	// metric never falls through to the generic em-dash treatment.
+	if ( current.state === 'warming' ) {
+		return { label, description, warming: true };
 	}
 	if ( current.not_configured ) {
 		return { label, description, notConfigured: true };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
@@ -96,7 +96,7 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 						value={ recovery.value }
 						format="percent"
 						previousValue={ previous?.lapsed_donor_recovery_rate?.computable ? previous.lapsed_donor_recovery_rate.value : null }
-						secondary={ cohortSubtitle( recovery.denominator ) }
+						secondary={ cohortSubtitle( recovery.denominator ?? 0 ) }
 						description={ RECOVERY_DESCRIPTION() }
 					/>
 				) : (
@@ -113,7 +113,7 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 						value={ retention.value }
 						format="percent"
 						previousValue={ previous?.recurring_donor_retention?.computable ? previous.recurring_donor_retention.value : null }
-						secondary={ cohortSubtitle( retention.denominator ) }
+						secondary={ cohortSubtitle( retention.denominator ?? 0 ) }
 						description={ RETENTION_DESCRIPTION() }
 					/>
 				) : (

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
@@ -57,4 +57,15 @@ describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
 		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'shows the warming note (not the insufficient-history copy) when the hub snapshot is still backfilling (NEWS-2603)', () => {
+		render(
+			<ScorecardSection
+				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'warming' } } ) }
+			/>
+		);
+		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -88,8 +88,13 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				// "Data temporarily unavailable." note; the string isn't shown, so pass the
 				// state sentinel rather than a translatable string that never renders.
 				error={ snapshot.newsletter_conversion.state === 'error' ? snapshot.newsletter_conversion.state : undefined }
+				// Hub snapshot cache miss being backfilled (NEWS-2603): render the
+				// "still calculating" note rather than the insufficient-history copy.
+				warming={ snapshot.newsletter_conversion.state === 'warming' }
 				notComputableMessage={
-					! snapshot.newsletter_conversion.computable && snapshot.newsletter_conversion.state !== 'error'
+					! snapshot.newsletter_conversion.computable &&
+					snapshot.newsletter_conversion.state !== 'error' &&
+					snapshot.newsletter_conversion.state !== 'warming'
 						? __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
 						: undefined
 				}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
@@ -57,4 +57,15 @@ describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
 		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'shows the warming note (not the insufficient-history copy) when the hub snapshot is still backfilling (NEWS-2603)', () => {
+		render(
+			<ScorecardSection
+				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'warming' } } ) }
+			/>
+		);
+		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -83,8 +83,13 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				// "Data temporarily unavailable." note; the string isn't shown, so pass the
 				// state sentinel rather than a translatable string that never renders.
 				error={ snapshot.newsletter_conversion.state === 'error' ? snapshot.newsletter_conversion.state : undefined }
+				// Hub snapshot cache miss being backfilled (NEWS-2603): render the
+				// "still calculating" note rather than the insufficient-history copy.
+				warming={ snapshot.newsletter_conversion.state === 'warming' }
 				notComputableMessage={
-					! snapshot.newsletter_conversion.computable && snapshot.newsletter_conversion.state !== 'error'
+					! snapshot.newsletter_conversion.computable &&
+					snapshot.newsletter_conversion.state !== 'error' &&
+					snapshot.newsletter_conversion.state !== 'warming'
 						? __( 'Not enough newsletter signups with a full year of history yet.', 'newspack-plugin' )
 						: undefined
 				}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -220,7 +220,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					format="percent"
 					previousValue={ refundEmptyMessage ? undefined : refundPrevious }
 					lowerIsBetter
-					secondary={ refundEmptyMessage ? undefined : ordersCohortSubtitle( refund.denominator ) }
+					secondary={ refundEmptyMessage ? undefined : ordersCohortSubtitle( refund.denominator ?? 0 ) }
 					notComputableMessage={ refundEmptyMessage }
 					description={ __( 'Refunds ÷ subscription orders', 'newspack-plugin' ) }
 				/>
@@ -229,7 +229,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					value={ retry.computable ? retry.value : 0 }
 					format="percent"
 					previousValue={ retryEmptyMessage ? undefined : retryPrevious }
-					secondary={ retryEmptyMessage ? undefined : retriesCohortSubtitle( retry.denominator ) }
+					secondary={ retryEmptyMessage ? undefined : retriesCohortSubtitle( retry.denominator ?? 0 ) }
 					notComputableMessage={ retryEmptyMessage }
 					description={ __( 'Recovered retries ÷ retry attempts', 'newspack-plugin' ) }
 				/>

--- a/plugins/newspack-plugin/tests/mocks/class-newspack-manager.php
+++ b/plugins/newspack-plugin/tests/mocks/class-newspack-manager.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Test-only stand-in for `Newspack_Manager`, which lives in the separate
+ * (non-monorepo) newspack-manager-admin plugin. `BigQuery_Proxy_Client`
+ * resolves its hub URL/API key against this class (in the global namespace)
+ * when no explicit endpoint/key are injected into its constructor.
+ *
+ * Defaults to "not connected" — `authenticate_manager_admin_url()` returns
+ * `false`, matching the real class's contract for an unauthenticated site, so
+ * `BigQuery_Proxy_Client::is_configured()` stays false and every test that
+ * doesn't explicitly arm this stub keeps exercising the (already-handled)
+ * not-configured code paths. Call `enable_stub_connection()` /
+ * `disable_stub_connection()` around the one or two tests per file that need
+ * a live-looking hub round-trip.
+ *
+ * @package Newspack\Tests
+ */
+
+if ( ! class_exists( '\Newspack_Manager' ) ) {
+	/**
+	 * Minimal Newspack_Manager stub, off (not connected) by default.
+	 */
+	class Newspack_Manager {
+
+		/**
+		 * Whether the stub reports as connected. Toggled per-test.
+		 *
+		 * @var bool
+		 */
+		private static $connected = false;
+
+		/**
+		 * Arm the stub: subsequent calls report a fixed hub URL + key.
+		 *
+		 * @return void
+		 */
+		public static function enable_stub_connection() {
+			self::$connected = true;
+		}
+
+		/**
+		 * Disarm the stub: subsequent calls report "not connected" (matches the
+		 * default / real class's contract when unauthenticated).
+		 *
+		 * @return void
+		 */
+		public static function disable_stub_connection() {
+			self::$connected = false;
+		}
+
+		/**
+		 * Stubbed hub URL, or false when not "connected".
+		 *
+		 * @param string $path Route path appended to the stub host.
+		 * @return string|false
+		 */
+		public static function authenticate_manager_admin_url( $path ) {
+			if ( ! self::$connected ) {
+				return false;
+			}
+			return 'https://hub.example.com' . $path . '?api_key=test-key';
+		}
+
+		/**
+		 * Stubbed API key, empty when not "connected".
+		 *
+		 * @return string
+		 */
+		public static function get_manager_admin_api_key() {
+			return self::$connected ? 'test-key' : '';
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
@@ -511,10 +511,12 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 		// Core-metric-error variant (NEWS-2603 follow-up): every core Audience
 		// BigQuery query fails with an HTTP error (which BigQuery_Proxy_Client
 		// turns into a WP_Error, shaped by proxy_scalar/proxy_rows into a
-		// `computable:false` + `error` payload). The newsletter query returns a
-		// harmless empty set — the test leaves WooCommerce inactive so the
-		// newsletter metric short-circuits to `not_configured` and never calls
-		// the hub, isolating a core-metric error as the sole data_status driver.
+		// `computable:false` + `error` payload), isolating a core-metric error
+		// as the sole data_status driver. The test leaves WooCommerce inactive so
+		// the newsletter metric short-circuits to `not_configured` before calling
+		// the hub — so the newsletter branch below normally isn't reached; it
+		// returns an empty (non-error) set defensively, only in case that query
+		// is ever invoked, so it never contributes an error of its own.
 		if ( 'core_error' === $this->bq_hub_response_variant ) {
 			if ( $is_newsletter_conversion ) {
 				return [

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
@@ -450,6 +450,38 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NEWS-2603 follow-up end-to-end: a failed CORE Audience BigQuery metric
+	 * (not the newsletter snapshot) makes `data_status` 'incomplete'. Core
+	 * metrics signal a hub failure as `computable:false` + an `error` string
+	 * with no `state` key; Metric_Status::derive() must recognise that legacy
+	 * convention so the warning banner reflects a genuine core-BQ outage.
+	 * WooCommerce is left inactive so the newsletter metric short-circuits to
+	 * `not_configured` (a populated, non-error state) — isolating the core
+	 * metric error as the sole driver.
+	 */
+	public function test_data_status_is_incomplete_when_core_bq_metric_errors() {
+		add_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10, 3 );
+		\Newspack_Manager::enable_stub_connection();
+		$this->bq_hub_response_variant = 'core_error';
+
+		try {
+			$response = $this->dispatch(
+				[
+					'start' => '2026-01-01',
+					'end'   => '2026-01-31',
+				]
+			);
+
+			$this->assertSame( 200, $response->get_status() );
+			$data = $response->get_data()['data'];
+			$this->assertSame( 'incomplete', $data['data_status'] );
+		} finally {
+			remove_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10 );
+			\Newspack_Manager::disable_stub_connection();
+		}
+	}
+
+	/**
 	 * `pre_http_request` responder: the newsletter-conversion catalog queries
 	 * return either the hub's warming marker or an HTTP error, per
 	 * $this->bq_hub_response_variant; every other catalog query (the 19
@@ -475,6 +507,31 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 			],
 			true
 		);
+
+		// Core-metric-error variant (NEWS-2603 follow-up): every core Audience
+		// BigQuery query fails with an HTTP error (which BigQuery_Proxy_Client
+		// turns into a WP_Error, shaped by proxy_scalar/proxy_rows into a
+		// `computable:false` + `error` payload). The newsletter query returns a
+		// harmless empty set — the test leaves WooCommerce inactive so the
+		// newsletter metric short-circuits to `not_configured` and never calls
+		// the hub, isolating a core-metric error as the sole data_status driver.
+		if ( 'core_error' === $this->bq_hub_response_variant ) {
+			if ( $is_newsletter_conversion ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode( [] ),
+				];
+			}
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => wp_json_encode(
+					[
+						'code'    => 'bigquery_proxy_http_error',
+						'message' => 'Simulated core metric failure.',
+					]
+				),
+			];
+		}
 
 		if ( ! $is_newsletter_conversion ) {
 			return [

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
@@ -354,22 +354,23 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * NEWS-2603: `build_response()` must compute `data_status` by calling
-	 * `Metric_Status::derive()` on the response it just assembled — not by
-	 * hardcoding 'complete'. Proven directly: `build_response()`'s
-	 * `data_status` must equal `Metric_Status::derive()` run independently
-	 * over the same response with `data_status` stripped out, so the two can
-	 * never drift apart.
+	 * NEWS-2603: `data_status` is stamped centrally by the shared
+	 * `Cached_Controller_Trait::status_stamped_window_payload()` — the single
+	 * path every cached/refreshed/pre-warmed current window flows through — by
+	 * calling `Metric_Status::derive()` on the assembled window, never by
+	 * hardcoding 'complete'. Proven directly: the stamped `data_status` must
+	 * equal `Metric_Status::derive()` run independently over the same payload
+	 * with `data_status` stripped out, so the two can never drift apart.
 	 */
 	public function test_data_status_matches_independent_deriver_call() {
 		$controller = new Audience_REST_Controller();
-		$m          = new ReflectionMethod( $controller, 'build_response' );
+		$m          = new ReflectionMethod( $controller, 'status_stamped_window_payload' );
 		$m->setAccessible( true );
 
 		$start = new DateTimeImmutable( '2026-01-01' );
 		$end   = new DateTimeImmutable( '2026-01-31' );
 
-		$response = $m->invoke( $controller, $start, $end, null, null );
+		$response = $m->invoke( $controller, $start, $end );
 
 		$this->assertArrayHasKey( 'data_status', $response );
 

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
@@ -17,6 +17,7 @@ namespace Newspack\Tests\Insights;
 use DateTimeImmutable;
 use Newspack\Insights\Cache;
 use Newspack\Insights\Audience_REST_Controller;
+use Newspack\Insights\Metric_Status;
 use WP_REST_Request;
 use WP_REST_Server;
 use WP_UnitTestCase;
@@ -25,6 +26,16 @@ use ReflectionMethod;
 // Registered-readers metric reads reader roles via Reader_Activation and
 // product detection via WC stubs — pull in the shared stubs.
 require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+// Newspack_Manager stub (the real class lives in a separate, non-monorepo
+// plugin), declared in the global namespace to match
+// BigQuery_Proxy_Client's `\Newspack_Manager` reference. Off (not connected)
+// by default — armed only around the two data_status end-to-end tests below
+// via \Newspack_Manager::enable_stub_connection()/disable_stub_connection()
+// — so every other test in this file (and this file's presence doesn't
+// affect other test files, since none of them load this mock) keeps
+// exercising the default "hub not configured" path.
+require_once __DIR__ . '/../../mocks/class-newspack-manager.php';
 
 /**
  * Audience_REST_Controller test class.
@@ -41,6 +52,15 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 	 * @var WP_REST_Server
 	 */
 	private $server;
+
+	/**
+	 * Which canned response `stub_bq_hub_response()` returns for the
+	 * newsletter-conversion catalog queries: 'warming' | 'error'. Set by each
+	 * end-to-end data_status test right before dispatching.
+	 *
+	 * @var string
+	 */
+	private $bq_hub_response_variant = 'warming';
 
 	/**
 	 * Set up: an admin user + a registered Audience route on a fresh server.
@@ -312,5 +332,171 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'data', $body );
 		$this->assertSame( Cache::SOURCE_EXTERNAL, $body['cache']['source'] );
 		$this->assertArrayNotHasKey( 'tab_pending', $body['data'] );
+	}
+
+	/**
+	 * With no BQ hub configured (the default test-env state), no metric in the
+	 * Audience envelope carries a 'warming' or 'error' state, so the NEWS-2603
+	 * top-level `data_status` field is 'complete'.
+	 */
+	public function test_data_status_is_complete_by_default() {
+		$response = $this->dispatch(
+			[
+				'start' => '2026-01-01',
+				'end'   => '2026-01-31',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data()['data'];
+		$this->assertArrayHasKey( 'data_status', $data );
+		$this->assertSame( 'complete', $data['data_status'] );
+	}
+
+	/**
+	 * NEWS-2603: `build_response()` must compute `data_status` by calling
+	 * `Metric_Status::derive()` on the response it just assembled — not by
+	 * hardcoding 'complete'. Proven directly: `build_response()`'s
+	 * `data_status` must equal `Metric_Status::derive()` run independently
+	 * over the same response with `data_status` stripped out, so the two can
+	 * never drift apart.
+	 */
+	public function test_data_status_matches_independent_deriver_call() {
+		$controller = new Audience_REST_Controller();
+		$m          = new ReflectionMethod( $controller, 'build_response' );
+		$m->setAccessible( true );
+
+		$start = new DateTimeImmutable( '2026-01-01' );
+		$end   = new DateTimeImmutable( '2026-01-31' );
+
+		$response = $m->invoke( $controller, $start, $end, null, null );
+
+		$this->assertArrayHasKey( 'data_status', $response );
+
+		$without_status = $response;
+		unset( $without_status['data_status'] );
+
+		$this->assertSame(
+			Metric_Status::derive( $without_status ),
+			$response['data_status']
+		);
+	}
+
+	/**
+	 * NEWS-2603 end-to-end: when the hub's newsletter-conversion snapshot
+	 * query returns the warming marker (a cache-miss-being-backfilled signal
+	 * — see Conversion_Metric::warming_scalar()), that state now propagates
+	 * through Conversion_Metric::get_newsletter_subscriber_value_3yr() (fixed
+	 * alongside this test — it previously dropped the state entirely) into
+	 * the Audience envelope's top-level `data_status`. Requires WooCommerce
+	 * "active" (via the newspack_insights_woocommerce_active filter, mirroring
+	 * how other Insights tests toggle it) so get_newsletter_subscriber_value_3yr()
+	 * reaches the hub call at all, and the stubbed Newspack_Manager +
+	 * pre_http_request so BigQuery_Proxy_Client::is_configured() is true and
+	 * the hub round-trip is reachable in-process.
+	 */
+	public function test_data_status_is_warming_when_newsletter_metric_is_warming() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		add_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10, 3 );
+		\Newspack_Manager::enable_stub_connection();
+		$this->bq_hub_response_variant = 'warming';
+
+		try {
+			$response = $this->dispatch(
+				[
+					'start' => '2026-01-01',
+					'end'   => '2026-01-31',
+				]
+			);
+
+			$this->assertSame( 200, $response->get_status() );
+			$data = $response->get_data()['data'];
+			$this->assertSame( 'warming', $data['data_status'] );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+			remove_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10 );
+			\Newspack_Manager::disable_stub_connection();
+		}
+	}
+
+	/**
+	 * NEWS-2603 end-to-end: an errored newsletter-conversion hub query makes
+	 * `data_status` 'incomplete' — error takes precedence over any concurrent
+	 * warming signal elsewhere in the envelope.
+	 */
+	public function test_data_status_is_incomplete_when_newsletter_metric_errors() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		add_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10, 3 );
+		\Newspack_Manager::enable_stub_connection();
+		$this->bq_hub_response_variant = 'error';
+
+		try {
+			$response = $this->dispatch(
+				[
+					'start' => '2026-01-01',
+					'end'   => '2026-01-31',
+				]
+			);
+
+			$this->assertSame( 200, $response->get_status() );
+			$data = $response->get_data()['data'];
+			$this->assertSame( 'incomplete', $data['data_status'] );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+			remove_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10 );
+			\Newspack_Manager::disable_stub_connection();
+		}
+	}
+
+	/**
+	 * `pre_http_request` responder: the newsletter-conversion catalog queries
+	 * return either the hub's warming marker or an HTTP error, per
+	 * $this->bq_hub_response_variant; every other catalog query (the 19
+	 * Audience metrics) returns an empty result set, which the corresponding
+	 * metric shapers already degrade to a non-computable, non-`state`-bearing
+	 * value for (see Audience_Metric::proxy_scalar()/proxy_rows()) — so only
+	 * the newsletter metric contributes a state to the envelope.
+	 *
+	 * @param mixed  $preempt Pre-emptive response (unused).
+	 * @param array  $args    Request args, including the JSON-encoded body.
+	 * @param string $url     Request URL (unused).
+	 * @return array
+	 */
+	public function stub_bq_hub_response( $preempt, $args, $url ) {
+		$decoded    = json_decode( $args['body'] ?? '{}', true );
+		$query_name = is_array( $decoded ) ? ( $decoded['query_name'] ?? '' ) : '';
+
+		$is_newsletter_conversion = in_array(
+			$query_name,
+			[
+				'conversion_journey_newsletter_to_subscription',
+				'conversion_journey_newsletter_to_donation',
+			],
+			true
+		);
+
+		if ( ! $is_newsletter_conversion ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => wp_json_encode( [] ),
+			];
+		}
+
+		if ( 'error' === $this->bq_hub_response_variant ) {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => wp_json_encode(
+					[
+						'code'    => 'bigquery_proxy_http_error',
+						'message' => 'Simulated hub failure.',
+					]
+				),
+			];
+		}
+
+		return [
+			'response' => [ 'code' => 200 ],
+			'body'     => wp_json_encode( [ [ '__status' => 'warming' ] ] ),
+		];
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -3363,6 +3363,172 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 		$this->assertSame( 'Mon 2026-06-29 06:00', $result, 'Sunday night must schedule next-day Monday.' );
 	}
 
+	// --- NEWS-2603 Task 2: get_newsletter_subscriber_value_3yr() state propagation ---
+
+	/**
+	 * Build a Subscribers_Metric mock whose get_supporter_clv_3yr() returns a
+	 * fixed computable/non-computable CLV.
+	 *
+	 * @param bool $computable Whether the CLV should read as computable.
+	 * @return Subscribers_Metric
+	 */
+	private function subscribers_metric_with_clv( bool $computable ): Subscribers_Metric {
+		$mock = $this->createMock( Subscribers_Metric::class );
+		$mock->method( 'get_supporter_clv_3yr' )->willReturn(
+			[
+				'value'       => $computable ? 100.0 : 0.0,
+				'computable'  => $computable,
+				'denominator' => $computable ? 10 : 0,
+			]
+		);
+		return $mock;
+	}
+
+	/**
+	 * Build a Donors_Metric mock whose get_supporter_clv_3yr() returns a fixed
+	 * computable/non-computable CLV.
+	 *
+	 * @param bool $computable Whether the CLV should read as computable.
+	 * @return Donors_Metric
+	 */
+	private function donors_metric_with_clv( bool $computable ): Donors_Metric {
+		$mock = $this->createMock( Donors_Metric::class );
+		$mock->method( 'get_supporter_clv_3yr' )->willReturn(
+			[
+				'value'       => $computable ? 50.0 : 0.0,
+				'computable'  => $computable,
+				'denominator' => $computable ? 5 : 0,
+			]
+		);
+		return $mock;
+	}
+
+	/**
+	 * Not-configured branch (no WooCommerce): 'state' is 'populated' — this is
+	 * deliberate non-applicability, not a data problem, so it must not make the
+	 * Audience envelope's data_status anything other than 'complete'.
+	 */
+	public function test_newsletter_subscriber_value_not_configured_state_is_populated() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_false' );
+		try {
+			$metric          = new Conversion_Metric( $this->proxy_returning( [] ) );
+			[ $start, $end ] = $this->window();
+			$result          = $metric->get_newsletter_subscriber_value_3yr( $start, $end );
+
+			$this->assertTrue( $result['not_configured'] );
+			$this->assertFalse( $result['computable'] );
+			$this->assertSame( 'populated', $result['state'] );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_false' );
+		}
+	}
+
+	/**
+	 * Computable branch (both a rate and its CLV are computable): 'state' is
+	 * 'populated'.
+	 */
+	public function test_newsletter_subscriber_value_computable_state_is_populated() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		try {
+			$row = [
+				'newsletter_conversion_rate' => 0.05,
+				'newsletter_signups'         => 200,
+			];
+			$metric          = new Conversion_Metric(
+				$this->proxy_returning( [ $row ] ),
+				$this->subscribers_metric_with_clv( true ),
+				$this->donors_metric_with_clv( true )
+			);
+			[ $start, $end ] = $this->window();
+			$result          = $metric->get_newsletter_subscriber_value_3yr( $start, $end );
+
+			$this->assertTrue( $result['computable'] );
+			$this->assertSame( 'populated', $result['state'] );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		}
+	}
+
+	/**
+	 * Error branch: a proxy WP_Error on the rate query (surfaced by the rate
+	 * scalar as `state === 'error'`) propagates as 'state' => 'error' on the
+	 * aggregate, taking precedence over any warming signal from the other path.
+	 */
+	public function test_newsletter_subscriber_value_error_state_propagates() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		try {
+			$metric          = new Conversion_Metric(
+				$this->proxy_returning( new \WP_Error( 'bigquery_proxy_http_error', 'boom' ) ),
+				$this->subscribers_metric_with_clv( false ),
+				$this->donors_metric_with_clv( false )
+			);
+			[ $start, $end ] = $this->window();
+			$result          = $metric->get_newsletter_subscriber_value_3yr( $start, $end );
+
+			$this->assertFalse( $result['computable'] );
+			$this->assertSame( 'error', $result['state'] );
+			$this->assertArrayHasKey( 'error', $result );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		}
+	}
+
+	/**
+	 * Warming branch (NEWS-2603): when neither path is computable and neither
+	 * rate errored, but at least one rate is warming (a hub snapshot cache miss
+	 * being backfilled — see Conversion_Metric::warming_scalar()), the aggregate
+	 * must surface 'state' => 'warming', not silently fall through to the
+	 * generic insufficient-history 'populated' state.
+	 */
+	public function test_newsletter_subscriber_value_warming_state_when_rate_is_warming() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		try {
+			// Bare [] from the snapshot query is the hub's warming signal (see
+			// test_bare_empty_from_snapshot_query_is_treated_as_warming above).
+			$metric          = new Conversion_Metric(
+				$this->proxy_returning( [] ),
+				$this->subscribers_metric_with_clv( false ),
+				$this->donors_metric_with_clv( false )
+			);
+			[ $start, $end ] = $this->window();
+			$result          = $metric->get_newsletter_subscriber_value_3yr( $start, $end );
+
+			$this->assertFalse( $result['computable'] );
+			$this->assertSame( 'warming', $result['state'] );
+			$this->assertArrayNotHasKey( 'error', $result );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		}
+	}
+
+	/**
+	 * Genuine insufficient-history branch: both rates are real computed zero
+	 * cohorts (never warming, never error), so 'state' stays 'populated'.
+	 */
+	public function test_newsletter_subscriber_value_insufficient_history_state_is_populated() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		try {
+			$row = [
+				'newsletter_signups'         => 0,
+				'converted_within_window'    => 0,
+				'newsletter_conversion_rate' => null,
+			];
+			$metric          = new Conversion_Metric(
+				$this->proxy_returning( [ $row ] ),
+				$this->subscribers_metric_with_clv( false ),
+				$this->donors_metric_with_clv( false )
+			);
+			[ $start, $end ] = $this->window();
+			$result          = $metric->get_newsletter_subscriber_value_3yr( $start, $end );
+
+			$this->assertFalse( $result['computable'] );
+			$this->assertSame( 'populated', $result['state'] );
+			$this->assertArrayNotHasKey( 'error', $result );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		}
+	}
+
 	/**
 	 * Clear the cohort snapshot transient between tests.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -405,6 +405,57 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NEWS-2603 (warming state): the hub returns the warming marker
+	 * (`[ [ '__status' => 'warming' ] ]`) on a snapshot cache miss — the
+	 * background refresh hasn't populated the snapshot yet. This is a
+	 * distinct, expected, transient state — NOT an error and NOT
+	 * `data_missing` — so no error_code/error_message must be set.
+	 */
+	public function test_warming_marker_yields_warming_state() {
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ [ '__status' => 'warming' ] ] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_newsletter_to_subscription_conversion( $start, $end );
+
+		$this->assertSame( 'warming', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+		$this->assertFalse( $result['data_missing'] );
+		$this->assertArrayNotHasKey( 'error_code', $result );
+		$this->assertArrayNotHasKey( 'error_message', $result );
+	}
+
+	/**
+	 * NEWS-2603 (warming state): a bare `[]` from the snapshot query is also
+	 * treated as warming — an un-updated hub returns an empty result set on
+	 * a cache miss rather than the marker row.
+	 */
+	public function test_bare_empty_from_snapshot_query_is_treated_as_warming() {
+		$metric          = new Conversion_Metric( $this->proxy_returning( [] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_newsletter_to_subscription_conversion( $start, $end );
+
+		$this->assertSame( 'warming', $result['state'] );
+	}
+
+	/**
+	 * NEWS-2603 (warming state): a genuine data row for an empty cohort
+	 * (zero newsletter signups, NULL rate) is a real computed result, not a
+	 * cache miss — it must stay 'populated', never 'warming'.
+	 */
+	public function test_real_zero_cohort_row_stays_populated_not_warming() {
+		$row             = [
+			'newsletter_signups'         => 0,
+			'converted_within_window'    => 0,
+			'newsletter_conversion_rate' => null,
+		];
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ $row ] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_newsletter_to_subscription_conversion( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+	}
+
+	/**
 	 * C3 empty: proxy returns [] → state 'empty', empty stages array.
 	 */
 	public function test_anon_to_registered_funnel_returns_empty_state_on_no_rows() {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-metric.php
@@ -456,6 +456,35 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NEWS-2603 (warming scope): a bare `[]` from a NON-snapshot influenced-rate
+	 * query is a legitimately empty window (0 / non-computable), NOT warming.
+	 * Only the two newsletter snapshot queries treat `[]` as a not-yet-warmed
+	 * miss; the shared compute_influenced_rate_from_proxy() also serves the live
+	 * 14-day influenced-rate methods, where an empty result is a real zero.
+	 */
+	public function test_bare_empty_from_non_snapshot_query_stays_populated() {
+		$metric          = new Conversion_Metric( $this->proxy_returning( [] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_influenced_subscription_rate_14d( $start, $end );
+
+		$this->assertSame( 'populated', $result['state'] );
+		$this->assertFalse( $result['computable'] );
+	}
+
+	/**
+	 * NEWS-2603 (warming scope): the explicit warming marker is honored
+	 * regardless of query name — if the hub ever emits it for a non-snapshot
+	 * query, that still means "still building".
+	 */
+	public function test_warming_marker_yields_warming_even_for_non_snapshot_query() {
+		$metric          = new Conversion_Metric( $this->proxy_returning( [ [ '__status' => 'warming' ] ] ) );
+		[ $start, $end ] = $this->window();
+		$result          = $metric->get_influenced_subscription_rate_14d( $start, $end );
+
+		$this->assertSame( 'warming', $result['state'] );
+	}
+
+	/**
 	 * C3 empty: proxy returns [] → state 'empty', empty stages array.
 	 */
 	public function test_anon_to_registered_funnel_returns_empty_state_on_no_rows() {
@@ -3495,6 +3524,49 @@ class Test_Conversion_Metric extends WP_UnitTestCase {
 
 			$this->assertFalse( $result['computable'] );
 			$this->assertSame( 'warming', $result['state'] );
+			$this->assertArrayNotHasKey( 'error', $result );
+		} finally {
+			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		}
+	}
+
+	/**
+	 * Partial-warming (NEWS-2603): when ONE revenue path is fully computable but
+	 * the OTHER is still warming, the aggregate must report 'warming' rather than
+	 * a value built from only the ready path. A single-path value understates the
+	 * modeled subscriber value and would show with no "still calculating" note;
+	 * warming takes precedence over a partial computable result (error still
+	 * beats warming, asserted separately).
+	 */
+	public function test_newsletter_subscriber_value_warming_when_one_path_computable_other_warming() {
+		add_filter( 'newspack_insights_woocommerce_active', '__return_true' );
+		try {
+			// Subscription snapshot returns a real, computable rate; the donation
+			// snapshot is still warming (a bare [] miss on its snapshot query).
+			$proxy = $this->createMock( BigQuery_Proxy_Client::class );
+			$proxy->method( 'query' )->willReturnCallback(
+				function ( $query_name ) {
+					if ( 'conversion_journey_newsletter_to_subscription' === $query_name ) {
+						return [
+							[
+								'newsletter_conversion_rate' => 0.05,
+								'newsletter_signups' => 200,
+							],
+						];
+					}
+					return [];
+				}
+			);
+			$metric          = new Conversion_Metric(
+				$proxy,
+				$this->subscribers_metric_with_clv( true ),
+				$this->donors_metric_with_clv( true )
+			);
+			[ $start, $end ] = $this->window();
+			$result          = $metric->get_newsletter_subscriber_value_3yr( $start, $end );
+
+			$this->assertSame( 'warming', $result['state'] );
+			$this->assertFalse( $result['computable'] );
 			$this->assertArrayNotHasKey( 'error', $result );
 		} finally {
 			remove_filter( 'newspack_insights_woocommerce_active', '__return_true' );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -521,12 +521,13 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 
 	/**
 	 * Audience (Tab 1) now carries its own `cache_schema_version()` override
-	 * ('2', bumped for the NEWS-2603 `data_status` envelope field — see
-	 * Audience_REST_Controller::cache_schema_version()) instead of inheriting
-	 * Cache::ENVELOPE_SCHEMA_VERSION from the trait default. This mirrors the
-	 * Subscribers/Donors tabs, which already opt out of the global version via
-	 * their own overrides, so a per-tab bump doesn't bust every other tab's
-	 * cache.
+	 * ('3' — bumped to '2' for the NEWS-2603 `data_status` envelope field, then
+	 * to '3' when core-BQ-outage discrimination changed the derived value and
+	 * added `error_code`; see Audience_REST_Controller::cache_schema_version())
+	 * instead of inheriting Cache::ENVELOPE_SCHEMA_VERSION from the trait
+	 * default. This mirrors the Subscribers/Donors tabs, which already opt out
+	 * of the global version via their own overrides, so a per-tab bump doesn't
+	 * bust every other tab's cache.
 	 */
 	public function test_audience_has_its_own_schema_version_override() {
 		$controller = new Audience_REST_Controller();
@@ -540,7 +541,7 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 
 		// Five parts: tab version + start + end + null + null.
 		$this->assertCount( 5, $parts );
-		$this->assertSame( '2', $parts[0] );
+		$this->assertSame( '3', $parts[0] );
 		$this->assertNotSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
 		$this->assertSame( '2026-01-01', $parts[1] );
 		$this->assertSame( '2026-01-31', $parts[2] );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -520,12 +520,15 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Global-version consolidation: a previously-unversioned tab (Audience, Tab 1)
-	 * now inherits Cache::ENVELOPE_SCHEMA_VERSION from the trait default, confirming
-	 * that the consolidation applies to ALL tabs — not just the three that formerly
-	 * opted in via per-tab CACHE_PREFIX overrides.
+	 * Audience (Tab 1) now carries its own `cache_schema_version()` override
+	 * ('2', bumped for the NEWS-2603 `data_status` envelope field — see
+	 * Audience_REST_Controller::cache_schema_version()) instead of inheriting
+	 * Cache::ENVELOPE_SCHEMA_VERSION from the trait default. This mirrors the
+	 * Subscribers/Donors tabs, which already opt out of the global version via
+	 * their own overrides, so a per-tab bump doesn't bust every other tab's
+	 * cache.
 	 */
-	public function test_global_version_applies_to_previously_unversioned_tab() {
+	public function test_audience_has_its_own_schema_version_override() {
 		$controller = new Audience_REST_Controller();
 		$request    = new WP_REST_Request( 'GET', '/newspack-insights/v1/audience' );
 		$request->set_param( 'start', '2026-01-01' );
@@ -535,9 +538,10 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 		$method->setAccessible( true );
 		$parts = $method->invoke( $controller, $request );
 
-		// Five parts: global version + start + end + null + null.
+		// Five parts: tab version + start + end + null + null.
 		$this->assertCount( 5, $parts );
-		$this->assertSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
+		$this->assertSame( '2', $parts[0] );
+		$this->assertNotSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
 		$this->assertSame( '2026-01-01', $parts[1] );
 		$this->assertSame( '2026-01-31', $parts[2] );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Test Metric_Status::derive() (NEWS-2603 Task 2).
+ *
+ * @package Newspack\Tests\Insights
+ */
+
+namespace Newspack\Tests\Insights;
+
+use Newspack\Insights\Metric_Status;
+use WP_UnitTestCase;
+
+/**
+ * Metric_Status test class.
+ *
+ * @group insights
+ */
+class Test_Metric_Status extends WP_UnitTestCase {
+
+	/**
+	 * Any errored metric-scalar, however deeply nested, wins over a warming
+	 * one elsewhere in the envelope — error precedence beats warming.
+	 */
+	public function test_derive_incomplete_when_any_metric_errored() {
+		$env = [
+			'a' => [ 'state' => 'populated' ],
+			'b' => [ 'nested' => [ 'state' => 'error' ] ],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * With no errors present, any warming metric-scalar makes the whole
+	 * envelope 'warming'.
+	 */
+	public function test_derive_warming_when_any_metric_warming_and_none_errored() {
+		$env = [
+			'a' => [ 'state' => 'populated' ],
+			'b' => [ 'state' => 'warming' ],
+		];
+		$this->assertSame( 'warming', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * All metric-scalars populated (or otherwise non-error/non-warming)
+	 * yields 'complete'.
+	 */
+	public function test_derive_complete_when_all_populated() {
+		$env = [
+			'a' => [ 'state' => 'populated' ],
+			'b' => [ 'state' => 'populated' ],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * An envelope with no `state`-bearing nodes anywhere (e.g. all metrics
+	 * predate the state-envelope convention) defaults to 'complete' — no
+	 * state at all is not the same as an error or a warming signal.
+	 */
+	public function test_derive_complete_when_no_state_keys_present() {
+		$env = [
+			'a' => [ 'value' => 1 ],
+			'b' => [ 'nested' => [ 'value' => 2 ] ],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * Once a node carries a `state` key it is treated as a leaf scalar — its
+	 * own children are not descended into, even if they happen to also carry
+	 * `state` keys of their own.
+	 */
+	public function test_does_not_recurse_past_a_scalar_node() {
+		$env = [
+			'a' => [
+				'state' => 'populated',
+				// This nested 'error' must be ignored: 'a' is already a
+				// scalar (it has its own top-level 'state' key), so its
+				// children are not walked.
+				'child' => [ 'state' => 'error' ],
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * Error precedence holds even when the warming node is discovered before
+	 * the errored node during the walk.
+	 */
+	public function test_error_precedence_regardless_of_walk_order() {
+		$env = [
+			'a' => [ 'state' => 'warming' ],
+			'b' => [ 'state' => 'populated' ],
+			'c' => [ 'state' => 'error' ],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * An empty envelope has no metric-scalars at all, so it is 'complete'.
+	 */
+	public function test_derive_complete_for_empty_envelope() {
+		$this->assertSame( 'complete', Metric_Status::derive( [] ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
@@ -103,4 +103,112 @@ class Test_Metric_Status extends WP_UnitTestCase {
 	public function test_derive_complete_for_empty_envelope() {
 		$this->assertSame( 'complete', Metric_Status::derive( [] ) );
 	}
+
+	/**
+	 * NEWS-2603 follow-up: the core BigQuery-proxy metrics (Audience's
+	 * proxy_scalar/proxy_rows) predate the three-state model and signal a hub
+	 * failure as `computable:false` + a non-empty `error` message string, with
+	 * NO `state` key. Such a node must make the envelope 'incomplete' — a core
+	 * metric that failed to fetch is a genuine incomplete data load.
+	 */
+	public function test_derive_incomplete_when_metric_has_error_key_without_state() {
+		$env = [
+			'a' => [
+				'value'      => 5,
+				'computable' => true,
+			],
+			'b' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'BigQuery proxy unavailable.',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a core-metric `error` key wins over a warming
+	 * metric-scalar elsewhere in the envelope — error precedence holds across
+	 * both the `state:'error'` and the legacy `error`-string conventions.
+	 */
+	public function test_derive_incomplete_when_error_key_beats_warming() {
+		$env = [
+			'a' => [ 'state' => 'warming' ],
+			'b' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'Simulated core failure.',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a `computable:false` node with NO error (an empty
+	 * cohort, an overlay/not-configured metric, etc.) is NOT a failure — it
+	 * must stay 'complete'. Only a genuine `error` (or `state:'error'`) counts.
+	 */
+	public function test_derive_complete_when_computable_false_without_error() {
+		$env = [
+			'a' => [
+				'value'      => 3,
+				'computable' => true,
+			],
+			'b' => [
+				'value'      => 0,
+				'computable' => false,
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: an empty-string `error` is not a failure signal —
+	 * only a non-empty error message flips the envelope to 'incomplete'.
+	 */
+	public function test_derive_ignores_empty_error_string() {
+		$env = [
+			'a' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => '',
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a `not_configured` proxy error is a setup state (the
+	 * hub was never connected), NOT a failed data fetch — it must stay
+	 * 'complete' so the "last data fetch didn't finish" warning banner doesn't
+	 * fire on a never-connected hub. Distinguished by the WP_Error code carried
+	 * alongside the message.
+	 */
+	public function test_derive_complete_when_error_is_only_not_configured() {
+		$env = [
+			'a' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'BigQuery proxy is not configured.',
+				'error_code' => 'bigquery_proxy_not_configured',
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a genuine fetch failure (any error code other than
+	 * the not-configured setup code) still flips the envelope to 'incomplete'.
+	 */
+	public function test_derive_incomplete_when_error_code_is_a_genuine_failure() {
+		$env = [
+			'a' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'Simulated hub HTTP failure.',
+				'error_code' => 'bigquery_proxy_http_error',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
@@ -211,4 +211,35 @@ class Test_Metric_Status extends WP_UnitTestCase {
 		];
 		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
 	}
+
+	/**
+	 * NEWS-2603 follow-up: a not-configured setup error on the THREE-STATE path
+	 * (`state: 'error'` + the not-configured `error_code`, as `error_scalar()`
+	 * emits for an unconfigured hub — e.g. Subscribers/Donors `newsletter_conversion`)
+	 * is a setup state, not a failed fetch, and must stay 'complete' — the same
+	 * exclusion the legacy `error`-string path already gets.
+	 */
+	public function test_derive_complete_when_state_error_is_not_configured() {
+		$env = [
+			'a' => [
+				'state'      => 'error',
+				'error_code' => 'bigquery_proxy_not_configured',
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a genuine fetch failure on the three-state path
+	 * (`state: 'error'` with a non-setup `error_code`) still flips to 'incomplete'.
+	 */
+	public function test_derive_incomplete_when_state_error_is_a_genuine_failure() {
+		$env = [
+			'a' => [
+				'state'      => 'error',
+				'error_code' => 'bigquery_proxy_http_error',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-ondemand.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/test-cache-ondemand.php
@@ -194,6 +194,75 @@ class Test_Cache_Ondemand extends WP_UnitTestCase {
 		Cache::prune_durable( $this->tab, [] );
 	}
 
+	/**
+	 * A provisional (warming) payload is cached with the short TTL_PROVISIONAL
+	 * transient expiry and is NOT written through to the on-demand durable pool,
+	 * even though the source/window would otherwise be on-demand-eligible.
+	 */
+	public function test_store_uses_provisional_ttl_and_skips_ondemand_for_warming_payload() {
+		$k     = $this->key( '2026-08-01', '2026-08-10' );
+		$win   = $this->window( '2026-08-01', '2026-08-10' );
+		$start = time();
+		$env   = Cache::store(
+			$this->tab,
+			$this->source,
+			$k,
+			fn() => [
+				'data_status' => 'warming',
+				'n'           => 1,
+			],
+			$win
+		);
+		$this->assertSame( 'warming', $env['payload']['data_status'] );
+
+		// No on-demand durable entry written for a provisional payload.
+		$this->assertNull( Cache::peek_ondemand( $this->tab, $this->source, $k ) );
+
+		// The transient's expiry reflects TTL_PROVISIONAL, not ttl_for( $source ).
+		$transient_key = 'newspack_insights_' . $this->tab . '_' . md5( (string) wp_json_encode( $k ) );
+		$timeout       = (int) get_option( '_transient_timeout_' . $transient_key );
+		$this->assertNotEmpty( $timeout, 'Transient must be written with a timeout.' );
+		$this->assertEqualsWithDelta( $start + Cache::TTL_PROVISIONAL, $timeout, 5, 'Transient TTL should be TTL_PROVISIONAL for a warming payload.' );
+	}
+
+	/**
+	 * A complete payload (data_status absent or 'complete') still uses the
+	 * ordinary durable/on-demand write-through path with the source's normal TTL.
+	 */
+	public function test_store_uses_normal_ttl_and_writes_ondemand_for_complete_payload() {
+		$k     = $this->key( '2026-08-11', '2026-08-20' );
+		$win   = $this->window( '2026-08-11', '2026-08-20' );
+		$start = time();
+		$env   = Cache::store(
+			$this->tab,
+			$this->source,
+			$k,
+			fn() => [
+				'data_status' => 'complete',
+				'n'           => 2,
+			],
+			$win
+		);
+		$this->assertSame( 'complete', $env['payload']['data_status'] );
+
+		// On-demand durable entry IS written for a complete payload.
+		$ondemand = Cache::peek_ondemand( $this->tab, $this->source, $k );
+		$this->assertNotNull( $ondemand );
+		$this->assertSame(
+			[
+				'data_status' => 'complete',
+				'n'           => 2,
+			],
+			$ondemand['payload']
+		);
+
+		// The transient's expiry reflects the source's normal TTL (TTL_EXTERNAL here).
+		$transient_key = 'newspack_insights_' . $this->tab . '_' . md5( (string) wp_json_encode( $k ) );
+		$timeout       = (int) get_option( '_transient_timeout_' . $transient_key );
+		$this->assertNotEmpty( $timeout );
+		$this->assertEqualsWithDelta( $start + Cache::TTL_EXTERNAL, $timeout, 5, 'Transient TTL should be the normal source TTL for a complete payload.' );
+	}
+
 	/** A stale on-demand entry is recomputed inline and the refreshed payload is stored. */
 	public function test_stale_ondemand_is_recomputed_inline() {
 		$k   = $this->key( '2026-03-01', '2026-03-10' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Makes the Insights UI honest and self-updating while a hub newsletter-conversion snapshot is still being computed ("warming"). This is the **consumer** half of NEWS-2603; it consumes the hub's warming-marker contract but does not depend on the hub's deploy order.

Three metric states are threaded end-to-end — **populated** (real value), **warming** (snapshot still computing), and **error** (hard failure) — from the PHP metric layer, through a new REST envelope field, into React:

- **Per-metric "still calculating" note.** A warming metric renders `Still calculating — check back shortly.` instead of a bare em-dash, so a cold snapshot reads as *pending*, not *empty*.
- **Two-tier top-of-tab banner.** A soft/info notice ("Some metrics are still being calculated and will appear shortly.") while warming; a stronger warning ("The last data fetch didn't finish, so some figures may be missing or out of date.") on a genuine failure or when warming never resolves.
- **Faster fill-in.** Provisional (warming) payloads are cached with a short 3-minute TTL (instead of the ~25h durable cache) and the tab quietly re-fetches every ~20s while warming, so the real value appears on its own without a manual reload. If it's still warming after ~2 minutes, the soft banner escalates to the warning banner.

Backward/forward compatible with the hub: both the warming marker and a bare empty result from the two snapshot queries are treated as warming, while a genuine-zero cohort (a real data row) stays populated and a `WP_Error` stays an error. The only response-shape change is the new top-level `data_status` field; affected tabs' cache schema versions are bumped so cached payloads adopt the new shape, and no other tab is affected.

Closes NEWS-2603.

### How to test the changes in this Pull Request:

1. Check out this branch, build the plugin assets (`pnpm install` at the workspace root, then `npm run build` in `plugins/newspack-plugin`), and load **Insights → Audience / Subscribers / Donors** on a site connected to a hub whose newsletter-conversion snapshot has **not** been built yet (a cold snapshot).
2. **Warming state:** With the snapshot warming, confirm the newsletter-conversion card shows the note **"Still calculating — check back shortly."** (not a bare "—"), and the tab shows the soft top-of-tab banner **"Some metrics are still being calculated and will appear shortly."**
3. **Auto fill-in:** Leave the tab open without reloading. Within ~a couple of minutes (once the hub finishes warming), confirm the card fills in with the real value on its own and both the note and the soft banner disappear.
4. **Escalation:** Force the snapshot to stay warming beyond ~2 minutes (e.g. keep the hub from completing). Confirm the soft banner escalates to the **warning** banner **"The last data fetch didn't finish, so some figures may be missing or out of date."** and the client stops re-fetching (no runaway requests — check the Network tab: at most ~6 refresh calls, then it stops).
5. **Genuine error:** Force the hub proxy to return an error (e.g. non-200 / timeout). Confirm the tab shows the **warning** banner (not the soft one) and the affected card shows its error note — warming is never shown for a hard failure.
6. **Genuine-zero cohort (regression):** On a site with a real but empty newsletter cohort (newsletter signups = 0, real data row), confirm the metric renders as a normal populated/incalculable value — **not** as "warming" and **not** as an error.
7. **Backward-compat:** Point at an un-updated hub that returns a bare empty result on a snapshot miss and confirm it is still treated as warming (soft banner + note), not as a hard error.
8. **Cache schema:** Confirm existing cached payloads for Subscribers/Donors/Audience are transparently recomputed (schema-version bumps) and no other Insights tab regresses.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (PHPUnit `insights` group + Jest; 11 new tests across PHP and React.)
* [x] Have you successfully run tests with your changes locally? (PHP `insights` group 791 passing; Jest suite 771 passing.)

---

**Coordination:** Depends on the warming-marker **contract** from the hub (manager-admin, Plan 1a), but **not** on its deploy order — a bare empty result is also treated as warming, so this ships safely against an old or new hub. Independent of the hub warm self-heal work (Plan 2).

**Known follow-up (out of scope):** `data_status` currently reflects only the newsletter-conversion metric. A BigQuery outage on the ~19 core Audience metrics (which don't emit a `state`) won't trip the warning banner; extending the three-state model to those metrics is tracked separately.
