### PR TITLE
refactor(insights): full-width Dividers between tab sections

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -1,8 +1,8 @@
 /**
- * AdvertisingTab (Tab 8, NPPD-1618).
+ * AdvertisingTab (Tab 8).
  *
  * GAM-backed Advertising tab. Fetches the Advertising orchestrator endpoint
- * (NPPD-1663) and renders the report sections. Unlike the GA4 tabs, visibility
+ * and renders the report sections. Unlike the GA4 tabs, visibility
  * (GAM ad provider active) and reporting readiness (OAuth scope + network code)
  * are distinct signals, so this tab has an extra "finish connecting" state
  * between the hidden and ready states. Because GAM reports run asynchronously,
@@ -21,6 +21,7 @@ import type { DateRange } from '../state/useDateRange';
 import useAdvertisingData from '../hooks/useAdvertisingData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import TabLoading from './components/TabLoading';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import DataLagIndicator from './components/DataLagIndicator';
@@ -82,19 +83,21 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 			{ current && (
 				<>
 					<DataLagIndicator dataAsOf={ current.data_as_of } hasEstimatedData={ current.has_estimated_data } />
-					<ReachRevenueSection
-						current={ current.metrics }
-						previous={ previous }
-						hasWindowActivity={ current.has_window_activity }
-						lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
-					/>
-					<RevenueTrendSection current={ current.metrics } previous={ previous } />
-					{ /* Channel pie + device table: after the trend, before the per-site and
-					     top-performer tables. */ }
-					<ChannelDeviceSection current={ current.metrics } previous={ previous } />
-					{ /* Per-site breakdown (NPPD-1671): network members only; absent otherwise. */ }
-					{ current.is_network_member && <SitePerformanceSection current={ current.metrics } previous={ previous } /> }
-					<TopPerformersSection current={ current.metrics } previous={ previous } />
+					<TabSections>
+						<ReachRevenueSection
+							current={ current.metrics }
+							previous={ previous }
+							hasWindowActivity={ current.has_window_activity }
+							lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
+						/>
+						<RevenueTrendSection current={ current.metrics } previous={ previous } />
+						{ /* Channel pie + device table: after the trend, before the per-site and
+						     top-performer tables. */ }
+						<ChannelDeviceSection current={ current.metrics } previous={ previous } />
+						{ /* Per-site breakdown: network members only; absent otherwise. */ }
+						{ current.is_network_member && <SitePerformanceSection current={ current.metrics } previous={ previous } /> }
+						<TopPerformersSection current={ current.metrics } previous={ previous } />
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -1,5 +1,5 @@
 /**
- * AppTab (Tab 10, NPPD-1882).
+ * AppTab (Tab 10).
  *
  * Mobile-app analytics for Pugpig app publishers, live from the GA4 Data API
  * against a publisher-selected app property. Drives the connect → select → render
@@ -25,6 +25,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { Notice, Button, Grid, SelectControl } from '../../../../packages/components/src';
 import WizardsActionCard from '../../wizards-action-card';
 import TabSpinner from './components/TabSpinner';
+import TabSections from './components/TabSections';
 import LastUpdated from '../components/LastUpdated';
 import useAppMetricsData from '../hooks/useAppMetricsData';
 import ReachSection from './app/ReachSection';
@@ -139,16 +140,15 @@ const AppMetricsView = ( { range, previousRange }: Pick< TabSectionProps, 'range
 
 	return (
 		<div className="newspack-insights__app-tab">
-			{ /* Ordered as a narrative: scale (Reach) → depth (Engagement) → what
-			     they read (Content) → who they are (Audience) → loyalty (Retention)
-			     → the app-ops channels (Notifications, Editions) last. */ }
-			<ReachSection metrics={ current } previous={ previous } lastUpdated={ lastUpdated } />
-			<EngagementSection metrics={ current } previous={ previous } />
-			<ContentSection metrics={ current } />
-			<CompositionSection metrics={ current } />
-			<RetentionSection metrics={ current } />
-			<NotificationsSection metrics={ current } previous={ previous } />
-			<DownloadsSection metrics={ current } previous={ previous } />
+			<TabSections>
+				<ReachSection metrics={ current } previous={ previous } lastUpdated={ lastUpdated } />
+				<EngagementSection metrics={ current } previous={ previous } />
+				<ContentSection metrics={ current } />
+				<CompositionSection metrics={ current } />
+				<RetentionSection metrics={ current } />
+				<NotificationsSection metrics={ current } previous={ previous } />
+				<DownloadsSection metrics={ current } previous={ previous } />
+			</TabSections>
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -1,5 +1,5 @@
 /**
- * AudienceTab (Tab 1, NPPD-1649).
+ * AudienceTab (Tab 1).
  *
  * GA4-backed Audience tab. Fetches the Audience orchestrator endpoint and
  * renders six sections. When GA4 isn't connected the orchestrator returns a
@@ -20,6 +20,7 @@ import useAudienceData from '../hooks/useAudienceData';
 import LastUpdated from '../components/LastUpdated';
 import ConnectBanner from './components/ConnectBanner';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import TabStatusBanner from './components/TabStatusBanner';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ReachSection from './audience/sections/ReachSection';
@@ -45,10 +46,10 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 	// Fixture mode returns a `previous` window unconditionally, so gate on the
 	// toggle here rather than on the response — matches Gates/Subscribers/Donors.
 	const previous = previousRange ? data?.previous ?? null : null;
-	// Registered readers (NPPD-1733) come from local wp_users, so they render even
+	// Registered readers come from local wp_users, so they render even
 	// when GA4 isn't connected — present in both the banner and the normal branch.
 	const registeredReaders = data?.registered_readers ?? null;
-	// Modeled newsletter-subscriber value (NEWS-2603): GA4-independent, like
+	// Modeled newsletter-subscriber value: GA4-independent, like
 	// registered readers — rendered in both branches.
 	const newsletterSubscriberValue = data?.newsletter_subscriber_value ?? null;
 	const showComparison = !! previousRange;
@@ -66,28 +67,32 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 				( data.tab_error || ! current ? (
 					<>
 						<ConnectBanner text={ data.banner_text } />
-						{ registeredReaders && (
-							<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
-						) }
-						{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
+						<TabSections>
+							{ registeredReaders && (
+								<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
+							) }
+							{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
+						</TabSections>
 					</>
 				) : (
 					<>
 						<TabStatusBanner status={ data.data_status } />
-						<ReachSection
-							current={ current }
-							previous={ previous }
-							lastUpdated={ <LastUpdated tab="audience" range={ range } previousRange={ previousRange } /> }
-						/>
-						{ registeredReaders && (
-							<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
-						) }
-						{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
-						<CompositionSection current={ current } previous={ previous } />
-						<TrafficSourcesSection current={ current } previous={ previous } />
-						<GeographicSection current={ current } previous={ previous } />
-						<ContentPerformanceSection current={ current } previous={ previous } />
-						<TimeTrendsSection current={ current } previous={ previous } />
+						<TabSections>
+							<ReachSection
+								current={ current }
+								previous={ previous }
+								lastUpdated={ <LastUpdated tab="audience" range={ range } previousRange={ previousRange } /> }
+							/>
+							{ registeredReaders && (
+								<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
+							) }
+							{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
+							<CompositionSection current={ current } previous={ previous } />
+							<TrafficSourcesSection current={ current } previous={ previous } />
+							<GeographicSection current={ current } previous={ previous } />
+							<ContentPerformanceSection current={ current } previous={ previous } />
+							<TimeTrendsSection current={ current } previous={ previous } />
+						</TabSections>
 					</>
 				) ) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.tsx
@@ -1,5 +1,5 @@
 /**
- * ConversionTab (NPPD-1609, Phase 2).
+ * ConversionTab (Phase 2).
  *
  * Tab 3 orchestrator. Mirrors the PromptsTab loading / error / success
  * lifecycle and composes the eight Conversion Journey sections.
@@ -31,6 +31,7 @@ import LastUpdated from '../components/LastUpdated';
 import CooldownNotice from '../components/CooldownNotice';
 import TabStateView from './components/TabStateView';
 import TabErrorBanner from './components/TabErrorBanner';
+import TabSections from './components/TabSections';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ReaderLifecycleSection from './conversion/ReaderLifecycleSection';
 import PerJourneyConversionFunnelsSection from './conversion/PerJourneyConversionFunnelsSection';
@@ -63,17 +64,19 @@ const ConversionTab = ( { range, previousRange }: ConversionTabProps ) => {
 				<>
 					{ data.tab_error && <TabErrorBanner /> }
 					<CooldownNotice tab="conversion" range={ range } previousRange={ previousRange } />
-					<ReaderLifecycleSection
-						current={ data.current }
-						lastUpdated={ <LastUpdated tab="conversion" range={ range } previousRange={ previousRange } /> }
-					/>
-					<PerJourneyConversionFunnelsSection current={ data.current } />
-					<WhereConversionsComeFromSection current={ data.current } />
-					<HowLongConversionsTakeSection current={ data.current } />
-					<CohortRetentionSection current={ data.current } />
-					<ConversionRateTrendsSection current={ data.current } />
-					<CrossTabInfluencedAttributionSection current={ data.current } previous={ data.previous } />
-					<OpportunityBucketsSection current={ data.current } />
+					<TabSections>
+						<ReaderLifecycleSection
+							current={ data.current }
+							lastUpdated={ <LastUpdated tab="conversion" range={ range } previousRange={ previousRange } /> }
+						/>
+						<PerJourneyConversionFunnelsSection current={ data.current } />
+						<WhereConversionsComeFromSection current={ data.current } />
+						<HowLongConversionsTakeSection current={ data.current } />
+						<CohortRetentionSection current={ data.current } />
+						<ConversionRateTrendsSection current={ data.current } />
+						<CrossTabInfluencedAttributionSection current={ data.current } previous={ data.previous } />
+						<OpportunityBucketsSection current={ data.current } />
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/DonorsTab.tsx
@@ -1,5 +1,5 @@
 /**
- * DonorsTab (NPPD-1617).
+ * DonorsTab.
  *
  * Orchestrates the Tab 7 view: fetches data for the active range +
  * comparison range, then composes the four sections (scorecard,
@@ -22,6 +22,7 @@ import type { DateRange } from '../state/useDateRange';
 import useDonorsData from '../hooks/useDonorsData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import TabStatusBanner from './components/TabStatusBanner';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ScorecardSection from './donors/ScorecardSection';
@@ -51,19 +52,21 @@ const DonorsTab = ( { range, previousRange }: DonorsTabProps ) => {
 			{ data && (
 				<>
 					<TabStatusBanner status={ data.data_status } />
-					<ScorecardSection
-						snapshot={ data.snapshot }
-						lastUpdated={ <LastUpdated tab="donors" range={ range } previousRange={ previousRange } /> }
-					/>
-					<WindowedSection
-						range={ range }
-						current={ data.current }
-						previous={ data.previous }
-						activeDonors={ data.snapshot.active_donors }
-					/>
-					<RetentionSection current={ data.current } previous={ data.previous } />
-					<PerformanceSection rows={ data.current.donations_by_tier } />
-					<CampaignSection rows={ data.current.donations_by_campaign } />
+					<TabSections>
+						<ScorecardSection
+							snapshot={ data.snapshot }
+							lastUpdated={ <LastUpdated tab="donors" range={ range } previousRange={ previousRange } /> }
+						/>
+						<WindowedSection
+							range={ range }
+							current={ data.current }
+							previous={ data.previous }
+							activeDonors={ data.snapshot.active_donors }
+						/>
+						<RetentionSection current={ data.current } previous={ data.previous } />
+						<PerformanceSection rows={ data.current.donations_by_tier } />
+						<CampaignSection rows={ data.current.donations_by_campaign } />
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.tsx
@@ -1,5 +1,5 @@
 /**
- * EngagementTab (Tab 2, NPPD-1649).
+ * EngagementTab (Tab 2).
  *
  * GA4-backed Engagement tab. Fetches the Engagement orchestrator endpoint and
  * renders three sections — Overall engagement quality, Reader segments, Content
@@ -20,6 +20,7 @@ import useEngagementData from '../hooks/useEngagementData';
 import LastUpdated from '../components/LastUpdated';
 import ConnectBanner from './components/ConnectBanner';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import QualitySection from './engagement/sections/QualitySection';
 import ContentEngagementSection from './engagement/sections/ContentEngagementSection';
@@ -52,7 +53,7 @@ const EngagementTab = ( { range, previousRange }: EngagementTabProps ) => {
 				( data.tab_error || ! current ? (
 					<ConnectBanner text={ data.banner_text } />
 				) : (
-					<>
+					<TabSections>
 						<QualitySection
 							current={ current }
 							previous={ previous }
@@ -60,7 +61,7 @@ const EngagementTab = ( { range, previousRange }: EngagementTabProps ) => {
 						/>
 						<ReaderSegmentsSection current={ current } previous={ previous } />
 						<ContentEngagementSection current={ current } previous={ previous } />
-					</>
+					</TabSections>
 				) ) }
 		</TabStateView>
 	);

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/GatesTab.tsx
@@ -1,5 +1,5 @@
 /**
- * GatesTab (NPPD-1604).
+ * GatesTab.
  *
  * Tab 4 orchestrator. Mirrors the SubscribersTab / DonorsTab
  * loading / error / success lifecycle and composes the five Gates
@@ -24,6 +24,7 @@ import type { DateRange } from '../state/useDateRange';
 import useGatesData from '../hooks/useGatesData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import TabErrorBanner from './components/TabErrorBanner';
 import GateExposureSection from './gates/GateExposureSection';
@@ -53,15 +54,17 @@ const GatesTab = ( { range, previousRange }: GatesTabProps ) => {
 			{ data && (
 				<>
 					{ data.tab_error && <TabErrorBanner /> }
-					<GateExposureSection
-						current={ data.current }
-						previous={ data.previous }
-						lastUpdated={ <LastUpdated tab="gates" range={ range } previousRange={ previousRange } /> }
-					/>
-					<FreeReaderConversionSection current={ data.current } previous={ data.previous } />
-					<PaidReaderConversionSection current={ data.current } previous={ data.previous } />
-					<HowReadersConvertSection current={ data.current } />
-					<PerformanceByGateSection data={ data.current.performance_by_gate } />
+					<TabSections>
+						<GateExposureSection
+							current={ data.current }
+							previous={ data.previous }
+							lastUpdated={ <LastUpdated tab="gates" range={ range } previousRange={ previousRange } /> }
+						/>
+						<FreeReaderConversionSection current={ data.current } previous={ data.previous } />
+						<PaidReaderConversionSection current={ data.current } previous={ data.previous } />
+						<HowReadersConvertSection current={ data.current } />
+						<PerformanceByGateSection data={ data.current.performance_by_gate } />
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.tsx
@@ -1,5 +1,5 @@
 /**
- * NewsletterAdsTab (NPPD-1861).
+ * NewsletterAdsTab.
  *
  * Newsletter Ads tab. Fetches the newsletter-ads orchestrator endpoint and
  * renders three sections. Lifecycle mirrors {@see AdvertisingTab} with one
@@ -23,6 +23,7 @@ import type { DateRange } from '../state/useDateRange';
 import useNewsletterAdsData from '../hooks/useNewsletterAdsData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import FinishConnectingDiagnostic from './components/FinishConnectingDiagnostic';
 import OverviewSection from './newsletter_ads/sections/OverviewSection';
 import TrendSection from './newsletter_ads/sections/TrendSection';
@@ -102,22 +103,20 @@ const NewsletterAdsTab = ( { range, previousRange }: NewsletterAdsTabProps ) => 
 							) }
 						</Notice>
 					) ) }
-					<OverviewSection
-						current={ current.metrics }
-						previous={ previous }
-						// The whole-section empty collapse only applies to a resolved report:
-						// while not ready, the lifetime cards must stay on screen, so the
-						// signal is withheld (undefined never collapses).
-						hasWindowActivity={ isReportReady ? current.has_window_activity : undefined }
-						lastUpdated={ <LastUpdated tab="newsletter_ads" range={ range } previousRange={ previousRange } /> }
-					/>
-					{ /* Timeframe-scoped sections need the stats table; withheld until ready. */ }
-					{ isReportReady && (
-						<>
-							<TrendSection current={ current.metrics } previous={ previous } />
-							<TablesSection current={ current.metrics } />
-						</>
-					) }
+					<TabSections>
+						<OverviewSection
+							current={ current.metrics }
+							previous={ previous }
+							// The whole-section empty collapse only applies to a resolved report:
+							// while not ready, the lifetime cards must stay on screen, so the
+							// signal is withheld (undefined never collapses).
+							hasWindowActivity={ isReportReady ? current.has_window_activity : undefined }
+							lastUpdated={ <LastUpdated tab="newsletter_ads" range={ range } previousRange={ previousRange } /> }
+						/>
+						{ /* Timeframe-scoped sections need the stats table; withheld until ready. */ }
+						{ isReportReady && <TrendSection current={ current.metrics } previous={ previous } /> }
+						{ isReportReady && <TablesSection current={ current.metrics } /> }
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.tsx
@@ -1,5 +1,5 @@
 /**
- * PromptsTab (NPPD-1607).
+ * PromptsTab.
  *
  * Tab 5 orchestrator. Mirrors the GatesTab loading / error / success
  * lifecycle and composes the seven Prompts sections, plus a tab-level
@@ -24,6 +24,7 @@ import type { DateRange } from '../state/useDateRange';
 import usePromptsData from '../hooks/usePromptsData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import TabErrorBanner from './components/TabErrorBanner';
 import PromptExposureSection from './prompts/PromptExposureSection';
@@ -55,17 +56,19 @@ const PromptsTab = ( { range, previousRange }: PromptsTabProps ) => {
 			{ data && (
 				<>
 					{ data.tab_error && <TabErrorBanner /> }
-					<PromptExposureSection
-						current={ data.current }
-						previous={ data.previous }
-						lastUpdated={ <LastUpdated tab="prompts" range={ range } previousRange={ previousRange } /> }
-					/>
-					<PromptEngagementSection current={ data.current } previous={ data.previous } />
-					<FreeReaderConversionSection current={ data.current } previous={ data.previous } />
-					<PaidReaderConversionSection current={ data.current } previous={ data.previous } />
-					<RevenueFromPromptsSection current={ data.current } previous={ data.previous } />
-					<HowReadersConvertSection current={ data.current } />
-					<PerformanceBreakdownSection current={ data.current } />
+					<TabSections>
+						<PromptExposureSection
+							current={ data.current }
+							previous={ data.previous }
+							lastUpdated={ <LastUpdated tab="prompts" range={ range } previousRange={ previousRange } /> }
+						/>
+						<PromptEngagementSection current={ data.current } previous={ data.previous } />
+						<FreeReaderConversionSection current={ data.current } previous={ data.previous } />
+						<PaidReaderConversionSection current={ data.current } previous={ data.previous } />
+						<RevenueFromPromptsSection current={ data.current } previous={ data.previous } />
+						<HowReadersConvertSection current={ data.current } />
+						<PerformanceBreakdownSection current={ data.current } />
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/SubscribersTab.tsx
@@ -1,5 +1,5 @@
 /**
- * SubscribersTab (NPPD-1616).
+ * SubscribersTab.
  *
  * Orchestrates the Tab 6 view: fetches data for the active range +
  * comparison range, then composes the four sections (scorecard,
@@ -26,6 +26,7 @@ import type { DateRange } from '../state/useDateRange';
 import useSubscribersData from '../hooks/useSubscribersData';
 import LastUpdated from '../components/LastUpdated';
 import TabStateView from './components/TabStateView';
+import TabSections from './components/TabSections';
 import TabStatusBanner from './components/TabStatusBanner';
 import { TAB_LOADING_MESSAGES } from './components/loading-messages';
 import ScorecardSection from './subscribers/ScorecardSection';
@@ -55,19 +56,21 @@ const SubscribersTab = ( { range, previousRange }: SubscribersTabProps ) => {
 			{ data && (
 				<>
 					<TabStatusBanner status={ data.data_status } />
-					<ScorecardSection
-						snapshot={ data.snapshot }
-						lastUpdated={ <LastUpdated tab="subscribers" range={ range } previousRange={ previousRange } /> }
-					/>
-					<WindowedSection
-						range={ range }
-						current={ data.current }
-						previous={ data.previous }
-						activeSubscribers={ data.snapshot.active_subscribers }
-					/>
-					<TenureSection rows={ data.snapshot.tenure_distribution } />
-					<PerformanceSection rows={ data.current.subscriptions_by_product } />
-					<CampaignSection rows={ data.current.subscriptions_by_campaign } />
+					<TabSections>
+						<ScorecardSection
+							snapshot={ data.snapshot }
+							lastUpdated={ <LastUpdated tab="subscribers" range={ range } previousRange={ previousRange } /> }
+						/>
+						<WindowedSection
+							range={ range }
+							current={ data.current }
+							previous={ data.previous }
+							activeSubscribers={ data.snapshot.active_subscribers }
+						/>
+						<TenureSection rows={ data.snapshot.tenure_distribution } />
+						<PerformanceSection rows={ data.current.subscriptions_by_product } />
+						<CampaignSection rows={ data.current.subscriptions_by_campaign } />
+					</TabSections>
 				</>
 			) }
 		</TabStateView>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -6,1091 +6,1119 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
     aria-busy="false"
     class="newspack-insights__tab-body newspack-insights__prompts-tab"
   >
-    <section
-      aria-labelledby="newspack-insights-prompts-exposure-heading"
-      class="newspack-insights__section newspack-insights__section--exposure"
+    <div
+      class="newspack-insights__tab-sections"
     >
-      <div
-        class="newspack-insights__section-header-container"
+      <section
+        aria-labelledby="newspack-insights-prompts-exposure-heading"
+        class="newspack-insights__section newspack-insights__section--exposure"
       >
         <div
-          class="newspack-insights__section-header-text"
+          class="newspack-insights__section-header-container"
         >
           <div
-            class="newspack-section-header__container newspack-insights__section-heading"
-            id="newspack-insights-prompts-exposure-heading"
+            class="newspack-insights__section-header-text"
           >
             <div
-              class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
+              class="newspack-section-header__container newspack-insights__section-heading"
+              id="newspack-insights-prompts-exposure-heading"
             >
               <div
-                class="newspack-section-header__title-container"
+                class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
               >
-                <h2>
-                  Prompt exposure
-                </h2>
+                <div
+                  class="newspack-section-header__title-container"
+                >
+                  <h2>
+                    Prompt exposure
+                  </h2>
+                </div>
+                <p>
+                  Top of the funnel. How many readers see prompts in this timeframe.
+                </p>
               </div>
-              <p>
-                Top of the funnel. How many readers see prompts in this timeframe.
-              </p>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
+        <div
+          class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
+        >
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Total Prompt Impressions
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Every prompt view in this timeframe
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Unique Readers Reached
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Distinct readers who saw at least one prompt
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Avg Prompts per Reader
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0.0
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  How many prompts a typical reader sees
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+        </div>
+      </section>
+      <hr
+        class="newspack-divider newspack-divider--alignment-full-width newspack-divider--variant-tertiary"
+        style="--divider-margin-bottom: 64px; --divider-margin-top: 64px;"
+      />
+      <section
+        aria-labelledby="newspack-insights-prompts-engagement-heading"
+        class="newspack-insights__section newspack-insights__section--engagement"
       >
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-section-header__container newspack-insights__section-heading"
+          id="newspack-insights-prompts-engagement-heading"
         >
           <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
           >
             <div
-              class="newspack-card--core__body"
+              class="newspack-section-header__title-container"
             >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Total Prompt Impressions
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Every prompt view in this timeframe
-              </div>
+              <h2>
+                Prompt engagement
+              </h2>
             </div>
+            <p>
+              How readers respond to prompts they see. Engagement is any interaction beyond just seeing the prompt.
+            </p>
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
         >
           <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
             <div
-              class="newspack-card--core__body"
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
             >
               <div
-                class="newspack-insights__metric-card-label"
-              >
-                Unique Readers Reached
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
+                class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-value"
+                  class="newspack-insights__metric-card-label"
                 >
-                  0
+                  Click-Through Rate
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Clicks ÷ prompt impressions
                 </div>
               </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Distinct readers who saw at least one prompt
-              </div>
             </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
           <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
             data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            data-wp-component="Card"
           >
             <div
-              class="newspack-card--core__body"
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
             >
               <div
-                class="newspack-insights__metric-card-label"
-              >
-                Avg Prompts per Reader
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
+                class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-value"
+                  class="newspack-insights__metric-card-label"
                 >
-                  0.0
+                  Form Submission Rate
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Form submissions ÷ impressions on form-bearing prompts
                 </div>
               </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                How many prompts a typical reader sees
-              </div>
             </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
           <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
             data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Dismissal Rate
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Explicit dismissals ÷ prompt impressions
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
         </div>
-      </div>
-    </section>
-    <section
-      aria-labelledby="newspack-insights-prompts-engagement-heading"
-      class="newspack-insights__section newspack-insights__section--engagement"
-    >
-      <div
-        class="newspack-section-header__container newspack-insights__section-heading"
-        id="newspack-insights-prompts-engagement-heading"
+      </section>
+      <hr
+        class="newspack-divider newspack-divider--alignment-full-width newspack-divider--variant-tertiary"
+        style="--divider-margin-bottom: 64px; --divider-margin-top: 64px;"
+      />
+      <section
+        aria-labelledby="newspack-insights-prompts-free-heading"
+        class="newspack-insights__section newspack-insights__section--free-reader"
       >
         <div
-          class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
+          class="newspack-section-header__container newspack-insights__section-heading"
+          id="newspack-insights-prompts-free-heading"
         >
           <div
-            class="newspack-section-header__title-container"
+            class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
           >
-            <h2>
-              Prompt engagement
-            </h2>
+            <div
+              class="newspack-section-header__title-container"
+            >
+              <h2>
+                Free reader conversion
+              </h2>
+            </div>
+            <p>
+              How effectively prompts convert readers into registered readers and newsletter subscribers. Direct counts conversions submitted through a prompt’s own form. Influenced counts conversions in a later session within 7 days of seeing a prompt.
+            </p>
           </div>
-          <p>
-            How readers respond to prompts they see. Engagement is any interaction beyond just seeing the prompt.
-          </p>
         </div>
-      </div>
-      <div
-        class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
+        <div
+          class="newspack-insights__metric-grid"
+        >
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Registration Conversion (Direct)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Registrations submitted through a prompt’s registration block ÷ impressions of prompts with a registration block
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Registration Conversion (Influenced, 7d)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Newsletter Signup Conversion (Direct)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Newsletter signups submitted through a prompt’s newsletter block ÷ impressions of prompts with a newsletter block
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Newsletter Signup Conversion (Influenced, 7d)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+        </div>
+      </section>
+      <hr
+        class="newspack-divider newspack-divider--alignment-full-width newspack-divider--variant-tertiary"
+        style="--divider-margin-bottom: 64px; --divider-margin-top: 64px;"
+      />
+      <section
+        aria-labelledby="newspack-insights-prompts-paid-heading"
+        class="newspack-insights__section newspack-insights__section--paid-reader"
       >
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-section-header__container newspack-insights__section-heading"
+          id="newspack-insights-prompts-paid-heading"
         >
           <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
           >
             <div
-              class="newspack-card--core__body"
+              class="newspack-section-header__title-container"
             >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Click-Through Rate
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Clicks ÷ prompt impressions
-              </div>
+              <h2>
+                Paid reader conversion
+              </h2>
             </div>
+            <p>
+              How effectively prompts convert readers into donors and subscribers. Direct counts conversions completed through a prompt’s own donation block or checkout button. Influenced counts conversions in a later session within 14 days of seeing a prompt.
+            </p>
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-insights__metric-grid"
         >
           <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
             <div
-              class="newspack-card--core__body"
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
             >
               <div
-                class="newspack-insights__metric-card-label"
-              >
-                Form Submission Rate
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
+                class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-value"
+                  class="newspack-insights__metric-card-label"
                 >
-                  0%
+                  Donation Conversion (Direct)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Donations completed through a prompt’s donation block ÷ impressions of prompts with a donation block
                 </div>
               </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Form submissions ÷ impressions on form-bearing prompts
-              </div>
             </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
           <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
             data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            data-wp-component="Card"
           >
             <div
-              class="newspack-card--core__body"
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
             >
               <div
-                class="newspack-insights__metric-card-label"
-              >
-                Dismissal Rate
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
+                class="newspack-card--core__body"
               >
                 <div
-                  class="newspack-insights__metric-card-value"
+                  class="newspack-insights__metric-card-label"
                 >
-                  0%
+                  Donation Conversion (Influenced, 14d)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
                 </div>
               </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Explicit dismissals ÷ prompt impressions
-              </div>
             </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
           <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
             data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Subscription Conversion (Direct)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Subscriptions purchased through a prompt’s checkout button ÷ impressions of prompts with a checkout button
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
           <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
             data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Subscription Conversion (Influenced, 14d)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    0%
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
         </div>
-      </div>
-    </section>
-    <section
-      aria-labelledby="newspack-insights-prompts-free-heading"
-      class="newspack-insights__section newspack-insights__section--free-reader"
-    >
-      <div
-        class="newspack-section-header__container newspack-insights__section-heading"
-        id="newspack-insights-prompts-free-heading"
+      </section>
+      <hr
+        class="newspack-divider newspack-divider--alignment-full-width newspack-divider--variant-tertiary"
+        style="--divider-margin-bottom: 64px; --divider-margin-top: 64px;"
+      />
+      <section
+        aria-labelledby="newspack-insights-prompts-revenue-heading"
+        class="newspack-insights__section newspack-insights__section--revenue"
       >
         <div
-          class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
+          class="newspack-section-header__container newspack-insights__section-heading"
+          id="newspack-insights-prompts-revenue-heading"
         >
           <div
-            class="newspack-section-header__title-container"
+            class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
           >
-            <h2>
-              Free reader conversion
-            </h2>
+            <div
+              class="newspack-section-header__title-container"
+            >
+              <h2>
+                Revenue from prompts
+              </h2>
+            </div>
+            <p>
+              Donation and subscription revenue completed after a prompt impression. Direct totals Woo order revenue from conversions completed through a prompt’s own block. Influenced totals checkout revenue from later-session completions within 14 days of seeing a prompt.
+            </p>
           </div>
-          <p>
-            How effectively prompts convert readers into registered readers and newsletter subscribers. Direct counts conversions submitted through a prompt’s own form. Influenced counts conversions in a later session within 7 days of seeing a prompt.
-          </p>
         </div>
-      </div>
-      <div
-        class="newspack-insights__metric-grid"
+        <div
+          class="newspack-insights__metric-grid"
+        >
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Donation Revenue (Direct)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    $0.00
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Sum of Woo donation order totals from donations completed through a prompt’s donation block
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Donation Revenue (Influenced, 14d)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    $0.00
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Checkout revenue from donation completions in a later session within 14 days of seeing a donation-intent prompt
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Subscription Revenue (Direct)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    $0.00
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Sum of Woo subscription order totals from subscriptions purchased through a prompt’s checkout button
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
+          >
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <div
+                  class="newspack-insights__metric-card-label"
+                >
+                  Subscription Revenue (Influenced, 14d)
+                </div>
+                <div
+                  class="newspack-insights__metric-card-body"
+                >
+                  <div
+                    class="newspack-insights__metric-card-value"
+                  >
+                    $0.00
+                  </div>
+                </div>
+                <div
+                  class="newspack-insights__metric-card-description"
+                >
+                  Checkout revenue from subscription completions in a later session within 14 days of seeing a subscription-intent prompt
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+        </div>
+      </section>
+      <hr
+        class="newspack-divider newspack-divider--alignment-full-width newspack-divider--variant-tertiary"
+        style="--divider-margin-bottom: 64px; --divider-margin-top: 64px;"
+      />
+      <section
+        aria-labelledby="newspack-insights-prompts-convert-heading"
+        class="newspack-insights__section newspack-insights__section--convert"
       >
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-section-header__container newspack-insights__section-heading"
+          id="newspack-insights-prompts-convert-heading"
         >
           <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
           >
             <div
-              class="newspack-card--core__body"
+              class="newspack-section-header__title-container"
             >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Registration Conversion (Direct)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Registrations submitted through a prompt’s registration block ÷ impressions of prompts with a registration block
-              </div>
+              <h2>
+                How readers convert
+              </h2>
             </div>
+            <p>
+              The journey from prompt impression to conversion. The funnel shows where readers drop off; the distribution shows how many touches it typically takes before conversion.
+            </p>
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-insights__prompts-convert-grid"
         >
           <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="newspack-insights__prompts-convert-col"
           >
-            <div
-              class="newspack-card--core__body"
+            <p
+              class="newspack-insights__section-empty"
             >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Registration Conversion (Influenced, 7d)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Registrants whose registration followed a registration-prompt exposure in a prior session within 7 days ÷ all new registrations
-              </div>
-            </div>
+              No funnel data yet. The funnel will populate once readers begin moving through your prompts.
+            </p>
           </div>
           <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="newspack-insights__prompts-convert-col"
           >
-            <div
-              class="newspack-card--core__body"
+            <p
+              class="newspack-insights__section-empty"
             >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Newsletter Signup Conversion (Direct)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Newsletter signups submitted through a prompt’s newsletter block ÷ impressions of prompts with a newsletter block
-              </div>
-            </div>
+              No distribution data yet. This will populate once readers begin converting.
+            </p>
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Newsletter Signup Conversion (Influenced, 7d)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                New newsletter subscribers whose signup followed a newsletter-prompt exposure in a prior session within 7 days ÷ all new newsletter signups
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-      </div>
-    </section>
-    <section
-      aria-labelledby="newspack-insights-prompts-paid-heading"
-      class="newspack-insights__section newspack-insights__section--paid-reader"
-    >
-      <div
-        class="newspack-section-header__container newspack-insights__section-heading"
-        id="newspack-insights-prompts-paid-heading"
+      </section>
+      <hr
+        class="newspack-divider newspack-divider--alignment-full-width newspack-divider--variant-tertiary"
+        style="--divider-margin-bottom: 64px; --divider-margin-top: 64px;"
+      />
+      <section
+        aria-labelledby="newspack-insights-prompts-performance-heading"
+        class="newspack-insights__section newspack-insights__section--performance"
       >
         <div
-          class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
+          class="newspack-section-header__container newspack-insights__section-heading"
+          id="newspack-insights-prompts-performance-heading"
         >
           <div
-            class="newspack-section-header__title-container"
-          >
-            <h2>
-              Paid reader conversion
-            </h2>
-          </div>
-          <p>
-            How effectively prompts convert readers into donors and subscribers. Direct counts conversions completed through a prompt’s own donation block or checkout button. Influenced counts conversions in a later session within 14 days of seeing a prompt.
-          </p>
-        </div>
-      </div>
-      <div
-        class="newspack-insights__metric-grid"
-      >
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
           >
             <div
-              class="newspack-card--core__body"
+              class="newspack-section-header__title-container"
             >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Donation Conversion (Direct)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Donations completed through a prompt’s donation block ÷ impressions of prompts with a donation block
-              </div>
+              <h2>
+                Performance breakdown
+              </h2>
             </div>
+            <p>
+              Per-prompt, per-intent, and per-placement breakdowns for the selected timeframe. Click any column to re-sort.
+            </p>
           </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
         </div>
         <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
+          class="newspack-insights__prompts-subsection"
         >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+          <h3
+            class="newspack-insights__prompts-subsection-heading"
           >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Donation Conversion (Influenced, 14d)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Donors whose conversion followed a donation-prompt exposure in a prior session within 14 days ÷ all new donors
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Subscription Conversion (Direct)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Subscriptions purchased through a prompt’s checkout button ÷ impressions of prompts with a checkout button
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Subscription Conversion (Influenced, 14d)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  0%
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Subscribers whose conversion followed a subscription-prompt exposure in a prior session within 14 days ÷ all new subscribers
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-      </div>
-    </section>
-    <section
-      aria-labelledby="newspack-insights-prompts-revenue-heading"
-      class="newspack-insights__section newspack-insights__section--revenue"
-    >
-      <div
-        class="newspack-section-header__container newspack-insights__section-heading"
-        id="newspack-insights-prompts-revenue-heading"
-      >
-        <div
-          class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
-        >
-          <div
-            class="newspack-section-header__title-container"
-          >
-            <h2>
-              Revenue from prompts
-            </h2>
-          </div>
-          <p>
-            Donation and subscription revenue completed after a prompt impression. Direct totals Woo order revenue from conversions completed through a prompt’s own block. Influenced totals checkout revenue from later-session completions within 14 days of seeing a prompt.
-          </p>
-        </div>
-      </div>
-      <div
-        class="newspack-insights__metric-grid"
-      >
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Donation Revenue (Direct)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  $0.00
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Sum of Woo donation order totals from donations completed through a prompt’s donation block
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Donation Revenue (Influenced, 14d)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  $0.00
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Checkout revenue from donation completions in a later session within 14 days of seeing a donation-intent prompt
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Subscription Revenue (Direct)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  $0.00
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Sum of Woo subscription order totals from subscriptions purchased through a prompt’s checkout button
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-        >
-          <div
-            class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
-          >
-            <div
-              class="newspack-card--core__body"
-            >
-              <div
-                class="newspack-insights__metric-card-label"
-              >
-                Subscription Revenue (Influenced, 14d)
-              </div>
-              <div
-                class="newspack-insights__metric-card-body"
-              >
-                <div
-                  class="newspack-insights__metric-card-value"
-                >
-                  $0.00
-                </div>
-              </div>
-              <div
-                class="newspack-insights__metric-card-description"
-              >
-                Checkout revenue from subscription completions in a later session within 14 days of seeing a subscription-intent prompt
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-      </div>
-    </section>
-    <section
-      aria-labelledby="newspack-insights-prompts-convert-heading"
-      class="newspack-insights__section newspack-insights__section--convert"
-    >
-      <div
-        class="newspack-section-header__container newspack-insights__section-heading"
-        id="newspack-insights-prompts-convert-heading"
-      >
-        <div
-          class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
-        >
-          <div
-            class="newspack-section-header__title-container"
-          >
-            <h2>
-              How readers convert
-            </h2>
-          </div>
-          <p>
-            The journey from prompt impression to conversion. The funnel shows where readers drop off; the distribution shows how many touches it typically takes before conversion.
-          </p>
-        </div>
-      </div>
-      <div
-        class="newspack-insights__prompts-convert-grid"
-      >
-        <div
-          class="newspack-insights__prompts-convert-col"
-        >
+            Performance by prompt
+          </h3>
           <p
             class="newspack-insights__section-empty"
           >
-            No funnel data yet. The funnel will populate once readers begin moving through your prompts.
+            No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.
+          </p>
+          <p
+            class="newspack-insights__prompts-subsection-note"
+          >
+            Showing the top 10 prompts by the sorted column; use “See more” to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear.
           </p>
         </div>
         <div
-          class="newspack-insights__prompts-convert-col"
+          class="newspack-insights__prompts-subsection"
         >
+          <h3
+            class="newspack-insights__prompts-subsection-heading"
+          >
+            Performance by prompt intent
+          </h3>
           <p
             class="newspack-insights__section-empty"
           >
-            No distribution data yet. This will populate once readers begin converting.
+            No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.
           </p>
-        </div>
-      </div>
-    </section>
-    <section
-      aria-labelledby="newspack-insights-prompts-performance-heading"
-      class="newspack-insights__section newspack-insights__section--performance"
-    >
-      <div
-        class="newspack-section-header__container newspack-insights__section-heading"
-        id="newspack-insights-prompts-performance-heading"
-      >
-        <div
-          class="newspack-grid newspack-grid__columns-1 newspack-grid__gutter-8 newspack-section-header newspack-section-header--no-margin"
-        >
-          <div
-            class="newspack-section-header__title-container"
+          <p
+            class="newspack-insights__prompts-subsection-note"
           >
-            <h2>
-              Performance breakdown
-            </h2>
-          </div>
-          <p>
-            Per-prompt, per-intent, and per-placement breakdowns for the selected timeframe. Click any column to re-sort.
+            Answers 'are my donation prompts working better than my registration prompts?' at a glance.
           </p>
         </div>
-      </div>
-      <div
-        class="newspack-insights__prompts-subsection"
-      >
-        <h3
-          class="newspack-insights__prompts-subsection-heading"
+        <div
+          class="newspack-insights__prompts-subsection"
         >
-          Performance by prompt
-        </h3>
-        <p
-          class="newspack-insights__section-empty"
-        >
-          No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.
-        </p>
-        <p
-          class="newspack-insights__prompts-subsection-note"
-        >
-          Showing the top 10 prompts by the sorted column; use “See more” to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear.
-        </p>
-      </div>
-      <div
-        class="newspack-insights__prompts-subsection"
-      >
-        <h3
-          class="newspack-insights__prompts-subsection-heading"
-        >
-          Performance by prompt intent
-        </h3>
-        <p
-          class="newspack-insights__section-empty"
-        >
-          No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.
-        </p>
-        <p
-          class="newspack-insights__prompts-subsection-note"
-        >
-          Answers 'are my donation prompts working better than my registration prompts?' at a glance.
-        </p>
-      </div>
-      <div
-        class="newspack-insights__prompts-subsection"
-      >
-        <h3
-          class="newspack-insights__prompts-subsection-heading"
-        >
-          Performance by prompt placement
-        </h3>
-        <p
-          class="newspack-insights__section-empty"
-        >
-          No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.
-        </p>
-        <p
-          class="newspack-insights__prompts-subsection-note"
-        >
-          Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.
-        </p>
-      </div>
-    </section>
+          <h3
+            class="newspack-insights__prompts-subsection-heading"
+          >
+            Performance by prompt placement
+          </h3>
+          <p
+            class="newspack-insights__section-empty"
+          >
+            No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.
+          </p>
+          <p
+            class="newspack-insights__prompts-subsection-note"
+          >
+            Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.
+          </p>
+        </div>
+      </section>
+    </div>
   </div>
 </div>
 `;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -37,11 +37,13 @@ import type { ReactNode } from 'react';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
 import type { InsightsWindow } from '../../../api/advertising';
+import { Grid } from '../../../../../../packages/components/src';
 import EmptyMetricSection from '../../components/EmptyMetricSection';
 import MetricCard from '../../components/MetricCard';
 import Scorecard from '../../components/Scorecard';
@@ -90,74 +92,76 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 	return (
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
 			<SectionHeading id="newspack-insights-advertising-reach-revenue" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
-			{ /* Row 1: the four headline scorecards. Volume + revenue (raw), then the
+			<VStack spacing={ 4 }>
+				{ /* Row 1: the four headline scorecards. Volume + revenue (raw), then the
 			     two cross-system derived cards (NPPD-1675) — RPM and impressions per
 			     session — which join GAM figures with GA4 sessions. */ }
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
-				<Scorecard
-					label={ __( 'Impressions', 'newspack-plugin' ) }
-					description={ __( 'Total ad impressions served on your site', 'newspack-plugin' ) }
-					current={ current.total_impressions }
-					previous={ previous?.total_impressions }
-				/>
-				{ noRevenue ? (
-					<MetricCard
-						label={ __( 'Revenue', 'newspack-plugin' ) }
-						value={ 0 }
-						format="currency"
-						// No previousValue → the period delta is suppressed; a "↓ 100%" would
-						// misread the honest zero against a prior window that had revenue.
-						secondary={ sprintf(
-							/* translators: %s: count of ad impressions in this timeframe */
-							__( '%s impressions, but no revenue this timeframe', 'newspack-plugin' ),
-							formatNumber( impressions?.value ?? 0 )
-						) }
-						description={ __( 'Total ad revenue earned, before fees', 'newspack-plugin' ) }
-					/>
-				) : (
+				<Grid columns={ 4 } gutter={ 16 } noMargin>
 					<Scorecard
-						label={ __( 'Revenue', 'newspack-plugin' ) }
-						description={ __( 'Total ad revenue earned, before fees', 'newspack-plugin' ) }
-						current={ current.total_revenue }
-						previous={ previous?.total_revenue }
+						label={ __( 'Impressions', 'newspack-plugin' ) }
+						description={ __( 'Total ad impressions served on your site', 'newspack-plugin' ) }
+						current={ current.total_impressions }
+						previous={ previous?.total_impressions }
 					/>
-				) }
-				<Scorecard
-					label={ __( 'RPM', 'newspack-plugin' ) }
-					description={ __( 'Revenue per 1,000 sessions', 'newspack-plugin' ) }
-					current={ current.rpm }
-					previous={ previous?.rpm }
-				/>
-				<Scorecard
-					label={ __( 'Impressions per session', 'newspack-plugin' ) }
-					description={ __( 'Avg ad impressions a reader sees each session', 'newspack-plugin' ) }
-					current={ current.avg_impressions_per_session }
-					previous={ previous?.avg_impressions_per_session }
-				/>
-			</div>
-			{ /* Row 2: inventory-quality scorecards (moved from the former Inventory
+					{ noRevenue ? (
+						<MetricCard
+							label={ __( 'Revenue', 'newspack-plugin' ) }
+							value={ 0 }
+							format="currency"
+							// No previousValue → the period delta is suppressed; a "↓ 100%" would
+							// misread the honest zero against a prior window that had revenue.
+							secondary={ sprintf(
+								/* translators: %s: count of ad impressions in this timeframe */
+								__( '%s impressions, but no revenue this timeframe', 'newspack-plugin' ),
+								formatNumber( impressions?.value ?? 0 )
+							) }
+							description={ __( 'Total ad revenue earned, before fees', 'newspack-plugin' ) }
+						/>
+					) : (
+						<Scorecard
+							label={ __( 'Revenue', 'newspack-plugin' ) }
+							description={ __( 'Total ad revenue earned, before fees', 'newspack-plugin' ) }
+							current={ current.total_revenue }
+							previous={ previous?.total_revenue }
+						/>
+					) }
+					<Scorecard
+						label={ __( 'RPM', 'newspack-plugin' ) }
+						description={ __( 'Revenue per 1,000 sessions', 'newspack-plugin' ) }
+						current={ current.rpm }
+						previous={ previous?.rpm }
+					/>
+					<Scorecard
+						label={ __( 'Impressions per session', 'newspack-plugin' ) }
+						description={ __( 'Avg ad impressions a reader sees each session', 'newspack-plugin' ) }
+						current={ current.avg_impressions_per_session }
+						previous={ previous?.avg_impressions_per_session }
+					/>
+				</Grid>
+				{ /* Row 2: inventory-quality scorecards (moved from the former Inventory
 			     performance section). The old Revenue mix card was retired in favor
 			     of the Impressions by type breakdown (NPPD-1881). */ }
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
-				<Scorecard
-					label={ __( 'Average eCPM', 'newspack-plugin' ) }
-					description={ __( 'Your ad rate', 'newspack-plugin' ) }
-					current={ current.avg_ecpm }
-					previous={ previous?.avg_ecpm }
-				/>
-				<Scorecard
-					label={ __( 'Fill Rate', 'newspack-plugin' ) }
-					description={ __( 'How often slots fill', 'newspack-plugin' ) }
-					current={ current.fill_rate }
-					previous={ previous?.fill_rate }
-				/>
-				<Scorecard
-					label={ __( 'Viewability Rate', 'newspack-plugin' ) }
-					description={ __( 'How often ads are seen', 'newspack-plugin' ) }
-					current={ current.viewability_rate }
-					previous={ previous?.viewability_rate }
-				/>
-			</div>
+				<Grid columns={ 4 } gutter={ 16 } noMargin>
+					<Scorecard
+						label={ __( 'Average eCPM', 'newspack-plugin' ) }
+						description={ __( 'Your ad rate', 'newspack-plugin' ) }
+						current={ current.avg_ecpm }
+						previous={ previous?.avg_ecpm }
+					/>
+					<Scorecard
+						label={ __( 'Fill Rate', 'newspack-plugin' ) }
+						description={ __( 'How often slots fill', 'newspack-plugin' ) }
+						current={ current.fill_rate }
+						previous={ previous?.fill_rate }
+					/>
+					<Scorecard
+						label={ __( 'Viewability Rate', 'newspack-plugin' ) }
+						description={ __( 'How often ads are seen', 'newspack-plugin' ) }
+						current={ current.viewability_rate }
+						previous={ previous?.viewability_rate }
+					/>
+				</Grid>
+			</VStack>
 		</section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
