### PR TITLE
fix(blocks): fix express checkout address validation in modal checkout

### DIFF
--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -1402,8 +1402,9 @@ final class Modal_Checkout {
 	 * Express checkout wallets submit to wc/store/v1/checkout and can supply
 	 * values the buyer never sees or corrects (e.g. Apple Pay sending a suburb
 	 * as the state), which hard-fails Store API address validation. Values the
-	 * validation would accept are left untouched. Runs on rest_pre_dispatch
-	 * because the validation happens during dispatch.
+	 * validation would accept are left untouched, and only the billing address
+	 * is scrubbed. Runs on rest_pre_dispatch because the validation happens
+	 * during dispatch.
 	 *
 	 * @param mixed            $result  Response to replace the requested version with.
 	 * @param \WP_REST_Server  $server  Server instance.
@@ -1434,17 +1435,21 @@ final class Modal_Checkout {
 			return $result;
 		}
 
-		foreach ( [ 'billing_address', 'shipping_address' ] as $param ) {
-			$address = $request->get_param( $param );
+		// Physical-goods flows are never modified. The cart is not always
+		// initialized this early in Store API requests; when it is, bail for
+		// carts that need a shipping address. Only the billing address is
+		// scrubbed, so shipping data is never touched either way.
+		if ( \WC()->cart && \WC()->cart->needs_shipping_address() ) {
+			return $result;
+		}
 
-			if ( ! is_array( $address ) ) {
-				continue;
-			}
+		$address = $request->get_param( 'billing_address' );
 
+		if ( is_array( $address ) ) {
 			$scrubbed = self::scrub_invalid_address_values( $address, $billing_fields );
 
 			if ( $scrubbed !== $address ) {
-				$request->set_param( $param, $scrubbed );
+				$request->set_param( 'billing_address', $scrubbed );
 			}
 		}
 

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -1345,21 +1345,20 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Remove the configured-off billing fields from checkout.
+	 * Remove the configured-off billing fields from modal checkout requests.
 	 *
-	 * Not limited to modal checkout requests (NPPM-2937): the fields must be
-	 * unregistered wherever WooCommerce renders or validates them. When they were
-	 * only removed from the modal render, they stayed registered on the standard
-	 * checkout page, and express checkout wallets (e.g. Apple Pay) would populate
-	 * and fail validation on fields the buyer could not see or edit.
+	 * Deliberately scoped to modal checkout: some publishers rely on standard
+	 * Woo checkout flows that predate Audience Management, so those keep the
+	 * stock field set. The express checkout gap this leaves (wallets submitting
+	 * values for fields the buyer cannot see) is handled for modal-originated
+	 * requests by scrub_store_api_checkout_address() below.
 	 *
 	 * @param array $fields Checkout fields.
 	 *
 	 * @return array
 	 */
 	public static function woocommerce_checkout_fields( $fields ) {
-		// My Account checkouts relax required flags instead of removing fields.
-		if ( method_exists( 'Newspack\WooCommerce_My_Account', 'is_from_my_account' ) && \Newspack\WooCommerce_My_Account::is_from_my_account() ) {
+		if ( ! self::is_modal_checkout() ) {
 			return $fields;
 		}
 		$cart = \WC()->cart;
@@ -1397,7 +1396,7 @@ final class Modal_Checkout {
 
 	/**
 	 * Scrub invalid address values from Store API checkout requests when the
-	 * corresponding billing fields are configured off (NPPM-2937).
+	 * corresponding billing fields are configured off.
 	 *
 	 * Express checkout wallets submit to wc/store/v1/checkout and can supply
 	 * values the buyer never sees or corrects (e.g. Apple Pay sending a suburb
@@ -1405,6 +1404,10 @@ final class Modal_Checkout {
 	 * validation would accept are left untouched, and only the billing address
 	 * is scrubbed. Runs on rest_pre_dispatch because the validation happens
 	 * during dispatch.
+	 *
+	 * Scoped to requests originating from the modal checkout, so any Store API
+	 * checkout outside the modal (e.g. the blocks checkout page or express
+	 * buttons on product pages) keeps stock behavior.
 	 *
 	 * @param mixed            $result  Response to replace the requested version with.
 	 * @param \WP_REST_Server  $server  Server instance.
@@ -1422,6 +1425,10 @@ final class Modal_Checkout {
 			'POST' !== $request->get_method() ||
 			0 !== strpos( $request->get_route(), '/wc/store/v1/checkout' )
 		) {
+			return $result;
+		}
+
+		if ( ! self::is_modal_checkout_referer() ) {
 			return $result;
 		}
 
@@ -1454,6 +1461,23 @@ final class Modal_Checkout {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Whether the current request originates from the modal checkout, based on
+	 * the referer.
+	 *
+	 * Express checkout submissions go to the Store API as JSON, so the usual
+	 * modal_checkout request params are absent. The requests are made from the
+	 * modal checkout iframe, whose URL carries modal_checkout=1, so it shows up
+	 * as the (same-origin) referer.
+	 *
+	 * @return bool
+	 */
+	private static function is_modal_checkout_referer() {
+		$referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		return false !== strpos( $referer, 'modal_checkout=1' );
 	}
 
 	/**
@@ -1496,7 +1520,7 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Relax locale-required flags for configured-off billing fields (NPPM-2937).
+	 * Relax locale-required flags for configured-off billing fields.
 	 *
 	 * After an invalid wallet value is scrubbed (see
 	 * scrub_store_api_checkout_address), the Store API order validation would
@@ -1504,11 +1528,18 @@ final class Modal_Checkout {
 	 * required. A field the site is configured not to collect cannot be
 	 * required.
 	 *
+	 * Scoped to modal-originated requests so standard Woo flows keep the stock
+	 * locale rules.
+	 *
 	 * @param array $locale Country locale field settings.
 	 *
 	 * @return array
 	 */
 	public static function relax_configured_off_locale_fields( $locale ) {
+		if ( ! self::is_modal_checkout_referer() && ! self::is_modal_checkout() ) {
+			return $locale;
+		}
+
 		$billing_fields = apply_filters( 'newspack_blocks_donate_billing_fields_keys', [] );
 
 		if ( empty( $billing_fields ) ) {

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -30,6 +30,17 @@ final class Modal_Checkout {
 	const CHECKOUT_REGISTRATION_ORDER_META_KEY = '_newspack_checkout_registration_meta';
 
 	/**
+	 * Billing fields with server-side format validation in the Store API,
+	 * mapped from their classic checkout keys to Store API address keys.
+	 *
+	 * @var string[]
+	 */
+	const STORE_API_VALIDATED_ADDRESS_FIELDS = [
+		'billing_state'    => 'state',
+		'billing_postcode' => 'postcode',
+	];
+
+	/**
 	 * Whether the modal checkout has been enqueued.
 	 *
 	 * @var boolean
@@ -157,6 +168,8 @@ final class Modal_Checkout {
 		add_filter( 'woocommerce_get_checkout_order_received_url', [ __CLASS__, 'woocommerce_get_return_url' ], 10, 2 );
 		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 2 );
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'woocommerce_checkout_fields' ] );
+		add_filter( 'rest_pre_dispatch', [ __CLASS__, 'scrub_store_api_checkout_address' ], 10, 3 );
+		add_filter( 'woocommerce_get_country_locale', [ __CLASS__, 'relax_configured_off_locale_fields' ] );
 		add_filter( 'woocommerce_update_order_review_fragments', [ __CLASS__, 'order_review_fragments' ] );
 		add_filter( 'woocommerce_cart_needs_payment', [ __CLASS__, 'cart_needs_payment' ] );
 		add_filter( 'newspack_recaptcha_verify_captcha', [ __CLASS__, 'recaptcha_verify_captcha' ], 10, 3 );
@@ -1380,6 +1393,148 @@ final class Modal_Checkout {
 		}
 
 		return $fields;
+	}
+
+	/**
+	 * Scrub invalid address values from Store API checkout requests when the
+	 * corresponding billing fields are configured off (NPPM-2937).
+	 *
+	 * Express checkout wallets submit to wc/store/v1/checkout and can supply
+	 * values the buyer never sees or corrects (e.g. Apple Pay sending a suburb
+	 * as the state), which hard-fails Store API address validation. Values the
+	 * validation would accept are left untouched. Runs on rest_pre_dispatch
+	 * because the validation happens during dispatch.
+	 *
+	 * @param mixed            $result  Response to replace the requested version with.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request Request used to generate the response.
+	 *
+	 * @return mixed
+	 */
+	public static function scrub_store_api_checkout_address( $result, $server, $request ) {
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		if (
+			! $request instanceof \WP_REST_Request ||
+			'POST' !== $request->get_method() ||
+			0 !== strpos( $request->get_route(), '/wc/store/v1/checkout' )
+		) {
+			return $result;
+		}
+
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Validation' ) ) {
+			return $result;
+		}
+
+		$billing_fields = apply_filters( 'newspack_blocks_donate_billing_fields_keys', [] );
+
+		if ( empty( $billing_fields ) ) {
+			return $result;
+		}
+
+		foreach ( [ 'billing_address', 'shipping_address' ] as $param ) {
+			$address = $request->get_param( $param );
+
+			if ( ! is_array( $address ) ) {
+				continue;
+			}
+
+			$scrubbed = self::scrub_invalid_address_values( $address, $billing_fields );
+
+			if ( $scrubbed !== $address ) {
+				$request->set_param( $param, $scrubbed );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Drop configured-off address values that would fail Store API validation.
+	 *
+	 * @param array    $address        Store API address (billing or shipping).
+	 * @param string[] $billing_fields Configured billing field keys.
+	 *
+	 * @return array Scrubbed address.
+	 */
+	private static function scrub_invalid_address_values( $address, $billing_fields ) {
+		$country = isset( $address['country'] ) ? $address['country'] : '';
+
+		if (
+			! in_array( 'billing_state', $billing_fields, true ) &&
+			! empty( $address['state'] ) &&
+			$country
+		) {
+			$states = \WC()->countries->get_states( $country );
+
+			if ( is_array( $states ) && ! empty( $states ) ) {
+				$code_match = array_key_exists( strtoupper( $address['state'] ), array_change_key_case( $states, CASE_UPPER ) );
+				$name_match = in_array( strtolower( $address['state'] ), array_map( 'strtolower', $states ), true );
+
+				if ( ! $code_match && ! $name_match ) {
+					$address['state'] = '';
+				}
+			}
+		}
+
+		if (
+			! in_array( 'billing_postcode', $billing_fields, true ) &&
+			! empty( $address['postcode'] ) &&
+			! \WC_Validation::is_postcode( $address['postcode'], $country )
+		) {
+			$address['postcode'] = '';
+		}
+
+		return $address;
+	}
+
+	/**
+	 * Relax locale-required flags for configured-off billing fields (NPPM-2937).
+	 *
+	 * After an invalid wallet value is scrubbed (see
+	 * scrub_store_api_checkout_address), the Store API order validation would
+	 * still reject the checkout when the country locale marks the field as
+	 * required. A field the site is configured not to collect cannot be
+	 * required.
+	 *
+	 * @param array $locale Country locale field settings.
+	 *
+	 * @return array
+	 */
+	public static function relax_configured_off_locale_fields( $locale ) {
+		$billing_fields = apply_filters( 'newspack_blocks_donate_billing_fields_keys', [] );
+
+		if ( empty( $billing_fields ) ) {
+			return $locale;
+		}
+
+		// Never relax requirements when the cart needs a shipping address:
+		// physical-goods flows keep the full locale rules.
+		if ( function_exists( 'WC' ) && \WC()->cart && \WC()->cart->needs_shipping_address() ) {
+			return $locale;
+		}
+
+		$off = [];
+
+		foreach ( self::STORE_API_VALIDATED_ADDRESS_FIELDS as $config_key => $address_key ) {
+			if ( ! in_array( $config_key, $billing_fields, true ) ) {
+				$off[] = $address_key;
+			}
+		}
+
+		if ( empty( $off ) ) {
+			return $locale;
+		}
+
+		foreach ( array_keys( $locale ) as $country ) {
+			foreach ( $off as $address_key ) {
+				$locale[ $country ][ $address_key ]['required'] = false;
+			}
+		}
+
+		return $locale;
 	}
 
 	/**

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -1332,19 +1332,26 @@ final class Modal_Checkout {
 	}
 
 	/**
-	 * Modify fields for modal checkout.
+	 * Remove the configured-off billing fields from checkout.
+	 *
+	 * Not limited to modal checkout requests (NPPM-2937): the fields must be
+	 * unregistered wherever WooCommerce renders or validates them. When they were
+	 * only removed from the modal render, they stayed registered on the standard
+	 * checkout page, and express checkout wallets (e.g. Apple Pay) would populate
+	 * and fail validation on fields the buyer could not see or edit.
 	 *
 	 * @param array $fields Checkout fields.
 	 *
 	 * @return array
 	 */
 	public static function woocommerce_checkout_fields( $fields ) {
-		if ( ! self::is_modal_checkout() ) {
+		// My Account checkouts relax required flags instead of removing fields.
+		if ( method_exists( 'Newspack\WooCommerce_My_Account', 'is_from_my_account' ) && \Newspack\WooCommerce_My_Account::is_from_my_account() ) {
 			return $fields;
 		}
 		$cart = \WC()->cart;
-		// Don't modify fields if shipping is required.
-		if ( $cart->needs_shipping_address() ) {
+		// Don't modify fields if there is no cart or shipping is required.
+		if ( ! $cart || $cart->needs_shipping_address() ) {
 			return $fields;
 		}
 		/**

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -1405,6 +1405,11 @@ final class Modal_Checkout {
 	 * is scrubbed. Runs on rest_pre_dispatch because the validation happens
 	 * during dispatch.
 	 *
+	 * The shipping address is intentionally out of scope. Carts that need a
+	 * shipping address bail below, and wallets return only billing contact when
+	 * shipping is not requested, so a virtual-cart request carries no shipping
+	 * address to scrub.
+	 *
 	 * Scoped to requests originating from the modal checkout, so any Store API
 	 * checkout outside the modal (e.g. the blocks checkout page or express
 	 * buttons on product pages) keeps stock behavior.
@@ -1477,7 +1482,14 @@ final class Modal_Checkout {
 	private static function is_modal_checkout_referer() {
 		$referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		return false !== strpos( $referer, 'modal_checkout=1' );
+		if ( ! $referer ) {
+			return false;
+		}
+
+		$query_string = \wp_parse_url( $referer, PHP_URL_QUERY );
+		\wp_parse_str( (string) $query_string, $query_params );
+
+		return ! empty( $query_params['modal_checkout'] );
 	}
 
 	/**
@@ -1494,6 +1506,7 @@ final class Modal_Checkout {
 		if (
 			! in_array( 'billing_state', $billing_fields, true ) &&
 			! empty( $address['state'] ) &&
+			is_string( $address['state'] ) &&
 			$country
 		) {
 			$states = \WC()->countries->get_states( $country );
@@ -1511,6 +1524,7 @@ final class Modal_Checkout {
 		if (
 			! in_array( 'billing_postcode', $billing_fields, true ) &&
 			! empty( $address['postcode'] ) &&
+			is_string( $address['postcode'] ) &&
 			! \WC_Validation::is_postcode( $address['postcode'], $country )
 		) {
 			$address['postcode'] = '';

--- a/plugins/newspack-blocks/tests/mocks/newspack-plugin-mocks.php
+++ b/plugins/newspack-blocks/tests/mocks/newspack-plugin-mocks.php
@@ -1,0 +1,21 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing
+
+namespace Newspack;
+
+if ( ! class_exists( WooCommerce_My_Account::class ) ) {
+	/**
+	 * Minimal mock of Newspack\WooCommerce_My_Account (newspack-plugin), used when
+	 * newspack-plugin is not loaded in the test environment.
+	 *
+	 * The $is_from_my_account flag defaults to false so that code paths guarded by
+	 * method_exists + is_from_my_account() behave the same as when the class is
+	 * absent. Tests that need a My Account request set the flag and the shared
+	 * set_up() resets it.
+	 */
+	class WooCommerce_My_Account {
+		public static $is_from_my_account = false;
+		public static function is_from_my_account() {
+			return self::$is_from_my_account;
+		}
+	}
+}

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -67,6 +67,31 @@ if ( ! function_exists( 'WC' ) ) {
 				public $cart = null;
 
 				/**
+				 * Countries double exposing a US-only states list.
+				 *
+				 * @var object
+				 */
+				public $countries;
+
+				/**
+				 * Set up the countries double.
+				 */
+				public function __construct() {
+					$this->countries = new class() {
+						/**
+						 * Get states for a country.
+						 *
+						 * @param string $country Country code.
+						 *
+						 * @return array
+						 */
+						public function get_states( $country ) {
+							return 'US' === $country ? [ 'CA' => 'California' ] : [];
+						}
+					};
+				}
+
+				/**
 				 * Mimic WC()->payment_gateways() with no registered gateways.
 				 *
 				 * @return object
@@ -86,6 +111,26 @@ if ( ! function_exists( 'WC' ) ) {
 			};
 		}
 		return $newspack_blocks_test_wc;
+	}
+}
+
+if ( ! class_exists( 'WC_Validation' ) ) {
+	/**
+	 * Mock WooCommerce postcode validation.
+	 */
+	class WC_Validation {
+		/**
+		 * Mock postcode check: only the literal "INVALID" fails.
+		 *
+		 * @param string $postcode Postcode.
+		 * @param string $country  Country code.
+		 *
+		 * @return bool
+		 */
+		public static function is_postcode( $postcode, $country ) {
+			unset( $country );
+			return 'INVALID' !== $postcode;
+		}
 	}
 }
 
@@ -109,7 +154,9 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$newspack_blocks_test_limited_product_id = null;
 		$newspack_blocks_test_limited_user_id    = null;
 		$newspack_blocks_test_wc                 = null;
-		\Newspack\WooCommerce_My_Account::$is_from_my_account = false;
+		if ( property_exists( \Newspack\WooCommerce_My_Account::class, 'is_from_my_account' ) ) {
+			\Newspack\WooCommerce_My_Account::$is_from_my_account = false;
+		}
 		remove_all_filters( 'woocommerce_cart_item_removed_message' );
 		remove_all_filters( 'newspack_blocks_donate_billing_fields_keys' );
 		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
@@ -624,6 +671,10 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * instead of removing fields).
 	 */
 	public function test_checkout_fields_noop_for_my_account_checkout() {
+		if ( ! property_exists( \Newspack\WooCommerce_My_Account::class, 'is_from_my_account' ) ) {
+			$this->markTestSkipped( 'The WooCommerce_My_Account mock is not in use.' );
+		}
+
 		$this->set_mock_checkout_cart();
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
 		\Newspack\WooCommerce_My_Account::$is_from_my_account = true;
@@ -651,5 +702,188 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$fields['billing']['billing_phone']['class'],
 			'The billing phone field should get the form-row-last class.'
 		);
+	}
+
+	/**
+	 * Build a Store API checkout request with the given billing address.
+	 *
+	 * @param array $billing_address Billing address.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function get_store_api_checkout_request( $billing_address ) {
+		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_param( 'billing_address', $billing_address );
+
+		return $request;
+	}
+
+	/**
+	 * An invalid state is scrubbed from Store API checkout requests when the
+	 * state field is configured off.
+	 */
+	public function test_store_api_scrub_drops_invalid_state_when_configured_off() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$request = $this->get_store_api_checkout_request(
+			[
+				'country'  => 'US',
+				'state'    => 'REMUERA',
+				'postcode' => '94043',
+			]
+		);
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$address = $request->get_param( 'billing_address' );
+
+		$this->assertSame( '', $address['state'], 'An invalid state should be scrubbed.' );
+		$this->assertSame( '94043', $address['postcode'], 'A valid postcode should be kept.' );
+	}
+
+	/**
+	 * Valid state values pass through untouched, whether provided as a code or
+	 * a name.
+	 */
+	public function test_store_api_scrub_keeps_valid_state_values() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		foreach ( [ 'CA', 'ca', 'California' ] as $state ) {
+			$request = $this->get_store_api_checkout_request(
+				[
+					'country' => 'US',
+					'state'   => $state,
+				]
+			);
+
+			\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+			$this->assertSame(
+				$state,
+				$request->get_param( 'billing_address' )['state'],
+				"A valid state value ({$state}) should be left untouched."
+			);
+		}
+	}
+
+	/**
+	 * An invalid postcode is scrubbed when the postcode field is configured off.
+	 */
+	public function test_store_api_scrub_drops_invalid_postcode_when_configured_off() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$request = $this->get_store_api_checkout_request(
+			[
+				'country'  => 'US',
+				'postcode' => 'INVALID',
+			]
+		);
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$this->assertSame( '', $request->get_param( 'billing_address' )['postcode'], 'An invalid postcode should be scrubbed.' );
+	}
+
+	/**
+	 * Nothing is scrubbed when the fields are part of the configured list.
+	 */
+	public function test_store_api_scrub_noop_when_fields_configured_on() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email', 'billing_state', 'billing_postcode' ] );
+
+		$address = [
+			'country'  => 'US',
+			'state'    => 'REMUERA',
+			'postcode' => 'INVALID',
+		];
+		$request = $this->get_store_api_checkout_request( $address );
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$this->assertSame( $address, $request->get_param( 'billing_address' ), 'Configured-on fields should never be scrubbed.' );
+	}
+
+	/**
+	 * Nothing is scrubbed with the default (empty) configuration.
+	 */
+	public function test_store_api_scrub_noop_for_default_config() {
+		$this->set_mock_checkout_cart();
+
+		$address = [
+			'country' => 'US',
+			'state'   => 'REMUERA',
+		];
+		$request = $this->get_store_api_checkout_request( $address );
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$this->assertSame( $address, $request->get_param( 'billing_address' ), 'Default configuration should never be scrubbed.' );
+	}
+
+	/**
+	 * Carts needing a shipping address are never scrubbed.
+	 */
+	public function test_store_api_scrub_bails_for_shipping_carts() {
+		$this->set_mock_checkout_cart( true );
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$address = [
+			'country' => 'US',
+			'state'   => 'REMUERA',
+		];
+		$request = $this->get_store_api_checkout_request( $address );
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$this->assertSame( $address, $request->get_param( 'billing_address' ), 'Shipping carts should never be scrubbed.' );
+	}
+
+	/**
+	 * Locale required flags are relaxed for configured-off state and postcode.
+	 */
+	public function test_locale_relaxation_for_configured_off_fields() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$locale = [
+			'US' => [
+				'state'    => [ 'required' => true ],
+				'postcode' => [ 'required' => true ],
+				'city'     => [ 'required' => true ],
+			],
+		];
+
+		$relaxed = \Newspack_Blocks\Modal_Checkout::relax_configured_off_locale_fields( $locale );
+
+		$this->assertFalse( $relaxed['US']['state']['required'], 'Configured-off state should not be required.' );
+		$this->assertFalse( $relaxed['US']['postcode']['required'], 'Configured-off postcode should not be required.' );
+		$this->assertTrue( $relaxed['US']['city']['required'], 'Fields without Store API validation should be untouched.' );
+	}
+
+	/**
+	 * Locale required flags are untouched for shipping carts, configured-on
+	 * fields, and the default configuration.
+	 */
+	public function test_locale_relaxation_noop_cases() {
+		$locale = [
+			'US' => [ 'state' => [ 'required' => true ] ],
+		];
+
+		// Default (empty) configuration.
+		$this->set_mock_checkout_cart();
+		$this->assertSame( $locale, \Newspack_Blocks\Modal_Checkout::relax_configured_off_locale_fields( $locale ), 'Default configuration should not relax locale fields.' );
+
+		// Configured-on fields.
+		$this->set_configured_billing_fields( [ 'billing_state', 'billing_postcode' ] );
+		$this->assertSame( $locale, \Newspack_Blocks\Modal_Checkout::relax_configured_off_locale_fields( $locale ), 'Configured-on fields should not be relaxed.' );
+
+		// Shipping carts.
+		remove_all_filters( 'newspack_blocks_donate_billing_fields_keys' );
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+		$this->set_mock_checkout_cart( true );
+		$this->assertSame( $locale, \Newspack_Blocks\Modal_Checkout::relax_configured_off_locale_fields( $locale ), 'Shipping carts should not be relaxed.' );
 	}
 }

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -43,14 +43,73 @@ if ( ! function_exists( 'wcs_get_product_limitation' ) ) {
 	}
 }
 
+require_once __DIR__ . '/mocks/newspack-plugin-mocks.php';
+
+if ( ! function_exists( 'WC' ) ) {
+	/**
+	 * Mock WC() function returning a controllable container.
+	 *
+	 * Defining WC() makes function_exists( 'WC' ) gates pass across the whole
+	 * suite, so the container must keep previously-gated paths behaving as if
+	 * WooCommerce had no state: no cart and no registered payment gateways.
+	 *
+	 * @return object
+	 */
+	function WC() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce global.
+		global $newspack_blocks_test_wc;
+		if ( empty( $newspack_blocks_test_wc ) ) {
+			$newspack_blocks_test_wc = new class() {
+				/**
+				 * Cart double, set by tests.
+				 *
+				 * @var object|null
+				 */
+				public $cart = null;
+
+				/**
+				 * Mimic WC()->payment_gateways() with no registered gateways.
+				 *
+				 * @return object
+				 */
+				public function payment_gateways() {
+					return new class() {
+						/**
+						 * Get registered gateways.
+						 *
+						 * @return array
+						 */
+						public function payment_gateways() {
+							return [];
+						}
+					};
+				}
+			};
+		}
+		return $newspack_blocks_test_wc;
+	}
+}
+
+if ( ! function_exists( 'wc_get_checkout_url' ) ) {
+	/**
+	 * Mock WooCommerce checkout URL helper.
+	 *
+	 * @return string
+	 */
+	function wc_get_checkout_url() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce global.
+		return 'https://example.com/checkout/';
+	}
+}
+
 class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	/**
 	 * Clean up request data.
 	 */
 	public function tear_down() {
-		global $newspack_blocks_test_limited_product_id, $newspack_blocks_test_limited_user_id;
+		global $newspack_blocks_test_limited_product_id, $newspack_blocks_test_limited_user_id, $newspack_blocks_test_wc;
 		$newspack_blocks_test_limited_product_id = null;
 		$newspack_blocks_test_limited_user_id    = null;
+		$newspack_blocks_test_wc                 = null;
+		\Newspack\WooCommerce_My_Account::$is_from_my_account = false;
 		remove_all_filters( 'woocommerce_cart_item_removed_message' );
 		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
 		parent::tear_down();
@@ -414,6 +473,182 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 					]
 				)
 			)
