### PR TITLE
feat(insights): App tab Content per-publication selector (NPPD-1882)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
@@ -523,6 +523,74 @@ final class App_Metric {
 	}
 
 	/**
+	 * Two-dimension KG breakdown (e.g. `KGCollectionSet` × `KGSection`) powering
+	 * the Content section's per-publication selector: one report returns the whole
+	 * matrix and the frontend pivots it client-side, so no per-collection query is
+	 * needed. An unregistered dimension (`custom_dimension_missing`, no Data API
+	 * call) becomes `not_configured` — so pubs without the collection dim pay
+	 * nothing and the selector simply doesn't render. Rows with a `(not set)`/empty
+	 * value on either axis are dropped.
+	 *
+	 * @param string $property   GA4 property ID.
+	 * @param array  $range      The dateRanges wrapper.
+	 * @param string $kg_param_a First KG parameter (grouping axis, e.g. collection).
+	 * @param string $kg_param_b Second KG parameter (e.g. section).
+	 * @param string $metric     GA4 metric apiName.
+	 * @param string $key_a      Output key for the first dimension.
+	 * @param string $key_b      Output key for the second dimension.
+	 * @param string $metric_key Output key for the metric value.
+	 * @return array
+	 */
+	private static function kg_breakdown_2d( string $property, array $range, string $kg_param_a, string $kg_param_b, string $metric, string $key_a, string $key_b, string $metric_key ): array {
+		$result = Client::run_report(
+			$property,
+			$range + [
+				'dimensions' => [ [ 'name' => 'customEvent:' . $kg_param_a ], [ 'name' => 'customEvent:' . $kg_param_b ] ],
+				'metrics'    => [ [ 'name' => $metric ] ],
+				'orderBys'   => [
+					[
+						'metric' => [ 'metricName' => $metric ],
+						'desc'   => true,
+					],
+				],
+				// Generous: the whole collection × section matrix in one page, so the
+				// client can take top-N per collection.
+				'limit'      => 250,
+			]
+		);
+		if ( is_wp_error( $result ) ) {
+			if ( 'custom_dimension_missing' === $result->get_error_code() ) {
+				return [
+					'rows'           => [],
+					'computable'     => false,
+					'not_configured' => true,
+					'type'           => 'breakdown',
+				];
+			}
+			return self::not_computable_rows( 'breakdown' );
+		}
+
+		$rows = [];
+		foreach ( $result['rows'] ?? [] as $row ) {
+			$a = (string) ( $row['dimensionValues'][0]['value'] ?? '' );
+			$b = (string) ( $row['dimensionValues'][1]['value'] ?? '' );
+			if ( '' === $a || '(not set)' === $a || '' === $b || '(not set)' === $b ) {
+				continue;
+			}
+			$rows[] = [
+				$key_a      => $a,
+				$key_b      => $b,
+				$metric_key => (int) ( $row['metricValues'][0]['value'] ?? 0 ),
+			];
+		}
+		return [
+			'rows'       => $rows,
+			'computable' => true,
+			'type'       => 'breakdown',
+		];
+	}
+
+	/**
 	 * Map a KG breakdown report result to a card payload. An unregistered
 	 * dimension (`custom_dimension_missing`) becomes the `not_configured` unlock
 	 * state; any other failure (auth/API outage) degrades to a generic
@@ -840,6 +908,11 @@ final class App_Metric {
 			'top_authors'             => self::kg_breakdown( $property, $range, 'KGAuthor', 'screenPageViews', 'author', 'views' ),
 			'subscriber_mix'          => self::kg_breakdown( $property, $range, 'KGSubscriberStatus', 'activeUsers', 'status', 'users' ),
 			'content_cost'            => self::kg_breakdown( $property, $range, 'KGStoryCost', 'screenPageViews', 'cost', 'views' ),
+			// 2-D matrices powering the Content section's per-publication selector
+			// (multi-property apps). `not_configured` — and no Data API call — where
+			// KGCollectionSet isn't registered, so the selector just doesn't render.
+			'sections_by_collection'  => self::kg_breakdown_2d( $property, $range, 'KGCollectionSet', 'KGSection', 'screenPageViews', 'collection', 'section', 'views' ),
+			'authors_by_collection'   => self::kg_breakdown_2d( $property, $range, 'KGCollectionSet', 'KGAuthor', 'screenPageViews', 'collection', 'author', 'views' ),
 			// Multi-property apps tag downloads with the collection (publication);
 			// count completed downloads per collection. Absent/single-value on
 			// single-property apps, where the tab hides the table.
@@ -1199,6 +1272,94 @@ final class App_Metric {
 					[
 						'collection' => 'valley',
 						'downloads'  => 557,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			// Content × collection matrices for the per-publication selector.
+			'sections_by_collection'   => [
+				'rows'       => [
+					[
+						'collection' => 'example city',
+						'section'    => 'News',
+						'views'      => 5024,
+					],
+					[
+						'collection' => 'example city',
+						'section'    => 'Life & Culture',
+						'views'      => 4302,
+					],
+					[
+						'collection' => 'example city',
+						'section'    => 'Obituaries',
+						'views'      => 3752,
+					],
+					[
+						'collection' => 'example city',
+						'section'    => 'Sports',
+						'views'      => 594,
+					],
+					[
+						'collection' => 'northside',
+						'section'    => 'News',
+						'views'      => 1200,
+					],
+					[
+						'collection' => 'northside',
+						'section'    => 'Sports',
+						'views'      => 402,
+					],
+					[
+						'collection' => 'harbor',
+						'section'    => 'News',
+						'views'      => 900,
+					],
+					[
+						'collection' => 'harbor',
+						'section'    => 'Obituaries',
+						'views'      => 311,
+					],
+					[
+						'collection' => 'valley',
+						'section'    => 'News',
+						'views'      => 205,
+					],
+				],
+				'computable' => true,
+				'type'       => 'breakdown',
+			],
+			'authors_by_collection'    => [
+				'rows'       => [
+					[
+						'collection' => 'example city',
+						'author'     => 'Alex Rivera',
+						'views'      => 2100,
+					],
+					[
+						'collection' => 'example city',
+						'author'     => 'Jordan Lee',
+						'views'      => 1800,
+					],
+					[
+						'collection' => 'northside',
+						'author'     => 'Alex Rivera',
+						'views'      => 500,
+					],
+					[
+						'collection' => 'northside',
+						'author'     => 'Sam Okafor',
+						'views'      => 305,
+					],
+					[
+						'collection' => 'harbor',
+						'author'     => 'Casey Nguyen',
+						'views'      => 250,
+					],
+					[
+						'collection' => 'valley',
+						'author'     => 'Alex Rivera',
+						'views'      => 92,
 					],
 				],
 				'computable' => true,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
@@ -553,8 +553,10 @@ final class App_Metric {
 						'desc'   => true,
 					],
 				],
-				// Generous: the whole collection × section matrix in one page, so the
-				// client can take top-N per collection.
+				// One page big enough to hold a realistic collection × section matrix
+				// (a handful of publications × a few dozen sections), so the client
+				// can take top-N per collection. Capped at 250 — a runaway taxonomy
+				// would be truncated, which is fine for a "top sections" view.
 				'limit'      => 250,
 			]
 		);

--- a/plugins/newspack-plugin/src/wizards/insights/api/app.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/app.ts
@@ -90,6 +90,9 @@ export interface AppMetrics {
 	top_authors?: MetricPayload;
 	subscriber_mix?: MetricPayload;
 	content_cost?: MetricPayload;
+	/** collection × section/author matrices for the Content per-publication selector (multi-property apps). */
+	sections_by_collection?: MetricPayload;
+	authors_by_collection?: MetricPayload;
 }
 
 /** The windowed report the cache envelope wraps: current + optional prior window. */

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -63,6 +63,22 @@ const metricsMap = (): AppMetrics => ( {
 	},
 	top_sections: { rows: [ { section: 'News', views: 7078 } ], computable: true, type: 'breakdown' },
 	top_authors: { rows: [ { author: 'Alex Rivera', views: 3120 } ], computable: true, type: 'breakdown' },
+	sections_by_collection: {
+		rows: [
+			{ collection: 'example city', section: 'News', views: 5024 },
+			{ collection: 'northside', section: 'News', views: 1200 },
+		],
+		computable: true,
+		type: 'breakdown',
+	},
+	authors_by_collection: {
+		rows: [
+			{ collection: 'example city', author: 'Alex Rivera', views: 2100 },
+			{ collection: 'northside', author: 'Sam Okafor', views: 305 },
+		],
+		computable: true,
+		type: 'breakdown',
+	},
 	subscriber_mix: { rows: [ { status: 'ExistingSubscriber', users: 483 } ], computable: true, type: 'breakdown' },
 	content_cost: { rows: [ { cost: 'Free', views: 52140 } ], computable: true, type: 'breakdown' },
 } );
