### PR TITLE
feat(insights): App tab Last updated chrome + period comparison (NPPD-1882)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-app-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-app-rest-controller.php
@@ -55,20 +55,19 @@ class App_REST_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_metrics' ],
 					'permission_callback' => [ $this, 'permissions_check' ],
-					'args'                => [
-						'start' => [
-							'type'              => 'string',
-							'required'          => true,
-							'validate_callback' => [ $this, 'validate_date_string' ],
-							'sanitize_callback' => [ $this, 'sanitize_date' ],
-						],
-						'end'   => [
-							'type'              => 'string',
-							'required'          => true,
-							'validate_callback' => [ $this, 'validate_date_string' ],
-							'sanitize_callback' => [ $this, 'sanitize_date' ],
-						],
-					],
+					'args'                => $this->window_args(),
+				],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/refresh',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'refresh_metrics' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => $this->window_args(),
 				],
 			]
 		);
@@ -109,12 +108,55 @@ class App_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * GET handler — windowed metric payloads for the selected app property.
+	 * The windowed-report args, shared by the GET and refresh routes: a required
+	 * current window (`start`/`end`) and an optional comparison window
+	 * (`compare_start`/`compare_end`), all validated/sanitized as YYYY-MM-DD.
+	 *
+	 * @return array
+	 */
+	private function window_args(): array {
+		$date_arg = [
+			'type'              => 'string',
+			'validate_callback' => [ $this, 'validate_date_string' ],
+			'sanitize_callback' => [ $this, 'sanitize_date' ],
+		];
+		return [
+			'start'         => array_merge( $date_arg, [ 'required' => true ] ),
+			'end'           => array_merge( $date_arg, [ 'required' => true ] ),
+			'compare_start' => $date_arg,
+			'compare_end'   => $date_arg,
+		];
+	}
+
+	/**
+	 * GET handler — windowed metric envelope for the selected app property.
 	 *
 	 * @param WP_REST_Request $request Request.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_metrics( WP_REST_Request $request ) {
+		return $this->report_response( $request, false );
+	}
+
+	/**
+	 * POST /app/refresh handler — bypass the per-window transient and recompute.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function refresh_metrics( WP_REST_Request $request ) {
+		return $this->report_response( $request, true );
+	}
+
+	/**
+	 * Build the windowed-report response (envelope shape the shared insightsCache
+	 * consumes). A comparison window is honored only when both bounds are present.
+	 *
+	 * @param WP_REST_Request $request       Request.
+	 * @param bool            $force_refresh Bypass the transient and recompute.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	private function report_response( WP_REST_Request $request, bool $force_refresh ) {
 		$start = (string) $request->get_param( 'start' );
 		$end   = (string) $request->get_param( 'end' );
 		if ( '' === $start || '' === $end ) {
@@ -124,7 +166,17 @@ class App_REST_Controller extends WP_REST_Controller {
 				[ 'status' => 400 ]
 			);
 		}
-		return rest_ensure_response( [ 'current' => App_Metric::get_metrics( $start, $end ) ] );
+
+		$compare_start = (string) $request->get_param( 'compare_start' );
+		$compare_end   = (string) $request->get_param( 'compare_end' );
+		if ( '' === $compare_start || '' === $compare_end ) {
+			$compare_start = '';
+			$compare_end   = '';
+		}
+
+		$response = rest_ensure_response( App_Metric::get_report( $start, $end, $compare_start, $compare_end, $force_refresh ) );
+		$response->header( 'Cache-Control', 'no-store, private' );
+		return $response;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
@@ -49,7 +49,7 @@ final class App_Metric {
 	/**
 	 * Metrics transient key prefix.
 	 */
