### PR TITLE
fix(insights): version-fold App + Newsletter Ads local caches

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-cache.php
@@ -23,11 +23,18 @@ final class Cache {
 	const SOURCE_SNAPSHOT = 'snapshot';
 
 	/**
-	 * Global envelope cache-schema version, folded into every Insights window
-	 * cache key (durable + transient) via Cached_Controller_Trait. Bump this on
-	 * ANY Insights window-payload shape change so a shape-changing deploy cannot
-	 * serve an old-shaped durable/transient payload to the new frontend. A bump
-	 * busts every tab's window cache at once (one cold pre-warm cycle).
+	 * Global envelope cache-schema version. Bump this on ANY Insights
+	 * window-payload shape change so a shape-changing deploy cannot serve an
+	 * old-shaped payload to the new frontend; a bump busts every tab's window
+	 * cache at once — trait-backed tabs recompute on their next pre-warm cycle,
+	 * the local-cache tabs on their next request.
+	 *
+	 * Trait-backed tabs fold it into every durable/transient key via
+	 * Cached_Controller_Trait. The two local-cache tabs that don't go through the
+	 * trait's cached path — App (no trait) and Newsletter Ads (SOURCE_LOCAL, so
+	 * Cache::store() is a pass-through) — fold it into their own metric-layer
+	 * transient keys instead ({@see App_Metric::metrics_cache_key()} /
+	 * {@see Newsletter_Ads_Metric::envelope_cache_key()}), so a bump busts them too.
 	 */
 	const ENVELOPE_SCHEMA_VERSION = 'v1';
 

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-app-metric.php
@@ -300,7 +300,7 @@ final class App_Metric {
 			];
 		}
 
