### PR TITLE
test: short-circuit wp_mail in e2e-plugin so reader flows don't depend on mail delivery (NPPM-2919)

### DIFF
--- a/e2e/e2e-plugin.php
+++ b/e2e/e2e-plugin.php
@@ -54,27 +54,36 @@ add_action(
 );
 
 // Save outgoing emails as email_log CPT.
-add_action(
-	'wp_mail',
-	function ( $attributes ) {
-		$recipient = $attributes['to'];
-		if ( empty( $recipient ) ) {
-			return;
-		}
+// Capture outgoing mail into the sendbox AND short-circuit the real send.
+// Using `pre_wp_mail` (not the `wp_mail` action) lets us return success without
+// actually sending, so wp_mail() always reports true. Reader flows that branch
+// on wp_mail()'s return value — password reset, email change, account
+// verification — then show their success notice regardless of the site's real
+// mail deliverability; the captured copy in the sendbox is the suite's source of
+// truth. Hooking the action instead left the real (often failing) send in play,
+// which surfaced as "the email could not be sent" and broke those flows.
+add_filter(
+	'pre_wp_mail',
+	function ( $short_circuit, $attributes ) {
+		$recipient = is_array( $attributes['to'] ?? '' ) ? ( $attributes['to'][0] ?? '' ) : ( $attributes['to'] ?? '' );
 		// Only save emails sent to non-admin users.
-		$user = get_user_by( 'email', $recipient );
-		if ( $user && in_array( 'administrator', $user->roles ) ) {
-			return;
+		$user = $recipient ? get_user_by( 'email', $recipient ) : false;
+		if ( $recipient && ! ( $user && in_array( 'administrator', $user->roles, true ) ) ) {
+			$message = preg_replace( '/<\/title>.*?<div/s', '</title><div', $attributes['message'] );
+			wp_insert_post(
+				[
+					'post_title'   => $attributes['subject'] . ' (' . $recipient . ')',
+					'post_content' => $message,
+					'post_status'  => 'publish',
+					'post_type'    => 'email_log',
+				]
+			);
 		}
-		$attributes['message'] = preg_replace( '/<\/title>.*?<div/s', '</title><div', $attributes['message'] );
-		$post_data = [
-			'post_title'   => $attributes['subject'] . ' (' . $recipient . ')',
-			'post_content' => $attributes['message'],
-			'post_status'  => 'publish',
-			'post_type'    => 'email_log',
-		];
-		wp_insert_post( $post_data );
-	}
+		// Report success without a real send.
+		return true;
+	},
+	10,
+	2
 );
 
 // Display all sent emails.

--- a/e2e/e2e-plugin.php
+++ b/e2e/e2e-plugin.php
@@ -66,9 +66,14 @@ add_filter(
 	'pre_wp_mail',
 	function ( $short_circuit, $attributes ) {
 		$recipient = is_array( $attributes['to'] ?? '' ) ? ( $attributes['to'][0] ?? '' ) : ( $attributes['to'] ?? '' );
+		// No recipient: leave the value untouched so core still validates the
+		// input and returns false, rather than reporting a bogus success.
+		if ( empty( $recipient ) ) {
+			return $short_circuit;
+		}
 		// Only save emails sent to non-admin users.
-		$user = $recipient ? get_user_by( 'email', $recipient ) : false;
-		if ( $recipient && ! ( $user && in_array( 'administrator', $user->roles, true ) ) ) {
+		$user = get_user_by( 'email', $recipient );
+		if ( ! ( $user && in_array( 'administrator', $user->roles, true ) ) ) {
 			$message = preg_replace( '/<\/title>.*?<div/s', '</title><div', $attributes['message'] );
 			wp_insert_post(
 				[


### PR DESCRIPTION
### Root cause (reproduced on a live site)

`reader-registration.spec.ts` fails **consistently on staging** while passing locally. Root cause, confirmed by driving the flow on a live staging site with broken mail:

- The e2e helper captures outgoing mail with `add_action( 'wp_mail', … )` — it records the message to the `/_email` sendbox but **lets the real send proceed**, which returns `false` when the site can't actually deliver.
- Reader flows that branch on `wp_mail()`'s return value — password reset (`retrieve_password()`), email change, account verification — then set an **error** notice (*"The email could not be sent…"*) instead of the success notice the test asserts (e.g. *"Please check your email inbox…"*). The test times out waiting for text that was replaced by the error.
- The email itself **is** captured (the `wp_mail` action fires regardless), so it's purely the on-screen notice that breaks — at whichever send-dependent step hits the failure first (password reset, then email change, …).

### Fix

Switch the helper from the `wp_mail` **action** to the **`pre_wp_mail` filter**: capture the message to the sendbox as before, then `return true` to short-circuit the real send. `wp_mail()` always reports success, the success notices render, and the captured copy in `/_email` remains the suite's source of truth — decoupling the whole suite from the site's mail deliverability, and fixing every send-dependent step at once (not just one).

### Verification (live, before/after on the same broken-mail site)

| Config | Result |
| --- | --- |
| unmodified spec + old `wp_mail` action hook | ❌ fails at the password-reset notice |
| (a spec-only patch of just that step) | ❌ then fails at the email-change notice — same class |
| unmodified spec + this `pre_wp_mail` fix | ✅ passes end to end |

No test/spec changes needed — the fix is entirely in the helper plugin.

Supersedes #559 (which patched only the password-reset step in the spec).

Part of NPPM-2919.