### PR TITLE
feat(insights): surface core BigQuery metric errors in data_status

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-audience-rest-controller.php
@@ -66,12 +66,16 @@ class Audience_REST_Controller extends WP_REST_Controller {
 	 * serving a stale tab-level envelope. Overrides the global default so only
 	 * the audience envelope is busted — other tabs keep their caches. v2 adds
 	 * the NEWS-2603 top-level `data_status` field (a stale v1 envelope would
-	 * lack it and the warming banner would never render).
+	 * lack it and the warming banner would never render). v3 adds `error_code`
+	 * to the core BigQuery-proxy metric error payloads AND changes how
+	 * `data_status` is derived (core-metric outages now flip it to
+	 * `incomplete`); a stale v2 window would keep serving the pre-fix
+	 * `data_status: 'complete'` and hide the outage banner until natural expiry.
 	 *
 	 * @return string
 	 */
 	protected function cache_schema_version(): string {
-		return '2';
+		return '3';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/class-bigquery-proxy-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-bigquery-proxy-client.php
@@ -46,6 +46,17 @@ class BigQuery_Proxy_Client {
 	const REQUEST_TIMEOUT = 30;
 
 	/**
+	 * WP_Error code returned when the hub proxy isn't set up (Newspack Manager
+	 * not connected). This is a SETUP state, not a failed data fetch —
+	 * {@see \Newspack\Insights\Metric_Status::derive()} excludes it from the
+	 * envelope `data_status` so a never-connected hub doesn't trip the "last
+	 * data fetch didn't finish" warning banner.
+	 *
+	 * @var string
+	 */
+	const ERROR_NOT_CONFIGURED = 'bigquery_proxy_not_configured';
+
+	/**
 	 * Logger header so all BQ proxy failures land in one Logstash bucket.
 	 *
 	 * @var string
@@ -144,7 +155,7 @@ class BigQuery_Proxy_Client {
 	public function query( string $query_name, DateTimeInterface $start, DateTimeInterface $end ) {
 		if ( ! $this->is_configured() ) {
 			$error = new WP_Error(
-				'bigquery_proxy_not_configured',
+				self::ERROR_NOT_CONFIGURED,
 				__( 'Newspack Manager is not configured for BigQuery proxy calls.', 'newspack-plugin' )
 			);
 			$this->log_failure( $error, $query_name, $start, $end );

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-audience-metric.php
@@ -336,6 +336,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $column, $rows[0] ) ) {
@@ -387,6 +388,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( ! is_array( $rows ) ) {
@@ -465,6 +467,7 @@ final class Audience_Metric {
 				'numerator'   => 0,
 				'denominator' => 0,
 				'error'       => $rows->get_error_message(),
+				'error_code'  => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) ) {
@@ -510,6 +513,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => 'count',
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! isset( $rows[0]['sessions'] ) ) {
@@ -956,6 +960,7 @@ final class Audience_Metric {
 				'computable' => false,
 				'type'       => 'rate',
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( 'returning_reader_rate', $rows[0] ) ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-engagement-metric.php
@@ -217,6 +217,7 @@ final class Engagement_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( empty( $rows ) || ! is_array( $rows[0] ) || ! array_key_exists( $column, $rows[0] ) ) {
@@ -268,6 +269,7 @@ final class Engagement_Metric {
 				'computable' => false,
 				'type'       => $type,
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( ! is_array( $rows ) ) {
@@ -498,6 +500,7 @@ final class Engagement_Metric {
 				'computable' => false,
 				'type'       => 'table',
 				'error'      => $rows->get_error_message(),
+				'error_code' => $rows->get_error_code(),
 			];
 		}
 		if ( ! is_array( $rows ) ) {

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
@@ -24,13 +24,11 @@ defined( 'ABSPATH' ) || exit;
 class Metric_Status {
 
 	/**
-	 * Derive the envelope-level status from every metric-scalar `state` found
-	 * in the response, recursively. A node is treated as a metric scalar when
-	 * it is an array carrying a `state` key — its own children are not
-	 * descended into (the `state` key is the leaf signal); any other array is
-	 * walked further. Error takes precedence over warming: a single errored
-	 * metric makes the whole tab `incomplete` even if others are still
-	 * warming up.
+	 * Derive the envelope-level status from every metric-scalar found in the
+	 * response, recursively. Each leaf metric resolves to one of `error` /
+	 * `warming` / `populated` (see {@see self::leaf_state()}); error takes
+	 * precedence over warming, so a single errored metric makes the whole tab
+	 * `incomplete` even if others are still warming up.
 	 *
 	 * @param array $envelope Assembled tab response (or any sub-array of it).
 	 * @return string One of 'complete' | 'warming' | 'incomplete'.
@@ -51,16 +49,22 @@ class Metric_Status {
 	}
 
 	/**
-	 * Yield every metric-scalar `state` value found by recursively walking
-	 * array children, without descending into a node once it's identified as
-	 * a metric scalar.
+	 * Yield the resolved state of every metric-scalar found by recursively
+	 * walking array children, without descending into a node once it's
+	 * identified as a metric scalar.
+	 *
+	 * A node is a metric-scalar leaf when it carries either a `state` key (the
+	 * three-state model, {@see \Newspack\Insights\Conversion_Metric}) or the
+	 * universal `computable` marker emitted by every metric shaper — including
+	 * the core BigQuery-proxy metrics (Audience's proxy_scalar/proxy_rows)
+	 * which predate the three-state model and never set a `state` key.
 	 *
 	 * @param array $node Current array node.
 	 * @return \Generator<string>
 	 */
 	private static function walk_states( array $node ) {
-		if ( array_key_exists( 'state', $node ) ) {
-			yield (string) $node['state'];
+		if ( array_key_exists( 'state', $node ) || array_key_exists( 'computable', $node ) ) {
+			yield self::leaf_state( $node );
 			return;
 		}
 
@@ -69,5 +73,40 @@ class Metric_Status {
 				yield from self::walk_states( $child );
 			}
 		}
+	}
+
+	/**
+	 * Resolve a single metric-scalar leaf to `error` | `warming` | `populated`.
+	 *
+	 * A hub/proxy failure surfaces either as an explicit `state` of `error`
+	 * (three-state metrics) or as a non-empty `error` message string alongside
+	 * `computable:false` (core BigQuery-proxy metrics, which predate the
+	 * three-state model). Either means the last data fetch for that metric
+	 * failed. A `computable:false` node with no error — an empty cohort, an
+	 * overlay, a not-configured metric — is NOT a failure and stays populated.
+	 *
+	 * The one legacy `error` explicitly excluded is the proxy's "not
+	 * configured" code: a never-connected hub is a setup state, not a failed
+	 * fetch, so it must not read as `incomplete`.
+	 *
+	 * @param array $node Metric-scalar leaf node.
+	 * @return string One of 'error' | 'warming' | 'populated'.
+	 */
+	private static function leaf_state( array $node ): string {
+		$is_error = ( isset( $node['state'] ) && 'error' === $node['state'] )
+			|| (
+				! empty( $node['error'] ) && is_string( $node['error'] )
+				&& BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED !== ( $node['error_code'] ?? null )
+			);
+
+		if ( $is_error ) {
+			return 'error';
+		}
+
+		if ( isset( $node['state'] ) && 'warming' === $node['state'] ) {
+			return 'warming';
+		}
+
+		return 'populated';
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-metric-status.php
@@ -79,28 +79,33 @@ class Metric_Status {
 	 * Resolve a single metric-scalar leaf to `error` | `warming` | `populated`.
 	 *
 	 * A hub/proxy failure surfaces either as an explicit `state` of `error`
-	 * (three-state metrics) or as a non-empty `error` message string alongside
-	 * `computable:false` (core BigQuery-proxy metrics, which predate the
-	 * three-state model). Either means the last data fetch for that metric
-	 * failed. A `computable:false` node with no error — an empty cohort, an
-	 * overlay, a not-configured metric — is NOT a failure and stays populated.
+	 * (three-state metrics, via `Conversion_Metric::error_scalar()`) or as a
+	 * non-empty `error` message string alongside `computable:false` (core
+	 * BigQuery-proxy metrics, which predate the three-state model). Either means
+	 * the last data fetch for that metric failed. A `computable:false` node with
+	 * no error signal — an empty cohort or an overlay — is NOT a failure and
+	 * stays populated.
 	 *
-	 * The one legacy `error` explicitly excluded is the proxy's "not
-	 * configured" code: a never-connected hub is a setup state, not a failed
-	 * fetch, so it must not read as `incomplete`.
+	 * The one exception, applied to BOTH failure paths, is the proxy's "not
+	 * configured" `error_code`: a never-connected hub is a setup state, not a
+	 * failed fetch, so it must never read as `incomplete`. Both `error_scalar()`
+	 * and the core proxy shapers carry the WP_Error code as `error_code`.
 	 *
 	 * @param array $node Metric-scalar leaf node.
 	 * @return string One of 'error' | 'warming' | 'populated'.
 	 */
 	private static function leaf_state( array $node ): string {
-		$is_error = ( isset( $node['state'] ) && 'error' === $node['state'] )
-			|| (
-				! empty( $node['error'] ) && is_string( $node['error'] )
-				&& BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED !== ( $node['error_code'] ?? null )
-			);
+		// "Not configured" is a setup state, not a failed fetch — exclude it from
+		// both the three-state `state === 'error'` path and the legacy
+		// `error`-string path so a never-connected hub reads as complete on any tab.
+		$is_setup_not_configured = BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED === ( $node['error_code'] ?? null );
 
-		if ( $is_error ) {
-			return 'error';
+		if ( ! $is_setup_not_configured ) {
+			$is_error = ( isset( $node['state'] ) && 'error' === $node['state'] )
+				|| ( ! empty( $node['error'] ) && is_string( $node['error'] ) );
+			if ( $is_error ) {
+				return 'error';
+			}
 		}
 
 		if ( isset( $node['state'] ) && 'warming' === $node['state'] ) {

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
@@ -511,10 +511,12 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 		// Core-metric-error variant (NEWS-2603 follow-up): every core Audience
 		// BigQuery query fails with an HTTP error (which BigQuery_Proxy_Client
 		// turns into a WP_Error, shaped by proxy_scalar/proxy_rows into a
-		// `computable:false` + `error` payload). The newsletter query returns a
-		// harmless empty set — the test leaves WooCommerce inactive so the
-		// newsletter metric short-circuits to `not_configured` and never calls
-		// the hub, isolating a core-metric error as the sole data_status driver.
+		// `computable:false` + `error` payload), isolating a core-metric error
+		// as the sole data_status driver. The test leaves WooCommerce inactive so
+		// the newsletter metric short-circuits to `not_configured` before calling
+		// the hub — so the newsletter branch below normally isn't reached; it
+		// returns an empty (non-error) set defensively, only in case that query
+		// is ever invoked, so it never contributes an error of its own.
 		if ( 'core_error' === $this->bq_hub_response_variant ) {
 			if ( $is_newsletter_conversion ) {
 				return [

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-audience-rest-controller.php
@@ -450,6 +450,38 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NEWS-2603 follow-up end-to-end: a failed CORE Audience BigQuery metric
+	 * (not the newsletter snapshot) makes `data_status` 'incomplete'. Core
+	 * metrics signal a hub failure as `computable:false` + an `error` string
+	 * with no `state` key; Metric_Status::derive() must recognise that legacy
+	 * convention so the warning banner reflects a genuine core-BQ outage.
+	 * WooCommerce is left inactive so the newsletter metric short-circuits to
+	 * `not_configured` (a populated, non-error state) — isolating the core
+	 * metric error as the sole driver.
+	 */
+	public function test_data_status_is_incomplete_when_core_bq_metric_errors() {
+		add_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10, 3 );
+		\Newspack_Manager::enable_stub_connection();
+		$this->bq_hub_response_variant = 'core_error';
+
+		try {
+			$response = $this->dispatch(
+				[
+					'start' => '2026-01-01',
+					'end'   => '2026-01-31',
+				]
+			);
+
+			$this->assertSame( 200, $response->get_status() );
+			$data = $response->get_data()['data'];
+			$this->assertSame( 'incomplete', $data['data_status'] );
+		} finally {
+			remove_filter( 'pre_http_request', [ $this, 'stub_bq_hub_response' ], 10 );
+			\Newspack_Manager::disable_stub_connection();
+		}
+	}
+
+	/**
 	 * `pre_http_request` responder: the newsletter-conversion catalog queries
 	 * return either the hub's warming marker or an HTTP error, per
 	 * $this->bq_hub_response_variant; every other catalog query (the 19
@@ -475,6 +507,31 @@ class Test_Audience_REST_Controller extends WP_UnitTestCase {
 			],
 			true
 		);
+
+		// Core-metric-error variant (NEWS-2603 follow-up): every core Audience
+		// BigQuery query fails with an HTTP error (which BigQuery_Proxy_Client
+		// turns into a WP_Error, shaped by proxy_scalar/proxy_rows into a
+		// `computable:false` + `error` payload). The newsletter query returns a
+		// harmless empty set — the test leaves WooCommerce inactive so the
+		// newsletter metric short-circuits to `not_configured` and never calls
+		// the hub, isolating a core-metric error as the sole data_status driver.
+		if ( 'core_error' === $this->bq_hub_response_variant ) {
+			if ( $is_newsletter_conversion ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode( [] ),
+				];
+			}
+			return [
+				'response' => [ 'code' => 500 ],
+				'body'     => wp_json_encode(
+					[
+						'code'    => 'bigquery_proxy_http_error',
+						'message' => 'Simulated core metric failure.',
+					]
+				),
+			];
+		}
 
 		if ( ! $is_newsletter_conversion ) {
 			return [

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-conversion-rest-controller.php
@@ -521,12 +521,13 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 
 	/**
 	 * Audience (Tab 1) now carries its own `cache_schema_version()` override
-	 * ('2', bumped for the NEWS-2603 `data_status` envelope field — see
-	 * Audience_REST_Controller::cache_schema_version()) instead of inheriting
-	 * Cache::ENVELOPE_SCHEMA_VERSION from the trait default. This mirrors the
-	 * Subscribers/Donors tabs, which already opt out of the global version via
-	 * their own overrides, so a per-tab bump doesn't bust every other tab's
-	 * cache.
+	 * ('3' — bumped to '2' for the NEWS-2603 `data_status` envelope field, then
+	 * to '3' when core-BQ-outage discrimination changed the derived value and
+	 * added `error_code`; see Audience_REST_Controller::cache_schema_version())
+	 * instead of inheriting Cache::ENVELOPE_SCHEMA_VERSION from the trait
+	 * default. This mirrors the Subscribers/Donors tabs, which already opt out
+	 * of the global version via their own overrides, so a per-tab bump doesn't
+	 * bust every other tab's cache.
 	 */
 	public function test_audience_has_its_own_schema_version_override() {
 		$controller = new Audience_REST_Controller();
@@ -540,7 +541,7 @@ class Test_Conversion_REST_Controller extends WP_UnitTestCase {
 
 		// Five parts: tab version + start + end + null + null.
 		$this->assertCount( 5, $parts );
-		$this->assertSame( '2', $parts[0] );
+		$this->assertSame( '3', $parts[0] );
 		$this->assertNotSame( Cache::ENVELOPE_SCHEMA_VERSION, $parts[0] );
 		$this->assertSame( '2026-01-01', $parts[1] );
 		$this->assertSame( '2026-01-31', $parts[2] );

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
@@ -103,4 +103,112 @@ class Test_Metric_Status extends WP_UnitTestCase {
 	public function test_derive_complete_for_empty_envelope() {
 		$this->assertSame( 'complete', Metric_Status::derive( [] ) );
 	}
+
+	/**
+	 * NEWS-2603 follow-up: the core BigQuery-proxy metrics (Audience's
+	 * proxy_scalar/proxy_rows) predate the three-state model and signal a hub
+	 * failure as `computable:false` + a non-empty `error` message string, with
+	 * NO `state` key. Such a node must make the envelope 'incomplete' — a core
+	 * metric that failed to fetch is a genuine incomplete data load.
+	 */
+	public function test_derive_incomplete_when_metric_has_error_key_without_state() {
+		$env = [
+			'a' => [
+				'value'      => 5,
+				'computable' => true,
+			],
+			'b' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'BigQuery proxy unavailable.',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a core-metric `error` key wins over a warming
+	 * metric-scalar elsewhere in the envelope — error precedence holds across
+	 * both the `state:'error'` and the legacy `error`-string conventions.
+	 */
+	public function test_derive_incomplete_when_error_key_beats_warming() {
+		$env = [
+			'a' => [ 'state' => 'warming' ],
+			'b' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'Simulated core failure.',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a `computable:false` node with NO error (an empty
+	 * cohort, an overlay/not-configured metric, etc.) is NOT a failure — it
+	 * must stay 'complete'. Only a genuine `error` (or `state:'error'`) counts.
+	 */
+	public function test_derive_complete_when_computable_false_without_error() {
+		$env = [
+			'a' => [
+				'value'      => 3,
+				'computable' => true,
+			],
+			'b' => [
+				'value'      => 0,
+				'computable' => false,
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: an empty-string `error` is not a failure signal —
+	 * only a non-empty error message flips the envelope to 'incomplete'.
+	 */
+	public function test_derive_ignores_empty_error_string() {
+		$env = [
+			'a' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => '',
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a `not_configured` proxy error is a setup state (the
+	 * hub was never connected), NOT a failed data fetch — it must stay
+	 * 'complete' so the "last data fetch didn't finish" warning banner doesn't
+	 * fire on a never-connected hub. Distinguished by the WP_Error code carried
+	 * alongside the message.
+	 */
+	public function test_derive_complete_when_error_is_only_not_configured() {
+		$env = [
+			'a' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'BigQuery proxy is not configured.',
+				'error_code' => 'bigquery_proxy_not_configured',
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a genuine fetch failure (any error code other than
+	 * the not-configured setup code) still flips the envelope to 'incomplete'.
+	 */
+	public function test_derive_incomplete_when_error_code_is_a_genuine_failure() {
+		$env = [
+			'a' => [
+				'value'      => 0,
+				'computable' => false,
+				'error'      => 'Simulated hub HTTP failure.',
+				'error_code' => 'bigquery_proxy_http_error',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-metric-status.php
@@ -211,4 +211,35 @@ class Test_Metric_Status extends WP_UnitTestCase {
 		];
 		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
 	}
+
+	/**
+	 * NEWS-2603 follow-up: a not-configured setup error on the THREE-STATE path
+	 * (`state: 'error'` + the not-configured `error_code`, as `error_scalar()`
+	 * emits for an unconfigured hub — e.g. Subscribers/Donors `newsletter_conversion`)
+	 * is a setup state, not a failed fetch, and must stay 'complete' — the same
+	 * exclusion the legacy `error`-string path already gets.
+	 */
+	public function test_derive_complete_when_state_error_is_not_configured() {
+		$env = [
+			'a' => [
+				'state'      => 'error',
+				'error_code' => 'bigquery_proxy_not_configured',
+			],
+		];
+		$this->assertSame( 'complete', Metric_Status::derive( $env ) );
+	}
+
+	/**
+	 * NEWS-2603 follow-up: a genuine fetch failure on the three-state path
+	 * (`state: 'error'` with a non-setup `error_code`) still flips to 'incomplete'.
+	 */
+	public function test_derive_incomplete_when_state_error_is_a_genuine_failure() {
+		$env = [
+			'a' => [
+				'state'      => 'error',
+				'error_code' => 'bigquery_proxy_http_error',
+			],
+		];
+		$this->assertSame( 'incomplete', Metric_Status::derive( $env ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

> **Stacked on #553** (`news-2603-consumer-warming-visibility`). Review/merge that first; this PR's base will follow it onto `feat/insights-rsm`.

Follow-up to #553. That PR added the envelope-level `data_status` (`complete` / `warming` / `incomplete`) that drives the Insights two-tier status banner, but `Metric_Status::derive()` only inspected metrics carrying a three-state `state` key. The **core Audience BigQuery metrics** predate that model — on a hub fetch failure they return `computable:false` + an `error` message string with no `state` key — so a genuine BigQuery outage on those metrics left the tab `data_status: 'complete'` and the warning banner never fired.

This teaches the deriver to treat a `computable`-marked metric leaf carrying a non-empty `error` as a failure, so a real core-BQ outage now surfaces the "The last data fetch didn't finish…" warning banner on the Audience tab.

**Setup vs. failure.** A *not-configured* hub (Newspack Manager never connected) also makes every core metric error — but that's a setup state, not a failed fetch, and shouldn't trip the warning banner. The deriver excludes the proxy's `not_configured` error code (surfaced on the metric payload via a new `error_code` field + a shared `BigQuery_Proxy_Client::ERROR_NOT_CONFIGURED` constant); only genuine fetch failures on a *configured* hub flip the tab to `incomplete`.

Notes:
- **Audience-scoped in effect.** Subscribers/Donors core metrics are local (`$wpdb`) computations that don't produce a fetch error, so their `data_status` was already correctly driven by the newsletter snapshot — they're unaffected.
- **Additive shape change + schema bump:** `data_status` already exists (from #553). This adds an optional `error_code` field to the core-metric *error* payloads and changes the derived `data_status` value for an Audience tab with a genuinely erroring core metric, so the **Audience cache schema is bumped v2→v3** — a stale v2 window would keep serving the pre-fix `data_status: 'complete'` and hide the outage banner until natural expiry. Per-card error notes are unchanged.
- Engagement's identically-shaped proxy error branches also gained `error_code` for uniformity (inert today — the Engagement tab doesn't derive `data_status` — but future-proofs the same setup-vs-failure distinction).
- **Known follow-up (deferred):** only the *client-side* `bigquery_proxy_not_configured` code is excluded from the outage banner. A hub that's connected but hasn't provisioned BigQuery returns a *hub-side* setup/auth code that would still trip the banner; excluding it needs the `newspack-manager-admin` error vocabulary (hub-side, separate repo) and is tracked as [NEWS-2615](https://linear.app/a8c/issue/NEWS-2615).

### How to test the changes in this Pull Request:

1. Check out this branch on top of #553, build the plugin (`pnpm install` at the workspace root, `npm run build` in `plugins/newspack-plugin`), and open **Insights → Audience** on a site with the hub (Newspack Manager) **configured**.
2. **Core-BQ outage → warning banner:** Force a core Audience BigQuery query to fail (e.g. make the hub proxy return a non-200 / timeout for the `audience_*` catalog queries). Confirm the tab shows the **warning** banner — "The last data fetch didn't finish, so some figures may be missing or out of date." — and the affected cards show their error notes.
3. **Not-configured hub → NO warning banner:** On a site where the hub is **not** configured (Newspack Manager not connected), confirm the Audience tab does **not** show the warning banner (`data_status` stays `complete`), even though individual cards show their "unavailable" notes. This is a setup state, not a failed fetch.
4. **Healthy hub → complete:** With the hub configured and all core queries returning data, confirm no banner (`data_status: 'complete'`).
5. **Warming still works (regression):** With the newsletter-conversion snapshot warming (per #553), confirm the soft "still calculating" banner still appears and error precedence holds (a concurrent core error shows the warning banner, not the soft one).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (9 new PHPUnit tests: deriver unit tests for the `error`-key + not-configured discrimination on both the legacy `error`-string and three-state `state:'error'` paths, and an Audience end-to-end core-metric-error test.)
* [x] Have you successfully run tests with your changes locally? (Full `insights` group: 803 passing, 2907 assertions.)