### PR TITLE
test: deploy e2e-plugin.php from the repo during provisioning (NPPM-2919)

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -41,8 +41,11 @@ installed plugin code, so a plugin/core update can't leave a stale fixture behin
   (ads/newsletters/manager), Stripe test keys, editor preferences, timezone, etc.
   `--woo` / `--no-woo` selects the WooCommerce stack.
 - **`tests/site-setup.ts`** (`setupSite`) is how the Playwright setup projects run
-  it: it copies `site-setup.sh` onto the target and streams `e2e-setup.sh` (which
-  points at the copy via `SITE_SETUP_SCRIPT`). Locally it `docker cp` + `docker exec`s
+  it: it copies `site-setup.sh` and `e2e-plugin.php` onto the target and streams
+  `e2e-setup.sh`, pointing it at the copies via `SITE_SETUP_SCRIPT` /
+  `E2E_PLUGIN_SRC`. `e2e-setup.sh` then deploys the plugin into the site's plugins
+  dir before activating it, so the running plugin always matches the committed
+  source. Locally it `docker cp` + `docker exec`s
   into the env container (as root, `--allow-root`, full `wp db reset`); on CI it
   SSHes to the host (no `--allow-root`, `--reset clean` since a managed host can't
   `DROP DATABASE`). Local vs remote is decided from the `SITE_URL` host.
@@ -52,8 +55,9 @@ installed plugin code, so a plugin/core update can't leave a stale fixture behin
   `ADMIN_PASSWORD=password` is for the local env; staging's lives in the a8c secret
   store (README → `secret_id=12168`).
 - **On-site prerequisites**: the WooCommerce stack for the `--woo` path, and the
-  `e2e-plugin` + the Newspack plugins the suite activates (incl. `newspack-manager`)
-  must be installed. `site-setup.sh` itself is shipped from this repo, not the site.
+  Newspack plugins the suite activates (incl. `newspack-manager`) must be installed.
+  `site-setup.sh` and `e2e-plugin.php` are shipped from this repo, not the site –
+  provisioning deploys the plugin every run, so it can't drift out of sync.
 
 ## CI (TeamCity) notes
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -8,8 +8,10 @@ Will need a local test site – set it up with [`newspack-docker`](https://githu
 
 1. One-time setup (unless the files mentioned below are updated)
    - create an `.env` file (see `.env-sample`).
-   - put `e2e-plugin.php` in the test site's plugins directory
    - set up payments - see "Payments" section below
+
+   Provisioning deploys `e2e-plugin.php` onto the site from this repo on every run,
+   so there is no separate step to install it (and no stale copy to keep in sync).
 2. Testing
    - run `npm run test:setup` for a full run that provisions the site before each phase
    - run `npm t` to run the specs against the site's current state (no provisioning)
@@ -113,12 +115,14 @@ underlying `site-setup.sh`) create it, so it's rebuilt on every run.
 
 ## Provisioning the test site manually
 
-`e2e-setup.sh` and `site-setup.sh` can be run by hand. Copy both into the site's
-WordPress root (they must sit together so `e2e-setup.sh` finds `site-setup.sh`
-next to it), then, inside the local Docker container:
+`e2e-setup.sh` and `site-setup.sh` can be run by hand. Copy them, plus
+`e2e-plugin.php`, into the site's WordPress root (they must sit together so
+`e2e-setup.sh` finds `site-setup.sh` and `e2e-plugin.php` next to it), then,
+inside the local Docker container:
 ```
-docker cp site-setup.sh <container>:/var/www/html/
-docker cp e2e-setup.sh  <container>:/var/www/html/
+docker cp site-setup.sh  <container>:/var/www/html/
+docker cp e2e-setup.sh   <container>:/var/www/html/
+docker cp e2e-plugin.php <container>:/var/www/html/
 docker exec -i <container> bash /var/www/html/e2e-setup.sh --woo --allow-root \
   --url <site-url> --admin-user admin --admin-password password
 ```

--- a/e2e/e2e-setup.sh
+++ b/e2e/e2e-setup.sh
@@ -88,6 +88,19 @@ if [ ! -f "$SITE_SETUP" ]; then
   exit 1
 fi
 
