### PR TITLE
feat(experimental-tools): show location hint for enabled tools

### DIFF
--- a/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
+++ b/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
@@ -252,6 +252,7 @@ class Experimental_Tools {
 				'label'           => $tool['label'] ?? $slug,
 				'description'     => $tool['description'] ?? '',
 				'disclosure'      => $tool['disclosure'] ?? '',
+				'location_hint'   => $tool['location_hint'] ?? '',
 				'llm'             => $tool['llm'] ?? null,
 				'constant'        => $tool['constant'] ?? null,
 				'constant_active' => $constant_active,

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/configure-view.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/configure-view.tsx
@@ -8,7 +8,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { TextareaControl, TextControl, SelectControl, ToggleControl, Spinner } from '@wordpress/components';
+import { TextareaControl, TextControl, SelectControl, ToggleControl, Spinner, Notice } from '@wordpress/components';
 import { Icon, chevronLeft, chevronDown, chevronUp } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -262,6 +262,12 @@ export default function ConfigureView( {
 				<h1>{ tool.label }</h1>
 			</div>
 			<p className="newspack-wizard__sections__description">{ tool.description }</p>
+
+			{ tool.location_hint && (
+				<Notice status="info" isDismissible={ false } className="experimental-tools__location-hint">
+					{ tool.location_hint }
+				</Notice>
+			) }
 
 			<div className="experimental-tools__configure-fields">
 				{ editableFields.map( ( field: ToolField ) => (

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/enable-modal.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/enable-modal.tsx
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -34,6 +35,11 @@ export default function EnableModal( {
 				<p>{ tool.disclosure }</p>
 			) : (
 				<p>{ __( 'This tool is in active development. Your experience using it directly shapes what it becomes.', 'newspack-plugin' ) }</p>
+			) }
+			{ tool.location_hint && (
+				<Notice status="info" isDismissible={ false } className="experimental-tools__location-hint">
+					{ tool.location_hint }
+				</Notice>
 			) }
 			<Card buttonsCard noBorder className="justify-end">
 				<Button variant="secondary" onClick={ onClose } disabled={ disabled }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/style.scss
@@ -164,3 +164,11 @@
 		overflow-y: auto;
 	}
 }
+
+.experimental-tools__location-hint {
+	margin: 16px 0 0;
+}
+
+.experimental-tools__configure .experimental-tools__location-hint {
+	margin-bottom: 24px;
+}

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/types.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/experimental-tools/types.ts
@@ -18,6 +18,7 @@ export interface Tool {
 	label: string;
 	description: string;
 	disclosure?: string;
+	location_hint?: string;
 	llm?: string;
 	constant: string | null;
 	constant_active: boolean;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds an optional per-tool `location_hint` to the Experimental Tools settings UI. When a tool provides one, it renders as an info notice in two places:

- the **Enable** confirmation modal (so publishers learn where the tool lives the moment they turn it on), and
- the tool's **Configure** view (a persistent reference).

This closes a discoverability gap: enabling an experimental tool (e.g. Editorial Assistant) gave no indication of *where* to use it in the editor, so publishers reported the tool as "missing" even though it was working. The field is generic and reusable by any experimental tool; the companion string for Editorial Assistant is added in newspack-manager (separate PR).

The mechanism mirrors the existing `disclosure` key: `get_tools()` forwards the registered value with a `?? ''` fallback, and the React side renders it as auto-escaped text (no `dangerouslySetInnerHTML`).

### How to test the changes in this Pull Request:

1. Have newspack-manager active with the companion `location_hint` change (or register any experimental tool with a `location_hint` via the `newspack_experimental_tools` filter).
2. Go to **Newspack → Settings → Experimental tools**.
3. Click **Enable** on the tool → the confirmation modal shows the location hint below the disclosure.
4. With the tool enabled, click **Configure** → the same hint shows as an info notice under the description.

### Other information:

* [x] Have you successfully run tests with your changes locally? (PHPCS, ESLint, Stylelint clean; verified in an isolated env)
* [ ] Have you written new tests for your changes, as applicable? (Passthrough of an optional field; no new test added.)