### PR TITLE
feat(insights): gate date range & compare changes behind Apply

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/components/ConfirmModal.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ConfirmModal.test.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ConfirmModal from './ConfirmModal';
+
+describe( 'ConfirmModal', () => {
+	it( 'renders the warning message and both buttons', () => {
+		render( <ConfirmModal onContinue={ jest.fn() } onCancel={ jest.fn() } /> );
+		expect( screen.getByText( 'The data for these settings may take a while to load. Continue?' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls onContinue when Continue is clicked', () => {
+		const onContinue = jest.fn();
+		render( <ConfirmModal onContinue={ onContinue } onCancel={ jest.fn() } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+		expect( onContinue ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls onCancel when Cancel is clicked', () => {
+		const onCancel = jest.fn();
+		render( <ConfirmModal onContinue={ jest.fn() } onCancel={ onCancel } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( onCancel ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/ConfirmModal.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ConfirmModal.tsx
@@ -19,9 +19,19 @@ export interface ConfirmModalProps {
 	onCancel: () => void;
 }
 
+// Wire the warning text to the dialog's accessible description (WP Modal
+// forwards `aria.describedby` onto the dialog) so screen readers announce the
+// message, not just the title — matching the FeedbackModal convention.
+const MESSAGE_ID = 'newspack-insights-confirm-modal-message';
+
 const ConfirmModal = ( { onContinue, onCancel }: ConfirmModalProps ) => (
-	<Modal title={ __( 'Load new data?', 'newspack-plugin' ) } onRequestClose={ onCancel } className="newspack-insights__confirm-modal">
-		<p className="newspack-insights__confirm-modal-message">
+	<Modal
+		title={ __( 'Load new data?', 'newspack-plugin' ) }
+		onRequestClose={ onCancel }
+		className="newspack-insights__confirm-modal"
+		aria={ { describedby: MESSAGE_ID } }
+	>
+		<p id={ MESSAGE_ID } className="newspack-insights__confirm-modal-message">
 			{ __( 'The data for these settings may take a while to load. Continue?', 'newspack-plugin' ) }
 		</p>
 		<div className="newspack-insights__confirm-modal-actions">

--- a/plugins/newspack-plugin/src/wizards/insights/components/ConfirmModal.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/ConfirmModal.tsx
@@ -1,0 +1,38 @@
+/**
+ * ConfirmModal
+ *
+ * Confirmation dialog shown before applying an expensive Insights control
+ * change (a custom date range, or a comparison-mode toggle). Warns that the
+ * data may be slow to load. Assembled from @wordpress/components Modal + Button,
+ * following the FeedbackModal convention — a horizontal, right-aligned action
+ * row with the dismiss button first.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal, Button } from '@wordpress/components';
+
+export interface ConfirmModalProps {
+	onContinue: () => void;
+	onCancel: () => void;
+}
+
+const ConfirmModal = ( { onContinue, onCancel }: ConfirmModalProps ) => (
+	<Modal title={ __( 'Load new data?', 'newspack-plugin' ) } onRequestClose={ onCancel } className="newspack-insights__confirm-modal">
+		<p className="newspack-insights__confirm-modal-message">
+			{ __( 'The data for these settings may take a while to load. Continue?', 'newspack-plugin' ) }
+		</p>
+		<div className="newspack-insights__confirm-modal-actions">
+			<Button variant="tertiary" onClick={ onCancel }>
+				{ __( 'Cancel', 'newspack-plugin' ) }
+			</Button>
+			<Button variant="primary" onClick={ onContinue }>
+				{ __( 'Continue', 'newspack-plugin' ) }
+			</Button>
+		</div>
+	</Modal>
+);
+
+export default ConfirmModal;

--- a/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.test.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import HeaderControls from './HeaderControls';
+import usePendingControls from '../state/usePendingControls';
+import type { DateRange } from '../state/useDateRange';
+
+const DEFAULT_RANGE: DateRange = { preset: 'last-30', start: '2026-05-01', end: '2026-05-30' };
+
+const Harness = ( { comparison = false }: { comparison?: boolean } ) => {
+	const controls = usePendingControls( { defaultRange: DEFAULT_RANGE, defaultComparison: comparison } );
+	return <HeaderControls controls={ controls } />;
+};
+
+const renderHarness = ( comparison = false ) => {
+	window.history.replaceState( {}, '', '/wp-admin/admin.php?page=newspack-insights' );
+	return render( <Harness comparison={ comparison } /> );
+};
+
+// The preset SelectControl is the only <select> (role combobox) in the row.
+const selectPreset = ( value: string ) => fireEvent.change( screen.getByRole( 'combobox' ), { target: { value } } );
+const compareCheckbox = () => screen.getByRole( 'checkbox', { name: /Compare to previous period/ } ) as HTMLInputElement;
+
+describe( 'HeaderControls', () => {
+	it( 'hides Apply/Cancel until a control changes', () => {
+		renderHarness();
+		expect( screen.queryByRole( 'button', { name: 'Apply' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Cancel' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'reveals Apply/Cancel when a preset changes', () => {
+		renderHarness();
+		selectPreset( 'last-7' );
+		expect( screen.getByRole( 'button', { name: 'Apply' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'Cancel restores the control and hides the buttons', () => {
+		renderHarness();
+		selectPreset( 'last-7' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( screen.queryByRole( 'button', { name: 'Apply' } ) ).not.toBeInTheDocument();
+		expect( ( screen.getByRole( 'combobox' ) as HTMLSelectElement ).value ).toBe( 'last-30' );
+	} );
+
+	it( 'preset→preset Apply commits without a modal', () => {
+		renderHarness();
+		selectPreset( 'last-7' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+		expect( screen.queryByText( /may take a while to load/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Apply' } ) ).not.toBeInTheDocument(); // committed → clean
+	} );
+
+	it( 'applying a custom range opens the modal', () => {
+		renderHarness();
+		selectPreset( 'custom' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+		expect( screen.getByText( /may take a while to load/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'toggling compare + Apply opens the modal; Continue commits', () => {
+		renderHarness();
+		fireEvent.click( compareCheckbox() );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+		expect( screen.getByText( /may take a while to load/ ) ).toBeInTheDocument();
+		fireEvent.click( within( screen.getByRole( 'dialog' ) ).getByRole( 'button', { name: 'Continue' } ) );
+		expect( screen.queryByText( /may take a while to load/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Apply' } ) ).not.toBeInTheDocument(); // committed → clean
+	} );
+
+	it( 'modal Cancel discards the change', () => {
+		renderHarness();
+		fireEvent.click( compareCheckbox() );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+		// Global Cancel and modal Cancel both exist — target the one inside the dialog.
+		fireEvent.click( within( screen.getByRole( 'dialog' ) ).getByRole( 'button', { name: 'Cancel' } ) );
+		expect( screen.queryByText( /may take a while to load/ ) ).not.toBeInTheDocument();
+		expect( compareCheckbox().checked ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.tsx
@@ -35,7 +35,7 @@ const HeaderControls = ( { controls }: HeaderControlsProps ) => {
 				<DateRangePicker range={ draftRange } onPresetChange={ setPreset } onCustomChange={ setCustom } />
 				<ComparisonToggle enabled={ draftCompare } onChange={ setCompare } />
 			</div>
-			{ isDirty && (
+			{ isDirty && ! confirmOpen && (
 				<div className="newspack-insights__header-controls-actions">
 					<Button variant="secondary" isSmall onClick={ apply }>
 						{ __( 'Apply', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.tsx
@@ -1,0 +1,53 @@
+/**
+ * HeaderControls
+ *
+ * The Insights global-controls block rendered above the tabs: the date-range
+ * picker + comparison toggle (editing a draft), an Apply / Cancel action row
+ * shown only when the draft differs from the applied (viewed) state, and the
+ * confirmation modal for expensive changes. All state lives in
+ * usePendingControls — this component is the presentation of that hook.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import DateRangePicker from './DateRangePicker';
+import ComparisonToggle from './ComparisonToggle';
+import ConfirmModal from './ConfirmModal';
+import type { UsePendingControlsReturn } from '../state/usePendingControls';
+
+export interface HeaderControlsProps {
+	controls: UsePendingControlsReturn;
+}
+
+const HeaderControls = ( { controls }: HeaderControlsProps ) => {
+	const { draftRange, draftCompare, setPreset, setCustom, setCompare, isDirty, confirmOpen, apply, cancel, confirmApply } = controls;
+
+	return (
+		<div className="newspack-insights__header-controls">
+			<div className="newspack-insights__header-controls-row">
+				<DateRangePicker range={ draftRange } onPresetChange={ setPreset } onCustomChange={ setCustom } />
+				<ComparisonToggle enabled={ draftCompare } onChange={ setCompare } />
+			</div>
+			{ isDirty && (
+				<div className="newspack-insights__header-controls-actions">
+					<Button variant="secondary" isSmall onClick={ apply }>
+						{ __( 'Apply', 'newspack-plugin' ) }
+					</Button>
+					<Button variant="tertiary" isSmall onClick={ cancel }>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+				</div>
+			) }
+			{ confirmOpen && <ConfirmModal onContinue={ confirmApply } onCancel={ cancel } /> }
+		</div>
+	);
+};
+
+export default HeaderControls;

--- a/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/HeaderControls.tsx
@@ -13,6 +13,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,18 +32,14 @@ const HeaderControls = ( { controls }: HeaderControlsProps ) => {
 
 	return (
 		<div className="newspack-insights__header-controls">
-			<div className="newspack-insights__header-controls-row">
-				<DateRangePicker range={ draftRange } onPresetChange={ setPreset } onCustomChange={ setCustom } />
-				<ComparisonToggle enabled={ draftCompare } onChange={ setCompare } />
-			</div>
+			<DateRangePicker range={ draftRange } onPresetChange={ setPreset } onCustomChange={ setCustom } />
+			<ComparisonToggle enabled={ draftCompare } onChange={ setCompare } />
 			{ isDirty && ! confirmOpen && (
 				<div className="newspack-insights__header-controls-actions">
-					<Button variant="secondary" isSmall onClick={ apply }>
+					<Button variant="secondary" size={ 'small' } onClick={ apply }>
 						{ __( 'Apply', 'newspack-plugin' ) }
 					</Button>
-					<Button variant="tertiary" isSmall onClick={ cancel }>
-						{ __( 'Cancel', 'newspack-plugin' ) }
-					</Button>
+					<Button variant="tertiary" size={ 'small' } onClick={ cancel } icon={ closeSmall } label={ __( 'Cancel', 'newspack-plugin' ) } />
 				</div>
 			) }
 			{ confirmOpen && <ConfirmModal onContinue={ confirmApply } onCancel={ cancel } /> }

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -25,16 +25,15 @@ import type { ErrorInfo, ReactNode } from 'react';
  * Internal dependencies
  */
 import { Wizard } from '../../../../packages/components/src';
-import ComparisonToggle from './ComparisonToggle';
-import DateRangePicker from './DateRangePicker';
 import CooldownNotice from './CooldownNotice';
+import HeaderControls from './HeaderControls';
 import PrintDocumentMeta from './PrintDocumentMeta';
 import TabFeedback from './TabFeedback';
 import NextSteps from './NextSteps';
 import FeedbackShipCallback from './FeedbackShipCallback';
 import TabSpinner from '../tabs/components/TabSpinner';
-import useComparisonMode from '../state/useComparisonMode';
-import useDateRange, { type DateRange } from '../state/useDateRange';
+import usePendingControls from '../state/usePendingControls';
+import type { DateRange } from '../state/useDateRange';
 import { RefreshRegistryProvider } from '../state/refreshRegistry';
 
 export type TabKey =
@@ -249,17 +248,9 @@ const TabSection = ( {
 );
 
 const InsightsWizard = ( { config }: InsightsWizardProps ) => {
-	const { range, setPreset, setCustom } = useDateRange( {
+	const controls = usePendingControls( {
 		defaultRange: config.defaultDateRange,
-	} );
-
-	const {
-		enabled: comparisonEnabled,
-		setEnabled: setComparisonEnabled,
-		previousRange,
-	} = useComparisonMode( {
-		defaultEnabled: config.defaultComparison,
-		currentRange: range,
+		defaultComparison: config.defaultComparison,
 	} );
 
 	// Backwards-compat: rewrite legacy ?tab=X URLs to #/X so existing
@@ -310,8 +301,8 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 		props: {
 			tabKey: t.key,
 			tabLabel: t.label,
-			range,
-			previousRange,
+			range: controls.appliedRange,
+			previousRange: controls.appliedPreviousRange,
 			publisherName: config.publisherName,
 			nextStepsLinks: config.nextStepsLinks?.[ t.key ] ?? [],
 			feedbackBeaconUrl: config.feedbackBeaconUrl,
@@ -319,12 +310,7 @@ const InsightsWizard = ( { config }: InsightsWizardProps ) => {
 		},
 	} ) );
 
-	const renderAboveSections = () => (
-		<div className="newspack-insights__header-controls">
-			<DateRangePicker range={ range } onPresetChange={ setPreset } onCustomChange={ setCustom } />
-			<ComparisonToggle enabled={ comparisonEnabled } onChange={ setComparisonEnabled } />
-		</div>
-	);
+	const renderAboveSections = () => <HeaderControls controls={ controls } />;
 
 	return (
 		<RefreshRegistryProvider>

--- a/plugins/newspack-plugin/src/wizards/insights/state/controlsUrl.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/controlsUrl.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { writeDateRangeUrl, writeComparisonUrl } from './controlsUrl';
+
+describe( 'controlsUrl', () => {
+	beforeEach( () => {
+		window.history.replaceState( {}, '', '/wp-admin/admin.php?page=newspack-insights' );
+	} );
+
+	it( 'writes a preset range and clears custom start/end', () => {
+		writeDateRangeUrl( { preset: 'last-30', start: '2026-05-01', end: '2026-05-30' } );
+		const params = new URLSearchParams( window.location.search );
+		expect( params.get( 'range' ) ).toBe( 'last-30' );
+		expect( params.get( 'start' ) ).toBeNull();
+		expect( params.get( 'end' ) ).toBeNull();
+	} );
+
+	it( 'writes a custom range with start and end', () => {
+		writeDateRangeUrl( { preset: 'custom', start: '2026-04-01', end: '2026-04-30' } );
+		const params = new URLSearchParams( window.location.search );
+		expect( params.get( 'range' ) ).toBe( 'custom' );
+		expect( params.get( 'start' ) ).toBe( '2026-04-01' );
+		expect( params.get( 'end' ) ).toBe( '2026-04-30' );
+	} );
+
+	it( 'writes compare=1 when enabled and compare=0 when disabled', () => {
+		writeComparisonUrl( true );
+		expect( new URLSearchParams( window.location.search ).get( 'compare' ) ).toBe( '1' );
+		writeComparisonUrl( false );
+		expect( new URLSearchParams( window.location.search ).get( 'compare' ) ).toBe( '0' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/state/controlsUrl.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/controlsUrl.ts
@@ -1,0 +1,42 @@
+/**
+ * controlsUrl
+ *
+ * Commit-time URL persistence for the Insights global controls. The date-range
+ * and comparison hooks still hydrate from these query params on mount, but no
+ * longer write on every change — usePendingControls calls these writers only
+ * when the user applies a change, so the URL always reflects the viewed data.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from './useDateRange';
+
+export const writeDateRangeUrl = ( range: DateRange ): void => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const params = new URLSearchParams( window.location.search );
+	params.set( 'range', range.preset );
+	if ( range.preset === 'custom' ) {
+		params.set( 'start', range.start );
+		params.set( 'end', range.end );
+	} else {
+		params.delete( 'start' );
+		params.delete( 'end' );
+	}
+	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
+	window.history.replaceState( window.history.state, '', next );
+};
+
+export const writeComparisonUrl = ( enabled: boolean ): void => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const params = new URLSearchParams( window.location.search );
+	// Persist both states explicitly ('0' round-trips cleanly with readUrl in
+	// useComparisonMode) so an explicit "disabled" choice survives a refresh.
+	params.set( 'compare', enabled ? '1' : '0' );
+	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
+	window.history.replaceState( window.history.state, '', next );
+};

--- a/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useComparisonMode.ts
@@ -3,14 +3,15 @@
  *
  * Owns the "compare to previous period" toggle. When enabled, computes
  * the previous-period range as the same length immediately preceding the
- * current range. Hydrates from URL query (?compare=1) and persists on
- * change.
+ * current range. Hydrates from URL query (?compare=1). URL persistence
+ * happens at commit time via `writeComparisonUrl` (see `./controlsUrl`),
+ * not here.
  */
 
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -77,21 +78,6 @@ const readUrl = (): boolean | undefined => {
 	return undefined;
 };
 
-const writeUrl = ( enabled: boolean ) => {
-	if ( typeof window === 'undefined' ) {
-		return;
-	}
-	const params = new URLSearchParams( window.location.search );
-	// Persist both states explicitly. Previously the disabled state
-	// deleted the param, which meant an explicit user choice of
-	// "disabled" would silently revert to the boot config default on
-	// refresh whenever that default is true. `readUrl` already accepts
-	// '0' so this round-trips cleanly.
-	params.set( 'compare', enabled ? '1' : '0' );
-	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
-	window.history.replaceState( window.history.state, '', next );
-};
-
 export interface UseComparisonModeOptions {
 	defaultEnabled: boolean;
 	currentRange: DateRange;
@@ -108,10 +94,6 @@ const useComparisonMode = ( { defaultEnabled, currentRange }: UseComparisonModeO
 		const fromUrl = readUrl();
 		return fromUrl !== undefined ? fromUrl : defaultEnabled;
 	} );
-
-	useEffect( () => {
-		writeUrl( enabled );
-	}, [ enabled ] );
 
 	const setEnabled = useCallback( ( v: boolean ) => {
 		setEnabledState( v );

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -3,15 +3,15 @@
  *
  * Owns the active date range state for the Insights wizard. Hydrates
  * initial state from URL query (so refresh / direct links preserve range)
- * with fallback to the boot config default; persists changes back to URL
- * via history.replaceState (no history pollution).
+ * with fallback to the boot config default. URL persistence happens at
+ * commit time via `writeDateRangeUrl` (see `./controlsUrl`), not here.
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 export type DateRangePreset = 'last-7' | 'last-30' | 'last-90' | 'this-month' | 'last-month' | 'custom';
 
@@ -145,23 +145,6 @@ const readUrl = (): Partial< DateRange > => {
 	return out;
 };
 
-const writeUrl = ( range: DateRange ) => {
-	if ( typeof window === 'undefined' ) {
-		return;
-	}
-	const params = new URLSearchParams( window.location.search );
-	params.set( 'range', range.preset );
-	if ( range.preset === 'custom' ) {
-		params.set( 'start', range.start );
-		params.set( 'end', range.end );
-	} else {
-		params.delete( 'start' );
-		params.delete( 'end' );
-	}
-	const next = `${ window.location.pathname }?${ params.toString() }${ window.location.hash }`;
-	window.history.replaceState( window.history.state, '', next );
-};
-
 export interface UseDateRangeOptions {
 	defaultRange: DateRange;
 }
@@ -170,13 +153,14 @@ export interface UseDateRangeReturn {
 	range: DateRange;
 	setPreset: ( preset: DateRangePreset ) => void;
 	setCustom: ( start: string, end: string ) => void;
+	setRange: ( range: DateRange ) => void;
 }
 
 /**
- * Hydrate from URL first, fall back to defaultRange. Persist on change.
+ * Hydrate from URL first, fall back to defaultRange.
  */
 const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeReturn => {
-	const [ range, setRange ] = useState< DateRange >( () => {
+	const [ range, setRangeState ] = useState< DateRange >( () => {
 		const fromUrl = readUrl();
 		// Custom preset requires both start and end from URL; otherwise fall
 		// back to default.
@@ -199,16 +183,12 @@ const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeRetu
 		return defaultRange;
 	} );
 
-	useEffect( () => {
-		writeUrl( range );
-	}, [ range ] );
-
 	const setPreset = useCallback( ( preset: DateRangePreset ) => {
 		if ( preset === 'custom' ) {
 			// Custom needs explicit start/end; setCustom handles that path.
 			// Hitting "Custom" without supplying dates keeps the current
 			// range but flags it as custom so the picker opens.
-			setRange( prev => ( {
+			setRangeState( prev => ( {
 				preset: 'custom',
 				start: prev.start,
 				end: prev.end,
@@ -217,7 +197,7 @@ const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeRetu
 		}
 		const computed = computeRangeForPreset( preset );
 		if ( computed ) {
-			setRange( { preset, ...computed } );
+			setRangeState( { preset, ...computed } );
 		}
 	}, [] );
 
@@ -231,10 +211,14 @@ const useDateRange = ( { defaultRange }: UseDateRangeOptions ): UseDateRangeRetu
 		// otherwise propagates a nonsensical range into the URL and
 		// breaks computePreviousRange.
 		const [ s, e ] = start <= end ? [ start, end ] : [ end, start ];
-		setRange( { preset: 'custom', start: s, end: e } );
+		setRangeState( { preset: 'custom', start: s, end: e } );
 	}, [] );
 
-	return { range, setPreset, setCustom };
+	const setRange = useCallback( ( next: DateRange ): void => {
+		setRangeState( next );
+	}, [] );
+
+	return { range, setPreset, setCustom, setRange };
 };
 
 export default useDateRange;

--- a/plugins/newspack-plugin/src/wizards/insights/state/usePendingControls.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/usePendingControls.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import usePendingControls from './usePendingControls';
+import type { DateRange } from './useDateRange';
+
+const DEFAULT_RANGE: DateRange = { preset: 'last-30', start: '2026-05-01', end: '2026-05-30' };
+
+const setup = ( comparison = false ) => {
+	window.history.replaceState( {}, '', '/wp-admin/admin.php?page=newspack-insights' );
+	return renderHook( () => usePendingControls( { defaultRange: DEFAULT_RANGE, defaultComparison: comparison } ) );
+};
+
+describe( 'usePendingControls', () => {
+	it( 'starts clean — not dirty, applied equals the default range', () => {
+		const { result } = setup();
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.appliedRange ).toEqual( DEFAULT_RANGE );
+		expect( result.current.appliedPreviousRange ).toBeNull();
+	} );
+
+	it( 'a preset change is dirty and applies immediately (no modal)', () => {
+		const { result } = setup();
+		act( () => result.current.setPreset( 'last-7' ) );
+		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.appliedRange.preset ).toBe( 'last-30' ); // not yet applied
+		act( () => result.current.apply() );
+		expect( result.current.confirmOpen ).toBe( false );
+		expect( result.current.appliedRange.preset ).toBe( 'last-7' );
+		expect( result.current.isDirty ).toBe( false );
+	} );
+
+	it( 'cancel restores the draft to the applied value', () => {
+		const { result } = setup();
+		act( () => result.current.setPreset( 'last-90' ) );
+		act( () => result.current.cancel() );
+		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.draftRange.preset ).toBe( 'last-30' );
+	} );
+
+	it( 'applying a custom range opens the modal; confirmApply commits', () => {
+		const { result } = setup();
+		act( () => result.current.setCustom( '2026-04-01', '2026-04-15' ) );
+		act( () => result.current.apply() );
+		expect( result.current.confirmOpen ).toBe( true );
+		expect( result.current.appliedRange.preset ).toBe( 'last-30' ); // still not applied
+		act( () => result.current.confirmApply() );
+		expect( result.current.confirmOpen ).toBe( false );
+		expect( result.current.appliedRange ).toEqual( { preset: 'custom', start: '2026-04-01', end: '2026-04-15' } );
+	} );
+
+	it( 'toggling compare opens the modal on apply; cancel discards', () => {
+		const { result } = setup();
+		act( () => result.current.setCompare( true ) );
+		act( () => result.current.apply() );
+		expect( result.current.confirmOpen ).toBe( true );
+		act( () => result.current.cancel() );
+		expect( result.current.confirmOpen ).toBe( false );
+		expect( result.current.draftCompare ).toBe( false );
+		expect( result.current.appliedPreviousRange ).toBeNull();
+	} );
+
+	it( 'commits a previousRange when compare is applied', () => {
+		const { result } = setup();
+		act( () => result.current.setCompare( true ) );
+		act( () => result.current.confirmApply() );
+		expect( result.current.appliedPreviousRange ).not.toBeNull();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/state/usePendingControls.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/usePendingControls.test.ts
@@ -76,4 +76,31 @@ describe( 'usePendingControls', () => {
 		act( () => result.current.confirmApply() );
 		expect( result.current.appliedPreviousRange ).not.toBeNull();
 	} );
+
+	it( 'writes the URL only on apply — an un-applied edit leaves it untouched', () => {
+		const { result } = setup();
+		// No commit on mount, so no range param is written yet.
+		expect( new URLSearchParams( window.location.search ).get( 'range' ) ).toBeNull();
+		// Editing the draft must NOT touch the URL — persistence is commit-time only.
+		act( () => result.current.setPreset( 'last-7' ) );
+		expect( new URLSearchParams( window.location.search ).get( 'range' ) ).toBeNull();
+		// Applying commits the range (and compare) to the URL.
+		act( () => result.current.apply() );
+		const params = new URLSearchParams( window.location.search );
+		expect( params.get( 'range' ) ).toBe( 'last-7' );
+		expect( params.get( 'compare' ) ).toBe( '0' );
+	} );
+
+	it( 'writes custom range params to the URL on confirmApply', () => {
+		const { result } = setup();
+		act( () => result.current.setCustom( '2026-04-01', '2026-04-15' ) );
+		// Still un-applied — the URL stays untouched even for a custom edit.
+		expect( new URLSearchParams( window.location.search ).get( 'range' ) ).toBeNull();
+		act( () => result.current.apply() ); // opens the confirmation modal for custom
+		act( () => result.current.confirmApply() ); // commits
+		const params = new URLSearchParams( window.location.search );
+		expect( params.get( 'range' ) ).toBe( 'custom' );
+		expect( params.get( 'start' ) ).toBe( '2026-04-01' );
+		expect( params.get( 'end' ) ).toBe( '2026-04-15' );
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/state/usePendingControls.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/usePendingControls.ts
@@ -1,0 +1,120 @@
+/**
+ * usePendingControls
+ *
+ * Draft/apply orchestration for the Insights global controls. The header
+ * controls edit a draft (the existing useDateRange / useComparisonMode hooks);
+ * a committed "applied" snapshot is what flows to the tabs, so no data refetch
+ * happens until the user applies a change. Applying a custom range, or any
+ * comparison-toggle change, routes through a confirmation modal; plain
+ * preset→preset changes commit immediately. The URL is written only on commit.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useDateRange, { type DateRange, type DateRangePreset } from './useDateRange';
+import useComparisonMode from './useComparisonMode';
+import { writeDateRangeUrl, writeComparisonUrl } from './controlsUrl';
+
+const rangeEqual = ( a: DateRange, b: DateRange ): boolean => a.preset === b.preset && a.start === b.start && a.end === b.end;
+
+export interface UsePendingControlsOptions {
+	defaultRange: DateRange;
+	defaultComparison: boolean;
+}
+
+export interface UsePendingControlsReturn {
+	draftRange: DateRange;
+	draftCompare: boolean;
+	setPreset: ( preset: DateRangePreset ) => void;
+	setCustom: ( start: string, end: string ) => void;
+	setCompare: ( enabled: boolean ) => void;
+	appliedRange: DateRange;
+	appliedPreviousRange: DateRange | null;
+	isDirty: boolean;
+	confirmOpen: boolean;
+	apply: () => void;
+	cancel: () => void;
+	confirmApply: () => void;
+}
+
+interface AppliedState {
+	range: DateRange;
+	previousRange: DateRange | null;
+	compare: boolean;
+}
+
+const usePendingControls = ( { defaultRange, defaultComparison }: UsePendingControlsOptions ): UsePendingControlsReturn => {
+	const { range: draftRange, setPreset, setCustom, setRange } = useDateRange( { defaultRange } );
+	const {
+		enabled: draftCompare,
+		setEnabled: setCompare,
+		previousRange: draftPreviousRange,
+	} = useComparisonMode( { defaultEnabled: defaultComparison, currentRange: draftRange } );
+
+	// Initial applied snapshot = initial draft (already hydrated from URL / boot).
+	const [ applied, setApplied ] = useState< AppliedState >( () => ( {
+		range: draftRange,
+		previousRange: draftPreviousRange,
+		compare: draftCompare,
+	} ) );
+
+	const [ confirmOpen, setConfirmOpen ] = useState( false );
+
+	const isDirty = useMemo(
+		() => ! rangeEqual( draftRange, applied.range ) || draftCompare !== applied.compare,
+		[ draftRange, draftCompare, applied ]
+	);
+
+	const commit = useCallback( () => {
+		setApplied( { range: draftRange, previousRange: draftPreviousRange, compare: draftCompare } );
+		writeDateRangeUrl( draftRange );
+		writeComparisonUrl( draftCompare );
+		setConfirmOpen( false );
+	}, [ draftRange, draftPreviousRange, draftCompare ] );
+
+	const apply = useCallback( () => {
+		if ( ! isDirty ) {
+			return;
+		}
+		// Custom ranges and any comparison change are the slow paths — confirm first.
+		const needsConfirm = draftRange.preset === 'custom' || draftCompare !== applied.compare;
+		if ( needsConfirm ) {
+			setConfirmOpen( true );
+			return;
+		}
+		commit();
+	}, [ isDirty, draftRange.preset, draftCompare, applied.compare, commit ] );
+
+	const cancel = useCallback( () => {
+		setRange( applied.range );
+		setCompare( applied.compare );
+		setConfirmOpen( false );
+	}, [ applied.range, applied.compare, setRange, setCompare ] );
+
+	const confirmApply = useCallback( () => {
+		commit();
+	}, [ commit ] );
+
+	return {
+		draftRange,
+		draftCompare,
+		setPreset,
+		setCustom,
+		setCompare,
+		appliedRange: applied.range,
+		appliedPreviousRange: applied.previousRange,
+		isDirty,
+		confirmOpen,
+		apply,
+		cancel,
+		confirmApply,
+	};
+};
+
+export default usePendingControls;

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -40,6 +40,11 @@
 		align-items: center;
 		justify-content: flex-end;
 		gap: 16px;
+		// Full width so `justify-content` actually positions the controls: the
+		// parent column sets `align-items: flex-end`, which would otherwise
+		// shrink this row to its content and keep it right-aligned even when the
+		// media query flips `justify-content` to flex-start at <=782px.
+		width: 100%;
 
 		@media ( max-width: 782px ) {
 			justify-content: flex-start;

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -24,20 +24,31 @@
 .newspack-insights {
 	color: wp-colors.$gray-900;
 
-	// Date range picker + comparison toggle row rendered via the
-	// Wizard's renderAboveSections slot. Sits above the section
-	// content, right-aligned to mirror the old header-right placement.
+	// Column: the controls row on top, the Apply / Cancel action row beneath,
+	// both right-aligned. Rendered via the Wizard's renderAboveSections slot.
 	&__header-controls {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 12px;
+		margin-bottom: 24px;
+	}
+
+	&__header-controls-row {
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: flex-end;
 		gap: 16px;
-		margin-bottom: 24px;
 
 		@media ( max-width: 782px ) {
 			justify-content: flex-start;
 		}
+	}
+
+	&__header-controls-actions {
+		display: flex;
+		gap: 8px;
 	}
 
 	// While a tab is loading (chunk Suspense fallback OR in-tab loading view),
@@ -256,6 +267,18 @@
 	&__info-callout-title {
 		margin: 0;
 		font-size: 14px;
+	}
+
+	&__confirm-modal-message {
+		margin: 0;
+	}
+
+	// Match the FeedbackModal action row: horizontal, right-aligned.
+	&__confirm-modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 24px;
 	}
 }
 

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -27,33 +27,28 @@
 	// Column: the controls row on top, the Apply / Cancel action row beneath,
 	// both right-aligned. Rendered via the Wizard's renderAboveSections slot.
 	&__header-controls {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-end;
-		gap: 12px;
-		margin-bottom: 24px;
-	}
-
-	&__header-controls-row {
+		align-items: flex-start;
 		display: flex;
 		flex-wrap: wrap;
-		align-items: center;
-		justify-content: flex-end;
 		gap: 16px;
-		// Full width so `justify-content` actually positions the controls: the
-		// parent column sets `align-items: flex-end`, which would otherwise
-		// shrink this row to its content and keep it right-aligned even when the
-		// media query flips `justify-content` to flex-start at <=782px.
-		width: 100%;
+		margin-bottom: 24px;
 
-		@media ( max-width: 782px ) {
-			justify-content: flex-start;
+		@media ( min-width: 783px ) {
+			align-items: center;
+			justify-content: flex-end;
+		}
+
+		.components-button.has-icon svg {
+			fill: wp-colors.$gray-900;
 		}
 	}
 
 	&__header-controls-actions {
 		display: flex;
-		gap: 8px;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: flex-start;
+		gap: 4px;
 	}
 
 	// While a tab is loading (chunk Suspense fallback OR in-tab loading view),
@@ -123,9 +118,9 @@
 		margin: 0;
 	}
 
-	// Date range picker
-
-	&__date-range-picker {
+	// Date range picker + comparison toggle
+	&__date-range-picker,
+	&__comparison-toggle {
 		display: flex;
 		align-items: center;
 		gap: 8px;
@@ -146,10 +141,11 @@
 		gap: 6px;
 
 		input[type="date"] {
-			font-size: 13px;
+			font-size: 12px;
+			min-height: 34px;
 			padding: 6px 8px;
 			border: 1px solid wp-colors.$gray-300;
-			border-radius: 4px;
+			border-radius: 2px;
 			background: #fff;
 			color: wp-colors.$gray-900;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changing the global date range (preset or custom) or the "Compare to previous period" toggle in the Insights wizard no longer refetches tab data immediately. Edits now stage as a pending change, guarding against unintended — and potentially slow — refetches from incidental control changes.

- An **Apply** button (secondary, small) and a **Cancel** button (borderless) appear beneath the date-range and compare controls, right-aligned, and only while the staged settings differ from what's currently displayed.
- **Apply** commits the change and refreshes the view; **Cancel** discards it and restores the controls to the displayed state.
- Applying a **custom date range**, or **any change to the compare toggle**, first shows a confirmation dialog — "The data for these settings may take a while to load. Continue?" — with Continue / Cancel. Switching between preset ranges (e.g. Last 7 → Last 90) applies immediately with no dialog.
- The URL (`?range` / `?start` / `?end` / `?compare`) now updates only when a change is applied, so it always reflects the data on screen (not an un-applied draft).

### How to test the changes in this Pull Request:

1. Open the Insights wizard (Newspack → Insights). Confirm no Apply/Cancel buttons show initially.
2. Change the date-range preset (e.g. Last 30 → Last 7 days). Confirm **Apply** (secondary, small) and **Cancel** (borderless) appear, stacked beneath the controls and right-aligned, and that no refetch has happened yet.
3. Click **Cancel** — the preset reverts to its previous value and the buttons disappear; no refetch occurs.
4. Change the preset again and click **Apply** — the view refreshes and the buttons disappear. Confirm there is **no** confirmation dialog for a preset→preset change.
5. Set the range to **Custom**, pick a start/end, and click **Apply** — the confirmation modal appears. Click **Continue** — the view loads the custom range.
6. Repeat step 5 but dismiss the modal via its **Cancel** button (and separately via Esc / clicking the overlay) — the change is discarded and the controls revert.
7. Toggle **Compare to previous period** and click **Apply** — the modal appears; **Continue** loads the comparison, **Cancel** discards it.
8. Apply a change, then reload the page — the URL reflects the applied settings and they persist. Confirm that mid-edit (before Apply) the URL does **not** change.
9. Confirm the controls still hide while a tab is loading, and that the layout holds on a narrow (< 782px) viewport.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
