### PR TITLE
fix(newspack-blocks): skip article-block image crops on wpcom uploads

### DIFF
--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -25,6 +25,7 @@ class Newspack_Blocks {
 	 */
 	public static function init() {
 		add_action( 'after_setup_theme', [ __CLASS__, 'add_image_sizes' ] );
+		add_filter( 'intermediate_image_sizes_advanced', [ __CLASS__, 'maybe_skip_article_block_image_subsizes' ] );
 		add_post_type_support( 'post', 'newspack_blocks' );
 		add_post_type_support( 'page', 'newspack_blocks' );
 		add_action( 'jetpack_register_gutenberg_extensions', [ __CLASS__, 'disable_jetpack_donate' ], 99 );
@@ -540,6 +541,57 @@ class Newspack_Blocks {
 		add_image_size( 'newspack-article-block-square-tiny', 200, 200, true );
 
 		add_image_size( 'newspack-article-block-uncropped', 1200, 9999, false );
+	}
+
+	/**
+	 * Optionally skip generating the physical `newspack-article-block-*` crop
+	 * files when an image is uploaded.
+	 *
+	 * These sizes stay registered (via `add_image_sizes()`) so the blocks keep
+	 * resolving correctly-cropped URLs, but on platforms where an image CDN
+	 * resizes/crops on the fly (WordPress.com Simple and Atomic), the physical
+	 * crop files are redundant. Skipping them also keeps derivative generation
+	 * consistent across upload paths: on wpcom, `newspack-blocks` is loaded via
+	 * jetpack-mu-wpcom only for editor/REST requests, so an image uploaded through
+	 * the editor's Image block (REST) would otherwise get the crops while the same
+	 * image uploaded through the Media Library (async-upload.php) would not.
+	 *
+	 * @param array $sizes Associative array of image sub-sizes to be generated,
+	 *                     keyed by size name.
+	 * @return array Filtered sizes.
+	 */
+	public static function maybe_skip_article_block_image_subsizes( $sizes ) {
+		/**
+		 * Filters whether to skip generating the physical `newspack-article-block-*`
+		 * crop files on upload. Defaults to true on WordPress.com platform sites
+		 * (Simple and Atomic), where an image CDN handles cropping on the fly.
+		 * Self-hosted sites can opt in, e.g. when using the Jetpack Image CDN.
+		 *
+		 * @param bool $skip Whether to skip physical crop generation.
+		 */
+		$skip = apply_filters( 'newspack_blocks_skip_article_image_subsizes', self::is_wpcom_platform() );
+		if ( ! $skip ) {
+			return $sizes;
+		}
+
+		foreach ( array_keys( $sizes ) as $size_name ) {
+			if ( is_string( $size_name ) && 0 === strpos( $size_name, 'newspack-article-block-' ) ) {
+				unset( $sizes[ $size_name ] );
+			}
+		}
+		return $sizes;
+	}
+
+	/**
+	 * Whether the current site runs on the WordPress.com platform (Simple or Atomic).
+	 *
+	 * @return bool
+	 */
+	private static function is_wpcom_platform() {
+		if ( ! class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
+			return false;
+		}
+		return ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_platform();
 	}
 
 	/**

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -544,28 +544,21 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Optionally skip generating the physical `newspack-article-block-*` crop
-	 * files when an image is uploaded.
+	 * Skip generating the physical `newspack-article-block-*` crop files on upload.
 	 *
-	 * These sizes stay registered (via `add_image_sizes()`) so the blocks keep
-	 * resolving correctly-cropped URLs, but on platforms where an image CDN
-	 * resizes/crops on the fly (WordPress.com Simple and Atomic), the physical
-	 * crop files are redundant. Skipping them also keeps derivative generation
-	 * consistent across upload paths: on wpcom, `newspack-blocks` is loaded via
-	 * jetpack-mu-wpcom only for editor/REST requests, so an image uploaded through
-	 * the editor's Image block (REST) would otherwise get the crops while the same
-	 * image uploaded through the Media Library (async-upload.php) would not.
+	 * The sizes stay registered, so blocks still resolve correctly-cropped URLs;
+	 * we only skip writing the files where an image CDN crops on the fly (wpcom).
+	 * This also makes the Image block (REST) and Media Library upload paths behave
+	 * the same on wpcom, where they otherwise differ.
 	 *
-	 * @param array $sizes Associative array of image sub-sizes to be generated,
-	 *                     keyed by size name.
+	 * @param array $sizes Image sub-sizes to generate, keyed by size name.
 	 * @return array Filtered sizes.
 	 */
 	public static function maybe_skip_article_block_image_subsizes( $sizes ) {
 		/**
-		 * Filters whether to skip generating the physical `newspack-article-block-*`
-		 * crop files on upload. Defaults to true on WordPress.com platform sites
-		 * (Simple and Atomic), where an image CDN handles cropping on the fly.
-		 * Self-hosted sites can opt in, e.g. when using the Jetpack Image CDN.
+		 * Filters whether to skip physical `newspack-article-block-*` crop generation.
+		 * Defaults to true on WordPress.com (Simple/Atomic); self-hosted sites can
+		 * opt in, e.g. when using the Jetpack Image CDN.
 		 *
 		 * @param bool $skip Whether to skip physical crop generation.
 		 */

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -544,31 +544,36 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Skip generating the physical `newspack-article-block-*` crop files on upload.
+	 * Skip generating the physical `newspack-article-block-*` sub-size files on upload.
 	 *
 	 * The sizes stay registered, so blocks still resolve correctly-cropped URLs;
-	 * we only skip writing the files where an image CDN crops on the fly (wpcom).
-	 * This also makes the Image block (REST) and Media Library upload paths behave
-	 * the same on wpcom, where they otherwise differ.
+	 * we only skip writing the files where an on-the-fly image CDN can reproduce them
+	 * from the registered sizes. The prefix match removes every `newspack-article-block-*`
+	 * sub-size, including `newspack-article-block-uncropped` (registered with
+	 * `crop => false` — a plain downscale, not a crop); the CDN resizes as well as
+	 * crops, so none of them need a physical file. This also makes the Image block
+	 * (REST) and Media Library upload paths behave the same on wpcom, where they
+	 * otherwise differ.
 	 *
 	 * @param array $sizes Image sub-sizes to generate, keyed by size name.
 	 * @return array Filtered sizes.
 	 */
-	public static function maybe_skip_article_block_image_subsizes( $sizes ) {
+	public static function maybe_skip_article_block_image_subsizes( array $sizes ): array {
 		/**
-		 * Filters whether to skip physical `newspack-article-block-*` crop generation.
-		 * Defaults to true on WordPress.com (Simple/Atomic); self-hosted sites can
-		 * opt in, e.g. when using the Jetpack Image CDN.
+		 * Filters whether to skip physical `newspack-article-block-*` sub-size generation.
+		 * Defaults to true where an on-the-fly image CDN reproduces the sizes: WordPress.com
+		 * Simple (always) and Atomic (only when the Jetpack Image CDN is active). Self-hosted
+		 * sites can opt in, e.g. when fronting uploads with the Jetpack Image CDN.
 		 *
-		 * @param bool $skip Whether to skip physical crop generation.
+		 * @param bool $skip Whether to skip physical sub-size generation.
 		 */
-		$skip = apply_filters( 'newspack_blocks_skip_article_image_subsizes', self::is_wpcom_platform() );
+		$skip = apply_filters( 'newspack_blocks_skip_article_image_subsizes', self::is_wpcom_image_cdn_active() );
 		if ( ! $skip ) {
 			return $sizes;
 		}
 
 		foreach ( array_keys( $sizes ) as $size_name ) {
-			if ( is_string( $size_name ) && 0 === strpos( $size_name, 'newspack-article-block-' ) ) {
+			if ( is_string( $size_name ) && str_starts_with( $size_name, 'newspack-article-block-' ) ) {
 				unset( $sizes[ $size_name ] );
 			}
 		}
@@ -576,15 +581,30 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Whether the current site runs on the WordPress.com platform (Simple or Atomic).
+	 * Whether this site serves images through an on-the-fly image CDN that crops and
+	 * resizes from the registered sizes, making the physical `newspack-article-block-*`
+	 * files redundant.
+	 *
+	 * WordPress.com Simple always serves images through the platform image CDN. On
+	 * Atomic the Jetpack Image CDN (Photon) can be toggled off, so it counts only when
+	 * the module is active — otherwise the crops must still be generated. Self-hosted
+	 * sites are not auto-detected here; they opt in via the filter above.
 	 *
 	 * @return bool
 	 */
-	private static function is_wpcom_platform() {
+	private static function is_wpcom_image_cdn_active(): bool {
 		if ( ! class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
 			return false;
 		}
-		return ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_platform();
+		$host = new \Automattic\Jetpack\Status\Host();
+		if ( $host->is_wpcom_simple() ) {
+			return true;
+		}
+		if ( $host->is_wpcom_platform() ) {
+			// Atomic: only skip when the Image CDN (Photon) is actually active to crop on the fly.
+			return class_exists( 'Jetpack' ) && \Jetpack::is_module_active( 'photon' );
+		}
+		return false;
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-image-sizes.php
+++ b/plugins/newspack-blocks/tests/test-image-sizes.php
@@ -67,19 +67,23 @@ class ImageSizesTest extends WP_UnitTestCase { // phpcs:ignore
 			array_filter(
 				array_keys( $sizes ),
 				function ( $key ) {
-					return 0 === strpos( $key, 'newspack-article-block-' );
+					return str_starts_with( $key, 'newspack-article-block-' );
 				}
 			)
 		);
 	}
 
 	/**
-	 * Default (not skipping): all article block crops are left in place.
+	 * Default (no filter, no on-the-fly image CDN detected): all article block crops
+	 * are left in place.
+	 *
+	 * With no filter attached this exercises the real default — `is_wpcom_image_cdn_active()`,
+	 * which returns false in the test env because the Jetpack Status\Host and Jetpack classes
+	 * aren't loaded — so it also covers the `class_exists` guard, the branch most likely to
+	 * regress.
 	 */
 	public function test_article_block_subsizes_kept_by_default() {
-		add_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_false' );
 		$filtered = apply_filters( 'intermediate_image_sizes_advanced', $this->sample_sizes(), [], 0 );
-		remove_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_false' );
 
 		$this->assertCount( 16, $this->article_block_keys( $filtered ), 'All 16 article block crops should be retained.' );
 	}

--- a/plugins/newspack-blocks/tests/test-image-sizes.php
+++ b/plugins/newspack-blocks/tests/test-image-sizes.php
@@ -1,0 +1,103 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class ImageSizesTest
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Tests for Newspack article block image sub-size generation.
+ */
+class ImageSizesTest extends WP_UnitTestCase { // phpcs:ignore
+
+	/**
+	 * A representative set of sub-sizes as passed to
+	 * `intermediate_image_sizes_advanced`: core sizes plus the Newspack article
+	 * block crops.
+	 *
+	 * @return array
+	 */
+	private function sample_sizes() {
+		$sizes = [
+			'thumbnail'    => [
+				'width'  => 150,
+				'height' => 150,
+				'crop'   => true,
+			],
+			'medium'       => [
+				'width'  => 300,
+				'height' => 300,
+				'crop'   => false,
+			],
+			'medium_large' => [
+				'width'  => 768,
+				'height' => 0,
+				'crop'   => false,
+			],
+			'large'        => [
+				'width'  => 1024,
+				'height' => 1024,
+				'crop'   => false,
+			],
+		];
+		foreach ( [ 'landscape', 'portrait', 'square' ] as $orientation ) {
+			foreach ( [ 'large', 'medium', 'intermediate', 'small', 'tiny' ] as $tier ) {
+				$sizes[ "newspack-article-block-{$orientation}-{$tier}" ] = [
+					'width'  => 400,
+					'height' => 300,
+					'crop'   => true,
+				];
+			}
+		}
+		$sizes['newspack-article-block-uncropped'] = [
+			'width'  => 1200,
+			'height' => 9999,
+			'crop'   => false,
+		];
+		return $sizes;
+	}
+
+	/**
+	 * Returns the article-block size keys present in a sizes array.
+	 *
+	 * @param array $sizes Sizes array.
+	 * @return string[]
+	 */
+	private function article_block_keys( $sizes ) {
+		return array_values(
+			array_filter(
+				array_keys( $sizes ),
+				function ( $key ) {
+					return 0 === strpos( $key, 'newspack-article-block-' );
+				}
+			)
+		);
+	}
+
+	/**
+	 * By default (self-hosted, not skipping) the article block sub-sizes are
+	 * generated as physical files, i.e. left untouched by the filter.
+	 */
+	public function test_article_block_subsizes_kept_by_default() {
+		add_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_false' );
+		$filtered = apply_filters( 'intermediate_image_sizes_advanced', $this->sample_sizes(), [], 0 );
+		remove_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_false' );
+
+		$this->assertCount( 16, $this->article_block_keys( $filtered ), 'All 16 article block crops should be retained.' );
+	}
+
+	/**
+	 * When skipping is enabled (wpcom / image CDN), the article block sub-sizes
+	 * are removed from physical generation while core sizes are retained.
+	 */
+	public function test_article_block_subsizes_removed_when_skipping() {
+		add_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_true' );
+		$filtered = apply_filters( 'intermediate_image_sizes_advanced', $this->sample_sizes(), [], 0 );
+		remove_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_true' );
+
+		$this->assertSame( [], $this->article_block_keys( $filtered ), 'No article block crops should be generated when skipping.' );
+		$this->assertArrayHasKey( 'thumbnail', $filtered, 'Core thumbnail size must be retained.' );
+		$this->assertArrayHasKey( 'large', $filtered, 'Core large size must be retained.' );
+		$this->assertCount( 4, $filtered, 'Only the four core sizes should remain.' );
+	}
+}

--- a/plugins/newspack-blocks/tests/test-image-sizes.php
+++ b/plugins/newspack-blocks/tests/test-image-sizes.php
@@ -11,9 +11,8 @@
 class ImageSizesTest extends WP_UnitTestCase { // phpcs:ignore
 
 	/**
-	 * A representative set of sub-sizes as passed to
-	 * `intermediate_image_sizes_advanced`: core sizes plus the Newspack article
-	 * block crops.
+	 * Sample sub-sizes as passed to `intermediate_image_sizes_advanced`:
+	 * core sizes plus the Newspack article block crops.
 	 *
 	 * @return array
 	 */
@@ -75,8 +74,7 @@ class ImageSizesTest extends WP_UnitTestCase { // phpcs:ignore
 	}
 
 	/**
-	 * By default (self-hosted, not skipping) the article block sub-sizes are
-	 * generated as physical files, i.e. left untouched by the filter.
+	 * Default (not skipping): all article block crops are left in place.
 	 */
 	public function test_article_block_subsizes_kept_by_default() {
 		add_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_false' );
@@ -87,8 +85,8 @@ class ImageSizesTest extends WP_UnitTestCase { // phpcs:ignore
 	}
 
 	/**
-	 * When skipping is enabled (wpcom / image CDN), the article block sub-sizes
-	 * are removed from physical generation while core sizes are retained.
+	 * Skipping enabled (wpcom / image CDN): article block crops are removed,
+	 * core sizes are retained.
 	 */
 	public function test_article_block_subsizes_removed_when_skipping() {
 		add_filter( 'newspack_blocks_skip_article_image_subsizes', '__return_true' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Uploading an image through the editor's Image block generated a full set of ~16 `newspack-article-block-*` crop derivatives, while uploading the same image through the Media Library generated only the core sizes. On WordPress.com sites this is inconsistent because `newspack-blocks` (and its image-size registration) is loaded by jetpack-mu-wpcom only for editor/REST requests: the REST upload path from the Image block (`is_admin()` is false) registers the crop sizes and generates the files, whereas the Media Library's `async-upload.php` path does not.

This skips generating the **physical** `newspack-article-block-*` crop files on WordPress.com platform sites (Simple and Atomic), where an image CDN crops on the fly from the source image. The sizes stay registered, so the blocks still resolve correctly-cropped URLs via the CDN — only the redundant physical files are skipped. The result is consistent across both upload paths (neither generates the extra files on wpcom).

* Adds an `intermediate_image_sizes_advanced` filter that removes the `newspack-article-block-*` sub-sizes from physical generation when the site is on the wpcom platform.
* Leaves the sizes registered so `image_size_for_orientation()` still resolves the cropped CDN URL (and falls back to `large` if a crop can't be resolved).
* Self-hosted sites are unaffected — they keep generating the physical crops. A new `newspack_blocks_skip_article_image_subsizes` filter lets self-hosted sites opt in (e.g. when using the Jetpack Image CDN).

Note: on wpcom this fix takes effect once the change is synced into `jetpack-mu-wpcom` (the blocks there are auto-synced from this plugin).

Closes NPPM-2798.

### How to test the changes in this Pull Request:

**Unit tests (local):**

1. `cd plugins/newspack-blocks && n test-php --filter ImageSizesTest` — both tests pass (crops retained by default; removed when skipping is enabled).
2. `n test-php` — full suite is green.

**wpcom / Atomic (full behavior — needs a WP Cloud site with this change synced into jetpack-mu-wpcom, and without the standalone `newspack-blocks` plugin):**

3. Upload an image via the editor's **Image block**. Confirm no `newspack-article-block-*` derivatives are created (e.g. via EWWW's file listing, or by inspecting the uploads dir).
4. Upload the same image via the **Media Library**. Confirm the result matches step 3 — both paths now produce the same (core-only) derivatives.
5. Add a Homepage Posts / Blog Posts block using that image and confirm the thumbnail still renders correctly cropped (served via the image CDN), not stretched or full-size.

**Self-hosted regression:**

6. On a self-hosted site (no wpcom platform), upload an image and confirm the `newspack-article-block-*` crops are still generated as before — behavior is unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