-	const METRICS_CACHE_PREFIX = 'newspack_insights_app_metrics_v1:';
+	const METRICS_CACHE_PREFIX = 'newspack_insights_app_metrics_v2:';
 
 	/**
 	 * Retention transient TTL + key prefix. Retention is window-independent (its
@@ -241,34 +241,142 @@ final class App_Metric {
 		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
 			return self::get_fixture_metrics();
 		}
+		return self::get_window_report( $start_date, $end_date )['metrics'];
+	}
 
+	/**
+	 * Cache-freshness-aware envelope for the tab: the current window's metrics,
+	 * an optional comparison window, and the `cache` meta the shared insightsCache
+	 * consumes (so the "Last updated" chrome and period-over-period deltas work
+	 * like every other Insights tab).
+	 *
+	 * @param string $start_date    YYYY-MM-DD.
+	 * @param string $end_date      YYYY-MM-DD.
+	 * @param string $compare_start Optional prior-window start (YYYY-MM-DD).
+	 * @param string $compare_end   Optional prior-window end (YYYY-MM-DD).
+	 * @param bool   $force_refresh Bypass the per-window transient and recompute.
+	 * @return array{ data: array{ current: array, previous: ?array }, cache: array }
+	 */
+	public static function get_report( string $start_date, string $end_date, string $compare_start = '', string $compare_end = '', bool $force_refresh = false ): array {
+		$comparing = '' !== $compare_start && '' !== $compare_end;
+
+		// Fixture mode: canned current, plus a derived prior window when comparing
+		// so the toggle is demoable locally. Marked SOURCE_LOCAL / stamped now.
+		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
+			$current = self::get_fixture_metrics();
+			return self::envelope( $current, $comparing ? self::scale_previous( $current ) : null, 'local', self::now_timestamp() );
+		}
+
+		$current  = self::get_window_report( $start_date, $end_date, $force_refresh );
+		$previous = $comparing ? self::get_window_report( $compare_start, $compare_end, $force_refresh )['metrics'] : null;
+		return self::envelope( $current['metrics'], $previous, 'external', $current['computed_at'] );
+	}
+
+	/**
+	 * One window's metrics plus the timestamp they were computed at (for the
+	 * "Last updated" chrome). Window-dependent metrics are cached per
+	 * property+window; retention is window-independent (its own trailing
+	 * complete-week cohorts), cached per property with a daily TTL. Returns a
+	 * `tab_error` metrics map (and a null timestamp) when there's no property or
+	 * connection, so the tab surfaces a single banner instead of N failed reports.
+	 *
+	 * @param string $start_date    YYYY-MM-DD.
+	 * @param string $end_date      YYYY-MM-DD.
+	 * @param bool   $force_refresh Bypass the transient and recompute.
+	 * @return array{ metrics: array, computed_at: ?string }
+	 */
+	private static function get_window_report( string $start_date, string $end_date, bool $force_refresh = false ): array {
 		$property = self::get_selected_property_id();
 		if ( '' === $property ) {
-			return [ 'tab_error' => 'no_property' ];
+			return [
+				'metrics'     => [ 'tab_error' => 'no_property' ],
+				'computed_at' => null,
+			];
 		}
 		if ( ! self::is_connected() ) {
-			return [ 'tab_error' => 'not_connected' ];
+			return [
+				'metrics'     => [ 'tab_error' => 'not_connected' ],
+				'computed_at' => null,
+			];
 		}
 
-		// Window-dependent metrics (Reach, Engagement, Notifications, Editions),
-		// cached per property+window.
 		$window_key = self::METRICS_CACHE_PREFIX . md5( $property . '|' . $start_date . '|' . $end_date );
-		$window     = get_transient( $window_key );
-		if ( ! is_array( $window ) ) {
-			$window = self::compute_metrics( $property, $start_date, $end_date );
+		$cached     = $force_refresh ? false : get_transient( $window_key );
+		if ( is_array( $cached ) && isset( $cached['metrics'], $cached['computed_at'] ) ) {
+			$window = $cached;
+		} else {
+			$window = [
+				'metrics'     => self::compute_metrics( $property, $start_date, $end_date ),
+				'computed_at' => self::now_timestamp(),
+			];
 			set_transient( $window_key, $window, self::METRICS_CACHE_TTL );
 		}
 
-		// Retention is window-independent (its own trailing complete-week cohorts);
-		// cache it per property with a daily TTL so date-range changes reuse it.
 		$retention_key = self::RETENTION_CACHE_PREFIX . md5( $property );
-		$retention     = get_transient( $retention_key );
+		$retention     = $force_refresh ? false : get_transient( $retention_key );
 		if ( ! is_array( $retention ) ) {
 			$retention = self::compute_retention( $property );
 			set_transient( $retention_key, $retention, self::RETENTION_CACHE_TTL );
 		}
 
-		return array_merge( $window, [ 'retention' => $retention ] );
+		return [
+			'metrics'     => array_merge( $window['metrics'], [ 'retention' => $retention ] ),
+			'computed_at' => $window['computed_at'],
+		];
+	}
+
+	/**
+	 * Wrap current/previous metrics in the shared cache envelope.
+	 *
+	 * @param array       $current     Current-window metrics map.
+	 * @param array|null  $previous    Prior-window metrics map, or null.
+	 * @param string      $source      Cache source tag ('external' live GA4, 'local' fixture).
+	 * @param string|null $computed_at ISO-8601 timestamp the current window was computed at.
+	 * @return array
+	 */
+	private static function envelope( array $current, ?array $previous, string $source, ?string $computed_at ): array {
+		return [
+			'data'  => [
+				'current'  => $current,
+				'previous' => $previous,
+			],
+			'cache' => [
+				'source'         => $source,
+				'computed_at'    => $computed_at,
+				'cooldown_until' => null,
+			],
+		];
+	}
+
+	/**
+	 * Derive a plausible prior window from the fixture's current window by scaling
+	 * scalar values down (counts ~12% lower, rates a touch lower) so the
+	 * comparison toggle shows realistic deltas locally. Breakdown/timeseries
+	 * payloads pass through unchanged.
+	 *
+	 * @param array $metrics Current-window fixture metrics.
+	 * @return array
+	 */
+	private static function scale_previous( array $metrics ): array {
+		$previous = [];
+		foreach ( $metrics as $key => $payload ) {
+			if ( is_array( $payload ) && isset( $payload['value'] ) && is_numeric( $payload['value'] ) ) {
+				$payload['value'] = 'rate' === ( $payload['type'] ?? '' )
+					? round( (float) $payload['value'] * 0.95, 4 )
+					: (int) round( (float) $payload['value'] * 0.88 );
+			}
+			$previous[ $key ] = $payload;
+		}
+		return $previous;
+	}
+
+	/**
+	 * Current UTC time as an ISO-8601 `Z` timestamp for cache `computed_at`.
+	 *
+	 * @return string
+	 */
+	private static function now_timestamp(): string {
+		return gmdate( 'Y-m-d\TH:i:s\Z' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/wizards/insights/api/app.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/app.ts
@@ -17,6 +17,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import type { MetricPayload } from '../tabs/components/metrics';
+import { type CachedEnvelope } from '../state/insightsCache';
 
 /** One selectable GA4 property (spans accounts — app data often lives in a separate account). */
 export interface AppProperty {
@@ -90,14 +91,41 @@ export interface AppMetrics {
 	content_cost?: MetricPayload;
 }
 
-export interface AppMetricsResponse {
+/** The windowed report the cache envelope wraps: current + optional prior window. */
+export interface AppReportData {
 	current: AppMetrics;
+	previous: AppMetrics | null;
+}
+
+/** Date window (+ optional comparison window) for a metrics request. */
+export interface AppMetricsQuery {
+	start: string;
+	end: string;
+	compare_start?: string;
+	compare_end?: string;
 }
 
 const METRICS_ENDPOINT = '/newspack-insights/v1/app';
 
-export const fetchAppMetrics = async ( start: string, end: string ): Promise< AppMetricsResponse > =>
-	apiFetch< AppMetricsResponse >( {
-		path: `${ METRICS_ENDPOINT }?start=${ encodeURIComponent( start ) }&end=${ encodeURIComponent( end ) }`,
+const queryString = ( query: AppMetricsQuery ): string => {
+	const params = new URLSearchParams();
+	params.set( 'start', query.start );
+	params.set( 'end', query.end );
+	if ( query.compare_start && query.compare_end ) {
+		params.set( 'compare_start', query.compare_start );
+		params.set( 'compare_end', query.compare_end );
+	}
+	return params.toString();
+};
+
+export const fetchAppMetricsData = async ( query: AppMetricsQuery ): Promise< CachedEnvelope< AppReportData > > =>
+	apiFetch< CachedEnvelope< AppReportData > >( {
+		path: `${ METRICS_ENDPOINT }?${ queryString( query ) }`,
 		method: 'GET',
+	} );
+
+export const refreshAppMetricsData = async ( query: AppMetricsQuery ): Promise< CachedEnvelope< AppReportData > > =>
+	apiFetch< CachedEnvelope< AppReportData > >( {
+		path: `${ METRICS_ENDPOINT }/refresh?${ queryString( query ) }`,
+		method: 'POST',
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/hooks/useAppMetricsData.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/hooks/useAppMetricsData.ts
@@ -1,0 +1,68 @@
+/**
+ * useAppMetricsData (NPPD-1882).
+ *
+ * Reads the App tab's windowed metrics through the shared module insightsCache,
+ * mirroring {@see useNewsletterAdsData}. Adopting the cache is what gives the App
+ * tab the "Last updated" + kebab chrome (LastUpdated reads the same slot) and
+ * period-over-period comparison (the slot key embeds the comparison window, and
+ * the fetch forwards it so the server returns a `previous` window too).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useSyncExternalStore } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from '../state/useDateRange';
+import { fetchAppMetricsData, refreshAppMetricsData, type AppMetricsQuery, type AppReportData } from '../api/app';
+import { insightsCache, makeSlotKey } from '../state/insightsCache';
+import { useRegisterRefresh } from '../state/refreshRegistry';
+
+export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UseAppMetricsDataResult {
+	status: FetchStatus;
+	data: AppReportData | null;
+	error: string | null;
+	refetch: () => void;
+	computedAt: string | null;
+}
+
+const queryFrom = ( range: DateRange, previousRange: DateRange | null ): AppMetricsQuery => ( {
+	start: range.start,
+	end: range.end,
+	compare_start: previousRange?.start,
+	compare_end: previousRange?.end,
+} );
+
+const useAppMetricsData = ( range: DateRange, previousRange: DateRange | null ): UseAppMetricsDataResult => {
+	const key = makeSlotKey( 'app', range, previousRange );
+
+	const slot = useSyncExternalStore(
+		listener => insightsCache.subscribe( key, listener ),
+		() => insightsCache.getSlot< AppReportData >( key )
+	);
+
+	useEffect( () => {
+		insightsCache.ensureFetched( key, () => fetchAppMetricsData( queryFrom( range, previousRange ) ) );
+	}, [ key, range.start, range.end, previousRange?.start, previousRange?.end ] );
+
+	const refetch = useCallback( () => {
+		insightsCache.refresh( key, () => refreshAppMetricsData( queryFrom( range, previousRange ) ) );
+	}, [ key, range.start, range.end, previousRange?.start, previousRange?.end ] );
+
+	useRegisterRefresh( 'app', refetch );
+
+	return {
+		status: slot.status,
+		data: slot.data,
+		error: slot.error,
+		refetch,
+		computedAt: slot.computedAt,
+	};
+};
+
+export default useAppMetricsData;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -143,10 +143,18 @@ describe( 'AppTab', () => {
 	} );
 
 	it( 'renders the Reach section when a visible property is selected', async () => {
-		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
+		mockFetch.mockResolvedValue(
+			baseConfig( {
+				selected_property: '533212292',
+				selected_is_visible: true,
+				properties: [ { account_id: '1', account_name: 'YubaNet', property_id: '533212292', property_name: 'yubanetapp' } ],
+			} )
+		);
 		renderTab();
 
 		expect( await screen.findByText( 'Reach' ) ).toBeInTheDocument();
+		// The property-context line names the property the tab is reading.
+		expect( screen.getByText( /App property: YubaNet → yubanetapp \(533212292\)/ ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Active users' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Engagement' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Avg. engagement time' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tab-level tests for AppTab (Tab 10, NPPD-1882): the connect → select → render
- * state machine, driven by the /app/config response.
+ * state machine, driven by the /app/config response, plus the ready state driven
+ * by the shared useAppMetricsData cache hook.
  */
 
 /**
@@ -12,51 +13,61 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import AppTab from './AppTab';
-import { fetchAppConfig, saveAppProperty, fetchAppMetrics, type AppConfig } from '../api/app';
+import { fetchAppConfig, saveAppProperty, type AppConfig } from '../api/app';
+import useAppMetricsData from '../hooks/useAppMetricsData';
 import type { DateRange } from '../state/useDateRange';
 
 jest.mock( '../api/app' );
+jest.mock( '../hooks/useAppMetricsData' );
 
 const mockFetch = fetchAppConfig as jest.Mock;
 const mockSave = saveAppProperty as jest.Mock;
-const mockMetrics = fetchAppMetrics as jest.Mock;
+const mockUseData = useAppMetricsData as jest.Mock;
 
 const range = { start: '2026-05-01', end: '2026-05-31', preset: 'last-30' } as unknown as DateRange;
 
-/** A minimal metrics response so the ready state renders the Reach section. */
-const metricsResponse = () => ( {
-	current: {
-		active_users: { value: 892, computable: true, type: 'count' },
-		new_users: { value: 150, computable: true, type: 'count' },
-		sessions: { value: 12790, computable: true, type: 'count' },
-		platform: { rows: [ { platform: 'iOS', active_users: 590 } ], computable: true, type: 'breakdown' },
-		app_version: { rows: [ { app_version: '1.2', active_users: 840 } ], computable: true, type: 'breakdown' },
-		avg_engagement_time: { value: 1130, computable: true, type: 'duration' },
-		engagement_rate: { value: 0.83, computable: true, type: 'rate' },
-		engaged_sessions: { value: 10600, computable: true, type: 'count' },
-		screens_per_session: { value: 6.2, computable: true, type: 'decimal' },
-		screen_views: { value: 70473, computable: true, type: 'count' },
-		retention: {
-			rows: [
-				{ week: 0, retention: 1.0 },
-				{ week: 1, retention: 0.55 },
-				{ week: 2, retention: 0.32 },
-			],
-			computable: true,
-			type: 'timeseries',
-		},
-		notification_open_rate: { value: 0.228, computable: true, type: 'rate' },
-		notifications_received: { value: 614, computable: true, type: 'count' },
-		notification_opt_changes: { value: 123, computable: true, type: 'count' },
-		downloads_started: { value: 35495, computable: true, type: 'count' },
-		downloads_completed: { value: 33805, computable: true, type: 'count' },
-		download_completion_rate: { value: 0.952, computable: true, type: 'rate' },
-		edition_opens: { value: 4180, computable: true, type: 'count' },
-		top_sections: { rows: [ { section: 'News', views: 7078 } ], computable: true, type: 'breakdown' },
-		top_authors: { rows: [ { author: 'Alex Rivera', views: 3120 } ], computable: true, type: 'breakdown' },
-		subscriber_mix: { rows: [ { status: 'ExistingSubscriber', users: 483 } ], computable: true, type: 'breakdown' },
-		content_cost: { rows: [ { cost: 'Free', views: 52140 } ], computable: true, type: 'breakdown' },
+/** A minimal current-window metrics map so the ready state renders every section. */
+const metricsMap = () => ( {
+	active_users: { value: 892, computable: true, type: 'count' },
+	new_users: { value: 150, computable: true, type: 'count' },
+	sessions: { value: 12790, computable: true, type: 'count' },
+	platform: { rows: [ { platform: 'iOS', active_users: 590 } ], computable: true, type: 'breakdown' },
+	app_version: { rows: [ { app_version: '1.2', active_users: 840 } ], computable: true, type: 'breakdown' },
+	avg_engagement_time: { value: 1130, computable: true, type: 'duration' },
+	engagement_rate: { value: 0.83, computable: true, type: 'rate' },
+	engaged_sessions: { value: 10600, computable: true, type: 'count' },
+	screens_per_session: { value: 6.2, computable: true, type: 'decimal' },
+	screen_views: { value: 70473, computable: true, type: 'count' },
+	retention: {
+		rows: [
+			{ week: 0, retention: 1.0 },
+			{ week: 1, retention: 0.55 },
+			{ week: 2, retention: 0.32 },
+		],
+		computable: true,
+		type: 'timeseries',
 	},
+	notification_open_rate: { value: 0.228, computable: true, type: 'rate' },
+	notifications_received: { value: 614, computable: true, type: 'count' },
+	notification_opt_changes: { value: 123, computable: true, type: 'count' },
+	downloads_started: { value: 35495, computable: true, type: 'count' },
+	downloads_completed: { value: 33805, computable: true, type: 'count' },
+	download_completion_rate: { value: 0.952, computable: true, type: 'rate' },
+	edition_opens: { value: 4180, computable: true, type: 'count' },
+	top_sections: { rows: [ { section: 'News', views: 7078 } ], computable: true, type: 'breakdown' },
+	top_authors: { rows: [ { author: 'Alex Rivera', views: 3120 } ], computable: true, type: 'breakdown' },
+	subscriber_mix: { rows: [ { status: 'ExistingSubscriber', users: 483 } ], computable: true, type: 'breakdown' },
+	content_cost: { rows: [ { cost: 'Free', views: 52140 } ], computable: true, type: 'breakdown' },
+} );
+
+/** The useAppMetricsData return for a resolved window (overridable per test). */
+const readyState = ( overrides: Record< string, unknown > = {} ) => ( {
+	status: 'success',
+	data: { current: metricsMap(), previous: null },
+	error: null,
+	computedAt: '2026-05-31T00:00:00Z',
+	refetch: jest.fn(),
+	...overrides,
 } );
 
 const baseConfig = ( overrides: Partial< AppConfig > = {} ): AppConfig => ( {
@@ -73,10 +84,14 @@ const baseConfig = ( overrides: Partial< AppConfig > = {} ): AppConfig => ( {
 const renderTab = () => render( <AppTab range={ range } previousRange={ null } /> );
 
 describe( 'AppTab', () => {
+	beforeEach( () => {
+		mockUseData.mockReturnValue( readyState() );
+	} );
+
 	afterEach( () => {
 		mockFetch.mockReset();
 		mockSave.mockReset();
-		mockMetrics.mockReset();
+		mockUseData.mockReset();
 	} );
 
 	it( 'shows the Connections CTA (not Site Kit) when not connected', async () => {
@@ -117,20 +132,18 @@ describe( 'AppTab', () => {
 			} )
 		);
 		mockSave.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
-		mockMetrics.mockResolvedValue( metricsResponse() );
 		renderTab();
 
 		fireEvent.change( await screen.findByRole( 'combobox' ), { target: { value: '533212292' } } );
 		fireEvent.click( screen.getByRole( 'button', { name: /Save property/i } ) );
 
 		await waitFor( () => expect( mockSave ).toHaveBeenCalledWith( '533212292' ) );
-		// After saving, the ready state fetches metrics and renders the Reach section.
+		// After saving, the ready state reads the metrics cache and renders the Reach section.
 		expect( await screen.findByText( 'Reach' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the Reach section when a visible property is selected', async () => {
 		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
-		mockMetrics.mockResolvedValue( metricsResponse() );
 		renderTab();
 
 		expect( await screen.findByText( 'Reach' ) ).toBeInTheDocument();
@@ -150,18 +163,38 @@ describe( 'AppTab', () => {
 		expect( screen.getByText( 'Free vs. paid content' ) ).toBeInTheDocument();
 		// Raw KG status values are humanized for display ("ExistingSubscriber" → "Existing subscriber").
 		expect( screen.getByText( 'Existing subscriber' ) ).toBeInTheDocument();
-		await waitFor( () => expect( mockMetrics ).toHaveBeenCalledWith( '2026-05-01', '2026-05-31' ) );
+		// The tab reads through the shared cache hook for the current window (no comparison).
+		expect( mockUseData ).toHaveBeenCalledWith( range, null );
+	} );
+
+	it( 'threads the comparison window into the data hook', async () => {
+		const previousRange = { start: '2026-04-01', end: '2026-04-30', preset: 'last-30' } as unknown as DateRange;
+		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
+		mockUseData.mockReturnValue(
+			readyState( {
+				data: {
+					current: metricsMap(),
+					previous: { ...metricsMap(), active_users: { value: 800, computable: true, type: 'count' } },
+				},
+			} )
+		);
+		render( <AppTab range={ range } previousRange={ previousRange } /> );
+
+		expect( await screen.findByText( 'Reach' ) ).toBeInTheDocument();
+		// The comparison window flows to the cache hook, which the server uses to
+		// return a `previous` window that Scorecards turn into deltas.
+		expect( mockUseData ).toHaveBeenCalledWith( range, previousRange );
 	} );
 
 	it( 'shows the not-configured note for Tier-2 cards whose KG dimension is unregistered', async () => {
 		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
-		const response = metricsResponse();
+		const current = metricsMap();
 		// Runtime tiering: the backend emits not_configured for KG breakdowns that
 		// aren't registered on the property. The card renders the unlock note
 		// instead of data, and the rest of the tab still renders.
-		response.current.top_sections = { rows: [], computable: false, not_configured: true, type: 'breakdown' };
-		response.current.subscriber_mix = { rows: [], computable: false, not_configured: true, type: 'breakdown' };
-		mockMetrics.mockResolvedValue( response );
+		current.top_sections = { rows: [], computable: false, not_configured: true, type: 'breakdown' } as never;
+		current.subscriber_mix = { rows: [], computable: false, not_configured: true, type: 'breakdown' } as never;
+		mockUseData.mockReturnValue( readyState( { data: { current, previous: null } } ) );
 		renderTab();
 
 		// The section titles still render (the cards are present, just gated).

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -13,7 +13,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import AppTab from './AppTab';
-import { fetchAppConfig, saveAppProperty, type AppConfig } from '../api/app';
+import { fetchAppConfig, saveAppProperty, type AppConfig, type AppMetrics } from '../api/app';
 import useAppMetricsData from '../hooks/useAppMetricsData';
 import type { DateRange } from '../state/useDateRange';
 
@@ -27,7 +27,7 @@ const mockUseData = useAppMetricsData as jest.Mock;
 const range = { start: '2026-05-01', end: '2026-05-31', preset: 'last-30' } as unknown as DateRange;
 
 /** A minimal current-window metrics map so the ready state renders every section. */
-const metricsMap = () => ( {
+const metricsMap = (): AppMetrics => ( {
 	active_users: { value: 892, computable: true, type: 'count' },
 	new_users: { value: 150, computable: true, type: 'count' },
 	sessions: { value: 12790, computable: true, type: 'count' },
@@ -200,8 +200,8 @@ describe( 'AppTab', () => {
 		// Runtime tiering: the backend emits not_configured for KG breakdowns that
 		// aren't registered on the property. The card renders the unlock note
 		// instead of data, and the rest of the tab still renders.
-		current.top_sections = { rows: [], computable: false, not_configured: true, type: 'breakdown' } as never;
-		current.subscriber_mix = { rows: [], computable: false, not_configured: true, type: 'breakdown' } as never;
+		current.top_sections = { rows: [], computable: false, not_configured: true, type: 'breakdown' };
+		current.subscriber_mix = { rows: [], computable: false, not_configured: true, type: 'breakdown' };
 		mockUseData.mockReturnValue( readyState( { data: { current, previous: null } } ) );
 		renderTab();
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -16,7 +16,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 
 /**
@@ -193,11 +193,26 @@ const AppTab = ( { range, previousRange }: TabSectionProps ) => {
 		);
 	}
 
+	// Name the property the tab is reading — it often lives in a different Google
+	// account than the website, so surfacing which one confirms you're looking at
+	// the right data. `selected_is_visible` guarantees it's in the list here.
+	const selected = config.properties.find( property => property.property_id === config.selected_property );
+
 	return (
 		<>
 			<div className="newspack-insights__app-toolbar">
+				<span className="newspack-insights__app-property">
+					{ sprintf(
+						/* translators: %s: the selected GA4 app property (name and id). */
+						__( 'App property: %s', 'newspack-plugin' ),
+						selected ? propertyLabel( selected ) : config.selected_property
+					) }
+				</span>
+				<span className="newspack-insights__app-property-sep" aria-hidden="true">
+					·
+				</span>
 				<Button variant="link" onClick={ () => setChanging( true ) }>
-					{ __( 'Change app property', 'newspack-plugin' ) }
+					{ __( 'Change', 'newspack-plugin' ) }
 				</Button>
 			</div>
 			<AppMetricsView range={ range } previousRange={ previousRange } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -120,13 +120,16 @@ const AppMetricsView = ( { range, previousRange }: Pick< TabSectionProps, 'range
 	// (Fixture mode returns a `previous` window unconditionally, so gate here.)
 	const previous = previousRange ? data?.previous ?? null : null;
 
-	if ( status === 'loading' && ! current ) {
-		return <TabSpinner className="newspack-insights__tab-fallback" />;
-	}
 	if ( status === 'error' ) {
 		return <Notice isError noticeText={ error || __( 'Could not load app analytics.', 'newspack-plugin' ) } />;
 	}
-	if ( ! current || current.tab_error ) {
+	// `idle`/`loading` before the first payload lands: show the spinner rather
+	// than briefly flashing the "not available" notice (the cache slot starts
+	// idle with null data, before the fetch effect runs).
+	if ( ! current ) {
+		return <TabSpinner className="newspack-insights__tab-fallback" />;
+	}
+	if ( current.tab_error ) {
 		return <Notice noticeText={ __( 'App analytics aren’t available for this property yet.', 'newspack-plugin' ) } />;
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -25,6 +25,8 @@ import { useEffect, useState } from '@wordpress/element';
 import { Notice, Button, Grid, SelectControl } from '../../../../packages/components/src';
 import WizardsActionCard from '../../wizards-action-card';
 import TabSpinner from './components/TabSpinner';
+import LastUpdated from '../components/LastUpdated';
+import useAppMetricsData from '../hooks/useAppMetricsData';
 import ReachSection from './app/ReachSection';
 import EngagementSection from './app/EngagementSection';
 import RetentionSection from './app/RetentionSection';
@@ -34,7 +36,7 @@ import ContentSection from './app/ContentSection';
 import CompositionSection from './app/CompositionSection';
 import type { TabSectionProps } from '../components/InsightsWizard';
 import './app/app.scss';
-import { fetchAppConfig, saveAppProperty, fetchAppMetrics, type AppConfig, type AppProperty, type AppMetrics } from '../api/app';
+import { fetchAppConfig, saveAppProperty, type AppConfig, type AppProperty } from '../api/app';
 
 /** Label a property option so a separate (e.g. Firebase) account is distinguishable. */
 const propertyLabel = ( p: AppProperty ): string =>
@@ -110,51 +112,45 @@ const PropertyPicker = ( { config, onSaved }: { config: AppConfig; onSaved: ( ne
 	);
 };
 
-/** Ready state — fetch the windowed metrics for the selected property and render the sections. */
-const AppMetricsView = ( { range }: { range: TabSectionProps[ 'range' ] } ) => {
-	const [ metrics, setMetrics ] = useState< AppMetrics | null >( null );
-	const [ loading, setLoading ] = useState( true );
-	const [ error, setError ] = useState< string | null >( null );
+/** Ready state — read the windowed metrics (via the shared cache) and render the sections. */
+const AppMetricsView = ( { range, previousRange }: Pick< TabSectionProps, 'range' | 'previousRange' > ) => {
+	const { status, data, error } = useAppMetricsData( range, previousRange );
+	const current = data?.current ?? null;
+	// Only surface period-over-period deltas when the comparison toggle is on.
+	// (Fixture mode returns a `previous` window unconditionally, so gate here.)
+	const previous = previousRange ? data?.previous ?? null : null;
 
-	useEffect( () => {
-		let active = true;
-		setLoading( true );
-		setError( null );
-		fetchAppMetrics( range.start, range.end )
-			.then( response => active && setMetrics( response.current ) )
-			.catch( e => active && setError( e instanceof Error ? e.message : String( e ) ) )
-			.finally( () => active && setLoading( false ) );
-		return () => {
-			active = false;
-		};
-	}, [ range.start, range.end ] );
-
-	if ( loading ) {
+	if ( status === 'loading' && ! current ) {
 		return <TabSpinner className="newspack-insights__tab-fallback" />;
 	}
-	if ( error ) {
-		return <Notice isError noticeText={ error } />;
+	if ( status === 'error' ) {
+		return <Notice isError noticeText={ error || __( 'Could not load app analytics.', 'newspack-plugin' ) } />;
 	}
-	if ( ! metrics || metrics.tab_error ) {
+	if ( ! current || current.tab_error ) {
 		return <Notice noticeText={ __( 'App analytics aren’t available for this property yet.', 'newspack-plugin' ) } />;
 	}
+
+	// The shared "Last updated: … + kebab (Refresh / Print / Export JSON)" chrome,
+	// hosted in the first section's heading like the other data tabs.
+	const lastUpdated = <LastUpdated tab="app" range={ range } previousRange={ previousRange } />;
+
 	return (
 		<div className="newspack-insights__app-tab">
 			{ /* Ordered as a narrative: scale (Reach) → depth (Engagement) → what
 			     they read (Content) → who they are (Audience) → loyalty (Retention)
 			     → the app-ops channels (Notifications, Editions) last. */ }
-			<ReachSection metrics={ metrics } />
-			<EngagementSection metrics={ metrics } />
-			<ContentSection metrics={ metrics } />
-			<CompositionSection metrics={ metrics } />
-			<RetentionSection metrics={ metrics } />
-			<NotificationsSection metrics={ metrics } />
-			<EditionsSection metrics={ metrics } />
+			<ReachSection metrics={ current } previous={ previous } lastUpdated={ lastUpdated } />
+			<EngagementSection metrics={ current } previous={ previous } />
+			<ContentSection metrics={ current } />
+			<CompositionSection metrics={ current } />
+			<RetentionSection metrics={ current } />
+			<NotificationsSection metrics={ current } previous={ previous } />
+			<EditionsSection metrics={ current } previous={ previous } />
 		</div>
 	);
 };
 
-const AppTab = ( { range }: TabSectionProps ) => {
+const AppTab = ( { range, previousRange }: TabSectionProps ) => {
 	const [ config, setConfig ] = useState< AppConfig | null >( null );
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState< string | null >( null );
@@ -204,7 +200,7 @@ const AppTab = ( { range }: TabSectionProps ) => {
 					{ __( 'Change app property', 'newspack-plugin' ) }
 				</Button>
 			</div>
-			<AppMetricsView range={ range } />
+			<AppMetricsView range={ range } previousRange={ previousRange } />
 		</>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EditionsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EditionsSection.tsx
@@ -20,9 +20,10 @@ import SectionHeading from '../components/SectionHeading';
 
 export interface EditionsSectionProps {
 	metrics: AppMetrics;
+	previous?: AppMetrics | null;
 }
 
-const EditionsSection = ( { metrics }: EditionsSectionProps ) => (
+const EditionsSection = ( { metrics, previous }: EditionsSectionProps ) => (
 	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-editions-heading">
 		<SectionHeading
 			id="newspack-insights-app-editions-heading"
@@ -34,21 +35,25 @@ const EditionsSection = ( { metrics }: EditionsSectionProps ) => (
 				label={ __( 'Downloads started', 'newspack-plugin' ) }
 				description={ __( 'Edition downloads begun', 'newspack-plugin' ) }
 				current={ metrics.downloads_started }
+				previous={ previous?.downloads_started }
 			/>
 			<Scorecard
 				label={ __( 'Downloads completed', 'newspack-plugin' ) }
 				description={ __( 'Edition downloads that finished successfully', 'newspack-plugin' ) }
 				current={ metrics.downloads_completed }
+				previous={ previous?.downloads_completed }
 			/>
 			<Scorecard
 				label={ __( 'Download completion rate', 'newspack-plugin' ) }
 				description={ __( 'Share of started edition downloads that completed', 'newspack-plugin' ) }
 				current={ metrics.download_completion_rate }
+				previous={ previous?.download_completion_rate }
 			/>
 			<Scorecard
 				label={ __( 'Edition opens', 'newspack-plugin' ) }
 				description={ __( 'Times readers opened an edition', 'newspack-plugin' ) }
 				current={ metrics.edition_opens }
+				previous={ previous?.edition_opens }
 			/>
 		</div>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
@@ -21,9 +21,10 @@ import SectionHeading from '../components/SectionHeading';
 
 export interface EngagementSectionProps {
 	metrics: AppMetrics;
+	previous?: AppMetrics | null;
 }
 
-const EngagementSection = ( { metrics }: EngagementSectionProps ) => (
+const EngagementSection = ( { metrics, previous }: EngagementSectionProps ) => (
 	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-engagement-heading">
 		<SectionHeading
 			id="newspack-insights-app-engagement-heading"
@@ -35,26 +36,31 @@ const EngagementSection = ( { metrics }: EngagementSectionProps ) => (
 				label={ __( 'Avg. engagement time', 'newspack-plugin' ) }
 				description={ __( 'Average time in the app per session — app readers tend to stay far longer than on the web', 'newspack-plugin' ) }
 				current={ metrics.avg_engagement_time }
+				previous={ previous?.avg_engagement_time }
 			/>
 			<Scorecard
 				label={ __( 'Engagement rate', 'newspack-plugin' ) }
 				description={ __( 'Share of sessions that were engaged (meaningful time, a conversion, or multiple screens)', 'newspack-plugin' ) }
 				current={ metrics.engagement_rate }
+				previous={ previous?.engagement_rate }
 			/>
 			<Scorecard
 				label={ __( 'Engaged sessions', 'newspack-plugin' ) }
 				description={ __( 'Sessions that lasted 10+ seconds, had a key event, or viewed 2+ screens', 'newspack-plugin' ) }
 				current={ metrics.engaged_sessions }
+				previous={ previous?.engaged_sessions }
 			/>
 			<Scorecard
 				label={ __( 'Screens per session', 'newspack-plugin' ) }
 				description={ __( 'Average screens viewed per app session', 'newspack-plugin' ) }
 				current={ metrics.screens_per_session }
+				previous={ previous?.screens_per_session }
 			/>
 			<Scorecard
 				label={ __( 'Screen views', 'newspack-plugin' ) }
 				description={ __( 'Total app screens viewed', 'newspack-plugin' ) }
 				current={ metrics.screen_views }
+				previous={ previous?.screen_views }
 			/>
 		</div>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
@@ -20,9 +20,10 @@ import SectionHeading from '../components/SectionHeading';
 
 export interface NotificationsSectionProps {
 	metrics: AppMetrics;
+	previous?: AppMetrics | null;
 }
 
-const NotificationsSection = ( { metrics }: NotificationsSectionProps ) => (
+const NotificationsSection = ( { metrics, previous }: NotificationsSectionProps ) => (
 	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-notifications-heading">
 		<SectionHeading
 			id="newspack-insights-app-notifications-heading"
@@ -34,16 +35,19 @@ const NotificationsSection = ( { metrics }: NotificationsSectionProps ) => (
 				label={ __( 'Notification open rate', 'newspack-plugin' ) }
 				description={ __( 'Share of received push notifications that were opened', 'newspack-plugin' ) }
 				current={ metrics.notification_open_rate }
+				previous={ previous?.notification_open_rate }
 			/>
 			<Scorecard
 				label={ __( 'Notifications received', 'newspack-plugin' ) }
 				description={ __( 'Push notifications delivered to app users', 'newspack-plugin' ) }
 				current={ metrics.notifications_received }
+				previous={ previous?.notifications_received }
 			/>
 			<Scorecard
 				label={ __( 'Opt-in changes', 'newspack-plugin' ) }
 				description={ __( 'Times users changed their push-notification permission', 'newspack-plugin' ) }
 				current={ metrics.notification_opt_changes }
+				previous={ previous?.notification_opt_changes }
 			/>
 		</div>
 	</section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
@@ -8,6 +8,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -24,30 +29,37 @@ import SectionHeading from '../components/SectionHeading';
 
 export interface ReachSectionProps {
 	metrics: AppMetrics;
+	previous?: AppMetrics | null;
+	/** The shared "Last updated" + kebab chrome, hosted in this (first) section's heading. */
+	lastUpdated?: ReactNode;
 }
 
-const ReachSection = ( { metrics }: ReachSectionProps ) => (
+const ReachSection = ( { metrics, previous, lastUpdated }: ReachSectionProps ) => (
 	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-reach-heading">
 		<SectionHeading
 			id="newspack-insights-app-reach-heading"
 			title={ __( 'Reach', 'newspack-plugin' ) }
 			description={ __( 'How many people use your app, and on what.', 'newspack-plugin' ) }
+			actions={ lastUpdated }
 		/>
 		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
 			<Scorecard
 				label={ __( 'Active users', 'newspack-plugin' ) }
 				description={ __( 'Distinct people who opened the app', 'newspack-plugin' ) }
 				current={ metrics.active_users }
+				previous={ previous?.active_users }
 			/>
 			<Scorecard
 				label={ __( 'New users', 'newspack-plugin' ) }
 				description={ __( 'First-time app users', 'newspack-plugin' ) }
 				current={ metrics.new_users }
+				previous={ previous?.new_users }
 			/>
 			<Scorecard
 				label={ __( 'Sessions', 'newspack-plugin' ) }
 				description={ __( 'Total app sessions', 'newspack-plugin' ) }
 				current={ metrics.sessions }
+				previous={ previous?.sessions }
 			/>
 		</div>
 		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/app.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/app.scss
@@ -6,11 +6,23 @@
  * layout (sections, metric grid) comes from the shared `sections` partial loaded
  * by the wizard's top-level `style.scss`.
  */
+@use "~@wordpress/base-styles/colors" as wp-colors;
 @use "../components/insights-charts";
 
-// Right-aligned "Change app property" action above the metric sections.
+// Left-aligned property-context line above the metric sections: names the GA4
+// property the tab is reading, with an inline "Change" affordance.
 .newspack-insights__app-toolbar {
 	display: flex;
-	justify-content: flex-end;
-	margin-bottom: 8px;
+	align-items: baseline;
+	gap: 6px;
+	margin-bottom: 16px;
+}
+
+.newspack-insights__app-property {
+	font-size: 13px;
+	color: wp-colors.$gray-700;
+}
+
+.newspack-insights__app-property-sep {
+	color: wp-colors.$gray-400;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
@@ -246,6 +246,73 @@ class Test_App_Metric extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The report envelope wraps the current window in the `{ data, cache }` shape
+	 * the shared insightsCache consumes. Without a comparison window, `previous`
+	 * is null; the cache source is `external` (live GA4). No network is hit (the
+	 * no-property gate returns before any report).
+	 */
+	public function test_get_report_envelope_shape() {
+		$report = App_Metric::get_report( '2026-06-09', '2026-07-08' );
+
+		$this->assertArrayHasKey( 'data', $report );
+		$this->assertArrayHasKey( 'cache', $report );
+		$this->assertSame( 'no_property', $report['data']['current']['tab_error'] );
+		$this->assertNull( $report['data']['previous'] );
+		$this->assertSame( 'external', $report['cache']['source'] );
+		$this->assertArrayHasKey( 'computed_at', $report['cache'] );
+		$this->assertNull( $report['cache']['cooldown_until'] );
+	}
+
+	/**
+	 * A fully specified comparison window makes the envelope carry a (non-null)
+	 * `previous` window alongside `current`.
+	 */
+	public function test_get_report_with_comparison_adds_previous_window() {
+		$report = App_Metric::get_report( '2026-06-09', '2026-07-08', '2026-05-01', '2026-05-31' );
+
+		$this->assertIsArray( $report['data']['previous'] );
+		$this->assertSame( 'no_property', $report['data']['previous']['tab_error'] );
+	}
+
+	/**
+	 * The fixture prior-window derivation scales scalar values down (so the
+	 * comparison toggle shows deltas locally) while leaving breakdown/timeseries
+	 * rows untouched.
+	 */
+	public function test_scale_previous_scales_scalars_only() {
+		$method = new \ReflectionMethod( App_Metric::class, 'scale_previous' );
+		$method->setAccessible( true );
+
+		$current  = [
+			'active_users'    => [
+				'value'      => 1000,
+				'computable' => true,
+				'type'       => 'count',
+			],
+			'engagement_rate' => [
+				'value'      => 0.8,
+				'computable' => true,
+				'type'       => 'rate',
+			],
+			'top_sections'    => [
+				'rows'       => [
+					[
+						'section' => 'News',
+						'views'   => 500,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+		];
+		$previous = $method->invoke( null, $current );
+
+		$this->assertSame( 880, $previous['active_users']['value'] );          // 1000 * 0.88.
+		$this->assertEqualsWithDelta( 0.76, $previous['engagement_rate']['value'], 0.0001 ); // 0.8 * 0.95.
+		$this->assertSame( $current['top_sections'], $previous['top_sections'] ); // Breakdown untouched.
+	}
+
+	/**
 	 * With no Google connection (test env), the config reports not-connected with
 	 * an empty property list and a Connections URL, and never throws.
 	 */


### PR DESCRIPTION
## Insights App tab — "Last updated" chrome + period comparison + property context (NPPD-1882)

Brings the App tab to parity with the other Insights data tabs. All three items here share one root cause: the App tab was a bespoke state machine that never touched the shared `insightsCache`, so it was missing the chrome and comparison that cache powers.

### 1. "Last updated" + kebab
The App tab now reads its metrics through the shared `insightsCache` via a new `useAppMetricsData` hook (mirroring `useNewsletterAdsData`). That's the slot `LastUpdated` subscribes to, so the **"Last updated: … + ⋮"** header renders — with **Refresh now** (new `POST /app/refresh` route), **Print / Save as PDF…**, and **Export JSON…**. Previously this rendered nothing because the tab never wrote a `computed_at`.

### 2. Compare to previous period
The `/app` endpoint now returns the `{ data: { current, previous }, cache: { source, computed_at, cooldown_until } }` envelope, accepts an optional `compare_start`/`compare_end` window, and the hook forwards it (the comparison window is also baked into the cache slot key). Scorecards thread the `previous` payload into period-over-period deltas. Previously the toggle did nothing because the tab only ever fetched `current`. Fixture mode derives a scaled prior window so the toggle is demoable locally.

### 3. Property-context line
Replaced the context-free "Change app property" link with a left-aligned, muted line above the sections — **"App property: `<name>` (`<id>`) · Change"** — so it's clear which GA4 property the tab is reading. This matters here specifically because a Pugpig app property often lives in a *different* Google account than the website (the label surfaces the `account → property` form exactly when that's the case).

### Backend
- `App_Metric::get_report()` builds the envelope over the existing per-window transient (no double-caching against the BQ `Cache` framework — this tab is live-GA4, not BQ-pipeline). `get_window_report()` now carries a `computed_at`; the metrics-cache prefix is bumped `v1 → v2` for the new shape. Fixture prior window via `scale_previous()`.
- `App_REST_Controller` adds the `compare_*` args + a `/refresh` route, both routed through one `report_response()` helper.

### Testing
- **PHP** (`Test_App_Metric`): 17 tests / 58 assertions — added envelope-shape, comparison-adds-previous, and fixture-scaling coverage.
- **JS** (`AppTab.test.tsx`): 9 tests — reworked to drive the ready state through the mocked `useAppMetricsData` hook; added a comparison-wiring test and a property-context-line assertion.
- PHPCS + tsc + wp-prettier + stylelint clean; webpack build green.
- **Verified live in the browser** (fixture mode): the "Last updated" timestamp + kebab menu (Refresh/Print/Export), the compare toggle showing green ↑13.6% deltas, and the property-context line + Change→picker round-trip.

### Not in this PR
Tier-2b (auto-registering the KG custom dimensions — the one net-new *write* to the publisher's property) remains the tracked follow-up.