### PR TITLE
test: harden reader-registration against the password-reset cache flake (NPPM-2919)

### DIFF
--- a/e2e/tests/reader-registration.spec.ts
+++ b/e2e/tests/reader-registration.spec.ts
@@ -9,8 +9,6 @@ import {
   goToMyAccount,
 } from "./utils";
 
-const emailAddress = randomEmailAddress();
-
 test.beforeEach(addClickIndicator);
 
 test("Register on the site", {
@@ -22,6 +20,10 @@ test("Register on the site", {
   // round-trips against remote staging, where CI also applies slowMo. The
   // default 120s is too tight once staging latency varies, so allow more room.
   test.setTimeout(240000);
+  // Scoped to the test body (not module scope) so a Playwright retry, which
+  // reuses the worker, gets a fresh reader instead of re-running against the
+  // half-registered account from the failed attempt.
+  const emailAddress = randomEmailAddress();
   /**
    * Create a new reader account using the "Sign In" header link. The auth modal
    * is a single email-first form: entering an email that isn't associated with
@@ -76,17 +78,26 @@ test("Register on the site", {
   await expect(page.getByPlaceholder("Your Last Name")).toHaveValue("Doe");
 
   /**
-   * Reader sets up a password.
+   * Reader sets up a password. The "Create a password" link is a GET that runs a
+   * server-side password reset (emails a "Set a new password" link and shows a
+   * confirmation notice) via a redirect. On a cached environment that GET can be
+   * served from the page cache, so the handler never runs — no email, no notice
+   * (NPPM-2919). Drive it with a cache-busting param (as openEmail does), and
+   * gate on the real outcome (the email landing in the sendbox) rather than the
+   * transient notice, re-triggering until the email is captured.
    */
-  await page
+  const resetPasswordHref = await page
     .getByRole("link", { name: "Create a password" })
-    .click();
-  await expect(
-    page.getByText(
-      "Please check your email inbox for instructions on how to set a new password."
-    )
-  ).toBeVisible();
-  await openEmail(page, "Set a new password", emailAddress);
+    .getAttribute("href");
+  const resetPasswordURL = new URL(resetPasswordHref, page.url());
+  await expect(async () => {
+    resetPasswordURL.searchParams.set(
+      "cachebust",
+      `${emailAddress}-${Date.now()}`
+    );
+    await page.goto(resetPasswordURL.toString());
+    await openEmail(page, "Set a new password", emailAddress);
+  }).toPass({ timeout: 90000 });
   await clickLinkURL(page, "Set password");
 
   const password = randomString(14);


### PR DESCRIPTION
### Problem

`reader-registration.spec.ts` fails **consistently on staging** (2/2 recent nightly runs, identical) while passing **consistently locally** (0/9 repro), on identical code (the flow is byte-identical 6.43.7 → staging's 6.44.9).

The failing step is "Create a password" → assert *"Please check your email inbox…"*. The captured page snapshot at failure shows the reset simply **never took effect**: profile saved (John/Doe), but the **notice region is empty** (no success *and* no error text) and the **"Create a password" link is still present** (`?reset-password=…`).

That link is a **GET** that runs a server-side password reset (`retrieve_password()` → email + `wc_add_notice()` confirmation) via a redirect. Empty notice + link still present ⇒ the handler didn't run. The most consistent explanation is the `?reset-password=` GET being served from the **page cache** on staging (Atomic), so no email is sent and no notice appears. The local docker env has no page cache, so it always works.

### Change

- **Drive the reset cache-proof and gate on the real outcome.** Navigate to the reset-password URL with a `cachebust` query param (the same idiom `openEmail` already uses), and wait for the **"Set a new password" email** to land in the sendbox rather than asserting the transient notice — re-triggering until it arrives. This is robust whether the cause is a cached GET *or* a notice that fails to render.
- **Scope `emailAddress` to the test body** so a Playwright retry (which reuses the worker) gets a fresh reader instead of re-running against the half-registered account from the failed attempt.

### Testing

- Local (env built via `n env e2e-setup`): the hardened test passes — 2/2 here, plus it never regressed across ~9 local runs. No behavioural change on the happy path.
- ⚠️ **Not verifiable locally:** the staging-only failure this targets can't be reproduced on the local env (no page cache). Draft until it's confirmed against staging — the fix is hypothesis-driven from the page snapshot + code path. If the reset-password GET is genuinely cached, cache-busting resolves it; if the true cause is elsewhere (e.g. nonce/session), the email-gating still improves robustness but may not fully fix it.

Part of NPPM-2919.