### PR TITLE
feat(insights): merge prompt conversion columns, freeze prompt column

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -392,12 +392,68 @@
 	}
 }
 
+// Opt-in sticky first column (Performance by prompt): a many-column table that
+// still overflows keeps its identifying first column (the prompt name) frozen
+// while the metric columns scroll, so a row is never scrolled away from its
+// label. Scoped to the modifier class so no other Insights table is affected.
+// The frozen cell needs an opaque background to cover the columns sliding under
+// it, plus a divider so the seam reads cleanly.
+.newspack-insights-dataview--sticky-first .dataviews-view-table {
+	th:first-child,
+	td:first-child {
+		position: sticky;
+		left: 0;
+		z-index: 1;
+		background: wp-colors.$white;
+		border-right: 1px solid wp-colors.$gray-200;
+	}
+
+	// Header corner sits above the body's frozen cells when both axes scroll.
+	th:first-child {
+		z-index: 2;
+	}
+
+	// Honor word boundaries in this table's cells. The shared wrap rule breaks at
+	// any character (`overflow-wrap: anywhere`) so DataViews' widest tables never
+	// force a scroll; this table already fits, and any-point breaking just chops
+	// short labels ("Registrati on"). `break-word` keeps whole words together
+	// while still wrapping long prompt titles at spaces.
+	tbody .dataviews-view-table__cell-content-wrapper {
+		overflow-wrap: break-word;
+	}
+}
+
 // Indented, de-emphasized label for a flattened child/variation row inside a
 // read-only DataViews table (e.g. the Donations-by-tier product variations),
 // which DataViews' flat table can't indent natively.
 .newspack-insights__dataview-subrow {
 	display: inline-block;
 	padding-left: 16px;
+	color: wp-colors.$gray-700;
+}
+
+// Stacked, field-driven "Conversions" cell (Performance by prompt): one line per
+// conversion type a prompt actually drove — count, plus rate in parens where a
+// rate applies. The type label disambiguates rows that convert more than one way
+// (e.g. a register-then-pay prompt logging both registrations and subscriptions).
+// Each line stays on one row; the type label and rate are de-emphasized so the
+// counts read first.
+.newspack-insights__conversions {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+}
+
+.newspack-insights__conversion-line {
+	white-space: nowrap;
+
+	& + & {
+		margin-top: 2px;
+	}
+}
+
+.newspack-insights__conversion-label,
+.newspack-insights__conversion-rate {
 	color: wp-colors.$gray-700;
 }
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.tsx
@@ -77,6 +77,12 @@ export interface InsightsDataViewProps< Row > {
 	expandable?: boolean;
 	/** Rows shown while collapsed. */
 	defaultRowLimit?: number;
+	/**
+	 * Freeze the first column while the rest scroll horizontally (opt-in). Use on
+	 * wide tables where a row would otherwise scroll away from its identifying
+	 * first column (e.g. Performance by prompt). Styled in `insights/style.scss`.
+	 */
+	stickyFirstColumn?: boolean;
 }
 
 /**
@@ -112,6 +118,7 @@ const InsightsDataView = < Row, >( {
 	notConfigured,
 	expandable = false,
 	defaultRowLimit,
+	stickyFirstColumn = false,
 }: InsightsDataViewProps< Row > ) => {
 	const defaultColumn = columns.find( col => col.key === defaultSortKey );
 	const initialDirection = defaultSortDirection ?? ( defaultColumn?.numeric ? 'desc' : 'asc' );
@@ -202,7 +209,7 @@ const InsightsDataView = < Row, >( {
 	return (
 		<>
 			<DataViews
-				className="newspack-insights-dataview"
+				className={ `newspack-insights-dataview${ stickyFirstColumn ? ' newspack-insights-dataview--sticky-first' : '' }` }
 				data={ visibleRows }
 				// The Newspack DataViews wrapper collapses its item type to `unknown`;
 				// our fields/getItemId are typed against `Row`, so narrow at the boundary.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/SortableTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/SortableTable.tsx
@@ -54,6 +54,12 @@ export interface SortableTableProps< Row > {
 	 * cap is applied after sorting, so collapsing always shows the current top N.
 	 */
 	initialRowLimit?: number;
