### PR TITLE
fix(insights): honor site currency + fix non-US currency symbol (DSGNEWS-188)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-wizard.php
@@ -455,6 +455,11 @@ class Insights_Wizard extends Wizard {
 			// to the matching help-site Playbooks flow, rendered as a strip in the
 			// tab footer. Product-owned mapping; see get_next_steps_links().
 			'nextStepsLinks'      => self::get_next_steps_links(),
+			// Site WooCommerce currency code (DSGNEWS-188). The client formats Woo
+			// revenue in this currency (in an en-US locale, so the symbol reads
+			// unambiguously: USD → "$", CAD → "CA$", …, rather than the
+			// viewer-locale "US$"). Falls back to USD when WooCommerce is inactive.
+			'currency'            => function_exists( 'get_woocommerce_currency' ) ? get_woocommerce_currency() : 'USD',
 		];
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/InsightsWizard.tsx
@@ -100,6 +100,12 @@ export interface InsightsBootConfig {
 	 * the map and render no strip. Optional so config fixtures need not set it.
 	 */
 	nextStepsLinks?: Partial< Record< TabKey, NextStepLink[] > >;
+	/**
+	 * Site WooCommerce currency code (e.g. "USD", "CAD") — Woo revenue is
+	 * formatted in this currency (DSGNEWS-188). Optional so config fixtures need
+	 * not set it; the formatter falls back to USD.
+	 */
+	currency?: string;
 }
 
 export interface InsightsWizardProps {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
@@ -1,10 +1,13 @@
 /**
- * Tab 6 formatting helpers (NPPD-1616).
+ * Insights formatting helpers (NPPD-1616).
  *
- * Lightweight wrappers around Intl.NumberFormat. Locale is taken from
- * the browser; currency code is hardcoded to USD for v1 (the publisher
- * may have multiple Woo currencies, and v1 sums them naively — a
- * multi-currency rollup is v1.1+ and is documented in the formula doc).
+ * Wrappers around Intl.NumberFormat. Everything is formatted in one fixed
+ * locale (`en-US`) so the display is consistent regardless of the admin's own
+ * browser locale — and, critically, so the currency symbol is unambiguous:
+ * en-US renders USD as "$" and non-US dollars as "CA$" / "NZ$" / "A$", whereas
+ * a non-US admin's own locale renders USD as "US$" / "$US" (DSGNEWS-188). The
+ * currency code is the site's WooCommerce currency from the boot config
+ * (`window.newspackInsights.currency`), falling back to USD.
  */
 
 /**
@@ -12,56 +15,59 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const numberFormatter = new Intl.NumberFormat( undefined, {
+const LOCALE = 'en-US';
+const SITE_CURRENCY = ( typeof window !== 'undefined' && window.newspackInsights?.currency ) || 'USD';
+
+const numberFormatter = new Intl.NumberFormat( LOCALE, {
 	maximumFractionDigits: 0,
 } );
 
-const decimalFormatter = new Intl.NumberFormat( undefined, {
+const decimalFormatter = new Intl.NumberFormat( LOCALE, {
 	minimumFractionDigits: 1,
 	maximumFractionDigits: 1,
 } );
 
 // Three tiers keep large dashboard values readable (NPPD-1684): small amounts
 // keep cents, thousands drop cents, millions+ abbreviate with the full value in
-// a tooltip. All USD for v1 (see file header on multi-currency).
-const USD_WITH_CENTS = new Intl.NumberFormat( undefined, {
+// a tooltip. Formatted in the site's Woo currency (see file header).
+const CURRENCY_WITH_CENTS = new Intl.NumberFormat( LOCALE, {
 	style: 'currency',
-	currency: 'USD',
+	currency: SITE_CURRENCY,
 	minimumFractionDigits: 2,
 	maximumFractionDigits: 2,
 } );
 
-const USD_NO_CENTS = new Intl.NumberFormat( undefined, {
+const CURRENCY_NO_CENTS = new Intl.NumberFormat( LOCALE, {
 	style: 'currency',
-	currency: 'USD',
+	currency: SITE_CURRENCY,
 	minimumFractionDigits: 0,
 	maximumFractionDigits: 0,
 } );
 
-const USD_COMPACT = new Intl.NumberFormat( undefined, {
+const CURRENCY_COMPACT = new Intl.NumberFormat( LOCALE, {
 	style: 'currency',
-	currency: 'USD',
+	currency: SITE_CURRENCY,
 	notation: 'compact',
 	maximumFractionDigits: 1,
 } );
 
-const NUMBER_COMPACT = new Intl.NumberFormat( undefined, {
+const NUMBER_COMPACT = new Intl.NumberFormat( LOCALE, {
 	notation: 'compact',
 	maximumFractionDigits: 1,
 } );
 
-const percentFormatter = new Intl.NumberFormat( undefined, {
+const percentFormatter = new Intl.NumberFormat( LOCALE, {
 	style: 'percent',
 	maximumFractionDigits: 1,
 } );
 
-const signedPercentFormatter = new Intl.NumberFormat( undefined, {
+const signedPercentFormatter = new Intl.NumberFormat( LOCALE, {
 	style: 'percent',
 	signDisplay: 'exceptZero',
 	maximumFractionDigits: 1,
 } );
 
-const shortDateFormatter = new Intl.DateTimeFormat( undefined, {
+const shortDateFormatter = new Intl.DateTimeFormat( LOCALE, {
 	month: 'short',
 	day: 'numeric',
 } );
@@ -89,22 +95,22 @@ export interface FormattedCurrency {
 }
 
 /**
- * Tiered currency: `<$1K` keeps cents, `$1K–<$1M` drops cents, `>=$1M`
+ * Tiered currency: `<1K` keeps cents, `1K–<1M` drops cents, `>=1M`
  * abbreviates (e.g. "$1.2M") and carries the full value as `title`. The sign is
  * handled by the formatter; tier is chosen by magnitude, so negatives tier the
- * same. Zero renders as "$0.00".
+ * same. Zero renders as "$0.00" (in the site currency).
  */
 export const formatCurrency = ( value: number ): FormattedCurrency => {
 	const abs = Math.abs( value );
 	if ( abs < 1000 ) {
-		return { display: USD_WITH_CENTS.format( value ), title: null };
+		return { display: CURRENCY_WITH_CENTS.format( value ), title: null };
 	}
 	if ( abs < 1_000_000 ) {
-		return { display: USD_NO_CENTS.format( value ), title: null };
+		return { display: CURRENCY_NO_CENTS.format( value ), title: null };
 	}
 	return {
-		display: USD_COMPACT.format( value ),
-		title: USD_WITH_CENTS.format( value ),
+		display: CURRENCY_COMPACT.format( value ),
+		title: CURRENCY_WITH_CENTS.format( value ),
 	};
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
@@ -16,7 +16,9 @@
 import { __ } from '@wordpress/i18n';
 
 const LOCALE = 'en-US';
-const SITE_CURRENCY = ( typeof window !== 'undefined' && window.newspackInsights?.currency ) || 'USD';
+// ISO 4217 code (Intl requires uppercase); WooCommerce already returns uppercase
+// but normalize defensively.
+const SITE_CURRENCY = ( ( typeof window !== 'undefined' && window.newspackInsights?.currency ) || 'USD' ).toUpperCase();
 
 const numberFormatter = new Intl.NumberFormat( LOCALE, {
 	maximumFractionDigits: 0,
@@ -28,16 +30,16 @@ const decimalFormatter = new Intl.NumberFormat( LOCALE, {
 } );
 
 // Three tiers keep large dashboard values readable (NPPD-1684): small amounts
-// keep cents, thousands drop cents, millions+ abbreviate with the full value in
-// a tooltip. Formatted in the site's Woo currency (see file header).
-const CURRENCY_WITH_CENTS = new Intl.NumberFormat( LOCALE, {
+// show the currency's natural minor units, thousands+ round to whole units, and
+// millions+ abbreviate with the full value in a tooltip. Formatted in the site's
+// Woo currency (see file header). `CURRENCY_FULL` sets no fraction count, so Intl
+// uses each currency's default minor units — 0 (JPY), 2 (USD), 3 (BHD).
+const CURRENCY_FULL = new Intl.NumberFormat( LOCALE, {
 	style: 'currency',
 	currency: SITE_CURRENCY,
-	minimumFractionDigits: 2,
-	maximumFractionDigits: 2,
 } );
 
-const CURRENCY_NO_CENTS = new Intl.NumberFormat( LOCALE, {
+const CURRENCY_ROUNDED = new Intl.NumberFormat( LOCALE, {
 	style: 'currency',
 	currency: SITE_CURRENCY,
 	minimumFractionDigits: 0,
@@ -95,22 +97,23 @@ export interface FormattedCurrency {
 }
 
 /**
- * Tiered currency: `<1K` keeps cents, `1K–<1M` drops cents, `>=1M`
- * abbreviates (e.g. "$1.2M") and carries the full value as `title`. The sign is
- * handled by the formatter; tier is chosen by magnitude, so negatives tier the
- * same. Zero renders as "$0.00" (in the site currency).
+ * Tiered currency: below 1,000 shows the currency's natural minor units (e.g.
+ * `$89.42`, `¥523`); 1,000–<1M rounds to whole units (`$41,690`); >=1M
+ * abbreviates (`$1.2M`) and carries the full value as `title`. The sign is
+ * handled by the formatter; the tier is chosen by magnitude, so negatives tier
+ * the same. All in the site's Woo currency.
  */
 export const formatCurrency = ( value: number ): FormattedCurrency => {
 	const abs = Math.abs( value );
 	if ( abs < 1000 ) {
-		return { display: CURRENCY_WITH_CENTS.format( value ), title: null };
+		return { display: CURRENCY_FULL.format( value ), title: null };
 	}
 	if ( abs < 1_000_000 ) {
-		return { display: CURRENCY_NO_CENTS.format( value ), title: null };
+		return { display: CURRENCY_ROUNDED.format( value ), title: null };
 	}
 	return {
 		display: CURRENCY_COMPACT.format( value ),
-		title: CURRENCY_WITH_CENTS.format( value ),
+		title: CURRENCY_FULL.format( value ),
 	};
 };
 


### PR DESCRIPTION
## Summary

Two related currency issues from the [DSGNEWS-188](https://linear.app/a8c/issue/DSGNEWS-188) review.

### Root cause
`format.ts` built its currency formatters as `Intl.NumberFormat( undefined, { currency: 'USD' } )`:
- **`undefined` locale = the viewer's browser locale.** For a non-US admin, `Intl` renders USD with a disambiguating prefix — `US$1,234` (en-CA/en-GB) or `1 234 $US` (fr-FR). A US admin sees plain `$`. **That's the "US" Thomas saw** — he isn't US-based.
- **Currency was hardcoded to `USD`.** A Canadian / NZ / UK publisher's Woo revenue was formatted as US dollars regardless of their actual WooCommerce currency.

### Fix
- **PHP:** the site's `get_woocommerce_currency()` now rides in the Insights boot config (`currency`, falling back to `USD` when WooCommerce is inactive).
- **JS:** `format.ts` formats in that currency, pinned to the **`en-US`** locale so the symbol is unambiguous regardless of who's viewing:

| Site currency | Renders |
|---|---|
| USD | `$1,234,567` |
| CAD | `CA$1,234,567` |
| NZD | `NZ$1,234,567` |
| GBP | `£1,234,567` |
| EUR | `€1,234,567` |

The en-US pin also makes all numbers/percents format consistently across admins (no more `1 234 568 $US` for a French viewer).

## Testing
- Insights Jest suite green — **69 suites / 466 tests** (`format.test` unchanged: USD still `$89.42` / `$1.2M`).
- `tsc`, ESLint, PHPCS (workspace-root standard) clean.
- **Verified live:** set the dev site to `CAD` → Subscribers revenue rendered **`CA$80.00`**; reverted to `USD` → `$`.

Linear: [DSGNEWS-188](https://linear.app/a8c/issue/DSGNEWS-188)