### PR TITLE
fix(insights): wrap long DataViews table headers and cell values

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -335,6 +335,31 @@
 		min-width: 0;
 	}
 
+	// DataViews defaults both column headers and cell values to
+	// `white-space: nowrap`, so a long heading ("Paid access gate conversion
+	// rate") or a long value (article titles, author names) forces the table
+	// wider than its container and it scrolls horizontally. Let both wrap.
+	.dataviews-view-table-header-button {
+		white-space: normal;
+		height: auto;
+	}
+
+	// Numeric columns are right-aligned (`align: end`); keep the wrapped header
+	// text aligned over its values rather than defaulting to the left.
+	.dataviews-view-table__cell-align-end .dataviews-view-table-header-button {
+		justify-content: flex-end;
+		text-align: right;
+	}
+
+	// The `tbody` mirrors DataViews' own
+	// `.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper`
+	// nowrap rule so this out-specifies it and long values wrap in place
+	// instead of overflowing.
+	.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
 	// Trim the 48px page-gutter edge padding so cell content aligns to the frame.
 	.dataviews-view-table {
 		th:first-child,


### PR DESCRIPTION
## Summary

Long column headings and long cell values were forcing Insights DataViews tables wider than their container, producing an awkward horizontal scroll:

- **Performance by gate** (Gates tab): long headings like "Paid access gate conversion rate" couldn't wrap, so each column stayed as wide as its header.
- **Most-engaged articles / Top authors** (Engagement tab): long article titles and author names couldn't wrap, so the value ran off the side (and with the card layout, bled into the neighbouring table).

`@wordpress/dataviews` ships two `white-space: nowrap` defaults — one on the header button, one on the cell content wrapper — the latter with an extra `tbody` in its selector, so a naive override loses the specificity fight. This PR overrides both, scoped to `.newspack-insights-dataview` so every Insights table wraps consistently.

## Changes

One CSS block in `src/wizards/insights/style.scss`:

- **Headers wrap** (`.dataviews-view-table-header-button` → `white-space: normal`), and numeric columns (`align: end`) keep their header text right-aligned over the values rather than defaulting left.
- **Cell values wrap** — the override mirrors DataViews' own `.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper` selector so it out-specifies the `nowrap` default and long values wrap in place.

## Testing

Verified from compiled CSS (fixture mode) on a local site:

- Performance-by-gate headings wrap to multiple lines, right-aligned over their values — no horizontal scroll.
- A long article title and a long author name wrap cleanly inside both side-by-side engagement tables — no scroll, no bleed into the neighbour.

CSS-only; no behaviour or test changes.