### PR TITLE
test(wizards): fix stale content gate toggle label assertion

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gate-settings.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gate-settings.test.js
@@ -101,8 +101,8 @@ describe( 'ContentGateSettings per-gate actions', () => {
 		const ContentGateSettings = require( './content-gate-settings' ).default;
 		render( <ContentGateSettings gate={ mockGate } updateGatesData={ () => {} } /> );
 
-		// gate.status === 'publish' -> the toggle action is labelled "Deactivate".
-		fireEvent.click( screen.getByRole( 'button', { name: 'Deactivate' } ) );
+		// gate.status === 'publish' -> the toggle action is labelled "Set to inactive".
+		fireEvent.click( screen.getByRole( 'button', { name: 'Set to inactive' } ) );
 
 		await waitFor( () => {
 			expect( mockAddNotice ).toHaveBeenCalledWith(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`main` is currently red on the `JS / newspack` CI job. The `ContentGateSettings` per-gate actions test (`content-gate-settings.test.js`, added by NPPM-2733 / #513) asserts a toggle button labelled **"Deactivate"**, but #408 renamed that action to **"Set to inactive" / "Set to active"**. Because #513 branched off `main` before #408 landed, the test shipped stale and the suite has been failing ever since (`Unable to find an accessible element with the role "button" and name "Deactivate"`).

This aligns the test's expected button name with the current UI label. No production code changes — test-only.

Every PR that merges `main` inherits this failure, so this also unblocks open feature branches (e.g. #315).

### How to test the changes in this Pull Request:

1. Check out `main` and run the newspack-plugin JS suite (`pnpm --filter "newspack" run test`) — observe `content-gate-settings.test.js` failing with the "Deactivate" button error.
2. Check out this branch and run the same suite — `content-gate-settings.test.js` now passes.
3. Confirm the `JS / newspack` CI job on this PR is green.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?