### PR TITLE
fix(themes): remove unintended highlight behind colored text

### DIFF
--- a/themes/newspack-block-theme/src/scss/_base.scss
+++ b/themes/newspack-block-theme/src/scss/_base.scss
@@ -19,6 +19,14 @@ html {
 	border-radius: 100%;
 }
 
+// Gutenberg's inline text-color format wraps text in mark.has-inline-color.
+// That mark is a color carrier, not a highlight, so it must not get the
+// browser's default yellow highlight background. Explicitly-set inline
+// background colors still win over this rule.
+mark.has-inline-color {
+	background-color: transparent;
+}
+
 figcaption {
 	color: var(--wp--preset--color--contrast-3);
 	font-size: var(--wp--preset--font-size--x-small);

--- a/themes/newspack-theme/newspack-theme/sass/style-editor-base.scss
+++ b/themes/newspack-theme/newspack-theme/sass/style-editor-base.scss
@@ -1639,3 +1639,10 @@ $colors: (
 .has-grad-6-gradient-background {
 	background-image: linear-gradient(135deg, rgb(221, 221, 221) 0%, rgb(255, 255, 255) 100%);
 }
+
+// Gutenberg's inline text-color format wraps text in mark.has-inline-color.
+// Keep the editor canvas consistent with the frontend fix: color-carrier
+// marks get no highlight background (browser default is yellow).
+mark.has-inline-color {
+	background-color: transparent;
+}

--- a/themes/newspack-theme/newspack-theme/sass/typography/_copy.scss
+++ b/themes/newspack-theme/newspack-theme/sass/typography/_copy.scss
@@ -45,6 +45,14 @@ ins {
 	text-decoration: none;
 }
 
+// Gutenberg's inline text-color format wraps text in mark.has-inline-color.
+// That mark is a color carrier, not a highlight, so it must not inherit the
+// highlight background above. Explicitly-set inline background colors still
+// win over this rule.
+mark.has-inline-color {
+	background-color: transparent;
+}
+
 big {
 	font-size: 125%;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reference: NPPM-2938

When an editor applies a text color to part of a button label or paragraph, some sites showed an unexpected yellow highlight behind that text. The reported case was a checkout button, where the site worked around it with custom CSS.

## What this does

Text that only has an inline color applied no longer picks up a highlight background. The editor's text-color tool wraps colored text in a `<mark>` element, and the theme's generic highlight styling (`mark, ins { background: #fff9c0 }`) applied to it — adding a highlight the author never chose.

The same one-line rule (`mark.has-inline-color { background-color: transparent }`) is added in three places:

- newspack-theme front-end styles — covers all six classic themes, where the theme's own highlight color was showing;
- newspack-theme editor styles — so the editor canvas matches the front end;
- newspack-block-theme — which has no theme `mark` styling, so the highlight there was the browser's built-in yellow; the same rule removes it.

Deliberate highlights are untouched: a plain `<mark>` keeps its yellow, and an explicitly-chosen background color always wins over this rule because the editor applies those as inline styles.

### How to test the changes in this Pull Request:

**Reproduce the problem** (on `release` without this fix):
1. On a classic-theme site, edit any post, select some text, and set a **text color** (toolbar ▸ More ▸ Highlight ▸ Text tab — choose a color for the text, not the background).
2. View the post — the colored text sits on a pale-yellow background nobody chose.

**Verify the fix:**
1. Load the same content with this branch — colored text, no yellow.
2. A plain highlight (a raw `<mark>` in a Custom HTML block) still shows yellow.
3. In the editor, the canvas matches the front end: colored text clean, plain mark yellow.
4. Using the same toolbar, set a **background** color on some text — it still applies.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (CSS-only change — verified via compiled output and rendered pages)
* [x] Have you successfully run tests with your changes locally?

## Notes for reviewers
- This is not a regression of newspack-blocks #1363. That fix is intact, but it scoped its resets to two blocks (Donate, Homepage Articles); the theme-level rule was still applying the highlight everywhere else inline-colored text appeared, including the checkout button. Fixing it in the theme covers every block at once.
- Verified against core's format library: explicit background choices are always written as inline styles, so this rule cannot override a background the editor chose deliberately.
- `background-color` longhand is used consistently rather than the `background` shorthand, which would also reset background-image — and the themes ship gradient background utilities.
- CSS-only. Compiled output verified in all six classic themes' `style.css`, the editor stylesheet, and the block theme.
- After this ships, the reporting site can remove its temporary `ins,mark{background:none!important}` override.

### Release risk

**Low.** A single CSS rule in three stylesheets, no logic changes. It's publisher-visible only where content contains inline-colored text, and there the yellow is the reported bug. If a publisher was deliberately using text color to get a yellow highlight, their fix is one click — set an explicit background color, which this rule never overrides — and a mention in the weekly hotfix roundup covers the communication. Rollback is a plain revert of the rule.
