### PR TITLE
feat(gates): capture gate id on landing-page conversions (NPPD-1887)

### DIFF
--- a/plugins/newspack-blocks/src/modal-checkout/modal.js
+++ b/plugins/newspack-blocks/src/modal-checkout/modal.js
@@ -25,6 +25,7 @@ import {
 	getFormattedAmount,
 } from './utils';
 import { resolveCheckoutButtonForm, readCheckoutData } from './checkout-button-trigger';
+import { applyCtaAttribution } from '../shared/js/cta-attribution';
 
 const CLASS_PREFIX = newspackBlocksModal.newspack_class_prefix;
 const IFRAME_NAME = 'newspack_modal_checkout_iframe';
@@ -300,6 +301,13 @@ domReady( () => {
 		}
 		const form = ev.target;
 		form.classList.add( 'modal-processing' );
+
+		// NPPD-1887: if the reader arrived here by clicking a paid-intent CTA in a gate
+		// or prompt, replay that surface's id as a hidden field so the order carries
+		// `_gate_post_id` / `_newspack_popup_id`. No-ops when the form already has one
+		// (a form rendered inside the surface itself always wins) or when the form is
+		// inside a gate. Must run BEFORE getCheckoutData(), which snapshots the form.
+		applyCtaAttribution( form );
 
 		const checkoutData = getCheckoutData( form );
 

--- a/plugins/newspack-blocks/src/shared/js/cta-attribution.js
+++ b/plugins/newspack-blocks/src/shared/js/cta-attribution.js
@@ -19,6 +19,7 @@
  * plugins ship independently and share no JS package. Change one, change the other.
  *
  *   sessionStorage[ 'newspack_cta_attribution' ] = JSON.stringify( {
+ *     v:    1,
  *     type: 'gate' | 'prompt',
  *     id:   '123',
  *     ts:   1751932800000,
@@ -27,6 +28,14 @@
 
 /** Storage key. Shared with newspack-plugin. */
 export const STORAGE_KEY = 'newspack_cta_attribution';
+
+/**
+ * Storage-record schema version. Must match the writer's in newspack-plugin. A record
+ * whose `v` differs is treated as absent rather than trusted, so a drift between the two
+ * duplicated copies (e.g. one changes the record shape or TTL) fails safe instead of
+ * silently honoring a stale record. (dkoo review, #575.)
+ */
+export const SCHEMA = 1;
 
 /** Attribution lifetime, in ms. Kept in sync with newspack-plugin. */
 export const TTL_MS = 30 * 60 * 1000;
@@ -62,7 +71,8 @@ export function readCtaAttribution() {
 	} catch ( e ) {
 		return null;
 	}
-	if ( ! record || ! FIELD_BY_TYPE[ record.type ] || ! record.id ) {
+	// Reject records written by a different schema version (drift fail-safe).
+	if ( ! record || record.v !== SCHEMA || ! FIELD_BY_TYPE[ record.type ] || ! record.id ) {
 		return null;
 	}
 	// Session-scoped AND time-bounded (NPPD-1887 product decision). A reader who clicks

--- a/plugins/newspack-blocks/src/shared/js/cta-attribution.js
+++ b/plugins/newspack-blocks/src/shared/js/cta-attribution.js
@@ -1,0 +1,120 @@
+/**
+ * CTA attribution replay (NPPD-1887).
+ *
+ * The consumer half of the hand-off written by newspack-plugin when a reader clicks a
+ * paid-intent CTA inside a gate or prompt and is sent to a landing page. We re-inject
+ * the surface's id as a hidden form field, so the existing server chain
+ * (`INPUT_GET` -> cart item data -> `_gate_post_id` / `_newspack_popup_id` order meta)
+ * fires exactly as it does for a form rendered inside the gate itself.
+ *
+ * Two cart paths exist, and they apply DIFFERENT filters. Checkout buttons go through
+ * `Modal_Checkout::add_to_cart_and_redirect()` -> `newspack_blocks_modal_checkout_cart_item_data`;
+ * donations go through `Donations::process_donation_request()` -> `newspack_donations_cart_item_data`.
+ * Injecting the field here is necessary but not sufficient — a listener must exist on
+ * whichever filter the target form uses, or the id rides all the way into `INPUT_GET`
+ * and is then dropped.
+ *
+ * ── Storage contract ────────────────────────────────────────────────────────────
+ * DUPLICATED from newspack-plugin (`src/shared/js/cta-attribution.js`). The two
+ * plugins ship independently and share no JS package. Change one, change the other.
+ *
+ *   sessionStorage[ 'newspack_cta_attribution' ] = JSON.stringify( {
+ *     type: 'gate' | 'prompt',
+ *     id:   '123',
+ *     ts:   1751932800000,
+ *   } )
+ */
+
+/** Storage key. Shared with newspack-plugin. */
+export const STORAGE_KEY = 'newspack_cta_attribution';
+
+/** Attribution lifetime, in ms. Kept in sync with newspack-plugin. */
+export const TTL_MS = 30 * 60 * 1000;
+
+/** Surface type -> the form field the server reads. */
+const FIELD_BY_TYPE = {
+	gate: 'gate_post_id',
+	prompt: 'newspack_popup_id',
+};
+
+/**
+ * Read a fresh attribution record, or null.
+ *
+ * Never throws: `sessionStorage` access raises in Safari private mode, and the stored
+ * value is user-writable so `JSON.parse` can fail. Attribution is best-effort — a bad
+ * record must never block a checkout.
+ *
+ * @return {{type: string, id: string, ts: number}|null} The record, or null.
+ */
+export function readCtaAttribution() {
+	let raw;
+	try {
+		raw = window.sessionStorage.getItem( STORAGE_KEY );
+	} catch ( e ) {
+		return null;
+	}
+	if ( ! raw ) {
+		return null;
+	}
+	let record;
+	try {
+		record = JSON.parse( raw );
+	} catch ( e ) {
+		return null;
+	}
+	if ( ! record || ! FIELD_BY_TYPE[ record.type ] || ! record.id ) {
+		return null;
+	}
+	// Session-scoped AND time-bounded (NPPD-1887 product decision). A reader who clicks
+	// the CTA, wanders off, and converts two hours later in the same tab gets no credit.
+	if ( 'number' !== typeof record.ts || Date.now() - record.ts > TTL_MS ) {
+		return null;
+	}
+	return record;
+}
+
+/**
+ * Inject the persisted surface id into a checkout/donate form, if it needs one.
+ *
+ * Two guards, both load-bearing:
+ *
+ *   1. A form that ALREADY carries the field wins. That is a form rendered inside the
+ *      gate or prompt itself, whose id was stamped server-side (prompts) or by
+ *      `gate.js::addFormInputs()` (gates). A replayed value must never overwrite the
+ *      surface the reader is actually looking at. Same precedence rule that
+ *      `copyContextFields()` applies to PICKER_CONTEXT_FIELDS.
+ *
+ *   2. A form inside a gate is never replayed into. `gate.js` owns attribution there,
+ *      and it binds on the gate's 'seen' event — which may not have fired yet when
+ *      this runs. Without this guard, a stale id from a gate on a PREVIOUS page could
+ *      beat the current page's gate to the field.
+ *
+ * Called from the submit handler rather than at DOM-ready, so it observes the final
+ * state of the form after every other script has had its turn.
+ *
+ * @param {HTMLFormElement} form The form about to be submitted.
+ *
+ * @return {boolean} Whether a field was injected.
+ */
+export function applyCtaAttribution( form ) {
+	if ( ! form || 'function' !== typeof form.querySelector ) {
+		return false;
+	}
+	if ( form.closest( '.newspack-content-gate__gate' ) ) {
+		return false;
+	}
+	const record = readCtaAttribution();
+	if ( ! record ) {
+		return false;
+	}
+	const name = FIELD_BY_TYPE[ record.type ];
+	if ( form.querySelector( `input[name="${ name }"]` ) ) {
+		return false;
+	}
+	const input = document.createElement( 'input' );
+	input.type = 'hidden';
+	input.name = name;
+	input.value = record.id;
+	form.prepend( input );
+	return true;
+}

--- a/plugins/newspack-blocks/src/shared/js/cta-attribution.test.js
+++ b/plugins/newspack-blocks/src/shared/js/cta-attribution.test.js
@@ -2,14 +2,21 @@
  * Tests for the CTA attribution replay (NPPD-1887).
  */
 
-import { STORAGE_KEY, TTL_MS, readCtaAttribution, applyCtaAttribution } from './cta-attribution';
+import { STORAGE_KEY, SCHEMA, TTL_MS, readCtaAttribution, applyCtaAttribution } from './cta-attribution';
 
 /**
  * Write a raw value into sessionStorage.
  *
+ * Object records are stamped with the current SCHEMA unless they specify their own `v`,
+ * mirroring how persistCtaAttribution actually writes — so tests read realistic records,
+ * while the version-mismatch test can still supply a drifted `v`.
+ *
  * @param {*} value Value to store (stringified unless already a string).
  */
 function store( value ) {
+	if ( value && 'object' === typeof value && undefined === value.v ) {
+		value = { v: SCHEMA, ...value };
+	}
 	window.sessionStorage.setItem( STORAGE_KEY, 'string' === typeof value ? value : JSON.stringify( value ) );
 }
 
@@ -54,7 +61,15 @@ describe( 'cta-attribution', () => {
 
 		it( 'returns a fresh gate record', () => {
 			store( { type: 'gate', id: '42', ts: Date.now() } );
-			expect( readCtaAttribution() ).toEqual( { type: 'gate', id: '42', ts: expect.any( Number ) } );
+			expect( readCtaAttribution() ).toEqual( { v: SCHEMA, type: 'gate', id: '42', ts: expect.any( Number ) } );
+		} );
+
+		// Drift fail-safe: the storage contract is duplicated across newspack-plugin and
+		// newspack-blocks. A record written by a different schema version must be ignored,
+		// not silently honored. (dkoo review, #575.)
+		it( 'rejects a record written by a different schema version', () => {
+			store( { v: SCHEMA + 1, type: 'gate', id: '42', ts: Date.now() } );
+			expect( readCtaAttribution() ).toBeNull();
 		} );
 
 		it( 'rejects a record older than the TTL', () => {

--- a/plugins/newspack-blocks/src/shared/js/cta-attribution.test.js
+++ b/plugins/newspack-blocks/src/shared/js/cta-attribution.test.js
@@ -1,0 +1,150 @@
+/**
+ * Tests for the CTA attribution replay (NPPD-1887).
+ */
+
+import { STORAGE_KEY, TTL_MS, readCtaAttribution, applyCtaAttribution } from './cta-attribution';
+
+/**
+ * Write a raw value into sessionStorage.
+ *
+ * @param {*} value Value to store (stringified unless already a string).
+ */
+function store( value ) {
+	window.sessionStorage.setItem( STORAGE_KEY, 'string' === typeof value ? value : JSON.stringify( value ) );
+}
+
+/**
+ * Build a detached form, optionally with a pre-existing hidden input.
+ *
+ * @param {Object} options          Options.
+ * @param {string} options.existing Name of a hidden input to pre-add.
+ * @param {string} options.wrapper  Class name for a wrapping element.
+ * @return {HTMLFormElement} The form (attached to document.body).
+ */
+function makeForm( { existing = null, wrapper = null } = {} ) {
+	const form = document.createElement( 'form' );
+	if ( existing ) {
+		const input = document.createElement( 'input' );
+		input.type = 'hidden';
+		input.name = existing;
+		input.value = 'original';
+		form.appendChild( input );
+	}
+	if ( wrapper ) {
+		const el = document.createElement( 'div' );
+		el.className = wrapper;
+		el.appendChild( form );
+		document.body.appendChild( el );
+	} else {
+		document.body.appendChild( form );
+	}
+	return form;
+}
+
+describe( 'cta-attribution', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'readCtaAttribution', () => {
+		it( 'returns null when nothing is stored', () => {
+			expect( readCtaAttribution() ).toBeNull();
+		} );
+
+		it( 'returns a fresh gate record', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() } );
+			expect( readCtaAttribution() ).toEqual( { type: 'gate', id: '42', ts: expect.any( Number ) } );
+		} );
+
+		it( 'rejects a record older than the TTL', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() - TTL_MS - 1000 } );
+			expect( readCtaAttribution() ).toBeNull();
+		} );
+
+		it( 'accepts a record right at the TTL boundary', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() - TTL_MS + 5000 } );
+			expect( readCtaAttribution() ).not.toBeNull();
+		} );
+
+		it( 'rejects an unknown surface type', () => {
+			store( { type: 'banner', id: '42', ts: Date.now() } );
+			expect( readCtaAttribution() ).toBeNull();
+		} );
+
+		it( 'rejects a record with no id', () => {
+			store( { type: 'gate', ts: Date.now() } );
+			expect( readCtaAttribution() ).toBeNull();
+		} );
+
+		it( 'rejects a non-numeric timestamp rather than treating it as fresh', () => {
+			store( { type: 'gate', id: '42', ts: 'now' } );
+			expect( readCtaAttribution() ).toBeNull();
+		} );
+
+		it( 'survives malformed JSON', () => {
+			store( '{not json' );
+			expect( readCtaAttribution() ).toBeNull();
+		} );
+	} );
+
+	describe( 'applyCtaAttribution', () => {
+		it( 'injects gate_post_id on a bare landing-page form', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() } );
+			const form = makeForm();
+
+			expect( applyCtaAttribution( form ) ).toBe( true );
+			expect( form.querySelector( 'input[name="gate_post_id"]' ).value ).toBe( '42' );
+		} );
+
+		it( 'injects newspack_popup_id for a prompt record', () => {
+			store( { type: 'prompt', id: '7', ts: Date.now() } );
+			const form = makeForm();
+
+			expect( applyCtaAttribution( form ) ).toBe( true );
+			expect( form.querySelector( 'input[name="newspack_popup_id"]' ).value ).toBe( '7' );
+		} );
+
+		// Precedence: a form rendered inside the surface itself already carries the id,
+		// stamped server-side (prompts) or by gate.js::addFormInputs (gates). A replayed
+		// value must never overwrite the surface the reader is actually looking at.
+		it( 'never overwrites an existing hidden input', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() } );
+			const form = makeForm( { existing: 'gate_post_id' } );
+
+			expect( applyCtaAttribution( form ) ).toBe( false );
+			expect( form.querySelector( 'input[name="gate_post_id"]' ).value ).toBe( 'original' );
+			expect( form.querySelectorAll( 'input[name="gate_post_id"]' ) ).toHaveLength( 1 );
+		} );
+
+		// gate.js owns attribution inside a gate, and it binds on the gate's 'seen'
+		// event, which may not have fired yet. Without this guard a stale id from a gate
+		// on a PREVIOUS page could beat the current page's gate to the field.
+		it( 'never injects into a form inside a gate', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() } );
+			const form = makeForm( { wrapper: 'newspack-content-gate__gate' } );
+
+			expect( applyCtaAttribution( form ) ).toBe( false );
+			expect( form.querySelector( 'input[name="gate_post_id"]' ) ).toBeNull();
+		} );
+
+		it( 'does nothing when the record is stale', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() - TTL_MS - 1 } );
+			const form = makeForm();
+
+			expect( applyCtaAttribution( form ) ).toBe( false );
+			expect( form.querySelector( 'input[name="gate_post_id"]' ) ).toBeNull();
+		} );
+
+		it( 'does nothing when nothing is stored', () => {
+			const form = makeForm();
+			expect( applyCtaAttribution( form ) ).toBe( false );
+		} );
+
+		it( 'tolerates a missing form', () => {
+			store( { type: 'gate', id: '42', ts: Date.now() } );
+			expect( applyCtaAttribution( null ) ).toBe( false );
+			expect( applyCtaAttribution( undefined ) ).toBe( false );
+		} );
+	} );
+} );