+# Resolve the e2e helper plugin source. setupSite (tests/site-setup.ts) copies it
+# onto the target and sets E2E_PLUGIN_SRC to point at that copy; a manual
+# `bash e2e-setup.sh` leaves it unset and we fall back to the copy next to this
+# script (there $0 is a real path, unlike the piped `bash -s` flow, which always
+# sets E2E_PLUGIN_SRC). We track which case we're in so a missing shipped copy
+# fails loudly while a missing manual copy only warns (see the sync step below).
+if [ -n "${E2E_PLUGIN_SRC:-}" ]; then
+  E2E_PLUGIN_SRC_EXPLICIT=true
+else
+  E2E_PLUGIN_SRC_EXPLICIT=false
+  E2E_PLUGIN_SRC="$(dirname "$0")/e2e-plugin.php"
+fi
+
 echo "==> Running site-setup.sh (woo=$WOO)"
 SITE_SETUP_ARGS=(
   --posts-count 20      # A handful is plenty for e2e; 40 is slow to generate.
@@ -109,6 +122,24 @@ wp --skip-plugins --skip-themes config set NEWSPACK_IS_E2E true --raw
 wp --skip-plugins --skip-themes config set NEWSPACK_EMAIL_CHANGE_ENABLED true --raw
 
 wp --skip-themes option update timezone_string 'America/New_York'
+
+# Sync the e2e helper plugin from the repo copy so the running plugin always
+# matches the committed source. It's a single-file plugin that provisioning only
+# *activates*, so without this an edit to e2e-plugin.php would never reach the
+# site (it would keep running whatever was last installed there by hand).
+if [ -f "$E2E_PLUGIN_SRC" ]; then
+  E2E_PLUGINS_DIR="$(wp --skip-plugins --skip-themes plugin path)"
+  cp "$E2E_PLUGIN_SRC" "$E2E_PLUGINS_DIR/e2e-plugin.php"
+elif [ "$E2E_PLUGIN_SRC_EXPLICIT" = true ]; then
+  # The caller pointed E2E_PLUGIN_SRC at a copy it shipped onto the target, so a
+  # missing file means that copy never arrived. Fail loudly rather than silently
+  # running whatever stale plugin is already on the site - that drift is exactly
+  # what deploying from the repo is meant to eliminate.
+  echo "ERROR: E2E_PLUGIN_SRC is set to '$E2E_PLUGIN_SRC' but no file exists there - the shipped e2e-plugin.php did not arrive on the target." >&2
+  exit 1
+else
+  echo "WARNING: e2e-plugin.php source not found at $E2E_PLUGIN_SRC; relying on the copy already installed on the site." >&2
+fi
 
 # Activate the remaining Newspack plugins the suite exercises, plus the e2e helper
 # plugin (custom logout endpoint, outgoing-email log, admin-email-check bypass).

--- a/e2e/tests/site-setup.ts
+++ b/e2e/tests/site-setup.ts
@@ -19,6 +19,11 @@ const SCRIPT_PATH = resolve(__dirname, "..", "e2e-setup.sh");
 // and point e2e-setup.sh at it via SITE_SETUP_SCRIPT.
 const SITE_SETUP_PATH = resolve(__dirname, "..", "site-setup.sh");
 const REMOTE_SITE_SETUP = "/tmp/e2e-site-setup.sh";
+// The e2e helper plugin ships in this repo too. We copy it onto the target and
+// point e2e-setup.sh at it (E2E_PLUGIN_SRC) so the site always runs the committed
+// version rather than a stale copy left installed by hand.
+const E2E_PLUGIN_PATH = resolve(__dirname, "..", "e2e-plugin.php");
+const REMOTE_E2E_PLUGIN = "/tmp/e2e-helper-plugin.php";
 
 // A site is "local" when it lives in a Docker env we can `docker exec` into:
 // *.local / *.test hosts and loopback addresses. Everything else is remote (SSH).
@@ -72,6 +77,7 @@ export const setupSite = ({ woo }: SetupOptions): void => {
 
   const script = readFileSync(SCRIPT_PATH);
   const siteSetup = readFileSync(SITE_SETUP_PATH);
+  const e2ePlugin = readFileSync(E2E_PLUGIN_PATH);
   const args = scriptArgs(woo);
   // Forward Stripe test keys (if present) into the target environment.
   const stripeEnv = ["STRIPE_PUB_KEY", "STRIPE_SECRET_KEY"];
@@ -84,12 +90,16 @@ export const setupSite = ({ woo }: SetupOptions): void => {
     execFileSync("docker", ["cp", SITE_SETUP_PATH, `${container}:${REMOTE_SITE_SETUP}`], {
       stdio: ["ignore", "inherit", "inherit"],
     });
+    execFileSync("docker", ["cp", E2E_PLUGIN_PATH, `${container}:${REMOTE_E2E_PLUGIN}`], {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
     const envForwards = stripeEnv.flatMap((v) => (process.env[v] ? ["-e", v] : []));
     execFileSync(
       "docker",
       [
         "exec", "-i",
         "-e", `SITE_SETUP_SCRIPT=${REMOTE_SITE_SETUP}`,
+        "-e", `E2E_PLUGIN_SRC=${REMOTE_E2E_PLUGIN}`,
         ...envForwards,
         container, "bash", "-s", "--", ...args, "--allow-root", "--reset", "full",
       ],
@@ -126,12 +136,14 @@ export const setupSite = ({ woo }: SetupOptions): void => {
     }
   };
 
-  // 1. Ship site-setup.sh onto the target.
+  // 1. Ship site-setup.sh and the e2e helper plugin onto the target.
   runSsh(`cat > ${shQuote(REMOTE_SITE_SETUP)}`, siteSetup);
+  runSsh(`cat > ${shQuote(REMOTE_E2E_PLUGIN)}`, e2ePlugin);
 
-  // 2. Run e2e-setup.sh (piped), pointing it at the copy and forwarding Stripe keys.
+  // 2. Run e2e-setup.sh (piped), pointing it at the copies and forwarding Stripe keys.
   const inlineEnv = [
     `SITE_SETUP_SCRIPT=${shQuote(REMOTE_SITE_SETUP)}`,
+    `E2E_PLUGIN_SRC=${shQuote(REMOTE_E2E_PLUGIN)}`,
     ...stripeEnv
       .filter((v) => process.env[v])
       .map((v) => `${v}=${shQuote(process.env[v] as string)}`),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The e2e helper plugin (`e2e/e2e-plugin.php`) was a pre-installed on-site file that provisioning only *activated* (`wp plugin activate e2e-plugin`) and never synced from the repo. An edit to `e2e-plugin.php` therefore never reached the target site until it was redeployed by hand, so the site could keep running a stale copy of the plugin even after the committed version changed.

This makes provisioning deploy the plugin from the repo on every run, mirroring how `site-setup.sh` is already shipped:

- `tests/site-setup.ts` (`setupSite`) copies `e2e-plugin.php` onto the target next to `site-setup.sh` (local `docker cp`, remote `cat >` over SSH) and forwards `E2E_PLUGIN_SRC`.
- `e2e-setup.sh` copies `E2E_PLUGIN_SRC` into `$(wp plugin path)/e2e-plugin.php` before activating it, so the running plugin always matches the committed source and can't drift.
- Failure handling: a copy the caller shipped but that didn't arrive is **fatal** (loud, rather than silently re-masking drift); a manual `bash e2e-setup.sh` run with no source set only **warns** and falls back to whatever is already installed.
- Docs (`README.md`, `AGENTS.md`) updated: the manual "install `e2e-plugin.php`" step is gone, and the on-site-prerequisite note now reflects that the plugin is shipped from the repo.

Part of NPPM-2919 (bringing the e2e suite into the monorepo).

### How to test the changes in this Pull Request:

1. On a local env, run provisioning (`npm run test:setup`, or `n env e2e-setup <name>`).
2. Confirm the site's installed `e2e-plugin.php` byte-matches `e2e/e2e-plugin.php` from the repo (edit the repo copy, re-provision, confirm the change is live).
3. Confirm a run with `E2E_PLUGIN_SRC` set to a non-existent path aborts with a clear error; a manual run with it unset and no file next to the script warns and continues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (Provisioning tooling; verified by running provisioning.)
* [x] Have you successfully run tests with your changes locally?