### PR TITLE
feat(insights): alternative `Funnel` design

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Tests for the Funnel viz: the pure helpers (opacity interpolation, clamped
- * drop-off) and render smoke tests covering the hover/focus-revealed label
- * Popovers, the stepped section widths and trapezoidal separators, and the edge
- * cases.
+ * Tests for the Funnel viz: the pure helpers (clamped drop-off) and render smoke
+ * tests covering the hover/focus-revealed label Popovers, the stepped section
+ * widths and trapezoidal separators, the primary-scale fill/separator colors, and
+ * the edge cases.
  */
 
 /**
@@ -13,20 +13,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import Funnel, { stepOpacity, dropFromPrevious, type FunnelStage } from './Funnel';
+import Funnel, { dropFromPrevious, type FunnelStage } from './Funnel';
 
 describe( 'Funnel helpers', () => {
-	describe( 'stepOpacity', () => {
-		it( 'runs 1.0 at the first step to 0.6 at the last', () => {
-			expect( stepOpacity( 0, 3 ) ).toBeCloseTo( 1.0, 5 );
-			expect( stepOpacity( 1, 3 ) ).toBeCloseTo( 0.8, 5 );
-			expect( stepOpacity( 2, 3 ) ).toBeCloseTo( 0.6, 5 );
-		} );
-		it( 'is full opacity for a single step', () => {
-			expect( stepOpacity( 0, 1 ) ).toBe( 1 );
-		} );
-	} );
-
 	describe( 'dropFromPrevious', () => {
 		it( 'computes 1 - count/prev', () => {
 			expect( dropFromPrevious( 2000, 25000 ) ).toBeCloseTo( 0.92, 3 ); // Mid-size publisher engagement step.
@@ -134,15 +123,19 @@ describe( 'Funnel render', () => {
 		} );
 	} );
 
-	it( 'sets both gradient opacity custom properties on every section', () => {
-		// These drive the SCSS gradient fill; assert they are emitted so a rename
-		// drift between the component and the stylesheet is caught here.
+	it( 'sets a primary-scale fill on every section and a separator color on every connector', () => {
+		// These drive the SCSS `background-color`; assert they are emitted so a
+		// rename drift between the component and the stylesheet is caught here.
 		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
 		const steps = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' );
 		expect( steps ).toHaveLength( 3 );
 		steps.forEach( step => {
-			expect( step.style.getPropertyValue( '--band-opacity-top' ) ).not.toBe( '' );
-			expect( step.style.getPropertyValue( '--band-opacity-bottom' ) ).not.toBe( '' );
+			expect( step.style.getPropertyValue( '--band-fill' ) ).not.toBe( '' );
+		} );
+		const separators = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-separator' );
+		expect( separators ).toHaveLength( 2 );
+		separators.forEach( separator => {
+			expect( separator.style.getPropertyValue( '--band-separator' ) ).not.toBe( '' );
 		} );
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -1,13 +1,14 @@
 /**
- * Tests for the Funnel viz: the pure layout/geometry helpers (mode selection,
- * opacity interpolation, clamped drop-off) and render smoke tests covering the
- * descriptive labels and the edge cases.
+ * Tests for the Funnel viz: the pure helpers (opacity interpolation, clamped
+ * drop-off) and render smoke tests covering the hover/focus-revealed label
+ * Popovers, the stepped section widths and trapezoidal separators, and the edge
+ * cases.
  */
 
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -58,16 +59,40 @@ describe( 'Funnel render', () => {
 		expect( screen.getByText( '400' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows drop-off descriptors for stages after the first only', () => {
-		render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
+	it( 'reveals drop-off descriptors only while the funnel is hovered', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
+		const funnel = container.querySelector( '.newspack-insights__funnel' ) as HTMLElement;
+		// Hidden until the funnel is hovered.
+		expect( screen.queryByText( /of Impressions/ ) ).toBeNull();
+		fireEvent.mouseEnter( funnel );
 		expect( screen.getByText( /of Impressions/ ) ).toBeInTheDocument();
 		// Exactly one drop-off line: the first stage has none.
 		expect( screen.getAllByText( /drop-off/ ) ).toHaveLength( 1 );
+		// Hidden again once the pointer leaves.
+		fireEvent.mouseLeave( funnel );
+		expect( screen.queryByText( /of Impressions/ ) ).toBeNull();
 	} );
 
-	it( 'renders a single-stage funnel without descriptors', () => {
-		render( <Funnel stages={ stages( [ 'Only', 100 ] ) } /> );
+	it( 'reveals descriptors on focus and hides them on blur', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
+		const funnel = container.querySelector( '.newspack-insights__funnel' ) as HTMLElement;
+		fireEvent.focus( funnel );
+		expect( screen.getByText( /drop-off/ ) ).toBeInTheDocument();
+		fireEvent.blur( funnel );
+		expect( screen.queryByText( /drop-off/ ) ).toBeNull();
+	} );
+
+	it( "reveals every section's descriptors at once on hover", () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		fireEvent.mouseEnter( container.querySelector( '.newspack-insights__funnel' ) as HTMLElement );
+		// Both post-first stages reveal their drop-off line together.
+		expect( screen.getAllByText( /drop-off/ ) ).toHaveLength( 2 );
+	} );
+
+	it( 'renders a single-stage funnel without descriptors even on hover', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'Only', 100 ] ) } /> );
 		expect( screen.getByText( 'Only' ) ).toBeInTheDocument();
+		fireEvent.mouseEnter( container.querySelector( '.newspack-insights__funnel' ) as HTMLElement );
 		expect( screen.queryByText( /drop-off/ ) ).toBeNull();
 	} );
 
@@ -81,21 +106,35 @@ describe( 'Funnel render', () => {
 		expect( screen.getByText( 'Not enough data to chart the funnel.' ) ).toBeInTheDocument();
 	} );
 
-	it( 'no longer renders a separate legend or side-label column', () => {
+	it( 'renders no separate legend or SVG chart', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'A', 100 ], [ 'B', 50 ] ) } /> );
 		expect( container.querySelector( '.newspack-insights__funnel-legend' ) ).toBeNull();
-		expect( container.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 		expect( container.querySelector( '.newspack-insights__funnel-svg' ) ).toBeNull();
 	} );
 
-	it( 'renders equal-width rectangular fills with no trapezoid clip-path', () => {
-		// The sections are full-width rectangles differentiated by color alone, so
-		// no band carries the old inline clip-path geometry.
+	it( 'renders rectangular section fills and a trapezoidal separator between each pair', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 100 ], [ 'C', 5 ] ) } /> );
+		// The sections themselves are rectangles — no clip-path on the fills.
 		const fills = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-fill' );
 		expect( fills ).toHaveLength( 3 );
 		fills.forEach( fill => {
 			expect( fill.style.clipPath ).toBe( '' );
 		} );
+		// One separator per adjacent pair (n − 1), each clipped to a trapezoid.
+		const separators = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-separator' );
+		expect( separators ).toHaveLength( 2 );
+		separators.forEach( separator => {
+			expect( separator.style.clipPath ).toMatch( /^polygon\(/ );
+		} );
+	} );
+
+	it( 'steps section widths down from a full-width top section', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		const widths = Array.from( container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' ) ).map( step =>
+			parseFloat( step.style.maxWidth )
+		);
+		expect( widths[ 0 ] ).toBe( 100 ); // top section pinned to the full width
+		expect( widths[ 1 ] ).toBeLessThan( widths[ 0 ] );
+		expect( widths[ 2 ] ).toBeLessThan( widths[ 1 ] );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -59,41 +59,46 @@ describe( 'Funnel render', () => {
 		expect( screen.getByText( '400' ) ).toBeInTheDocument();
 	} );
 
-	it( 'reveals drop-off descriptors only while the funnel is hovered', () => {
+	it( 'keeps descriptors available to assistive tech and reveals the visual Popover on hover', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
 		const funnel = container.querySelector( '.newspack-insights__funnel' ) as HTMLElement;
-		// Hidden until the funnel is hovered.
-		expect( screen.queryByText( /of Impressions/ ) ).toBeNull();
+		// The drop-off text is always in the DOM as a screen-reader copy, even unhovered.
+		const srText = container.querySelector( '.screen-reader-text' );
+		expect( srText?.textContent ).toMatch( /of Impressions/ );
+		expect( srText?.textContent ).toMatch( /drop-off/ );
+		// The floating visual Popover (portaled to body) appears only on hover…
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 		fireEvent.mouseEnter( funnel );
-		expect( screen.getByText( /of Impressions/ ) ).toBeInTheDocument();
-		// Exactly one drop-off line: the first stage has none.
-		expect( screen.getAllByText( /drop-off/ ) ).toHaveLength( 1 );
-		// Hidden again once the pointer leaves.
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).not.toBeNull();
+		// …and hides again once the pointer leaves.
 		fireEvent.mouseLeave( funnel );
-		expect( screen.queryByText( /of Impressions/ ) ).toBeNull();
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 	} );
 
-	it( 'reveals descriptors on focus and hides them on blur', () => {
+	it( 'reveals the visual Popover on focus and hides it on blur', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'Impressions', 25000 ], [ 'Engaged', 2000 ] ) } /> );
 		const funnel = container.querySelector( '.newspack-insights__funnel' ) as HTMLElement;
 		fireEvent.focus( funnel );