--- a/plugins/newspack-plugin/includes/class-cta-intent-classifier.php
+++ b/plugins/newspack-plugin/includes/class-cta-intent-classifier.php
@@ -1,0 +1,456 @@
+<?php
+/**
+ * Newspack CTA intent classifier.
+ *
+ * Classifies a call-to-action link target (an href) into a conversion intent —
+ * donation, newsletter, subscription — or into a clearly non-conversion tell
+ * (event, sponsor, editorial), or abstains.
+ *
+ * Originally written for NPPD-1837 as a display-only labeller for block-less
+ * button prompts, living in newspack-popups. Moved here (NPPD-1887) because
+ * content gates need the same classification and must not depend on Campaigns
+ * being active. `Newspack_Popups_Data_Api` now delegates to this class, and
+ * degrades to "no inferred intent" when newspack-plugin is absent — the same
+ * silent-degradation contract segmentation already uses for `\Newspack\Reader_Data`.
+ *
+ * Two distinct consumers, two very different risk profiles:
+ *
+ *   1. Prompts (NPPD-1837/1840) use the verdict as a DISPLAY LABEL only. It never
+ *      touches a `prompt_has_*` flag, `action_type`, or a conversion denominator.
+ *   2. Gates (NPPD-1887) use it to decide whether a CTA anchor gets stamped with
+ *      `data-newspack-cta`, which DOES lead to attribution: clicking such an anchor
+ *      persists the gate id, which is later written to `_gate_post_id` order meta.
+ *
+ * Because of (2), precision matters more than recall. A false "subscription"
+ * verdict on an editorial link would credit a gate for a conversion it had
+ * nothing to do with. Every ambiguous case abstains.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classifies CTA link targets into conversion intents.
+ */
+final class CTA_Intent_Classifier {
+
+	/**
+	 * Intents that represent a reader converting.
+	 *
+	 * @var string[]
+	 */
+	const CONVERSION_INTENTS = [ 'donation', 'newsletter', 'subscription' ];
+
+	/**
+	 * Conversion intents that end in a WooCommerce order.
+	 *
+	 * These are the only intents whose CTA anchors are stamped for attribution
+	 * (NPPD-1887 v1 scope). Registration and newsletter signups don't produce an
+	 * order, and the regwall's Direct rate is already session-scoped and correct,
+	 * so persisting attribution for them would add surface area without closing a
+	 * measured gap.
+	 *
+	 * @var string[]
+	 */
+	const PAID_INTENTS = [ 'donation', 'subscription' ];
+
+	/**
+	 * Memoized output of get_site_conversion_urls().
+	 *
+	 * Per-request. A class property rather than a static local so tests can reset it
+	 * (see reset_cache()) after mutating options or the permalink structure.
+	 *
+	 * @var array|null
+	 */
+	private static $conversion_urls_cache = null;
+
+	/**
+	 * Reset the memoized conversion-URL cache.
+	 *
+	 * Only useful in tests, and after changing options/permalinks mid-request.
+	 *
+	 * @return void
+	 */
+	public static function reset_cache() {
+		self::$conversion_urls_cache = null;
+	}
+
+	/**
+	 * Classify a chunk of block content by its button link target(s).
+	 *
+	 * Only conversion-legible or clearly non-conversion targets return a value;
+	 * anything ambiguous returns null (precision over recall — a false conversion
+	 * label is worse than an honest blank).
+	 *
+	 * @param string $content Block markup (e.g. a prompt's or gate's post_content).
+	 * @return array|null ['intent' => string, 'source' => string] or null to abstain.
+	 */
+	public static function classify_content( $content ) {
+		$hrefs = self::extract_button_hrefs( $content );
+		if ( empty( $hrefs ) ) {
+			return null;
+		}
+
+		$config = self::get_site_conversion_urls();
+
+		// Classify every button; a prompt or gate can hold more than one.
+		$hits = [];
+		foreach ( $hrefs as $href ) {
+			$hit = self::classify_href( $href, $config );
+			if ( $hit ) {
+				$hits[] = $hit;
+			}
+		}
+		if ( empty( $hits ) ) {
+			return null;
+		}
+
+		// Resolution when buttons disagree: a conversion intent wins over a
+		// non-conversion one; if two DIFFERENT conversion intents appear, abstain
+		// (don't guess). There is no precedence ORDER among the conversion intents —
+		// they are only partitioned from the non-conversion ones here, and a tie between
+		// two of them is unresolvable by definition. Ties within a SINGLE intent are
+		// broken below, on source confidence.
+		$conversion     = [];
+		$non_conversion = [];
+		foreach ( $hits as $hit ) {
+			if ( in_array( $hit['intent'], self::CONVERSION_INTENTS, true ) ) {
+				$conversion[] = $hit;
+			} else {
+				$non_conversion[] = $hit;
+			}
+		}
+
+		if ( ! empty( $conversion ) ) {
+			$distinct = array_unique( array_column( $conversion, 'intent' ) );
+			if ( 1 < count( $distinct ) ) {
+				return null; // Conflicting conversion signals -> abstain.
+			}
+			// All remaining hits share one intent, so break ties on source confidence
+			// (site_config > processor > pattern) for a deterministic, best-available source.
+			$source_rank = [
+				'site_config' => 1,
+				'processor'   => 2,
+				'pattern'     => 3,
+			];
+			usort(
+				$conversion,
+				function ( $a, $b ) use ( $source_rank ) {
+					return ( $source_rank[ $a['source'] ] ?? PHP_INT_MAX ) <=> ( $source_rank[ $b['source'] ] ?? PHP_INT_MAX );
+				}
+			);
+			return $conversion[0];
+		}
+
+		// Only non-conversion signals: report the first (sponsor/editorial/event) so
+		// the dashboard can show a non-conversion label instead of a bare "undefined".
+		return $non_conversion[0];
+	}
+
+	/**
+	 * Stamp `data-newspack-cta="<intent>"` on rendered button anchors whose href
+	 * classifies into one of the allowed intents.
+	 *
+	 * Operates on RENDERED html (post-`do_blocks`), and scopes itself to anchors
+	 * carrying the `wp-block-button__link` class — the rendered counterpart of the
+	 * `core/button`-only scope that extract_button_hrefs() applies to block markup.
+	 * Body-copy links are deliberately untouched: a reader clicking "read more" in a
+	 * gate must never attribute a later subscription to that gate.
+	 *
+	 * Per-anchor, not per-container. classify_content() has to collapse a multi-button
+	 * surface to a single verdict (and abstains when two conversion intents disagree);
+	 * here each anchor carries its own, which is both more precise and lets a gate mix
+	 * a "Subscribe" button with a "Read our latest" button without losing either.
+	 *
+	 * @param string   $html            Rendered HTML.
+	 * @param string[] $allowed_intents Intents worth stamping. Defaults to PAID_INTENTS.
+	 * @return string The HTML, with attributes added. Unchanged if nothing classified.
+	 */
+	public static function annotate_button_anchors( $html, $allowed_intents = null ) {
+		if ( empty( $html ) || ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
+			return $html;
+		}
+		$allowed_intents = null === $allowed_intents ? self::PAID_INTENTS : $allowed_intents;
+		if ( empty( $allowed_intents ) ) {
+			return $html;
+		}
+
+		$config    = self::get_site_conversion_urls();
+		$processor = new \WP_HTML_Tag_Processor( $html );
+		$touched   = false;
+
+		while ( $processor->next_tag( [ 'tag_name' => 'A' ] ) ) {
+			if ( ! $processor->has_class( 'wp-block-button__link' ) ) {
+				continue;
+			}
+			$href = $processor->get_attribute( 'href' );
+			if ( ! is_string( $href ) || '' === $href ) {
+				continue;
+			}
+			$hit = self::classify_href( strtolower( $href ), $config );
+			if ( ! $hit || ! in_array( $hit['intent'], $allowed_intents, true ) ) {
+				continue;
+			}
+			$processor->set_attribute( 'data-newspack-cta', $hit['intent'] );
+			$processor->set_attribute( 'data-newspack-cta-source', $hit['source'] );
+			$touched = true;
+		}
+
+		return $touched ? $processor->get_updated_html() : $html;
+	}
+
+	/**
+	 * Pull hrefs from core/button blocks in block markup.
+	 *
+	 * Scope is intentionally limited to button blocks (not every <a> in body copy)
+	 * to keep precision high. Recurses so buttons nested inside core/buttons wrappers
+	 * are covered.
+	 *
+	 * @param string $content Block markup.
+	 * @return string[] Lowercased hrefs.
+	 */
+	public static function extract_button_hrefs( $content ) {
+		$blocks  = \parse_blocks( $content );
+		$buttons = self::find_blocks( 'core/button', $blocks );
+		$hrefs   = [];
+		foreach ( $buttons as $button ) {
+			$url = $button['attrs']['url'] ?? '';
+			if ( empty( $url ) && ! empty( $button['innerHTML'] ) ) {
+				// Older button blocks store the href only in the saved markup.
+				if ( preg_match( '/href="([^"]+)"/i', $button['innerHTML'], $matches ) ) {
+					$url = $matches[1];
+				}
+			}
+			if ( ! empty( $url ) ) {
+				$hrefs[] = strtolower( $url );
+			}
+		}
+		return $hrefs;
+	}
+
+	/**
+	 * Recursively collect blocks of a given name.
+	 *
+	 * @param string $block_name Block name to find.
+	 * @param array  $blocks     Parsed blocks.
+	 * @return array
+	 */
+	private static function find_blocks( $block_name, $blocks ) {
+		$found = [];
+		foreach ( $blocks as $block ) {
+			if ( $block_name === $block['blockName'] ) {
+				$found[] = $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = array_merge( $found, self::find_blocks( $block_name, $block['innerBlocks'] ) );
+			}
+		}
+		return $found;
+	}
+
+	/**
+	 * Classify a single href. Precedence:
+	 *   1) site-configured conversion URLs (highest confidence; catches the
+	 *      unguessable cases like a bespoke on-site donation page),
+	 *   2) known third-party processor domains,
+	 *   3) path / substring patterns,
+	 *   4) non-conversion tells (event, sponsor, editorial),
+	 *   else null (abstain).
+	 *
+	 * @param string     $href   Lowercased href.
+	 * @param array|null $config Output of get_site_conversion_urls(). Resolved if null.
+	 * @return array|null ['intent' => string, 'source' => string] or null.
+	 */
+	public static function classify_href( $href, $config = null ) {
+		$config = null === $config ? self::get_site_conversion_urls() : $config;
+
+		// 1) Site config (substring match against this site's own configured URLs).
+		foreach ( self::CONVERSION_INTENTS as $intent ) {
+			foreach ( $config[ $intent ] as $configured ) {
+				if ( $configured && str_contains( $href, $configured ) ) {
+					return [
+						'intent' => $intent,
+						'source' => 'site_config',
+					];
+				}
+			}
+		}
+
+		// 2) Processor domains (empirically ranked in NPPD-1836; fundjournalism dominant).
+		$donation_processors = [ 'fundjournalism', 'donorbox', 'actblue', 'fundraiseup', 'classy.org', 'givebutter' ];
+		foreach ( $donation_processors as $needle ) {
+			if ( str_contains( $href, $needle ) ) {
+				return [
+					'intent' => 'donation',
+					'source' => 'processor',
+				];
+			}
+		}
+		// giving.<institution>.edu (e.g. giving.umich.edu) — institutional donation.
+		if ( preg_match( '#://giving\.[^/]+\.edu#', $href ) ) {
+			return [
+				'intent' => 'donation',
+				'source' => 'processor',
+			];
+		}
+
+		// 3) Path / substring patterns. Substring (not slash-anchored) on purpose, so
+		// membership fragments and newslettersignup slugs are caught (NPPD-1836).
+		// Order matters: donation, then newsletter, then subscription.
+		// (?<![a-z]) applies only to the keyword branch so mid-word matches (e.g. "member"
+		// inside "remember") don't false-positive; the href is already lowercased. Digits,
+		// "-", "/", "#" and start-of-string are all valid boundaries, so "/donate",
+		// "-membership" and "#...-membership" still match. /give and /support stay
+		// slash-anchored exactly as before.
+		if ( preg_match( '/(?<![a-z])(?:donate|donation|contribute|donor|member|membership)|\/give\b|\/support\b/', $href ) ) {
+			return [
+				'intent' => 'donation',
+				'source' => 'pattern',
+			];
+		}
+		if ( str_contains( $href, 'newsletter' ) ) {
+			return [
+				'intent' => 'newsletter',
+				'source' => 'pattern',
+			];
+		}
+		if ( preg_match( '#://(account|app|subscribe|checkout|my-?account)\.#', $href )
+			|| preg_match( '/subscribe|subscription|\/checkout|my-?account|\/offer|\/join\b|\/digital|\/plans|\/pricing/', $href ) ) {
+			return [
+				'intent' => 'subscription',
+				'source' => 'pattern',
+			];
+		}
+
+		// 4) Non-conversion tells.
+		// Sponsor/ad: outbound link tagged utm_medium=referral.
+		// TODO(confirm): compare utm_source to the site slug/home host rather than
+		// matching the medium literally.
+		if ( str_contains( $href, 'utm_medium=referral' ) && self::is_external_host( $href ) ) {
+			return [
+				'intent' => 'sponsor',
+				'source' => 'pattern',
+			];
+		}
+		// Event / ticketing.
+		if ( preg_match( '#/events?(/|$)|eventbrite|tribfest|/fest\b#', $href ) ) {
+			return [
+				'intent' => 'event',
+				'source' => 'pattern',
+			];
+		}
+		// Editorial / navigation on this site's own domain (article slugs, author pages).
+		if ( ! self::is_external_host( $href )
+			&& preg_match( '#/[0-9]{4}/[0-9]{2}/|/author/|/[a-z0-9]+(?:-[a-z0-9]+){2,}(/[a-z]+)?/?($|\?)#', $href ) ) {
+			return [
+				'intent' => 'editorial',
+				'source' => 'pattern',
+			];
+		}
+
+		// Abstain: query-param forms (?form=), bare homepages, unrecognized externals.
+		return null;
+	}
+
+	/**
+	 * This site's configured conversion URLs, normalized to lowercase host+path
+	 * fragments suitable for str_contains() matching. Memoized per request.
+	 *
+	 * Side-effect-free by design: the donation page URL is read from the
+	 * newspack_donation_page_id option, NOT Donations::get_donation_page_info(),
+	 * which creates the page via wp_insert_post when none exists — unsafe on this
+	 * per-render path.
+	 *
+	 * Coverage ceiling: covers WooCommerce publishers whose button links to their own
+	 * donation page, checkout, or my-account. External processor URLs (fundjournalism
+	 * etc.) and bespoke campaign landing pages are not stored by Newspack — those are
+	 * handled by the processor dictionary and patterns in classify_href(), or not at all.
+	 *
+	 * @return array{donation:string[],newsletter:string[],subscription:string[]}
+	 */
+	public static function get_site_conversion_urls() {
+		if ( null !== self::$conversion_urls_cache ) {
+			return self::$conversion_urls_cache;
+		}
+
+		$urls = [
+			'donation'     => [],
+			'newsletter'   => [],
+			'subscription' => [],
+		];
+
+		// Donation: on-site donation page, read from the option (no side effects).
+		if ( class_exists( '\Newspack\Donations' ) ) {
+			$page_id = \get_option( Donations::DONATION_PAGE_ID_OPTION, 0 );
+			if ( $page_id && 'page' === \get_post_type( $page_id ) ) {
+				$urls['donation'][] = self::normalize_url( \get_permalink( $page_id ) );
+			}
+		}
+
+		// Subscription / checkout.
+		if ( function_exists( 'wc_get_checkout_url' ) ) {
+			$urls['subscription'][] = self::normalize_url( wc_get_checkout_url() );
+		}
+		if ( function_exists( 'wc_get_page_permalink' ) ) {
+			$urls['subscription'][] = self::normalize_url( wc_get_page_permalink( 'myaccount' ) );
+		}
+
+		// Newsletter: nothing to wire — Newspack has no configured newsletter page
+		// (signup is the inline subscribe block). Newsletter recovery is pattern-only.
+
+		// Drop empties and any URL that normalized to a bare host with no meaningful
+		// path (e.g. a non-pretty permalink collapsing to "host/"), which would
+		// otherwise substring-match every same-host link.
+		foreach ( $urls as $key => $list ) {
+			$urls[ $key ] = array_values(
+				array_filter(
+					$list,
+					static function ( $normalized ) {
+						return '' !== $normalized && 1 === preg_match( '#/[^/]#', $normalized );
+					}
+				)
+			);
+		}
+
+		self::$conversion_urls_cache = $urls;
+		return self::$conversion_urls_cache;
+	}
+
+	/**
+	 * Normalize a full URL to a lowercased host+path fragment for matching.
+	 *
+	 * @param string $url URL.
+	 * @return string
+	 */
+	private static function normalize_url( $url ) {
+		if ( empty( $url ) ) {
+			return '';
+		}
+		$parts = \wp_parse_url( strtolower( $url ) );
+		if ( empty( $parts['host'] ) ) {
+			return '';
+		}
+		$host = preg_replace( '/^www\./', '', $parts['host'] );
+		return $host . ( $parts['path'] ?? '' );
+	}
+
+	/**
+	 * Is this href pointing off the current site's host?
+	 *
+	 * @param string $href Lowercased href.
+	 * @return bool
+	 */
+	private static function is_external_host( $href ) {
+		$href_host = \wp_parse_url( $href, PHP_URL_HOST );
+		$home_host = \wp_parse_url( strtolower( \home_url() ), PHP_URL_HOST );
+		if ( empty( $href_host ) || empty( $home_host ) ) {
+			return false;
+		}
+		$href_host = preg_replace( '/^www\./', '', $href_host );
+		$home_host = preg_replace( '/^www\./', '', $home_host );
+		return $href_host !== $home_host;
+	}
+}