+	/**
+	 * Freeze the first column while the rest scroll horizontally (opt-in). Use on
+	 * wide tables where a row would otherwise scroll away from its identifying
+	 * first column (e.g. Performance by prompt).
+	 */
+	stickyFirstColumn?: boolean;
 }
 
 function SortableTable< Row >( {
@@ -64,6 +70,7 @@ function SortableTable< Row >( {
 	emptyMessage,
 	errorMessage,
 	initialRowLimit,
+	stickyFirstColumn,
 }: SortableTableProps< Row > ) {
 	return (
 		<InsightsDataView< Row >
@@ -74,6 +81,7 @@ function SortableTable< Row >( {
 			emptyMessage={ errorMessage ?? emptyMessage }
 			expandable={ typeof initialRowLimit === 'number' }
 			defaultRowLimit={ initialRowLimit }
+			stickyFirstColumn={ stickyFirstColumn }
 		/>
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for the merged, field-driven Conversions column in the Performance by
+ * prompt table (Table 7.1). The old six per-type conversion columns collapse
+ * into one column that stacks only the conversion types a prompt actually drove
+ * — including the register-then-pay case where a registration-intent prompt also
+ * logs subscription conversions (attributed to the popup by id, not action_type).
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PerformanceByPromptTable from './PerformanceByPromptTable';
+import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as TableData } from '../../../api/prompts';
+
+const makeRow = ( overrides: Partial< PromptsPerformanceByPromptRow > ): PromptsPerformanceByPromptRow => ( {
+	popup_id: 1,
+	prompt_title: 'A prompt',
+	intent: 'donation',
+	intent_label: 'Donation',
+	placement: 'overlay',
+	impressions: 1000,
+	unique_viewers: 800,
+	ctr: 0.05,
+	form_submission_rate: 0.04,
+	dismissal_rate: 0.1,
+	registrations: 0,
+	newsletter_signups: 0,
+	donation_conversions: null,
+	donation_conversion_rate: null,
+	subscription_conversions: null,
+	subscription_conversion_rate: null,
+	...overrides,
+} );
+
+const makeData = ( rows: PromptsPerformanceByPromptRow[] ): TableData => ( { state: 'populated', rows } );
+
+describe( 'PerformanceByPromptTable — merged Conversions column', () => {
+	it( 'renders one merged Conversions column, not the per-type columns', () => {
+		render( <PerformanceByPromptTable data={ makeData( [ makeRow( {} ) ] ) } /> );
+		expect( screen.getByText( 'Conversions' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Donation conversions' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Subscription conversion rate' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Newsletter signups' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows a donation prompt as a single count + rate line', () => {
+		const { container } = render(
+			<PerformanceByPromptTable data={ makeData( [ makeRow( { donation_conversions: 65, donation_conversion_rate: 0.016 } ) ] ) } />
+		);
+		expect( container ).toHaveTextContent( 'Donation 65 (1.6%)' );
+	} );
+
+	it( 'stacks both lines for a register-then-pay prompt (registrations + subscription conversions)', () => {
+		const { container } = render(
+			<PerformanceByPromptTable
+				data={ makeData( [
+					makeRow( {
+						intent: 'registration',
+						intent_label: 'Registration',
+						registrations: 84,
+						subscription_conversions: 18,
+						subscription_conversion_rate: 0.006,
+					} ),
+				] ) }
+			/>
+		);
+		expect( container ).toHaveTextContent( 'Registrations 84' );
+		expect( container ).toHaveTextContent( 'Subscription 18 (0.6%)' );
+	} );
+
+	it( 'renders the not-applicable em-dash when a prompt drove no conversions', () => {
+		render( <PerformanceByPromptTable data={ makeData( [ makeRow( { ctr: 0.05, form_submission_rate: 0.04, dismissal_rate: 0.1 } ) ] ) } /> );
+		// registrations / newsletter are 0 and donation / subscription are null, so
+		// the merged cell falls back to the shared not-applicable em-dash.
+		expect( screen.getAllByLabelText( 'Not applicable' ).length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -2,12 +2,14 @@
  * PerformanceByPromptTable (NPPD-1607, Table 7.1).
  *
  * One row per prompt, sorted by impressions descending by default.
- * Thin wrapper over the tab-local {@see SortableTable}. Donation and
- * subscription columns report *conversions* (Woo-completed outcomes) —
- * count + rate for each — matching the Gates v1.1 decision (NPPD-1684).
- * Count and rate cells render a muted em-dash for non-applicable
- * prompts (e.g. donation conversions on a registration prompt),
- * distinct from a real 0 / 0%.
+ * Thin wrapper over the tab-local {@see SortableTable}.
+ *
+ * The four conversion outcomes (registrations, newsletter signups, and
+ * Woo-completed donation / subscription conversions — the last two count + rate,
+ * per the Gates v1.1 decision, NPPD-1684) are merged into a single, field-driven
+ * "Conversions" column: each row stacks only the types it actually drove, so the
+ * table no longer carries six mostly-empty per-type columns. The identifying
+ * Prompt column is frozen while the metric columns scroll.
  *
  * Phase 1 renders the spec's empty-state row; the sort chrome stays
  * visible so it's identical between phases.
@@ -23,14 +25,71 @@ import { __ } from '@wordpress/i18n';
  */
 import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as TableData } from '../../../api/prompts';
 import { getPostEditUrl } from '../../components/adminLinks';
-import { formatNumber } from '../../components/format';
-import SortableTable, { renderCount, renderRate, type SortableColumn } from '../../components/SortableTable';
+import { formatNumber, formatPercent } from '../../components/format';
+import SortableTable, { NotApplicable, renderRate, type SortableColumn } from '../../components/SortableTable';
 import { humanizeTerm } from './humanize';
 import { SECTION_ERROR_MESSAGE } from '../SectionState';
 
 export interface PerformanceByPromptTableProps {
 	data: TableData;
 }
+
+/**
+ * The conversion outcomes a prompt can drive, in a fixed display order. A prompt
+ * can legitimately drive more than one (a register-then-pay membership prompt
+ * logs both `registrations` and `subscription_conversions`, because the paid
+ * subscription is attributed back to the popup by id regardless of the prompt's
+ * `action_type` — see class-prompts-metric.php), so the Conversions cell stacks
+ * every type that actually fired rather than picking one by intent. `count` and
+ * (where it exists) `rate` are read straight off the row; `null`/`0` counts are
+ * treated as "did not fire" and omitted. Registration and newsletter signups
+ * carry no rate; donation and subscription do.
+ */
+const CONVERSION_TYPES: {
+	key: string;
+	label: string;
+	count: ( row: PromptsPerformanceByPromptRow ) => number | null;
+	rate?: ( row: PromptsPerformanceByPromptRow ) => number | null;
+}[] = [
+	{ key: 'registrations', label: __( 'Registrations', 'newspack-plugin' ), count: r => r.registrations },
+	{ key: 'newsletter', label: __( 'Newsletter', 'newspack-plugin' ), count: r => r.newsletter_signups },
+	{ key: 'donation', label: __( 'Donation', 'newspack-plugin' ), count: r => r.donation_conversions, rate: r => r.donation_conversion_rate },
+	{
+		key: 'subscription',
+		label: __( 'Subscription', 'newspack-plugin' ),
+		count: r => r.subscription_conversions,
+		rate: r => r.subscription_conversion_rate,
+	},
+];
+
+/** Sum of every conversion a prompt drove — the sort key for the merged column. */
+const conversionTotal = ( row: PromptsPerformanceByPromptRow ): number =>
+	CONVERSION_TYPES.reduce( ( sum, type ) => sum + ( type.count( row ) ?? 0 ), 0 );
+
+/**
+ * Stacked, field-driven Conversions cell: one line per conversion type the
+ * prompt actually drove (count, plus rate in parens where applicable). Renders a
+ * muted em-dash when the prompt converted nobody.
+ */
+const renderConversions = ( row: PromptsPerformanceByPromptRow ): React.ReactNode => {
+	const lines = CONVERSION_TYPES.map( type => ( { type, count: type.count( row ) } ) )
+		.filter( ( { count } ) => typeof count === 'number' && count > 0 )
+		.map( ( { type, count } ) => {
+			const rate = type.rate ? type.rate( row ) : null;
+			return (
+				<div className="newspack-insights__conversion-line" key={ type.key }>
+					<span className="newspack-insights__conversion-label">{ type.label }</span> { formatNumber( count as number ) }
+					{ rate !== null && rate !== undefined && (
+						<span className="newspack-insights__conversion-rate"> ({ formatPercent( rate ) })</span>
+					) }
+				</div>
+			);
+		} );
+	// Wrap in one block container: the DataViews cell content wrapper is a flex
+	// row, so bare sibling lines would lay out horizontally — the container is a
+	// single flex item whose children stack vertically in normal flow.
+	return lines.length > 0 ? <div className="newspack-insights__conversions">{ lines }</div> : <NotApplicable />;
+};
 
 const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 	{
@@ -84,46 +143,17 @@ const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 		sortValue: r => r.dismissal_rate,
 	},
 	{
-		key: 'registrations',
-		label: __( 'Registrations', 'newspack-plugin' ),
-		numeric: true,
-		render: r => formatNumber( r.registrations ),
-		sortValue: r => r.registrations,
-	},
-	{
-		key: 'newsletter_signups',
-		label: __( 'Newsletter signups', 'newspack-plugin' ),
-		numeric: true,
-		render: r => formatNumber( r.newsletter_signups ),
-		sortValue: r => r.newsletter_signups,
-	},
-	{
-		key: 'donation_conversions',
-		label: __( 'Donation conversions', 'newspack-plugin' ),
-		numeric: true,
-		render: r => renderCount( r.donation_conversions ),
-		sortValue: r => r.donation_conversions,
-	},
-	{
-		key: 'donation_conversion_rate',
-		label: __( 'Donation conversion rate', 'newspack-plugin' ),
-		numeric: true,
-		render: r => renderRate( r.donation_conversion_rate ),
-		sortValue: r => r.donation_conversion_rate,
-	},
-	{
-		key: 'subscription_conversions',
-		label: __( 'Subscription conversions', 'newspack-plugin' ),
-		numeric: true,
-		render: r => renderCount( r.subscription_conversions ),
-		sortValue: r => r.subscription_conversions,
-	},
-	{
-		key: 'subscription_conversion_rate',
-		label: __( 'Subscription conversion rate', 'newspack-plugin' ),
-		numeric: true,
-		render: r => renderRate( r.subscription_conversion_rate ),
-		sortValue: r => r.subscription_conversion_rate,
+		// Merged, field-driven column: replaces the six per-type conversion
+		// columns (registrations / newsletter / donation count+rate / subscription
+		// count+rate), which left most cells empty on any given row since a prompt
+		// only drives the conversion types it's built for. `numeric: false` because
+		// the cell holds labeled, sometimes-stacked lines, not a single figure; it
+		// still sorts, by total conversions driven.
+		key: 'conversions',
+		label: __( 'Conversions', 'newspack-plugin' ),
+		numeric: false,
+		render: renderConversions,
+		sortValue: r => conversionTotal( r ),
 	},
 ];
 
@@ -136,6 +166,7 @@ const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => 
 			getRowKey={ row => row.popup_id }
 			defaultSortKey="impressions"
 			initialRowLimit={ 10 }
+			stickyFirstColumn
 			emptyMessage={ __(
 				'No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.',
 				'newspack-plugin'


### PR DESCRIPTION
## Summary

The **Performance by prompt** table (Prompts tab, Table 7.1) carried 14 columns, six of them per-type conversion columns (registrations, newsletter signups, donation count + rate, subscription count + rate). Because a prompt only drives the conversion types it's built for, most of those cells were empty on any given row, and the table scrolled horizontally as a "hot mess." This reworks it to 9 columns.

## Changes

**Merged, field-driven Conversions column** — the six per-type columns collapse into one. Each row stacks *only* the conversion types it actually drove (count, plus rate in parens where a rate exists), read straight off the row's populated fields rather than keyed off intent. This correctly handles the register-then-pay case: a registration-intent membership prompt logs both `registrations` and `subscription_conversions` (the paid subscription is attributed to the popup by id, independent of `action_type`), so it renders two stacked lines — `Registrations 84` / `Subscription 18 (0.6%)` — instead of hiding one. A prompt that converted nobody shows the shared not-applicable em-dash. Sorts by total conversions driven.

**Sticky Prompt column** — new opt-in `stickyFirstColumn` prop on `SortableTable` / `InsightsDataView` (reusable by any wide Insights table). On a table narrow enough to still scroll, the identifying Prompt column stays frozen while the metric columns scroll, so a row is never scrolled away from its label.

**Word-boundary wrapping** — scoped to this table, the shared DataViews wrap rule (`overflow-wrap: anywhere`, which lets the widest tables avoid a scroll) is softened to `break-word` so short labels stay whole ("Registration", not "Registrati on") while long prompt titles still wrap at spaces.

## Testing

- New `PerformanceByPromptTable.test.tsx`: merged column present / per-type columns gone, single donation line, register-then-pay dual-line stacking, and the em-dash fallback.
- Existing PromptsTab snapshot unchanged (it captures the Phase-1 empty state, where no column headers render).
- `tsc`, ESLint, and Stylelint clean.
- Verified from compiled CSS on a local fixture site: 9-column layout with no horizontal scroll, stacked Conversions cells, and the frozen Prompt column confirmed by scrolling a narrowed viewport.

Docs (insights-docs Tab 7.1 column list) updated separately.