### PR TITLE
feat(newsletters): customizable Mailchimp resubscribe error message

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
@@ -102,6 +102,19 @@ class Newspack_Newsletters_Settings {
 				'sanitize_callback' => 'boolval',
 				'onboarding'        => true,
 			),
+			// Stored raw when saved via the wizard's REST path (update_settings() writes
+			// the option directly); sanitized with wp_kses_post at output.
+			array(
+				'description'       => esc_html__( 'Resubscribe error message', 'newspack-newsletters' ),
+				'key'               => 'newspack_newsletters_mailchimp_resubscribe_message',
+				'type'              => 'textarea',
+				'default'           => '',
+				'provider'          => 'mailchimp',
+				'placeholder'       => esc_attr__( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' ),
+				'sanitize_callback' => 'wp_kses_post',
+				'help'              => esc_html__( 'Shown to readers who unsubscribed from Mailchimp and try to resubscribe on the site. HTML links are allowed. Leave empty for the default message.', 'newspack-newsletters' ),
+				'onboarding'        => false,
+			),
 			array(
 				'description' => esc_html__( 'Constant Contact API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_constant_contact_api_key',

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
@@ -110,7 +110,10 @@ class Newspack_Newsletters_Settings {
 				'type'              => 'textarea',
 				'default'           => '',
 				'provider'          => 'mailchimp',
-				'placeholder'       => esc_attr__( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' ),
+				// Plain __() — the value is delivered over REST and set as a React attribute
+				// (placeholder={ props.placeholder }); React escapes attributes at render, so
+				// PHP-side esc_attr/esc_html here would only encode the apostrophe (We&#039;ll).
+				'placeholder'       => __( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' ),
 				'sanitize_callback' => 'wp_kses_post',
 				'help'              => esc_html__( 'Shown to readers who unsubscribed from Mailchimp and try to resubscribe on the site. HTML links are allowed. Leave empty for the default message.', 'newspack-newsletters' ),
 				'onboarding'        => false,

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
@@ -110,10 +110,12 @@ class Newspack_Newsletters_Settings {
 				'type'              => 'textarea',
 				'default'           => '',
 				'provider'          => 'mailchimp',
-				// Plain __() — the value is delivered over REST and set as a React attribute
-				// (placeholder={ props.placeholder }); React escapes attributes at render, so
-				// PHP-side esc_attr/esc_html here would only encode the apostrophe (We&#039;ll).
-				'placeholder'       => __( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' ),
+				// Previews the real fallback copy, so it reads from the same getter the
+				// fallback itself uses. Plain (unescaped) — the value is delivered over REST
+				// and set as a React attribute (placeholder={ props.placeholder }); React
+				// escapes attributes at render, so PHP-side esc_attr/esc_html here would only
+				// encode the apostrophe (We&#039;ll).
+				'placeholder'       => Newspack_Newsletters_Mailchimp::get_default_resubscribe_message(),
 				'sanitize_callback' => 'wp_kses_post',
 				'help'              => esc_html__( 'Shown to readers who unsubscribed from Mailchimp and try to resubscribe on the site. HTML links are allowed. Leave empty for the default message.', 'newspack-newsletters' ),
 				'onboarding'        => false,

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
@@ -577,6 +577,13 @@ class Newspack_Newsletters_Settings {
 					<?php endif; ?>
 				/>
 			<?php
+		} elseif ( 'textarea' === $type ) {
+			printf(
+				'<textarea id="%s" name="%s" rows="4" class="widefat">%s</textarea>',
+				esc_attr( $key ),
+				esc_attr( $key ),
+				esc_textarea( $value )
+			);
 		} else {
 			printf(
 				'<input type="text" id="%s" name="%s" value="%s" class="widefat" />',

--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -667,7 +667,7 @@ Error message(s) received:
 		);
 		// The message reaches reader-facing surfaces that render markup (including
 		// innerHTML in the subscribe block), so sanitize whatever any callback produced.
-		return wp_kses_post( $reader_error );
+		return wp_kses_post( (string) $reader_error );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -665,7 +665,9 @@ Error message(s) received:
 			$params,
 			$raw_error
 		);
-		return $reader_error;
+		// The message reaches reader-facing surfaces that render markup (including
+		// innerHTML in the subscribe block), so sanitize whatever any callback produced.
+		return wp_kses_post( $reader_error );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1645,7 +1645,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( is_wp_error( $raw_error ) && false !== strpos( $raw_error->get_error_message(), 'Member In Compliance State' ) ) {
 			// Mailchimp forbids resubscribing such contacts via its API, so the reader must be
 			// pointed elsewhere — publishers can customize the message (HTML links allowed).
-			$custom_message = get_option( 'newspack_newsletters_mailchimp_resubscribe_message', '' );
+			$custom_message = trim( (string) get_option( 'newspack_newsletters_mailchimp_resubscribe_message', '' ) );
 			if ( ! empty( $custom_message ) ) {
 				return $custom_message;
 			}

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1643,6 +1643,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	public function reader_error_message( $reader_error, $params, $raw_error ) {
 		// Handle special case where a user is in compliance state.
 		if ( is_wp_error( $raw_error ) && false !== strpos( $raw_error->get_error_message(), 'Member In Compliance State' ) ) {
+			// Mailchimp forbids resubscribing such contacts via its API, so the reader must be
+			// pointed elsewhere — publishers can customize the message (HTML links allowed).
+			$custom_message = get_option( 'newspack_newsletters_mailchimp_resubscribe_message', '' );
+			if ( ! empty( $custom_message ) ) {
+				return $custom_message;
+			}
 			$reader_error = __( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' );
 		}
 		return $reader_error;

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1632,6 +1632,20 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * The fallback message shown to readers whose Mailchimp contact is in a
+	 * compliance state, used when no custom message has been configured.
+	 *
+	 * Shared with the settings list, which uses it as the field placeholder so the
+	 * wizard previews the real fallback copy. A method rather than a class constant
+	 * because gettext extraction requires a string literal inside __().
+	 *
+	 * @return string The default resubscribe error message.
+	 */
+	public static function get_default_resubscribe_message() {
+		return __( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' );
+	}
+
+	/**
 	 * Filters the error message shown to readers when an error occurs.
 	 *
 	 * @param string $reader_error The default error message.
@@ -1649,7 +1663,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			if ( ! empty( $custom_message ) ) {
 				return $custom_message;
 			}
-			$reader_error = __( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' );
+			$reader_error = self::get_default_resubscribe_message();
 		}
 		return $reader_error;
 	}

--- a/plugins/newspack-newsletters/tests/test-mailchimp-reader-error-message.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-reader-error-message.php
@@ -81,6 +81,18 @@ class MailchimpReaderErrorMessageTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A whitespace-only saved message counts as empty — the default message shows.
+	 */
+	public function test_whitespace_only_message_falls_back_to_default() {
+		update_option( self::OPTION_NAME, "  \n  " );
+		$message = self::get_message( new WP_Error( 'mc', 'Member In Compliance State' ) );
+		self::assertSame(
+			"We'll need to subscribe this email address manually. Please contact our support team.",
+			$message
+		);
+	}
+
+	/**
 	 * The custom message applies ONLY to compliance-state errors; other errors keep the generic default.
 	 */
 	public function test_custom_message_does_not_apply_to_other_errors() {

--- a/plugins/newspack-newsletters/tests/test-mailchimp-reader-error-message.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-reader-error-message.php
@@ -1,0 +1,128 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests the Mailchimp reader-facing error message customization (NPPM-2912).
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Test the Mailchimp resubscribe (compliance-state) error message.
+ *
+ * @group mailchimp_reader_error
+ */
+class MailchimpReaderErrorMessageTest extends WP_UnitTestCase {
+	const OPTION_NAME = 'newspack_newsletters_mailchimp_resubscribe_message';
+
+	/**
+	 * Set up before class.
+	 */
+	public static function wpSetUpBeforeClass() {
+		update_option( 'newspack_mailchimp_api_key', 'test-us' );
+	}
+
+	/**
+	 * Tear down after class.
+	 */
+	public static function wpTearDownAfterClass() {
+		delete_option( 'newspack_mailchimp_api_key' );
+	}
+
+	/**
+	 * Reset the option between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * Get the provider's reader error message for a given raw error.
+	 *
+	 * @param WP_Error|null $raw_error The raw ESP error.
+	 * @return string
+	 */
+	private static function get_message( $raw_error ) {
+		$mailchimp = Newspack_Newsletters_Mailchimp::instance();
+		return $mailchimp->get_reader_error_message( [ 'email' => 'reader@example.com' ], $raw_error );
+	}
+
+	/**
+	 * Compliance-state errors show the default support-team message when no custom message is set.
+	 */
+	public function test_compliance_error_shows_default_message() {
+		$message = self::get_message( new WP_Error( 'mc', 'Bad Request: Member In Compliance State' ) );
+		self::assertSame(
+			"We'll need to subscribe this email address manually. Please contact our support team.",
+			$message
+		);
+	}
+
+	/**
+	 * A publisher-defined message replaces the default on compliance-state errors.
+	 */
+	public function test_compliance_error_shows_custom_message() {
+		update_option( self::OPTION_NAME, 'Please <a href="https://example.com/signup">use our signup page</a> to resubscribe.' );
+		$message = self::get_message( new WP_Error( 'mc', 'Bad Request: Member In Compliance State' ) );
+		self::assertSame(
+			'Please <a href="https://example.com/signup">use our signup page</a> to resubscribe.',
+			$message,
+			'The custom message, including HTML links, should be shown verbatim.'
+		);
+	}
+
+	/**
+	 * Stored markup is sanitized on output — scripts don't survive.
+	 */
+	public function test_custom_message_is_sanitized() {
+		update_option( self::OPTION_NAME, 'Resubscribe <a href="https://example.com/s">here</a>.<script>alert(1)</script>' );
+		$message = self::get_message( new WP_Error( 'mc', 'Member In Compliance State' ) );
+		self::assertStringContainsString( '<a href="https://example.com/s">here</a>', $message );
+		self::assertStringNotContainsString( '<script>', $message );
+	}
+
+	/**
+	 * The custom message applies ONLY to compliance-state errors; other errors keep the generic default.
+	 */
+	public function test_custom_message_does_not_apply_to_other_errors() {
+		update_option( self::OPTION_NAME, 'Custom resubscribe copy.' );
+		$message = self::get_message( new WP_Error( 'mc', 'Invalid Resource' ) );
+		self::assertSame(
+			'Sorry, an error has occurred. Please try again later or contact us for support.',
+			$message
+		);
+	}
+
+	/**
+	 * The filter output is sanitized at the choke point, whatever callback produced it.
+	 */
+	public function test_filter_output_is_sanitized_for_any_producer() {
+		add_filter(
+			'newspack_newsletters_add_contact_reader_error_message',
+			function () {
+				return 'Try <a href="https://example.com/s">this</a>.<script>alert(1)</script>';
+			},
+			99
+		);
+		$message = self::get_message( new WP_Error( 'mc', 'Invalid Resource' ) );
+		self::assertStringContainsString( '<a href="https://example.com/s">this</a>', $message );
+		self::assertStringNotContainsString( '<script>', $message );
+	}
+
+	/**
+	 * The setting is registered in the settings list, scoped to Mailchimp, with a kses sanitizer.
+	 */
+	public function test_setting_is_registered() {
+		$settings = Newspack_Newsletters_Settings::get_settings_list();
+		$entry    = null;
+		foreach ( $settings as $setting ) {
+			if ( isset( $setting['key'] ) && self::OPTION_NAME === $setting['key'] ) {
+				$entry = $setting;
+				break;
+			}
+		}
+		self::assertNotNull( $entry, 'The resubscribe message setting should be registered.' );
+		self::assertSame( 'mailchimp', $entry['provider'] ?? null );
+		self::assertSame( 'wp_kses_post', $entry['sanitize_callback'] ?? null );
+		self::assertSame( 'textarea', $entry['type'] ?? null, 'A message with a link needs a multi-line field.' );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-mailchimp-reader-error-message.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-reader-error-message.php
@@ -121,6 +121,16 @@ class MailchimpReaderErrorMessageTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A filter callback returning a non-string never breaks the sanitizer.
+	 */
+	public function test_non_string_filter_output_is_coerced() {
+		add_filter( 'newspack_newsletters_add_contact_reader_error_message', '__return_null', 99 );
+		$message = self::get_message( new WP_Error( 'mc', 'Invalid Resource' ) );
+		remove_filter( 'newspack_newsletters_add_contact_reader_error_message', '__return_null', 99 );
+		self::assertSame( '', $message );
+	}
+
+	/**
 	 * The setting is registered in the settings list, scoped to Mailchimp, with a kses sanitizer.
 	 */
 	public function test_setting_is_registered() {

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.js
@@ -241,6 +241,7 @@ export const Settings = ( {
 						label={ props.label }
 						value={ props.value }
 						placeholder={ props.placeholder }
+						help={ config.settings[ setting.key ]?.help }
 						onChange={ props.onChange }
 						disabled={ props.disabled }
 						rows={ 3 }

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.js
@@ -18,6 +18,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import {
 	ExternalLink,
 	Notice as WpNotice,
+	TextareaControl,
 	ToggleControl,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -232,6 +233,21 @@ export const Settings = ( {
 			return null;
 		}
 		switch ( setting.type ) {
+			case 'textarea': {
+				const props = getSettingProps( setting.key );
+				return (
+					<TextareaControl
+						key={ setting.key }
+						label={ props.label }
+						value={ props.value }
+						placeholder={ props.placeholder }
+						onChange={ props.onChange }
+						disabled={ props.disabled }
+						rows={ 3 }
+						__nextHasNoMarginBottom
+					/>
+				);
+			}
 			case 'select':
 				return <SelectControl key={ setting.key } { ...getSettingProps( setting.key ) } />;
 			case 'checkbox': {


### PR DESCRIPTION
When a reader who unsubscribed from a publisher's Mailchimp list tries to resubscribe on the site, Mailchimp rejects the API request — the address is in what Mailchimp calls a compliance state, and the reader has to opt back in through a Mailchimp-hosted form. The site showed a hardcoded message — "We'll need to subscribe this email address manually. Please contact our support team." — with no way for a publisher to customize it. The reporting publisher wants to point those readers at their own signup page instead.

Reference: NPPM-2912

### What this does

Adds a **Resubscribe error message** setting to the newsletters settings page, on the Mailchimp card. Left empty, nothing changes — readers see the same default message as today. Filled in, readers see the publisher's own message instead — links survive, so it can point readers at a signup page. The custom message appears only for this specific Mailchimp refusal; every other error keeps the generic message.

The field renders as a multi-line text area and only appears when Mailchimp is the connected provider.
<img width="554" height="123" alt="Screenshot 2026-07-09 at 9 44 09 AM" src="https://github.com/user-attachments/assets/83932d32-b386-484b-af3f-9a094679c55c" />

### How to test

Reproduce the problem (on `release`, without this branch):

1. Go to `/wp-admin/edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters` with Mailchimp as the connected provider. There is no message setting on the Mailchimp card.
2. On a dev site, print what a reader sees for Mailchimp's refusal: `wp eval 'echo Newspack_Newsletters_Mailchimp::instance()->get_reader_error_message( [], new WP_Error( "mc", "Member In Compliance State" ) );'` — output is the hardcoded support-team message.

Verify the fix (on this branch):

1. On the same settings page, the Mailchimp card now shows a "Resubscribe error message" text area. Enter a message containing a link, e.g. `Please <a href="https://example.com/signup">use our signup page</a> to resubscribe.` and save.
2. Run the same `wp eval` command — output is the custom message with the link intact.
3. Run it with a different error, e.g. `new WP_Error( "mc", "Invalid Resource" )` — output stays the generic "Sorry, an error has occurred…" message.
4. Clear the setting and rerun step 2 — the original default message returns.
5. Unit coverage: `n test-php --group mailchimp_reader_error` in `plugins/newspack-newsletters` (default, custom, link survival, script stripping, other-errors-unaffected, setting registration).

### Notes for reviewers

- Most of the feature is one settings-list entry — the wizard renders settings metadata automatically. The only shared UI change is a multi-line field type for the newsletters wizard.
- The message reaches reader-facing surfaces that render markup (WooCommerce notices, the subscribe block's message container), so sanitization sits on the shared output path all message producers flow through: `get_reader_error_message()` in the provider base class applies `wp_kses_post` to the filter output. A test injects a `<script>` via the public filter and asserts it is stripped while links survive.
- The option is stored raw when saved through the wizard's REST path (that path writes options directly); output-time kses covers it, and a comment at the settings entry warns future consumers. The standalone settings path honors the entry's `wp_kses_post` sanitize callback on write.
- Touches both plugins: the setting + consumption live in newspack-newsletters; the multi-line field type is ~15 lines in newspack-plugin's newsletters wizard (`TextareaControl` from `@wordpress/components`).
- Deliberately out of scope (both pre-existing, to be tracked separately): the async subscription flow (behind an experimental constant) stores the raw ESP error and never consults this message system; the no-JavaScript form fallback shows an error code rather than the message.
- A full round trip against a live Mailchimp account with a genuinely unsubscribed member was not run — the vendored Mailchimp client uses raw cURL and can't be stubbed at the HTTP boundary. The refusal-string match and all message plumbing are unit-covered.

### Release risk

Low to medium. The setting is additive and off (empty) by default, so shipped behavior only changes for publishers who fill it in. The one behavior change reviewers should weigh is the shared-output-path sanitization: any third-party filter callback already customizing this message now has its output passed through `wp_kses_post` — kses-safe links and formatting survive; scripts and exotic markup are stripped.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