@@ -1,5 +1,5 @@
 /**
- * Advertising › Top performers (NPPD-1618, Section 3).
+ * Advertising › Top performers (Section 3).
  *
  * Top ad units, Top advertisers, and Top campaigns (direct-sold orders), each
  * its own top-level section (h2) stacked at full width — ad unit and advertiser
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import type { InsightsWindow } from '../../../api/advertising';
 import MetricTable from '../../components/MetricTable';
 import SectionHeading from '../../components/SectionHeading';
+import TabSections from '../../components/TabSections';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -27,7 +28,7 @@ export interface SectionProps {
 }
 
 const TopPerformersSection = ( { current }: SectionProps ) => (
-	<>
+	<TabSections>
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
 			<SectionHeading id="newspack-insights-advertising-top-ad-units" title={ __( 'Top ad units', 'newspack-plugin' ) } />
 			<MetricTable
@@ -79,7 +80,7 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 				] }
 			/>
 		</section>
-	</>
+	</TabSections>
 );
 
 export default TopPerformersSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/TabSections.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/TabSections.tsx
@@ -1,0 +1,36 @@
+/**
+ * TabSections — renders a tab's sections with a full-width Divider between each
+ * one (never before the first). Falsy children (from conditionally-rendered
+ * sections) are dropped first, so a divider only ever appears between two sections
+ * that actually render — matching the old `&__section + &__section` CSS rule this
+ * replaces, but with the shared Newspack Divider (as used in Access Control).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Children, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Divider } from '../../../../../packages/components/src';
+
+const TabSections = ( { children }: { children: React.ReactNode } ) => {
+	const sections = Children.toArray( children ).filter( Boolean );
+	// A gap-free flex column so the Divider's own 64px margins are the sole source
+	// of inter-section spacing — uniform across tabs regardless of their container
+	// gap (which varies), unlike the old adjacent-sibling CSS rule.
+	return (
+		<div className="newspack-insights__tab-sections">
+			{ sections.map( ( section, index ) => (
+				<Fragment key={ index }>
+					{ index > 0 && <Divider alignment="full-width" variant="tertiary" /> }
+					{ section }
+				</Fragment>
+			) ) }
+		</div>
+	);
+};
+
+export default TabSections;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -1,5 +1,5 @@
 /**
- * Newspack Insights — shared tab chrome (NPPD-1602/1616)
+ * Newspack Insights — shared tab chrome
  *
  * Generic visuals that every Insights tab inherits: section wrappers
  * and headings, the metric card chrome + responsive grid, the table
@@ -63,13 +63,12 @@
 		gap: 16px;
 	}
 
-	// Hairline separator + breathing room between consecutive sections so a
-	// long tab doesn't read as one dense block (DSGNEWS-188 — "white space is
-	// very important"). The tab wrapper's 32px flex gap sits above the border;
-	// the padding balances the same space below it.
-	&__section + &__section {
-		padding-top: 32px;
-		border-top: 1px solid wp-colors.$gray-200;
+	// Wraps a tab's sections; the interleaved full-width Dividers supply all the
+	// inter-section spacing via their own margins, so no gap here (a gap would
+	// stack with the divider margins).
+	&__tab-sections {
+		display: flex;
+		flex-direction: column;
 	}
 
 	&__section-empty {
@@ -124,14 +123,14 @@
 	//            + body padding.
 	//   description — pinned to the bottom edge, left-aligned
 	//
-	// Cards carry no blanket top accent (DSGNEWS-188 — a brand-color bar on
+	// Cards carry no blanket top accent (a brand-color bar on
 	// every tile in a row added no value). The CoreCard's own border + 4px
 	// radius are the chrome; the `--highlighted` modifier adds a 4px accent
 	// (bumped from the old 3px) for the rare case of marking a single tile.
 
 	&__metric-card {
 		// Establish a size container so the hero value can scale to the card
-		// width (DSGNEWS-188 — long numbers overflowed the fixed 44px on narrow
+		// width (long numbers overflowed the fixed 44px on narrow
 		// cards). See `&-value` below.
 		container-type: inline-size;
 
@@ -208,7 +207,7 @@
 			font-family: wp-vars.$default-font;
 			// Cap at the 44px design size, but scale down with the card width so a
 			// long formatted number (e.g. "1,392,000") can't overflow a narrow
-			// tile (DSGNEWS-188). `container-type` is set on `&__metric-card`.
+			// tile. `container-type` is set on `&__metric-card`.
 			font-size: 44px; // fallback where container-query units aren't supported.
 			font-size: min( 44px, 14cqi );
 			font-weight: 500;
@@ -223,8 +222,8 @@
 		}
 
 		// Count-fallback heroes ("0 of 17", "0 conversions") are short phrases,
-		// not single numbers — the 44px number scale overflows the narrow card
-		// (NPPD-1694). Render them smaller and let them wrap so they stay inside
+		// not single numbers — the 44px number scale overflows the narrow card.
+		// Render them smaller and let them wrap so they stay inside
 		// the border. The em-dash null glyph keeps the full hero scale.
 		&-value--count {
 			font-size: 24px;
@@ -413,7 +412,7 @@
 			}
 		}
 
-		// The trailing "(no campaign)" denominator row (NEWS-2580): renders its
+		// The trailing "(no campaign)" denominator row: renders its
 		// real count + revenue but muted (gray-600) so the untagged remainder reads
 		// as context rather than a ranked campaign. Backend orders it last.
 		&-row--untagged td {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
@@ -23,6 +23,7 @@ import type { ReactNode } from 'react';
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ import type { InsightsWindow } from '../../../api/newsletter_ads';
 import EmptyMetricSection from '../../components/EmptyMetricSection';
 import Scorecard from '../../components/Scorecard';
 import SectionHeading from '../../components/SectionHeading';
+import { Grid } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -77,71 +79,73 @@ const OverviewSection = ( { current, previous, hasWindowActivity, lastUpdated }:
 	return (
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-overview">
 			<SectionHeading id="newspack-insights-newsletter-ads-overview" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
-			{ /* Row 1: the four timeframe headline scorecards. */ }
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
-				<Scorecard
-					label={ __( 'Impressions', 'newspack-plugin' ) }
-					description={ __( 'How many times your ads were seen', 'newspack-plugin' ) }
-					current={ current.total_impressions }
-					previous={ previous?.total_impressions }
-					// Timeframe counts are non-computable only when dated tracking is
-					// unavailable (not-ready) — an em-dash there, not a fake 0.
-					notComputableMessage={ NOT_TRACKED_MESSAGE }
-				/>
-				<Scorecard
-					label={ __( 'Clicks', 'newspack-plugin' ) }
-					description={ __( 'How many times your ads were clicked', 'newspack-plugin' ) }
-					current={ current.total_clicks }
-					previous={ previous?.total_clicks }
-					notComputableMessage={ NOT_TRACKED_MESSAGE }
-				/>
-				<Scorecard
-					label={ __( 'CTR', 'newspack-plugin' ) }
-					description={ __( 'Clicks per impression', 'newspack-plugin' ) }
-					current={ current.ctr }
-					previous={ previous?.ctr }
-					// A non-computable rate renders the em-dash treatment — never "0%".
-					notComputableMessage={ __( 'No impressions in this timeframe to calculate a click-through rate.', 'newspack-plugin' ) }
-				/>
-				<Scorecard
-					label={ __( 'Revenue', 'newspack-plugin' ) }
-					description={ __( 'What your ads earned', 'newspack-plugin' ) }
-					current={ current.total_revenue }
-					previous={ previous?.total_revenue }
-					notComputableMessage={ NOT_TRACKED_MESSAGE }
-				/>
-			</div>
-			{ /* Row 2: remaining timeframe cards + the all-time lifetime counters.
+			<VStack spacing={ 4 }>
+				{ /* Row 1: the four timeframe headline scorecards. */ }
+				<Grid columns={ 4 } gutter={ 16 } noMargin>
+					<Scorecard
+						label={ __( 'Impressions', 'newspack-plugin' ) }
+						description={ __( 'How many times your ads were seen', 'newspack-plugin' ) }
+						current={ current.total_impressions }
+						previous={ previous?.total_impressions }
+						// Timeframe counts are non-computable only when dated tracking is
+						// unavailable (not-ready) — an em-dash there, not a fake 0.
+						notComputableMessage={ NOT_TRACKED_MESSAGE }
+					/>
+					<Scorecard
+						label={ __( 'Clicks', 'newspack-plugin' ) }
+						description={ __( 'How many times your ads were clicked', 'newspack-plugin' ) }
+						current={ current.total_clicks }
+						previous={ previous?.total_clicks }
+						notComputableMessage={ NOT_TRACKED_MESSAGE }
+					/>
+					<Scorecard
+						label={ __( 'CTR', 'newspack-plugin' ) }
+						description={ __( 'Clicks per impression', 'newspack-plugin' ) }
+						current={ current.ctr }
+						previous={ previous?.ctr }
+						// A non-computable rate renders the em-dash treatment — never "0%".
+						notComputableMessage={ __( 'No impressions in this timeframe to calculate a click-through rate.', 'newspack-plugin' ) }
+					/>
+					<Scorecard
+						label={ __( 'Revenue', 'newspack-plugin' ) }
+						description={ __( 'What your ads earned', 'newspack-plugin' ) }
+						current={ current.total_revenue }
+						previous={ previous?.total_revenue }
+						notComputableMessage={ NOT_TRACKED_MESSAGE }
+					/>
+				</Grid>
+				{ /* Row 2: remaining timeframe cards + the all-time lifetime counters.
 			     Lifetime cards deliberately pass no `previous` — they're cumulative,
 			     so a period delta is meaningless. */ }
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
-				<Scorecard
-					label={ __( 'eCPM', 'newspack-plugin' ) }
-					description={ __( 'Revenue per 1,000 impressions', 'newspack-plugin' ) }
-					current={ current.ecpm }
-					previous={ previous?.ecpm }
-					// eCPM is an undefined division without both revenue and impressions —
-					// em-dash, never a misleading "$0.00".
-					notComputableMessage={ __( 'Requires both revenue and impressions in this timeframe to calculate.', 'newspack-plugin' ) }
-				/>
-				<Scorecard
-					label={ __( 'Active ads', 'newspack-plugin' ) }
-					description={ __( 'Ads that ran in newsletters', 'newspack-plugin' ) }
-					current={ current.active_ads }
-					previous={ previous?.active_ads }
-					notComputableMessage={ NOT_TRACKED_MESSAGE }
-				/>
-				<Scorecard
-					label={ __( 'All-time impressions', 'newspack-plugin' ) }
-					description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
-					current={ current.lifetime_impressions }
-				/>
-				<Scorecard
-					label={ __( 'All-time clicks', 'newspack-plugin' ) }
-					description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
-					current={ current.lifetime_clicks }
-				/>
-			</div>
+				<Grid columns={ 4 } gutter={ 16 } noMargin>
+					<Scorecard
+						label={ __( 'eCPM', 'newspack-plugin' ) }
+						description={ __( 'Revenue per 1,000 impressions', 'newspack-plugin' ) }
+						current={ current.ecpm }
+						previous={ previous?.ecpm }
+						// eCPM is an undefined division without both revenue and impressions —
+						// em-dash, never a misleading "$0.00".
+						notComputableMessage={ __( 'Requires both revenue and impressions in this timeframe to calculate.', 'newspack-plugin' ) }
+					/>
+					<Scorecard
+						label={ __( 'Active ads', 'newspack-plugin' ) }
+						description={ __( 'Ads that ran in newsletters', 'newspack-plugin' ) }
+						current={ current.active_ads }
+						previous={ previous?.active_ads }
+						notComputableMessage={ NOT_TRACKED_MESSAGE }
+					/>
+					<Scorecard
+						label={ __( 'All-time impressions', 'newspack-plugin' ) }
+						description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
+						current={ current.lifetime_impressions }
+					/>
+					<Scorecard
+						label={ __( 'All-time clicks', 'newspack-plugin' ) }
+						description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
+						current={ current.lifetime_clicks }
+					/>
+				</Grid>
+			</VStack>
 			{ excludedAds > 0 && (
 				<p className="newspack-insights__table-footnote">
 					{ sprintf(

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
@@ -1,5 +1,5 @@
 /**
- * Newsletter Ads › performance tables (NPPD-1861).
+ * Newsletter Ads › performance tables.
  *
  * Three MetricTables (static, not sortable), each rendered as its own
  * full-width H2 section — Top ads, Top advertisers, and Ad performance by
@@ -22,6 +22,7 @@ import type { MetricPayload } from '../../components/metrics';
 import { formatShortDate } from '../../components/format';
 import MetricTable from '../../components/MetricTable';
 import SectionHeading from '../../components/SectionHeading';
+import TabSections from '../../components/TabSections';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -46,7 +47,7 @@ const withDisplayDates = ( payload?: MetricPayload ): MetricPayload | undefined 
 };
 
 const TablesSection = ( { current }: SectionProps ) => (
-	<>
+	<TabSections>
 		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-ads">
 			<SectionHeading id="newspack-insights-newsletter-ads-top-ads" title={ __( 'Top ads', 'newspack-plugin' ) } />
 			<MetricTable
@@ -96,7 +97,7 @@ const TablesSection = ( { current }: SectionProps ) => (
 				] }
 			/>
 		</section>
-	</>
+	</TabSections>
 );
 
 export default TablesSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
@@ -15,6 +15,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalHStack as HStack, FlexBlock } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -51,14 +52,18 @@ const TrendSection = ( { current, previous }: SectionProps ) => (
 			title={ __( 'Performance trend', 'newspack-plugin' ) }
 			description={ __( 'Daily impressions and clicks across the selected timeframe.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
-			<ChartCard title={ __( 'Impressions', 'newspack-plugin' ) } payload={ current.performance_by_day }>
-				<LineChart series={ buildSeries( current, previous, 'impressions' ) } formatLabel={ formatDateLabel } />
-			</ChartCard>
-			<ChartCard title={ __( 'Clicks', 'newspack-plugin' ) } payload={ current.performance_by_day }>
-				<LineChart series={ buildSeries( current, previous, 'clicks' ) } formatLabel={ formatDateLabel } />
-			</ChartCard>
-		</div>
+		<HStack spacing={ 4 } alignment="stretch">
+			<FlexBlock>
+				<ChartCard title={ __( 'Impressions', 'newspack-plugin' ) } payload={ current.performance_by_day }>
+					<LineChart series={ buildSeries( current, previous, 'impressions' ) } formatLabel={ formatDateLabel } />
+				</ChartCard>
+			</FlexBlock>
+			<FlexBlock>
+				<ChartCard title={ __( 'Clicks', 'newspack-plugin' ) } payload={ current.performance_by_day }>
+					<LineChart series={ buildSeries( current, previous, 'clicks' ) } formatLabel={ formatDateLabel } />
+				</ChartCard>
+			</FlexBlock>
+		</HStack>
 	</section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
@@ -52,7 +52,7 @@ const TrendSection = ( { current, previous }: SectionProps ) => (
 			title={ __( 'Performance trend', 'newspack-plugin' ) }
 			description={ __( 'Daily impressions and clicks across the selected timeframe.', 'newspack-plugin' ) }
 		/>
-		<HStack spacing={ 4 } alignment="stretch">
+		<HStack spacing={ 4 } alignment="stretch" wrap>
 			<FlexBlock>
 				<ChartCard title={ __( 'Impressions', 'newspack-plugin' ) } payload={ current.performance_by_day }>
 					<LineChart series={ buildSeries( current, previous, 'impressions' ) } formatLabel={ formatDateLabel } />


### PR DESCRIPTION
### Changes proposed in this Pull Request

Replaces the CSS `&__section + &__section` hairline separator with the shared Newspack **`<Divider alignment="full-width" variant="tertiary" />`** (the Access Control treatment) between the sections of every Insights tab, plus some related grouping/spacing cleanup.

**Section dividers**
- New `TabSections` wrapper (`tabs/components/TabSections.tsx`): a gap-free flex column that interleaves a full-width Divider between each rendered section (never before the first), auto-skipping conditionally-rendered sections. Wired into all 10 tab orchestrators; notices/banners stay outside so no divider strands next to them.
- Removed the old `&__section + &__section` rule; added `&__tab-sections`.

**Grouping / spacing**
- Advertising **Top performers** and Newsletter Ads **performance tables** use `TabSections` so their sub-tables (Top ad units / advertisers / campaigns; Top ads / advertisers / by-newsletter) are divider-separated.
- Newsletter Ads **Performance trend** charts (Impressions / Clicks) now sit in an `HStack` + `FlexBlock` (equal width, `spacing={4}`).
- Advertising **Reach & revenue** and Newsletter Ads **Overview** grids swapped from the custom `metric-grid` divs to the `<Grid columns={4} gutter={16} noMargin>` component, the two rows wrapped in a `VStack spacing={4}`.

**Housekeeping**
- Stripped Linear ticket IDs from comments in the touched files (explanations kept).
- Regenerated the PromptsTab snapshot (structural only).

### How to test

1. `n build newspack-plugin`, open **Insights**, and visit each tab.
2. Confirm a full-width light divider separates consecutive sections, with none before the first section or beside notices/banners.
3. Advertising & Newsletter Ads: confirm dividers between the sub-tables, the equal-width trend charts, and the `<Grid>`-based Reach & revenue / Overview rows.

Targets `feat/insights-rsm`.