-		$window_key = self::METRICS_CACHE_PREFIX . md5( $property . '|' . $start_date . '|' . $end_date );
+		$window_key = self::metrics_cache_key( $property, $start_date, $end_date );
 		$cached     = $force_refresh ? false : get_transient( $window_key );
 		if ( is_array( $cached ) && isset( $cached['metrics'], $cached['computed_at'] ) ) {
 			$window = $cached;
@@ -312,7 +312,7 @@ final class App_Metric {
 			set_transient( $window_key, $window, self::METRICS_CACHE_TTL );
 		}
 
-		$retention_key = self::RETENTION_CACHE_PREFIX . md5( $property );
+		$retention_key = self::retention_cache_key( $property );
 		$retention     = $force_refresh ? false : get_transient( $retention_key );
 		if ( ! is_array( $retention ) ) {
 			$retention = self::compute_retention( $property );
@@ -323,6 +323,34 @@ final class App_Metric {
 			'metrics'     => array_merge( $window['metrics'], [ 'retention' => $retention ] ),
 			'computed_at' => $window['computed_at'],
 		];
+	}
+
+	/**
+	 * Transient key for a property/window's metric payload. Folds in the global
+	 * {@see Cache::ENVELOPE_SCHEMA_VERSION} alongside the prefix's own local
+	 * payload-version token, so a cross-tab envelope-shape bump busts this tab's
+	 * cache too — the guarantee the BigQuery/external tabs get for free from
+	 * {@see Cached_Controller_Trait}, which this GA4-only tab doesn't use.
+	 *
+	 * @param string $property   GA4 property ID.
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string
+	 */
+	private static function metrics_cache_key( string $property, string $start_date, string $end_date ): string {
+		return self::METRICS_CACHE_PREFIX . Cache::ENVELOPE_SCHEMA_VERSION . ':' . md5( $property . '|' . $start_date . '|' . $end_date );
+	}
+
+	/**
+	 * Transient key for a property's retention payload. Version-folded like
+	 * {@see self::metrics_cache_key()}; retention is window-independent, so the
+	 * key is property-scoped only.
+	 *
+	 * @param string $property GA4 property ID.
+	 * @return string
+	 */
+	private static function retention_cache_key( string $property ): string {
+		return self::RETENTION_CACHE_PREFIX . Cache::ENVELOPE_SCHEMA_VERSION . ':' . md5( $property );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-newsletter-ads-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-newsletter-ads-metric.php
@@ -357,7 +357,7 @@ class Newsletter_Ads_Metric {
 	 */
 	private static function read_envelope( string $start_date, string $end_date ): array {
 		$cache_disabled = defined( 'NEWSPACK_INSIGHTS_CACHE_DISABLED' ) && NEWSPACK_INSIGHTS_CACHE_DISABLED;
-		$cache_key      = self::CACHE_KEY_PREFIX . $start_date . ':' . $end_date;
+		$cache_key      = self::envelope_cache_key( $start_date, $end_date );
 		if ( ! $cache_disabled ) {
 			$cached = get_transient( $cache_key );
 			if ( is_array( $cached ) ) {
@@ -369,6 +369,22 @@ class Newsletter_Ads_Metric {
 			set_transient( $cache_key, $envelope, self::CACHE_TTL );
 		}
 		return $envelope;
+	}
+
+	/**
+	 * Transient key for a window's envelope. Folds in the global
+	 * {@see Cache::ENVELOPE_SCHEMA_VERSION} alongside the prefix's own local
+	 * payload-version token. This tab uses {@see Cached_Controller_Trait} but is
+	 * SOURCE_LOCAL, so {@see Cache::store()} short-circuits to a pass-through and
+	 * never consults the trait's version-folded key — this transient is the real
+	 * cache, so it must carry the version itself for a global bump to bust it.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string
+	 */
+	private static function envelope_cache_key( string $start_date, string $end_date ): string {
+		return self::CACHE_KEY_PREFIX . Cache::ENVELOPE_SCHEMA_VERSION . ':' . $start_date . ':' . $end_date;
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-app-metric.php
@@ -14,6 +14,7 @@
 namespace Newspack\Tests\Insights;
 
 use Newspack\Insights\App_Metric;
+use Newspack\Insights\Cache;
 use WP_UnitTestCase;
 
 /**
@@ -458,5 +459,50 @@ class Test_App_Metric extends WP_UnitTestCase {
 		// Equal views (500) → alphabetical: News before Sports.
 		$this->assertSame( 'News', $payload['rows'][0]['section'] );
 		$this->assertSame( 'Sports', $payload['rows'][1]['section'] );
+	}
+
+	/**
+	 * The metrics transient key folds in the global Cache::ENVELOPE_SCHEMA_VERSION
+	 * after its own prefix, so a cross-tab envelope-shape bump busts this tab's
+	 * (trait-less) cache too.
+	 */
+	public function test_metrics_cache_key_includes_envelope_version() {
+		$method = new \ReflectionMethod( App_Metric::class, 'metrics_cache_key' );
+		$method->setAccessible( true );
+		$key = $method->invoke( null, '123456789', '2026-01-01', '2026-01-31' );
+
+		$this->assertStringStartsWith( App_Metric::METRICS_CACHE_PREFIX . Cache::ENVELOPE_SCHEMA_VERSION . ':', $key );
+	}
+
+	/**
+	 * The (window-independent) retention transient key is version-folded the same
+	 * way as the metrics key.
+	 */
+	public function test_retention_cache_key_includes_envelope_version() {
+		$method = new \ReflectionMethod( App_Metric::class, 'retention_cache_key' );
+		$method->setAccessible( true );
+		$key = $method->invoke( null, '123456789' );
+
+		$this->assertStringStartsWith( App_Metric::RETENTION_CACHE_PREFIX . Cache::ENVELOPE_SCHEMA_VERSION . ':', $key );
+	}
+
+	/**
+	 * The key-builders stay injective over their inputs: distinct property/window
+	 * combinations, and the two key families, never collide — guards the md5
+	 * extraction from silently collapsing distinct windows onto one entry.
+	 */
+	public function test_app_cache_keys_vary_by_inputs() {
+		$metrics   = new \ReflectionMethod( App_Metric::class, 'metrics_cache_key' );
+		$retention = new \ReflectionMethod( App_Metric::class, 'retention_cache_key' );
+		$metrics->setAccessible( true );
+		$retention->setAccessible( true );
+
+		$base       = $metrics->invoke( null, '111', '2026-01-01', '2026-01-31' );
+		$other_prop = $metrics->invoke( null, '222', '2026-01-01', '2026-01-31' );
+		$other_win  = $metrics->invoke( null, '111', '2026-02-01', '2026-02-28' );
+
+		$this->assertNotSame( $base, $other_prop );
+		$this->assertNotSame( $base, $other_win );
+		$this->assertNotSame( $base, $retention->invoke( null, '111' ) );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/insights/class-test-newsletter-ads-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights/class-test-newsletter-ads-metric.php
@@ -23,6 +23,7 @@
 
 namespace Newspack\Tests\Insights;
 
+use Newspack\Insights\Cache;
 use Newspack\Insights\Newsletter_Ads_Metric;
 use WP_UnitTestCase;
 
@@ -150,7 +151,11 @@ class Test_Newsletter_Ads_Metric extends WP_UnitTestCase {
 	 * @return array
 	 */
 	private function fresh_get_all( string $orchestrator, string $start, string $end ): array {
-		delete_transient( Newsletter_Ads_Metric::CACHE_KEY_PREFIX . $start . ':' . $end );
+		// Derive the key from the production builder (not an inline copy) so this
+		// helper can't drift from the real cache key on a future key-shape change.
+		$key_method = new \ReflectionMethod( Newsletter_Ads_Metric::class, 'envelope_cache_key' );
+		$key_method->setAccessible( true );
+		delete_transient( $key_method->invoke( null, $start, $end ) );
 		return call_user_func( [ $orchestrator, 'get_all' ], $start, $end );
 	}
 
@@ -427,5 +432,21 @@ class Test_Newsletter_Ads_Metric extends WP_UnitTestCase {
 		// Daily series is chronological and skips zero-recorded days.
 		$days = array_column( $metrics['performance_by_day']['rows'], 'date' );
 		$this->assertSame( [ '2026-06-10', '2026-06-12', '2026-06-13' ], $days );
+	}
+
+	/**
+	 * The envelope transient key folds in the global Cache::ENVELOPE_SCHEMA_VERSION
+	 * after its prefix. This tab uses Cached_Controller_Trait but is SOURCE_LOCAL
+	 * (so Cache::store() never consults the trait's versioned key) — this
+	 * metric-layer transient is the real cache, so it must carry the version for a
+	 * global bump to bust it.
+	 */
+	public function test_envelope_cache_key_includes_envelope_version() {
+		$method = new \ReflectionMethod( Newsletter_Ads_Metric::class, 'envelope_cache_key' );
+		$method->setAccessible( true );
+		$key = $method->invoke( null, '2026-01-01', '2026-01-31' );
+
+		$this->assertStringStartsWith( Newsletter_Ads_Metric::CACHE_KEY_PREFIX . Cache::ENVELOPE_SCHEMA_VERSION . ':', $key );
+		$this->assertStringEndsWith( '2026-01-01:2026-01-31', $key );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Insights **App** and **Newsletter Ads** tabs cache their metric payloads in site transients that were **not** tied to the global Insights envelope-schema version (`Cache::ENVELOPE_SCHEMA_VERSION`). The BigQuery/external tabs get that versioning for free from `Cached_Controller_Trait`, but these two don't go through the trait's cached path:

- **App** doesn't use the trait at all (GA4-only, no BigQuery).
- **Newsletter Ads** uses the trait but is `SOURCE_LOCAL`, so `Cache::store()` short-circuits to a pass-through and never consults the trait's version-folded key — its real cache is a metric-layer transient.

Because of this, bumping `ENVELOPE_SCHEMA_VERSION` on a payload-shape change did **not** bust these two tabs' caches. A shape-changing deploy could therefore serve an old-shaped payload to the new frontend until the transient expired — up to 15 min for window metrics, and **up to 24 h for App retention** (its own daily, property-scoped transient).

This PR folds the global version into both tabs' transient keys (keeping each tab's own local `_vN` payload token as an independent axis, mirroring the trait's two-version model), so a global bump busts them too. It also tightens the `ENVELOPE_SCHEMA_VERSION` docblock to describe this path accurately.

Scope is cache-keying only — no change to data sources, the durable/on-demand pools, the daily pre-warm pipeline, or any hub-side handling (neither tab uses BigQuery, so none is required). Relates to the App tab (NPPD-1882) and Newsletter Ads tab (NPPD-1861).

### How to test the changes in this Pull Request:

1. Run the Insights PHP test group: `n test-php --group insights`. All tests pass (this PR adds 4 tests asserting both tabs' cache keys carry the version, plus fixes a test helper that was rebuilding the old unversioned key).
2. Confirm the new key shapes: the App tab's transients are keyed `newspack_insights_app_metrics_v2:v1:<hash>` and `newspack_insights_app_retention_v1:v1:<hash>`; Newsletter Ads is `newspack_insights_newsletter_ads_v1:v1:<start>:<end>` (the `v1` segment is `ENVELOPE_SCHEMA_VERSION`).
3. Regression — App tab (an app-publisher site with a selected GA4 property) and Newsletter Ads tab both still render, cache, and serve normally; the per-tab refresh action still recomputes.
4. Deploy simulation — locally change `Cache::ENVELOPE_SCHEMA_VERSION` (e.g. `v1` → `v2`), load both tabs, and confirm they recompute rather than serving a pre-bump cached payload.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?