### PR TITLE
refactor(insights): popups use shared CTA classifier (NPPD-1887)

### DIFF
--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -928,11 +928,20 @@ class Donations {
 	 * @return void
 	 */
 	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
-		if ( ! empty( $values['newspack_popup_id'] ) ) {
-			$order->add_meta_data( '_newspack_popup_id', $values['newspack_popup_id'] );
-		}
-		if ( ! empty( $values['prompt_title'] ) ) {
-			$order->add_meta_data( '_prompt_title', $values['prompt_title'] );
+		// The popup id is client-supplied, and since NPPD-1887 it can be replayed from
+		// sessionStorage onto a donation form on a landing page. Verify it names a real
+		// prompt before writing it into order meta — Insights reads `_newspack_popup_id`
+		// as a prompt identity. `Newspack_Popups` is only defined when Campaigns is
+		// active; without it there is no prompt to attribute to anyway.
+		$popup_id = ! empty( $values['newspack_popup_id'] ) ? (int) $values['newspack_popup_id'] : 0;
+		$is_prompt = 0 < $popup_id
+			&& class_exists( 'Newspack_Popups' )
+			&& \Newspack_Popups::NEWSPACK_POPUPS_CPT === get_post_type( $popup_id );
+		if ( $is_prompt ) {
+			$order->add_meta_data( '_newspack_popup_id', $popup_id );
+			if ( ! empty( $values['prompt_title'] ) ) {
+				$order->add_meta_data( '_prompt_title', $values['prompt_title'] );
+			}
 		}
 		if ( ! empty( $values['referer'] ) ) {
 			$order->add_meta_data( '_newspack_referer', $values['referer'] );

--- a/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
@@ -22,16 +22,6 @@ final class Newspack_Popups_Data_Api {
 	protected static $popups = [];
 
 	/**
-	 * Memoized site conversion URLs for block-less CTA classification.
-	 *
-	 * See get_site_conversion_urls(). A class property (rather than a
-	 * function-local static) so it can be reset between tests.
-	 *
-	 * @var array|null
-	 */
-	private static $conversion_urls_cache = null;
-
-	/**
 	 * Registers the hooks.
 	 */
 	public static function init() {
@@ -209,307 +199,72 @@ final class Newspack_Popups_Data_Api {
 	}
 
 	/**
+	 * Whether the shared classifier (newspack-plugin) is available.
+	 *
+	 * The classifier moved to \Newspack\CTA_Intent_Classifier in NPPD-1887 so that
+	 * content gates could use it without depending on Campaigns. When newspack-plugin
+	 * is inactive we degrade silently to "no inferred intent" — the same contract
+	 * segmentation already has with \Newspack\Reader_Data.
+	 *
+	 * @return bool
+	 */
+	private static function has_classifier() {
+		return class_exists( '\Newspack\CTA_Intent_Classifier' );
+	}
+
+	/**
 	 * Classify a block-less prompt by its button link target(s).
 	 *
-	 * Only conversion-legible or clearly non-conversion targets return a value;
-	 * anything ambiguous returns null and the prompt stays 'undefined' (precision
-	 * over recall — a false conversion label is worse than an honest blank).
+	 * Delegates to \Newspack\CTA_Intent_Classifier::classify_content().
 	 *
 	 * @param string $content The prompt post_content.
 	 * @return array|null ['intent' => string, 'source' => string] or null to abstain.
 	 */
 	public static function classify_blockless_cta( $content ) {
-		$hrefs = self::extract_button_hrefs( $content );
-		if ( empty( $hrefs ) ) {
-			return null;
-		}
-
-		$config = self::get_site_conversion_urls();
-
-		// Classify every button; a prompt can hold more than one.
-		$hits = [];
-		foreach ( $hrefs as $href ) {
-			$hit = self::classify_href( $href, $config );
-			if ( $hit ) {
-				$hits[] = $hit;
-			}
-		}
-		if ( empty( $hits ) ) {
-			return null;
-		}
-
-		// Resolution when buttons disagree: a conversion intent wins over a
-		// non-conversion one; if two DIFFERENT conversion intents appear, abstain
-		// (don't guess). Precedence within conversion: donation, newsletter, subscription.
-		$precedence     = [
-			'donation'     => 1,
-			'newsletter'   => 2,
-			'subscription' => 3,
-		];
-		$conversion     = [];
-		$non_conversion = [];
-		foreach ( $hits as $hit ) {
-			if ( isset( $precedence[ $hit['intent'] ] ) ) {
-				$conversion[] = $hit;
-			} else {
-				$non_conversion[] = $hit;
-			}
-		}
-
-		if ( ! empty( $conversion ) ) {
-			$distinct = array_unique( array_column( $conversion, 'intent' ) );
-			if ( 1 < count( $distinct ) ) {
-				return null; // Conflicting conversion signals -> abstain.
-			}
-			// All remaining hits share one intent, so break ties on source confidence
-			// (site_config > processor > pattern) for a deterministic, best-available source.
-			$source_rank = [
-				'site_config' => 1,
-				'processor'   => 2,
-				'pattern'     => 3,
-			];
-			usort(
-				$conversion,
-				function ( $a, $b ) use ( $source_rank ) {
-					return ( $source_rank[ $a['source'] ] ?? PHP_INT_MAX ) <=> ( $source_rank[ $b['source'] ] ?? PHP_INT_MAX );
-				}
-			);
-			return $conversion[0];
-		}
-
-		// Only non-conversion signals: report the first (sponsor/editorial/event) so
-		// the dashboard can show a non-conversion label instead of a bare "undefined".
-		return $non_conversion[0];
+		return self::has_classifier() ? \Newspack\CTA_Intent_Classifier::classify_content( $content ) : null;
 	}
 
 	/**
 	 * Pull hrefs from core/button blocks in the prompt content.
 	 *
-	 * Scope is intentionally limited to button blocks (not every <a> in body copy)
-	 * to keep precision high. Reuses the recursive get_block_data() helper, so
-	 * buttons nested inside core/buttons wrappers are covered.
+	 * Delegates to \Newspack\CTA_Intent_Classifier::extract_button_hrefs().
 	 *
 	 * @param string $content The prompt post_content.
 	 * @return string[] Lowercased hrefs.
 	 */
 	public static function extract_button_hrefs( $content ) {
-		$blocks  = \parse_blocks( $content );
-		$buttons = self::get_block_data( 'core/button', $blocks );
-		$hrefs   = [];
-		foreach ( $buttons as $button ) {
-			$url = $button['attrs']['url'] ?? '';
-			if ( empty( $url ) && ! empty( $button['innerHTML'] ) ) {
-				// Older button blocks store the href only in the saved markup.
-				if ( preg_match( '/href="([^"]+)"/i', $button['innerHTML'], $matches ) ) {
-					$url = $matches[1];
-				}
-			}
-			if ( ! empty( $url ) ) {
-				$hrefs[] = strtolower( $url );
-			}
-		}
-		return $hrefs;
+		return self::has_classifier() ? \Newspack\CTA_Intent_Classifier::extract_button_hrefs( $content ) : [];
 	}
 
 	/**
-	 * Classify a single href. Precedence:
-	 *   1) site-configured conversion URLs (highest confidence; catches the
-	 *      unguessable cases like a bespoke on-site donation page),
-	 *   2) known third-party processor domains,
-	 *   3) path / substring patterns,
-	 *   4) non-conversion tells (event, sponsor, editorial),
-	 *   else null (abstain).
+	 * Classify a single href.
 	 *
-	 * @param string $href   Lowercased href.
-	 * @param array  $config Output of get_site_conversion_urls().
+	 * Delegates to \Newspack\CTA_Intent_Classifier::classify_href().
+	 *
+	 * @param string     $href   Lowercased href.
+	 * @param array|null $config Output of get_site_conversion_urls().
 	 * @return array|null ['intent' => string, 'source' => string] or null.
 	 */
-	public static function classify_href( $href, $config ) {
-		// 1) Site config (substring match against this site's own configured URLs).
-		foreach ( [ 'donation', 'newsletter', 'subscription' ] as $intent ) {
-			foreach ( $config[ $intent ] as $configured ) {
-				if ( $configured && str_contains( $href, $configured ) ) {
-					return [
-						'intent' => $intent,
-						'source' => 'site_config',
-					];
-				}
-			}
-		}
-
-		// 2) Processor domains (empirically ranked in NPPD-1836; fundjournalism dominant).
-		$donation_processors = [ 'fundjournalism', 'donorbox', 'actblue', 'fundraiseup', 'classy.org', 'givebutter' ];
-		foreach ( $donation_processors as $needle ) {
-			if ( str_contains( $href, $needle ) ) {
-				return [
-					'intent' => 'donation',
-					'source' => 'processor',
-				];
-			}
-		}
-		// giving.<institution>.edu (e.g. giving.umich.edu) — institutional donation.
-		if ( preg_match( '#://giving\.[^/]+\.edu#', $href ) ) {
-			return [
-				'intent' => 'donation',
-				'source' => 'processor',
-			];
-		}
-
-		// 3) Path / substring patterns. Substring (not slash-anchored) on purpose, so
-		// membership fragments and newslettersignup slugs are caught (NPPD-1836).
-		// Order matters: donation, then newsletter, then subscription.
-		// (?<![a-z]) applies only to the keyword branch so mid-word matches (e.g. "member"
-		// inside "remember") don't false-positive; the href is already lowercased. Digits,
-		// "-", "/", "#" and start-of-string are all valid boundaries, so "/donate",
-		// "-membership" and "#...-membership" still match. /give and /support stay
-		// slash-anchored exactly as before.
-		if ( preg_match( '/(?<![a-z])(?:donate|donation|contribute|donor|member|membership)|\/give\b|\/support\b/', $href ) ) {
-			return [
-				'intent' => 'donation',
-				'source' => 'pattern',
-			];
-		}
-		if ( str_contains( $href, 'newsletter' ) ) {
-			return [
-				'intent' => 'newsletter',
-				'source' => 'pattern',
-			];
-		}
-		if ( preg_match( '#://(account|app|subscribe|checkout|my-?account)\.#', $href )
-			|| preg_match( '/subscribe|subscription|\/checkout|my-?account|\/offer|\/join\b|\/digital|\/plans|\/pricing/', $href ) ) {
-			return [
-				'intent' => 'subscription',
-				'source' => 'pattern',
-			];
-		}
-
-		// 4) Non-conversion tells.
-		// Sponsor/ad: outbound link tagged utm_medium=referral.
-		// TODO(confirm): compare utm_source to the site slug/home host rather than
-		// matching the medium literally.
-		if ( str_contains( $href, 'utm_medium=referral' ) && self::is_external_host( $href ) ) {
-			return [
-				'intent' => 'sponsor',
-				'source' => 'pattern',
-			];
-		}
-		// Event / ticketing.
-		if ( preg_match( '#/events?(/|$)|eventbrite|tribfest|/fest\b#', $href ) ) {
-			return [
-				'intent' => 'event',
-				'source' => 'pattern',
-			];
-		}
-		// Editorial / navigation on this site's own domain (article slugs, author pages).
-		if ( ! self::is_external_host( $href )
-			&& preg_match( '#/[0-9]{4}/[0-9]{2}/|/author/|/[a-z0-9]+(?:-[a-z0-9]+){2,}(/[a-z]+)?/?($|\?)#', $href ) ) {
-			return [
-				'intent' => 'editorial',
-				'source' => 'pattern',
-			];
-		}
-
-		// Abstain: query-param forms (?form=), bare homepages, unrecognized externals.
-		return null;
+	public static function classify_href( $href, $config = null ) {
+		return self::has_classifier() ? \Newspack\CTA_Intent_Classifier::classify_href( $href, $config ) : null;
 	}
 
 	/**
-	 * This site's configured conversion URLs, normalized to lowercase host+path
-	 * fragments suitable for str_contains() matching. Memoized per request.
+	 * This site's configured conversion URLs.
 	 *
-	 * Side-effect-free by design: the donation page URL is read from the
-	 * newspack_donation_page_id option, NOT \Newspack\Donations::get_donation_page_info(),
-	 * which creates the page via wp_insert_post when none exists — unsafe on this
-	 * per-render path.
-	 *
-	 * Coverage ceiling: covers WooCommerce publishers whose button links to their own
-	 * donation page, checkout, or my-account. External processor URLs (fundjournalism
-	 * etc.) and bespoke campaign landing pages are not stored by Newspack — those are
-	 * handled by the processor dictionary and patterns in classify_href(), or not at all.
+	 * Delegates to \Newspack\CTA_Intent_Classifier::get_site_conversion_urls().
 	 *
 	 * @return array{donation:string[],newsletter:string[],subscription:string[]}
 	 */
 	public static function get_site_conversion_urls() {
-		if ( null !== self::$conversion_urls_cache ) {
-			return self::$conversion_urls_cache;
+		if ( ! self::has_classifier() ) {
+			return [
+				'donation'     => [],
+				'newsletter'   => [],
+				'subscription' => [],
+			];
 		}
-
-		$urls = [
-			'donation'     => [],
-			'newsletter'   => [],
-			'subscription' => [],
-		];
-
-		// Donation: on-site donation page, read from the option (no side effects).
-		if ( class_exists( '\Newspack\Donations' ) ) {
-			$page_id = \get_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION, 0 );
-			if ( $page_id && 'page' === \get_post_type( $page_id ) ) {
-				$urls['donation'][] = self::normalize_url( \get_permalink( $page_id ) );
-			}
-		}
-
-		// Subscription / checkout.
-		if ( function_exists( 'wc_get_checkout_url' ) ) {
-			$urls['subscription'][] = self::normalize_url( wc_get_checkout_url() );
-		}
-		if ( function_exists( 'wc_get_page_permalink' ) ) {
-			$urls['subscription'][] = self::normalize_url( wc_get_page_permalink( 'myaccount' ) );
-		}
-
-		// Newsletter: nothing to wire — Newspack has no configured newsletter page
-		// (signup is the inline subscribe block). Newsletter recovery is pattern-only.
-
-		// Drop empties and any URL that normalized to a bare host with no meaningful
-		// path (e.g. a non-pretty permalink collapsing to "host/"), which would
-		// otherwise substring-match every same-host link.
-		foreach ( $urls as $key => $list ) {
-			$urls[ $key ] = array_values(
-				array_filter(
-					$list,
-					static function ( $normalized ) {
-						return '' !== $normalized && 1 === preg_match( '#/[^/]#', $normalized );
-					}
-				)
-			);
-		}
-
-		self::$conversion_urls_cache = $urls;
-		return self::$conversion_urls_cache;
-	}
-
-	/**
-	 * Normalize a full URL to a lowercased host+path fragment for matching.
-	 *
-	 * @param string $url URL.
-	 * @return string
-	 */
-	private static function normalize_url( $url ) {
-		if ( empty( $url ) ) {
-			return '';
-		}
-		$parts = \wp_parse_url( strtolower( $url ) );
-		if ( empty( $parts['host'] ) ) {
-			return '';
-		}
-		$host = preg_replace( '/^www\./', '', $parts['host'] );
-		return $host . ( $parts['path'] ?? '' );
-	}
-
-	/**
-	 * Is this href pointing off the current site's host?
-	 *
-	 * @param string $href Lowercased href.
-	 * @return bool
-	 */
-	private static function is_external_host( $href ) {
-		$href_host = \wp_parse_url( $href, PHP_URL_HOST );
-		$home_host = \wp_parse_url( strtolower( \home_url() ), PHP_URL_HOST );
-		if ( empty( $href_host ) || empty( $home_host ) ) {
-			return false;
-		}
-		$href_host = preg_replace( '/^www\./', '', $href_host );
-		$home_host = preg_replace( '/^www\./', '', $home_host );
-		return $href_host !== $home_host;
+		return \Newspack\CTA_Intent_Classifier::get_site_conversion_urls();
 	}
 
 	/**
@@ -612,12 +367,42 @@ final class Newspack_Popups_Data_Api {
 	 * @return void
 	 */
 	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
-		if ( ! empty( $values['newspack_popup_id'] ) ) {
-			$order->add_meta_data( '_newspack_popup_id', $values['newspack_popup_id'] );
+		if ( empty( $values['newspack_popup_id'] ) ) {
+			return;
 		}
+		$popup_id = self::get_valid_popup_id( $values['newspack_popup_id'] );
+		if ( false === $popup_id ) {
+			return;
+		}
+		$order->add_meta_data( '_newspack_popup_id', $popup_id );
 		if ( ! empty( $values['prompt_title'] ) ) {
 			$order->add_meta_data( '_prompt_title', $values['prompt_title'] );
 		}
+	}
+
+	/**
+	 * Is this a real prompt post?
+	 *
+	 * The id arrives from a client-supplied form field — the hidden input the prompt
+	 * injects into its own forms. Since NPPD-1887 it can also be REPLAYED from
+	 * sessionStorage onto a landing-page checkout form, which widens the surface enough
+	 * to be worth checking before writing it into order meta: Insights reads
+	 * `_newspack_popup_id` as a prompt identity, and an arbitrary integer would silently
+	 * corrupt the per-prompt breakdown.
+	 *
+	 * Returns the CAST id, not a bool, so the caller persists the integer rather than the
+	 * raw candidate. `(int) '123 OR 1=1'` is 123 — validating the cast while writing the
+	 * original would let a malformed string land in `_newspack_popup_id`.
+	 *
+	 * @param mixed $popup_id Candidate post ID.
+	 * @return int|false The validated prompt post ID, or false.
+	 */
+	private static function get_valid_popup_id( $popup_id ) {
+		$popup_id = (int) $popup_id;
+		if ( 0 >= $popup_id ) {
+			return false;
+		}
+		return Newspack_Popups::NEWSPACK_POPUPS_CPT === get_post_type( $popup_id ) ? $popup_id : false;
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/bootstrap.php
+++ b/plugins/newspack-popups/tests/bootstrap.php
@@ -30,6 +30,21 @@ function _manually_load_plugin() {
 	require dirname( __DIR__ ) . '/src/blocks/custom-placement/view.php';
 	require dirname( __DIR__ ) . '/includes/class-newspack-popups-exporter.php';
 	require dirname( __DIR__ ) . '/includes/class-newspack-popups-importer.php';
+
+	// The CTA intent classifier lives in newspack-plugin (NPPD-1887), which this
+	// suite does not load. Pull in just that one dependency-free class when the
+	// sibling checkout is present (always, in the monorepo and in CI) so the
+	// block-less CTA tests exercise the real classifier.
+	//
+	// When it is absent — e.g. running this suite from a standalone newspack-popups
+	// checkout — Data_Api degrades to "no inferred intent" by design, and DataApiTest
+	// SKIPS entirely (see its require_classifier()). The degradation itself is
+	// guaranteed by the class_exists guards in Data_Api, not by a test: it cannot be
+	// asserted in the same process once the class is loaded.
+	$classifier = dirname( __DIR__, 2 ) . '/newspack-plugin/includes/class-cta-intent-classifier.php';
+	if ( file_exists( $classifier ) ) {
+		require_once $classifier;
+	}
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/plugins/newspack-popups/tests/test-data-api.php
+++ b/plugins/newspack-popups/tests/test-data-api.php
@@ -20,17 +20,34 @@ class DataApiTest extends WP_UnitTestCase {
 
 	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		parent::set_up();
+		$this->require_classifier();
 		$this->reset_conversion_cache();
 	}
 
 	/**
 	 * Reset the memoized conversion-URL cache (it is per-request; tests that change
 	 * options or permalinks after a prior call must reset before re-reading).
+	 *
+	 * The cache moved with the classifier into newspack-plugin (NPPD-1887); the
+	 * bootstrap loads that one class from the sibling checkout.
 	 */
 	private function reset_conversion_cache() {
-		$property = new \ReflectionProperty( 'Newspack_Popups_Data_Api', 'conversion_urls_cache' );
-		$property->setAccessible( true );
-		$property->setValue( null, null );
+		if ( class_exists( '\Newspack\CTA_Intent_Classifier' ) ) {
+			\Newspack\CTA_Intent_Classifier::reset_cache();
+		}
+	}
+
+	/**
+	 * Skip when the shared classifier isn't loadable.
+	 *
+	 * Data_Api then degrades to "no inferred intent" by design (NPPD-1887). That
+	 * degradation can't be asserted in the same process once the class IS loaded,
+	 * so it's covered by the class_exists guards in Data_Api rather than a test.
+	 */
+	private function require_classifier() {
+		if ( ! class_exists( '\Newspack\CTA_Intent_Classifier' ) ) {
+			$this->markTestSkipped( 'newspack-plugin (CTA_Intent_Classifier) is not available.' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Refs [NPPD-1887](https://linear.app/a8c/issue/NPPD-1887/insights-credit-gates-and-prompts-for-conversions-that-happen-on-a). **Trimmed to prompts-only** — the gate capture shipped separately via #575 (→ `release`) and has since promoted onto `feat/insights-rsm`, so this PR now carries only the parts unique to the popups/prompts side.

Originally this PR was the full gate + prompts capture. #575 carved out the gate half and merged to `release`; that half then reached `insights-rsm` via the normal promotion. Keeping the gate commits here would have duplicated it (and did — that's what caused the merge conflict). Rewritten to the delta.

## What's left (4 files, net −174 lines)

1. **De-duplicate the classifier.** The promotion put `Newspack\CTA_Intent_Classifier` on `insights-rsm`, but newspack-popups still had its own inline copy (NPPD-1837). This removes that inline implementation and delegates to the shared class behind a `class_exists` guard — degrading to "no inferred intent" when newspack-plugin is absent, the same contract segmentation already has with `Reader_Data`. (The bulk of the −289 lines.)
2. **Validate `newspack_popup_id` before writing order meta** (`class-donations.php` + the popups line-item writer) — mirrors the gate-side validation from #575.
3. **Test wiring** — the popups suite loads the shared classifier from the sibling checkout and skips gracefully when it's absent.

## Not in this PR

This is classifier **de-duplication + validation hardening**, *not* prompt landing-page capture. The click→persist wiring for prompts is still Phase 3, gated behind the [NPPD-1888](https://linear.app/a8c/issue/NPPD-1888) binary-capability decision.

## Testing

- newspack-popups `DataApiTest`: **17/17 pass** against current `insights-rsm` — the delegation resolves against the real shared classifier.
- Rebased clean onto `feat/insights-rsm` (no overlap with the gate files).