### PR TITLE
feat(insights): show App tab for all Pugpig publishers (NPPD-1882)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -349,32 +349,15 @@ class Insights_Wizard extends Wizard {
 	}
 
 	/**
-	 * App tab (Tab 10, NPPD-1882) preview flag — keeps it dark on real
-	 * app-publisher sites until the build is ready, mirroring the Gates preview
-	 * gate.
-	 *
-	 * @constant NEWSPACK_INSIGHTS_APP_PREVIEW
-	 * @example define( 'NEWSPACK_INSIGHTS_APP_PREVIEW', true );
-	 * @return bool
-	 */
-	public static function is_app_preview_enabled(): bool {
-		return defined( 'NEWSPACK_INSIGHTS_APP_PREVIEW' ) && NEWSPACK_INSIGHTS_APP_PREVIEW;
-	}
-
-	/**
 	 * Whether the App (Tab 10) nav entry should render: Pugpig ("Bolt") app
-	 * publishers only, behind the preview flag during phased rollout — or fixture
-	 * mode for dev testing. Public because {@see Insights_Section_App::init()}
-	 * gates its own initialization on this.
+	 * publishers only — or fixture mode for dev testing. Public because
+	 * {@see Insights_Section_App::init()} gates its own initialization on this.
 	 *
 	 * @return bool
 	 */
 	public static function is_app_tab_visible(): bool {
 		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
 			return true;
-		}
-		if ( ! self::is_app_preview_enabled() ) {
-			return false;
 		}
 		return class_exists( '\Newspack_Manager\Pugpig\Pugpig' )
 			&& \Newspack_Manager\Pugpig\Pugpig::is_enabled();
@@ -439,8 +422,8 @@ class Insights_Wizard extends Wizard {
 				// Newsletter Ads (NPPD-1861): shown when the site has published
 				// newsletter ads (or fixture mode). See is_newsletter_ads_tab_visible().
 				'newsletter_ads' => self::is_newsletter_ads_tab_visible(),
-				// App (Tab 10, NPPD-1882): Pugpig app publishers, behind the
-				// NEWSPACK_INSIGHTS_APP_PREVIEW flag during phased rollout.
+				// App (Tab 10, NPPD-1882): shown for Pugpig app publishers (or
+				// fixture mode). See is_app_tab_visible().
 				'app'            => self::is_app_tab_visible(),
 			],
 			'defaultDateRange'    => [


### PR DESCRIPTION
## Insights App tab — remove the preview rollout gate (NPPD-1882)

The App tab build is ready, so drop the `NEWSPACK_INSIGHTS_APP_PREVIEW` dark-launch flag. The tab now renders for **any Pugpig app publisher** — gated solely on `Pugpig::is_enabled()` — with fixture mode still forcing it visible for local dev.

```php
public static function is_app_tab_visible(): bool {
    if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
        return true;
    }
    return class_exists( '\Newspack_Manager\Pugpig\Pugpig' )
        && \Newspack_Manager\Pugpig\Pugpig::is_enabled();
}
```

- Removes the now-dead `is_app_preview_enabled()` helper and the two stale comments referencing the flag.
- No other references to `NEWSPACK_INSIGHTS_APP_PREVIEW` remain anywhere in the plugin.

### Effect
App-publisher sites get the App tab automatically once this merges and redeploys — no per-site constant needed. Site owners still need Newspack's Google OAuth connected + an app GA4 property selected (the tab's own connect→select flow), which is unchanged.

### Testing
- PHPCS clean; PHPUnit `Test_App_Metric` 17/17.
- `wp eval` on a live site confirms `is_app_tab_visible()` → `true` under fixture mode (bypass intact) and that `is_app_preview_enabled` no longer exists.