### PR TITLE
feat(insights): simplify `Funnel` data viz component

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/_print.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/_print.scss
@@ -187,10 +187,9 @@
 	}
 
 	// --- Watch item: Funnel (in-band HTML layout) ----------------------------
-	// The funnel renders as stacked HTML bands (clip-path trapezoid fills behind
-	// flowing label/count/descriptor text), sized by CSS. Pin a deterministic max
-	// width so it lays out predictably on the narrower print page rather than
-	// overflowing.
+	// The funnel renders as equal-width HTML bands (gradient fills behind flowing
+	// label/count/descriptor text), sized by CSS. Pin a deterministic max width so
+	// it lays out predictably on the narrower print page rather than overflowing.
 	.newspack-insights__funnel {
 		max-width: 17cm;
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -12,56 +12,9 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import Funnel, { stepOpacity, dropFromPrevious, computeDisplayHalfWidths, type FunnelStage } from './Funnel';
-
-const stage = ( label: string, count: number, pctOfTop: number ) => ( { label, count, pct_of_top: pctOfTop } );
+import Funnel, { stepOpacity, dropFromPrevious, type FunnelStage } from './Funnel';
 
 describe( 'Funnel helpers', () => {
-	describe( 'computeDisplayHalfWidths', () => {
-		// Chart half-width 160; MIN_HALF_WIDTH 44.8 (28%). Max taper is per-funnel:
-		// HALF_WIDTH / stepCount (80 for 2 steps, ~53 for 3, 32 for 5).
-		it( 'keeps the top level at full half-width', () => {
-			const halves = computeDisplayHalfWidths( [ stage( 'a', 1000, 1 ), stage( 'b', 500, 0.5 ) ], 1000 );
-			expect( halves[ 0 ] ).toBe( 160 );
-		} );
-		it( 'renders a moderate drop proportionally when within the clamps', () => {
-			// 2-step taper bound is 160 − 80 = 80; 900/1000 → 144 sits above it, so it passes through.
-			const halves = computeDisplayHalfWidths( [ stage( 'a', 1000, 1 ), stage( 'b', 900, 0.9 ) ], 1000 );
-			expect( halves[ 1 ] ).toBeCloseTo( 144, 5 );
-		} );
-		it( 'caps a steep drop at the per-funnel max taper from the level above', () => {
-			// 2-step funnel → taper 160/2 = 80. 200/1000 raw → 32, but capped to 160 − 80 = 80.
-			const halves = computeDisplayHalfWidths( [ stage( 'a', 1000, 1 ), stage( 'b', 200, 0.2 ) ], 1000 );
-			expect( halves[ 1 ] ).toBe( 80 );
-		} );
-		it( 'scales the taper to the step count so each funnel descends evenly', () => {
-			// 3-step funnel → taper 160/3. Steep tail steps 160 → ~106.7 → ~53.3.
-			const halves = computeDisplayHalfWidths( [ stage( 'a', 1000, 1 ), stage( 'b', 1, 0.001 ), stage( 'c', 1, 0.001 ) ], 1000 );
-			expect( halves[ 1 ] ).toBeCloseTo( 160 - 160 / 3, 5 );
-			expect( halves[ 2 ] ).toBeCloseTo( 160 - ( 2 * 160 ) / 3, 5 );
-		} );
-		it( 'floors a tiny level at the minimum segment width', () => {
-			// 5-step funnel → taper 160/5 = 32. Steep tail walks 160 → 128 → 96 → 64 → 44.8,
-			// bottoming out at MIN_HALF_WIDTH 44.8 rather than the ~0 raw widths.
-			const halves = computeDisplayHalfWidths(
-				[ stage( 'a', 1000, 1 ), stage( 'b', 100, 0.1 ), stage( 'c', 10, 0.01 ), stage( 'd', 1, 0.001 ), stage( 'e', 1, 0.001 ) ],
-				1000
-			);
-			expect( halves[ 4 ] ).toBeCloseTo( 44.8 );
-			expect( halves.every( h => h >= 44.8 - 0.0001 ) ).toBe( true );
-		} );
-		it( 'never flares: each level is at most the level above', () => {
-			// A later stage exceeding an earlier one (data drift) must not widen.
-			const halves = computeDisplayHalfWidths( [ stage( 'a', 500, 1 ), stage( 'b', 2000, 4 ) ], 500 );
-			for ( let i = 1; i < halves.length; i++ ) {
-				expect( halves[ i ] ).toBeLessThanOrEqual( halves[ i - 1 ] );
-			}
-		} );
-		it( 'returns zeros when the top count is non-positive', () => {
-			expect( computeDisplayHalfWidths( [ stage( 'a', 0, 0 ), stage( 'b', 0, 0 ) ], 0 ) ).toEqual( [ 0, 0 ] );
-		} );
-	} );
-
 	describe( 'stepOpacity', () => {
 		it( 'runs 1.0 at the first step to 0.6 at the last', () => {
 			expect( stepOpacity( 0, 3 ) ).toBeCloseTo( 1.0, 5 );
@@ -133,5 +86,16 @@ describe( 'Funnel render', () => {
 		expect( container.querySelector( '.newspack-insights__funnel-legend' ) ).toBeNull();
 		expect( container.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 		expect( container.querySelector( '.newspack-insights__funnel-svg' ) ).toBeNull();
+	} );
+
+	it( 'renders equal-width rectangular fills with no trapezoid clip-path', () => {
+		// The sections are full-width rectangles differentiated by color alone, so
+		// no band carries the old inline clip-path geometry.
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 100 ], [ 'C', 5 ] ) } /> );
+		const fills = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-fill' );
+		expect( fills ).toHaveLength( 3 );
+		fills.forEach( fill => {
+			expect( fill.style.clipPath ).toBe( '' );
+		} );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -1,31 +1,21 @@
 /**
- * Tests for the Funnel viz: the pure layout/geometry helpers (mode selection,
- * opacity interpolation, clamped drop-off) and render smoke tests covering the
- * descriptive labels and the edge cases.
+ * Tests for the Funnel viz: the pure helpers (clamped drop-off) and render smoke
+ * tests covering the hover/focus-revealed label Popovers, the stepped section
+ * widths and trapezoidal separators, the primary-scale fill/separator colors, and
+ * the edge cases.
  */
 
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
-import Funnel, { stepOpacity, dropFromPrevious, type FunnelStage } from './Funnel';
+import Funnel, { dropFromPrevious, type FunnelStage } from './Funnel';
 
 describe( 'Funnel helpers', () => {
-	describe( 'stepOpacity', () => {
-		it( 'runs 1.0 at the first step to 0.6 at the last', () => {
-			expect( stepOpacity( 0, 3 ) ).toBeCloseTo( 1.0, 5 );
-			expect( stepOpacity( 1, 3 ) ).toBeCloseTo( 0.8, 5 );
-			expect( stepOpacity( 2, 3 ) ).toBeCloseTo( 0.6, 5 );
-		} );
-		it( 'is full opacity for a single step', () => {
-			expect( stepOpacity( 0, 1 ) ).toBe( 1 );
-		} );
-	} );
-
 	describe( 'dropFromPrevious', () => {
 		it( 'computes 1 - count/prev', () => {
 			expect( dropFromPrevious( 2000, 25000 ) ).toBeCloseTo( 0.92, 3 ); // Mid-size publisher engagement step.
@@ -58,17 +48,46 @@ describe( 'Funnel render', () => {
 		expect( screen.getByText( '400' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows drop-off descriptors for stages after the first only', () => {
-		render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
-		expect( screen.getByText( /of Impressions/ ) ).toBeInTheDocument();
-		// Exactly one drop-off line: the first stage has none.
-		expect( screen.getAllByText( /drop-off/ ) ).toHaveLength( 1 );
+	it( 'keeps descriptors available to assistive tech and reveals the visual Popover on hover', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
+		const funnel = container.querySelector( '.newspack-insights__funnel' ) as HTMLElement;
+		// The drop-off text is always in the DOM as a screen-reader copy, even unhovered.
+		const srText = container.querySelector( '.screen-reader-text' );
+		expect( srText?.textContent ).toMatch( /of Impressions/ );
+		expect( srText?.textContent ).toMatch( /drop-off/ );
+		// The floating visual Popover (portaled to body) appears only on hover…
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
+		fireEvent.mouseEnter( funnel );
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).not.toBeNull();
+		// …and hides again once the pointer leaves.
+		fireEvent.mouseLeave( funnel );
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 	} );
 
-	it( 'renders a single-stage funnel without descriptors', () => {
-		render( <Funnel stages={ stages( [ 'Only', 100 ] ) } /> );
+	it( 'reveals the visual Popover on focus and hides it on blur', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
+		const funnel = container.querySelector( '.newspack-insights__funnel' ) as HTMLElement;
+		fireEvent.focus( funnel );
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).not.toBeNull();
+		fireEvent.blur( funnel );
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
+	} );
+
+	it( "reveals every section's Popover at once on hover", () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		// Both post-first stages carry an always-present screen-reader descriptor…
+		expect( container.querySelectorAll( '.screen-reader-text' ) ).toHaveLength( 2 );
+		// …and reveal their visual Popovers together on a single hover.
+		fireEvent.mouseEnter( container.querySelector( '.newspack-insights__funnel' ) as HTMLElement );
+		expect( document.querySelectorAll( '.newspack-insights__funnel-labels' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'renders a single-stage funnel without descriptors even on hover', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'Only', 100 ] ) } /> );
 		expect( screen.getByText( 'Only' ) ).toBeInTheDocument();
-		expect( screen.queryByText( /drop-off/ ) ).toBeNull();
+		expect( container.querySelector( '.screen-reader-text' ) ).toBeNull();
+		fireEvent.mouseEnter( container.querySelector( '.newspack-insights__funnel' ) as HTMLElement );
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 	} );
 
 	it( 'shows the empty message with no stages', () => {
@@ -81,21 +100,96 @@ describe( 'Funnel render', () => {
 		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
 	} );
 
-	it( 'no longer renders a separate legend or side-label column', () => {
+	it( 'renders no separate legend or SVG chart', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'A', 100 ], [ 'B', 50 ] ) } /> );
 		expect( container.querySelector( '.newspack-insights__funnel-legend' ) ).toBeNull();
-		expect( container.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 		expect( container.querySelector( '.newspack-insights__funnel-svg' ) ).toBeNull();
 	} );
 
-	it( 'renders equal-width rectangular fills with no trapezoid clip-path', () => {
-		// The sections are full-width rectangles differentiated by color alone, so
-		// no band carries the old inline clip-path geometry.
+	it( 'renders rectangular section fills and a trapezoidal separator between each pair', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 100 ], [ 'C', 5 ] ) } /> );
+		// The sections themselves are rectangles — no clip-path on the fills.
 		const fills = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-fill' );
 		expect( fills ).toHaveLength( 3 );
 		fills.forEach( fill => {
 			expect( fill.style.clipPath ).toBe( '' );
 		} );
+		// One separator per adjacent pair (n − 1). The trapezoid clip-path lives in
+		// CSS; the per-band bottom inset is supplied inline as a percentage.
+		const separators = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-separator' );
+		expect( separators ).toHaveLength( 2 );
+		separators.forEach( separator => {
+			expect( separator.style.getPropertyValue( '--separator-inset' ) ).toMatch( /%$/ );
+		} );
+	} );
+
+	it( 'sets a primary-scale fill on every section and a separator color on every connector', () => {
+		// These drive the SCSS `background-color`; assert they are emitted so a
+		// rename drift between the component and the stylesheet is caught here.
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		const steps = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' );
+		expect( steps ).toHaveLength( 3 );
+		steps.forEach( step => {
+			expect( step.style.getPropertyValue( '--band-fill' ) ).not.toBe( '' );
+		} );
+		const separators = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-separator' );
+		expect( separators ).toHaveLength( 2 );
+		separators.forEach( separator => {
+			expect( separator.style.getPropertyValue( '--band-separator' ) ).not.toBe( '' );
+		} );
+	} );
+
+	it( 'steps section widths down from a full-width top section', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		const widths = Array.from( container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' ) ).map( step =>
+			parseFloat( step.style.maxWidth )
+		);
+		expect( widths[ 0 ] ).toBe( 100 ); // top section pinned to the full width
+		expect( widths[ 1 ] ).toBeLessThan( widths[ 0 ] );
+		expect( widths[ 2 ] ).toBeLessThan( widths[ 1 ] );
+	} );
+
+	it( 'never widens a band beyond the one above, even for long funnels or data drift', () => {
+		// A 10-stage funnel (MINIMUM_BAND_PROPORTION * 10 > 1, so the floor would
+		// otherwise flare) that also contains a drift stage (S2 > S1). Widths must
+		// still stay ≤ 100% and strictly decrease band to band.
+		const { container } = render(
+			<Funnel
+				stages={ stages(
+					[ 'S0', 1000 ],
+					[ 'S1', 900 ],
+					[ 'S2', 950 ],
+					[ 'S3', 300 ],
+					[ 'S4', 250 ],
+					[ 'S5', 200 ],
+					[ 'S6', 150 ],
+					[ 'S7', 120 ],
+					[ 'S8', 100 ],
+					[ 'S9', 90 ]
+				) }
+			/>
+		);
+		const widths = Array.from( container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' ) ).map( step =>
+			parseFloat( step.style.maxWidth )
+		);
+		expect( widths[ 0 ] ).toBe( 100 );
+		widths.forEach( width => expect( width ).toBeLessThanOrEqual( 100 ) );
+		for ( let i = 1; i < widths.length; i++ ) {
+			expect( widths[ i ] ).toBeLessThan( widths[ i - 1 ] );
+		}
+	} );
+
+	it( 'keeps text full size above the width threshold, then eases it down gradually', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 700 ], [ 'C', 450 ], [ 'D', 100 ] ) } /> );
+		const steps = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' );
+		const scale = ( step: HTMLElement ) => parseFloat( step.style.getPropertyValue( '--funnel-font-scale' ) );
+		// At or above half the top width, text stays full size.
+		expect( scale( steps[ 0 ] ) ).toBe( 1 );
+		expect( scale( steps[ 1 ] ) ).toBe( 1 );
+		// Just past the threshold the reduction is slight — a ramp, not a hard step to
+		// the floor — and it keeps easing down as sections get narrower.
+		expect( scale( steps[ 2 ] ) ).toBeLessThan( 1 );
+		expect( scale( steps[ 2 ] ) ).toBeGreaterThan( 0.9 );
+		expect( scale( steps[ 3 ] ) ).toBeLessThan( scale( steps[ 2 ] ) );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -9,12 +9,14 @@
  * The sections are equal-width rectangles (the overall silhouette is a rectangle,
  * not a tapering funnel): the drop-off between steps is conveyed by the labels and
  * by color alone, not by width. Each band is a full-width <li> with two layers:
- *   - a solid FILL behind the text; and
+ *   - a gradient FILL behind the text; and
  *   - a flowing TEXT layer on top that wraps and grows the band height.
  *
  * Width is CSS-driven (width:100%, max-width cap), so no JS measurement is needed.
- * The single anchor color (primary-500) fades 1.0 → 0.6 down the funnel, and that
- * fade is the sole visual differentiator between sections; bands above
+ * The single anchor color (primary-500) fades 1.0 → 0.6 down the funnel: each
+ * band's fill ramps from its own opacity to the next band's, so the bands meet
+ * seamlessly and the stack is one continuous gradient — the sole visual
+ * differentiator between sections. Bands whose midpoint shade is above
  * DARK_TEXT_OPACITY_THRESHOLD take white text, below it dark text.
  */
 
@@ -107,15 +109,27 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	return (
 		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
 			{ stages.map( ( stage, index ) => {
-				const opacity = stepOpacity( index, stepCount );
-				const isDark = opacity > DARK_TEXT_OPACITY_THRESHOLD;
+				// The fill ramps from this step's opacity at the top to the next
+				// step's at the bottom, so adjacent bands meet seamlessly and the
+				// stack reads as one continuous 1.0 → 0.6 gradient. The last band
+				// holds the floor opacity (no step below it to ramp toward).
+				const topOpacity = stepOpacity( index, stepCount );
+				const bottomOpacity = index < stepCount - 1 ? stepOpacity( index + 1, stepCount ) : topOpacity;
+				// Text contrast tracks the band's midpoint shade, since the fill now
+				// varies across the band rather than being a single flat opacity.
+				const isDark = ( topOpacity + bottomOpacity ) / 2 > DARK_TEXT_OPACITY_THRESHOLD;
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
 				return (
 					<li
 						key={ index }
 						className={ 'newspack-insights__funnel-step ' + ( isDark ? 'is-on-dark' : 'is-on-light' ) }
-						style={ { '--band-opacity': opacity } as React.CSSProperties }
+						style={
+							{
+								'--band-opacity-top': topOpacity,
+								'--band-opacity-bottom': bottomOpacity,
+							} as React.CSSProperties
+						}
 					>
 						<span className="newspack-insights__funnel-fill" aria-hidden="true" />
 						<span className="newspack-insights__funnel-content">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -1,46 +1,76 @@
 /**
  * Funnel viz — shared across Insights tabs (Gates, Prompts, Conversion Journey).
  *
- * Self-labeling stacked funnel (NEWS-2586). Each section carries its own label,
- * count, and — for every step after the first — the drop-off descriptors
- * ("X% of {top}" share + "Y% drop-off") INSIDE the section. One uniform layout at
- * every viewport and step count: no side-label/compact split, no separate legend.
+ * Alternative "stepped" treatment (NEWS-2586). The sections are rectangles of
+ * DECREASING width: the top section spans the component's max width and each lower
+ * section is sized in proportion to the top count, floored at a minimum so long
+ * funnels don't collapse to slivers. Between every pair of sections a trapezoidal
+ * SEPARATOR connects the wider section above to the narrower one below.
  *
- * The sections are equal-width rectangles (the overall silhouette is a rectangle,
- * not a tapering funnel): the drop-off between steps is conveyed by the labels and
- * by color alone, not by width. Each band is a full-width <li> with two layers:
- *   - a gradient FILL behind the text; and
- *   - a flowing TEXT layer on top that wraps and grows the band height.
+ * Each section is an <li> with:
+ *   - a gradient FILL behind the text (primary-600, opacity fading 1.0 → 0.6 down
+ *     the funnel — each band ramps around its own shade for a distinct-sections
+ *     look); and
+ *   - a TEXT layer with the section label + count (white text with a dark shadow,
+ *     legible over both the dark upper bands and the faded lower ones).
+ * The per-step drop-off descriptors ("X% of {top}" + "Y% drop-off from previous")
+ * live in a Popover that floats beside the section and is revealed for the WHOLE
+ * funnel on hover/focus (see the hover/focus state in the component).
  *
- * Width is CSS-driven (width:100%, max-width cap), so no JS measurement is needed.
- * The single anchor color (primary-600) fades 1.0 → 0.6 down the funnel — the sole
- * visual differentiator between sections. Each band's fill is a vertical gradient
- * ramping symmetrically around its own shade (darker top → lighter bottom); because
- * adjacent bands don't share a boundary value, a visible step keeps the sections
- * distinct. Bands whose shade is above DARK_TEXT_OPACITY_THRESHOLD take white text,
- * below it dark text.
+ * Widths are set inline (maxWidth %) and the separators are trapezoids clipped in
+ * CSS (each band's bottom inset supplied inline via --separator-inset), so both
+ * scale fluidly with no JS measurement of the DOM.
  */
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Popover } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import colors from '../../../../../packages/colors/colors.module.scss';
 import { formatNumber, formatPercent } from './format';
 
-const FULL_OPACITY = 1;
-const TAIL_OPACITY = 0.6;
-// Above this band opacity the fill is dark enough for white text; below it the
-// faded band needs dark text.
-const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
-// Distinct-sections gradient: each band ramps symmetrically around its own shade
-// by this fraction of the step-to-step opacity gap (darker top → lighter bottom).
-// Kept below 0.5 so adjacent bands do NOT share a boundary value — a visible step
-// stays between them, unlike a seamless funnel-wide ramp.
-const INTERNAL_GRADIENT_FRACTION = 0.25;
+// Sections and their trapezoidal separators step through discrete stops of the
+// primary color scale (top = darkest, bottom = lightest) rather than fading by
+// opacity. Each band takes the next stop down from the top anchor by its position:
+// fills run primary-700, 600, 500, … ; separators run primary-200, 100, 050, … .
+// A short funnel simply stops early (a 3-step funnel is 700/600/500), and the
+// scales are sized for the 5-stage maximum so the index never runs off the end.
+const FUNNEL_FILL_SCALE = [ 'primary-700', 'primary-600', 'primary-500', 'primary-400', 'primary-300' ];
+const FUNNEL_SEPARATOR_SCALE = [ 'primary-200', 'primary-100', 'primary-050', 'primary-000' ];
+
+/**
+ * The scale stop for a band at `index`: one adjacent stop down from the top anchor
+ * per position, clamped to the last stop. Resolves the token to its hex via the
+ * color map, falling back to the token name if the map can't resolve it (e.g. under
+ * the test env's scss stub).
+ */
+const pickScale = ( scale: string[], index: number ): string => {
+	const token = scale[ Math.min( index, scale.length - 1 ) ];
+	return colors[ token ] ?? token;
+};
+
+// Each band's minimum width, as this fraction of the prior band's width times the
+// total number of steps, to avoid extremely narrow funnels. Capped by
+// MAX_BAND_TAPER below so the floor can never make a band as wide as the one above.
+const MINIMUM_BAND_PROPORTION = 0.12;
+// Each band is at most this fraction of the band above it, so widths always
+// decrease (a visible taper) — even for very long funnels (where
+// MINIMUM_BAND_PROPORTION * stepCount would otherwise exceed 1) or under data drift
+// (where a later stage's raw share of the top can exceed the prior band).
+const MAX_BAND_TAPER = 0.9;
+// Section text stays full size until a section narrows past FONT_SCALE_THRESHOLD of
+// the top width, then ramps down linearly toward FONT_SCALE_FLOOR of the top
+// section's size (reached only as the width approaches 0) — a gradual reduction
+// rather than a hard step at the threshold. Name and count share the one scale, so
+// their relative sizes stay constant as they shrink together.
+const FONT_SCALE_THRESHOLD = 0.5;
+const FONT_SCALE_FLOOR = 0.75;
 
 export interface FunnelStage {
 	label: string;
@@ -52,14 +82,6 @@ export interface FunnelProps {
 	stages: FunnelStage[];
 }
 
-/** Linear opacity from 1.0 at the first step to 0.6 at the last. */
-export const stepOpacity = ( index: number, stepCount: number ): number => {
-	if ( stepCount <= 1 ) {
-		return FULL_OPACITY;
-	}
-	return FULL_OPACITY + ( TAIL_OPACITY - FULL_OPACITY ) * ( index / ( stepCount - 1 ) );
-};
-
 /**
  * Drop-off from the previous step as a fraction in [0, 1]. Clamped at 0: funnel
  * stages are independent aggregates, so a later stage can occasionally exceed the
@@ -68,35 +90,57 @@ export const stepOpacity = ( index: number, stepCount: number ): number => {
 export const dropFromPrevious = ( count: number, prevCount: number ): number => ( prevCount > 0 ? Math.max( 0, 1 - count / prevCount ) : 0 );
 
 /**
- * The two descriptive lines for every step beyond the first: what share of the top
- * stage reached here, and the stage-to-stage drop-off. Color is inherited from the
- * band (white on dark bands, dark on faded ones) — these describe funnel
- * progression, not a period comparison, so never red/green.
+ * The two descriptor strings for every step beyond the first: what share of the top
+ * stage reached here, and the stage-to-stage drop-off. Built once and used by both
+ * the always-present screen-reader copy and the on-hover Popover.
  */
-const StepLabels = ( { pctOfTop, drop, topLabel }: { pctOfTop: number; drop: number; topLabel: string } ) => (
-	<>
-		<span className="newspack-insights__funnel-label-pct">
-			{ sprintf(
-				/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
-				__( '%1$s of %2$s', 'newspack-plugin' ),
-				formatPercent( pctOfTop ),
-				topLabel
-			) }
-		</span>
-		<span className="newspack-insights__funnel-label-drop">
-			<span aria-hidden="true" className="newspack-insights__funnel-label-drop-arrow">
-				↓
-			</span>{ ' ' }
-			{ sprintf(
-				/* translators: %s: percentage drop-off from the previous stage. */
-				__( '%s drop-off', 'newspack-plugin' ),
-				formatPercent( drop )
-			) }
-		</span>
-	</>
+const formatStepDescriptors = ( pctOfTop: number, drop: number, topLabel: string ) => ( {
+	share: sprintf(
+		/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
+		__( '%1$s of %2$s', 'newspack-plugin' ),
+		formatPercent( pctOfTop ),
+		topLabel
+	),
+	drop: sprintf(
+		/* translators: %s: percentage drop-off from the previous stage. */
+		__( '%s drop-off', 'newspack-plugin' ),
+		formatPercent( drop )
+	),
+} );
+
+/**
+ * The hover/focus-revealed Popover carrying a step's descriptors. It's a visual
+ * affordance only — the same text is always present in a screen-reader node on the
+ * section — so its content is aria-hidden to avoid a duplicate announcement. These
+ * describe funnel progression, not a period comparison, so never red/green.
+ */
+const StepLabels = ( { share, drop }: { share: string; drop: string } ) => (
+	<Popover className="newspack-insights__funnel-labels" offset={ 16 } placement="right" shift>
+		<div aria-hidden="true">
+			<p className="newspack-insights__funnel-label-pct">{ share }</p>
+			<p className="newspack-insights__funnel-label-drop">
+				<span className="newspack-insights__funnel-label-drop-arrow">↓</span> { drop }
+			</p>
+		</div>
+	</Popover>
 );
 
 const Funnel = ( { stages }: FunnelProps ) => {
+	// The floating label Popovers are revealed for the whole funnel while it is
+	// hovered or holds focus; tracking hover and focus separately keeps the labels
+	// up when the pointer leaves but keyboard focus is still inside, and vice versa.
+	const [ isHovered, setIsHovered ] = useState( false );
+	const [ isFocused, setIsFocused ] = useState( false );
+	const isActive = isHovered || isFocused;
+
+	// Blur only deactivates when focus actually leaves the funnel, not when it moves
+	// between sections inside it.
+	const handleBlur = ( event: React.FocusEvent< HTMLOListElement > ) => {
+		if ( ! event.currentTarget.contains( event.relatedTarget as Node | null ) ) {
+			setIsFocused( false );
+		}
+	};
+
 	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
 	const topLabel = stages.length > 0 ? stages[ 0 ].label : '';
 
@@ -111,32 +155,71 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	}
 
 	const stepCount = stages.length;
-	// Half the internal ramp per band, in opacity units. Derived from the step gap
-	// so the sheen scales with the funnel length (subtler on longer funnels).
-	const stepGap = stepCount > 1 ? ( FULL_OPACITY - TAIL_OPACITY ) / ( stepCount - 1 ) : 0;
-	const halfSpan = stepGap * INTERNAL_GRADIENT_FRACTION;
+	// Floor multiplier for each band's width, capped at MAX_BAND_TAPER so a long
+	// funnel (where MINIMUM_BAND_PROPORTION * stepCount ≥ 1) can't floor a band as
+	// wide as the one above.
+	const minBandPct = Math.min( MAX_BAND_TAPER, MINIMUM_BAND_PROPORTION * stepCount );
+	// Width fraction of each section. The top spans the full width; every lower
+	// section follows its share of the top count, but capped at MAX_BAND_TAPER of the
+	// band above (so widths strictly decrease, even when data drift pushes a raw
+	// share ≥ the prior band) and floored at minBandPct of it (so long funnels don't
+	// collapse to slivers).
+	const bandWidths: number[] = [];
+	stages.forEach( ( stage, index ) => {
+		if ( index === 0 ) {
+			bandWidths.push( 1 );
+			return;
+		}
+		const prev = bandWidths[ index - 1 ];
+		const share = topCount > 0 ? stage.count / topCount : 0;
+		bandWidths.push( Math.max( minBandPct * prev, Math.min( MAX_BAND_TAPER * prev, share ) ) );
+	} );
 
 	return (
-		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
+		<ol
+			className="newspack-insights__funnel"
+			aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }
+			tabIndex={ 0 }
+			onMouseEnter={ () => setIsHovered( true ) }
+			onMouseLeave={ () => setIsHovered( false ) }
+			onFocus={ () => setIsFocused( true ) }
+			onBlur={ handleBlur }
+		>
 			{ stages.map( ( stage, index ) => {
-				// Each band ramps symmetrically around its own shade (darker top →
-				// lighter bottom). Adjacent bands do NOT share a boundary value, so a
-				// visible step separates the sections. Clamped to a valid [0,1] alpha.
-				const bandOpacity = stepOpacity( index, stepCount );
-				const topOpacity = Math.min( FULL_OPACITY, bandOpacity + halfSpan );
-				const bottomOpacity = Math.max( 0, bandOpacity - halfSpan );
-				// Contrast tracks the band's own shade (its ramp midpoint).
-				const isDark = bandOpacity > DARK_TEXT_OPACITY_THRESHOLD;
+				// Each band takes a discrete stop of the primary scale (darkest at the
+				// top, lightest at the bottom); the separator below it steps through a
+				// lighter companion scale. Sampled evenly so a short funnel spans the
+				// same endpoints as the 5-stage maximum.
+				const fillColor = pickScale( FUNNEL_FILL_SCALE, index );
+				const separatorColor = pickScale( FUNNEL_SEPARATOR_SCALE, index );
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
+				// Descriptor strings for steps after the first; rendered both as an
+				// always-present screen-reader node and (on hover/focus) the Popover.
+				const descriptors = drop !== null ? formatStepDescriptors( pctOfTop, drop, topLabel ) : null;
+				const bandWidth = bandWidths[ index ];
+				// Text is full size at/above FONT_SCALE_THRESHOLD of the top width, then
+				// eases down linearly toward FONT_SCALE_FLOOR as the section narrows —
+				// a gradual ramp rather than a step at the threshold.
+				const widthRatio = Math.min( 1, bandWidth / FONT_SCALE_THRESHOLD );
+				const fontScale = FONT_SCALE_FLOOR + ( 1 - FONT_SCALE_FLOOR ) * widthRatio;
+				// The separator below this section is a trapezoid: its top edge spans
+				// this (wider) section and its bottom edge insets toward the next
+				// (narrower) section's width. The inset is a % of this section (the
+				// separator spans its full width); the CSS floors it so the bottom edge
+				// never drops below the section min-width. Ratio clamped to ≤ 1 (no flare).
+				const nextBandWidth = index < stepCount - 1 ? bandWidths[ index + 1 ] : bandWidth;
+				const separatorBottomRatio = bandWidth > 0 ? Math.min( 1, nextBandWidth / bandWidth ) : 1;
+				const separatorInsetPct = ( ( 1 - separatorBottomRatio ) / 2 ) * 100;
 				return (
 					<li
 						key={ index }
-						className={ 'newspack-insights__funnel-step ' + ( isDark ? 'is-on-dark' : 'is-on-light' ) }
+						className="newspack-insights__funnel-step"
 						style={
 							{
-								'--band-opacity-top': topOpacity,
-								'--band-opacity-bottom': bottomOpacity,
+								'--band-fill': fillColor,
+								'--funnel-font-scale': fontScale,
+								maxWidth: `${ bandWidth * 100 }%`,
 							} as React.CSSProperties
 						}
 					>
@@ -144,8 +227,25 @@ const Funnel = ( { stages }: FunnelProps ) => {
 						<span className="newspack-insights__funnel-content">
 							<span className="newspack-insights__funnel-label-name">{ stage.label }</span>
 							<span className="newspack-insights__funnel-label-count">{ formatNumber( stage.count ) }</span>
-							{ drop !== null && <StepLabels pctOfTop={ pctOfTop } drop={ drop } topLabel={ topLabel } /> }
+							{ descriptors && (
+								<>
+									<span className="screen-reader-text">{ `${ descriptors.share }. ${ descriptors.drop }.` }</span>
+									{ isActive && <StepLabels share={ descriptors.share } drop={ descriptors.drop } /> }
+								</>
+							) }
 						</span>
+						{ index < stages.length - 1 && (
+							<span
+								className="newspack-insights__funnel-separator"
+								aria-hidden="true"
+								style={
+									{
+										'--band-separator': separatorColor,
+										'--separator-inset': `${ separatorInsetPct }%`,
+									} as React.CSSProperties
+								}
+							/>
+						) }
 					</li>
 				);
 			} ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -13,7 +13,7 @@
  *   - a flowing TEXT layer on top that wraps and grows the band height.
  *
  * Width is CSS-driven (width:100%, max-width cap), so no JS measurement is needed.
- * The single anchor color (primary-500) fades 1.0 → 0.6 down the funnel — the sole
+ * The single anchor color (primary-600) fades 1.0 → 0.6 down the funnel — the sole
  * visual differentiator between sections. Each band's fill is a vertical gradient
  * ramping symmetrically around its own shade (darker top → lighter bottom); because
  * adjacent bands don't share a boundary value, a visible step keeps the sections

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -13,11 +13,12 @@
  *   - a flowing TEXT layer on top that wraps and grows the band height.
  *
  * Width is CSS-driven (width:100%, max-width cap), so no JS measurement is needed.
- * The single anchor color (primary-500) fades 1.0 → 0.6 down the funnel: each
- * band's fill ramps from its own opacity to the next band's, so the bands meet
- * seamlessly and the stack is one continuous gradient — the sole visual
- * differentiator between sections. Bands whose midpoint shade is above
- * DARK_TEXT_OPACITY_THRESHOLD take white text, below it dark text.
+ * The single anchor color (primary-500) fades 1.0 → 0.6 down the funnel — the sole
+ * visual differentiator between sections. Each band's fill is a vertical gradient
+ * ramping symmetrically around its own shade (darker top → lighter bottom); because
+ * adjacent bands don't share a boundary value, a visible step keeps the sections
+ * distinct. Bands whose shade is above DARK_TEXT_OPACITY_THRESHOLD take white text,
+ * below it dark text.
  */
 
 /**
@@ -35,6 +36,11 @@ const TAIL_OPACITY = 0.6;
 // Above this band opacity the fill is dark enough for white text; below it the
 // faded band needs dark text.
 const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
+// Distinct-sections gradient: each band ramps symmetrically around its own shade
+// by this fraction of the step-to-step opacity gap (darker top → lighter bottom).
+// Kept below 0.5 so adjacent bands do NOT share a boundary value — a visible step
+// stays between them, unlike a seamless funnel-wide ramp.
+const INTERNAL_GRADIENT_FRACTION = 0.25;
 
 export interface FunnelStage {
 	label: string;
@@ -105,19 +111,22 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	}
 
 	const stepCount = stages.length;
+	// Half the internal ramp per band, in opacity units. Derived from the step gap
+	// so the sheen scales with the funnel length (subtler on longer funnels).
+	const stepGap = stepCount > 1 ? ( FULL_OPACITY - TAIL_OPACITY ) / ( stepCount - 1 ) : 0;
+	const halfSpan = stepGap * INTERNAL_GRADIENT_FRACTION;
 
 	return (
 		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
 			{ stages.map( ( stage, index ) => {
-				// The fill ramps from this step's opacity at the top to the next
-				// step's at the bottom, so adjacent bands meet seamlessly and the
-				// stack reads as one continuous 1.0 → 0.6 gradient. The last band
-				// holds the floor opacity (no step below it to ramp toward).
-				const topOpacity = stepOpacity( index, stepCount );
-				const bottomOpacity = index < stepCount - 1 ? stepOpacity( index + 1, stepCount ) : topOpacity;
-				// Text contrast tracks the band's midpoint shade, since the fill now
-				// varies across the band rather than being a single flat opacity.
-				const isDark = ( topOpacity + bottomOpacity ) / 2 > DARK_TEXT_OPACITY_THRESHOLD;
+				// Each band ramps symmetrically around its own shade (darker top →
+				// lighter bottom). Adjacent bands do NOT share a boundary value, so a
+				// visible step separates the sections. Clamped to a valid [0,1] alpha.
+				const bandOpacity = stepOpacity( index, stepCount );
+				const topOpacity = Math.min( FULL_OPACITY, bandOpacity + halfSpan );
+				const bottomOpacity = Math.max( 0, bandOpacity - halfSpan );
+				// Contrast tracks the band's own shade (its ramp midpoint).
+				const isDark = bandOpacity > DARK_TEXT_OPACITY_THRESHOLD;
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
 				return (

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -6,18 +6,15 @@
  * ("X% of {top}" share + "Y% drop-off") INSIDE the section. One uniform layout at
  * every viewport and step count: no side-label/compact split, no separate legend.
  *
- * Each band is an <li> with two layers:
- *   - a clipped trapezoid FILL (CSS clip-path, insets from computeDisplayHalfWidths)
- *     behind the text, forming a continuous silhouette because adjacent band edges
- *     share width; and
- *   - a flowing TEXT layer on top that is NOT clipped, so it wraps, grows the band
- *     height, and is never cut off — when a band's fill is narrower than its text
- *     the text spills over the card (dark text on the faded lower bands keeps it
- *     legible there).
+ * The sections are equal-width rectangles (the overall silhouette is a rectangle,
+ * not a tapering funnel): the drop-off between steps is conveyed by the labels and
+ * by color alone, not by width. Each band is a full-width <li> with two layers:
+ *   - a solid FILL behind the text; and
+ *   - a flowing TEXT layer on top that wraps and grows the band height.
  *
- * Width is CSS-driven (width:100%, max-width cap); the clip-path percentages scale
- * intrinsically, so no JS measurement is needed. The single anchor color
- * (primary-500) fades 1.0 → 0.6 down the funnel; bands above
+ * Width is CSS-driven (width:100%, max-width cap), so no JS measurement is needed.
+ * The single anchor color (primary-500) fades 1.0 → 0.6 down the funnel, and that
+ * fade is the sole visual differentiator between sections; bands above
  * DARK_TEXT_OPACITY_THRESHOLD take white text, below it dark text.
  */
 
@@ -31,20 +28,11 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { formatNumber, formatPercent } from './format';
 
-// Coordinate basis for the half-width math and the clip-path percentages.
-const VIEWBOX_WIDTH = 320;
 const FULL_OPACITY = 1;
 const TAIL_OPACITY = 0.6;
 // Above this band opacity the fill is dark enough for white text; below it the
-// faded band (and any text spilling onto the white card) needs dark text.
+// faded band needs dark text.
 const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
-const HALF_WIDTH = VIEWBOX_WIDTH / 2;
-// The funnel is a rough relative-size viz: no segment is narrower than this share
-// of the chart width (avoids razor-thin bands and keeps the lowest band's fill
-// under its own text). The max per-segment taper is computed per-funnel from the
-// step count so funnels of any length descend evenly (see computeDisplayHalfWidths).
-const MIN_SEGMENT_WIDTH_RATIO = 0.28; // NEWS-2586: wider floor keeps the narrowest band's fill under its text.
-const MIN_HALF_WIDTH = ( MIN_SEGMENT_WIDTH_RATIO * VIEWBOX_WIDTH ) / 2;
 
 export interface FunnelStage {
 	label: string;
@@ -70,42 +58,6 @@ export const stepOpacity = ( index: number, stepCount: number ): number => {
  * prior one (data drift) — a negative "drop-off" is meaningless, so show 0%.
  */
 export const dropFromPrevious = ( count: number, prevCount: number ): number => ( prevCount > 0 ? Math.max( 0, 1 - count / prevCount ) : 0 );
-
-/**
- * Per-level display half-width for every stage. Raw width is proportional to the
- * stage's share of the top count, but clamped so the silhouette stays a readable
- * rough viz: never wider than the level above, never below MIN_HALF_WIDTH, and no
- * more than the per-funnel max taper (HALF_WIDTH / stepCount) narrower than the
- * level above. Counts/percentages in the labels are unaffected — only widths clamp.
- */
-export const computeDisplayHalfWidths = ( stages: FunnelStage[], topCount: number ): number[] => {
-	if ( topCount <= 0 ) {
-		return stages.map( () => 0 );
-	}
-	const maxTaperHalfWidth = HALF_WIDTH / stages.length;
-	const halves: number[] = [];
-	stages.forEach( ( stage, index ) => {
-		const raw = Math.min( HALF_WIDTH, ( stage.count / topCount ) * HALF_WIDTH );
-		if ( index === 0 ) {
-			halves.push( raw );
-			return;
-		}
-		const prev = halves[ index - 1 ];
-		const lower = Math.max( MIN_HALF_WIDTH, prev - maxTaperHalfWidth );
-		halves.push( Math.min( prev, Math.max( lower, raw ) ) );
-	} );
-	return halves;
-};
-
-/** Left inset (% of chart width) for a half-width; the right edge is 100 minus it. */
-const edgePercent = ( half: number ): number => ( ( HALF_WIDTH - half ) / VIEWBOX_WIDTH ) * 100;
-
-/** CSS clip-path polygon for a trapezoid from a top half-width to a bottom half-width. */
-const trapezoidClip = ( halfTop: number, halfBottom: number ): string => {
-	const lt = edgePercent( halfTop );
-	const lb = edgePercent( halfBottom );
-	return `polygon(${ lt }% 0, ${ 100 - lt }% 0, ${ 100 - lb }% 100%, ${ lb }% 100%)`;
-};
 
 /**
  * The two descriptive lines for every step beyond the first: what share of the top
@@ -140,7 +92,8 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
 	const topLabel = stages.length > 0 ? stages[ 0 ].label : '';
 
-	// Proportions can't be computed without a non-zero first step.
+	// Share-of-top and drop-off percentages can't be computed without a non-zero
+	// first step.
 	if ( stages.length === 0 || topCount <= 0 ) {
 		return (
 			<div className="newspack-insights__funnel">
@@ -150,14 +103,11 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	}
 
 	const stepCount = stages.length;
-	const halves = computeDisplayHalfWidths( stages, topCount );
 
 	return (
 		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
 			{ stages.map( ( stage, index ) => {
 				const opacity = stepOpacity( index, stepCount );
-				const halfTop = halves[ index ];
-				const halfBottom = index < stepCount - 1 ? halves[ index + 1 ] : halfTop;
 				const isDark = opacity > DARK_TEXT_OPACITY_THRESHOLD;
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
@@ -167,11 +117,7 @@ const Funnel = ( { stages }: FunnelProps ) => {
 						className={ 'newspack-insights__funnel-step ' + ( isDark ? 'is-on-dark' : 'is-on-light' ) }
 						style={ { '--band-opacity': opacity } as React.CSSProperties }
 					>
-						<span
-							className="newspack-insights__funnel-fill"
-							style={ { clipPath: trapezoidClip( halfTop, halfBottom ) } }
-							aria-hidden="true"
-						/>
+						<span className="newspack-insights__funnel-fill" aria-hidden="true" />
 						<span className="newspack-insights__funnel-content">
 							<span className="newspack-insights__funnel-label-name">{ stage.label }</span>
 							<span className="newspack-insights__funnel-label-count">{ formatNumber( stage.count ) }</span>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -595,11 +595,12 @@
 	}
 
 	// Funnel viz — shared across Gates, Prompts, and Conversion Journey tabs.
-	// Self-labeling stacked trapezoids (NEWS-2586): each band carries its label,
+	// Self-labeling equal-width rectangles (NEWS-2586): each band carries its label,
 	// count, and (for every step after the first) the drop-off descriptors INSIDE
 	// it. One uniform layout at every width/step-count — no side column, no legend.
-	// Each band is an <li> with a clipped trapezoid FILL behind a flowing TEXT
-	// layer that wraps, grows the band, and overflows a narrow fill without clipping.
+	// Each band is a full-width <li> with a solid FILL behind a flowing TEXT layer
+	// that wraps and grows the band. Sections are differentiated by color (opacity)
+	// alone, not by width.
 	&__funnel {
 		width: 100%;
 		max-width: 500px; // NEWS-2586 container cap; grid cells render narrower (fluid).
@@ -623,9 +624,9 @@
 			text-align: center;
 		}
 
-		// Fill: the single anchor color clipped to the per-band trapezoid (clip-path
-		// set inline). Opacity fades 1.0 → 0.6 via the inline --band-opacity. Sits
-		// BEHIND the text so the text is never clipped by the band edge.
+		// Fill: the single anchor color covering the full-width band. Opacity fades
+		// 1.0 → 0.6 via the inline --band-opacity, which is the sole differentiator
+		// between sections. Sits BEHIND the text.
 		&-fill {
 			position: absolute;
 			inset: 0;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -9,6 +9,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "../../../../../packages/colors/colors.module" as colors;
 
 // Categorical series palette for charts. Hardcoded because a chart needs
@@ -598,19 +599,23 @@
 	// Self-labeling equal-width rectangles (NEWS-2586): each band carries its label,
 	// count, and (for every step after the first) the drop-off descriptors INSIDE
 	// it. One uniform layout at every width/step-count — no side column, no legend.
-	// Each band is a full-width <li> with a solid FILL behind a flowing TEXT layer
+	// Each band is a full-width <li> with a gradient FILL behind a flowing TEXT layer
 	// that wraps and grows the band. Sections are differentiated by color (opacity)
 	// alone, not by width.
 	&__funnel {
+		// Absolute minimum rendered width of any section; also the floor the
+		// transition separators clamp their bottom edge to (see &-separator), so a
+		// connector never ends up narrower than the min-width section beneath it.
+		$funnel-min-band-width: 80px;
+
 		width: 100%;
-		max-width: 500px; // NEWS-2586 container cap; grid cells render narrower (fluid).
 		margin: 0 auto;
-		padding: 20px;
+		padding: wp-vars.$grid-unit-10;
 		box-sizing: border-box;
 		list-style: none;
-		background-color: #fff;
+		background-color: wp-colors.$white;
 		border: 1px solid wp-colors.$gray-200;
-		border-radius: 4px;
+		border-radius: wp-vars.$radius-medium;
 
 		&-step {
 			position: relative;
@@ -618,10 +623,38 @@
 			flex-direction: column;
 			align-items: center;
 			justify-content: center;
-			min-height: 72px; // baseline; grows with wrapped content.
+			margin-bottom: 24px;
+			margin-left: auto;
+			margin-right: auto;
+			min-height: 75px; // baseline; grows with wrapped content.
+			min-width: $funnel-min-band-width; // Absolute minimum width of any step.
 			padding: 12px 8px;
 			box-sizing: border-box;
 			text-align: center;
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		// Transition connector filling the 24px gap below each section (except the
+		// last). A filled box clipped to a trapezoid: its top edge spans the section
+		// above (this element's full width) and its bottom edge insets by the inline
+		// --separator-inset to match the narrower section below — but never so far
+		// that the bottom drops below the section min-width, so the connector always
+		// meets the top of the (min-width-floored) section beneath it. Opacity is set
+		// inline to track the band's shade.
+		&-separator {
+			position: absolute;
+			top: 100%;
+			left: 0;
+			width: 100%;
+			height: 24px;
+			background-color: var( --band-separator, #{colors.$primary-000} );
+			// Clamp the per-side inset so the bottom edge can't be narrower than the
+			// section min-width: ( 100% − min-width ) / 2 is the inset that yields
+			// exactly min-width at the bottom.
+			--_separator-inset: min( var( --separator-inset, 0% ), calc( ( 100% - #{ $funnel-min-band-width } ) / 2 ) );
+			clip-path: polygon( 0 0, 100% 0, calc( 100% - var( --_separator-inset ) ) 100%, var( --_separator-inset ) 100% );
 		}
 
 		// Fill: the single anchor color as a vertical gradient covering the full-width
@@ -634,11 +667,7 @@
 			position: absolute;
 			inset: 0;
 			z-index: 0;
-			background: linear-gradient(
-				to bottom,
-				rgba( #{ colors.$primary-600--rgb }, var( --band-opacity-top, 1 ) ) 0%,
-				rgba( #{ colors.$primary-600--rgb }, var( --band-opacity-bottom, 1 ) ) 100%
-			);
+			background-color: var( --band-fill, #{colors.$primary-300} );
 		}
 
 		&-content {
@@ -648,53 +677,54 @@
 			flex-direction: column;
 			align-items: center;
 			max-width: 160px; // wrap width for the descriptor lines.
+			color: wp-colors.$white;
 		}
 
+		&-labels {
+			.components-popover__content {
+				padding: 4px 8px;
+			}
+		}
+
+		// Name and count scale together with the section width via the shared
+		// --funnel-font-scale (set inline per section, floored in JS), so narrower
+		// sections shrink their text proportionally without changing the name:count
+		// ratio. Line-heights run through the same calc so they scale with the font.
 		&-label-name {
-			font-size: 14px;
+			font-size: calc( #{wp-vars.$font-size-medium} * var( --funnel-font-scale, 1 ) );
 			font-weight: 600;
-			line-height: 1.2;
+			line-height: calc( #{wp-vars.$font-line-height-medium} * var( --funnel-font-scale, 1 ) );
 		}
 
 		&-label-count {
-			font-size: 22px;
+			font-size: calc( #{wp-vars.$font-size-x-large} * var( --funnel-font-scale, 1 ) );
 			font-weight: 700;
 			font-variant-numeric: tabular-nums;
-			line-height: 1.15;
+			line-height: calc( #{wp-vars.$font-line-height-x-large} * var( --funnel-font-scale, 1 ) );
 		}
 
-		// Stage descriptors inherit the band's text color (white/dark); muted weight.
+		// Stage descriptors sit inside the floating Popover (its own light surface),
+		// so they use its default dark text; muted weight.
 		&-label-pct {
-			margin-top: 4px;
-			font-size: 12px;
-			line-height: 1.35;
+			font-size: wp-vars.$font-size-small;
+			line-height: wp-vars.$font-line-height-small;
+			margin: 0;
 		}
 
 		&-label-drop {
-			font-size: 12px;
-			line-height: 1.35;
+			font-size: wp-vars.$font-size-small;
+			line-height: wp-vars.$font-line-height-small;
 			font-variant-numeric: tabular-nums;
+			margin: 0;
 		}
 
 		&-empty {
 			margin: 0;
 			padding: 32px 20px;
 			text-align: center;
-			font-size: 13px;
+			font-size: wp-vars.$font-size-medium;
 			color: wp-colors.$gray-600;
 		}
-	}
-
-	// Contrast follows band opacity: white text on the dark upper bands (with a
-	// soft halo so any spill over the white card stays legible), dark text on the
-	// faded lower bands (reads on both the light fill and the card).
-	&__funnel-step.is-on-dark &__funnel-content {
-		color: #fff;
-		text-shadow: 0 1px 2px rgba( 13, 53, 102, 0.45 );
-	}
-
-	&__funnel-step.is-on-light &__funnel-content {
-		color: wp-colors.$gray-900;
 	}
 
 	// Sortable table affordances — shared across all tabs that embed SortableTable

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -624,15 +624,21 @@
 			text-align: center;
 		}
 
-		// Fill: the single anchor color covering the full-width band. Opacity fades
-		// 1.0 → 0.6 via the inline --band-opacity, which is the sole differentiator
-		// between sections. Sits BEHIND the text.
+		// Fill: the single anchor color as a vertical gradient covering the full-width
+		// band, ramping from --band-opacity-top to --band-opacity-bottom. Adjacent
+		// bands share their boundary opacity, so the stack reads as one continuous
+		// 1.0 → 0.6 gradient — the sole differentiator between sections. Alpha must
+		// live in the gradient stops (the `opacity` property can't be gradiented), so
+		// the color is expressed via the primary-500 RGB channels. Sits BEHIND text.
 		&-fill {
 			position: absolute;
 			inset: 0;
 			z-index: 0;
-			background-color: colors.$primary-500;
-			opacity: var( --band-opacity, 1 );
+			background: linear-gradient(
+				to bottom,
+				rgba( #{ colors.$primary-500--rgb }, var( --band-opacity-top, 1 ) ) 0%,
+				rgba( #{ colors.$primary-500--rgb }, var( --band-opacity-bottom, 1 ) ) 100%
+			);
 		}
 
 		&-content {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -625,19 +625,19 @@
 		}
 
 		// Fill: the single anchor color as a vertical gradient covering the full-width
-		// band, ramping from --band-opacity-top to --band-opacity-bottom. Adjacent
-		// bands share their boundary opacity, so the stack reads as one continuous
-		// 1.0 → 0.6 gradient — the sole differentiator between sections. Alpha must
-		// live in the gradient stops (the `opacity` property can't be gradiented), so
-		// the color is expressed via the primary-500 RGB channels. Sits BEHIND text.
+		// band, ramping from --band-opacity-top to --band-opacity-bottom (both set
+		// inline per band). Color fading is the sole differentiator between sections.
+		// Alpha must live in the gradient stops (the `opacity` property can't be
+		// gradiented), so the color is expressed via the primary-600 RGB channels.
+		// Sits BEHIND text.
 		&-fill {
 			position: absolute;
 			inset: 0;
 			z-index: 0;
 			background: linear-gradient(
 				to bottom,
-				rgba( #{ colors.$primary-500--rgb }, var( --band-opacity-top, 1 ) ) 0%,
-				rgba( #{ colors.$primary-500--rgb }, var( --band-opacity-bottom, 1 ) ) 100%
+				rgba( #{ colors.$primary-600--rgb }, var( --band-opacity-top, 1 ) ) 0%,
+				rgba( #{ colors.$primary-600--rgb }, var( --band-opacity-bottom, 1 ) ) 100%
 			);
 		}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -12,6 +12,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .newspack-insights {
 
@@ -180,10 +181,9 @@
 			// inherited font from flipping between cards (the bug was: digits
 			// in "35" rendered slim, "$738.33" rendered heavier with a slight
 			// optical slant — different chars resolving in different
-			// fallback fonts because no explicit family was declared). The
-			// stack matches @wordpress/base-styles' admin body font.
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-				Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			// fallback fonts because no explicit family was declared). Uses
+			// @wordpress/base-styles' admin body font token.
+			font-family: wp-vars.$default-font;
 			font-size: 44px;
 			font-weight: 500;
 			font-style: normal;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -91,16 +91,24 @@
 	}
 
 	// Section 2 — four per-journey funnels in a 2-column grid, stacking under
-	// ~720px container width.
+	// ~720px container width. Cells stretch so a shorter funnel (e.g. the 2-stage
+	// cross-upsell) matches the height of its taller row-mate.
 	&__conversion-journey-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 		gap: 24px;
-		align-items: start;
+		align-items: stretch;
 	}
 
 	&__conversion-journey-cell {
+		display: flex;
+		flex-direction: column;
 		min-width: 0;
+
+		// The funnel is the cell's last child; grow it to fill the stretched cell.
+		.newspack-insights__funnel {
+			flex: 1 1 auto;
+		}
 	}
 
 	// Section 3 — three source-mix pies side by side.

--- a/plugins/newspack-plugin/src/wizards/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/index.d.ts
@@ -7,6 +7,15 @@ declare module '*.png' {
 }
 
 /**
+ * Allow SCSS modules (e.g. the color token map) to be imported as a keyed record
+ * of string values.
+ */
+declare module '*.scss' {
+	const classes: { readonly [ key: string ]: string };
+	export default classes;
+}
+
+/**
  * Wizard API fetch function
  */
 type WizardApiFetch< T = {} > = (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Design feedback on the Insights **Funnel** visualization asked us to drop the literal funnel shape. This PR reworks the shared `Funnel` component so a funnel renders as a stack of **equal-width rectangular sections** — the overall silhouette is a rectangle, not a taper. Step-to-step progression is now conveyed by the labels and by **color alone**: each section is a vertical gradient of the anchor color (`primary-600`) whose opacity steps down the funnel (`1.0 → 0.6`), with a visible step between sections keeping them distinct.

<img width="1068" height="1211" alt="Screenshot 2026-07-09 at 1 22 21 PM" src="https://github.com/user-attachments/assets/11d7a113-e7ee-4e56-8fee-b907aef58e3f" />

This substantially simplifies the component:

- **Removes all width/geometry logic** that sized the trapezoids — `computeDisplayHalfWidths`, `edgePercent`, `trapezoidClip`, and the `VIEWBOX_WIDTH` / `HALF_WIDTH` / `MIN_SEGMENT_WIDTH_RATIO` / `MIN_HALF_WIDTH` constants — along with the per-band inline `clip-path`. No JS measurement remains; width is pure CSS.
- **Section fills are now a CSS `linear-gradient`** driven by two inline custom properties, `--band-opacity-top` / `--band-opacity-bottom`. Each band ramps symmetrically around its own shade (darker top → lighter bottom); the alpha lives in the gradient stops because the `opacity` property can't be gradiented. A single `INTERNAL_GRADIENT_FRACTION` constant controls the sheen, which auto-scales with funnel length.
- **Text is untouched:** labels, counts, drop-off descriptors, per-band light/dark contrast, and the empty state are unchanged.

Because the change is confined to the shared component, it applies uniformly everywhere the funnel is used: the **Gates**, **Prompts**, and **Conversion Journey** Insights tabs.

Related to [DSGNEWS-188](https://linear.app/a8c/issue/DSGNEWS-188/design-review-insights-data-dashboard-replacement#comment-fa574214).

### How to test the changes in this Pull Request:

1. Check out the branch and build the plugin: `n build newspack-plugin` (or `n watch` while iterating).
2. Open the **Insights** wizard and go to a tab that renders a funnel — **Conversion Journey**, **Gates**, or **Prompts**.
3. Confirm the funnel renders as a vertical stack of **equal-width rectangles** — no tapering funnel shape, no clipped trapezoid silhouette.
4. Confirm each section is filled with a subtle top-to-bottom gradient and that sections get progressively lighter down the stack, with a visible step between them.
5. Confirm the section labels, counts, and "X% of {top} / Y% drop-off" descriptors are unchanged and legible (white text on the darker upper bands, dark text on the lighter lower bands).
6. Confirm the empty state ("Not enough data to chart the funnel.") still shows when there is insufficient data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Unit tests were updated to match: the obsolete `computeDisplayHalfWidths` geometry suite was removed, and a regression test was added asserting the section fills carry no trapezoid `clip-path`. The `stepOpacity`, `dropFromPrevious`, and render tests are retained. `npm test` passes (full suite); ESLint and Stylelint are clean.
