### PR TITLE
fix(active-campaign): keep signups working after field tag edits

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1999,8 +1999,40 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$existing_fields = $this->get_all_contact_fields();
 			foreach ( $contact['metadata'] as $field_title => $value ) {
 				$field_perstag = strtoupper( str_replace( '-', '_', sanitize_title( $field_title ) ) );
-				/** For optimization, don't add the field if it already exists. */
-				if ( is_wp_error( $existing_fields ) || false === array_search( $field_perstag, array_column( $existing_fields, 'perstag' ) ) ) {
+
+				/**
+				 * For optimization, don't add the field if it already exists.
+				 * Match by perstag first, then by title — an ActiveCampaign
+				 * admin may have renamed a field's perstag, and creating a
+				 * field with a duplicate title fails.
+				 */
+				$existing_index = false;
+				if ( ! is_wp_error( $existing_fields ) ) {
+					// Index-preserving lookups: array_column() would reindex and skip
+					// rows missing the key, mapping a match to the wrong field.
+					foreach ( $existing_fields as $index => $existing_field ) {
+						if ( isset( $existing_field['perstag'] ) && $existing_field['perstag'] === $field_perstag ) {
+							$existing_index = $index;
+							break;
+						}
+					}
+					if ( false === $existing_index ) {
+						foreach ( $existing_fields as $index => $existing_field ) {
+							if (
+								isset( $existing_field['title'], $existing_field['perstag'] ) &&
+								0 === strcasecmp( trim( $existing_field['title'] ), trim( $field_title ) )
+							) {
+								$existing_index = $index;
+								break;
+							}
+						}
+					}
+				}
+
+				if ( false !== $existing_index ) {
+					/** Use the existing field's actual perstag — it may differ from the generated one. */
+					$field_perstag = $existing_fields[ $existing_index ]['perstag'];
+				} else {
 					$field_res = $this->api_v3_request(
 						'fields',
 						'POST',
@@ -2018,7 +2050,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 						]
 					);
 					if ( \is_wp_error( $field_res ) ) {
-						return $field_res;
+						/** A field that can't be registered must never block the signup — sync the contact without it. */
+						Newspack_Newsletters_Logger::log( 'Error creating ActiveCampaign field "' . $field_title . '": ' . $field_res->get_error_message() );
+						continue;
 					}
 					/** Set list relation. */
 					$this->api_v3_request(

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -2010,8 +2010,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				if ( ! is_wp_error( $existing_fields ) ) {
 					// Index-preserving lookups: array_column() would reindex and skip
 					// rows missing the key, mapping a match to the wrong field.
+					// A row with an empty perstag can't supply a usable payload key, so
+					// it must never match — `! empty()` rather than `isset()`.
 					foreach ( $existing_fields as $index => $existing_field ) {
-						if ( isset( $existing_field['perstag'] ) && $existing_field['perstag'] === $field_perstag ) {
+						if ( ! empty( $existing_field['perstag'] ) && $existing_field['perstag'] === $field_perstag ) {
 							$existing_index = $index;
 							break;
 						}
@@ -2019,7 +2021,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					if ( false === $existing_index ) {
 						foreach ( $existing_fields as $index => $existing_field ) {
 							if (
-								isset( $existing_field['title'], $existing_field['perstag'] ) &&
+								! empty( $existing_field['title'] ) && ! empty( $existing_field['perstag'] ) &&
 								0 === strcasecmp( trim( $existing_field['title'] ), trim( $field_title ) )
 							) {
 								$existing_index = $index;
@@ -2032,6 +2034,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				if ( false !== $existing_index ) {
 					/** Use the existing field's actual perstag — it may differ from the generated one. */
 					$field_perstag = $existing_fields[ $existing_index ]['perstag'];
+				} elseif ( empty( $field_perstag ) ) {
+					/**
+					 * The title sanitized down to nothing, so there's no perstag to create the
+					 * field under and no valid payload key to write to. Skip rather than emit a
+					 * malformed `field[%%,0]` key that two such fields would collide on.
+					 */
+					error_log( '[NEWSPACK-NEWSLETTERS]: Skipped ActiveCampaign field "' . $field_title . '": title produced an empty perstag.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					continue;
 				} else {
 					$field_res = $this->api_v3_request(
 						'fields',

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -2040,7 +2040,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					 * field under and no valid payload key to write to. Skip rather than emit a
 					 * malformed `field[%%,0]` key that two such fields would collide on.
 					 */
-					error_log( '[NEWSPACK-NEWSLETTERS]: Skipped ActiveCampaign field "' . $field_title . '": title produced an empty perstag.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( '[NEWSPACK-NEWSLETTERS]: Skipped ActiveCampaign field "' . sanitize_text_field( $field_title ) . '": title produced an empty perstag.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					continue;
 				} else {
 					$field_res = $this->api_v3_request(
@@ -2068,8 +2068,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 						 * no-ops unless NEWSPACK_LOG_LEVEL is defined — undefined on a default
 						 * production site. The dropped field carries Reader Activation data that
 						 * segments and automations key on, so it must stay diagnosable.
+						 *
+						 * Both interpolated values are sanitized: the error message is remote
+						 * API text, and a newline in it would forge a second log line.
 						 */
-						error_log( '[NEWSPACK-NEWSLETTERS]: Error creating ActiveCampaign field "' . $field_title . '": ' . $field_res->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						error_log( '[NEWSPACK-NEWSLETTERS]: Error creating ActiveCampaign field "' . sanitize_text_field( $field_title ) . '": ' . sanitize_text_field( $field_res->get_error_message() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 						continue;
 					}
 					/** Set list relation. */

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -2060,8 +2060,16 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 						]
 					);
 					if ( \is_wp_error( $field_res ) ) {
-						/** A field that can't be registered must never block the signup — sync the contact without it. */
-						Newspack_Newsletters_Logger::log( 'Error creating ActiveCampaign field "' . $field_title . '": ' . $field_res->get_error_message() );
+						/**
+						 * A field that can't be registered must never block the signup — sync the
+						 * contact without it.
+						 *
+						 * Logged with error_log() rather than Newspack_Newsletters_Logger, which
+						 * no-ops unless NEWSPACK_LOG_LEVEL is defined — undefined on a default
+						 * production site. The dropped field carries Reader Activation data that
+						 * segments and automations key on, so it must stay diagnosable.
+						 */
+						error_log( '[NEWSPACK-NEWSLETTERS]: Error creating ActiveCampaign field "' . $field_title . '": ' . $field_res->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 						continue;
 					}
 					/** Set list relation. */

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
@@ -138,7 +138,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 			],
 		];
 
-		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods, phpcsSniffs.Newsletters.ForbiddenContactsMethods.ForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader@example.net',
@@ -158,7 +158,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 	public function test_field_create_failure_does_not_block_signup() {
 		$this->remote_fields = []; // Field genuinely missing; create will fail with 422.
 
-		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods, phpcsSniffs.Newsletters.ForbiddenContactsMethods.ForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader2@example.net',
@@ -186,7 +186,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 			],
 		];
 
-		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods, phpcsSniffs.Newsletters.ForbiddenContactsMethods.ForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader3@example.net',
@@ -229,7 +229,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 			],
 		];
 
-		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods, phpcsSniffs.Newsletters.ForbiddenContactsMethods.ForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader4@example.net',

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
@@ -96,7 +96,17 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 		}
 		if ( false !== strpos( $url, '/api/3/fields' ) && 'POST' === $args['method'] ) {
 			$this->called_actions[] = 'v3:fields:create';
-			return $respond( 422, [ 'errors' => [ [ 'code' => 'duplicate', 'title' => 'There is already a field with this title' ] ] ] );
+			return $respond(
+				422,
+				[
+					'errors' => [
+						[
+							'code'  => 'duplicate',
+							'title' => 'There is already a field with this title',
+						],
+					],
+				] 
+			);
 		}
 		if ( false !== strpos( $url, '/api/3/contacts' ) ) {
 			$this->called_actions[] = 'v3:contacts';
@@ -128,6 +138,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 			],
 		];
 
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader@example.net',
@@ -147,6 +158,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 	public function test_field_create_failure_does_not_block_signup() {
 		$this->remote_fields = []; // Field genuinely missing; create will fail with 422.
 
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader2@example.net',
@@ -174,6 +186,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 			],
 		];
 
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader3@example.net',
@@ -201,9 +214,9 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 				// No title key at all.
 			],
 			[
-				'id'      => '5',
-				'title'   => 'Some Broken Field',
-				'type'    => 'text',
+				'id'    => '5',
+				'title' => 'Some Broken Field',
+				'type'  => 'text',
 				// Title but no perstag: unusable for payload, must not match.
 			],
 			[
@@ -216,6 +229,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 			],
 		];
 
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods -- this test exercises the provider method itself.
 		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
 			[
 				'email'    => 'reader4@example.net',

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
@@ -242,4 +242,64 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'field[%NEWSLETTERSSUBSCRIPTIONMETHOD%,0]', $this->contact_payload, 'Title match must resolve to the matched field\'s perstag, not a reindexed neighbor\'s.' );
 		$this->assertArrayNotHasKey( 'field[%UNRELATED_FIELD%,0]', $this->contact_payload, 'Value must not be written to an unrelated field.' );
 	}
+
+	/**
+	 * An empty-string perstag is as unusable as a missing one: it yields no
+	 * valid payload key, and two such fields would collide on `field[%%,0]`.
+	 * A row like that must never win a title match.
+	 */
+	public function test_title_match_skips_field_rows_with_empty_perstag() {
+		$this->remote_fields = [
+			[
+				'id'      => '4',
+				'title'   => 'Newsletter Subscription Method',
+				'perstag' => '',
+				'type'    => 'text',
+				// Matching title, but an empty perstag: unusable, must not match.
+			],
+			[
+				'id'      => '9',
+				'title'   => 'Newsletter Subscription Method',
+				'perstag' => 'NEWSLETTERSSUBSCRIPTIONMETHOD',
+				'type'    => 'text',
+			],
+		];
+
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods, phpcsSniffs.Newsletters.ForbiddenContactsMethods.ForbiddenContactsMethods -- this test exercises the provider method itself.
+		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
+			[
+				'email'    => 'reader5@example.net',
+				'metadata' => [ 'Newsletter Subscription Method' => 'newsletter-block' ],
+			],
+			'1'
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertArrayNotHasKey( 'field[%%,0]', $this->contact_payload, 'An empty perstag must never produce a payload key.' );
+		$this->assertArrayHasKey( 'field[%NEWSLETTERSSUBSCRIPTIONMETHOD%,0]', $this->contact_payload, 'Title match must skip the empty-perstag row and resolve to the usable field.' );
+		$this->assertNotContains( 'v3:fields:create', $this->called_actions, 'A usable field with the same title exists, so no create should be attempted.' );
+	}
+
+	/**
+	 * A metadata key that sanitizes down to an empty perstag has nowhere valid
+	 * to write, so it must be skipped outright rather than created — a create
+	 * that succeeded would still leave the payload key malformed.
+	 */
+	public function test_metadata_key_with_empty_generated_perstag_is_skipped() {
+		$this->remote_fields = [];
+
+		// phpcs:ignore phpcsSniffs.Newsletters.ForbiddenMethods.PossibleForbiddenContactsMethods, phpcsSniffs.Newsletters.ForbiddenContactsMethods.ForbiddenContactsMethods -- this test exercises the provider method itself.
+		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
+			[
+				'email'    => 'reader6@example.net',
+				'metadata' => [ '!!!' => 'newsletter-block' ],
+			],
+			'1'
+		);
+
+		$this->assertFalse( is_wp_error( $result ), 'An unusable metadata key must not abort the signup.' );
+		$this->assertNotContains( 'v3:fields:create', $this->called_actions, 'No field-create should be attempted for a key with no usable perstag.' );
+		$this->assertArrayNotHasKey( 'field[%%,0]', $this->contact_payload, 'An empty perstag must never produce a payload key.' );
+		$this->assertTrue( in_array( 'contact_add', $this->called_actions, true ) || in_array( 'contact_sync', $this->called_actions, true ), 'Contact sync must still run after skipping an unusable field.' );
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
@@ -1,0 +1,231 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for ActiveCampaign custom-field matching during contact upsert.
+ *
+ * Background: `add_contact()` registers metadata fields on ActiveCampaign
+ * before syncing the contact. A field is looked up by its generated perstag;
+ * when an AC admin has renamed a field's perstag, the lookup misses, the
+ * field-create call fails ("There is already a field with this title"), and
+ * the whole signup aborts. Fields must also match by title, the payload must
+ * carry the field's actual perstag, and a field-create failure must never
+ * block the contact sync.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Test ActiveCampaign field matching in add_contact().
+ */
+class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
+
+	/**
+	 * Every ActiveCampaign action invoked through the mocked HTTP layer, in order.
+	 *
+	 * @var string[]
+	 */
+	private $called_actions = [];
+
+	/**
+	 * Body of the last contact_sync/contact_add request.
+	 *
+	 * @var array
+	 */
+	private $contact_payload = [];
+
+	/**
+	 * Fields the mocked AC account reports via GET /api/3/fields.
+	 *
+	 * @var array
+	 */
+	private $remote_fields = [];
+
+	/**
+	 * Set up: configure credentials and intercept all outbound HTTP.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->called_actions  = [];
+		$this->contact_payload = [];
+		$this->remote_fields   = [];
+		Newspack_Newsletters_Active_Campaign::instance()->set_api_credentials(
+			[
+				'url' => 'https://example.api-us1.com',
+				'key' => 'test-key',
+			]
+		);
+		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http' ], 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Intercept outbound requests and play an AC account with $remote_fields.
+	 *
+	 * @param mixed  $preempt Short-circuit value.
+	 * @param array  $args    HTTP request arguments.
+	 * @param string $url     Request URL.
+	 *
+	 * @return array
+	 */
+	public function mock_http( $preempt, $args, $url ) {
+		$respond = function ( $code, $body ) {
+			return [
+				'response' => [
+					'code'    => $code,
+					'message' => 200 === $code ? 'OK' : 'Unprocessable Entity',
+				],
+				'body'     => wp_json_encode( $body ),
+			];
+		};
+
+		if ( false !== strpos( $url, '/api/3/fields' ) && 'GET' === $args['method'] ) {
+			$this->called_actions[] = 'v3:fields:list';
+			return $respond(
+				200,
+				[
+					'fields' => $this->remote_fields,
+					'meta'   => [ 'total' => count( $this->remote_fields ) ],
+				]
+			);
+		}
+		if ( false !== strpos( $url, '/api/3/fields' ) && 'POST' === $args['method'] ) {
+			$this->called_actions[] = 'v3:fields:create';
+			return $respond( 422, [ 'errors' => [ [ 'code' => 'duplicate', 'title' => 'There is already a field with this title' ] ] ] );
+		}
+		if ( false !== strpos( $url, '/api/3/contacts' ) ) {
+			$this->called_actions[] = 'v3:contacts';
+			return $respond( 200, [ 'contacts' => [] ] );
+		}
+		if ( false !== strpos( $url, 'admin/api.php' ) ) {
+			$action                 = isset( $args['body']['api_action'] ) ? $args['body']['api_action'] : 'v1:unknown';
+			$this->called_actions[] = $action;
+			if ( in_array( $action, [ 'contact_add', 'contact_sync', 'contact_edit' ], true ) ) {
+				$this->contact_payload = $args['body'];
+			}
+			return $respond( 200, [ 'result_code' => 1, 'subscriber_id' => 42 ] ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+		}
+		$this->called_actions[] = 'unmatched:' . $url;
+		return $respond( 200, [ 'result_code' => 1 ] ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+	}
+
+	/**
+	 * A field whose perstag was renamed on the AC side must be matched by
+	 * title, and the contact payload must carry the field's ACTUAL perstag.
+	 */
+	public function test_field_matched_by_title_when_perstag_renamed() {
+		$this->remote_fields = [
+			[
+				'id'      => '7',
+				'title'   => 'Newsletter Subscription Method',
+				'perstag' => 'NEWSLETTERSSUBSCRIPTIONMETHOD',
+				'type'    => 'text',
+			],
+		];
+
+		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
+			[
+				'email'    => 'reader@example.net',
+				'metadata' => [ 'Newsletter Subscription Method' => 'newsletter-block' ],
+			],
+			'1'
+		);
+
+		$this->assertFalse( is_wp_error( $result ), 'Signup must not fail when a field title exists with a renamed perstag. Got: ' . ( is_wp_error( $result ) ? $result->get_error_message() : '' ) );
+		$this->assertNotContains( 'v3:fields:create', $this->called_actions, 'No field-create should be attempted when a field with the same title exists.' );
+		$this->assertArrayHasKey( 'field[%NEWSLETTERSSUBSCRIPTIONMETHOD%,0]', $this->contact_payload, 'Contact payload must use the existing field\'s actual perstag.' );
+	}
+
+	/**
+	 * A failed field-create must not block the contact sync.
+	 */
+	public function test_field_create_failure_does_not_block_signup() {
+		$this->remote_fields = []; // Field genuinely missing; create will fail with 422.
+
+		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
+			[
+				'email'    => 'reader2@example.net',
+				'metadata' => [ 'Newsletter Subscription Method' => 'newsletter-block' ],
+			],
+			'1'
+		);
+
+		$this->assertFalse( is_wp_error( $result ), 'A field-create failure must not abort the signup.' );
+		$this->assertContains( 'v3:fields:create', $this->called_actions, 'Field creation should have been attempted.' );
+		$this->assertTrue( in_array( 'contact_add', $this->called_actions, true ) || in_array( 'contact_sync', $this->called_actions, true ), 'Contact sync must still run after a failed field-create.' );
+	}
+
+	/**
+	 * The perstag-match fast path is unchanged: no field-create attempted,
+	 * generated perstag used.
+	 */
+	public function test_field_matched_by_perstag_unchanged() {
+		$this->remote_fields = [
+			[
+				'id'      => '7',
+				'title'   => 'Newsletter Subscription Method',
+				'perstag' => 'NEWSLETTER_SUBSCRIPTION_METHOD',
+				'type'    => 'text',
+			],
+		];
+
+		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
+			[
+				'email'    => 'reader3@example.net',
+				'metadata' => [ 'Newsletter Subscription Method' => 'newsletter-block' ],
+			],
+			'1'
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertNotContains( 'v3:fields:create', $this->called_actions );
+		$this->assertArrayHasKey( 'field[%NEWSLETTER_SUBSCRIPTION_METHOD%,0]', $this->contact_payload );
+	}
+
+	/**
+	 * Title matching must survive malformed field rows: array_column() skips
+	 * rows missing the key and reindexes, which can map a match back to the
+	 * wrong field (and thus the wrong perstag).
+	 */
+	public function test_title_match_survives_field_rows_without_title() {
+		$this->remote_fields = [
+			[
+				'id'      => '3',
+				'perstag' => 'UNRELATED_FIELD',
+				'type'    => 'text',
+				// No title key at all.
+			],
+			[
+				'id'      => '5',
+				'title'   => 'Some Broken Field',
+				'type'    => 'text',
+				// Title but no perstag: unusable for payload, must not match.
+			],
+			[
+				'id'      => '7',
+				'title'   => 'newsletter subscription method ',
+				'perstag' => 'NEWSLETTERSSUBSCRIPTIONMETHOD',
+				'type'    => 'text',
+				// Re-cased + padded title: AC treats titles as duplicates
+				// case-insensitively, so this must still match.
+			],
+		];
+
+		$result = Newspack_Newsletters_Active_Campaign::instance()->add_contact(
+			[
+				'email'    => 'reader4@example.net',
+				'metadata' => [ 'Newsletter Subscription Method' => 'newsletter-block' ],
+			],
+			'1'
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertArrayHasKey( 'field[%NEWSLETTERSSUBSCRIPTIONMETHOD%,0]', $this->contact_payload, 'Title match must resolve to the matched field\'s perstag, not a reindexed neighbor\'s.' );
+		$this->assertArrayNotHasKey( 'field[%UNRELATED_FIELD%,0]', $this->contact_payload, 'Value must not be written to an unrelated field.' );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-matching.php
@@ -105,7 +105,7 @@ class ActiveCampaignFieldMatchingTest extends WP_UnitTestCase {
 							'title' => 'There is already a field with this title',
 						],
 					],
-				] 
+				]
 			);
 		}
 		if ( false !== strpos( $url, '/api/3/contacts' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reference: NPPM-283

When a custom field's personalization tag (perstag) is renamed in ActiveCampaign, newsletter signups that sync reader data start failing with "There is already a field with this title". Because Newspack attaches signup metadata to every signup, on an affected site that means all signups fail.

## What this does

Signup field-matching is now resilient to field edits made on the ActiveCampaign side:

- Fields are matched by their tag first (as before), and now **fall back to matching by title** — case-insensitively, since ActiveCampaign treats titles as duplicates regardless of case.
- When a field is matched by title, the contact data is written to that field's **actual** tag, so the value lands in the right place.
- If a field can't be registered at all, the signup **no longer fails**: the problem is logged, that one field is skipped, and the reader is still subscribed.

### How to test the changes in this Pull Request:

**Prerequisite:** a site with ActiveCampaign connected. Run at least one signup first so the Newspack-generated contact fields exist.

**Reproduce the problem** (on `release` without this fix):
1. In ActiveCampaign, under **Contacts → Fields → Manage**, change the personalization tag (`perstag`) of a Newspack-generated field (for example `NEWSLETTER_SUBSCRIPTION_METHOD` → `NEWSLETTERSSUBSCRIPTIONMETHOD`).
2. Register through Reader Activation so the signup syncs reader data. An email-only subscribe doesn't send this field and won't reproduce the problem.
3. The signup fails with "There is already a field with this title", and ActiveCampaign does not add the reader.

**Verify the fix:**
1. Keep the renamed personalization tag and sign up again on this branch. The signup succeeds, and ActiveCampaign saves the contact's data under the renamed field.
2. Sign up on a site with no renamed tags. The signup succeeds, and the contact data lands in the existing fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

## Notes for reviewers
- The change is confined to the field-registration block of `add_contact()` in the AC provider; the method's signature and everything downstream are untouched.
- Matching uses index-preserving loops rather than `array_search` over `array_column` — AC field rows can be missing keys, and `array_column` reindexes around them, which could map a match to the wrong field's perstag. A title match also requires the row to carry a usable perstag; otherwise it falls through to field creation.
- A failed field-create now logs via `Newspack_Newsletters_Logger` and continues; previously the raw `WP_Error` aborted the signup before any contact sync ran.
- Four tests using the suite's established `pre_http_request` mock pattern: renamed perstag matches by title and uses the actual perstag; a failed create doesn't block the signup; the perstag fast path is unchanged; malformed rows (missing title or perstag) and re-cased, whitespace-padded titles are handled. Full newsletters suite green (486 tests).

### Release risk

**Medium.** The change sits on the reader-signup path, but it only executes for publishers using ActiveCampaign as their ESP, and the common case — tag matches, no admin edits — is verified unchanged by tests. One deliberate trade-off: a field that can't be registered is now skipped with a log entry instead of failing the whole signup loudly; keeping signups working outweighs one metadata field. Rollback is a plain revert, which restores the previous hard-fail behavior.

