### PR TITLE
feat(insights): show metric card descriptions in tooltip instead of inline

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gate-settings.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gate-settings.test.js
@@ -101,8 +101,8 @@ describe( 'ContentGateSettings per-gate actions', () => {
 		const ContentGateSettings = require( './content-gate-settings' ).default;
 		render( <ContentGateSettings gate={ mockGate } updateGatesData={ () => {} } /> );
 
-		// gate.status === 'publish' -> the toggle action is labelled "Deactivate".
-		fireEvent.click( screen.getByRole( 'button', { name: 'Deactivate' } ) );
+		// gate.status === 'publish' -> the toggle action is labelled "Set to inactive".
+		fireEvent.click( screen.getByRole( 'button', { name: 'Set to inactive' } ) );
 
 		await waitFor( () => {
 			expect( mockAddNotice ).toHaveBeenCalledWith(

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -55,9 +55,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Total Prompt Impressions
+                  <span>
+                    Total Prompt Impressions
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -71,7 +75,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Every prompt view in this timeframe
+                  <p>
+                    Every prompt view in this timeframe
+                  </p>
                 </div>
               </div>
             </div>
@@ -100,9 +106,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Unique Readers Reached
+                  <span>
+                    Unique Readers Reached
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -116,7 +126,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Distinct readers who saw at least one prompt
+                  <p>
+                    Distinct readers who saw at least one prompt
+                  </p>
                 </div>
               </div>
             </div>
@@ -145,9 +157,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Avg Prompts per Reader
+                  <span>
+                    Avg Prompts per Reader
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -161,7 +177,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  How many prompts a typical reader sees
+                  <p>
+                    How many prompts a typical reader sees
+                  </p>
                 </div>
               </div>
             </div>
@@ -222,9 +240,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Click-Through Rate
+                  <span>
+                    Click-Through Rate
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -238,7 +260,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Clicks ÷ prompt impressions
+                  <p>
+                    Clicks ÷ prompt impressions
+                  </p>
                 </div>
               </div>
             </div>
@@ -267,9 +291,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Form Submission Rate
+                  <span>
+                    Form Submission Rate
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -283,7 +311,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Form submissions ÷ impressions on form-bearing prompts
+                  <p>
+                    Form submissions ÷ impressions on form-bearing prompts
+                  </p>
                 </div>
               </div>
             </div>
@@ -312,9 +342,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Dismissal Rate
+                  <span>
+                    Dismissal Rate
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -328,7 +362,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Explicit dismissals ÷ prompt impressions
+                  <p>
+                    Explicit dismissals ÷ prompt impressions
+                  </p>
                 </div>
               </div>
             </div>
@@ -389,9 +425,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Registration Conversion (Direct)
+                  <span>
+                    Registration Conversion (Direct)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -405,7 +445,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Registrations submitted through a prompt’s registration block ÷ impressions of prompts with a registration block
+                  <p>
+                    Registrations submitted through a prompt’s registration block ÷ impressions of prompts with a registration block
+                  </p>
                 </div>
               </div>
             </div>
@@ -434,9 +476,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Registration Conversion (Influenced, 7d)
+                  <span>
+                    Registration Conversion (Influenced, 7d)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -450,7 +496,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
+                  <p>
+                    Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
+                  </p>
                 </div>
               </div>
             </div>
@@ -479,9 +527,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Newsletter Signup Conversion (Direct)
+                  <span>
+                    Newsletter Signup Conversion (Direct)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -495,7 +547,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Newsletter signups submitted through a prompt’s newsletter block ÷ impressions of prompts with a newsletter block
+                  <p>
+                    Newsletter signups submitted through a prompt’s newsletter block ÷ impressions of prompts with a newsletter block
+                  </p>
                 </div>
               </div>
             </div>
@@ -524,9 +578,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Newsletter Signup Conversion (Influenced, 7d)
+                  <span>
+                    Newsletter Signup Conversion (Influenced, 7d)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -540,7 +598,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
+                  <p>
+                    New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
+                  </p>
                 </div>
               </div>
             </div>
@@ -601,9 +661,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Donation Conversion (Direct)
+                  <span>
+                    Donation Conversion (Direct)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -617,7 +681,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Donations completed through a prompt’s donation block ÷ impressions of prompts with a donation block
+                  <p>
+                    Donations completed through a prompt’s donation block ÷ impressions of prompts with a donation block
+                  </p>
                 </div>
               </div>
             </div>
@@ -646,9 +712,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Donation Conversion (Influenced, 14d)
+                  <span>
+                    Donation Conversion (Influenced, 14d)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -662,7 +732,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
+                  <p>
+                    Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
+                  </p>
                 </div>
               </div>
             </div>
@@ -691,9 +763,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Subscription Conversion (Direct)
+                  <span>
+                    Subscription Conversion (Direct)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -707,7 +783,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Subscriptions purchased through a prompt’s checkout button ÷ impressions of prompts with a checkout button
+                  <p>
+                    Subscriptions purchased through a prompt’s checkout button ÷ impressions of prompts with a checkout button
+                  </p>
                 </div>
               </div>
             </div>
@@ -736,9 +814,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Subscription Conversion (Influenced, 14d)
+                  <span>
+                    Subscription Conversion (Influenced, 14d)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -752,7 +834,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
+                  <p>
+                    Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
+                  </p>
                 </div>
               </div>
             </div>
@@ -813,9 +897,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Donation Revenue (Direct)
+                  <span>
+                    Donation Revenue (Direct)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -829,7 +917,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Sum of Woo donation order totals from donations completed through a prompt’s donation block
+                  <p>
+                    Sum of Woo donation order totals from donations completed through a prompt’s donation block
+                  </p>
                 </div>
               </div>
             </div>
@@ -858,9 +948,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Donation Revenue (Influenced, 14d)
+                  <span>
+                    Donation Revenue (Influenced, 14d)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -874,7 +968,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Checkout revenue from donation completions in a later session within 14 days of seeing a donation-intent prompt
+                  <p>
+                    Checkout revenue from donation completions in a later session within 14 days of seeing a donation-intent prompt
+                  </p>
                 </div>
               </div>
             </div>
@@ -903,9 +999,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Subscription Revenue (Direct)
+                  <span>
+                    Subscription Revenue (Direct)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -919,7 +1019,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Sum of Woo subscription order totals from subscriptions purchased through a prompt’s checkout button
+                  <p>
+                    Sum of Woo subscription order totals from subscriptions purchased through a prompt’s checkout button
+                  </p>
                 </div>
               </div>
             </div>
@@ -948,9 +1050,13 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-label"
+                  class="components-flex components-h-stack newspack-insights__metric-card-label css-txkh1g-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  Subscription Revenue (Influenced, 14d)
+                  <span>
+                    Subscription Revenue (Influenced, 14d)
+                  </span>
                 </div>
                 <div
                   class="newspack-insights__metric-card-body"
@@ -964,7 +1070,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                 <div
                   class="newspack-insights__metric-card-description"
                 >
-                  Checkout revenue from subscription completions in a later session within 14 days of seeing a subscription-intent prompt
+                  <p>
+                    Checkout revenue from subscription completions in a later session within 14 days of seeing a subscription-intent prompt
+                  </p>
                 </div>
               </div>
             </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -68,7 +68,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Every prompt view in this timeframe
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Every prompt view in this timeframe
+                </p>
               </div>
             </div>
           </div>
@@ -113,7 +125,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Distinct readers who saw at least one prompt
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Distinct readers who saw at least one prompt
+                </p>
               </div>
             </div>
           </div>
@@ -158,7 +182,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                How many prompts a typical reader sees
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  How many prompts a typical reader sees
+                </p>
               </div>
             </div>
           </div>
@@ -231,7 +267,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Clicks ÷ prompt impressions
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Clicks ÷ prompt impressions
+                </p>
               </div>
             </div>
           </div>
@@ -276,7 +324,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Form submissions ÷ impressions on form-bearing prompts
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Form submissions ÷ impressions on form-bearing prompts
+                </p>
               </div>
             </div>
           </div>
@@ -321,7 +381,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Explicit dismissals ÷ prompt impressions
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Explicit dismissals ÷ prompt impressions
+                </p>
               </div>
             </div>
           </div>
@@ -394,7 +466,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Registrations submitted through a prompt’s registration block ÷ impressions of prompts with a registration block
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Registrations submitted through a prompt’s registration block ÷ impressions of prompts with a registration block
+                </p>
               </div>
             </div>
           </div>
@@ -439,7 +523,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
+                </p>
               </div>
             </div>
           </div>
@@ -484,7 +580,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Newsletter signups submitted through a prompt’s newsletter block ÷ impressions of prompts with a newsletter block
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Newsletter signups submitted through a prompt’s newsletter block ÷ impressions of prompts with a newsletter block
+                </p>
               </div>
             </div>
           </div>
@@ -529,7 +637,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
+                </p>
               </div>
             </div>
           </div>
@@ -602,7 +722,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Donations completed through a prompt’s donation block ÷ impressions of prompts with a donation block
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Donations completed through a prompt’s donation block ÷ impressions of prompts with a donation block
+                </p>
               </div>
             </div>
           </div>
@@ -647,7 +779,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
+                </p>
               </div>
             </div>
           </div>
@@ -692,7 +836,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Subscriptions purchased through a prompt’s checkout button ÷ impressions of prompts with a checkout button
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Subscriptions purchased through a prompt’s checkout button ÷ impressions of prompts with a checkout button
+                </p>
               </div>
             </div>
           </div>
@@ -737,7 +893,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
+                </p>
               </div>
             </div>
           </div>
@@ -810,7 +978,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sum of Woo donation order totals from donations completed through a prompt’s donation block
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Sum of Woo donation order totals from donations completed through a prompt’s donation block
+                </p>
               </div>
             </div>
           </div>
@@ -855,7 +1035,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Checkout revenue from donation completions in a later session within 14 days of seeing a donation-intent prompt
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Checkout revenue from donation completions in a later session within 14 days of seeing a donation-intent prompt
+                </p>
               </div>
             </div>
           </div>
@@ -900,7 +1092,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Sum of Woo subscription order totals from subscriptions purchased through a prompt’s checkout button
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Sum of Woo subscription order totals from subscriptions purchased through a prompt’s checkout button
+                </p>
               </div>
             </div>
           </div>
@@ -945,7 +1149,19 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               <div
                 class="newspack-insights__metric-card-description"
               >
-                Checkout revenue from subscription completions in a later session within 14 days of seeing a subscription-intent prompt
+                <button
+                  class="components-button newspack-insights__metric-card-info-icon is-tertiary has-icon"
+                  type="button"
+                >
+                  <span
+                    class="dashicon dashicons dashicons-info"
+                  />
+                </button>
+                <p
+                  class="newspack-insights__metric-card-description-text"
+                >
+                  Checkout revenue from subscription completions in a later session within 14 days of seeing a subscription-intent prompt
+                </p>
               </div>
             </div>
           </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -19,6 +19,8 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Icon, Tooltip } from '@wordpress/components';
+import { info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -204,7 +206,14 @@ const MetricCard = ( props: MetricCardProps ) => {
 						warming={ warming }
 					/>
 				</div>
-				{ description && <div className="newspack-insights__metric-card-description">{ description }</div> }
+				{ description && (
+					<div className="newspack-insights__metric-card-description">
+						<Tooltip delay={ 250 } placement="bottom-start" text={ description }>
+							<Icon icon={ info } className="newspack-insights__metric-card-info-icon" />
+						</Tooltip>
+						<p className="newspack-insights__metric-card-description-text">{ description }</p>
+					</div>
+				) }
 			</Card>
 		);
 	}
@@ -366,7 +375,12 @@ const MetricCard = ( props: MetricCardProps ) => {
 			     metric is computed, which is moot when there's nothing to compute, and
 			     would just double the text block. */ }
 			{ description && ! notCapableMessage && ! notComputableMessage && (
-				<div className="newspack-insights__metric-card-description">{ description }</div>
+				<div className="newspack-insights__metric-card-description">
+					<Tooltip delay={ 250 } placement="bottom-start" text={ description }>
+						<Icon icon={ info } className="newspack-insights__metric-card-info-icon" />
+					</Tooltip>
+					<p className="newspack-insights__metric-card-description-text">{ description }</p>
+				</div>
 			) }
 		</Card>
 	);

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -19,7 +19,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Tooltip } from '@wordpress/components';
+import { Button, Tooltip, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { info } from '@wordpress/icons';
 
 /**
@@ -192,32 +192,6 @@ const MetricCard = ( props: MetricCardProps ) => {
 		notComputableMessage,
 	} = props;
 
-	// Shared graceful-failure state (missing dimension / not configured / error / data missing / warming).
-	if ( overlay || error || notConfigured || dataMissing || warming ) {
-		return (
-			<Card __experimentalCoreCard className="newspack-insights__metric-card newspack-insights__metric-card--note">
-				<div className="newspack-insights__metric-card-label">{ label }</div>
-				<div className="newspack-insights__metric-card-body">
-					<MetricNote
-						overlay={ overlay }
-						error={ !! error }
-						notConfigured={ notConfigured }
-						dataMissing={ dataMissing }
-						warming={ warming }
-					/>
-				</div>
-				{ description && (
-					<div className="newspack-insights__metric-card-description">
-						<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ description }>
-							<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
-						</Tooltip>
-						<p className="newspack-insights__metric-card-description-text">{ description }</p>
-					</div>
-				) }
-			</Card>
-		);
-	}
-
 	// --- Zero-state count fallback (NPPD-1694) -----------------------------
 	// Resolve a count-based hero/secondary before the normal value+delta path.
 	// Driven by the conversions (numerator) and opportunity (denominator) counts
@@ -277,6 +251,36 @@ const MetricCard = ( props: MetricCardProps ) => {
 				fallbackSecondary = noneInWindow( conversionsNoun );
 			}
 		}
+	}
+
+	// Shared graceful-failure state (missing dimension / not configured / error / data missing / warming).
+	if ( overlay || error || notConfigured || dataMissing || warming ) {
+		return (
+			<Card __experimentalCoreCard className="newspack-insights__metric-card newspack-insights__metric-card--note">
+				<HStack className="newspack-insights__metric-card-label" alignment="top" justify="space-between" spacing={ 2 }>
+					<span>{ label }</span>
+					{ ( fallbackSecondary ?? secondary ) && (
+						<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ fallbackSecondary ?? secondary }>
+							<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
+						</Tooltip>
+					) }
+				</HStack>
+				<div className="newspack-insights__metric-card-body">
+					<MetricNote
+						overlay={ overlay }
+						error={ !! error }
+						notConfigured={ notConfigured }
+						dataMissing={ dataMissing }
+						warming={ warming }
+					/>
+				</div>
+				{ description && (
+					<div className="newspack-insights__metric-card-description">
+						<p>{ description }</p>
+					</div>
+				) }
+			</Card>
+		);
 	}
 
 	// Suppress the period-over-period delta whenever a fallback hero is shown — a
@@ -342,7 +346,14 @@ const MetricCard = ( props: MetricCardProps ) => {
 
 	return (
 		<Card __experimentalCoreCard className="newspack-insights__metric-card">
-			<div className="newspack-insights__metric-card-label">{ label }</div>
+			<HStack className="newspack-insights__metric-card-label" alignment="top" justify="space-between" spacing={ 2 }>
+				<span>{ label }</span>
+				{ ( fallbackSecondary ?? secondary ) && (
+					<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ fallbackSecondary ?? secondary }>
+						<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
+					</Tooltip>
+				) }
+			</HStack>
 			<div className="newspack-insights__metric-card-body">
 				<div
 					className={
@@ -353,9 +364,6 @@ const MetricCard = ( props: MetricCardProps ) => {
 				>
 					{ heroContent }
 				</div>
-				{ ( fallbackSecondary ?? secondary ) && (
-					<div className="newspack-insights__metric-card-secondary">{ fallbackSecondary ?? secondary }</div>
-				) }
 				{ magnitude !== null && (
 					<div
 						className={ `newspack-insights__metric-card-delta newspack-insights__metric-card-delta--${ tone }` }
@@ -376,10 +384,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 			     would just double the text block. */ }
 			{ description && ! notCapableMessage && ! notComputableMessage && (
 				<div className="newspack-insights__metric-card-description">
-					<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ description }>
-						<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
-					</Tooltip>
-					<p className="newspack-insights__metric-card-description-text">{ description }</p>
+					<p>{ description }</p>
 				</div>
 			) }
 		</Card>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -364,6 +364,9 @@ const MetricCard = ( props: MetricCardProps ) => {
 				>
 					{ heroContent }
 				</div>
+				{ ( fallbackSecondary ?? secondary ) && (
+					<div className="newspack-insights__metric-card-secondary">{ fallbackSecondary ?? secondary }</div>
+				) }
 				{ magnitude !== null && (
 					<div
 						className={ `newspack-insights__metric-card-delta newspack-insights__metric-card-delta--${ tone }` }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -259,8 +259,8 @@ const MetricCard = ( props: MetricCardProps ) => {
 			<Card __experimentalCoreCard className="newspack-insights__metric-card newspack-insights__metric-card--note">
 				<HStack className="newspack-insights__metric-card-label" alignment="top" justify="space-between" spacing={ 2 }>
 					<span>{ label }</span>
-					{ ( fallbackSecondary ?? secondary ) && (
-						<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ fallbackSecondary ?? secondary }>
+					{ secondary && (
+						<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ secondary }>
 							<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
 						</Tooltip>
 					) }
@@ -273,6 +273,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 						dataMissing={ dataMissing }
 						warming={ warming }
 					/>
+					{ secondary && <div className="newspack-insights__metric-card-secondary">{ secondary }</div> }
 				</div>
 				{ description && (
 					<div className="newspack-insights__metric-card-description">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -19,7 +19,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, Tooltip } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { info } from '@wordpress/icons';
 
 /**
@@ -209,7 +209,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 				{ description && (
 					<div className="newspack-insights__metric-card-description">
 						<Tooltip delay={ 250 } placement="bottom-start" text={ description }>
-							<Icon icon={ info } className="newspack-insights__metric-card-info-icon" />
+							<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
 						</Tooltip>
 						<p className="newspack-insights__metric-card-description-text">{ description }</p>
 					</div>
@@ -377,7 +377,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 			{ description && ! notCapableMessage && ! notComputableMessage && (
 				<div className="newspack-insights__metric-card-description">
 					<Tooltip delay={ 250 } placement="bottom-start" text={ description }>
-						<Icon icon={ info } className="newspack-insights__metric-card-info-icon" />
+						<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
 					</Tooltip>
 					<p className="newspack-insights__metric-card-description-text">{ description }</p>
 				</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -208,7 +208,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 				</div>
 				{ description && (
 					<div className="newspack-insights__metric-card-description">
-						<Tooltip delay={ 250 } placement="bottom-start" text={ description }>
+						<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ description }>
 							<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
 						</Tooltip>
 						<p className="newspack-insights__metric-card-description-text">{ description }</p>
@@ -376,7 +376,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 			     would just double the text block. */ }
 			{ description && ! notCapableMessage && ! notComputableMessage && (
 				<div className="newspack-insights__metric-card-description">
-					<Tooltip delay={ 250 } placement="bottom-start" text={ description }>
+					<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ description }>
 						<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
 					</Tooltip>
 					<p className="newspack-insights__metric-card-description-text">{ description }</p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -273,6 +273,8 @@
 		&-info-icon.components-button.is-tertiary {
 			color: wp-colors.$gray-700;
 			display: none;
+			margin-right: -14px;
+			padding: 0;
 			&:active,
 			&:hover {
 				background-color: transparent;
@@ -289,7 +291,7 @@
 			line-height: 1.4;
 			color: wp-colors.$gray-700;
 			text-align: left;
-			&-text {
+			&--long {
 				@media screen and (min-width: 783px){
 					display: none;
 				}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -277,6 +277,7 @@
 			color: wp-colors.$gray-700;
 			display: none;
 			margin-right: -14px;
+			margin-top: -8px;
 			padding: 0;
 			&:active,
 			&:hover {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -245,9 +245,13 @@
 			}
 		}
 
-		&-info-icon {
+		&-info-icon.components-button.is-tertiary {
+			color: wp-colors.$gray-700;
 			display: none;
-			fill: wp-colors.$gray-700;
+			&:active,
+			&:hover {
+				background-color: transparent;
+			}
 			@media screen and (min-width: 783px){
 				display: inline-block;
 			}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -239,6 +239,9 @@
 			line-height: 1.4;
 			color: wp-colors.$gray-700;
 			font-variant-numeric: tabular-nums;
+			@media screen and (min-width: 783px){
+				display: none;
+			}
 		}
 
 		&-delta {
@@ -291,11 +294,6 @@
 			line-height: 1.4;
 			color: wp-colors.$gray-700;
 			text-align: left;
-			&--long {
-				@media screen and (min-width: 783px){
-					display: none;
-				}
-			}
 		}
 
 		// Empty-state variant: same card chrome as a populated metric

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -245,6 +245,14 @@
 			}
 		}
 
+		&-info-icon {
+			display: none;
+			fill: wp-colors.$gray-700;
+			@media screen and (min-width: 783px){
+				display: inline-block;
+			}
+		}
+
 		&-description {
 			margin: 16px 0 0;
 			font-size: 13px;
@@ -252,6 +260,11 @@
 			line-height: 1.4;
 			color: wp-colors.$gray-700;
 			text-align: left;
+			&-text {
+				@media screen and (min-width: 783px){
+					display: none;
+				}
+			}
 		}
 
 		// Empty-state variant: same card chrome as a populated metric


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related to [DSGNEWS-188](https://linear.app/a8c/issue/DSGNEWS-188/design-review-insights-data-dashboard-replacement#comment-12469319).

At large viewports, replaces the inline description text in `MetricCard` components with an (i) icon that displays the description text in a tooltip on hover. Some descriptions are very long, which resulted in an overly busy layout when many `MetricCard` components exist side-by-side.

<img width="1564" height="1024" alt="Screenshot 2026-07-09 at 10 49 35 AM" src="https://github.com/user-attachments/assets/26b27252-9aa0-4969-8830-d178ecfd87cf" />

At small viewports, description text is still shown inline due to the difficulties with hover-based interactions on small mobile touchscreens:

<img width="371" height="717" alt="Screenshot 2026-07-09 at 11 00 03 AM" src="https://github.com/user-attachments/assets/a28a230d-1ddb-4971-8b57-fc4f93b77517" />

### How to test the changes in this Pull Request:

1. With Insights enabled in fixture or live mode, view any tab at a large viewport (>783px) with a `MetricCard` component and confirm that the description appears only when hovering over the (i) icon.
2. View at a small viewport and confirm no change from the ancestor branch (description text is shown inline, no (i) icon or tooltip).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
