### PR TITLE
feat(env): support standalone repos/ worktrees in env create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/newspack-network/nodes-keys.json
 bin/newspack-network/service-accounts.secret
 rootCA.pem
 worktrees
+worktrees-repos
 envs
 docker-compose.env-*.yml
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,12 @@ n setup --env myenv --yes     # fully configured Newspack site
 ### Environment Commands
 ```bash
 n env create <name> [options]  # Create environment config
-  --worktree <repo>:<branch>   #   Mount a worktree (repeatable for multiple repos)
+  --worktree <repo>:<branch>   #   Mount a worktree (repeatable for multiple repos).
+                               #   <repo> may be a monorepo plugin/theme OR a standalone
+                               #   checkout under repos/ that is its own git repo (e.g.
+                               #   newspack-manager); the latter is worktree'd from that repo
+                               #   and mounted over just its /newspack-repos/<kind>/<name> path,
+                               #   so other envs keep the base checkout.
   --domain <domain>            #   Custom domain (default: <name>.test)
   --up                         #   Start the environment immediately after creation
 n env up <name> [--build]      # Start environment (creates DB, installs WP, sets up SSL)
@@ -291,7 +296,7 @@ n sh <name>                    # Shell into environment container
 - Each env mounts `envs/<name>/html/` as `/var/www/html` (isolated from `./html/`)
 - Each env gets its own database (`wordpress_<name>`) in the shared MariaDB server
 - Each env gets a unique `WP_CACHE_KEY_SALT` to prevent memcached key collisions
-- Worktrees override specific plugins (e.g., `newspack-plugin`) while sharing the rest from `./plugins/`
+- Worktrees override specific plugins (e.g., `newspack-plugin`) while sharing the rest from `./plugins/`. Monorepo worktrees live in `worktrees/<safe_branch>/` (a worktree of the whole workspace repo); standalone `repos/` worktrees live in `worktrees-repos/<name>/<safe_branch>/` (a worktree of that repo) and are mounted over just their `/newspack-repos/<kind>/<name>` subpath, leaving the base `repos/` checkout intact for other envs. Destroying a monorepo worktree deletes its branch; destroying a `repos/` worktree keeps the branch (standalone repos carry long-lived branches)
 - All env containers join a shared `newspack_envs` Docker bridge network with their domain as a DNS alias, enabling inter-container communication (e.g., hub/node setups)
 - `n env destroy` cleans up everything: container, DB, html dir, hosts entry, and worktrees
 

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -42,14 +42,25 @@ ip_for_env() {
     grep -o '127\.0\.0\.[0-9]*' "$1" | head -1
 }
 
-# Parse a docker-compose volume line for a worktree mount and emit "repo|branch".
-# Handles both shapes:
+# Parse a docker-compose volume line for a worktree mount and emit
+# "repo|branch|kind" (kind ∈ monorepo|repos). Handles three shapes:
 #   legacy (pre-monorepo): "- ./worktrees/<repo>/<branch>:/newspack-repos/<repo>"
 #   monorepo:              "- ./worktrees/<safe_branch>/plugins/<repo>:/newspack-plugins/<repo>"
 #                          "- ./worktrees/<safe_branch>/themes/<repo>:/newspack-themes/<repo>"
-# Returns non-zero for lines that don't match either shape.
+#   repos (standalone):    "- ./worktrees-repos/<repo>/<safe_branch>:/newspack-repos/{plugins,themes}/<repo>"
+# Returns non-zero for lines that don't match any shape.
 parse_worktree_mount() {
     local line="$1"
+    # Standalone repos/ worktree. Both fields come from the host path, which is
+    # always "worktrees-repos/<repo>/<safe_branch>" (neither segment has a slash);
+    # the container side is always under /newspack-repos/.
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+\./worktrees-repos/([^[:space:]/:]+)/([^[:space:]/:]+):/newspack-repos/ ]]; then
+        local repos_repo="${BASH_REMATCH[1]}"
+        local repos_branch="${BASH_REMATCH[2]}"
+        [[ -n "$repos_repo" && -n "$repos_branch" ]] || return 1
+        echo "$repos_repo|$repos_branch|repos"
+        return 0
+    fi
     # Use regex extraction so the parser tolerates exactly what the grep
     # admits (tabs / multi-space after the dash) and cuts cleanly at the
     # next `:` — so mount-mode suffixes (`:ro`, `:cached`) and trailing
@@ -79,7 +90,7 @@ parse_worktree_mount() {
             ;;
     esac
     [[ -n "$repo" && -n "$branch" ]] || return 1
-    echo "$repo|$branch"
+    echo "$repo|$branch|monorepo"
 }
 
 # Resolve the unsanitized git branch name for a worktree directory.
@@ -88,17 +99,25 @@ parse_worktree_mount() {
 # branch ref can't be resolved (e.g., detached HEAD).
 resolve_unsanitized_branch() {
     local safe_branch="$1"
+    local repos_repo="$2"  # set for standalone repos/ worktrees.
+    local wt_dir
+    if [[ -n "$repos_repo" ]]; then
+        wt_dir="$NABSPATH/worktrees-repos/$repos_repo/$safe_branch"
+    else
+        wt_dir="$NABSPATH/worktrees/$safe_branch"
+    fi
     local resolved
-    resolved=$(git -C "$NABSPATH/worktrees/$safe_branch" branch --show-current 2>/dev/null)
+    resolved=$(git -C "$wt_dir" branch --show-current 2>/dev/null)
     [[ -n "$resolved" ]] && echo "$resolved" || echo "$safe_branch"
 }
 
-# Iterate worktree mount lines in a compose file and yield "repo|branch" pairs.
+# Iterate worktree mount lines in a compose file and yield "repo|branch|kind"
+# triples (kind ∈ monorepo|repos), as emitted by parse_worktree_mount.
 each_worktree_in_env() {
     local file="$1"
     while IFS= read -r line; do
         parse_worktree_mount "$line"
-    done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$file" 2>/dev/null)
+    done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$file" 2>/dev/null)
 }
 
 case $1 in
@@ -122,6 +141,11 @@ case $1 in
         done
         shift 2
         worktree_volumes=""
+        # Worktrees to create are recorded here during arg parsing and only
+        # created after the whole arg list validates (below), so a bad later
+        # --worktree/--domain can't leave an orphaned worktree behind. Each entry
+        # is "mono|<branch>|<abs_dir>" or "repos|<repo>|<branch>|<abs_dir>".
+        wt_specs=()
         domain=""
         auto_up=false
         while [[ $# -gt 0 ]]; do
@@ -136,35 +160,53 @@ case $1 in
                     validate_name "$wt_branch" "branch"
                     # Sanitize branch for directory name (feat/foo -> feat-foo).
                     safe_branch=$(echo "$wt_branch" | tr '/' '-')
-                    # Create a monorepo worktree at this branch if it doesn't exist.
-                    if [[ ! -d "$NABSPATH/worktrees/$safe_branch" ]]; then
-                        echo "Creating worktree at branch $wt_branch..."
-                        "$NABSPATH/bin/worktree.sh" add "$wt_branch" || exit 1
-                    fi
-                    # Mount the specific plugin/theme subdirectory from the worktree.
                     wt_host_path=$(get_repo_host_path "$wt_repo")
-                    if [[ -z "$wt_host_path" ]]; then
-                        echo "Error: unknown project '$wt_repo'"
-                        exit 1
-                    fi
-                    if [[ "$wt_host_path" == themes/* ]]; then
-                        wt_container_path="/newspack-themes/$wt_repo"
+                    if [[ -n "$wt_host_path" ]]; then
+                        # ---- Monorepo plugin/theme: worktree of the workspace repo. ----
+                        # Record the worktree for creation after arg parsing.
+                        wt_specs+=("mono|$wt_branch|$NABSPATH/worktrees/$safe_branch")
+                        # Mount the specific plugin/theme subdirectory from the worktree.
+                        if [[ "$wt_host_path" == themes/* ]]; then
+                            wt_container_path="/newspack-themes/$wt_repo"
+                        else
+                            wt_container_path="/newspack-plugins/$wt_repo"
+                        fi
+                        worktree_dir="./worktrees/$safe_branch/$wt_host_path"
+                        # Mount the worktree subdir at BOTH container roots:
+                        #   - the site-serving path (/newspack-plugins|themes/<repo>), and
+                        #   - the pnpm-workspace path (/newspack-monorepo/<host_path>).
+                        # The site reads the first; the JS toolchain (n build / n test-js /
+                        # jest, all resolved under /newspack-monorepo) reads the second. Without
+                        # the workspace mount the toolchain builds/tests the *main* checkout's
+                        # source, never the worktree's, and the worktree's own node_modules has
+                        # relative pnpm symlinks (../../../packages/*) that only resolve when the
+                        # plugin sits at its real workspace location. Mounting here makes both
+                        # work, so builds land in the worktree's dist and are served immediately.
+                        worktree_volumes+="      - $worktree_dir:$wt_container_path"$'\n'
+                        worktree_volumes+="      - $worktree_dir:/newspack-monorepo/$wt_host_path"$'\n'
                     else
-                        wt_container_path="/newspack-plugins/$wt_repo"
+                        # ---- Standalone repos/ checkout: worktree of its own git repo. ----
+                        repos_host_path=$(get_standalone_repo_host_path "$wt_repo")
+                        if [[ -z "$repos_host_path" ]]; then
+                            echo "Error: unknown project '$wt_repo' (not a monorepo plugin/theme, and no repos/plugins|themes/$wt_repo checkout)"
+                            exit 1
+                        fi
+                        # Record the worktree for creation after arg parsing. add-repos
+                        # (run then) owns the standalone-repo validation -- it errors if
+                        # the checkout isn't its own git repo; here we only need
+                        # repos_host_path to derive the container subdir (plugins vs themes).
+                        wt_specs+=("repos|$wt_repo|$wt_branch|$NABSPATH/worktrees-repos/$wt_repo/$safe_branch")
+                        # kind is "plugins" or "themes" (from repos/<kind>/<name>).
+                        repos_kind="${repos_host_path#repos/}"
+                        repos_kind="${repos_kind%%/*}"
+                        worktree_dir="./worktrees-repos/$wt_repo/$safe_branch"
+                        # Single override mount: shadow just this checkout's subpath under
+                        # the whole-dir "./repos:/newspack-repos" mount, so this env serves
+                        # the worktree at the canonical name while other envs keep the base
+                        # checkout. No /newspack-monorepo mount -- repos/ plugins aren't pnpm
+                        # workspace members; they build standalone via build-repos.sh.
+                        worktree_volumes+="      - $worktree_dir:/newspack-repos/$repos_kind/$wt_repo"$'\n'
                     fi
-                    worktree_dir="./worktrees/$safe_branch/$wt_host_path"
-                    # Mount the worktree subdir at BOTH container roots:
-                    #   - the site-serving path (/newspack-plugins|themes/<repo>), and
-                    #   - the pnpm-workspace path (/newspack-monorepo/<host_path>).
-                    # The site reads the first; the JS toolchain (n build / n test-js /
-                    # jest, all resolved under /newspack-monorepo) reads the second. Without
-                    # the workspace mount the toolchain builds/tests the *main* checkout's
-                    # source, never the worktree's, and the worktree's own node_modules has
-                    # relative pnpm symlinks (../../../packages/*) that only resolve when the
-                    # plugin sits at its real workspace location. Mounting here makes both
-                    # work, so builds land in the worktree's dist and are served immediately.
-                    worktree_volumes+="      - $worktree_dir:$wt_container_path"$'\n'
-                    worktree_volumes+="      - $worktree_dir:/newspack-monorepo/$wt_host_path"$'\n'
                     shift 2
                     ;;
                 --domain)
@@ -185,6 +227,40 @@ case $1 in
                     exit 1
                     ;;
             esac
+        done
+        # All args validated -- now create the recorded worktrees. If a creation
+        # fails mid-batch, roll back the ones made in this run (worktree dir +
+        # registration only; branches are left alone) so we don't leave orphans.
+        created_gitdirs=()
+        created_wtdirs=()
+        wt_rollback() {
+            local i
+            for i in "${!created_wtdirs[@]}"; do
+                git -C "${created_gitdirs[$i]}" worktree remove --force "${created_wtdirs[$i]}" 2>/dev/null || rm -rf "${created_wtdirs[$i]}"
+                git -C "${created_gitdirs[$i]}" worktree prune 2>/dev/null || true
+            done
+        }
+        for spec in "${wt_specs[@]}"; do
+            IFS='|' read -r wt_kind wt_a wt_b wt_c <<< "$spec"
+            if [[ "$wt_kind" == "mono" ]]; then
+                # spec: mono|<branch>|<abs_dir>
+                [[ -d "$wt_b" ]] && continue  # pre-existing worktree; leave it.
+                if ! "$NABSPATH/bin/worktree.sh" add "$wt_a"; then
+                    wt_rollback
+                    exit 1
+                fi
+                created_gitdirs+=("$NABSPATH")
+                created_wtdirs+=("$wt_b")
+            else
+                # spec: repos|<repo>|<branch>|<abs_dir>
+                [[ -d "$wt_c" ]] && continue  # pre-existing worktree; leave it.
+                if ! "$NABSPATH/bin/worktree.sh" add-repos "$wt_a" "$wt_b"; then
+                    wt_rollback
+                    exit 1
+                fi
+                created_gitdirs+=("$NABSPATH/$(get_standalone_repo_host_path "$wt_a")")
+                created_wtdirs+=("$wt_c")
+            fi
         done
         ip=$(next_loopback_ip)
         if [[ -z "$domain" ]]; then
@@ -478,8 +554,8 @@ MIGRATE
             # Anchored regex (matching each_worktree_in_env / get_target_container
             # in n) so commented-out volume lines don't false-match and trigger
             # spurious copies.
-            grep -E '^[[:space:]]*-[[:space:]]+\./worktrees/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$compose_file" 2>/dev/null | while read -r line; do
-                # Parse volume line: "- ./worktrees/repo/branch:/newspack-{plugins,themes}/repo"
+            grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$compose_file" 2>/dev/null | while read -r line; do
+                # Parse volume line: "- ./worktrees[-repos]/…:/newspack-{plugins,themes,repos}/repo"
                 # Strip leading whitespace + dash with the same [[:space:]] class
                 # the grep above uses. `env create` only emits 6-space-indented
                 # mounts, so a tab here arises only from a hand-edited compose
@@ -487,8 +563,9 @@ MIGRATE
                 wt_path=$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*//' | cut -d: -f1)
                 container_path=$(echo "$line" | cut -d: -f2)
                 repo=$(basename "$container_path")
-                # Resolve the source from the monorepo layout.
+                # Resolve the source: monorepo layout first, else the standalone repos/ dir.
                 repo_host_path=$(get_repo_host_path "$repo")
+                [[ -z "$repo_host_path" ]] && repo_host_path=$(get_standalone_repo_host_path "$repo")
                 src="$NABSPATH/$repo_host_path"
                 dst="$NABSPATH/${wt_path#./}"
                 echo "Copying built assets for $repo..."
@@ -582,8 +659,12 @@ MIGRATE
         # across create/destroy cycles. A proper fix removes the dir by safe
         # name and deletes the branch by its resolved real name separately.
         for entry in "${worktree_entries[@]}"; do
-            IFS='|' read -r wt_repo wt_branch <<< "$entry"
-            "$NABSPATH/bin/worktree.sh" remove --yes "$wt_repo" "$wt_branch"
+            IFS='|' read -r wt_repo wt_branch wt_kind <<< "$entry"
+            if [[ "$wt_kind" == "repos" ]]; then
+                "$NABSPATH/bin/worktree.sh" remove-repos --yes "$wt_repo" "$wt_branch"
+            else
+                "$NABSPATH/bin/worktree.sh" remove --yes "$wt_repo" "$wt_branch"
+            fi
         done
         echo "Destroyed environment '$env_name'"
         ;;
@@ -609,8 +690,9 @@ MIGRATE
             # worktrees while leaving filesystem-operation paths to the safe
             # form.
             worktrees=""
-            while IFS='|' read -r repo safe_branch; do
-                branch=$(resolve_unsanitized_branch "$safe_branch")
+            while IFS='|' read -r repo safe_branch kind; do
+                [[ "$kind" == "repos" ]] && repos_repo="$repo" || repos_repo=""
+                branch=$(resolve_unsanitized_branch "$safe_branch" "$repos_repo")
                 [[ -n "$worktrees" ]] && worktrees="$worktrees,"
                 worktrees="${worktrees}${repo}:${branch}"
             done < <(each_worktree_in_env "$f")
@@ -619,9 +701,11 @@ MIGRATE
             else
                 echo "  $name ($status) https://${domain}/"
                 # Show worktrees mounted by this environment.
-                while IFS='|' read -r repo safe_branch; do
-                    branch=$(resolve_unsanitized_branch "$safe_branch")
-                    echo "    └ $repo ($branch)"
+                while IFS='|' read -r repo safe_branch kind; do
+                    [[ "$kind" == "repos" ]] && repos_repo="$repo" || repos_repo=""
+                    branch=$(resolve_unsanitized_branch "$safe_branch" "$repos_repo")
+                    label=$([[ "$kind" == "repos" ]] && echo " [repos]" || echo "")
+                    echo "    └ $repo ($branch)$label"
                 done < <(each_worktree_in_env "$f")
             fi
         done

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -49,3 +49,41 @@ get_repo_host_path() {
 	done
 	echo ""
 }
+
+# Maps a name to its standalone checkout under the gitignored repos/ dir,
+# returning the host-side path relative to the workspace root (e.g.
+# "repos/plugins/newspack-manager") or "" when no such checkout exists.
+#
+# Host-side only: needs $NABSPATH (the workspace root), so never call this from
+# code that runs inside the container, where repos.sh is sourced without it.
+# Monorepo plugins/themes take precedence, so callers should try
+# get_repo_host_path first and fall back to this.
+get_standalone_repo_host_path() {
+	local name="$1"
+	if [[ -d "$NABSPATH/repos/plugins/$name" ]]; then
+		echo "repos/plugins/$name"
+	elif [[ -d "$NABSPATH/repos/themes/$name" ]]; then
+		echo "repos/themes/$name"
+	else
+		echo ""
+	fi
+}
+
+# Verifies that a repos/ checkout is its own git repository (so a worktree can
+# be created from it). Some repos/ entries are plain unzipped plugins whose git
+# lookups resolve up to the monorepo's own .git — those cannot be worktree'd.
+# Prints nothing; returns 0 when standalone, 1 otherwise. Needs $NABSPATH.
+#
+# Both toplevels are taken from git (physical, symlink-resolved paths) so the
+# comparison holds even when $NABSPATH reaches the workspace through a symlink
+# (bin/_common.sh derives it with a plain `pwd`, which keeps symlinks). A raw
+# string compare against $NABSPATH would misclassify an unzipped plugin as
+# standalone in that case.
+is_standalone_git_repo() {
+	local host_path="$1"
+	local dir="$NABSPATH/$host_path"
+	local toplevel monorepo_toplevel
+	toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+	monorepo_toplevel=$(git -C "$NABSPATH" rev-parse --show-toplevel 2>/dev/null)
+	[[ -n "$toplevel" && "$toplevel" != "$monorepo_toplevel" ]]
+}

--- a/bin/worktree.sh
+++ b/bin/worktree.sh
@@ -13,6 +13,44 @@ sanitize_branch() {
     echo "$1" | tr '/' '-'
 }
 
+# Create a git worktree at <worktree_dir> for <branch>, running git in <git_dir>
+# (the workspace for monorepo worktrees, or a standalone repos/ checkout). Shared
+# by `add` and `add-repos`. Fetches the branch into its remote-tracking ref first
+# with an explicit, forced refspec -- `git fetch origin <branch>` alone only
+# writes FETCH_HEAD, leaving refs/remotes/origin/<branch> absent, so a remote-only
+# branch would be missed and a new local branch wrongly created from HEAD. Falls
+# back to creating the branch from <git_dir>'s current HEAD when it exists nowhere.
+# Returns the worktree-add exit status.
+_worktree_create() {
+    local git_dir="$1" worktree_dir="$2" branch="$3"
+    mkdir -p "$(dirname "$worktree_dir")"
+    git -C "$git_dir" fetch origin "+$branch:refs/remotes/origin/$branch" 2>/dev/null
+    if git -C "$git_dir" show-ref --verify --quiet "refs/heads/$branch" || \
+       git -C "$git_dir" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+        git -C "$git_dir" worktree add "$worktree_dir" "$branch"
+    else
+        echo "Creating branch '$branch' from $(git -C "$git_dir" rev-parse --abbrev-ref HEAD)..."
+        git -C "$git_dir" worktree add -b "$branch" "$worktree_dir"
+    fi
+}
+
+# Echo the name of the first environment whose compose file mounts <pattern>
+# (a fixed host-path substring), or nothing. Shared by `remove` and `remove-repos`
+# to block removal of an in-use worktree. Callers pass a pattern anchored with a
+# trailing '/' or ':' so branch 'feat' isn't matched inside 'feature'; -F keeps
+# any dot in the name/branch literal. Returns non-zero when no env matches.
+_worktree_env_using() {
+    local pattern="$1" f
+    for f in "$NABSPATH"/docker-compose.env-*.yml; do
+        [[ -f "$f" ]] || continue
+        if grep -qF "$pattern" "$f" 2>/dev/null; then
+            basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//'
+            return 0
+        fi
+    done
+    return 1
+}
+
 case $1 in
     add)
         # Usage: worktree.sh add <branch>
@@ -36,17 +74,116 @@ case $1 in
             echo "Worktree already exists at worktrees/$safe_branch"
             exit 0
         fi
-        mkdir -p "$(dirname "$worktree_dir")"
-        cd "$NABSPATH" || exit 1
-        # Fetch so we see remote branches.
-        git fetch origin "$branch" 2>/dev/null
-        if git show-ref --verify --quiet "refs/heads/$branch" || git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
-            git worktree add "$worktree_dir" "$branch" || exit 1
-        else
-            echo "Creating branch '$branch' from $(git rev-parse --abbrev-ref HEAD)..."
-            git worktree add -b "$branch" "$worktree_dir" || exit 1
-        fi
+        _worktree_create "$NABSPATH" "$worktree_dir" "$branch" || exit 1
         echo "Created worktree at worktrees/$safe_branch"
+        ;;
+    add-repos)
+        # Usage: worktree.sh add-repos <name> <branch>
+        # Creates a worktree of a *standalone* checkout under repos/ (its own git
+        # repo, e.g. newspack-manager), stored at worktrees-repos/<name>/<safe_branch>
+        # so it never lands under repos/ itself (link-repos.sh would otherwise
+        # symlink it as a second plugin). The env system mounts it over the
+        # canonical container path (/newspack-repos/{plugins,themes}/<name>).
+        name="$2"
+        branch="$3"
+        if [[ -z "$name" || -z "$branch" ]]; then
+            echo "Usage: n worktree add-repos <name> <branch>"
+            exit 1
+        fi
+        validate_name "$name" "repo"
+        validate_name "$(sanitize_branch "$branch")" "branch"
+        host_path=$(get_standalone_repo_host_path "$name")
+        if [[ -z "$host_path" ]]; then
+            echo "Error: no standalone checkout 'repos/plugins/$name' or 'repos/themes/$name' found."
+            echo "Clone or unzip it into repos/ first."
+            exit 1
+        fi
+        if ! is_standalone_git_repo "$host_path"; then
+            echo "Error: $host_path is not its own git repository, so it can't be worktree'd."
+            echo "(Its git lookups resolve to the monorepo. Standalone worktrees need a separate repo with its own .git.)"
+            exit 1
+        fi
+        repos_dir="$NABSPATH/$host_path"
+        safe_branch=$(sanitize_branch "$branch")
+        worktree_dir="$NABSPATH/worktrees-repos/$name/$safe_branch"
+        if [[ -d "$worktree_dir" ]]; then
+            echo "Worktree already exists at worktrees-repos/$name/$safe_branch"
+            exit 0
+        fi
+        _worktree_create "$repos_dir" "$worktree_dir" "$branch" || exit 1
+        echo "Created worktree at worktrees-repos/$name/$safe_branch"
+        ;;
+    remove-repos)
+        # Usage: worktree.sh remove-repos <name> <safe_branch> [--yes]
+        # Removes a standalone-repo worktree created by add-repos. Unlike the
+        # monorepo `remove`, this does NOT delete the branch: standalone repos
+        # carry long-lived feature branches the user still wants, and the worktree
+        # is the only disposable artifact. Re-creating reuses the existing branch.
+        skip_confirm=false
+        shift  # consume "remove-repos"
+        args=()
+        for arg in "$@"; do
+            if [[ "$arg" == "--yes" ]]; then
+                skip_confirm=true
+            else
+                args+=("$arg")
+            fi
+        done
+        name="${args[0]}"
+        safe_branch="${args[1]}"
+        if [[ -z "$name" || -z "$safe_branch" ]]; then
+            echo "Usage: n worktree remove-repos <name> <safe_branch> [--yes]"
+            exit 1
+        fi
+        # Reject '..'/leading-'/' etc. before these reach the rm target below --
+        # otherwise a direct call like `remove-repos ../.. x` would delete outside
+        # worktrees-repos. (The add path validates too; the destructive path must.)
+        validate_name "$name" "repo"
+        validate_name "$safe_branch" "branch"
+        worktree_dir="$NABSPATH/worktrees-repos/$name/$safe_branch"
+        host_path=$(get_standalone_repo_host_path "$name")
+        if [[ ! -d "$worktree_dir" ]]; then
+            # Dir already gone; prune any stale registration the source repo keeps.
+            if [[ -n "$host_path" ]] && is_standalone_git_repo "$host_path"; then
+                git -C "$NABSPATH/$host_path" worktree prune 2>/dev/null || true
+            fi
+            echo "Nothing to remove: no worktree at worktrees-repos/$name/$safe_branch."
+            exit 0
+        fi
+        # Block removal if an environment mounts this worktree (host path anchored
+        # with a trailing ':' so branch 'feat' isn't matched inside 'feature').
+        env_name=$(_worktree_env_using "worktrees-repos/$name/$safe_branch:")
+        if [[ -n "$env_name" ]]; then
+            echo "Error: worktree $name/$safe_branch is used by environment '$env_name'."
+            echo "Destroy the environment first: n env destroy $env_name"
+            exit 1
+        fi
+        echo "Worktree: $worktree_dir"
+        changes=$(cd "$worktree_dir" && git status --porcelain 2>/dev/null)
+        if [[ -n "$changes" ]]; then
+            echo ""
+            echo "WARNING: Worktree has uncommitted changes:"
+            echo "$changes" | head -10
+        fi
+        if [[ "$skip_confirm" != true ]]; then
+            echo ""
+            read -p "Remove worktree? (branch is kept) (y/N): " confirm
+            if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                echo "Aborted."
+                exit 0
+            fi
+        fi
+        if [[ -n "$host_path" ]] && is_standalone_git_repo "$host_path"; then
+            git -C "$NABSPATH/$host_path" worktree remove --force "$worktree_dir" || rm -rf "$worktree_dir"
+            # Clear the registration if the remove failed and we rm'd the dir instead.
+            git -C "$NABSPATH/$host_path" worktree prune 2>/dev/null || true
+        else
+            # Source repo is gone; drop the directory directly.
+            rm -rf "$worktree_dir"
+        fi
+        # Tidy the per-repo parent dir when it holds no more worktrees.
+        rmdir "$NABSPATH/worktrees-repos/$name" 2>/dev/null || true
+        echo "Removed worktree worktrees-repos/$name/$safe_branch"
         ;;
     list)
         cd "$NABSPATH" || exit 1
@@ -80,16 +217,15 @@ case $1 in
             echo "Nothing to remove: no worktree or branch '$branch' found."
             exit 0
         fi
-        # Block removal if an environment mounts this worktree.
-        for f in "$NABSPATH"/docker-compose.env-*.yml; do
-            [[ -f "$f" ]] || continue
-            if grep -q "worktrees/$safe_branch" "$f" 2>/dev/null; then
-                env_name=$(basename "$f" | sed 's/docker-compose\.env-//' | sed 's/\.yml//')
-                echo "Error: worktree $safe_branch is used by environment '$env_name'."
-                echo "Destroy the environment first: n env destroy $env_name"
-                exit 1
-            fi
-        done
+        # Block removal if an environment mounts this worktree (host path anchored
+        # with a trailing '/' -- the monorepo mount is worktrees/<safe_branch>/plugins/…
+        # -- so branch 'feat' isn't matched inside 'feat-2').
+        env_name=$(_worktree_env_using "worktrees/$safe_branch/")
+        if [[ -n "$env_name" ]]; then
+            echo "Error: worktree $safe_branch is used by environment '$env_name'."
+            echo "Destroy the environment first: n env destroy $env_name"
+            exit 1
+        fi
         echo "Worktree: $worktree_dir"
         echo "Branch:   $branch (will be deleted)"
         if [[ -d "$worktree_dir" ]]; then
@@ -223,10 +359,12 @@ case $1 in
         done
         ;;
     *)
-        echo "Usage: n worktree <add|list|remove|cleanup> [branch]"
-        echo "  add <branch>              Create a monorepo worktree at the given branch"
-        echo "  list                      List all worktrees"
-        echo "  remove <branch> [--yes]   Remove a worktree and delete the branch"
-        echo "  cleanup [--all] [--yes]   Interactive bulk cleanup"
+        echo "Usage: n worktree <add|add-repos|list|remove|remove-repos|cleanup> [args]"
+        echo "  add <branch>                       Create a monorepo worktree at the given branch"
+        echo "  add-repos <name> <branch>          Create a worktree of a standalone repos/ checkout"
+        echo "  list                               List all worktrees"
+        echo "  remove <branch> [--yes]            Remove a monorepo worktree and delete the branch"
+        echo "  remove-repos <name> <safe_branch> [--yes]  Remove a standalone-repo worktree (keeps the branch)"
+        echo "  cleanup [--all] [--yes]            Interactive bulk cleanup"
         ;;
 esac

--- a/n
+++ b/n
@@ -20,25 +20,26 @@ fi
 # file's actual mount lines and picks the LONGEST absolute path that PWD
 # starts with — unambiguous regardless of branch-name shape.
 get_target_container() {
-    if [[ "$PWD" == "$NABSPATH/worktrees/"* ]]; then
+    if [[ "$PWD" == "$NABSPATH/worktrees/"* || "$PWD" == "$NABSPATH/worktrees-repos/"* ]]; then
         local best_match="" best_env=""
         for f in "$NABSPATH"/docker-compose.env-*.yml; do
             [[ -f "$f" ]] || continue
             while IFS= read -r mount; do
-                # Mounts can take two shapes — pre-monorepo per-plugin worktrees
-                # (./worktrees/<repo>/<branch>:/newspack-repos/<repo>) and
-                # monorepo workspace worktrees (./worktrees/<safe_branch>/plugins/<name>:/newspack-plugins/<name>,
-                # or .../themes/<name>:/newspack-themes/<name>). For the
-                # monorepo shape, the env mounts a per-plugin subdir but we
+                # Mounts can take three shapes — pre-monorepo per-plugin worktrees
+                # (./worktrees/<repo>/<branch>:/newspack-repos/<repo>), monorepo
+                # workspace worktrees (./worktrees/<safe_branch>/plugins/<name>:/newspack-plugins/<name>,
+                # or .../themes/<name>:/newspack-themes/<name>), and standalone
+                # repos/ worktrees (./worktrees-repos/<name>/<safe_branch>:/newspack-repos/<kind>/<name>).
+                # For the monorepo shape, the env mounts a per-plugin subdir but we
                 # also want to route correctly from elsewhere inside the
                 # worktree (its root, bin/, packages/, sibling plugins). Match
                 # by the enclosing worktree root instead of only the mounted
                 # subdir. Regex extraction tolerates tabs/multi-space and cuts
                 # cleanly at the next `:` so mount-mode suffixes (`:ro`) and
                 # trailing comments don't corrupt the captured paths.
-                [[ "$mount" =~ ^[[:space:]]*-[[:space:]]+\./worktrees/([^[:space:]:]+):/newspack-(repos|plugins|themes)/[^[:space:]:]+ ]] || continue
-                local rel="worktrees/${BASH_REMATCH[1]}"
-                local container_type="${BASH_REMATCH[2]}"
+                [[ "$mount" =~ ^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/([^[:space:]:]+):/newspack-(repos|plugins|themes)/[^[:space:]:]+ ]] || continue
+                local rel="worktrees${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+                local container_type="${BASH_REMATCH[3]}"
                 local abs="$NABSPATH/$rel"
                 local worktree_root="$abs"
                 case "$container_type" in
@@ -59,7 +60,7 @@ get_target_container() {
                     best_match="$worktree_root"
                     best_env=$(basename "$f" | sed 's/docker-compose\.env-//;s/\.yml//')
                 fi
-            done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$f" 2>/dev/null)
+            done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$f" 2>/dev/null)
         done
         if [ -n "$best_env" ]; then
             echo "newspack_env_${best_env}" | tr '-' '_'
@@ -97,6 +98,12 @@ if [[ -z "$target_folder" && "$PWD" == *"/repos/plugins/"* ]]; then
     target_folder="${rest%%/*}"
 elif [[ -z "$target_folder" && "$PWD" == *"/repos/themes/"* ]]; then
     rest="${PWD##*/repos/themes/}"
+    target_folder="${rest%%/*}"
+elif [[ -z "$target_folder" && "$PWD" == *"/worktrees-repos/"* ]]; then
+    # Inside a standalone-repo worktree (worktrees-repos/<name>/<branch>/…): the
+    # project is <name>, so `n build`/`composer`/`watch` target it (and route to
+    # the env container via get_target_container above).
+    rest="${PWD##*/worktrees-repos/}"
     target_folder="${rest%%/*}"
 fi
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`n env create <name> --worktree <repo>:<branch>` previously only accepted monorepo plugins/themes. It now also accepts a standalone checkout under `repos/plugins/<name>` or `repos/themes/<name>` that is its own git repository (e.g. `newspack-manager`), so those plugins can be branch-isolated per environment just like monorepo plugins.

For a standalone repo, the branch is worktree'd from that repo into `worktrees-repos/<name>/<safe_branch>/` (kept out of `repos/` so `link-repos.sh` doesn't symlink it as a second plugin) and mounted over just its `/newspack-repos/<kind>/<name>` container path. Because that override shadows only one subpath of the wholesale `./repos` mount, the environment serves the worktree while every other environment keeps the base checkout. No `/newspack-monorepo` mount is added, since `repos/` plugins aren't pnpm-workspace members and build standalone via `build-repos.sh`.

Supporting behavior:

* `n env destroy` removes the worktree but **keeps the branch** (standalone repos carry long-lived feature branches, unlike monorepo worktrees whose branch is auto-created and auto-deleted).
* `n env list` shows standalone worktrees with a `[repos]` tag and the friendly branch name.
* `n worktree add-repos` / `remove-repos` expose the same capability standalone.
* Running `n build` / `n composer` / `n watch` from inside a `worktrees-repos/<name>/<branch>` checkout resolves the project and routes to the mounting environment's container.
* Environments where a bad argument follows a `--worktree` no longer leave an orphaned worktree behind: creation is deferred until all arguments validate, and a mid-batch failure is rolled back.

This also hardens a few pre-existing edge cases in the shared worktree tooling: remote-only branches are fetched into their tracking ref before checkout (so the worktree serves the requested branch, not a fresh one from HEAD), and the "environment in use" guard is anchored so a branch name isn't matched inside a longer one (e.g. `feat` vs `feature`).

### How to test the changes in this Pull Request:

1. Ensure a standalone checkout that is its own git repo exists under `repos/plugins/` (e.g. clone `newspack-manager` into `repos/plugins/newspack-manager`), with a feature branch to test.
2. Run `n env create mgrtest --worktree newspack-manager:<some-branch>`. Confirm it creates `worktrees-repos/newspack-manager/<safe-branch>/` checked out at that branch, and that `docker-compose.env-mgrtest.yml` contains a single mount `./worktrees-repos/newspack-manager/<safe-branch>:/newspack-repos/plugins/newspack-manager` and **no** `/newspack-monorepo` mount for it.
3. Run `n env up mgrtest` and confirm the site serves the worktree's code at that plugin (the plugin symlink under `wp-content/plugins/newspack-manager` resolves into the worktree). In a second environment without the worktree, confirm the same plugin still serves the base `repos/` checkout (per-environment isolation).
4. Run `n env list` and confirm the environment shows `└ newspack-manager (<branch>) [repos]`.
5. From inside `worktrees-repos/newspack-manager/<safe-branch>/`, run `n build` and confirm it targets the `mgrtest` container and the `newspack-manager` project.
6. Run `n env destroy mgrtest`. Confirm the worktree directory is removed, the compose file is gone, and the branch still exists in `repos/plugins/newspack-manager` (`git -C repos/plugins/newspack-manager branch`).
7. Remote-only branch: create a branch that exists only on `origin` (not fetched locally) and run `n env create rtest --worktree newspack-manager:<remote-only-branch>`. Confirm the worktree is checked out at the remote branch's content, not a fresh branch from `HEAD`.
8. Error handling: `n env create x --worktree unknown-thing:foo` (unknown project) and `--worktree <a-plain-unzipped-plugin-dir>:foo` (a `repos/` dir that isn't its own git repo) should both fail with a clear message and create no compose file.
9. Orphan prevention: `n env create x --worktree newspack-manager:<branch> --domain "bad domain!!"` should fail on the domain and leave no worktree behind.
10. Regression: confirm a monorepo worktree still works end to end — `n env create p --worktree newspack-plugin:<branch>` produces both the serving and `/newspack-monorepo` mounts, and `n env destroy p` removes the worktree and deletes its branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (This is shell dev-env tooling with no test harness; verified manually and via a multi-reviewer code review.)
* [x] Have you successfully run tests with your changes locally?