@@ -180,7 +196,11 @@ describe( 'AppTab', () => {
 		expect( screen.getByText( 'Existing subscriber' ) ).toBeInTheDocument();
 		// Multi-property apps get the downloads-by-publication table, title-cased.
 		expect( screen.getByText( 'Downloads by publication' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Example City' ) ).toBeInTheDocument();
+		// "Example City" renders both as a downloads-table row and a selector option.
+		expect( screen.getAllByText( 'Example City' ).length ).toBeGreaterThanOrEqual( 2 );
+		// ...and the Content section's per-publication selector (2+ collections).
+		expect( screen.getByRole( 'option', { name: 'All publications' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'option', { name: 'Northside' } ) ).toBeInTheDocument();
 		// The tab reads through the shared cache hook for the current window (no comparison).
 		expect( mockUseData ).toHaveBeenCalledWith( range, null );
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -205,6 +205,21 @@ describe( 'AppTab', () => {
 		expect( mockUseData ).toHaveBeenCalledWith( range, null );
 	} );
 
+	it( 'the Content per-publication selector re-scopes the tables', async () => {
+		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );
+		renderTab();
+
+		// "All publications" initially → the app-wide top author.
+		expect( await screen.findByText( 'Top authors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Alex Rivera' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Sam Okafor' ) ).not.toBeInTheDocument();
+
+		// Switch to Northside → its author appears and the app-wide author drops.
+		fireEvent.change( screen.getByRole( 'combobox' ), { target: { value: 'northside' } } );
+		expect( screen.getByText( 'Sam Okafor' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Alex Rivera' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'threads the comparison window into the data hook', async () => {
 		const previousRange = { start: '2026-04-01', end: '2026-04-30', preset: 'last-30' } as unknown as DateRange;
 		mockFetch.mockResolvedValue( baseConfig( { selected_property: '533212292', selected_is_visible: true } ) );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
@@ -1,67 +1,105 @@
 /**
- * ContentSection (App tab, Tab 10 — NPPD-1882, Tier-2a).
+ * ContentSection (App tab, Tab 10 — NPPD-1882).
  *
  * What readers actually read in the app: top sections and top authors, ranked
- * by screen views. Sourced from the Pugpig `KGSection` / `KGAuthor` custom
- * dimensions, so each card renders its "not configured" state on properties
- * where those dimensions aren't registered yet (auto-registration is Tier-2b).
+ * by screen views (`KGSection` / `KGAuthor`). Each card renders its "not
+ * configured" state where those dims aren't registered.
+ *
+ * Multi-property apps (one app serving several publications) get a per-publication
+ * selector: reading events are ~99% collection-tagged, so the tables can be scoped
+ * cleanly to one publication via the `collection × section/author` matrices. Shown
+ * only when 2+ collections exist; single-property apps see the app-wide tables.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { SelectControl } from '../../../../../packages/components/src';
 import type { AppMetrics } from '../../api/app';
 import ChartCard from '../components/ChartCard';
 import MetricTable from '../components/MetricTable';
 import SectionHeading from '../components/SectionHeading';
+import { collectionValues, titleCase, topByCollection } from './collections';
 
 export interface ContentSectionProps {
 	metrics: AppMetrics;
 }
 
-const ContentSection = ( { metrics }: ContentSectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-content-heading">
-		<SectionHeading
-			id="newspack-insights-app-content-heading"
-			title={ __( 'Content', 'newspack-plugin' ) }
-			description={ __( 'The sections and authors readers engage with most in the app.', 'newspack-plugin' ) }
+const ALL = 'all';
+
+const ContentSection = ( { metrics }: ContentSectionProps ) => {
+	const [ filter, setFilter ] = useState( ALL );
+
+	// Publications present in the content matrices. Only a multi-property app
+	// (2+ collections) gets the selector; otherwise the app-wide tables render.
+	const collections = collectionValues( metrics.sections_by_collection, metrics.authors_by_collection );
+	const hasSelector = collections.length >= 2;
+	// Guard against a stale selection after the data (timeframe/property) changes.
+	const active = hasSelector && collections.includes( filter ) ? filter : ALL;
+
+	const sections = active === ALL ? metrics.top_sections : topByCollection( metrics.sections_by_collection, active, 'section', 'views' );
+	const authors = active === ALL ? metrics.top_authors : topByCollection( metrics.authors_by_collection, active, 'author', 'views' );
+
+	const selector = hasSelector ? (
+		<SelectControl
+			className="newspack-insights__app-collection-select"
+			label={ __( 'Publication', 'newspack-plugin' ) }
+			hideLabelFromVision
+			value={ active }
+			options={ [
+				{ label: __( 'All publications', 'newspack-plugin' ), value: ALL },
+				...collections.map( collection => ( { label: titleCase( collection ), value: collection } ) ),
+			] }
+			onChange={ setFilter }
 		/>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
-			<ChartCard
-				title={ __( 'Top sections', 'newspack-plugin' ) }
-				caption={ __( 'Screen views by section', 'newspack-plugin' ) }
-				payload={ metrics.top_sections }
-			>
-				<MetricTable
-					payload={ metrics.top_sections }
-					columns={ [
-						{ key: 'section', label: __( 'Section', 'newspack-plugin' ) },
-						{ key: 'views', label: __( 'Views', 'newspack-plugin' ), format: 'number', align: 'right' },
-					] }
-					emptyMessage={ __( 'No section data for this timeframe.', 'newspack-plugin' ) }
-				/>
-			</ChartCard>
-			<ChartCard
-				title={ __( 'Top authors', 'newspack-plugin' ) }
-				caption={ __( 'Screen views by author', 'newspack-plugin' ) }
-				payload={ metrics.top_authors }
-			>
-				<MetricTable
-					payload={ metrics.top_authors }
-					columns={ [
-						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
-						{ key: 'views', label: __( 'Views', 'newspack-plugin' ), format: 'number', align: 'right' },
-					] }
-					emptyMessage={ __( 'No author data for this timeframe.', 'newspack-plugin' ) }
-				/>
-			</ChartCard>
-		</div>
-	</section>
-);
+	) : undefined;
+
+	return (
+		<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-content-heading">
+			<SectionHeading
+				id="newspack-insights-app-content-heading"
+				title={ __( 'Content', 'newspack-plugin' ) }
+				description={ __( 'The sections and authors readers engage with most in the app.', 'newspack-plugin' ) }
+				actions={ selector }
+			/>
+			<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+				<ChartCard
+					title={ __( 'Top sections', 'newspack-plugin' ) }
+					caption={ __( 'Screen views by section', 'newspack-plugin' ) }
+					payload={ sections }
+				>
+					<MetricTable
+						payload={ sections }
+						columns={ [
+							{ key: 'section', label: __( 'Section', 'newspack-plugin' ) },
+							{ key: 'views', label: __( 'Views', 'newspack-plugin' ), format: 'number', align: 'right' },
+						] }
+						emptyMessage={ __( 'No section data for this timeframe.', 'newspack-plugin' ) }
+					/>
+				</ChartCard>
+				<ChartCard
+					title={ __( 'Top authors', 'newspack-plugin' ) }
+					caption={ __( 'Screen views by author', 'newspack-plugin' ) }
+					payload={ authors }
+				>
+					<MetricTable
+						payload={ authors }
+						columns={ [
+							{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
+							{ key: 'views', label: __( 'Views', 'newspack-plugin' ), format: 'number', align: 'right' },
+						] }
+						emptyMessage={ __( 'No author data for this timeframe.', 'newspack-plugin' ) }
+					/>
+				</ChartCard>
+			</div>
+		</section>
+	);
+};
 
 export default ContentSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
@@ -16,11 +16,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { SelectControl } from '../../../../../packages/components/src';
 import type { AppMetrics } from '../../api/app';
 import ChartCard from '../components/ChartCard';
 import MetricTable from '../components/MetricTable';
@@ -34,7 +34,7 @@ export interface ContentSectionProps {
 const ALL = 'all';
 
 const ContentSection = ( { metrics }: ContentSectionProps ) => {
-	const [ filter, setFilter ] = useState( ALL );
+	const [ filter, setFilter ] = useState< string >( ALL );
 
 	// Publications present in the content matrices. Only a multi-property app
 	// (2+ collections) gets the selector; otherwise the app-wide tables render.
@@ -48,6 +48,7 @@ const ContentSection = ( { metrics }: ContentSectionProps ) => {
 
 	const selector = hasSelector ? (
 		<SelectControl
+			__nextHasNoMarginBottom
 			className="newspack-insights__app-collection-select"
 			label={ __( 'Publication', 'newspack-plugin' ) }
 			hideLabelFromVision

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/DownloadsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/DownloadsSection.tsx
@@ -27,14 +27,12 @@ import Scorecard from '../components/Scorecard';
 import ChartCard from '../components/ChartCard';
 import MetricTable from '../components/MetricTable';
 import SectionHeading from '../components/SectionHeading';
+import { titleCase } from './collections';
 
 export interface DownloadsSectionProps {
 	metrics: AppMetrics;
 	previous?: AppMetrics | null;
 }
-
-/** Title-case a raw collection value ("example city" → "Example City"). */
-const titleCase = ( value: string ): string => value.replace( /\b\w/g, char => char.toUpperCase() );
 
 const DownloadsSection = ( { metrics, previous }: DownloadsSectionProps ) => {
 	// The per-publication table is only meaningful for a multi-property app —

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/app.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/app.scss
@@ -26,3 +26,12 @@
 .newspack-insights__app-property-sep {
 	color: wp-colors.$gray-400;
 }
+
+// Compact per-publication filter in the Content section header.
+.newspack-insights__app-collection-select {
+	margin-bottom: 0;
+
+	.components-input-control__container {
+		min-width: 160px;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/collections.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/collections.ts
@@ -1,0 +1,72 @@
+/**
+ * Collection helpers (App tab, Tab 10 — NPPD-1882).
+ *
+ * Shared logic for the multi-property "collection" (publication) breakdowns:
+ * title-casing the raw lowercase values, listing the distinct collections, and
+ * pivoting a `collection × dimension` matrix down to one collection's top-N rows.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type { MetricPayload, MetricRow } from '../components/metrics';
+
+/** Title-case a raw collection value ("example city" → "Example City"). */
+export const titleCase = ( value: string ): string => value.replace( /\b\w/g, char => char.toUpperCase() );
+
+/** Distinct collection values present across the given breakdown payloads. */
+export const collectionValues = ( ...payloads: Array< MetricPayload | undefined > ): string[] => {
+	const seen = new Set< string >();
+	payloads.forEach( payload => {
+		( payload?.rows ?? [] ).forEach( row => {
+			const value = String( row.collection ?? '' );
+			if ( value ) {
+				seen.add( value );
+			}
+		} );
+	} );
+	return [ ...seen ];
+};
+
+/**
+ * Pivot a `collection × dimension` matrix to one collection's top-N rows: filter
+ * to the collection, merge case-duplicate labels (sum; keep the dominant casing),
+ * sort by metric desc with a label tie-breaker, and cap. Mirrors the server-side
+ * merge so a per-collection view matches the aggregate "All publications" view.
+ */
+export const topByCollection = (
+	payload: MetricPayload | undefined,
+	collection: string,
+	dimKey: string,
+	metricKey: string,
+	limit = 8
+): MetricPayload => {
+	const merged = new Map< string, { row: MetricRow; top: number } >();
+	( payload?.rows ?? [] )
+		.filter( row => String( row.collection ?? '' ) === collection )
+		.forEach( row => {
+			const label = String( row[ dimKey ] ?? '' );
+			const value = Number( row[ metricKey ] ?? 0 );
+			const key = label.toLowerCase();
+			const existing = merged.get( key );
+			if ( ! existing ) {
+				merged.set( key, { row: { [ dimKey ]: label, [ metricKey ]: value }, top: value } );
+				return;
+			}
+			existing.row[ metricKey ] = Number( existing.row[ metricKey ] ?? 0 ) + value;
+			if ( value > existing.top ) {
+				existing.row[ dimKey ] = label;
+				existing.top = value;
+			}
+		} );
+
+	const rows = [ ...merged.values() ]
+		.map( entry => entry.row )
+		.sort( ( a, b ) => {
+			const byMetric = Number( b[ metricKey ] ?? 0 ) - Number( a[ metricKey ] ?? 0 );
+			return byMetric !== 0 ? byMetric : String( a[ dimKey ] ?? '' ).localeCompare( String( b[ dimKey ] ?? '' ) );
+		} )
+		.slice( 0, limit );
+
+	return { rows, computable: true, type: 'breakdown' };
+};


### PR DESCRIPTION
## Insights App tab — Content per-publication selector (NPPD-1882)

Follow-up to the Downloads work (#562). Some publishers run **one app across several publications** (e.g. Source Media serves richland / knox / ashland / delaware, tagged by `KGCollectionSet`). This adds a **per-publication selector** to the Content section so those pubs can scope Top sections / Top authors to a single publication.

### Why this shape (data-driven)
A live GA4 probe settled the feasibility:
- **Reading events are ~99% collection-tagged** (`(not set)` = 754 / ~70,940) → content cards can be cleanly scoped by collection. ✅
- **Universal metrics are ~50% *un*tagged** (sessions `(not set)` ≈ 50%) → a *global* tab filter would silently drop half the Reach/Engagement/Retention signal. ❌

So collection filtering is scoped to the **Content section only**, where the data supports it — the universal metrics stay app-wide (correctly).

### How it works
- A selector (**All publications / Richland / Ashland / …**) in the Content section header re-scopes both tables. **All publications** = the existing app-wide `top_sections`/`top_authors`; a publication = pivoted from a 2-D matrix.
- Backed by **one 2-D report per table** (`KGCollectionSet × KGSection` / `× KGAuthor`) — the frontend pivots client-side (top-N per collection, case-merged), so switching publications is instant with **no fetch-on-change**.
- **Runtime-tiered**: shown only when 2+ collections exist. Single-property apps (e.g. YubaNet) never see it — and thanks to the client's `custom_dimension_missing` pre-check, pubs without `KGCollectionSet` make **no** extra Data API call.
- Raw lowercase values are title-cased (shared `titleCase` helper, also used by the Downloads-by-publication table).

### Testing
- **PHP** (`Test_App_Metric`): 19 tests / 63 assertions.
- **JS** (`AppTab.test.tsx`): 9 tests — asserts the selector renders (options) for a 2-collection fixture.
- PHPCS + tsc + wp-prettier clean; build green; **verified live** — switching publications re-scopes both tables (screenshotted).