-		expect( screen.getByText( /drop-off/ ) ).toBeInTheDocument();
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).not.toBeNull();
 		fireEvent.blur( funnel );
-		expect( screen.queryByText( /drop-off/ ) ).toBeNull();
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 	} );
 
-	it( "reveals every section's descriptors at once on hover", () => {
+	it( "reveals every section's Popover at once on hover", () => {
 		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		// Both post-first stages carry an always-present screen-reader descriptor…
+		expect( container.querySelectorAll( '.screen-reader-text' ) ).toHaveLength( 2 );
+		// …and reveal their visual Popovers together on a single hover.
 		fireEvent.mouseEnter( container.querySelector( '.newspack-insights__funnel' ) as HTMLElement );
-		// Both post-first stages reveal their drop-off line together.
-		expect( screen.getAllByText( /drop-off/ ) ).toHaveLength( 2 );
+		expect( document.querySelectorAll( '.newspack-insights__funnel-labels' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'renders a single-stage funnel without descriptors even on hover', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'Only', 100 ] ) } /> );
 		expect( screen.getByText( 'Only' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.screen-reader-text' ) ).toBeNull();
 		fireEvent.mouseEnter( container.querySelector( '.newspack-insights__funnel' ) as HTMLElement );
-		expect( screen.queryByText( /drop-off/ ) ).toBeNull();
+		expect( document.querySelector( '.newspack-insights__funnel-labels' ) ).toBeNull();
 	} );
 
 	it( 'shows the empty message with no stages', () => {
@@ -129,6 +134,18 @@ describe( 'Funnel render', () => {
 		} );
 	} );
 
+	it( 'sets both gradient opacity custom properties on every section', () => {
+		// These drive the SCSS gradient fill; assert they are emitted so a rename
+		// drift between the component and the stylesheet is caught here.
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
+		const steps = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' );
+		expect( steps ).toHaveLength( 3 );
+		steps.forEach( step => {
+			expect( step.style.getPropertyValue( '--band-opacity-top' ) ).not.toBe( '' );
+			expect( step.style.getPropertyValue( '--band-opacity-bottom' ) ).not.toBe( '' );
+		} );
+	} );
+
 	it( 'steps section widths down from a full-width top section', () => {
 		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 500 ], [ 'C', 100 ] ) } /> );
 		const widths = Array.from( container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' ) ).map( step =>
@@ -137,6 +154,36 @@ describe( 'Funnel render', () => {
 		expect( widths[ 0 ] ).toBe( 100 ); // top section pinned to the full width
 		expect( widths[ 1 ] ).toBeLessThan( widths[ 0 ] );
 		expect( widths[ 2 ] ).toBeLessThan( widths[ 1 ] );
+	} );
+
+	it( 'never widens a band beyond the one above, even for long funnels or data drift', () => {
+		// A 10-stage funnel (MINIMUM_BAND_PROPORTION * 10 > 1, so the floor would
+		// otherwise flare) that also contains a drift stage (S2 > S1). Widths must
+		// still stay ≤ 100% and strictly decrease band to band.
+		const { container } = render(
+			<Funnel
+				stages={ stages(
+					[ 'S0', 1000 ],
+					[ 'S1', 900 ],
+					[ 'S2', 950 ],
+					[ 'S3', 300 ],
+					[ 'S4', 250 ],
+					[ 'S5', 200 ],
+					[ 'S6', 150 ],
+					[ 'S7', 120 ],
+					[ 'S8', 100 ],
+					[ 'S9', 90 ]
+				) }
+			/>
+		);
+		const widths = Array.from( container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' ) ).map( step =>
+			parseFloat( step.style.maxWidth )
+		);
+		expect( widths[ 0 ] ).toBe( 100 );
+		widths.forEach( width => expect( width ).toBeLessThanOrEqual( 100 ) );
+		for ( let i = 1; i < widths.length; i++ ) {
+			expect( widths[ i ] ).toBeLessThan( widths[ i - 1 ] );
+		}
 	} );
 
 	it( 'keeps text full size above the width threshold, then eases it down gradually', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.test.tsx
@@ -120,11 +120,12 @@ describe( 'Funnel render', () => {
 		fills.forEach( fill => {
 			expect( fill.style.clipPath ).toBe( '' );
 		} );
-		// One separator per adjacent pair (n − 1), each clipped to a trapezoid.
+		// One separator per adjacent pair (n − 1). The trapezoid clip-path lives in
+		// CSS; the per-band bottom inset is supplied inline as a percentage.
 		const separators = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-separator' );
 		expect( separators ).toHaveLength( 2 );
 		separators.forEach( separator => {
-			expect( separator.style.clipPath ).toMatch( /^polygon\(/ );
+			expect( separator.style.getPropertyValue( '--separator-inset' ) ).toMatch( /%$/ );
 		} );
 	} );
 
@@ -136,5 +137,19 @@ describe( 'Funnel render', () => {
 		expect( widths[ 0 ] ).toBe( 100 ); // top section pinned to the full width
 		expect( widths[ 1 ] ).toBeLessThan( widths[ 0 ] );
 		expect( widths[ 2 ] ).toBeLessThan( widths[ 1 ] );
+	} );
+
+	it( 'keeps text full size above the width threshold, then eases it down gradually', () => {
+		const { container } = render( <Funnel stages={ stages( [ 'A', 1000 ], [ 'B', 700 ], [ 'C', 450 ], [ 'D', 100 ] ) } /> );
+		const steps = container.querySelectorAll< HTMLElement >( '.newspack-insights__funnel-step' );
+		const scale = ( step: HTMLElement ) => parseFloat( step.style.getPropertyValue( '--funnel-font-scale' ) );
+		// At or above half the top width, text stays full size.
+		expect( scale( steps[ 0 ] ) ).toBe( 1 );
+		expect( scale( steps[ 1 ] ) ).toBe( 1 );
+		// Just past the threshold the reduction is slight — a ramp, not a hard step to
+		// the floor — and it keeps easing down as sections get narrower.
+		expect( scale( steps[ 2 ] ) ).toBeLessThan( 1 );
+		expect( scale( steps[ 2 ] ) ).toBeGreaterThan( 0.9 );
+		expect( scale( steps[ 3 ] ) ).toBeLessThan( scale( steps[ 2 ] ) );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -32,16 +32,29 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import colors from '../../../../../packages/colors/colors.module.scss';
 import { formatNumber, formatPercent } from './format';
 
-const FULL_OPACITY = 1;
-const TAIL_OPACITY = 0.6;
-// Distinct-sections gradient: each band ramps symmetrically around its own shade
-// by this fraction of the step-to-step opacity gap (darker top → lighter bottom).
-const INTERNAL_GRADIENT_FRACTION = 0.5;
-// The bottom of the gradient should be a little less opaque than the top of the
-// next band, so the bands are visually distinct.
-const INTERNAL_GRADIENT_FLOOR = 0.15;
+// Sections and their trapezoidal separators step through discrete stops of the
+// primary color scale (top = darkest, bottom = lightest) rather than fading by
+// opacity. Each band takes the next stop down from the top anchor by its position:
+// fills run primary-700, 600, 500, … ; separators run primary-200, 100, 050, … .
+// A short funnel simply stops early (a 3-step funnel is 700/600/500), and the
+// scales are sized for the 5-stage maximum so the index never runs off the end.
+const FUNNEL_FILL_SCALE = [ 'primary-700', 'primary-600', 'primary-500', 'primary-400', 'primary-300' ];
+const FUNNEL_SEPARATOR_SCALE = [ 'primary-200', 'primary-100', 'primary-050', 'primary-000' ];
+
+/**
+ * The scale stop for a band at `index`: one adjacent stop down from the top anchor
+ * per position, clamped to the last stop. Resolves the token to its hex via the
+ * color map, falling back to the token name if the map can't resolve it (e.g. under
+ * the test env's scss stub).
+ */
+const pickScale = ( scale: string[], index: number ): string => {
+	const token = scale[ Math.min( index, scale.length - 1 ) ];
+	return colors[ token ] ?? token;
+};
+
 // Each band's minimum width, as this fraction of the prior band's width times the
 // total number of steps, to avoid extremely narrow funnels. Capped by
 // MAX_BAND_TAPER below so the floor can never make a band as wide as the one above.
@@ -68,14 +81,6 @@ export interface FunnelStage {
 export interface FunnelProps {
 	stages: FunnelStage[];
 }
-
-/** Linear opacity from 1.0 at the first step to 0.6 at the last. */
-export const stepOpacity = ( index: number, stepCount: number ): number => {
-	if ( stepCount <= 1 ) {
-		return FULL_OPACITY;
-	}
-	return FULL_OPACITY + ( TAIL_OPACITY - FULL_OPACITY ) * ( index / ( stepCount - 1 ) );
-};
 
 /**
  * Drop-off from the previous step as a fraction in [0, 1]. Clamped at 0: funnel
@@ -169,10 +174,6 @@ const Funnel = ( { stages }: FunnelProps ) => {
 		const share = topCount > 0 ? stage.count / topCount : 0;
 		bandWidths.push( Math.max( minBandPct * prev, Math.min( MAX_BAND_TAPER * prev, share ) ) );
 	} );
-	// Half the internal ramp per band, in opacity units. Derived from the step gap
-	// so the sheen scales with the funnel length (subtler on longer funnels).
-	const stepGap = stepCount > 1 ? ( FULL_OPACITY - TAIL_OPACITY ) / ( stepCount - 1 ) : 0;
-	const halfSpan = stepGap * INTERNAL_GRADIENT_FRACTION;
 
 	return (
 		<ol
@@ -185,12 +186,12 @@ const Funnel = ( { stages }: FunnelProps ) => {
 			onBlur={ handleBlur }
 		>
 			{ stages.map( ( stage, index ) => {
-				// Each band ramps symmetrically around its own shade (darker top →
-				// lighter bottom). Adjacent bands do NOT share a boundary value, so a
-				// visible step separates the sections. Clamped to a valid [0,1] alpha.
-				const bandOpacity = stepOpacity( index, stepCount );
-				const topOpacity = Math.min( FULL_OPACITY, bandOpacity + halfSpan );
-				const bottomOpacity = Math.max( 0, bandOpacity - halfSpan - INTERNAL_GRADIENT_FLOOR );
+				// Each band takes a discrete stop of the primary scale (darkest at the
+				// top, lightest at the bottom); the separator below it steps through a
+				// lighter companion scale. Sampled evenly so a short funnel spans the
+				// same endpoints as the 5-stage maximum.
+				const fillColor = pickScale( FUNNEL_FILL_SCALE, index );
+				const separatorColor = pickScale( FUNNEL_SEPARATOR_SCALE, index );
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
 				// Descriptor strings for steps after the first; rendered both as an
@@ -216,8 +217,7 @@ const Funnel = ( { stages }: FunnelProps ) => {
 						className="newspack-insights__funnel-step"
 						style={
 							{
-								'--band-opacity-top': topOpacity,
-								'--band-opacity-bottom': bottomOpacity,
+								'--band-fill': fillColor,
 								'--funnel-font-scale': fontScale,
 								maxWidth: `${ bandWidth * 100 }%`,
 							} as React.CSSProperties
@@ -240,7 +240,7 @@ const Funnel = ( { stages }: FunnelProps ) => {
 								aria-hidden="true"
 								style={
 									{
-										opacity: bandOpacity,
+										'--band-separator': separatorColor,
 										'--separator-inset': `${ separatorInsetPct }%`,
 									} as React.CSSProperties
 								}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -1,24 +1,23 @@
 /**
  * Funnel viz — shared across Insights tabs (Gates, Prompts, Conversion Journey).
  *
- * Self-labeling stacked funnel (NEWS-2586). Each section carries its own label,
- * count, and — for every step after the first — the drop-off descriptors
- * ("X% of {top}" share + "Y% drop-off") INSIDE the section. One uniform layout at
- * every viewport and step count: no side-label/compact split, no separate legend.
+ * Alternative "stepped" treatment (NEWS-2586). The sections are rectangles of
+ * DECREASING width: the top section spans the component's max width and each lower
+ * section is sized in proportion to the top count, floored at a minimum so long
+ * funnels don't collapse to slivers. Between every pair of sections a trapezoidal
+ * SEPARATOR connects the wider section above to the narrower one below.
  *
- * The sections are equal-width rectangles (the overall silhouette is a rectangle,
- * not a tapering funnel): the drop-off between steps is conveyed by the labels and
- * by color alone, not by width. Each band is a full-width <li> with two layers:
- *   - a gradient FILL behind the text; and
- *   - a flowing TEXT layer on top that wraps and grows the band height.
+ * Each section is an <li> with:
+ *   - a gradient FILL behind the text (primary-600, opacity fading 1.0 → 0.6 down
+ *     the funnel — each band ramps around its own shade for a distinct-sections
+ *     look; white text above DARK_TEXT_OPACITY_THRESHOLD, dark text below); and
+ *   - a TEXT layer with the section label + count.
+ * The per-step drop-off descriptors ("X% of {top}" + "Y% drop-off from previous")
+ * live in a Popover that floats beside the section and is revealed for the WHOLE
+ * funnel on hover/focus (see the hover/focus state in the component).
  *
- * Width is CSS-driven (width:100%, max-width cap), so no JS measurement is needed.
- * The single anchor color (primary-600) fades 1.0 → 0.6 down the funnel — the sole
- * visual differentiator between sections. Each band's fill is a vertical gradient
- * ramping symmetrically around its own shade (darker top → lighter bottom); because
- * adjacent bands don't share a boundary value, a visible step keeps the sections
- * distinct. Bands whose shade is above DARK_TEXT_OPACITY_THRESHOLD take white text,
- * below it dark text.
+ * Widths are set inline (maxWidth %) and the separators are trapezoids via an
+ * inline clip-path, so both scale fluidly with no JS measurement of the DOM.
  */
 
 /**
@@ -26,6 +25,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -79,28 +79,43 @@ export const dropFromPrevious = ( count: number, prevCount: number ): number => 
  */
 const StepLabels = ( { pctOfTop, drop, topLabel }: { pctOfTop: number; drop: number; topLabel: string } ) => (
 	<Popover className="newspack-insights__funnel-labels" offset={ 16 } placement="right" shift>
-		<span className="newspack-insights__funnel-label-pct">
+		<p className="newspack-insights__funnel-label-pct">
 			{ sprintf(
 				/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
 				__( '%1$s of %2$s', 'newspack-plugin' ),
 				formatPercent( pctOfTop ),
 				topLabel
 			) }
-		</span>{ ' ' }
-		<span className="newspack-insights__funnel-label-drop">
+		</p>
+		<p className="newspack-insights__funnel-label-drop">
 			<span aria-hidden="true" className="newspack-insights__funnel-label-drop-arrow">
 				↓
 			</span>{ ' ' }
 			{ sprintf(
 				/* translators: %s: percentage drop-off from the previous stage. */
-				__( '%s drop-off from previous', 'newspack-plugin' ),
+				__( '%s drop-off', 'newspack-plugin' ),
 				formatPercent( drop )
 			) }
-		</span>
+		</p>
 	</Popover>
 );
 
 const Funnel = ( { stages }: FunnelProps ) => {
+	// The floating label Popovers are revealed for the whole funnel while it is
+	// hovered or holds focus; tracking hover and focus separately keeps the labels
+	// up when the pointer leaves but keyboard focus is still inside, and vice versa.
+	const [ isHovered, setIsHovered ] = useState( false );
+	const [ isFocused, setIsFocused ] = useState( false );
+	const isActive = isHovered || isFocused;
+
+	// Blur only deactivates when focus actually leaves the funnel, not when it moves
+	// between sections inside it.
+	const handleBlur = ( event: React.FocusEvent< HTMLOListElement > ) => {
+		if ( ! event.currentTarget.contains( event.relatedTarget as Node | null ) ) {
+			setIsFocused( false );
+		}
+	};
+
 	const topCount = stages.length > 0 ? stages[ 0 ].count : 0;
 	const topLabel = stages.length > 0 ? stages[ 0 ].label : '';
 
@@ -123,7 +138,15 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	let prevBandWidth = 1;
 
 	return (
-		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
+		<ol
+			className="newspack-insights__funnel"
+			aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }
+			tabIndex={ 0 }
+			onMouseEnter={ () => setIsHovered( true ) }
+			onMouseLeave={ () => setIsHovered( false ) }
+			onFocus={ () => setIsFocused( true ) }
+			onBlur={ handleBlur }
+		>
 			{ stages.map( ( stage, index ) => {
 				// Each band ramps symmetrically around its own shade (darker top →
 				// lighter bottom). Adjacent bands do NOT share a boundary value, so a
@@ -137,6 +160,13 @@ const Funnel = ( { stages }: FunnelProps ) => {
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
 				const bandWidth = Math.max( minBandPct * prevBandWidth, pctOfTop );
 				prevBandWidth = bandWidth;
+				// The separator below this section is a trapezoid: its top edge spans
+				// this (wider) section and its bottom edge is clipped to the next
+				// (narrower) section's width. The ratio is relative to this section,
+				// since the separator spans its full width. Clamped to ≤ 1 (no flare).
+				const nextBandWidth = index < stepCount - 1 ? Math.max( minBandPct * bandWidth, stages[ index + 1 ].count / topCount ) : bandWidth;
+				const separatorBottomRatio = bandWidth > 0 ? Math.min( 1, nextBandWidth / bandWidth ) : 1;
+				const separatorInsetPct = ( ( 1 - separatorBottomRatio ) / 2 ) * 100;
 				return (
 					<li
 						key={ index }
@@ -153,13 +183,15 @@ const Funnel = ( { stages }: FunnelProps ) => {
 						<span className="newspack-insights__funnel-content">
 							<span className="newspack-insights__funnel-label-name">{ stage.label }</span>
 							<span className="newspack-insights__funnel-label-count">{ formatNumber( stage.count ) }</span>
-							{ drop !== null && <StepLabels pctOfTop={ pctOfTop } drop={ drop } topLabel={ topLabel } /> }
+							{ drop !== null && isActive && <StepLabels pctOfTop={ pctOfTop } drop={ drop } topLabel={ topLabel } /> }
 						</span>
 						{ index < stages.length - 1 && (
 							<span
 								className="newspack-insights__funnel-separator"
+								aria-hidden="true"
 								style={ {
 									opacity: bandOpacity,
+									clipPath: `polygon(0 0, 100% 0, ${ 100 - separatorInsetPct }% 100%, ${ separatorInsetPct }% 100%)`,
 								} }
 							/>
 						) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -10,14 +10,16 @@
  * Each section is an <li> with:
  *   - a gradient FILL behind the text (primary-600, opacity fading 1.0 → 0.6 down
  *     the funnel — each band ramps around its own shade for a distinct-sections
- *     look; white text above DARK_TEXT_OPACITY_THRESHOLD, dark text below); and
- *   - a TEXT layer with the section label + count.
+ *     look); and
+ *   - a TEXT layer with the section label + count (white text with a dark shadow,
+ *     legible over both the dark upper bands and the faded lower ones).
  * The per-step drop-off descriptors ("X% of {top}" + "Y% drop-off from previous")
  * live in a Popover that floats beside the section and is revealed for the WHOLE
  * funnel on hover/focus (see the hover/focus state in the component).
  *
- * Widths are set inline (maxWidth %) and the separators are trapezoids via an
- * inline clip-path, so both scale fluidly with no JS measurement of the DOM.
+ * Widths are set inline (maxWidth %) and the separators are trapezoids clipped in
+ * CSS (each band's bottom inset supplied inline via --separator-inset), so both
+ * scale fluidly with no JS measurement of the DOM.
  */
 
 /**
@@ -34,18 +36,21 @@ import { formatNumber, formatPercent } from './format';
 
 const FULL_OPACITY = 1;
 const TAIL_OPACITY = 0.6;
-// Above this band opacity the fill is dark enough for white text; below it the
-// faded band needs dark text.
-const DARK_TEXT_OPACITY_THRESHOLD = 0.4;
 // Distinct-sections gradient: each band ramps symmetrically around its own shade
 // by this fraction of the step-to-step opacity gap (darker top → lighter bottom).
 const INTERNAL_GRADIENT_FRACTION = 0.5;
 // The bottom of the gradient should be a little less opaque than the top of the
 // next band, so the bands are visually distinct.
 const INTERNAL_GRADIENT_FLOOR = 0.15;
-// Each band should be no less than this fraction of the prior band's width times
-// the total number of steps, toavoid extremely narrow funnels.
+// Each band's minimum width, as this fraction of the prior band's width times the
+// total number of steps, to avoid extremely narrow funnels. Capped by
+// MAX_BAND_TAPER below so the floor can never make a band as wide as the one above.
 const MINIMUM_BAND_PROPORTION = 0.12;
+// Each band is at most this fraction of the band above it, so widths always
+// decrease (a visible taper) — even for very long funnels (where
+// MINIMUM_BAND_PROPORTION * stepCount would otherwise exceed 1) or under data drift
+// (where a later stage's raw share of the top can exceed the prior band).
+const MAX_BAND_TAPER = 0.9;
 // Section text stays full size until a section narrows past FONT_SCALE_THRESHOLD of
 // the top width, then ramps down linearly toward FONT_SCALE_FLOOR of the top
 // section's size (reached only as the width approaches 0) — a gradual reduction
@@ -80,31 +85,38 @@ export const stepOpacity = ( index: number, stepCount: number ): number => {
 export const dropFromPrevious = ( count: number, prevCount: number ): number => ( prevCount > 0 ? Math.max( 0, 1 - count / prevCount ) : 0 );
 
 /**
- * The two descriptive lines for every step beyond the first: what share of the top
- * stage reached here, and the stage-to-stage drop-off. Color is inherited from the
- * band (white on dark bands, dark on faded ones) — these describe funnel
- * progression, not a period comparison, so never red/green.
+ * The two descriptor strings for every step beyond the first: what share of the top
+ * stage reached here, and the stage-to-stage drop-off. Built once and used by both
+ * the always-present screen-reader copy and the on-hover Popover.
  */
-const StepLabels = ( { pctOfTop, drop, topLabel }: { pctOfTop: number; drop: number; topLabel: string } ) => (
+const formatStepDescriptors = ( pctOfTop: number, drop: number, topLabel: string ) => ( {
+	share: sprintf(
+		/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
+		__( '%1$s of %2$s', 'newspack-plugin' ),
+		formatPercent( pctOfTop ),
+		topLabel
+	),
+	drop: sprintf(
+		/* translators: %s: percentage drop-off from the previous stage. */
+		__( '%s drop-off', 'newspack-plugin' ),
+		formatPercent( drop )
+	),
+} );
+
+/**
+ * The hover/focus-revealed Popover carrying a step's descriptors. It's a visual
+ * affordance only — the same text is always present in a screen-reader node on the
+ * section — so its content is aria-hidden to avoid a duplicate announcement. These
+ * describe funnel progression, not a period comparison, so never red/green.
+ */
+const StepLabels = ( { share, drop }: { share: string; drop: string } ) => (
 	<Popover className="newspack-insights__funnel-labels" offset={ 16 } placement="right" shift>
-		<p className="newspack-insights__funnel-label-pct">
-			{ sprintf(
-				/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
-				__( '%1$s of %2$s', 'newspack-plugin' ),
-				formatPercent( pctOfTop ),
-				topLabel
-			) }
-		</p>
-		<p className="newspack-insights__funnel-label-drop">
-			<span aria-hidden="true" className="newspack-insights__funnel-label-drop-arrow">
-				↓
-			</span>{ ' ' }
-			{ sprintf(
-				/* translators: %s: percentage drop-off from the previous stage. */
-				__( '%s drop-off', 'newspack-plugin' ),
-				formatPercent( drop )
-			) }
-		</p>
+		<div aria-hidden="true">
+			<p className="newspack-insights__funnel-label-pct">{ share }</p>
+			<p className="newspack-insights__funnel-label-drop">
+				<span className="newspack-insights__funnel-label-drop-arrow">↓</span> { drop }
+			</p>
+		</div>
 	</Popover>
 );
 
@@ -138,12 +150,29 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	}
 
 	const stepCount = stages.length;
-	const minBandPct = MINIMUM_BAND_PROPORTION * stepCount;
+	// Floor multiplier for each band's width, capped at MAX_BAND_TAPER so a long
+	// funnel (where MINIMUM_BAND_PROPORTION * stepCount ≥ 1) can't floor a band as
+	// wide as the one above.
+	const minBandPct = Math.min( MAX_BAND_TAPER, MINIMUM_BAND_PROPORTION * stepCount );
+	// Width fraction of each section. The top spans the full width; every lower
+	// section follows its share of the top count, but capped at MAX_BAND_TAPER of the
+	// band above (so widths strictly decrease, even when data drift pushes a raw
+	// share ≥ the prior band) and floored at minBandPct of it (so long funnels don't
+	// collapse to slivers).
+	const bandWidths: number[] = [];
+	stages.forEach( ( stage, index ) => {
+		if ( index === 0 ) {
+			bandWidths.push( 1 );
+			return;
+		}
+		const prev = bandWidths[ index - 1 ];
+		const share = topCount > 0 ? stage.count / topCount : 0;
+		bandWidths.push( Math.max( minBandPct * prev, Math.min( MAX_BAND_TAPER * prev, share ) ) );
+	} );
 	// Half the internal ramp per band, in opacity units. Derived from the step gap
 	// so the sheen scales with the funnel length (subtler on longer funnels).
 	const stepGap = stepCount > 1 ? ( FULL_OPACITY - TAIL_OPACITY ) / ( stepCount - 1 ) : 0;
 	const halfSpan = stepGap * INTERNAL_GRADIENT_FRACTION;
-	let prevBandWidth = 1;
 
 	return (
 		<ol
@@ -162,12 +191,12 @@ const Funnel = ( { stages }: FunnelProps ) => {
 				const bandOpacity = stepOpacity( index, stepCount );
 				const topOpacity = Math.min( FULL_OPACITY, bandOpacity + halfSpan );
 				const bottomOpacity = Math.max( 0, bandOpacity - halfSpan - INTERNAL_GRADIENT_FLOOR );
-				// Contrast tracks the band's own shade (its ramp midpoint).
-				const isDark = bandOpacity > DARK_TEXT_OPACITY_THRESHOLD;
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
-				const bandWidth = Math.max( minBandPct * prevBandWidth, pctOfTop );
-				prevBandWidth = bandWidth;
+				// Descriptor strings for steps after the first; rendered both as an
+				// always-present screen-reader node and (on hover/focus) the Popover.
+				const descriptors = drop !== null ? formatStepDescriptors( pctOfTop, drop, topLabel ) : null;
+				const bandWidth = bandWidths[ index ];
 				// Text is full size at/above FONT_SCALE_THRESHOLD of the top width, then
 				// eases down linearly toward FONT_SCALE_FLOOR as the section narrows —
 				// a gradual ramp rather than a step at the threshold.
@@ -178,13 +207,13 @@ const Funnel = ( { stages }: FunnelProps ) => {
 				// (narrower) section's width. The inset is a % of this section (the
 				// separator spans its full width); the CSS floors it so the bottom edge
 				// never drops below the section min-width. Ratio clamped to ≤ 1 (no flare).
-				const nextBandWidth = index < stepCount - 1 ? Math.max( minBandPct * bandWidth, stages[ index + 1 ].count / topCount ) : bandWidth;
+				const nextBandWidth = index < stepCount - 1 ? bandWidths[ index + 1 ] : bandWidth;
 				const separatorBottomRatio = bandWidth > 0 ? Math.min( 1, nextBandWidth / bandWidth ) : 1;
 				const separatorInsetPct = ( ( 1 - separatorBottomRatio ) / 2 ) * 100;
 				return (
 					<li
 						key={ index }
-						className={ 'newspack-insights__funnel-step ' + ( isDark ? 'is-on-dark' : 'is-on-light' ) }
+						className="newspack-insights__funnel-step"
 						style={
 							{
 								'--band-opacity-top': topOpacity,
@@ -198,7 +227,12 @@ const Funnel = ( { stages }: FunnelProps ) => {
 						<span className="newspack-insights__funnel-content">
 							<span className="newspack-insights__funnel-label-name">{ stage.label }</span>
 							<span className="newspack-insights__funnel-label-count">{ formatNumber( stage.count ) }</span>
-							{ drop !== null && isActive && <StepLabels pctOfTop={ pctOfTop } drop={ drop } topLabel={ topLabel } /> }
+							{ descriptors && (
+								<>
+									<span className="screen-reader-text">{ `${ descriptors.share }. ${ descriptors.drop }.` }</span>
+									{ isActive && <StepLabels share={ descriptors.share } drop={ descriptors.drop } /> }
+								</>
+							) }
 						</span>
 						{ index < stages.length - 1 && (
 							<span

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -25,6 +25,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -35,12 +36,15 @@ const FULL_OPACITY = 1;
 const TAIL_OPACITY = 0.6;
 // Above this band opacity the fill is dark enough for white text; below it the
 // faded band needs dark text.
-const DARK_TEXT_OPACITY_THRESHOLD = 0.75;
+const DARK_TEXT_OPACITY_THRESHOLD = 0.4;
 // Distinct-sections gradient: each band ramps symmetrically around its own shade
 // by this fraction of the step-to-step opacity gap (darker top → lighter bottom).
-// Kept below 0.5 so adjacent bands do NOT share a boundary value — a visible step
-// stays between them, unlike a seamless funnel-wide ramp.
-const INTERNAL_GRADIENT_FRACTION = 0.25;
+const INTERNAL_GRADIENT_FRACTION = 0.5;
+// The bottom of the gradient should be a little less opaque than the top of the
+// next band, so the bands are visually distinct.
+const INTERNAL_GRADIENT_FLOOR = 0.15;
+// Each band should be no less than this fraction of the prior band's width, to
+// avoid extremely narrow funnels.
 
 export interface FunnelStage {
 	label: string;
@@ -74,7 +78,7 @@ export const dropFromPrevious = ( count: number, prevCount: number ): number => 
  * progression, not a period comparison, so never red/green.
  */
 const StepLabels = ( { pctOfTop, drop, topLabel }: { pctOfTop: number; drop: number; topLabel: string } ) => (
-	<>
+	<Popover className="newspack-insights__funnel-labels" offset={ 16 } placement="right" shift>
 		<span className="newspack-insights__funnel-label-pct">
 			{ sprintf(
 				/* translators: 1: percentage, 2: name of the first/top funnel stage (e.g. "Impression"). */
@@ -82,18 +86,18 @@ const StepLabels = ( { pctOfTop, drop, topLabel }: { pctOfTop: number; drop: num
 				formatPercent( pctOfTop ),
 				topLabel
 			) }
-		</span>
+		</span>{ ' ' }
 		<span className="newspack-insights__funnel-label-drop">
 			<span aria-hidden="true" className="newspack-insights__funnel-label-drop-arrow">
 				↓
 			</span>{ ' ' }
 			{ sprintf(
 				/* translators: %s: percentage drop-off from the previous stage. */
-				__( '%s drop-off', 'newspack-plugin' ),
+				__( '%s drop-off from previous', 'newspack-plugin' ),
 				formatPercent( drop )
 			) }
 		</span>
-	</>
+	</Popover>
 );
 
 const Funnel = ( { stages }: FunnelProps ) => {
@@ -111,10 +115,12 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	}
 
 	const stepCount = stages.length;
+	const minBandPct = 0.15 * stepCount;
 	// Half the internal ramp per band, in opacity units. Derived from the step gap
 	// so the sheen scales with the funnel length (subtler on longer funnels).
 	const stepGap = stepCount > 1 ? ( FULL_OPACITY - TAIL_OPACITY ) / ( stepCount - 1 ) : 0;
 	const halfSpan = stepGap * INTERNAL_GRADIENT_FRACTION;
+	let prevBandWidth = 1;
 
 	return (
 		<ol className="newspack-insights__funnel" aria-label={ __( 'Conversion funnel', 'newspack-plugin' ) }>
@@ -124,11 +130,13 @@ const Funnel = ( { stages }: FunnelProps ) => {
 				// visible step separates the sections. Clamped to a valid [0,1] alpha.
 				const bandOpacity = stepOpacity( index, stepCount );
 				const topOpacity = Math.min( FULL_OPACITY, bandOpacity + halfSpan );
-				const bottomOpacity = Math.max( 0, bandOpacity - halfSpan );
+				const bottomOpacity = Math.max( 0, bandOpacity - halfSpan - INTERNAL_GRADIENT_FLOOR );
 				// Contrast tracks the band's own shade (its ramp midpoint).
 				const isDark = bandOpacity > DARK_TEXT_OPACITY_THRESHOLD;
 				const pctOfTop = topCount > 0 ? stage.count / topCount : 0;
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
+				const bandWidth = Math.max( minBandPct * prevBandWidth, pctOfTop );
+				prevBandWidth = bandWidth;
 				return (
 					<li
 						key={ index }
@@ -137,6 +145,7 @@ const Funnel = ( { stages }: FunnelProps ) => {
 							{
 								'--band-opacity-top': topOpacity,
 								'--band-opacity-bottom': bottomOpacity,
+								maxWidth: `${ bandWidth * 100 }%`,
 							} as React.CSSProperties
 						}
 					>
@@ -146,6 +155,14 @@ const Funnel = ( { stages }: FunnelProps ) => {
 							<span className="newspack-insights__funnel-label-count">{ formatNumber( stage.count ) }</span>
 							{ drop !== null && <StepLabels pctOfTop={ pctOfTop } drop={ drop } topLabel={ topLabel } /> }
 						</span>
+						{ index < stages.length - 1 && (
+							<span
+								className="newspack-insights__funnel-separator"
+								style={ {
+									opacity: bandOpacity,
+								} }
+							/>
+						) }
 					</li>
 				);
 			} ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Funnel.tsx
@@ -43,8 +43,16 @@ const INTERNAL_GRADIENT_FRACTION = 0.5;
 // The bottom of the gradient should be a little less opaque than the top of the
 // next band, so the bands are visually distinct.
 const INTERNAL_GRADIENT_FLOOR = 0.15;
-// Each band should be no less than this fraction of the prior band's width, to
-// avoid extremely narrow funnels.
+// Each band should be no less than this fraction of the prior band's width times
+// the total number of steps, toavoid extremely narrow funnels.
+const MINIMUM_BAND_PROPORTION = 0.12;
+// Section text stays full size until a section narrows past FONT_SCALE_THRESHOLD of
+// the top width, then ramps down linearly toward FONT_SCALE_FLOOR of the top
+// section's size (reached only as the width approaches 0) — a gradual reduction
+// rather than a hard step at the threshold. Name and count share the one scale, so
+// their relative sizes stay constant as they shrink together.
+const FONT_SCALE_THRESHOLD = 0.5;
+const FONT_SCALE_FLOOR = 0.75;
 
 export interface FunnelStage {
 	label: string;
@@ -130,7 +138,7 @@ const Funnel = ( { stages }: FunnelProps ) => {
 	}
 
 	const stepCount = stages.length;
-	const minBandPct = 0.15 * stepCount;
+	const minBandPct = MINIMUM_BAND_PROPORTION * stepCount;
 	// Half the internal ramp per band, in opacity units. Derived from the step gap
 	// so the sheen scales with the funnel length (subtler on longer funnels).
 	const stepGap = stepCount > 1 ? ( FULL_OPACITY - TAIL_OPACITY ) / ( stepCount - 1 ) : 0;
@@ -160,10 +168,16 @@ const Funnel = ( { stages }: FunnelProps ) => {
 				const drop = index > 0 ? dropFromPrevious( stage.count, stages[ index - 1 ].count ) : null;
 				const bandWidth = Math.max( minBandPct * prevBandWidth, pctOfTop );
 				prevBandWidth = bandWidth;
+				// Text is full size at/above FONT_SCALE_THRESHOLD of the top width, then
+				// eases down linearly toward FONT_SCALE_FLOOR as the section narrows —
+				// a gradual ramp rather than a step at the threshold.
+				const widthRatio = Math.min( 1, bandWidth / FONT_SCALE_THRESHOLD );
+				const fontScale = FONT_SCALE_FLOOR + ( 1 - FONT_SCALE_FLOOR ) * widthRatio;
 				// The separator below this section is a trapezoid: its top edge spans
-				// this (wider) section and its bottom edge is clipped to the next
-				// (narrower) section's width. The ratio is relative to this section,
-				// since the separator spans its full width. Clamped to ≤ 1 (no flare).
+				// this (wider) section and its bottom edge insets toward the next
+				// (narrower) section's width. The inset is a % of this section (the
+				// separator spans its full width); the CSS floors it so the bottom edge
+				// never drops below the section min-width. Ratio clamped to ≤ 1 (no flare).
 				const nextBandWidth = index < stepCount - 1 ? Math.max( minBandPct * bandWidth, stages[ index + 1 ].count / topCount ) : bandWidth;
 				const separatorBottomRatio = bandWidth > 0 ? Math.min( 1, nextBandWidth / bandWidth ) : 1;
 				const separatorInsetPct = ( ( 1 - separatorBottomRatio ) / 2 ) * 100;
@@ -175,6 +189,7 @@ const Funnel = ( { stages }: FunnelProps ) => {
 							{
 								'--band-opacity-top': topOpacity,
 								'--band-opacity-bottom': bottomOpacity,
+								'--funnel-font-scale': fontScale,
 								maxWidth: `${ bandWidth * 100 }%`,
 							} as React.CSSProperties
 						}
@@ -189,10 +204,12 @@ const Funnel = ( { stages }: FunnelProps ) => {
 							<span
 								className="newspack-insights__funnel-separator"
 								aria-hidden="true"
-								style={ {
-									opacity: bandOpacity,
-									clipPath: `polygon(0 0, 100% 0, ${ 100 - separatorInsetPct }% 100%, ${ separatorInsetPct }% 100%)`,
-								} }
+								style={
+									{
+										opacity: bandOpacity,
+										'--separator-inset': `${ separatorInsetPct }%`,
+									} as React.CSSProperties
+								}
 							/>
 						) }
 					</li>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -612,7 +612,7 @@
 		padding: 20px;
 		box-sizing: border-box;
 		list-style: none;
-		background-color: #fff;
+		background-color: wp-colors.$white;
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 4px;
 
@@ -622,7 +622,7 @@
 			flex-direction: column;
 			align-items: center;
 			justify-content: center;
-			margin-bottom: 25px;
+			margin-bottom: 24px;
 			margin-left: auto;
 			margin-right: auto;
 			min-height: 75px; // baseline; grows with wrapped content.
@@ -635,7 +635,7 @@
 			}
 		}
 
-		// Transition connector filling the 25px gap below each section (except the
+		// Transition connector filling the 24px gap below each section (except the
 		// last). A filled box clipped to a trapezoid: its top edge spans the section
 		// above (this element's full width) and its bottom edge insets by the inline
 		// --separator-inset to match the narrower section below — but never so far
@@ -647,7 +647,7 @@
 			top: 100%;
 			left: 0;
 			width: 100%;
-			height: 25px;
+			height: 24px;
 			background-color: #{colors.$primary-200};
 			// Clamp the per-side inset so the bottom edge can't be narrower than the
 			// section min-width: ( 100% − min-width ) / 2 is the inset that yields
@@ -680,6 +680,10 @@
 			flex-direction: column;
 			align-items: center;
 			max-width: 160px; // wrap width for the descriptor lines.
+			// Always white text; the dark shadow keeps it legible over both the dark
+			// upper bands and the faded (light) lower ones — no per-band color switch.
+			color: wp-colors.$white;
+			text-shadow: 0 1px 2px rgba( wp-colors.$gray-900, 0.5 );
 		}
 
 		&-labels {
@@ -705,7 +709,8 @@
 			line-height: 1.15;
 		}
 
-		// Stage descriptors inherit the band's text color (white/dark); muted weight.
+		// Stage descriptors sit inside the floating Popover (its own light surface),
+		// so they use its default dark text; muted weight.
 		&-label-pct {
 			font-size: 12px;
 			line-height: 1.35;
@@ -726,18 +731,6 @@
 			font-size: 13px;
 			color: wp-colors.$gray-600;
 		}
-	}
-
-	// Contrast follows band opacity: white text on the dark upper bands (with a
-	// soft halo so any spill over the white card stays legible), dark text on the
-	// faded lower bands (reads on both the light fill and the card).
-	&__funnel-step.is-on-dark &__funnel-content {
-		color: #fff;
-		text-shadow: 0 1px 1px #{colors.$primary-500};
-	}
-
-	&__funnel-step.is-on-light &__funnel-content {
-		color: wp-colors.$gray-900;
 	}
 
 	// Sortable table affordances — shared across all tabs that embed SortableTable

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -603,7 +603,7 @@
 	// alone, not by width.
 	&__funnel {
 		width: 100%;
-		max-width: 500px; // NEWS-2586 container cap; grid cells render narrower (fluid).
+		max-width: 600px; // NEWS-2586 container cap; grid cells render narrower (fluid).
 		margin: 0 auto;
 		padding: 20px;
 		box-sizing: border-box;
@@ -621,7 +621,7 @@
 			margin-bottom: 25px;
 			margin-left: auto;
 			margin-right: auto;
-			min-height: 100px; // baseline; grows with wrapped content.
+			min-height: 75px; // baseline; grows with wrapped content.
 			min-width: 80px; // Absolute minimum width of any step.
 			padding: 12px 8px;
 			box-sizing: border-box;
@@ -631,16 +631,18 @@
 			}
 		}
 
+		// Transition connector filling the 25px gap below each section (except the
+		// last). A filled box clipped to a trapezoid via an inline clip-path: its top
+		// edge spans the section above (this element's full width) and its bottom edge
+		// matches the narrower section below. Opacity is set inline to track the
+		// band's shade.
 		&-separator {
-			border-top: 25px solid #{colors.$primary-200};
-			border-left: 25px solid transparent;
-			border-right: 25px solid transparent;
-			content: '';
-			left: 0;
-			height: 0;
 			position: absolute;
 			top: 100%;
-			width: calc( 100% - 50px );
+			left: 0;
+			width: 100%;
+			height: 25px;
+			background-color: #{colors.$primary-200};
 		}
 
 		// Fill: the single anchor color as a vertical gradient covering the full-width
@@ -690,15 +692,16 @@
 
 		// Stage descriptors inherit the band's text color (white/dark); muted weight.
 		&-label-pct {
-			margin-top: 4px;
 			font-size: 12px;
 			line-height: 1.35;
+			margin: 0;
 		}
 
 		&-label-drop {
 			font-size: 12px;
 			line-height: 1.35;
 			font-variant-numeric: tabular-nums;
+			margin: 0;
 		}
 
 		&-empty {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -618,10 +618,29 @@
 			flex-direction: column;
 			align-items: center;
 			justify-content: center;
-			min-height: 72px; // baseline; grows with wrapped content.
+			margin-bottom: 25px;
+			margin-left: auto;
+			margin-right: auto;
+			min-height: 100px; // baseline; grows with wrapped content.
+			min-width: 80px; // Absolute minimum width of any step.
 			padding: 12px 8px;
 			box-sizing: border-box;
 			text-align: center;
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		&-separator {
+			border-top: 25px solid #{colors.$primary-200};
+			border-left: 25px solid transparent;
+			border-right: 25px solid transparent;
+			content: '';
+			left: 0;
+			height: 0;
+			position: absolute;
+			top: 100%;
+			width: calc( 100% - 50px );
 		}
 
 		// Fill: the single anchor color as a vertical gradient covering the full-width
@@ -648,6 +667,12 @@
 			flex-direction: column;
 			align-items: center;
 			max-width: 160px; // wrap width for the descriptor lines.
+		}
+
+		&-labels {
+			.components-popover__content {
+				padding: 4px 8px;
+			}
 		}
 
 		&-label-name {
@@ -690,7 +715,7 @@
 	// faded lower bands (reads on both the light fill and the card).
 	&__funnel-step.is-on-dark &__funnel-content {
 		color: #fff;
-		text-shadow: 0 1px 2px rgba( 13, 53, 102, 0.45 );
+		text-shadow: 0 1px 1px #{colors.$primary-500};
 	}
 
 	&__funnel-step.is-on-light &__funnel-content {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -598,7 +598,7 @@
 	// Self-labeling equal-width rectangles (NEWS-2586): each band carries its label,
 	// count, and (for every step after the first) the drop-off descriptors INSIDE
 	// it. One uniform layout at every width/step-count — no side column, no legend.
-	// Each band is a full-width <li> with a solid FILL behind a flowing TEXT layer
+	// Each band is a full-width <li> with a gradient FILL behind a flowing TEXT layer
 	// that wraps and grows the band. Sections are differentiated by color (opacity)
 	// alone, not by width.
 	&__funnel {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -615,7 +615,7 @@
 		list-style: none;
 		background-color: wp-colors.$white;
 		border: 1px solid wp-colors.$gray-200;
-		border-radius: 4px;
+		border-radius: wp-vars.$radius-medium;
 
 		&-step {
 			position: relative;
@@ -689,31 +689,31 @@
 		// Name and count scale together with the section width via the shared
 		// --funnel-font-scale (set inline per section, floored in JS), so narrower
 		// sections shrink their text proportionally without changing the name:count
-		// ratio. Unitless line-heights scale with the font automatically.
+		// ratio. Line-heights run through the same calc so they scale with the font.
 		&-label-name {
-			font-size: calc( 14px * var( --funnel-font-scale, 1 ) );
+			font-size: calc( #{wp-vars.$font-size-medium} * var( --funnel-font-scale, 1 ) );
 			font-weight: 600;
-			line-height: 1.2;
+			line-height: calc( #{wp-vars.$font-line-height-medium} * var( --funnel-font-scale, 1 ) );
 		}
 
 		&-label-count {
-			font-size: calc( 22px * var( --funnel-font-scale, 1 ) );
+			font-size: calc( #{wp-vars.$font-size-x-large} * var( --funnel-font-scale, 1 ) );
 			font-weight: 700;
 			font-variant-numeric: tabular-nums;
-			line-height: 1.15;
+			line-height: calc( #{wp-vars.$font-line-height-x-large} * var( --funnel-font-scale, 1 ) );
 		}
 
 		// Stage descriptors sit inside the floating Popover (its own light surface),
 		// so they use its default dark text; muted weight.
 		&-label-pct {
-			font-size: 12px;
-			line-height: 1.35;
+			font-size: wp-vars.$font-size-small;
+			line-height: wp-vars.$font-line-height-small;
 			margin: 0;
 		}
 
 		&-label-drop {
-			font-size: 12px;
-			line-height: 1.35;
+			font-size: wp-vars.$font-size-small;
+			line-height: wp-vars.$font-line-height-small;
 			font-variant-numeric: tabular-nums;
 			margin: 0;
 		}
@@ -722,7 +722,7 @@
 			margin: 0;
 			padding: 32px 20px;
 			text-align: center;
-			font-size: 13px;
+			font-size: wp-vars.$font-size-medium;
 			color: wp-colors.$gray-600;
 		}
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -602,8 +602,12 @@
 	// that wraps and grows the band. Sections are differentiated by color (opacity)
 	// alone, not by width.
 	&__funnel {
+		// Absolute minimum rendered width of any section; also the floor the
+		// transition separators clamp their bottom edge to (see &-separator), so a
+		// connector never ends up narrower than the min-width section beneath it.
+		$funnel-min-band-width: 80px;
+
 		width: 100%;
-		max-width: 600px; // NEWS-2586 container cap; grid cells render narrower (fluid).
 		margin: 0 auto;
 		padding: 20px;
 		box-sizing: border-box;
@@ -622,7 +626,7 @@
 			margin-left: auto;
 			margin-right: auto;
 			min-height: 75px; // baseline; grows with wrapped content.
-			min-width: 80px; // Absolute minimum width of any step.
+			min-width: $funnel-min-band-width; // Absolute minimum width of any step.
 			padding: 12px 8px;
 			box-sizing: border-box;
 			text-align: center;
@@ -632,10 +636,12 @@
 		}
 
 		// Transition connector filling the 25px gap below each section (except the
-		// last). A filled box clipped to a trapezoid via an inline clip-path: its top
-		// edge spans the section above (this element's full width) and its bottom edge
-		// matches the narrower section below. Opacity is set inline to track the
-		// band's shade.
+		// last). A filled box clipped to a trapezoid: its top edge spans the section
+		// above (this element's full width) and its bottom edge insets by the inline
+		// --separator-inset to match the narrower section below — but never so far
+		// that the bottom drops below the section min-width, so the connector always
+		// meets the top of the (min-width-floored) section beneath it. Opacity is set
+		// inline to track the band's shade.
 		&-separator {
 			position: absolute;
 			top: 100%;
@@ -643,6 +649,11 @@
 			width: 100%;
 			height: 25px;
 			background-color: #{colors.$primary-200};
+			// Clamp the per-side inset so the bottom edge can't be narrower than the
+			// section min-width: ( 100% − min-width ) / 2 is the inset that yields
+			// exactly min-width at the bottom.
+			--_separator-inset: min( var( --separator-inset, 0% ), calc( ( 100% - #{ $funnel-min-band-width } ) / 2 ) );
+			clip-path: polygon( 0 0, 100% 0, calc( 100% - var( --_separator-inset ) ) 100%, var( --_separator-inset ) 100% );
 		}
 
 		// Fill: the single anchor color as a vertical gradient covering the full-width
@@ -677,14 +688,18 @@
 			}
 		}
 
+		// Name and count scale together with the section width via the shared
+		// --funnel-font-scale (set inline per section, floored in JS), so narrower
+		// sections shrink their text proportionally without changing the name:count
+		// ratio. Unitless line-heights scale with the font automatically.
 		&-label-name {
-			font-size: 14px;
+			font-size: calc( 14px * var( --funnel-font-scale, 1 ) );
 			font-weight: 600;
 			line-height: 1.2;
 		}
 
 		&-label-count {
-			font-size: 22px;
+			font-size: calc( 22px * var( --funnel-font-scale, 1 ) );
 			font-weight: 700;
 			font-variant-numeric: tabular-nums;
 			line-height: 1.15;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -9,6 +9,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "../../../../../packages/colors/colors.module" as colors;
 
 // Categorical series palette for charts. Hardcoded because a chart needs
@@ -609,7 +610,7 @@
 
 		width: 100%;
 		margin: 0 auto;
-		padding: 20px;
+		padding: wp-vars.$grid-unit-10;
 		box-sizing: border-box;
 		list-style: none;
 		background-color: wp-colors.$white;
@@ -648,7 +649,7 @@
 			left: 0;
 			width: 100%;
 			height: 24px;
-			background-color: #{colors.$primary-200};
+			background-color: var( --band-separator, #{colors.$primary-000} );
 			// Clamp the per-side inset so the bottom edge can't be narrower than the
 			// section min-width: ( 100% − min-width ) / 2 is the inset that yields
 			// exactly min-width at the bottom.
@@ -666,11 +667,7 @@
 			position: absolute;
 			inset: 0;
 			z-index: 0;
-			background: linear-gradient(
-				to bottom,
-				rgba( #{ colors.$primary-600--rgb }, var( --band-opacity-top, 1 ) ) 0%,
-				rgba( #{ colors.$primary-600--rgb }, var( --band-opacity-bottom, 1 ) ) 100%
-			);
+			background-color: var( --band-fill, #{colors.$primary-300} );
 		}
 
 		&-content {
@@ -680,10 +677,7 @@
 			flex-direction: column;
 			align-items: center;
 			max-width: 160px; // wrap width for the descriptor lines.
-			// Always white text; the dark shadow keeps it legible over both the dark
-			// upper bands and the faded (light) lower ones — no per-band color switch.
 			color: wp-colors.$white;
-			text-shadow: 0 1px 2px rgba( wp-colors.$gray-900, 0.5 );
 		}
 
 		&-labels {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -12,6 +12,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .newspack-insights {
 
@@ -180,10 +181,9 @@
 			// inherited font from flipping between cards (the bug was: digits
 			// in "35" rendered slim, "$738.33" rendered heavier with a slight
 			// optical slant — different chars resolving in different
-			// fallback fonts because no explicit family was declared). The
-			// stack matches @wordpress/base-styles' admin body font.
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-				Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			// fallback fonts because no explicit family was declared). Uses
+			// @wordpress/base-styles' admin body font token.
+			font-family: wp-vars.$default-font;
 			font-size: 44px;
 			font-weight: 500;
 			font-style: normal;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -91,16 +91,24 @@
 	}
 
 	// Section 2 — four per-journey funnels in a 2-column grid, stacking under
-	// ~720px container width.
+	// ~720px container width. Cells stretch so a shorter funnel (e.g. the 2-stage
+	// cross-upsell) matches the height of its taller row-mate.
 	&__conversion-journey-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 		gap: 24px;
-		align-items: start;
+		align-items: stretch;
 	}
 
 	&__conversion-journey-cell {
+		display: flex;
+		flex-direction: column;
 		min-width: 0;
+
+		// The funnel is the cell's last child; grow it to fill the stretched cell.
+		.newspack-insights__funnel {
+			flex: 1 1 auto;
+		}
 	}
 
 	// Section 3 — three source-mix pies side by side.

--- a/plugins/newspack-plugin/src/wizards/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/index.d.ts
@@ -7,6 +7,15 @@ declare module '*.png' {
 }
 
 /**
+ * Allow SCSS modules (e.g. the color token map) to be imported as a keyed record
+ * of string values.
+ */
+declare module '*.scss' {
+	const classes: { readonly [ key: string ]: string };
+	export default classes;
+}
+
+/**
  * Wizard API fetch function
  */
 type WizardApiFetch< T = {} > = (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Alternative design exploration for the Insights `Funnel` viz.** This is a sibling to the simplified equal-width treatment in #594 — it reintroduces stepped section widths, but with a different visual language than the epic branch. It is **stacked on #594** (base branch `feat/insights-funnel-rectangles`), so that PR should be reviewed/merged first.

The whole change is confined to the shared `Funnel` component, so it applies uniformly to every tab that renders a funnel: **Gates**, **Prompts**, and **Conversion Journey**.

<img width="1086" height="1154" alt="Screenshot 2026-07-09 at 5 05 02 PM" src="https://github.com/user-attachments/assets/b55af5da-67e2-4b18-8209-bbc5ec21f763" />

What it does:

- **Stepped rectangular sections.** The top section spans the full width; each lower section is sized in proportion to the top count, with an absolute `min-width` floor (shared SCSS `$funnel-min-band-width: 80px`) so long/steep funnels don't collapse to slivers. The sections stay rectangles (no trapezoidal body). The funnel's `max-width` cap was removed so it fills its grid cell.
- **Trapezoidal transition separators.** Between each pair of sections a filled trapezoid connects the wider section above to the narrower one below, via a CSS `clip-path`. The per-band bottom inset is supplied inline (`--separator-inset`) but **clamped in CSS so the bottom edge never dips below the section `min-width`** — `min( var(--separator-inset), calc( (100% - 80px) / 2 ) )` — so a connector always meets the full top of a min-width-floored section. Fluid, no JS measurement.
- **Floating label Popovers.** The per-step descriptors ("X% of {top}" + "Y% drop-off") moved out of the section body into a `Popover` that floats beside the section. They are revealed for the **whole funnel** on hover or keyboard focus (`tabIndex=0` + a hover/focus-within state), and hidden when it loses both.
- **Proportional text scaling.** The section name and count share a single `--funnel-font-scale` so their relative sizes never change. Text stays full size until a section narrows past half the top width, then ramps down **linearly and continuously** toward a floor (¾ of full size) — a gradual reduction rather than a hard step.
- **Color/contrast tuning.** `primary-600` gradient fills with a distinct-sections ramp (per-band opacity floor), a lower dark-text threshold, and a softened text halo.

### How to test the changes in this Pull Request:

1. Check out the branch and build the plugin: `n build newspack-plugin` (or `n watch` while iterating).
2. Open the **Insights** wizard and go to a tab that renders a funnel — **Conversion Journey**, **Gates**, or **Prompts**.
3. Confirm the funnel renders as a vertical stack of **rectangles that step down in width**, with a **trapezoidal connector** filling the gap between each pair of sections.
4. Confirm very narrow / steep funnels bottom out at the `80px` `min-width`, and that each connector's **bottom edge meets the full top** of the section beneath it (no connector narrower than the section below).
5. Confirm the **name/count text scales down** on narrower sections (both together, ratio preserved) and stays full size on sections wider than half the top.
6. **Hover or tab-focus the funnel** — every section's "% of top / drop-off" label Popover appears beside its section at once; moving the pointer/focus away hides them all.
7. Confirm the empty state ("Not enough data to chart the funnel.") still shows when there is insufficient data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Unit tests were rebuilt for the new markup and behavior: hover/focus-revealed descriptors (shown for the whole funnel at once), stepped section widths, the trapezoidal separators (one per adjacent pair, driven by the inline inset), and the gradual font-scale ramp. `npm test` passes (full suite); ESLint and Stylelint are clean.
