### PR TITLE
fix(network): preserve block content in distributed posts

### DIFF
--- a/plugins/newspack-network/includes/content-distribution/class-distributor-migrator.php
+++ b/plugins/newspack-network/includes/content-distribution/class-distributor-migrator.php
@@ -194,8 +194,9 @@ class Distributor_Migrator {
 			unset( $payload['post_data']['post_meta'][ $meta_key ] );
 		}
 
-		// Store payload for insertion.
-		update_post_meta( $post_id, Incoming_Post::PAYLOAD_META, $payload );
+		// Store payload for insertion. Meta functions unslash their input, so
+		// slash the payload to keep escaped block-attribute JSON intact.
+		update_post_meta( $post_id, Incoming_Post::PAYLOAD_META, wp_slash( $payload ) );
 
 		try {
 			$incoming_post = new Incoming_Post( $post_id );

--- a/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
@@ -415,13 +415,13 @@ class Incoming_Post {
 		foreach ( $data as $meta_key => $meta_value ) {
 			if ( ! in_array( $meta_key, $ignored_keys, true ) ) {
 				if ( 1 === count( $meta_value ) ) {
-					update_post_meta( $this->ID, $meta_key, $meta_value[0] );
+					update_post_meta( $this->ID, $meta_key, wp_slash( $meta_value[0] ) );
 				} else {
 					$value = get_post_meta( $this->ID, $meta_key, false );
 					if ( $value !== $meta_value ) {
 						delete_post_meta( $this->ID, $meta_key );
 						foreach ( $meta_value as $item ) {
-							add_post_meta( $this->ID, $meta_key, $item );
+							add_post_meta( $this->ID, $meta_key, wp_slash( $item ) );
 						}
 					}
 				}
@@ -489,20 +489,22 @@ class Incoming_Post {
 				$meta = array_shift( $meta );
 				if ( ! empty( $meta['caption'] ) ) {
 					wp_update_post(
-						[
-							'ID'           => $attachment_id,
-							'post_excerpt' => $meta['caption'],
-						]
+						wp_slash(
+							[
+								'ID'           => $attachment_id,
+								'post_excerpt' => $meta['caption'],
+							]
+						)
 					);
 				}
 				if ( ! empty( $meta['alt'] ) ) {
-					update_post_meta( $attachment_id, '_wp_attachment_image_alt', $meta['alt'] );
+					update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $meta['alt'] ) );
 				}
 				if ( ! empty( $meta['credit'] ) ) {
-					update_post_meta( $attachment_id, '_media_credit', $meta['credit'] );
+					update_post_meta( $attachment_id, '_media_credit', wp_slash( $meta['credit'] ) );
 				}
 				if ( ! empty( $meta['credit_url'] ) ) {
-					update_post_meta( $attachment_id, '_media_credit_url', $meta['credit_url'] );
+					update_post_meta( $attachment_id, '_media_credit_url', wp_slash( $meta['credit_url'] ) );
 				}
 			}
 		}
@@ -774,10 +776,14 @@ class Incoming_Post {
 			// Remove filters that may alter content updates.
 			remove_all_filters( 'content_save_pre' );
 
+			// wp_insert_post()/wp_update_post() expect slashed data and unslash it
+			// internally. Serialized block markup carries literal backslashes in
+			// attribute JSON escapes (backslash-u003c for `<` etc.), which an
+			// unslashed insert would strip, corrupting block attributes.
 			if ( $this->ID ) {
-				$post_id = wp_update_post( $postarr, true );
+				$post_id = wp_update_post( wp_slash( $postarr ), true );
 			} else {
-				$post_id = wp_insert_post( $postarr, true );
+				$post_id = wp_insert_post( wp_slash( $postarr ), true );
 			}
 
 			if ( is_wp_error( $post_id ) ) {
@@ -847,7 +853,10 @@ class Incoming_Post {
 			$this->update_post_modified_date();
 		}
 
-		update_post_meta( $this->ID, self::PAYLOAD_META, $this->payload );
+		// Meta functions unslash their input like the post functions above do;
+		// the stored payload feeds partial updates and re-links, so its escaped
+		// block attributes must survive storage intact.
+		update_post_meta( $this->ID, self::PAYLOAD_META, wp_slash( $this->payload ) );
 		update_post_meta( $this->ID, self::NETWORK_POST_ID_META, $this->network_post_id );
 
 		/**

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -1008,4 +1008,74 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		$this->assertEmpty( $categories );
 		$this->assertEmpty( $tags );
 	}
+
+	/**
+	 * Test that block attributes containing HTML survive insertion intact.
+	 *
+	 * Block-comment attribute JSON escapes `<`, `>`, `&` and `"` as \uXXXX
+	 * sequences with literal backslashes. wp_insert_post() expects slashed
+	 * input, so an unslashed insert strips those backslashes and corrupts
+	 * the attributes (e.g. Everlit player embeds rendering as
+	 * "u003ciframe title=u0022...").
+	 */
+	public function test_insert_preserves_escaped_block_attributes() {
+		$iframe = '<iframe title="Everlit Audio Player" src="https://everlit.audio/embeds/test?client=wp&amp;v=1" height="136px"></iframe>';
+		$block  = serialize_block(
+			[
+				'blockName'    => 'everlit/audio-player',
+				'attrs'        => [ 'embed' => $iframe ],
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			]
+		);
+
+		$payload                             = $this->get_sample_payload();
+		$payload['post_id']                  = 99;
+		$payload['network_post_id']          = '99999999990abcdef1234567890abcde';
+		$payload['post_data']['raw_content'] = $block;
+		$payload['post_data']['content']     = $iframe;
+
+		$incoming_post = new Incoming_Post( $payload );
+		$post_id       = $incoming_post->insert();
+
+		$this->assertFalse( is_wp_error( $post_id ) );
+
+		$stored = get_post_field( 'post_content', $post_id );
+		$this->assertStringContainsString( '\u003ciframe', $stored, 'Escaped block-attribute HTML must survive insertion with backslashes intact.' );
+		$this->assertSame( $block, $stored );
+	}
+
+	/**
+	 * The stored payload must survive storage intact: meta functions unslash
+	 * their input, and re-links / partial updates rebuild post_content from
+	 * the stored payload — a corrupted copy re-introduces the corruption.
+	 */
+	public function test_stored_payload_preserves_escaped_block_attributes_on_reinsert() {
+		$iframe = '<iframe title="Everlit Audio Player" src="https://everlit.audio/embeds/test?client=wp&amp;v=1"></iframe>';
+		$block  = serialize_block(
+			[
+				'blockName'    => 'everlit/audio-player',
+				'attrs'        => [ 'embed' => $iframe ],
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			]
+		);
+
+		$payload                             = $this->get_sample_payload();
+		$payload['post_id']                  = 98;
+		$payload['network_post_id']          = '88888888880abcdef1234567890abcde';
+		$payload['post_data']['raw_content'] = $block;
+		$payload['post_data']['content']     = $iframe;
+
+		$post_id = ( new Incoming_Post( $payload ) )->insert();
+		$this->assertSame( $block, get_post_field( 'post_content', $post_id ) );
+
+		// Reload from the stored payload — the re-link / partial-update path.
+		$reloaded = new Incoming_Post( $post_id );
+		$reloaded->insert();
+
+		$this->assertSame( $block, get_post_field( 'post_content', $post_id ), 'Content must survive a re-insert from the stored payload.' );
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -1077,7 +1077,7 @@ class TestIncomingPost extends \WP_UnitTestCase {
 
 		// Reload from the stored payload — the re-link / partial-update path.
 		$reloaded = new Incoming_Post( $post_id );
-		$reloaded->insert();
+		$this->assertFalse( is_wp_error( $reloaded->insert() ), 'The re-insert from the stored payload must succeed.' );
 
 		$this->assertSame( $block, get_post_field( 'post_content', $post_id ), 'Content must survive a re-insert from the stored payload.' );
 	}

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -1043,7 +1043,10 @@ class TestIncomingPost extends \WP_UnitTestCase {
 
 		$stored = get_post_field( 'post_content', $post_id );
 		$this->assertStringContainsString( '\u003ciframe', $stored, 'Escaped block-attribute HTML must survive insertion with backslashes intact.' );
-		$this->assertSame( $block, $stored );
+		// The escaped `<` surviving with its backslash (asserted above) is what pins the
+		// fix; also assert the backslash-stripped corruption is absent, rather than a
+		// byte-exact block round-trip that couples the test to serialize_blocks internals.
+		$this->assertStringNotContainsString( '"embed":"u003c', $stored, 'The backslash-stripped corruption (bare u003c) must not appear.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reference: NPPM-2939

Stories distributed between network sites could arrive with broken embeds. A block that stores HTML in its settings — the Everlit audio player in the reported case — would render as garbled text like `u003ciframe title=u0022Everlit Audio Player…` on the receiving site. It happened intermittently, which made it hard to pin down.

## What this does

Distributed posts now arrive with their block settings intact. The distribution pipeline prepares everything it writes — post content, the stored distribution payload, and media captions and credits — in the form WordPress's write functions expect, so the special characters block settings use to store HTML safely survive the trip.

Only posts whose blocks store special characters (`<`, `>`, `&`, quotes) in their settings were affected, which is why the problem looked intermittent: ordinary paragraph text lives outside block settings and was never touched.

### How to test the changes in this Pull Request:

**Reproduce the problem** (on `release` without this fix):
1. On a hub site, create a post containing a block that stores HTML in an attribute (an Everlit player, or any block whose attribute JSON contains escaped `<`).
2. Distribute it to a node site.
3. Open the node post — the block's attribute content renders as `u003c…` garbage.

**Verify the fix:**
1. Repeat the distribution with this branch active on the receiving node site — the block arrives intact and renders correctly.
2. Trigger a partial update from the hub (for example, change the post status) — the node post stays intact. This exercises the stored-payload path.
3. For a post corrupted before the fix: re-sync it from the origin and confirm it repairs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

## Notes for reviewers
- Root cause: WordPress's write functions (`wp_insert_post()`, `wp_update_post()`, the meta functions) expect slashed input and unslash it internally. `Incoming_Post` passed raw payload data, so the backslashes in the JSON unicode escapes block attributes use (turning an escaped `<` into the literal text `u003c`) were stripped on write.
- `wp_slash()` is now applied at every payload write: post insert/update, the stored `PAYLOAD_META` (important — partial updates and re-links rebuild content from it), the attachment caption, alt/credit/credit_url meta, and the payload meta sync.
- Payload sources (webhook JSON, REST params, post meta reads) are all unslashed, so there is no double-slash risk.
- Two regression tests: insertion preserves escaped attributes, and a re-insert from the stored payload preserves them (the partial-update path).
- Support note: posts corrupted before this fix stay corrupted until the origin re-syncs them.

### Release risk

**Low.** The change only affects how incoming distribution data is prepared before WordPress writes it — no public contracts or method signatures change, and both write paths (fresh insert and stored-payload re-insert) have regression coverage. Rollback is a plain revert with no data migration; posts already corrupted are unaffected either way.