+		);
+	}
+
+	/**
+	 * Set WC()->cart to a cart double with a controllable needs_shipping_address().
+	 *
+	 * @param bool $needs_shipping Whether the cart needs a shipping address.
+	 */
+	private function set_mock_checkout_cart( $needs_shipping = false ) {
+		WC()->cart = new class( $needs_shipping ) {
+			/**
+			 * Whether the cart needs a shipping address.
+			 *
+			 * @var bool
+			 */
+			private $needs_shipping;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param bool $needs_shipping Whether the cart needs a shipping address.
+			 */
+			public function __construct( $needs_shipping ) {
+				$this->needs_shipping = $needs_shipping;
+			}
+
+			/**
+			 * Whether the cart needs a shipping address.
+			 *
+			 * @return bool
+			 */
+			public function needs_shipping_address() {
+				return $this->needs_shipping;
+			}
+		};
+	}
+
+	/**
+	 * Configure the billing fields returned by the config filter.
+	 *
+	 * @param string[] $billing_fields Billing field keys.
+	 */
+	private function set_configured_billing_fields( $billing_fields ) {
+		add_filter(
+			'newspack_blocks_donate_billing_fields_keys',
+			function() use ( $billing_fields ) {
+				return $billing_fields;
+			}
+		);
+	}
+
+	/**
+	 * Checkout fields fixture resembling the WooCommerce default structure.
+	 *
+	 * @return array
+	 */
+	private function get_checkout_fields_fixture() {
+		return [
+			'billing'  => [
+				'billing_first_name' => [ 'label' => 'First name' ],
+				'billing_last_name'  => [ 'label' => 'Last name' ],
+				'billing_country'    => [ 'label' => 'Country' ],
+				'billing_state'      => [ 'label' => 'State' ],
+				'billing_phone'      => [ 'label' => 'Phone' ],
+				'billing_email'      => [ 'label' => 'Email' ],
+			],
+			'shipping' => [
+				'shipping_first_name' => [ 'label' => 'First name' ],
+			],
+			'order'    => [
+				'order_comments' => [ 'label' => 'Order notes' ],
+			],
+		];
+	}
+
+	/**
+	 * Configured-off billing fields are removed on standard (non-modal) checkout
+	 * requests, so express checkout wallets cannot fail validation on fields the
+	 * buyer cannot see or edit (NPPM-2937).
+	 */
+	public function test_checkout_fields_removes_configured_off_fields_on_standard_checkout() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$fields = \Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $this->get_checkout_fields_fixture() );
+
+		$this->assertSame(
+			[ 'billing_first_name', 'billing_email' ],
+			array_keys( $fields['billing'] ),
+			'Billing fields not in the configured list should be removed.'
+		);
+		$this->assertArrayHasKey(
+			'shipping_first_name',
+			$fields['shipping'],
+			'Shipping fields should be untouched.'
+		);
+	}
+
+	/**
+	 * With no custom billing fields configured, checkout fields are unchanged.
+	 */
+	public function test_checkout_fields_noop_when_no_fields_configured() {
+		$this->set_mock_checkout_cart();
+
+		$fields = $this->get_checkout_fields_fixture();
+
+		$this->assertSame(
+			$fields,
+			\Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $fields ),
+			'Fields should be unchanged when no custom billing fields are configured.'
+		);
+	}
+
+	/**
+	 * Carts that need a shipping address keep the full field set.
+	 */
+	public function test_checkout_fields_noop_when_cart_needs_shipping() {
+		$this->set_mock_checkout_cart( true );
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$fields = $this->get_checkout_fields_fixture();
+
+		$this->assertSame(
+			$fields,
+			\Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $fields ),
+			'Fields should be unchanged when the cart needs a shipping address.'
+		);
+	}
+
+	/**
+	 * Contexts without a cart keep the full field set.
+	 */
+	public function test_checkout_fields_noop_when_cart_unavailable() {
+		WC()->cart = null;
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$fields = $this->get_checkout_fields_fixture();
+
+		$this->assertSame(
+			$fields,
+			\Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $fields ),
+			'Fields should be unchanged when no cart is available.'
+		);
+	}
+
+	/**
+	 * My Account checkouts keep the full field set (they relax required flags
+	 * instead of removing fields).
+	 */
+	public function test_checkout_fields_noop_for_my_account_checkout() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+		\Newspack\WooCommerce_My_Account::$is_from_my_account = true;
+
+		$fields = $this->get_checkout_fields_fixture();
+
+		$this->assertSame(
+			$fields,
+			\Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $fields ),
+			'Fields should be unchanged for My Account checkouts.'
+		);
+	}
+
+	/**
+	 * The billing phone field gets the form-row-last class when configured.
+	 */
+	public function test_checkout_fields_billing_phone_gets_form_row_last_class() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email', 'billing_phone' ] );
+
+		$fields = \Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $this->get_checkout_fields_fixture() );
+
+		$this->assertSame(
+			'form-row-last',
+			$fields['billing']['billing_phone']['class'],
+			'The billing phone field should get the form-row-last class.'
 		);
 	}
 }

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -111,6 +111,7 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$newspack_blocks_test_wc                 = null;
 		\Newspack\WooCommerce_My_Account::$is_from_my_account = false;
 		remove_all_filters( 'woocommerce_cart_item_removed_message' );
