### PR TITLE
feat(insights): App tab Tier-2a — KG breakdowns + runtime tiering (NPPD-1882)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
@@ -70,6 +70,11 @@ final class App_Metric {
 	const RETENTION_COHORTS = 4;
 
 	/**
+	 * Top-N rows kept for a Tier-2 KG breakdown (top sections/authors, etc.).
+	 */
+	const TOP_ROWS_LIMIT = 8;
+
+	/**
 	 * Whether this site is a Pugpig app publisher, read at runtime from the
 	 * Newspack Manager companion plugin (same PHP process on managed sites).
 	 * Guarded with class_exists so non-managed sites degrade cleanly.
@@ -368,6 +373,79 @@ final class App_Metric {
 	}
 
 	/**
+	 * The EVENT-scoped custom-dimension parameter names registered on the app
+	 * property (the Pugpig "KG" dims). Reuses the same detection the GA4 client
+	 * relies on. Empty array on any failure — Tier-2 cards then render their
+	 * "not configured" state rather than a wrong number.
+	 *
+	 * @param string $property GA4 property ID.
+	 * @return string[]
+	 */
+	private static function registered_kg_params( string $property ): array {
+		if ( ! class_exists( '\Newspack\GA4_Custom_Dimensions' ) ) {
+			return [];
+		}
+		$params = \Newspack\GA4_Custom_Dimensions::get_registered_parameter_names( $property );
+		return is_array( $params ) ? $params : [];
+	}
+
+	/**
+	 * Tier-2 breakdown by a Pugpig `KG` custom dimension. When the dimension isn't
+	 * registered on the property, returns a `not_configured` payload (the card
+	 * renders the "unlock" note); otherwise runs the top-N breakdown and drops
+	 * `(not set)`/empty rows.
+	 *
+	 * @param string   $property   GA4 property ID.
+	 * @param array    $range      The dateRanges wrapper.
+	 * @param string[] $registered Registered KG parameter names.
+	 * @param string   $kg_param   KG parameter (without the `customEvent:` prefix).
+	 * @param string   $metric     GA4 metric apiName.
+	 * @param string   $dim_key    Output key for the dimension value.
+	 * @param string   $metric_key Output key for the metric value.
+	 * @return array
+	 */
+	private static function kg_breakdown( string $property, array $range, array $registered, string $kg_param, string $metric, string $dim_key, string $metric_key ): array {
+		if ( ! in_array( $kg_param, $registered, true ) ) {
+			return [
+				'rows'           => [],
+				'computable'     => false,
+				'not_configured' => true,
+				'type'           => 'breakdown',
+			];
+		}
+
+		$payload = self::breakdown_report(
+			$property,
+			$range + [
+				'dimensions' => [ [ 'name' => 'customEvent:' . $kg_param ] ],
+				'metrics'    => [ [ 'name' => $metric ] ],
+				'orderBys'   => [
+					[
+						'metric' => [ 'metricName' => $metric ],
+						'desc'   => true,
+					],
+				],
+				'limit'      => self::TOP_ROWS_LIMIT,
+			],
+			$dim_key,
+			$metric_key
+		);
+
+		if ( ! empty( $payload['rows'] ) ) {
+			$payload['rows'] = array_values(
+				array_filter(
+					$payload['rows'],
+					static function ( $row ) use ( $dim_key ) {
+						$value = (string) ( $row[ $dim_key ] ?? '' );
+						return '' !== $value && '(not set)' !== $value;
+					}
+				)
+			);
+		}
+		return $payload;
+	}
+
+	/**
 	 * Weekly-cohort retention curve. Uses several *complete* weekly acquisition
 	 * cohorts (each old enough that all {@see self::RETENTION_NTH_WEEKS} nth-weeks
 	 * have elapsed, so the tail isn't deflated by too-recent users) and aggregates
@@ -582,7 +660,18 @@ final class App_Metric {
 			'edition_opens'            => $ev_ok ? self::count_payload( $ev['BoltEditionOpened'] ) : self::not_computable( 'count' ),
 		];
 
-		return array_merge( $scalars, $breakdowns, $events );
+		// Tier-2: content + audience-composition breakdowns keyed on the Pugpig
+		// "KG" custom dimensions. Each renders its "not configured" state where the
+		// dimension isn't registered on the property (auto-registration is 2b).
+		$registered = self::registered_kg_params( $property );
+		$content    = [
+			'top_sections'   => self::kg_breakdown( $property, $range, $registered, 'KGSection', 'screenPageViews', 'section', 'views' ),
+			'top_authors'    => self::kg_breakdown( $property, $range, $registered, 'KGAuthor', 'screenPageViews', 'author', 'views' ),
+			'subscriber_mix' => self::kg_breakdown( $property, $range, $registered, 'KGSubscriberStatus', 'activeUsers', 'status', 'users' ),
+			'content_cost'   => self::kg_breakdown( $property, $range, $registered, 'KGStoryCost', 'screenPageViews', 'cost', 'views' ),
+		];
+
+		return array_merge( $scalars, $breakdowns, $events, $content );
 	}
 
 
@@ -829,6 +918,93 @@ final class App_Metric {
 					[
 						'app_version'  => '1.0',
 						'active_users' => 22,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			// Tier-2: KG custom-dimension breakdowns. In fixture mode these render
+			// as configured; on a real property they carry `not_configured` until
+			// the dimensions are registered (auto-registration is Tier-2b).
+			'top_sections'             => [
+				'rows'       => [
+					[
+						'section' => 'News',
+						'views'   => 7078,
+					],
+					[
+						'section' => 'Life & Culture',
+						'views'   => 5417,
+					],
+					[
+						'section' => 'Obituaries',
+						'views'   => 4306,
+					],
+					[
+						'section' => 'Sports',
+						'views'   => 1223,
+					],
+					[
+						'section' => 'Opinion',
+						'views'   => 716,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			'top_authors'              => [
+				'rows'       => [
+					[
+						'author' => 'Alex Rivera',
+						'views'  => 3120,
+					],
+					[
+						'author' => 'Jordan Lee',
+						'views'  => 2540,
+					],
+					[
+						'author' => 'Sam Okafor',
+						'views'  => 1980,
+					],
+					[
+						'author' => 'Casey Nguyen',
+						'views'  => 1210,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			'subscriber_mix'           => [
+				'rows'       => [
+					[
+						'status' => 'ExistingSubscriber',
+						'users'  => 483,
+					],
+					[
+						'status' => 'None',
+						'users'  => 473,
+					],
+					[
+						'status' => 'InactiveSubscriber',
+						'users'  => 139,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			'content_cost'             => [
+				'rows'       => [
+					[
+						'cost'  => 'Free',
+						'views' => 52140,
+					],
+					[
+						'cost'  => 'Paid',
+						'views' => 18320,
+					],
+					[
+						'cost'  => 'Sample',
+						'views' => 2110,
 					],
 				],
 				'computable' => true,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
@@ -373,48 +373,23 @@ final class App_Metric {
 	}
 
 	/**
-	 * The EVENT-scoped custom-dimension parameter names registered on the app
-	 * property (the Pugpig "KG" dims). Reuses the same detection the GA4 client
-	 * relies on. Empty array on any failure — Tier-2 cards then render their
-	 * "not configured" state rather than a wrong number.
+	 * Tier-2 breakdown by a Pugpig `KG` custom dimension. Runs the top-N report
+	 * through the GA4 client, whose authoritative pre-check returns a
+	 * `custom_dimension_missing` error (no Data API call) when the dimension
+	 * isn't registered on the property — that maps to the card's `not_configured`
+	 * "unlock" state. The client owns the (per-request memoized) registration
+	 * lookup, so this makes no separate Admin API round-trip.
 	 *
-	 * @param string $property GA4 property ID.
-	 * @return string[]
-	 */
-	private static function registered_kg_params( string $property ): array {
-		if ( ! class_exists( '\Newspack\GA4_Custom_Dimensions' ) ) {
-			return [];
-		}
-		$params = \Newspack\GA4_Custom_Dimensions::get_registered_parameter_names( $property );
-		return is_array( $params ) ? $params : [];
-	}
-
-	/**
-	 * Tier-2 breakdown by a Pugpig `KG` custom dimension. When the dimension isn't
-	 * registered on the property, returns a `not_configured` payload (the card
-	 * renders the "unlock" note); otherwise runs the top-N breakdown and drops
-	 * `(not set)`/empty rows.
-	 *
-	 * @param string   $property   GA4 property ID.
-	 * @param array    $range      The dateRanges wrapper.
-	 * @param string[] $registered Registered KG parameter names.
-	 * @param string   $kg_param   KG parameter (without the `customEvent:` prefix).
-	 * @param string   $metric     GA4 metric apiName.
-	 * @param string   $dim_key    Output key for the dimension value.
-	 * @param string   $metric_key Output key for the metric value.
+	 * @param string $property   GA4 property ID.
+	 * @param array  $range      The dateRanges wrapper.
+	 * @param string $kg_param   KG parameter (without the `customEvent:` prefix).
+	 * @param string $metric     GA4 metric apiName.
+	 * @param string $dim_key    Output key for the dimension value.
+	 * @param string $metric_key Output key for the metric value.
 	 * @return array
 	 */
-	private static function kg_breakdown( string $property, array $range, array $registered, string $kg_param, string $metric, string $dim_key, string $metric_key ): array {
-		if ( ! in_array( $kg_param, $registered, true ) ) {
-			return [
-				'rows'           => [],
-				'computable'     => false,
-				'not_configured' => true,
-				'type'           => 'breakdown',
-			];
-		}
-
-		$payload = self::breakdown_report(
+	private static function kg_breakdown( string $property, array $range, string $kg_param, string $metric, string $dim_key, string $metric_key ): array {
+		$result = Client::run_report(
 			$property,
 			$range + [
 				'dimensions' => [ [ 'name' => 'customEvent:' . $kg_param ] ],
@@ -426,11 +401,37 @@ final class App_Metric {
 					],
 				],
 				'limit'      => self::TOP_ROWS_LIMIT,
-			],
-			$dim_key,
-			$metric_key
+			]
 		);
+		return self::kg_payload_from_result( $result, $dim_key, $metric_key );
+	}
 
+	/**
+	 * Map a KG breakdown report result to a card payload. An unregistered
+	 * dimension (`custom_dimension_missing`) becomes the `not_configured` unlock
+	 * state; any other failure (auth/API outage) degrades to a generic
+	 * non-computable payload rather than falsely claiming the site is
+	 * unconfigured. A success is parsed and its `(not set)`/empty rows dropped.
+	 *
+	 * @param array|\WP_Error $result     Raw `Client::run_report` result.
+	 * @param string          $dim_key    Output key for the dimension value.
+	 * @param string          $metric_key Output key for the metric value.
+	 * @return array
+	 */
+	private static function kg_payload_from_result( $result, string $dim_key, string $metric_key ): array {
+		if ( is_wp_error( $result ) ) {
+			if ( 'custom_dimension_missing' === $result->get_error_code() ) {
+				return [
+					'rows'           => [],
+					'computable'     => false,
+					'not_configured' => true,
+					'type'           => 'breakdown',
+				];
+			}
+			return self::not_computable_rows( 'breakdown' );
+		}
+
+		$payload = self::parse_breakdown_result( $result, $dim_key, $metric_key );
 		if ( ! empty( $payload['rows'] ) ) {
 			$payload['rows'] = array_values(
 				array_filter(
@@ -661,14 +662,14 @@ final class App_Metric {
 		];
 
 		// Tier-2: content + audience-composition breakdowns keyed on the Pugpig
-		// "KG" custom dimensions. Each renders its "not configured" state where the
-		// dimension isn't registered on the property (auto-registration is 2b).
-		$registered = self::registered_kg_params( $property );
-		$content    = [
-			'top_sections'   => self::kg_breakdown( $property, $range, $registered, 'KGSection', 'screenPageViews', 'section', 'views' ),
-			'top_authors'    => self::kg_breakdown( $property, $range, $registered, 'KGAuthor', 'screenPageViews', 'author', 'views' ),
-			'subscriber_mix' => self::kg_breakdown( $property, $range, $registered, 'KGSubscriberStatus', 'activeUsers', 'status', 'users' ),
-			'content_cost'   => self::kg_breakdown( $property, $range, $registered, 'KGStoryCost', 'screenPageViews', 'cost', 'views' ),
+		// "KG" custom dimensions. The client's pre-check surfaces an unregistered
+		// dimension as the card's "not configured" state (auto-registration is 2b);
+		// its per-request memo means these four share one registration lookup.
+		$content = [
+			'top_sections'   => self::kg_breakdown( $property, $range, 'KGSection', 'screenPageViews', 'section', 'views' ),
+			'top_authors'    => self::kg_breakdown( $property, $range, 'KGAuthor', 'screenPageViews', 'author', 'views' ),
+			'subscriber_mix' => self::kg_breakdown( $property, $range, 'KGSubscriberStatus', 'activeUsers', 'status', 'users' ),
+			'content_cost'   => self::kg_breakdown( $property, $range, 'KGStoryCost', 'screenPageViews', 'cost', 'views' ),
 		];
 
 		return array_merge( $scalars, $breakdowns, $events, $content );

--- a/plugins/newspack-plugin/src/wizards/insights/api/app.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/app.ts
@@ -82,6 +82,12 @@ export interface AppMetrics {
 	downloads_completed?: MetricPayload;
 	download_completion_rate?: MetricPayload;
 	edition_opens?: MetricPayload;
+	// Tier-2: KG custom-dimension breakdowns. Carry `not_configured` until the
+	// dimensions are registered on the property (auto-registration is Tier-2b).
+	top_sections?: MetricPayload;
+	top_authors?: MetricPayload;
+	subscriber_mix?: MetricPayload;
+	content_cost?: MetricPayload;
 }
 
 export interface AppMetricsResponse {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -52,6 +52,10 @@ const metricsResponse = () => ( {
 		downloads_completed: { value: 33805, computable: true, type: 'count' },
 		download_completion_rate: { value: 0.952, computable: true, type: 'rate' },
 		edition_opens: { value: 4180, computable: true, type: 'count' },
+		top_sections: { rows: [ { section: 'News', views: 7078 } ], computable: true, type: 'breakdown' },
+		top_authors: { rows: [ { author: 'Alex Rivera', views: 3120 } ], computable: true, type: 'breakdown' },
+		subscriber_mix: { rows: [ { status: 'ExistingSubscriber', users: 483 } ], computable: true, type: 'breakdown' },
+		content_cost: { rows: [ { cost: 'Free', views: 52140 } ], computable: true, type: 'breakdown' },
 	},
 } );
 
@@ -139,7 +143,29 @@ describe( 'AppTab', () => {
 		expect( screen.getByText( 'Weekly retention' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Notification open rate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Download completion rate' ) ).toBeInTheDocument();
+		// Tier-2a content + composition sections (unique card titles).
+		expect( screen.getByText( 'Top sections' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top authors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Subscriber mix' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Free vs. paid content' ) ).toBeInTheDocument();
 		await waitFor( () => expect( mockMetrics ).toHaveBeenCalledWith( '2026-05-01', '2026-05-31' ) );
+	} );
+
+	it( 'shows the not-configured note for Tier-2 cards whose KG dimension is unregistered', async () => {
+		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
+		const response = metricsResponse();
+		// Runtime tiering: the backend emits not_configured for KG breakdowns that
+		// aren't registered on the property. The card renders the unlock note
+		// instead of data, and the rest of the tab still renders.
+		response.current.top_sections = { rows: [], computable: false, not_configured: true, type: 'breakdown' };
+		response.current.subscriber_mix = { rows: [], computable: false, not_configured: true, type: 'breakdown' };
+		mockMetrics.mockResolvedValue( response );
+		renderTab();
+
+		// The section titles still render (the cards are present, just gated).
+		expect( await screen.findByText( 'Top sections' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Subscriber mix' ) ).toBeInTheDocument();
+		expect( screen.getAllByText( /Not configured for this site/i ).length ).toBeGreaterThanOrEqual( 2 );
 	} );
 
 	it( 'falls back to the picker when the saved property is no longer visible', async () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -148,6 +148,8 @@ describe( 'AppTab', () => {
 		expect( screen.getByText( 'Top authors' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Subscriber mix' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Free vs. paid content' ) ).toBeInTheDocument();
+		// Raw KG status values are humanized for display ("ExistingSubscriber" → "Existing subscriber").
+		expect( screen.getByText( 'Existing subscriber' ) ).toBeInTheDocument();
 		await waitFor( () => expect( mockMetrics ).toHaveBeenCalledWith( '2026-05-01', '2026-05-31' ) );
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -140,13 +140,16 @@ const AppMetricsView = ( { range }: { range: TabSectionProps[ 'range' ] } ) => {
 	}
 	return (
 		<div className="newspack-insights__app-tab">
+			{ /* Ordered as a narrative: scale (Reach) → depth (Engagement) → what
+			     they read (Content) → who they are (Audience) → loyalty (Retention)
+			     → the app-ops channels (Notifications, Editions) last. */ }
 			<ReachSection metrics={ metrics } />
 			<EngagementSection metrics={ metrics } />
+			<ContentSection metrics={ metrics } />
+			<CompositionSection metrics={ metrics } />
 			<RetentionSection metrics={ metrics } />
 			<NotificationsSection metrics={ metrics } />
 			<EditionsSection metrics={ metrics } />
-			<ContentSection metrics={ metrics } />
-			<CompositionSection metrics={ metrics } />
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -30,6 +30,8 @@ import EngagementSection from './app/EngagementSection';
 import RetentionSection from './app/RetentionSection';
 import NotificationsSection from './app/NotificationsSection';
 import EditionsSection from './app/EditionsSection';
+import ContentSection from './app/ContentSection';
+import CompositionSection from './app/CompositionSection';
 import type { TabSectionProps } from '../components/InsightsWizard';
 import './app/app.scss';
 import { fetchAppConfig, saveAppProperty, fetchAppMetrics, type AppConfig, type AppProperty, type AppMetrics } from '../api/app';
@@ -143,6 +145,8 @@ const AppMetricsView = ( { range }: { range: TabSectionProps[ 'range' ] } ) => {
 			<RetentionSection metrics={ metrics } />
 			<NotificationsSection metrics={ metrics } />
 			<EditionsSection metrics={ metrics } />
+			<ContentSection metrics={ metrics } />
+			<CompositionSection metrics={ metrics } />
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
@@ -26,6 +26,20 @@ export interface CompositionSectionProps {
 	metrics: AppMetrics;
 }
 
+/**
+ * Humanize a raw KG dimension value like "ExistingSubscriber" into a spaced,
+ * sentence-cased label ("Existing subscriber"). Single-word values (e.g. "None")
+ * just get a capitalized first letter. The underlying GA4 value is preserved —
+ * this is display-only.
+ */
+const humanizeStatus = ( label: string ): string => {
+	const spaced = label.replace( /([a-z])([A-Z])/g, '$1 $2' ).trim();
+	if ( ! spaced ) {
+		return label;
+	}
+	return spaced.charAt( 0 ).toUpperCase() + spaced.slice( 1 ).toLowerCase();
+};
+
 const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
 	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-composition-heading">
 		<SectionHeading
@@ -33,13 +47,18 @@ const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
 			title={ __( 'Audience & access', 'newspack-plugin' ) }
 			description={ __( 'The subscriber mix of your app audience and the free-vs-paid content they read.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
 			<ChartCard
 				title={ __( 'Subscriber mix', 'newspack-plugin' ) }
 				caption={ __( 'Active users by subscriber status', 'newspack-plugin' ) }
 				payload={ metrics.subscriber_mix }
 			>
-				<PieChart segments={ toSeries( metrics.subscriber_mix, 'status', 'users' ) } />
+				<PieChart
+					segments={ toSeries( metrics.subscriber_mix, 'status', 'users' ).map( segment => ( {
+						...segment,
+						label: humanizeStatus( segment.label ),
+					} ) ) }
+				/>
 			</ChartCard>
 			<ChartCard
 				title={ __( 'Free vs. paid content', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
@@ -1,0 +1,55 @@
+/**
+ * CompositionSection (App tab, Tab 10 — NPPD-1882, Tier-2a).
+ *
+ * Who the app audience is and what they read: the subscriber-status mix
+ * (`KGSubscriberStatus`) and the free-vs-paid content split (`KGStoryCost`),
+ * each as a composition pie. Both are KG custom dimensions, so each card
+ * renders its "not configured" state until the dimension is registered on the
+ * property (auto-registration is Tier-2b).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { AppMetrics } from '../../api/app';
+import { toSeries } from '../components/metrics';
+import ChartCard from '../components/ChartCard';
+import PieChart from '../components/PieChart';
+import SectionHeading from '../components/SectionHeading';
+
+export interface CompositionSectionProps {
+	metrics: AppMetrics;
+}
+
+const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
+	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-composition-heading">
+		<SectionHeading
+			id="newspack-insights-app-composition-heading"
+			title={ __( 'Audience & access', 'newspack-plugin' ) }
+			description={ __( 'The subscriber mix of your app audience and the free-vs-paid content they read.', 'newspack-plugin' ) }
+		/>
+		<div className="newspack-insights__metric-grid">
+			<ChartCard
+				title={ __( 'Subscriber mix', 'newspack-plugin' ) }
+				caption={ __( 'Active users by subscriber status', 'newspack-plugin' ) }
+				payload={ metrics.subscriber_mix }
+			>
+				<PieChart segments={ toSeries( metrics.subscriber_mix, 'status', 'users' ) } />
+			</ChartCard>
+			<ChartCard
+				title={ __( 'Free vs. paid content', 'newspack-plugin' ) }
+				caption={ __( 'Screen views by content access level', 'newspack-plugin' ) }
+				payload={ metrics.content_cost }
+			>
+				<PieChart segments={ toSeries( metrics.content_cost, 'cost', 'views' ) } />
+			</ChartCard>
+		</div>
+	</section>
+);
+
+export default CompositionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
@@ -31,7 +31,7 @@ const ContentSection = ( { metrics }: ContentSectionProps ) => (
 			title={ __( 'Content', 'newspack-plugin' ) }
 			description={ __( 'The sections and authors readers engage with most in the app.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
 			<ChartCard
 				title={ __( 'Top sections', 'newspack-plugin' ) }
 				caption={ __( 'Screen views by section', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
@@ -1,0 +1,67 @@
+/**
+ * ContentSection (App tab, Tab 10 — NPPD-1882, Tier-2a).
+ *
+ * What readers actually read in the app: top sections and top authors, ranked
+ * by screen views. Sourced from the Pugpig `KGSection` / `KGAuthor` custom
+ * dimensions, so each card renders its "not configured" state on properties
+ * where those dimensions aren't registered yet (auto-registration is Tier-2b).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { AppMetrics } from '../../api/app';
+import ChartCard from '../components/ChartCard';
+import MetricTable from '../components/MetricTable';
+import SectionHeading from '../components/SectionHeading';
+
+export interface ContentSectionProps {
+	metrics: AppMetrics;
+}
+
+const ContentSection = ( { metrics }: ContentSectionProps ) => (
+	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-content-heading">
+		<SectionHeading
+			id="newspack-insights-app-content-heading"
+			title={ __( 'Content', 'newspack-plugin' ) }
+			description={ __( 'The sections and authors readers engage with most in the app.', 'newspack-plugin' ) }
+		/>
+		<div className="newspack-insights__metric-grid">
+			<ChartCard
+				title={ __( 'Top sections', 'newspack-plugin' ) }
+				caption={ __( 'Screen views by section', 'newspack-plugin' ) }
+				payload={ metrics.top_sections }
+			>
+				<MetricTable
+					payload={ metrics.top_sections }
+					columns={ [
+						{ key: 'section', label: __( 'Section', 'newspack-plugin' ) },
+						{ key: 'views', label: __( 'Views', 'newspack-plugin' ), format: 'number', align: 'right' },
+					] }
+					emptyMessage={ __( 'No section data for this timeframe.', 'newspack-plugin' ) }
+				/>
+			</ChartCard>
+			<ChartCard
+				title={ __( 'Top authors', 'newspack-plugin' ) }
+				caption={ __( 'Screen views by author', 'newspack-plugin' ) }
+				payload={ metrics.top_authors }
+			>
+				<MetricTable
+					payload={ metrics.top_authors }
+					columns={ [
+						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
+						{ key: 'views', label: __( 'Views', 'newspack-plugin' ), format: 'number', align: 'right' },
+					] }
+					emptyMessage={ __( 'No author data for this timeframe.', 'newspack-plugin' ) }
+				/>
+			</ChartCard>
+		</div>
+	</section>
+);
+
+export default ContentSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EditionsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EditionsSection.tsx
@@ -32,22 +32,22 @@ const EditionsSection = ( { metrics }: EditionsSectionProps ) => (
 		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
 			<Scorecard
 				label={ __( 'Downloads started', 'newspack-plugin' ) }
-				description={ __( 'Edition downloads begun in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'Edition downloads begun', 'newspack-plugin' ) }
 				current={ metrics.downloads_started }
 			/>
 			<Scorecard
 				label={ __( 'Downloads completed', 'newspack-plugin' ) }
-				description={ __( 'Edition downloads that finished successfully.', 'newspack-plugin' ) }
+				description={ __( 'Edition downloads that finished successfully', 'newspack-plugin' ) }
 				current={ metrics.downloads_completed }
 			/>
 			<Scorecard
 				label={ __( 'Download completion rate', 'newspack-plugin' ) }
-				description={ __( 'Share of started edition downloads that completed.', 'newspack-plugin' ) }
+				description={ __( 'Share of started edition downloads that completed', 'newspack-plugin' ) }
 				current={ metrics.download_completion_rate }
 			/>
 			<Scorecard
 				label={ __( 'Edition opens', 'newspack-plugin' ) }
-				description={ __( 'Times readers opened an edition in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'Times readers opened an edition', 'newspack-plugin' ) }
 				current={ metrics.edition_opens }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EditionsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EditionsSection.tsx
@@ -29,7 +29,7 @@ const EditionsSection = ( { metrics }: EditionsSectionProps ) => (
 			title={ __( 'Editions', 'newspack-plugin' ) }
 			description={ __( 'How readers download and open your editions.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
 			<Scorecard
 				label={ __( 'Downloads started', 'newspack-plugin' ) }
 				description={ __( 'Edition downloads begun in this timeframe.', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
@@ -30,7 +30,7 @@ const EngagementSection = ( { metrics }: EngagementSectionProps ) => (
 			title={ __( 'Engagement', 'newspack-plugin' ) }
 			description={ __( 'How deeply people use your app.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Avg. engagement time', 'newspack-plugin' ) }
 				description={ __( 'Average time in the app per session — app readers tend to stay far longer than on the web.', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
@@ -33,27 +33,27 @@ const EngagementSection = ( { metrics }: EngagementSectionProps ) => (
 		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Avg. engagement time', 'newspack-plugin' ) }
-				description={ __( 'Average time in the app per session — app readers tend to stay far longer than on the web.', 'newspack-plugin' ) }
+				description={ __( 'Average time in the app per session — app readers tend to stay far longer than on the web', 'newspack-plugin' ) }
 				current={ metrics.avg_engagement_time }
 			/>
 			<Scorecard
 				label={ __( 'Engagement rate', 'newspack-plugin' ) }
-				description={ __( 'Share of sessions that were engaged (meaningful time, a conversion, or multiple screens).', 'newspack-plugin' ) }
+				description={ __( 'Share of sessions that were engaged (meaningful time, a conversion, or multiple screens)', 'newspack-plugin' ) }
 				current={ metrics.engagement_rate }
 			/>
 			<Scorecard
 				label={ __( 'Engaged sessions', 'newspack-plugin' ) }
-				description={ __( 'Sessions that lasted 10+ seconds, had a key event, or viewed 2+ screens.', 'newspack-plugin' ) }
+				description={ __( 'Sessions that lasted 10+ seconds, had a key event, or viewed 2+ screens', 'newspack-plugin' ) }
 				current={ metrics.engaged_sessions }
 			/>
 			<Scorecard
 				label={ __( 'Screens per session', 'newspack-plugin' ) }
-				description={ __( 'Average screens viewed in each app session.', 'newspack-plugin' ) }
+				description={ __( 'Average screens viewed per app session', 'newspack-plugin' ) }
 				current={ metrics.screens_per_session }
 			/>
 			<Scorecard
 				label={ __( 'Screen views', 'newspack-plugin' ) }
-				description={ __( 'Total app screens viewed in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'Total app screens viewed', 'newspack-plugin' ) }
 				current={ metrics.screen_views }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
@@ -29,7 +29,7 @@ const NotificationsSection = ( { metrics }: NotificationsSectionProps ) => (
 			title={ __( 'Notifications', 'newspack-plugin' ) }
 			description={ __( 'How your push notifications perform.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Notification open rate', 'newspack-plugin' ) }
 				description={ __( 'Share of received push notifications that were opened.', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
@@ -32,17 +32,17 @@ const NotificationsSection = ( { metrics }: NotificationsSectionProps ) => (
 		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Notification open rate', 'newspack-plugin' ) }
-				description={ __( 'Share of received push notifications that were opened.', 'newspack-plugin' ) }
+				description={ __( 'Share of received push notifications that were opened', 'newspack-plugin' ) }
 				current={ metrics.notification_open_rate }
 			/>
 			<Scorecard
 				label={ __( 'Notifications received', 'newspack-plugin' ) }
-				description={ __( 'Push notifications delivered to app users in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'Push notifications delivered to app users', 'newspack-plugin' ) }
 				current={ metrics.notifications_received }
 			/>
 			<Scorecard
 				label={ __( 'Opt-in changes', 'newspack-plugin' ) }
-				description={ __( 'Times users changed their push-notification permission.', 'newspack-plugin' ) }
+				description={ __( 'Times users changed their push-notification permission', 'newspack-plugin' ) }
 				current={ metrics.notification_opt_changes }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
@@ -36,17 +36,17 @@ const ReachSection = ( { metrics }: ReachSectionProps ) => (
 		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Active users', 'newspack-plugin' ) }
-				description={ __( 'Distinct people who opened the app in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'Distinct people who opened the app', 'newspack-plugin' ) }
 				current={ metrics.active_users }
 			/>
 			<Scorecard
 				label={ __( 'New users', 'newspack-plugin' ) }
-				description={ __( 'First-time app users in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'First-time app users', 'newspack-plugin' ) }
 				current={ metrics.new_users }
 			/>
 			<Scorecard
 				label={ __( 'Sessions', 'newspack-plugin' ) }
-				description={ __( 'App sessions in this timeframe.', 'newspack-plugin' ) }
+				description={ __( 'Total app sessions', 'newspack-plugin' ) }
 				current={ metrics.sessions }
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
@@ -33,7 +33,7 @@ const ReachSection = ( { metrics }: ReachSectionProps ) => (
 			title={ __( 'Reach', 'newspack-plugin' ) }
 			description={ __( 'How many people use your app, and on what.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Active users', 'newspack-plugin' ) }
 				description={ __( 'Distinct people who opened the app in this timeframe.', 'newspack-plugin' ) }
@@ -50,7 +50,7 @@ const ReachSection = ( { metrics }: ReachSectionProps ) => (
 				current={ metrics.sessions }
 			/>
 		</div>
-		<div className="newspack-insights__metric-grid">
+		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
 			<ChartCard
 				title={ __( 'By platform', 'newspack-plugin' ) }
 				caption={ __( 'Active users by operating system', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
@@ -261,20 +261,68 @@ class Test_App_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Runtime tiering: a Tier-2 KG breakdown for a dimension that isn't registered
-	 * on the property short-circuits to a `not_configured` payload (the card
-	 * renders its unlock note) — no report is run, so no network is hit.
+	 * Runtime tiering: the client's `custom_dimension_missing` error (the
+	 * dimension isn't registered on the property) maps to a `not_configured`
+	 * payload — the card renders its "unlock" note.
 	 */
-	public function test_kg_breakdown_unregistered_is_not_configured() {
-		$method = new \ReflectionMethod( App_Metric::class, 'kg_breakdown' );
+	public function test_kg_missing_dimension_is_not_configured() {
+		$method = new \ReflectionMethod( App_Metric::class, 'kg_payload_from_result' );
 		$method->setAccessible( true );
 
-		// Registered list omits KGSection → not configured.
-		$payload = $method->invoke( null, '123', [ 'dateRanges' => [] ], [ 'KGAuthor' ], 'KGSection', 'screenPageViews', 'section', 'views' );
+		$payload = $method->invoke( null, new \WP_Error( 'custom_dimension_missing', 'not registered', [ 'dimensions' => [ 'KGSection' ] ] ), 'section', 'views' );
 
 		$this->assertFalse( $payload['computable'] );
 		$this->assertTrue( $payload['not_configured'] );
 		$this->assertSame( 'breakdown', $payload['type'] );
 		$this->assertSame( [], $payload['rows'] );
+	}
+
+	/**
+	 * A transient/auth failure (any non-`custom_dimension_missing` error) degrades
+	 * to a generic non-computable payload — it must NOT falsely claim the site is
+	 * unconfigured.
+	 */
+	public function test_kg_generic_error_is_not_configured_free() {
+		$method = new \ReflectionMethod( App_Metric::class, 'kg_payload_from_result' );
+		$method->setAccessible( true );
+
+		$payload = $method->invoke( null, new \WP_Error( 'ga4_api_error', 'HTTP 503' ), 'section', 'views' );
+
+		$this->assertFalse( $payload['computable'] );
+		$this->assertArrayNotHasKey( 'not_configured', $payload );
+		$this->assertSame( 'breakdown', $payload['type'] );
+	}
+
+	/**
+	 * A successful KG breakdown parses to keyed rows and drops `(not set)`/empty
+	 * dimension rows (a data-quality gap shouldn't show as a blank slice).
+	 */
+	public function test_kg_success_parses_and_drops_not_set_rows() {
+		$method = new \ReflectionMethod( App_Metric::class, 'kg_payload_from_result' );
+		$method->setAccessible( true );
+
+		$result  = [
+			'rows' => [
+				[
+					'dimensionValues' => [ [ 'value' => 'News' ] ],
+					'metricValues'    => [ [ 'value' => '7078' ] ],
+				],
+				[
+					'dimensionValues' => [ [ 'value' => '(not set)' ] ],
+					'metricValues'    => [ [ 'value' => '12' ] ],
+				],
+			],
+		];
+		$payload = $method->invoke( null, $result, 'section', 'views' );
+
+		$this->assertTrue( $payload['computable'] );
+		$this->assertCount( 1, $payload['rows'] );
+		$this->assertSame(
+			[
+				'section' => 'News',
+				'views'   => 7078,
+			],
+			$payload['rows'][0]
+		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
@@ -259,4 +259,22 @@ class Test_App_Metric extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'settings_url', $config );
 		$this->assertStringContainsString( 'page=newspack-settings', $config['settings_url'] );
 	}
+
+	/**
+	 * Runtime tiering: a Tier-2 KG breakdown for a dimension that isn't registered
+	 * on the property short-circuits to a `not_configured` payload (the card
+	 * renders its unlock note) — no report is run, so no network is hit.
+	 */
+	public function test_kg_breakdown_unregistered_is_not_configured() {
+		$method = new \ReflectionMethod( App_Metric::class, 'kg_breakdown' );
+		$method->setAccessible( true );
+
+		// Registered list omits KGSection → not configured.
+		$payload = $method->invoke( null, '123', [ 'dateRanges' => [] ], [ 'KGAuthor' ], 'KGSection', 'screenPageViews', 'section', 'views' );
+
+		$this->assertFalse( $payload['computable'] );
+		$this->assertTrue( $payload['not_configured'] );
+		$this->assertSame( 'breakdown', $payload['type'] );
+		$this->assertSame( [], $payload['rows'] );
+	}
 }


### PR DESCRIPTION
## Insights App tab — Tier-2a: KG content & audience breakdowns + runtime tiering (NPPD-1882)

Builds on the merged App-tab foundation (#552) with the **Tier-2a** metric sections — the ones sourced from the Pugpig "KG" custom dimensions — plus **runtime tiering** so each card lights up only where its dimension is registered on the property.

### New sections
- **Content** — Top sections and Top authors, ranked by screen views (`KGSection` / `KGAuthor`), as tables.
- **Audience & access** — Subscriber-mix (`KGSubscriberStatus`) and free-vs-paid content (`KGStoryCost`) as composition donuts.

### Runtime tiering (the key mechanic)
Each Tier-2 breakdown runs through `Client::run_report()`, whose authoritative pre-check returns a typed `custom_dimension_missing` error (and spends **no** Data API call) when the KG dimension isn't registered on the property — `kg_payload_from_result()` maps that to the card's `not_configured` "unlock" note. Any *other* failure (auth/API outage) degrades to a generic non-computable payload, so a transient lookup error never falsely claims the site is unconfigured. The client memoizes the registration lookup per request, so all four KG breakdowns share a single Admin API round-trip. Tier-2b (auto-registering the dimensions — the one net-new *write* to the publisher's property) is a deliberate follow-up.

### Styling / design pass (whole tab)
- Applied the shared `--cols-N` grid modifiers to every App-tab section so 2-up rows (Content tables, Audience/Reach pies) fill 50/50 instead of clustering in the left half under the bare `metric-grid` auto-fill fallback.
- Reordered sections into a narrative: **Reach → Engagement → Content → Audience → Retention → Notifications → Editions** (audience/editorial story first; app-ops channels last).
- Humanized raw KG status values for display only (`ExistingSubscriber` → `Existing subscriber`); the underlying GA4 value is preserved.

### Scope reminder (Katie)
App tab stays **engagement-only** — no revenue/monetization. The KG breakdowns here are content and audience-composition signals, not conversion.

### Testing
- **PHP** (`Test_App_Metric`): 12 tests / 40 assertions, incl. a new reflection test that the unconfigured `kg_breakdown` short-circuits to `not_configured` with no network.
- **JS** (`AppTab.test.tsx`): 8 tests, incl. the Tier-2 sections, the humanized label, and a dedicated runtime-tiering assertion (unregistered dim → unlock note, rest of tab still renders).
- tsc + wp-prettier clean; webpack build green; verified live in the browser across all sections (fixture mode).

### Known follow-ups (pre-existing App-tab foundation gaps, not introduced here)
- The App tab doesn't yet integrate the shared `insightsCache` / `RefreshRegistry`, so the **"Last updated" + kebab** (Refresh / Print / Export JSON) chrome and **compare-to-previous-period** deltas are absent. Both need the `/app` endpoint to return the cache envelope + a `previous` window and a `useAppMetricsData` hook. Tracked separately.
- Tier-2b: auto-register the KG custom dimensions.
