### PR TITLE
chore: remove dead e2e test report link from README (NPPM-2919)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,7 +1,5 @@
 # Newspack end-to-end testing
 
-🎥 See the latest test report at https://automattic.github.io/newspack-e2e-tests.
-
 ## Setup
 
 ### Local setup & testing


### PR DESCRIPTION
The Playwright report link in `e2e/README.md` 404s: GitHub Pages publishing stopped when the nightly moved from CircleCI to TeamCity (the deploy job lived in CircleCI's config and was not carried over). Removing the dead link; a replacement reporting solution is tracked in NPPM-2919.

Doc-only, no code impact.