+		remove_all_filters( 'newspack_blocks_donate_billing_fields_keys' );
 		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
 		parent::tear_down();
 	}

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -159,7 +159,7 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		}
 		remove_all_filters( 'woocommerce_cart_item_removed_message' );
 		remove_all_filters( 'newspack_blocks_donate_billing_fields_keys' );
-		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'] );
+		unset( $_POST['billing_email'], $_POST['post_data'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'], $_SERVER['HTTP_REFERER'] );
 		parent::tear_down();
 	}
 
@@ -573,6 +573,21 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * Mark the current request as a modal checkout request.
+	 */
+	private function set_modal_checkout_request() {
+		$_REQUEST['modal_checkout'] = '1';
+	}
+
+	/**
+	 * Set a referer pointing at the modal checkout iframe, as express checkout
+	 * Store API requests carry.
+	 */
+	private function set_modal_checkout_referer() {
+		$_SERVER['HTTP_REFERER'] = 'https://example.com/checkout/?modal_checkout=1';
+	}
+
+	/**
 	 * Checkout fields fixture resembling the WooCommerce default structure.
 	 *
 	 * @return array
@@ -597,11 +612,10 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
-	 * Configured-off billing fields are removed on standard (non-modal) checkout
-	 * requests, so express checkout wallets cannot fail validation on fields the
-	 * buyer cannot see or edit (NPPM-2937).
+	 * Configured-off billing fields are removed on modal checkout requests.
 	 */
-	public function test_checkout_fields_removes_configured_off_fields_on_standard_checkout() {
+	public function test_checkout_fields_removes_configured_off_fields_on_modal_requests() {
+		$this->set_modal_checkout_request();
 		$this->set_mock_checkout_cart();
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
 
@@ -620,9 +634,27 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * Standard (non-modal) Woo checkouts keep the stock field set, by design:
+	 * publisher flows that predate Audience Management must not change.
+	 */
+	public function test_checkout_fields_noop_on_standard_checkout() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$fields = $this->get_checkout_fields_fixture();
+
+		$this->assertSame(
+			$fields,
+			\Newspack_Blocks\Modal_Checkout::woocommerce_checkout_fields( $fields ),
+			'Fields should be unchanged on standard checkout requests.'
+		);
+	}
+
+	/**
 	 * With no custom billing fields configured, checkout fields are unchanged.
 	 */
 	public function test_checkout_fields_noop_when_no_fields_configured() {
+		$this->set_modal_checkout_request();
 		$this->set_mock_checkout_cart();
 
 		$fields = $this->get_checkout_fields_fixture();
@@ -638,6 +670,7 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * Carts that need a shipping address keep the full field set.
 	 */
 	public function test_checkout_fields_noop_when_cart_needs_shipping() {
+		$this->set_modal_checkout_request();
 		$this->set_mock_checkout_cart( true );
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
 
@@ -654,6 +687,7 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * Contexts without a cart keep the full field set.
 	 */
 	public function test_checkout_fields_noop_when_cart_unavailable() {
+		$this->set_modal_checkout_request();
 		WC()->cart = null;
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
 
@@ -675,6 +709,7 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$this->markTestSkipped( 'The WooCommerce_My_Account mock is not in use.' );
 		}
 
+		$this->set_modal_checkout_request();
 		$this->set_mock_checkout_cart();
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
 		\Newspack\WooCommerce_My_Account::$is_from_my_account = true;
@@ -692,6 +727,7 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * The billing phone field gets the form-row-last class when configured.
 	 */
 	public function test_checkout_fields_billing_phone_gets_form_row_last_class() {
+		$this->set_modal_checkout_request();
 		$this->set_mock_checkout_cart();
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email', 'billing_phone' ] );
 
@@ -712,6 +748,8 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * @return WP_REST_Request
 	 */
 	private function get_store_api_checkout_request( $billing_address ) {
+		$this->set_modal_checkout_referer();
+
 		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
 		$request->set_param( 'billing_address', $billing_address );
 
@@ -842,9 +880,30 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * Requests not originating from the modal checkout are never scrubbed,
+	 * keeping standard Woo and blocks checkout flows stock.
+	 */
+	public function test_store_api_scrub_noop_without_modal_referer() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$address = [
+			'country' => 'US',
+			'state'   => 'REMUERA',
+		];
+		$request = $this->get_store_api_checkout_request( $address );
+		unset( $_SERVER['HTTP_REFERER'] );
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$this->assertSame( $address, $request->get_param( 'billing_address' ), 'Requests without a modal checkout referer should never be scrubbed.' );
+	}
+
+	/**
 	 * Locale required flags are relaxed for configured-off state and postcode.
 	 */
 	public function test_locale_relaxation_for_configured_off_fields() {
+		$this->set_modal_checkout_referer();
 		$this->set_mock_checkout_cart();
 		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
 
@@ -864,16 +923,23 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
-	 * Locale required flags are untouched for shipping carts, configured-on
-	 * fields, and the default configuration.
+	 * Locale required flags are untouched outside modal requests and, within
+	 * them, for shipping carts, configured-on fields, and the default
+	 * configuration.
 	 */
 	public function test_locale_relaxation_noop_cases() {
 		$locale = [
 			'US' => [ 'state' => [ 'required' => true ] ],
 		];
 
-		// Default (empty) configuration.
+		// No modal checkout referer or request param.
 		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+		$this->assertSame( $locale, \Newspack_Blocks\Modal_Checkout::relax_configured_off_locale_fields( $locale ), 'Non-modal requests should not relax locale fields.' );
+		remove_all_filters( 'newspack_blocks_donate_billing_fields_keys' );
+
+		// Default (empty) configuration.
+		$this->set_modal_checkout_referer();
 		$this->assertSame( $locale, \Newspack_Blocks\Modal_Checkout::relax_configured_off_locale_fields( $locale ), 'Default configuration should not relax locale fields.' );
 
 		// Configured-on fields.

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -900,6 +900,26 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * Array-valued state/postcode do not trigger a fatal on the string transforms;
+	 * the schema is left to reject them with its own clean error.
+	 */
+	public function test_store_api_scrub_ignores_non_string_values() {
+		$this->set_mock_checkout_cart();
+		$this->set_configured_billing_fields( [ 'billing_first_name', 'billing_email' ] );
+
+		$address = [
+			'country'  => 'US',
+			'state'    => [ 'REMUERA' ],
+			'postcode' => [ 'INVALID' ],
+		];
+		$request = $this->get_store_api_checkout_request( $address );
+
+		\Newspack_Blocks\Modal_Checkout::scrub_store_api_checkout_address( null, null, $request );
+
+		$this->assertSame( $address, $request->get_param( 'billing_address' ), 'Non-string address values should be left for the schema to reject.' );
+	}
+
+	/**
 	 * Locale required flags are relaxed for configured-off state and postcode.
 	 */
 	public function test_locale_relaxation_for_configured_off_fields() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Express checkout wallets (Apple Pay, Google Pay) in the modal checkout submit to the Store API (`wc/store/v1/checkout`), whose address validation rejects any state value not in the country's list. Wallets can supply values the buyer never sees and cannot correct (for example a locality in the state slot), hard-failing the payment on a field the site is configured not to collect.

The fix is scoped strictly to the modal checkout, so standard Woo checkout flows keep stock behavior (per review discussion, the modal-only scoping of the billing fields setting is deliberate):

* A `rest_pre_dispatch` scrub drops configured-off state/postcode values from modal-originated `wc/store/v1/checkout` requests, and only when the value would fail validation anyway; valid wallet values pass through untouched and are stored on the order. Modal origin is detected via the referer (the modal iframe URL carries `modal_checkout=1`), since express submissions carry no request params.
* A `woocommerce_get_country_locale` filter relaxes the required flag for configured-off state/postcode on modal-originated requests, so the scrubbed value's absence is accepted. It never applies when the cart needs a shipping address.
* The existing modal-only field removal is unchanged; its docblock now records that the modal-only scoping is by design.

Everything outside the modal is byte-for-byte stock: the standard Woo checkout page, the blocks checkout, express buttons on product/cart pages, My Account flows, and any cart needing a shipping address.

### How to test the changes in this Pull Request:

1. In Audience > Configuration > Checkout & Payment > Billing Fields, uncheck the state and address fields (keep name and email) and save.
2. Open the modal checkout via a donate block and confirm the form shows only the configured fields.
3. Complete an express payment (Apple Pay / Google Pay) in the modal using a wallet address whose state the store rejects (to simulate, temporarily filter `woocommerce_states` to replace the state list for your wallet's country). Confirm checkout completes with the invalid state dropped, instead of failing with "The provided state (...) is not valid".
4. Open the standard checkout page with a virtual product in the cart. Confirm the full address field set renders despite the reduced configuration.
5. On that standard checkout page, attempt the same express payment. Confirm stock behavior (the address validation error appears), since the fix must not apply outside the modal.
6. Add a physical (shippable) product and confirm standard checkout still renders and requires the full address field set.
7. Pay for an order from My Account and confirm those fields are unchanged.
8. Clear the billing fields configuration (default field set) and confirm modal express checkout validates addresses as stock.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
