### PR TITLE
style(insights): tweak color palette for chart colors

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/PieChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/PieChart.tsx
@@ -63,7 +63,7 @@ const PieChart = ( { segments, centerLabel, emptyMessage, formatValue = formatNu
 						const circle = (
 							<circle
 								key={ segment.label }
-								className={ `newspack-insights__pie-segment is-series-${ i % 7 }` }
+								className={ `newspack-insights__pie-segment is-series-${ i % 8 }` }
 								cx="21"
 								cy="21"
 								r={ RADIUS }
@@ -84,7 +84,7 @@ const PieChart = ( { segments, centerLabel, emptyMessage, formatValue = formatNu
 			<ul className="newspack-insights__pie-legend">
 				{ segments.map( ( segment, i ) => (
 					<li key={ segment.label }>
-						<span className={ `newspack-insights__legend-swatch is-series-${ i % 7 }` } aria-hidden="true" />
+						<span className={ `newspack-insights__legend-swatch is-series-${ i % 8 }` } aria-hidden="true" />
 						<span className="newspack-insights__legend-label">{ segment.label }</span>
 						<span className="newspack-insights__legend-value">
 							{ formatValue( segment.value ) } ({ formatPercent( segment.value / total ) })

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -11,16 +11,22 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "../../../../../packages/colors/colors.module" as colors;
 
-// Categorical series palette for charts. Hardcoded because a chart needs
-// distinct, stable category colors; applied via the --series-color custom
-// property so each viz element can map it to fill / stroke / background.
-.is-series-0 { --series-color: #{colors.$primary-600}; }
-.is-series-1 { --series-color: #0891B2; }
-.is-series-2 { --series-color: #{colors.$secondary-700}; }
-.is-series-3 { --series-color: #{colors.$quaternary-600}; }
-.is-series-4 { --series-color: #B91C1C; }
-.is-series-5 { --series-color: #7E22CE; }
+// Categorical series palette for charts (8 series): two monochrome families —
+// primary (blue) and orange, each a dark→light triad — then two neutral grays for
+// the tail. Every shade clears WCAG 1.4.11 non-text contrast (>=3:1) against the
+// white card, so thin line strokes and small legend swatches stay perceivable;
+// light tints are deliberately avoided. Blue↔orange is the colorblind-robust
+// pairing. The orange shades are hardcoded hex (no Newspack orange token clears
+// contrast on white) and are designer-approved. Applied via the --series-color
+// custom property; keep the count in sync with PieChart.tsx's modulo.
+.is-series-0 { --series-color: #{colors.$primary-700}; }
+.is-series-1 { --series-color: #{colors.$primary-500}; }
+.is-series-2 { --series-color: #{colors.$primary-300}; }
+.is-series-3 { --series-color: #9a3412; }
+.is-series-4 { --series-color: #c2410c; }
+.is-series-5 { --series-color: #ea580c; }
 .is-series-6 { --series-color: #{colors.$neutral-600}; }
+.is-series-7 { --series-color: #{colors.$neutral-800}; }
 
 .newspack-insights {
 	&__chart-grid {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -14,13 +14,13 @@
 // Categorical series palette for charts. Hardcoded because a chart needs
 // distinct, stable category colors; applied via the --series-color custom
 // property so each viz element can map it to fill / stroke / background.
-.is-series-0 { --series-color: #1c5ea8; }
-.is-series-1 { --series-color: #3eb24f; }
-.is-series-2 { --series-color: #d98b27; }
-.is-series-3 { --series-color: #8a4fbd; }
-.is-series-4 { --series-color: #c0392b; }
-.is-series-5 { --series-color: #1f8a8a; }
-.is-series-6 { --series-color: #6b7785; }
+.is-series-0 { --series-color: #{colors.$primary-600}; }
+.is-series-1 { --series-color: #0891B2; }
+.is-series-2 { --series-color: #{colors.$secondary-700}; }
+.is-series-3 { --series-color: #{colors.$quaternary-600}; }
+.is-series-4 { --series-color: #B91C1C; }
+.is-series-5 { --series-color: #7E22CE; }
+.is-series-6 { --series-color: #{colors.$neutral-600}; }
 
 .newspack-insights {
 	&__chart-grid {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks chart components' colors to a design-approved palette.

<table>
<tr>
<td>
Before:
<img width="1047" height="1074" alt="Screenshot 2026-07-09 at 11 16 21 AM" src="https://github.com/user-attachments/assets/c956b34c-fe4a-440f-aed1-5ec342ed16c3" />
</td>
<td>
After:
<img width="1040" height="1063" alt="Screenshot 2026-07-09 at 11 15 51 AM" src="https://github.com/user-attachments/assets/01eb1545-c0c8-47a1-9ce0-de470a4646cb" />
</td>
</tr>
</table>

Related to [DSGNEWS-188](https://linear.app/a8c/issue/DSGNEWS-188/design-review-insights-data-dashboard-replacement#comment-6d87ed21).

### How to test the changes in this Pull Request:

View any Insights tab containing a chart component and confirm that the colors match the new palette.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