--- a/plugins/newspack-plugin/includes/class-cta-intent-classifier.php
+++ b/plugins/newspack-plugin/includes/class-cta-intent-classifier.php
@@ -9,9 +9,11 @@
  * Originally written for NPPD-1837 as a display-only labeller for block-less
  * button prompts, living in newspack-popups. Moved here (NPPD-1887) because
  * content gates need the same classification and must not depend on Campaigns
- * being active. `Newspack_Popups_Data_Api` now delegates to this class, and
- * degrades to "no inferred intent" when newspack-plugin is absent — the same
- * silent-degradation contract segmentation already uses for `\Newspack\Reader_Data`.
+ * being active. Once the prompts side ships (#571), `Newspack_Popups_Data_Api`
+ * delegates to this class and degrades to "no inferred intent" when newspack-plugin
+ * is absent — the same silent-degradation contract segmentation already uses for
+ * `\Newspack\Reader_Data`. On its own (this branch) the class is self-contained and
+ * used only by the content gate.
  *
  * Two distinct consumers, two very different risk profiles:
  *
@@ -279,6 +281,24 @@ final class CTA_Intent_Classifier {
 			}
 		}
 
+		// 1.5) Strong editorial short-circuit (dkoo review, #575). A dated article path on
+		// this site's own host — /YYYY/MM/ — is unambiguously editorial and can never be a
+		// conversion page, yet its slug may contain a conversion token: e.g.
+		// /2026/06/12/school-board-member-profile/ matches the donation pattern on "member"
+		// (the hyphen before it is a valid boundary for the lookbehind). Left to fall through
+		// it would be stamped as a paid CTA, and a click on it would credit a gate for a
+		// conversion the reader never made. So we abstain to editorial BEFORE the conversion
+		// patterns. Deliberately narrow: only the dated prefix, so real conversion pages like
+		// /become-a-member/ (no date) still reach the donation pattern below. Non-dated
+		// editorial slugs that contain a token (e.g. /digital-divide/) remain a known residual
+		// — rarer, and bounded by the module's precision-first, under-attribution contract.
+		if ( ! self::is_external_host( $href ) && preg_match( '#/[0-9]{4}/[0-9]{2}/#', $href ) ) {
+			return [
+				'intent' => 'editorial',
+				'source' => 'pattern',
+			];
+		}
+
 		// 2) Processor domains (empirically ranked in NPPD-1836; fundjournalism dominant).
 		$donation_processors = [ 'fundjournalism', 'donorbox', 'actblue', 'fundraiseup', 'classy.org', 'givebutter' ];
 		foreach ( $donation_processors as $needle ) {
@@ -439,6 +459,13 @@ final class CTA_Intent_Classifier {
 
 	/**
 	 * Is this href pointing off the current site's host?
+	 *
+	 * Single-host detection: compares against `home_url()`'s host only (minus `www.`).
+	 * On multisite / multibrand installs served on more than one hostname, a genuine
+	 * on-site link on a secondary brand host reads as external, so the editorial-abstain
+	 * branch won't fire for it and the link abstains (returns null). The failure mode is
+	 * *under*-attribution, which is safe under this module's precision-first contract.
+	 * (dkoo review, #575.)
 	 *
 	 * @param string $href Lowercased href.
 	 * @return bool

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -147,6 +147,9 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/bylines/class-bylines.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-post-date.php';
 		include_once NEWSPACK_ABSPATH . 'includes/lite-site/class-lite-site.php';
+		// Classifies CTA link targets by conversion intent; used by the content gate
+		// (below) to stamp landing-page CTAs for order-meta attribution (NPPD-1887).
+		include_once NEWSPACK_ABSPATH . 'includes/class-cta-intent-classifier.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/trait-content-gate-layout.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/class-content-gate.php';
 

--- a/plugins/newspack-plugin/includes/content-gate/trait-content-gate-layout.php
+++ b/plugins/newspack-plugin/includes/content-gate/trait-content-gate-layout.php
@@ -288,12 +288,31 @@ trait Content_Gate_Layout {
 	}
 
 	/**
+	 * Stamp `data-newspack-cta` on paid-intent button anchors in rendered gate HTML.
+	 *
+	 * NPPD-1887. Applied at the two gate-HTML producers rather than as a filter on
+	 * `newspack_gate_content`, because that filter ALSO runs over the restricted
+	 * article excerpt (see get_visible_content() above and Metering::…). Stamping
+	 * there would let a reader clicking a button in the article body attribute a
+	 * later subscription to the gate. Gate content only.
+	 *
+	 * @param string $html Rendered gate HTML.
+	 * @return string
+	 */
+	private static function annotate_gate_ctas( $html ) {
+		if ( ! class_exists( '\Newspack\CTA_Intent_Classifier' ) ) {
+			return $html;
+		}
+		return \Newspack\CTA_Intent_Classifier::annotate_button_anchors( $html );
+	}
+
+	/**
 	 * Get the inline gate HTML for rendering.
 	 *
 	 * @return string
 	 */
 	public static function get_inline_gate_html() {
-		return apply_filters( 'newspack_gate_content', self::get_inline_gate_content() );
+		return self::annotate_gate_ctas( apply_filters( 'newspack_gate_content', self::get_inline_gate_content() ) );
 	}
 
 	/**
@@ -304,11 +323,12 @@ trait Content_Gate_Layout {
 	public static function render_overlay_gate_html( $gate_post_id ) {
 		$position = \get_post_meta( $gate_post_id, 'overlay_position', true );
 		$size     = \get_post_meta( $gate_post_id, 'overlay_size', true );
+		$content  = self::annotate_gate_ctas( \apply_filters( 'newspack_gate_content', \get_the_content( null, null, $gate_post_id ) ) );
 		?>
 		<div class="newspack-content-gate__gate newspack-content-gate__overlay-gate" style="display:none;" data-position="<?php echo \esc_attr( $position ); ?>" data-size="<?php echo \esc_attr( $size ); ?>">
 			<div class="newspack-content-gate__overlay-gate__container">
 				<div class="newspack-content-gate__overlay-gate__content">
-					<?php echo \apply_filters( 'newspack_gate_content', \get_the_content( null, null, $gate_post_id ) );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</div>
 			</div>
 		</div>

--- a/plugins/newspack-plugin/includes/data-events/class-memberships.php
+++ b/plugins/newspack-plugin/includes/data-events/class-memberships.php
@@ -40,12 +40,52 @@ final class Memberships {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
 		add_filter( 'newspack_blocks_modal_checkout_cart_item_data', [ __CLASS__, 'checkout_cart_item_data' ], 10, 2 );
+		// Donations add to cart through Donations::process_donation_request(), which applies
+		// its OWN cart-item-data filter and never the modal-checkout one above. Without this
+		// line a gate CTA pointing at the donation page carries `gate_post_id` all the way
+		// into `INPUT_GET` and then drops it — verified live, NPPD-1887. The line-item writer
+		// below is hooked globally, so this is the only missing link.
+		add_filter( 'newspack_donations_cart_item_data', [ __CLASS__, 'checkout_cart_item_data' ] );
 		add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
 		add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_auth_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_otp_login_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_register_reader_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_newsletters_subscription_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
+	}
+
+	/**
+	 * Is this a real gate post?
+	 *
+	 * The id arrives from a client-supplied form field. It always has (the gate injects
+	 * a hidden input into its own forms), but since NPPD-1887 it can also be REPLAYED
+	 * from sessionStorage onto a landing-page checkout form, which widens the surface
+	 * enough to be worth checking before writing it into order meta. Insights reads
+	 * `_gate_post_id` as a gate identity; an arbitrary integer would silently corrupt
+	 * the per-gate breakdown.
+	 *
+	 * Both gate CPTs are accepted: Content_Gate::get_gate_post_id() resolves to a
+	 * `np_memberships_gate` when WC Memberships is active and a `np_content_gate`
+	 * otherwise, and the client can't tell us which.
+	 *
+	 * Returns the CAST id, not a bool, so callers persist the integer rather than the
+	 * raw candidate. `(int) '1139 OR 1=1'` is 1139 — validating the cast while writing
+	 * the original would let a malformed string land in `_gate_post_id`, and Insights
+	 * GROUPs by that value.
+	 *
+	 * @param mixed $gate_post_id Candidate post ID.
+	 * @return int|false The validated gate post ID, or false.
+	 */
+	private static function get_valid_gate_post_id( $gate_post_id ) {
+		$gate_post_id = (int) $gate_post_id;
+		if ( 0 >= $gate_post_id ) {
+			return false;
+		}
+		$valid_types = [ Content_Gate::GATE_CPT ];
+		if ( class_exists( '\Newspack\Memberships' ) ) {
+			$valid_types[] = \Newspack\Memberships::GATE_CPT;
+		}
+		return in_array( get_post_type( $gate_post_id ), $valid_types, true ) ? $gate_post_id : false;
 	}
 
 	/**
@@ -73,8 +113,12 @@ final class Memberships {
 	 * @return void
 	 */
 	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
-		if ( ! empty( $values[ self::METADATA_NAME ] ) ) {
-			$order->add_meta_data( '_gate_post_id', $values[ self::METADATA_NAME ] );
+		if ( empty( $values[ self::METADATA_NAME ] ) ) {
+			return;
+		}
+		$gate_post_id = self::get_valid_gate_post_id( $values[ self::METADATA_NAME ] );
+		if ( false !== $gate_post_id ) {
+			$order->add_meta_data( '_gate_post_id', $gate_post_id );
 		}
 	}
 

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -5,8 +5,18 @@
 import './gate.scss';
 import { getEventPayload, sendEvent } from '../reader-activation/analytics';
 import { debugLog } from '../reader-activation/utils';
+import { persistCtaAttribution } from '../shared/js/cta-attribution';
 
 const EVENT_NAME = 'np_gate_interaction';
+
+/**
+ * Paid-intent CTA anchors, stamped server-side by \Newspack\CTA_Intent_Classifier.
+ *
+ * Only `core/button` anchors classifying as donation or subscription carry this
+ * attribute. Body-copy links never do — a reader clicking "read our latest" inside
+ * a gate must not attribute a later subscription to that gate.
+ */
+const CTA_SELECTOR = 'a[data-newspack-cta]';
 
 /**
  * Specify a function to execute when the DOM is fully loaded.
@@ -127,6 +137,43 @@ function addFormInputs( gate ) {
 }
 
 /**
+ * Persist gate attribution when a reader clicks a paid-intent CTA that leaves the page,
+ * and report the click to GA4.
+ *
+ * Two independent jobs, deliberately in that order:
+ *
+ *   1. Persist. This is what makes the conversion attributable. It must happen even
+ *      when gtag is absent (analytics blocked / consent denied), so it sits outside
+ *      the gtag guard — the same reasoning as addFormInputs() in handleSeen().
+ *   2. Report. Gates have never emitted a click event (only seen / dismissed /
+ *      form_submission), which is why the gates funnel has no engagement stage of its
+ *      own. `action: 'clicked'` closes that gap and mirrors what prompts already do.
+ *
+ * Scoped to the gate element, so anchors in the restricted article excerpt (a sibling
+ * of `.newspack-content-gate__gate`) can never fire this.
+ *
+ * @param {HTMLElement} gate The gate element.
+ */
+function manageCtaClicks( gate ) {
+	const anchors = [ ...gate.querySelectorAll( CTA_SELECTOR ) ];
+	anchors.forEach( anchor => {
+		anchor.addEventListener( 'click', () => {
+			persistCtaAttribution( 'gate', gateInfo.gate_post_id );
+
+			if ( 'function' !== typeof window.gtag ) {
+				return;
+			}
+			const payload = {
+				action: 'clicked',
+				action_value: anchor.getAttribute( 'href' ) || '',
+				cta_intent: anchor.dataset.newspackCta || '',
+			};
+			sendEvent( getGateEventPayload( payload, gate ), EVENT_NAME );
+		} );
+	} );
+}
+
+/**
  * Check if a DOM element is visible.
  */
 function isVisible( el ) {
@@ -152,6 +199,30 @@ function getGateEventPayload( payload, gate ) {
 		gateInfo.gate_has_checkout_button = isVisible( gate.querySelector( '.wp-block-newspack-blocks-checkout-button' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_registration_link = isVisible( gate.querySelector( 'a[href="#register_modal"]' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_signin_link = isVisible( gate.querySelector( 'a[href="#signin_modal"]' ) ) ? 'yes' : 'no';
+		// NPPD-1887: paid-intent CTA linking out to a landing page. The attribute is
+		// stamped server-side by CTA_Intent_Classifier; the DOM only reads the verdict.
+		// This is the gate analog of `gate_has_checkout_button` and widens the hub's
+		// `checkout_impressions` denominator so link-only gates stop being invisible.
+		//
+		// Deliberately matches ANY paid intent (donation OR subscription), not just
+		// `[data-newspack-cta="subscription"]`. Narrowing it looks correct and is a trap:
+		// classify_href() tests its donation pattern BEFORE its subscription pattern, and
+		// that pattern matches `member|membership|donor|contribute|/support`. So
+		// `/membership/`, `/become-a-member/` and `/support/` — the three most common
+		// paywall-gate destinations there are — all classify as `donation`. Scoping this
+		// flag to subscription-intent anchors would give those gates
+		// `checkout_impressions = 0`, and Gates_Metric::get_paywall_conversion_direct()
+		// skips any gate with `checkout_impressions <= 0` — silently dropping the exact
+		// conversions this ticket exists to capture, while their revenue still lands in
+		// `total_paywall_revenue_direct` (pure local).
+		//
+		// The cost is the mirror image: a gate whose ONLY paid CTA is an unambiguous
+		// donation page enters the paywall denominator without ever producing a
+		// subscription, diluting the rate. Accepted for v1 — a subscription-gated gate
+		// pointing readers at a donation page is not a pattern publishers use, whereas
+		// `/membership/` is everywhere. Revisit if the intent labels ever become reliable
+		// enough to gate capability on; see CTA_Intent_Classifier::classify_href().
+		gateInfo.gate_has_checkout_link = isVisible( gate.querySelector( CTA_SELECTOR ) ) ? 'yes' : 'no';
 	}
 
 	return getEventPayload( { ...payload, ...gateInfo } );
@@ -173,12 +244,18 @@ function handleSeen( gate, shouldRecordHit = false ) {
 		} );
 	}
 
+	// Add hidden form inputs. Deliberately BEFORE the gtag guard: `gate_post_id` is
+	// what stamps `_gate_post_id` onto the Woo order, i.e. the entire server-side
+	// Direct-attribution chain. Behind the guard (where it used to sit) a reader with
+	// analytics blocked or consent denied would check out through the gate's own
+	// checkout block and the order would carry no gate at all. Attribution must not
+	// depend on Google Analytics being loaded. (NPPD-1887)
+	addFormInputs( gate );
+
 	if ( 'function' !== typeof window.gtag ) {
 		return;
 	}
 
-	// Add hidden form inputs.
-	addFormInputs( gate );
 	const payload = {
 		action: 'seen',
 	};
@@ -317,6 +394,11 @@ domReady( function () {
 	if ( ! gate ) {
 		return;
 	}
+
+	// Bound at DOM-ready rather than on 'seen': an overlay gate is clickable the moment
+	// it renders, and an inline gate's 'seen' handler only runs once it scrolls into
+	// view. A CTA click must always persist attribution.
+	manageCtaClicks( gate );
 
 	initReloadHandler();
 	if ( gate.classList.contains( 'newspack-content-gate__overlay-gate' ) ) {

--- a/plugins/newspack-plugin/src/shared/js/cta-attribution.js
+++ b/plugins/newspack-plugin/src/shared/js/cta-attribution.js
@@ -15,6 +15,7 @@
  * package between them. Change one, change the other.
  *
  *   sessionStorage[ 'newspack_cta_attribution' ] = JSON.stringify( {
+ *     v:    1,                   // SCHEMA — reject records written by a drifted shape
  *     type: 'gate' | 'prompt',   // which surface
  *     id:   '123',               // gate_post_id or newspack_popup_id
  *     ts:   1751932800000,       // Date.now() at click
@@ -31,6 +32,16 @@
 
 /** Storage key. Shared with newspack-blocks. */
 export const STORAGE_KEY = 'newspack_cta_attribution';
+
+/**
+ * Storage-record schema version. The contract is duplicated across newspack-plugin and
+ * newspack-blocks (no shared JS package), so a mismatch is a real failure mode if the
+ * two ever drift — one side bumps TTL or the record shape, the other silently honors a
+ * stale record. Stamping the version and checking it on read makes drift fail safe: a
+ * record from a different version is ignored rather than trusted. Bump on any change to
+ * the record fields, the TTL semantics, or the storage key. (dkoo review, #575.)
+ */
+export const SCHEMA = 1;
 
 /**
  * Attribution lifetime, in milliseconds.
@@ -58,7 +69,7 @@ export function persistCtaAttribution( type, id ) {
 		return false;
 	}
 	try {
-		window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { type, id: String( id ), ts: Date.now() } ) );
+		window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { v: SCHEMA, type, id: String( id ), ts: Date.now() } ) );
 		return true;
 	} catch ( e ) {
 		return false;

--- a/plugins/newspack-plugin/src/shared/js/cta-attribution.js
+++ b/plugins/newspack-plugin/src/shared/js/cta-attribution.js
@@ -1,0 +1,66 @@
+/**
+ * CTA attribution hand-off (NPPD-1887).
+ *
+ * When a reader clicks a conversion-intent CTA inside a gate or prompt and is sent
+ * to a landing page, the surface that caused the conversion is left behind. This
+ * module persists the surface's identity so the landing page's checkout/donate form
+ * can replay it as a hidden field, letting the existing server chain
+ * (`INPUT_GET` -> cart item data -> `_gate_post_id` / `_newspack_popup_id` order meta)
+ * fire exactly as it does for a form rendered inside the gate itself.
+ *
+ * ── Storage contract ────────────────────────────────────────────────────────────
+ * This contract is DUPLICATED, by necessity, in newspack-blocks
+ * (`src/shared/js/cta-attribution.js`), which owns the checkout and donate forms and
+ * therefore owns the replay. Both plugins ship independently; there is no shared JS
+ * package between them. Change one, change the other.
+ *
+ *   sessionStorage[ 'newspack_cta_attribution' ] = JSON.stringify( {
+ *     type: 'gate' | 'prompt',   // which surface
+ *     id:   '123',               // gate_post_id or newspack_popup_id
+ *     ts:   1751932800000,       // Date.now() at click
+ *   } )
+ *
+ * `sessionStorage`, not a cookie, on purpose:
+ *   - survives multi-hop navigation (gate -> /subscribe -> /plans -> convert)
+ *   - is copied into a new tab opened from `target="_blank"`
+ *   - dies with the tab, which is a naturally conservative attribution window
+ *   - cannot vary a page-cache key
+ *
+ * Last touch wins: a second CTA click overwrites the first.
+ */
+
+/** Storage key. Shared with newspack-blocks. */
+export const STORAGE_KEY = 'newspack_cta_attribution';
+
+/**
+ * Attribution lifetime, in milliseconds.
+ *
+ * Session-scoped AND time-bounded (product decision, NPPD-1887): a reader who clicks
+ * the CTA, wanders off, and converts two hours later in the same tab gets no credit.
+ * Kept in sync with the same constant in newspack-blocks.
+ */
+export const TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Persist the surface that owns this click.
+ *
+ * Never throws: Safari private mode and storage-disabled browsers make
+ * `sessionStorage.setItem` raise. Attribution is best-effort — losing it must never
+ * break the navigation the reader actually asked for.
+ *
+ * @param {string}        type Surface type: 'gate' or 'prompt'.
+ * @param {string|number} id   The gate_post_id or newspack_popup_id.
+ *
+ * @return {boolean} Whether the value was stored.
+ */
+export function persistCtaAttribution( type, id ) {
+	if ( ! id || ( 'gate' !== type && 'prompt' !== type ) ) {
+		return false;
+	}
+	try {
+		window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { type, id: String( id ), ts: Date.now() } ) );
+		return true;
+	} catch ( e ) {
+		return false;
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/cta-intent-classifier.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cta-intent-classifier.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Tests the CTA_Intent_Classifier.
+ *
+ * Covers the annotation surface added by NPPD-1887. The classification rules
+ * themselves (NPPD-1836/1837) are exercised end-to-end by the newspack-popups
+ * suite, which loads this class from the sibling checkout; what matters here is
+ * the attribute stamping, because that IS the attribution decision — a wrongly
+ * stamped anchor credits a gate for a conversion it did not cause.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\CTA_Intent_Classifier;
+
+/**
+ * Test CTA_Intent_Classifier.
+ */
+class Newspack_Test_CTA_Intent_Classifier extends WP_UnitTestCase {
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		CTA_Intent_Classifier::reset_cache();
+	}
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::tear_down();
+		CTA_Intent_Classifier::reset_cache();
+	}
+
+	/**
+	 * Rendered core/button markup pointing at $href.
+	 *
+	 * @param string $href The button target.
+	 * @return string
+	 */
+	private function button_html( $href ) {
+		return sprintf(
+			'<div class="wp-block-buttons"><div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="%s">Act now</a></div></div>',
+			esc_url( $href )
+		);
+	}
+
+	/**
+	 * A subscription-intent button anchor is stamped with intent and source.
+	 */
+	public function test_subscription_button_is_stamped() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( 'https://example.org/subscribe/' ) );
+		$this->assertStringContainsString( 'data-newspack-cta="subscription"', $html );
+		$this->assertStringContainsString( 'data-newspack-cta-source="pattern"', $html );
+	}
+
+	/**
+	 * A donation-intent button anchor is stamped.
+	 */
+	public function test_donation_button_is_stamped() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( 'https://fundjournalism.org/donate/' ) );
+		$this->assertStringContainsString( 'data-newspack-cta="donation"', $html );
+		$this->assertStringContainsString( 'data-newspack-cta-source="processor"', $html );
+	}
+
+	/**
+	 * The whole point of per-anchor classification: an editorial link inside a gate is
+	 * NOT stamped, so clicking it can never persist attribution. A live probe found a
+	 * publisher whose block-less prompts were almost entirely article links — blanket
+	 * attribution on CTA clicks would have credited subscriptions to traffic reports.
+	 */
+	public function test_editorial_button_is_not_stamped() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( 'https://example.org/2026/06/12/some-long-slug/story' ) );
+		$this->assertStringNotContainsString( 'data-newspack-cta', $html );
+	}
+
+	/**
+	 * Non-conversion tells (event) are classified but never stamped.
+	 */
+	public function test_event_button_is_not_stamped() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( 'https://www.eventbrite.com/e/our-gala-123' ) );
+		$this->assertStringNotContainsString( 'data-newspack-cta', $html );
+	}
+
+	/**
+	 * Newsletter is a conversion intent, but out of the v1 PAID_INTENTS scope: a
+	 * newsletter signup produces no Woo order, so there is nothing to attribute.
+	 */
+	public function test_newsletter_button_is_not_stamped_by_default() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( 'https://example.org/newsletter/' ) );
+		$this->assertStringNotContainsString( 'data-newspack-cta', $html );
+
+		// ...but it is stamped when explicitly requested.
+		$html = CTA_Intent_Classifier::annotate_button_anchors(
+			$this->button_html( 'https://example.org/newsletter/' ),
+			[ 'newsletter' ]
+		);
+		$this->assertStringContainsString( 'data-newspack-cta="newsletter"', $html );
+	}
+
+	/**
+	 * Body-copy links are out of scope even when their href would classify. Only
+	 * `wp-block-button__link` anchors are candidates — the rendered counterpart of
+	 * extract_button_hrefs()'s core/button-only scope.
+	 */
+	public function test_body_copy_link_is_not_stamped() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( '<p>Please <a href="https://example.org/subscribe/">subscribe</a> today.</p>' );
+		$this->assertStringNotContainsString( 'data-newspack-cta', $html );
+	}
+
+	/**
+	 * Per-anchor, not per-container: a gate mixing a paid CTA with an editorial link
+	 * stamps only the former. classify_content() would abstain or collapse here.
+	 */
+	public function test_mixed_buttons_stamp_only_the_paid_one() {
+		$html  = $this->button_html( 'https://example.org/2026/06/12/some-long-slug/story' );
+		$html .= $this->button_html( 'https://example.org/subscribe/' );
+		$out   = CTA_Intent_Classifier::annotate_button_anchors( $html );
+
+		$this->assertSame( 1, substr_count( $out, 'data-newspack-cta="subscription"' ) );
+		// Exactly one intent attribute overall ('data-newspack-cta=' does not match the
+		// longer 'data-newspack-cta-source='), i.e. the editorial anchor stayed bare.
+		$this->assertSame( 1, substr_count( $out, 'data-newspack-cta=' ) );
+		$this->assertStringContainsString( 'some-long-slug', $out );
+	}
+
+	/**
+	 * Two different paid intents in one gate both get their own anchor stamped —
+	 * there is no single verdict to conflict over.
+	 */
+	public function test_two_paid_intents_both_stamped() {
+		$html  = $this->button_html( 'https://donorbox.org/give' );
+		$html .= $this->button_html( 'https://example.org/subscribe/' );
+		$out   = CTA_Intent_Classifier::annotate_button_anchors( $html );
+
+		$this->assertStringContainsString( 'data-newspack-cta="donation"', $out );
+		$this->assertStringContainsString( 'data-newspack-cta="subscription"', $out );
+	}
+
+	/**
+	 * Nothing classifies -> the HTML is returned byte-identical (no reserialization).
+	 */
+	public function test_unchanged_when_nothing_classifies() {
+		$html = $this->button_html( 'https://example.org/?form=123' );
+		$this->assertSame( $html, CTA_Intent_Classifier::annotate_button_anchors( $html ) );
+	}
+
+	/**
+	 * An anchor with no href is skipped rather than fatally classified.
+	 */
+	public function test_hrefless_button_is_skipped() {
+		$html = '<div class="wp-block-button"><a class="wp-block-button__link">No target</a></div>';
+		$this->assertSame( $html, CTA_Intent_Classifier::annotate_button_anchors( $html ) );
+	}
+
+	/**
+	 * Empty input is a no-op, not a fatal.
+	 */
+	public function test_empty_html_is_a_noop() {
+		$this->assertSame( '', CTA_Intent_Classifier::annotate_button_anchors( '' ) );
+	}
+
+	/**
+	 * Classification is case-insensitive on the href, as classify_href() expects
+	 * lowercase input and annotate_button_anchors() is responsible for lowering it.
+	 */
+	public function test_uppercase_href_still_classifies() {
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( 'https://FUNDJOURNALISM.org/DONATE/' ) );
+		$this->assertStringContainsString( 'data-newspack-cta="donation"', $html );
+	}
+
+	/**
+	 * The site's configured donation page wins over pattern matching, and carries the
+	 * higher-confidence source. Guards the option read (no wp_insert_post side effect).
+	 */
+	public function test_configured_donation_page_is_site_config() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'  => 'page',
+				'post_name'  => 'support-us',
+				'post_title' => 'Support us',
+			]
+		);
+		update_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION, $page_id );
+		CTA_Intent_Classifier::reset_cache();
+
+		$html = CTA_Intent_Classifier::annotate_button_anchors( $this->button_html( get_permalink( $page_id ) ) );
+		$this->assertStringContainsString( 'data-newspack-cta="donation"', $html );
+		$this->assertStringContainsString( 'data-newspack-cta-source="site_config"', $html );
+
+		delete_option( \Newspack\Donations::DONATION_PAGE_ID_OPTION );
+		$this->set_permalink_structure( '' );
+	}
+
+	/**
+	 * PAID_INTENTS is the v1 attribution scope and must not silently widen: adding an
+	 * intent here starts writing order meta for it.
+	 */
+	public function test_paid_intents_scope_is_locked() {
+		$this->assertSame( [ 'donation', 'subscription' ], CTA_Intent_Classifier::PAID_INTENTS );
+	}
+
+	/**
+	 * The most common paywall-gate destinations classify as `donation`, not
+	 * `subscription`, because classify_href() tests its donation pattern first and that
+	 * pattern matches `member|membership|donor|contribute|/support`.
+	 *
+	 * This is why `gate.js` derives `gate_has_checkout_link` from ANY paid intent rather
+	 * than from `[data-newspack-cta="subscription"]`. Narrowing it would give these gates
+	 * `checkout_impressions = 0`, and Gates_Metric::get_paywall_conversion_direct() skips
+	 * any gate with `checkout_impressions <= 0` — silently dropping the conversions
+	 * NPPD-1887 exists to capture. Raised in review on workspace#571; declined with this
+	 * test as the guard.
+	 *
+	 * If someone makes these classify as `subscription` (defensible!), the capability
+	 * selector in gate.js can then be narrowed. Until then it must not be.
+	 *
+	 * @dataProvider paywall_destinations_that_read_as_donation
+	 * @param string $href A URL a paywall gate would plausibly link to.
+	 */
+	public function test_common_paywall_destinations_classify_as_donation( $href ) {
+		$hit = CTA_Intent_Classifier::classify_href( $href );
+		$this->assertSame( 'donation', $hit['intent'], "Expected donation for $href" );
+		$this->assertContains( $hit['intent'], CTA_Intent_Classifier::PAID_INTENTS, 'Must still be a paid intent, or the anchor is never stamped.' );
+	}
+
+	/**
+	 * Paywall destinations whose hrefs read as "donation" to the classifier.
+	 *
+	 * @return array
+	 */
+	public function paywall_destinations_that_read_as_donation() {
+		return [
+			'membership'      => [ 'https://example.org/membership/' ],
+			'become a member' => [ 'https://example.org/become-a-member/' ],
+			'support'         => [ 'https://example.org/support/' ],
+		];
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/cta-intent-classifier.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cta-intent-classifier.php
@@ -233,4 +233,38 @@ class Newspack_Test_CTA_Intent_Classifier extends WP_UnitTestCase {
 			'support'         => [ 'https://example.org/support/' ],
 		];
 	}
