### PR TITLE
fix(insights): remove dead Move left/right column actions in tables

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.test.tsx
@@ -93,6 +93,16 @@ describe( 'InsightsDataView', () => {
 		expect( scores ).toEqual( [ '30', '10', '—' ] );
 	} );
 
+	it( 'offers sorting but not "Move left/right" reordering in the column header menu', async () => {
+		renderView( { defaultSortKey: 'score' } );
+		// Open the "Score" column header dropdown.
+		fireEvent.click( screen.getByRole( 'button', { name: /score/i } ) );
+		// Sort affordance stays; the read-only table drops column reordering.
+		expect( await screen.findByText( 'Sort descending' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Move left' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Move right' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'caps rows behind a "See more" toggle when expandable', () => {
 		const many: Row[] = Array.from( { length: 5 }, ( _, i ) => ( { id: String( i ), name: `Row ${ i }`, score: i } ) );
 		render(

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.tsx
@@ -179,6 +179,11 @@ const InsightsDataView = < Row, >( {
 				...view,
 				fields: columns.map( col => col.key ),
 				layout: {
+					// Read-only: keep click-to-sort but drop the column-header
+					// "Move left/right" reordering. Its onChangeView field reorder is
+					// discarded here anyway (fields is re-derived from columns above),
+					// so without this it's a dead affordance.
+					enableMoving: false,
 					styles: Object.fromEntries( columns.filter( col => col.numeric ).map( col => [ col.key, { align: 'end' as const } ] ) ),
 				},
 			} ) as View,


### PR DESCRIPTION
## Summary

Follow-up to #584 (NPPD-1889). The read-only DataViews tables showed **"Move left" / "Move right"** in every column-header menu, but clicking them did nothing.

`InsightsDataView`'s `activeView` always re-derives `fields` from the `columns` prop, so the reorder that those menu items dispatch via `onChangeView` is discarded on the next render — a dead affordance. #584 called this out ("Column-header 'Move left/right' is kept (no clean prop to remove it)").

There **is** a clean lever: in `@wordpress/dataviews` 10.3.0 the table layout gates those items on `canMove: view.layout?.enableMoving ?? true`. Setting `layout.enableMoving = false` stops both items from rendering (no DOM, no a11y node) while click-to-sort stays. It lives in the shared wrapper, so it applies to all 20 migrated tables at once.

## Testing

- New `InsightsDataView` test opens a real column-header menu and asserts "Sort descending" is present while "Move left/right" are absent.
- Full `InsightsDataView` suite green (8/8).
- `tsc` clean (`enableMoving` is a typed layout field); ESLint clean.

Linear: [NPPD-1889](https://linear.app/a8c/issue/NPPD-1889)