+
+	/**
+	 * A dated same-host article whose slug contains a conversion token abstains to
+	 * editorial, NOT the paid intent — the strong dated-article guard (/YYYY/MM/) runs
+	 * before the donation/subscription patterns. Without it,
+	 * /2026/06/12/school-board-member-profile/ classifies as `donation` on the "member"
+	 * token, and a click on that editorial button would credit a gate for a conversion
+	 * the reader never made. (dkoo review, #575.)
+	 *
+	 * Counterpart to test_common_paywall_destinations_classify_as_donation: the guard is
+	 * scoped to the dated prefix precisely so real conversion pages (/become-a-member/,
+	 * no date) still win. The WP test home host is example.org, so these are same-host.
+	 *
+	 * @dataProvider dated_articles_with_conversion_tokens
+	 * @param string $href A same-host dated article URL containing a conversion token.
+	 */
+	public function test_dated_article_with_token_abstains_to_editorial( $href ) {
+		$hit = CTA_Intent_Classifier::classify_href( $href );
+		$this->assertSame( 'editorial', $hit['intent'], "Expected editorial for $href" );
+		$this->assertNotContains( $hit['intent'], CTA_Intent_Classifier::PAID_INTENTS, 'A dated article must never be a paid CTA.' );
+	}
+
+	/**
+	 * Same-host dated articles whose slugs contain a conversion token.
+	 *
+	 * @return array
+	 */
+	public function dated_articles_with_conversion_tokens() {
+		return [
+			'member token'    => [ 'https://example.org/2026/06/12/school-board-member-profile/' ],
+			'donate token'    => [ 'https://example.org/2026/06/12/how-to-donate-blood-locally/' ],
+			'subscribe token' => [ 'https://example.org/2026/01/03/why-i-subscribe-to-print/' ],
+		];
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/gate-cta-annotation.php
+++ b/plugins/newspack-plugin/tests/unit-tests/gate-cta-annotation.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests the no-double-count invariant behind gate CTA attribution (NPPD-1887).
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\CTA_Intent_Classifier;
+
+/**
+ * Guards the invariant that makes landing-page attribution safe.
+ */
+class Newspack_Test_Gate_CTA_Annotation extends WP_UnitTestCase {
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		CTA_Intent_Classifier::reset_cache();
+	}
+
+	/**
+	 * THE load-bearing invariant.
+	 *
+	 * Two attribution paths write the same order meta:
+	 *   - in-gate  : the checkout button's own <form> carries a hidden gate_post_id
+	 *   - off-gate : a CTA click persists the gate id, replayed on the landing page
+	 *
+	 * They must never both fire for one conversion. Today they can't, because the
+	 * in-gate checkout button renders as `<button type="submit">` while the CTA click
+	 * listener binds only to `<a data-newspack-cta>`. That is a property of
+	 * newspack-blocks' markup, not a guarantee — if the checkout button ever becomes an
+	 * anchor, a single in-gate checkout would both stamp the form AND persist a replay
+	 * record, and the two paths would silently double-attribute.
+	 *
+	 * This test fails loudly if that markup changes. Read the NPPD-1887 issue before
+	 * "fixing" it: the fix is to exclude checkout-button anchors from the click
+	 * listener, not to delete the assertion.
+	 */
+	public function test_in_gate_checkout_button_is_not_an_anchor() {
+		$view = dirname( NEWSPACK_PLUGIN_FILE ) . '/../newspack-blocks/src/blocks/checkout-button/view.php';
+		if ( ! file_exists( $view ) ) {
+			$this->markTestSkipped( 'newspack-blocks sibling checkout is not available.' );
+		}
+		// Reading a local sibling file in a test; not remote, nothing to cache.
+		$source = file_get_contents( $view ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+
+		$this->assertStringContainsString(
+			'<button class="%1$s" style="%2$s" type="submit">%3$s</button>',
+			$source,
+			'The checkout button must render as <button>. An <a> would be picked up by the gate CTA click listener and double-attribute.'
+		);
+	}
+
+	/**
+	 * A gate whose only paywall path is a link gets its anchor stamped, which is what
+	 * makes both the click listener and `gate_has_checkout_link` fire.
+	 */
+	public function test_link_only_gate_anchor_is_stamped() {
+		$gate_html = '<div class="wp-block-buttons"><div class="wp-block-button">'
+			. '<a class="wp-block-button__link" href="https://example.org/subscribe/">Subscribe</a>'
+			. '</div></div>';
+
+		$out = CTA_Intent_Classifier::annotate_button_anchors( $gate_html );
+		$this->assertStringContainsString( 'data-newspack-cta="subscription"', $out );
+	}
+
+	/**
+	 * The classifier is a pure function of the href: it never mutates the anchor's
+	 * href, class, or text. A rewritten CTA target would silently break the reader's
+	 * navigation, which matters far more than the attribution.
+	 */
+	public function test_annotation_preserves_href_and_content() {
+		$href      = 'https://example.org/subscribe/?plan=annual&amp;ref=gate';
+		$gate_html = sprintf(
+			'<div class="wp-block-button"><a class="wp-block-button__link" href="%s">Subscribe now</a></div>',
+			$href
+		);
+
+		$out = CTA_Intent_Classifier::annotate_button_anchors( $gate_html );
+		$this->assertStringContainsString( 'href="' . $href . '"', $out );
+		$this->assertStringContainsString( '>Subscribe now</a>', $out );
+		$this->assertStringContainsString( 'wp-block-button__link', $out );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/gate-order-attribution.php
+++ b/plugins/newspack-plugin/tests/unit-tests/gate-order-attribution.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Tests gate-id validation before it reaches order meta (NPPD-1887).
+ *
+ * `_gate_post_id` is written from a client-supplied form field. Since NPPD-1887 that
+ * field can also be REPLAYED from sessionStorage onto a landing-page checkout form,
+ * so the value is validated before it is persisted. Insights GROUPs its per-gate
+ * breakdown by this meta value, so a junk id doesn't just fail to attribute — it
+ * invents a gate.
+ *
+ * Uses a duck-typed order stub: checkout_create_order_line_item() only ever calls
+ * add_meta_data(), so the test needs no WooCommerce.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events\Memberships;
+
+/**
+ * Test gate-id validation.
+ */
+class Newspack_Test_Gate_Order_Attribution extends WP_UnitTestCase {
+
+	/**
+	 * Minimal stand-in for WC_Order. Anonymous so the file holds one class, per PHPCS.
+	 *
+	 * @return object An object exposing add_meta_data() and a public $meta array.
+	 */
+	private function order_stub() {
+		return new class() {
+			/**
+			 * Collected meta.
+			 *
+			 * @var array
+			 */
+			public $meta = [];
+
+			/**
+			 * Record a meta write.
+			 *
+			 * @param string $key   Meta key.
+			 * @param mixed  $value Meta value.
+			 */
+			public function add_meta_data( $key, $value ) {
+				$this->meta[ $key ] = $value;
+			}
+		};
+	}
+
+	/**
+	 * Run the order-line-item hook with a candidate gate id and return the meta written.
+	 *
+	 * @param mixed $gate_post_id Candidate id.
+	 * @return array
+	 */
+	private function meta_for( $gate_post_id ) {
+		$order = $this->order_stub();
+		Memberships::checkout_create_order_line_item( null, null, [ 'gate_post_id' => $gate_post_id ], $order );
+		return $order->meta;
+	}
+
+	/**
+	 * The gate id must be collected on BOTH cart paths.
+	 *
+	 * Donations add to cart through Donations::process_donation_request(), which applies
+	 * `newspack_donations_cart_item_data` and never the modal-checkout filter. Without a
+	 * listener there, a gate CTA pointing at the donation page carries `gate_post_id` all
+	 * the way into `INPUT_GET` and then silently drops it — the client-side replay looks
+	 * wired but nothing persists. Caught by driving a real donation, not by unit tests.
+	 */
+	public function test_gate_id_is_collected_on_both_cart_paths() {
+		foreach ( [ 'newspack_blocks_modal_checkout_cart_item_data', 'newspack_donations_cart_item_data' ] as $filter ) {
+			$this->assertNotFalse(
+				has_filter( $filter, [ Memberships::class, 'checkout_cart_item_data' ] ),
+				"Memberships::checkout_cart_item_data must listen on $filter"
+			);
+		}
+	}
+
+	/**
+	 * A real gate is attributed, and persisted as an integer.
+	 */
+	public function test_real_gate_is_attributed_as_int() {
+		$gate_id = self::factory()->post->create( [ 'post_type' => \Newspack\Content_Gate::GATE_CPT ] );
+
+		$meta = $this->meta_for( $gate_id );
+		$this->assertSame( $gate_id, $meta['_gate_post_id'] );
+		$this->assertIsInt( $meta['_gate_post_id'] );
+	}
+
+	/**
+	 * The validator casts, so the WRITER must persist the cast value — not the raw
+	 * candidate. `(int) '123 OR 1=1'` is 123: validating the cast while writing the
+	 * original would land a malformed string in `_gate_post_id`, and Insights groups
+	 * its per-gate breakdown by that value.
+	 *
+	 * Found by driving a real checkout in a local environment, not by reading the code.
+	 */
+	public function test_malformed_id_is_normalized_not_persisted_raw() {
+		$gate_id = self::factory()->post->create( [ 'post_type' => \Newspack\Content_Gate::GATE_CPT ] );
+
+		foreach ( [ "$gate_id OR 1=1", "{$gate_id}abc", " $gate_id " ] as $candidate ) {
+			$meta = $this->meta_for( $candidate );
+			$this->assertSame( $gate_id, $meta['_gate_post_id'], "Candidate: $candidate" );
+			$this->assertIsInt( $meta['_gate_post_id'], "Candidate: $candidate" );
+		}
+	}
+
+	/**
+	 * A post that exists but is not a gate is rejected outright.
+	 */
+	public function test_non_gate_post_is_rejected() {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+		$this->assertArrayNotHasKey( '_gate_post_id', $this->meta_for( $post_id ) );
+	}
+
+	/**
+	 * Nonexistent, zero, negative and non-numeric ids are all rejected.
+	 *
+	 * @dataProvider bad_ids
+	 * @param mixed $candidate The id that must not be attributed.
+	 */
+	public function test_bad_ids_are_rejected( $candidate ) {
+		$this->assertArrayNotHasKey( '_gate_post_id', $this->meta_for( $candidate ), var_export( $candidate, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+	}
+
+	/**
+	 * Ids that must never reach order meta.
+	 *
+	 * @return array
+	 */
+	public function bad_ids() {
+		return [
+			'nonexistent'  => [ 99999999 ],
+			'zero'         => [ 0 ],
+			'negative'     => [ -5 ],
+			'non-numeric'  => [ 'abc' ],
+			'empty string' => [ '' ],
+		];
+	}
+}


### PR DESCRIPTION
Refs [NPPD-1887](https://linear.app/a8c/issue/NPPD-1887/insights-credit-gates-and-prompts-for-conversions-that-happen-on-a). **Targets `release`.**

## Why this exists separately, and why it targets `release`

The full NPPD-1887 work is [workspace#571](https://github.com/Automattic/newspack-workspace/pull/571) → `feat/insights-rsm`. That branch also carries the Insights *reading* side, the prompts half, and the hub denominator — none of which is released.

But one piece of #571 is **forward-only and unrecoverable**: the `_gate_post_id` order meta. It's written at order time, so any gate→landing-page conversion that happens before the capture code ships is unattributed *forever* — there's no backfill. Insights isn't released yet (0 files on `main`/`alpha`/`release`), but when it does launch it can only show history that was captured in the meantime.

So this PR extracts **just the gate-side capture** — the part that banks data — and targets `release` so orders start carrying `_gate_post_id` now, independent of the Insights UI. The reading side ships later with Insights and finds the history waiting.

**This is capture, not Insights.** Every changed file references Insights only in *comments*. `_gate_post_id` is plain WooCommerce order meta; the code that writes it (`GATE_CPT`, `Donations`, `data-events/Memberships`) already exists on `release`. Verified: the full capture test suite passes against the `release` baseline with no Insights and no NPPD-1837 present (29 tests).

## What it does

A reader clicks a paid-intent CTA inside a gate that links to a subscription/donation landing page, converts there, and the order now carries `_gate_post_id` — exactly as it does for a checkout block rendered inside the gate.

1. **`Newspack\CTA_Intent_Classifier`** — classifies a CTA href as `donation` / `subscription` / non-conversion. (This is NPPD-1837's classifier; on `release` it's brand-new, self-contained, no dependency on Campaigns or Insights.)
2. **Stamp at gate render** — `data-newspack-cta` on paid-intent `wp-block-button__link` anchors, at the two gate-HTML producers only (never the article excerpt).
3. **Persist on click** — `gate.js` writes `sessionStorage.newspack_cta_attribution` and fires a new `np_gate_interaction / action:'clicked'` event (gates never had a click event).
4. **Replay at submit** — `modal.js` injects the hidden field, guarded so a form already carrying the id wins and a form inside a gate is never touched.
5. **Validate before writing meta** — client-supplied ids are checked against the gate CPT and persisted as integers.

## The gtag fix — a live bug this also carries

`gate.js::addFormInputs()` — which stamps `gate_post_id` onto the gate's own checkout form, i.e. the entire in-gate attribution chain — sat **behind** an early `if ( 'function' !== typeof window.gtag ) return;`. So on `release` today, **every reader with GA blocked who converts through a gate's embedded checkout produces an order with no gate on it** — silent, ongoing, unrecoverable data loss on every gated site, unrelated to landing pages. Moved above the guard. Verified live with `window.gtag` forced `undefined`: the order carried `_gate_post_id`.

## Not included (stays on #571 → insights-rsm)

- Prompts capture (depends on NPPD-1837, which isn't on `release`)
- The popups classifier delegation and prompt-id validation hardening
- Everything Insights reads (`Subscribers_Metric`, Gates tab, etc.)
- The hub denominator PR

## Verified end-to-end on real orders (on the rsm build; identical code)

- gated post → stamped CTA → `/subscribe/` → real WooCommerce subscription → order carried **`_gate_post_id`**
- in-gate checkout with `window.gtag` forced undefined → order carried `_gate_post_id` (the gtag fix)
- editorial link click in the same gate → persists nothing

## Testing

- Capture PHP suite: **29 pass against the `release` baseline** (classifier, gate annotation, order-meta validation)
- JS byte-identical to the ESLint-clean #571 versions
- Root PHPCS clean

## Reviewer notes

- **Touches the live checkout path** (`modal.js` replay runs on every modal-checkout submit; classifier runs at gate render). All defensively guarded (try/catch on storage, null guards, two replay guards), but it warrants a careful human read before merge.
- This deliberately duplicates #571's gate-capture commits. When this reaches `main` via `release → main` and `feat/insights-rsm` next syncs `main`, the identical hunks reconcile. #571 can then drop its capture portion, or be merged as-is.
- Copilot review response on #571 applies here too: `gate_has_checkout_link` is stamped for **any** paid intent (not just subscription) on purpose — `classify_href()` reads `/membership/` as `donation`, and narrowing it would drop those conversions. See NPPD-1888.