### PR TITLE
feat(content-gate): restrict product purchases to members (NPPD-1899)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
@@ -69,8 +69,8 @@ class Content_Gate_API {
 		'custom_access'       => [
 			'type'       => 'object',
 			'properties' => [
-				'active'         => [ 'type' => 'boolean' ],
-				'metering'       => [
+				'active'                        => [ 'type' => 'boolean' ],
+				'metering'                      => [
 					'type'       => 'object',
 					'properties' => [
 						'enabled' => [ 'type' => 'boolean' ],
@@ -78,11 +78,11 @@ class Content_Gate_API {
 						'period'  => [ 'type' => 'string' ],
 					],
 				],
-				'gate_layout_id' => [
+				'gate_layout_id'                => [
 					'type'     => 'integer',
 					'required' => false,
 				],
-				'access_rules'   => [
+				'access_rules'                  => [
 					'type'  => 'array',
 					'items' => [
 						'type'  => 'array',
@@ -94,6 +94,14 @@ class Content_Gate_API {
 							],
 						],
 					],
+				],
+				'restricted_products'           => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'integer' ],
+				],
+				'restricted_product_categories' => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'integer' ],
 				],
 			],
 		],
@@ -182,7 +190,27 @@ class Content_Gate_API {
 		if ( isset( $custom_access['gate_layout_id'] ) ) {
 			$sanitized['gate_layout_id'] = absint( $custom_access['gate_layout_id'] );
 		}
+		if ( isset( $custom_access['restricted_products'] ) ) {
+			$sanitized['restricted_products'] = self::sanitize_ids( $custom_access['restricted_products'] );
+		}
+		if ( isset( $custom_access['restricted_product_categories'] ) ) {
+			$sanitized['restricted_product_categories'] = self::sanitize_ids( $custom_access['restricted_product_categories'] );
+		}
 		return $sanitized;
+	}
+
+	/**
+	 * Sanitize a list of object IDs (products, terms) into unique positive integers.
+	 *
+	 * @param array $ids The IDs.
+	 *
+	 * @return int[] The sanitized IDs.
+	 */
+	public static function sanitize_ids( $ids ) {
+		if ( ! is_array( $ids ) ) {
+			return [];
+		}
+		return array_values( array_unique( array_filter( array_map( 'absint', $ids ) ) ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
@@ -202,6 +202,9 @@ class Content_Gate_API {
 	/**
 	 * Sanitize a list of object IDs (products, terms) into unique positive integers.
 	 *
+	 * Non-positive values are dropped rather than coerced: `absint()` would turn a
+	 * negative into a positive ID, quietly pointing the rule at some other object.
+	 *
 	 * @param array $ids The IDs.
 	 *
 	 * @return int[] The sanitized IDs.
@@ -210,7 +213,17 @@ class Content_Gate_API {
 		if ( ! is_array( $ids ) ) {
 			return [];
 		}
-		return array_values( array_unique( array_filter( array_map( 'absint', $ids ) ) ) );
+		$ids = array_map( 'intval', $ids );
+		return array_values(
+			array_unique(
+				array_filter(
+					$ids,
+					function( $id ) {
+						return $id > 0;
+					}
+				)
+			)
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -118,6 +118,7 @@ class Content_Gate {
 		include __DIR__ . '/class-institution.php';
 		include __DIR__ . '/class-newsletters-access.php';
 		include __DIR__ . '/class-user-gate-access.php';
+		include __DIR__ . '/class-product-purchase-restriction.php';
 		include __DIR__ . '/class-premium-newsletters.php';
 		include __DIR__ . '/class-block-visibility.php';
 	}
@@ -1174,10 +1175,13 @@ class Content_Gate {
 		];
 
 		return [
-			'active'         => isset( $custom_access['active'] ) ? (bool) $custom_access['active'] : false,
-			'metering'       => isset( $custom_access['metering'] ) && is_array( $custom_access['metering'] ) ? wp_parse_args( $custom_access['metering'], $default_metering ) : $default_metering,
-			'access_rules'   => $access_rules,
-			'gate_layout_id' => isset( $custom_access['gate_layout_id'] ) ? (int) $custom_access['gate_layout_id'] : 0,
+			'active'                        => isset( $custom_access['active'] ) ? (bool) $custom_access['active'] : false,
+			'metering'                      => isset( $custom_access['metering'] ) && is_array( $custom_access['metering'] ) ? wp_parse_args( $custom_access['metering'], $default_metering ) : $default_metering,
+			'access_rules'                  => $access_rules,
+			'gate_layout_id'                => isset( $custom_access['gate_layout_id'] ) ? (int) $custom_access['gate_layout_id'] : 0,
+			// Products whose *purchase* is restricted to readers passing the access rules above.
+			'restricted_products'           => isset( $custom_access['restricted_products'] ) ? array_map( 'intval', (array) $custom_access['restricted_products'] ) : [],
+			'restricted_product_categories' => isset( $custom_access['restricted_product_categories'] ) ? array_map( 'intval', (array) $custom_access['restricted_product_categories'] ) : [],
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -1180,8 +1180,10 @@ class Content_Gate {
 			'access_rules'                  => $access_rules,
 			'gate_layout_id'                => isset( $custom_access['gate_layout_id'] ) ? (int) $custom_access['gate_layout_id'] : 0,
 			// Products whose *purchase* is restricted to readers passing the access rules above.
-			'restricted_products'           => isset( $custom_access['restricted_products'] ) ? array_map( 'intval', (array) $custom_access['restricted_products'] ) : [],
-			'restricted_product_categories' => isset( $custom_access['restricted_product_categories'] ) ? array_map( 'intval', (array) $custom_access['restricted_product_categories'] ) : [],
+			// Normalized on read, not just on save: meta written outside the REST API (a migration
+			// script, WP-CLI) could otherwise smuggle in zeros, negatives or duplicates.
+			'restricted_products'           => isset( $custom_access['restricted_products'] ) ? Content_Gate_API::sanitize_ids( $custom_access['restricted_products'] ) : [],
+			'restricted_product_categories' => isset( $custom_access['restricted_product_categories'] ) ? Content_Gate_API::sanitize_ids( $custom_access['restricted_product_categories'] ) : [],
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -286,22 +286,24 @@ class Content_Restriction_Control {
 	 * Expand a set of taxonomy term IDs to include descendant terms when the
 	 * taxonomy is hierarchical.
 	 *
-	 * A content rule targeting a parent term should also match content assigned
-	 * only to that term's descendants, mirroring WooCommerce Memberships' cascade
-	 * behavior. Expansion happens at evaluation time so newly-added child terms
-	 * are covered without re-saving the rule. Non-hierarchical taxonomies (e.g.
-	 * tags) have no descendants and are returned as integer-cast IDs unchanged.
+	 * A rule targeting a parent term should also match content assigned only to
+	 * that term's descendants, mirroring WooCommerce Memberships' cascade
+	 * behavior. Used by content rules and by the gate's product-category purchase
+	 * restriction (Product_Purchase_Restriction), which cascades the same way.
+	 * Expansion happens at evaluation time so newly-added child terms are covered
+	 * without re-saving the rule. Non-hierarchical taxonomies (e.g. tags) have no
+	 * descendants and are returned as integer-cast IDs unchanged.
 	 *
 	 * Descendant lookups are memoised per (taxonomy, term) for the request so the
 	 * tree is walked at most once per term, even across many rules and posts (e.g.
 	 * the Premium Newsletters cron loop).
 	 *
-	 * @param array        $term_ids Term IDs from a content rule's value (may be stored as strings).
+	 * @param array        $term_ids Term IDs from a rule's value (may be stored as strings).
 	 * @param \WP_Taxonomy $taxonomy Taxonomy object the term IDs belong to.
 	 *
 	 * @return int[] De-duplicated term IDs including descendants.
 	 */
-	private static function expand_hierarchical_terms( array $term_ids, \WP_Taxonomy $taxonomy ): array {
+	public static function expand_hierarchical_terms( array $term_ids, \WP_Taxonomy $taxonomy ): array {
 		$term_ids = array_map( 'intval', $term_ids );
 		if ( ! $taxonomy->hierarchical ) {
 			return $term_ids;

--- a/plugins/newspack-plugin/includes/content-gate/class-product-purchase-restriction.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-product-purchase-restriction.php
@@ -1,0 +1,459 @@
+<?php
+/**
+ * Newspack Content Gate - product purchase restriction.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Restricts *purchasing* of WooCommerce products to readers who pass a gate's
+ * access rules.
+ *
+ * Only the purchase is blocked: the product page, its price and the shop
+ * catalog stay visible to everyone, and a notice on the product page tells the
+ * reader how to unlock it. This mirrors WooCommerce Memberships' product
+ * "purchase" restriction, which Access Control replaces.
+ *
+ * A gate restricts purchasing when its custom access is active, it has access
+ * rules (the WHO), and it lists restricted products and/or product categories
+ * (the WHAT). Content rules are not required — a purchase-only gate has none,
+ * which also keeps it out of content restriction entirely, since
+ * Content_Restriction_Control::get_post_gates() skips gates without content rules.
+ */
+class Product_Purchase_Restriction {
+
+	/**
+	 * The WooCommerce product category taxonomy.
+	 */
+	const PRODUCT_CATEGORY_TAXONOMY = 'product_cat';
+
+	/**
+	 * The gate blocking a purchase, keyed by "{product_id}_{user_id}", or false
+	 * when the product is purchasable. WooCommerce evaluates purchasability
+	 * several times per product per request (catalog loop, single product
+	 * template, cart validation), so the decision is memoized.
+	 *
+	 * @var array<string, array|false>
+	 */
+	private static array $blocking_gates = [];
+
+	/**
+	 * Published gates that restrict purchasing. Null until first looked up.
+	 *
+	 * @var array[]|null
+	 */
+	private static ?array $restricting_gates = null;
+
+	/**
+	 * Restricted product categories (including child categories), keyed by gate ID.
+	 *
+	 * @var array<int, int[]>
+	 */
+	private static array $restricted_categories = [];
+
+	/**
+	 * Whether a user passes a gate, keyed by "{gate_id}_{user_id}". A gate's verdict
+	 * depends on the reader, not the product, so it is reused across every product a
+	 * gate restricts — otherwise a catalog page of N restricted products would re-run
+	 * the (uncached) subscription lookups behind an access rule N times.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static array $gate_access = [];
+
+	/**
+	 * Products the notice has already been rendered for this request, so the classic
+	 * and block templates can't both emit it.
+	 *
+	 * @var array<int, bool>
+	 */
+	private static array $rendered_notices = [];
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		// Priority 999, as WooCommerce Memberships does: a restriction must have the
+		// final say, or a later callback (e.g. WooCommerce Subscriptions' renewal-cart
+		// limiter, which runs at 12 and returns true) can hand the purchase back.
+		add_filter( 'woocommerce_is_purchasable', [ __CLASS__, 'filter_is_purchasable' ], 999, 2 );
+		add_filter( 'woocommerce_variation_is_purchasable', [ __CLASS__, 'filter_is_purchasable' ], 999, 2 );
+		// Priority 31: right after the add-to-cart form (30), where WooCommerce Memberships puts its own notice.
+		add_action( 'woocommerce_single_product_summary', [ __CLASS__, 'render_restricted_message' ], 31 );
+		// Block themes never fire the action above; the notice rides the add-to-cart block instead.
+		add_filter( 'render_block', [ __CLASS__, 'filter_add_to_cart_block' ], 10, 2 );
+	}
+
+	/**
+	 * Whether purchase restriction is enforced at all.
+	 *
+	 * While WooCommerce Memberships is active it owns purchase restriction, and
+	 * enforcing ours on top would double-gate a site mid-migration. Mirrors
+	 * Content_Restriction_Control::is_post_restricted().
+	 *
+	 * @return bool
+	 */
+	private static function is_enforced(): bool {
+		return Content_Gate::is_newspack_feature_enabled() && ! Memberships::is_active();
+	}
+
+	/**
+	 * Block purchasing of a restricted product for readers who fail its gate.
+	 *
+	 * @param bool        $purchasable Whether the product is purchasable.
+	 * @param \WC_Product $product     The product (or variation).
+	 *
+	 * @return bool Whether the product is purchasable.
+	 */
+	public static function filter_is_purchasable( $purchasable, $product ) {
+		// Never make a product purchasable that WooCommerce already ruled out.
+		if ( ! $purchasable ) {
+			return $purchasable;
+		}
+		return false === self::get_blocking_gate( $product ) ? $purchasable : false;
+	}
+
+	/**
+	 * Get the gate blocking the current reader from purchasing a product.
+	 *
+	 * @param \WC_Product $product The product (or variation).
+	 * @param int|null    $user_id Optional user ID. Defaults to the current user.
+	 *
+	 * @return array|false The blocking gate, or false if the product can be purchased.
+	 */
+	public static function get_blocking_gate( $product, $user_id = null ) {
+		if ( ! self::is_enforced() || ! $product instanceof \WC_Product ) {
+			return false;
+		}
+		$product_id = (int) $product->get_id();
+		if ( ! $product_id ) {
+			return false;
+		}
+		$user_id   = null === $user_id ? get_current_user_id() : (int) $user_id;
+		$cache_key = $product_id . '_' . $user_id;
+		if ( ! isset( self::$blocking_gates[ $cache_key ] ) ) {
+			self::$blocking_gates[ $cache_key ] = self::find_blocking_gate( $product, $user_id );
+		}
+		return self::$blocking_gates[ $cache_key ];
+	}
+
+	/**
+	 * Find the first gate that restricts the product and that the user fails.
+	 *
+	 * A reader must pass *every* gate restricting the product — "any of these
+	 * rules" is expressed within a single gate, by its rule groups.
+	 *
+	 * @param \WC_Product $product The product (or variation).
+	 * @param int         $user_id The user ID (0 for anonymous readers).
+	 *
+	 * @return array|false The blocking gate, or false if the product can be purchased.
+	 */
+	private static function find_blocking_gate( $product, $user_id ) {
+		$blocking_gate = false;
+
+		// Shop managers can always purchase, so a restriction can't lock a publisher out of their own store (WCM parity).
+		if ( ! user_can( $user_id, 'manage_woocommerce' ) ) {
+			foreach ( self::get_restricting_gates() as $gate ) {
+				if ( ! self::gate_restricts_product( $gate, $product ) ) {
+					continue;
+				}
+				if ( ! self::user_passes_gate( $gate, $user_id ) ) {
+					$blocking_gate = $gate;
+					break;
+				}
+			}
+		}
+
+		/**
+		 * Filters the gate blocking a reader from purchasing a product.
+		 *
+		 * @param array|false $blocking_gate The blocking gate, or false if the product can be purchased.
+		 * @param \WC_Product $product       The product (or variation).
+		 * @param int         $user_id       The user ID (0 for anonymous readers).
+		 */
+		return apply_filters( 'newspack_product_purchase_blocking_gate', $blocking_gate, $product, $user_id );
+	}
+
+	/**
+	 * Whether a user satisfies a gate's access rules.
+	 *
+	 * @param array $gate    The gate.
+	 * @param int   $user_id The user ID (0 for anonymous readers).
+	 *
+	 * @return bool
+	 */
+	private static function user_passes_gate( array $gate, int $user_id ): bool {
+		$cache_key = $gate['id'] . '_' . $user_id;
+		if ( ! isset( self::$gate_access[ $cache_key ] ) ) {
+			$access = User_Gate_Access::evaluate_gate_for_user( $gate, $user_id );
+			self::$gate_access[ $cache_key ] = ! empty( $access['can_bypass'] );
+		}
+		return self::$gate_access[ $cache_key ];
+	}
+
+	/**
+	 * Get the published gates that restrict product purchasing.
+	 *
+	 * @return array[] The gates.
+	 */
+	private static function get_restricting_gates(): array {
+		if ( null !== self::$restricting_gates ) {
+			return self::$restricting_gates;
+		}
+		$gates = Content_Gate::get_gates( Content_Gate::GATE_CPT, 'publish' );
+
+		self::$restricting_gates = array_values(
+			array_filter(
+				$gates,
+				function( $gate ) {
+					if ( is_wp_error( $gate ) ) {
+						return false;
+					}
+					$custom_access = $gate['custom_access'];
+					// A gate with no access rules grants access to everyone (see
+					// User_Gate_Access::evaluate_gate_for_user), so it can't block a purchase.
+					// A rule with an empty value passes everyone too, and is left to the same
+					// evaluation below rather than second-guessed here — so a half-configured
+					// gate fails open, exactly as it does for content.
+					return ! empty( $custom_access['active'] )
+						&& ! empty( $custom_access['access_rules'] )
+						&& ( ! empty( $custom_access['restricted_products'] ) || ! empty( $custom_access['restricted_product_categories'] ) );
+				}
+			)
+		);
+		return self::$restricting_gates;
+	}
+
+	/**
+	 * Whether a gate restricts purchasing of a given product.
+	 *
+	 * A variation is restricted through its parent, which is what the publisher
+	 * selects in the gate.
+	 *
+	 * @param array       $gate    The gate.
+	 * @param \WC_Product $product The product (or variation).
+	 *
+	 * @return bool
+	 */
+	private static function gate_restricts_product( array $gate, $product ): bool {
+		$custom_access = $gate['custom_access'];
+		$product_id    = (int) $product->get_id();
+		$parent_id     = (int) $product->get_parent_id();
+
+		// A variation is restricted when it is listed itself or when its parent is.
+		foreach ( array_filter( [ $product_id, $parent_id ] ) as $id ) {
+			if ( in_array( $id, $custom_access['restricted_products'], true ) ) {
+				return true;
+			}
+		}
+
+		if ( empty( $custom_access['restricted_product_categories'] ) ) {
+			return false;
+		}
+
+		// Product categories live on the parent product; a variation never carries them.
+		$categorized_id = $parent_id ? $parent_id : $product_id;
+
+		return (bool) has_term( self::get_restricted_category_ids( $gate ), self::PRODUCT_CATEGORY_TAXONOMY, $categorized_id );
+	}
+
+	/**
+	 * Get a gate's restricted product categories, expanded to include child
+	 * categories.
+	 *
+	 * `product_cat` is hierarchical: restricting a parent category restricts
+	 * everything filed under it, matching both WooCommerce Memberships and the
+	 * gate's own content rules. Without this, a gate restricting "Premium" would
+	 * leave every product in "Premium > Merch" purchasable by anyone.
+	 *
+	 * @param array $gate The gate.
+	 *
+	 * @return int[] The category IDs, including descendants.
+	 */
+	private static function get_restricted_category_ids( array $gate ): array {
+		$gate_id = (int) $gate['id'];
+		if ( isset( self::$restricted_categories[ $gate_id ] ) ) {
+			return self::$restricted_categories[ $gate_id ];
+		}
+
+		$category_ids = array_map( 'intval', $gate['custom_access']['restricted_product_categories'] );
+		$taxonomy     = get_taxonomy( self::PRODUCT_CATEGORY_TAXONOMY );
+		if ( $taxonomy ) {
+			$category_ids = Content_Restriction_Control::expand_hierarchical_terms( $category_ids, $taxonomy );
+		}
+
+		self::$restricted_categories[ $gate_id ] = $category_ids;
+		return self::$restricted_categories[ $gate_id ];
+	}
+
+	/**
+	 * Render the notice on a classic product template.
+	 */
+	public static function render_restricted_message() {
+		global $product;
+
+		echo wp_kses_post( self::get_restricted_message_html( $product ) );
+	}
+
+	/**
+	 * Render the notice on a block-theme product template, where
+	 * `woocommerce_single_product_summary` never fires.
+	 *
+	 * The add-to-cart block renders nothing for a product the reader can't buy, so
+	 * without this the purchase is blocked with no explanation — the reader just
+	 * finds the button missing.
+	 *
+	 * @param string $block_content The block's rendered content.
+	 * @param array  $block         The parsed block.
+	 *
+	 * @return string The block content, with the notice appended when the reader can't purchase.
+	 */
+	public static function filter_add_to_cart_block( $block_content, $block ) {
+		// Only the single-product add-to-cart blocks. The catalog's product button is left
+		// alone: the shop loop stays as WooCommerce renders it, exactly as for a product
+		// that's out of stock.
+		$add_to_cart_blocks = [ 'woocommerce/add-to-cart-form', 'woocommerce/add-to-cart-with-options' ];
+		if ( ! in_array( $block['blockName'] ?? '', $add_to_cart_blocks, true ) ) {
+			return $block_content;
+		}
+
+		$product = self::get_block_product( $block );
+		if ( ! $product ) {
+			return $block_content;
+		}
+
+		return $block_content . self::get_restricted_message_html( $product );
+	}
+
+	/**
+	 * Resolve the product a block is rendering for.
+	 *
+	 * @param array $block The parsed block.
+	 *
+	 * @return \WC_Product|null The product, or null if it can't be resolved.
+	 */
+	private static function get_block_product( $block ) {
+		$product_id = (int) ( $block['attrs']['productId'] ?? $block['context']['postId'] ?? get_the_ID() );
+		if ( ! $product_id || ! function_exists( 'wc_get_product' ) ) {
+			return null;
+		}
+		$product = wc_get_product( $product_id );
+		return $product instanceof \WC_Product ? $product : null;
+	}
+
+	/**
+	 * Build the notice markup for a product the reader can't purchase.
+	 *
+	 * Returns an empty string when the product is purchasable, so both the classic
+	 * and block templates can call it unconditionally. The notice is emitted once
+	 * per product per request, so a template that runs both paths can't double it up.
+	 *
+	 * @param \WC_Product|null $product The product.
+	 *
+	 * @return string The notice HTML, escaped, or an empty string.
+	 */
+	private static function get_restricted_message_html( $product ): string {
+		if ( ! $product instanceof \WC_Product ) {
+			return '';
+		}
+
+		$gate = self::get_blocking_gate( $product );
+		if ( ! $gate ) {
+			return '';
+		}
+
+		$product_id = (int) $product->get_id();
+		if ( isset( self::$rendered_notices[ $product_id ] ) ) {
+			return '';
+		}
+		self::$rendered_notices[ $product_id ] = true;
+
+		$message = self::get_restricted_message( $product, $gate );
+		if ( ! $message ) {
+			return '';
+		}
+
+		return sprintf(
+			'<div class="woocommerce-info newspack-product-purchase-restricted">%s</div>',
+			wp_kses_post( $message )
+		);
+	}
+
+	/**
+	 * Build the message shown to a reader who can't purchase a product.
+	 *
+	 * @param \WC_Product $product The product.
+	 * @param array       $gate    The gate blocking the purchase.
+	 *
+	 * @return string The message. May contain links, so it is escaped with wp_kses_post() on output.
+	 */
+	public static function get_restricted_message( $product, $gate ) {
+		$subscription_links = self::get_subscription_product_links( $gate );
+
+		if ( empty( $subscription_links ) ) {
+			$message = __( 'This product can only be purchased by members.', 'newspack-plugin' );
+		} else {
+			$message = sprintf(
+				/* translators: %s: list of linked subscription product names. */
+				__( 'This product can only be purchased by members. To purchase this product, subscribe to %s.', 'newspack-plugin' ),
+				// wp_sprintf( '%l' ) builds the list with the locale's separators ("A, B and C").
+				wp_sprintf( '%l', $subscription_links )
+			);
+		}
+
+		/**
+		 * Filters the notice shown to a reader who can't purchase a restricted product.
+		 *
+		 * @param string      $message The message. Rendered through wp_kses_post().
+		 * @param \WC_Product $product The product.
+		 * @param array       $gate    The gate blocking the purchase.
+		 */
+		return apply_filters( 'newspack_product_purchase_restricted_message', $message, $product, $gate );
+	}
+
+	/**
+	 * Get links to the subscription products that unlock a gate, so the reader
+	 * knows what to buy. Empty when the gate grants access by other means
+	 * (email domain, institution, reader data), which have no product to link to.
+	 *
+	 * A subscription the reader can't buy either — because a gate restricts it too —
+	 * is left out rather than pointed at, so the notice never sends someone to a
+	 * product they've just been barred from purchasing.
+	 *
+	 * @param array $gate The gate.
+	 *
+	 * @return string[] The product links, keyed by product ID.
+	 */
+	private static function get_subscription_product_links( array $gate ): array {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return [];
+		}
+
+		$links = [];
+		foreach ( $gate['custom_access']['access_rules'] as $rule_group ) {
+			foreach ( $rule_group as $rule ) {
+				if ( 'subscription' !== ( $rule['slug'] ?? '' ) || empty( $rule['value'] ) ) {
+					continue;
+				}
+				foreach ( (array) $rule['value'] as $product_id ) {
+					$product_id           = (int) $product_id;
+					$subscription_product = wc_get_product( $product_id );
+					if ( ! $subscription_product || false !== self::get_blocking_gate( $subscription_product ) ) {
+						continue;
+					}
+					$links[ $product_id ] = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( (string) get_permalink( $product_id ) ),
+						esc_html( $subscription_product->get_name() )
+					);
+				}
+			}
+		}
+		return $links;
+	}
+}
+Product_Purchase_Restriction::init();

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -101,6 +101,8 @@ class Audience_Content_Gates extends Wizard {
 				'edit_gate_layout_url'    => Content_Gate::get_edit_gate_layout_url(),
 				'presave_checks_enabled'  => Content_Gate::get_presave_checks_enabled(),
 				'default_gate_status'     => Content_Gate::get_default_new_gate_status(),
+				// Purchase restriction only makes sense with a store to restrict.
+				'has_woocommerce'         => class_exists( 'WooCommerce' ),
 			]
 		);
 
@@ -335,6 +337,25 @@ class Audience_Content_Gates extends Wizard {
 			]
 		);
 
+		$search_args = [
+			'search'   => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'include'  => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'per_page' => [
+				'type'              => 'integer',
+				'default'           => 10,
+				'minimum'           => 1,
+				'maximum'           => 100,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
+
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/posts-search',
@@ -342,24 +363,31 @@ class Audience_Content_Gates extends Wizard {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'posts_search' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'search'   => [
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'include'  => [
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'per_page' => [
-						'type'              => 'integer',
-						'default'           => 10,
-						'minimum'           => 1,
-						'maximum'           => 100,
-						'sanitize_callback' => 'absint',
-						'validate_callback' => 'rest_validate_request_arg',
-					],
-				],
+				'args'                => $search_args,
+			]
+		);
+
+		// Products and product categories back the gate's purchase restriction.
+		// Without WooCommerce there are no products to find, and both routes return an empty list.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/products-search',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'products_search' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => $search_args,
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/product-categories-search',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'product_categories_search' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => $search_args,
 			]
 		);
 
@@ -543,11 +571,103 @@ class Audience_Content_Gates extends Wizard {
 	 * @return \WP_REST_Response
 	 */
 	public function posts_search( $request ) {
-		$post_types = array_column( Content_Restriction_Control::get_available_post_types(), 'value' );
+		return rest_ensure_response( $this->search_posts( $request, array_column( Content_Restriction_Control::get_available_post_types(), 'value' ) ) );
+	}
+
+	/**
+	 * REST callback: search WooCommerce products, for the gate's purchase restriction.
+	 *
+	 * Returns an empty list when WooCommerce is not active.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response
+	 */
+	public function products_search( $request ) {
+		// Unlike posts, products are routinely private or held as drafts before launch,
+		// and the restriction binds as soon as they go live — so let publishers pick them.
+		return rest_ensure_response( $this->search_posts( $request, [ 'product' ], [ 'publish', 'private', 'draft' ] ) );
+	}
+
+	/**
+	 * REST callback: search WooCommerce product categories, for the gate's purchase restriction.
+	 *
+	 * Returns items in the shape consumed by ContentRuleControlTokenField:
+	 * `[{ id, name, type_label }]`. Returns an empty list when WooCommerce is not active.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response
+	 */
+	public function product_categories_search( $request ) {
+		if ( ! taxonomy_exists( Product_Purchase_Restriction::PRODUCT_CATEGORY_TAXONOMY ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		$args = [
+			'taxonomy'   => Product_Purchase_Restriction::PRODUCT_CATEGORY_TAXONOMY,
+			'hide_empty' => false,
+			'number'     => (int) $request->get_param( 'per_page' ),
+			'orderby'    => 'name',
+			'order'      => 'ASC',
+		];
+
+		$include = $request->get_param( 'include' );
+		if ( ! empty( $include ) ) {
+			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
+			if ( empty( $ids ) ) {
+				return rest_ensure_response( [] );
+			}
+			$args['include'] = $ids;
+			$args['number']  = min( count( $ids ), 100 );
+			$args['orderby'] = 'include';
+		}
+
+		$search = $request->get_param( 'search' );
+		if ( ! empty( $search ) ) {
+			// Numeric search: treat as a term ID lookup.
+			if ( is_numeric( $search ) ) {
+				$args['include'] = [ absint( $search ) ];
+			} else {
+				$args['search'] = $search;
+			}
+		}
+
+		$terms = get_terms( $args );
+		if ( is_wp_error( $terms ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		$data = array_map(
+			function( $term ) {
+				return [
+					'id'         => (int) $term->term_id,
+					'name'       => $term->name,
+					'type_label' => __( 'Product category', 'newspack-plugin' ),
+				];
+			},
+			$terms
+		);
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Search posts of the given post types.
+	 *
+	 * @param \WP_REST_Request $request      The request object.
+	 * @param string[]         $post_types   The post types to search.
+	 * @param string[]         $post_statuses Statuses to search. Defaults to published only.
+	 *
+	 * @return array Items in the shape `[{ id, name, type_label }]`.
+	 */
+	private function search_posts( $request, $post_types, $post_statuses = [ 'publish' ] ) {
+		$post_types = array_values( array_filter( $post_types, 'post_type_exists' ) );
+		if ( empty( $post_types ) ) {
+			return [];
+		}
 
 		$args = [
 			'post_type'      => $post_types,
-			'post_status'    => 'publish',
+			'post_status'    => $post_statuses,
 			'posts_per_page' => (int) $request->get_param( 'per_page' ),
 			'orderby'        => 'title',
 			'order'          => 'ASC',
@@ -558,7 +678,7 @@ class Audience_Content_Gates extends Wizard {
 		if ( ! empty( $include ) ) {
 			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
 			if ( empty( $ids ) ) {
-				return rest_ensure_response( [] );
+				return [];
 			}
 			// Broader status filter when hydrating saved tokens so the editor
 			// keeps showing items whose status changed since the gate was saved.
@@ -586,7 +706,7 @@ class Audience_Content_Gates extends Wizard {
 			$labels[ $pt ] = $obj && isset( $obj->labels->singular_name ) ? $obj->labels->singular_name : $pt;
 		}
 
-		$data = array_map(
+		return array_map(
 			function( $post ) use ( $labels ) {
 				return [
 					'id'         => (int) $post->ID,
@@ -596,7 +716,5 @@ class Audience_Content_Gates extends Wizard {
 			},
 			$query->posts
 		);
-
-		return rest_ensure_response( $data );
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
@@ -21,8 +21,27 @@ const debounce = ( func: ( search?: string ) => void, wait: number ) => {
 	};
 };
 
-export default function ContentRuleControlTokenField( { slug, value, exclusion, onChange, isStatic = false }: GateRuleControlProps ) {
-	const rule = useMemo( () => window.newspackAudienceContentGates.available_content_rules[ slug ], [ slug ] );
+type ContentRuleControlTokenFieldProps = GateRuleControlProps & {
+	// Token fields that aren't a content rule (e.g. purchase-restricted products) pass their own
+	// config instead of being looked up in `available_content_rules`.
+	config?: { name: string; endpoint: string };
+	// Content rules are labelled by their own toggle, so they render the field unlabelled.
+	label?: string;
+};
+
+export default function ContentRuleControlTokenField( {
+	slug,
+	value,
+	exclusion,
+	onChange,
+	isStatic = false,
+	config,
+	label = '',
+}: ContentRuleControlTokenFieldProps ) {
+	const rule = useMemo(
+		() => config ?? window.newspackAudienceContentGates.available_content_rules[ slug ],
+		[ slug, config ]
+	);
 
 	const [ savedItems, setSavedItems ] = useState< { value: string; label: string }[] >( [] );
 	const [ suggestions, setSuggestions ] = useState< { value: string; label: string }[] >( [] );
@@ -42,7 +61,7 @@ export default function ContentRuleControlTokenField( { slug, value, exclusion, 
 				_endpoint = slug;
 		}
 		return 'wp/v2/' + _endpoint;
-	}, [ slug ] );
+	}, [ slug, rule ] );
 
 	const fetchSuggestions = useCallback(
 		( search: string = '' ) => {
@@ -171,7 +190,7 @@ export default function ContentRuleControlTokenField( { slug, value, exclusion, 
 	return (
 		<>
 			<FormTokenField
-				label={ '' }
+				label={ label }
 				suggestions={ suggestions.map( s => s.label ) }
 				onInputChange={ handleInputChange }
 				value={ tokens }

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
@@ -38,10 +38,7 @@ export default function ContentRuleControlTokenField( {
 	config,
 	label = '',
 }: ContentRuleControlTokenFieldProps ) {
-	const rule = useMemo(
-		() => config ?? window.newspackAudienceContentGates.available_content_rules[ slug ],
-		[ slug, config ]
-	);
+	const rule = useMemo( () => config ?? window.newspackAudienceContentGates.available_content_rules[ slug ], [ slug, config ] );
 
 	const [ savedItems, setSavedItems ] = useState< { value: string; label: string }[] >( [] );
 	const [ suggestions, setSuggestions ] = useState< { value: string; label: string }[] >( [] );
@@ -146,7 +143,7 @@ export default function ContentRuleControlTokenField( {
 			? '-'
 			: tokens
 					.map( token => token.split( ':' ).slice( 1 ).join( ':' ).trim() )
-					.filter( label => label.length > 0 )
+					.filter( tokenLabel => tokenLabel.length > 0 )
 					.join( ', ' );
 	}, [ tokens ] );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.test.jsx
@@ -21,14 +21,22 @@ describe( 'CustomAccess gate settings', () => {
 			metering: { enabled: false },
 			access_rules: [],
 			gate_layout_id: 456,
+			restricted_products: [ 12 ],
+			restricted_product_categories: [],
 		};
 
 		render( <CustomAccess customAccess={ customAccess } onChange={ onChange } isNewsletter /> );
 
 		fireEvent.click( screen.getByTestId( 'set-rules' ) );
 
+		// The purchase restriction is one of those unmanaged fields: editing the access
+		// rules must not drop the products the gate restricts.
 		expect( onChange ).toHaveBeenCalledWith(
-			expect.objectContaining( { access_rules: [ [ { name: 'active_subscription' } ] ], gate_layout_id: 456 } )
+			expect.objectContaining( {
+				access_rules: [ [ { name: 'active_subscription' } ] ],
+				gate_layout_id: 456,
+				restricted_products: [ 12 ],
+			} )
 		);
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.tsx
@@ -12,7 +12,7 @@ import AccessRules from './access-rules';
 import RestrictedProducts from './restricted-products';
 
 // wp_localize_script() stringifies booleans ('1'/'').
-const hasWooCommerce = Boolean( window.newspackAudienceContentGates.has_woocommerce );
+const hasWooCommerce = Boolean( window.newspackAudienceContentGates?.has_woocommerce );
 
 interface CustomAccessProps {
 	customAccess: CustomAccess;

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/custom-access.tsx
@@ -9,6 +9,10 @@ import { useCallback } from '@wordpress/element';
  */
 import Metering from './metering';
 import AccessRules from './access-rules';
+import RestrictedProducts from './restricted-products';
+
+// wp_localize_script() stringifies booleans ('1'/'').
+const hasWooCommerce = Boolean( window.newspackAudienceContentGates.has_woocommerce );
 
 interface CustomAccessProps {
 	customAccess: CustomAccess;
@@ -51,6 +55,16 @@ export default function CustomAccess( { customAccess, onChange, isNewsletter = f
 				</>
 			) }
 			<AccessRules rules={ currentRules } onChange={ handleRulesChange } />
+			{ ! isNewsletter && hasWooCommerce && (
+				<>
+					<CardDivider />
+					<RestrictedProducts
+						products={ customAccess.restricted_products || [] }
+						productCategories={ customAccess.restricted_product_categories || [] }
+						onChange={ handleChange }
+					/>
+				</>
+			) }
 		</>
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -81,7 +81,14 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 		content_rules: isNewsletter ? [ { slug: 'newsletters', value: [] } ] : [ { slug: 'post_types', value: [ 'post' ] } ],
 		content_rules_match: 'all',
 		registration: { active: false, metering: { enabled: false, count: 1, period: 'month' }, require_verification: false, gate_layout_id: 0 },
-		custom_access: { active: false, metering: { enabled: false, count: 1, period: 'month' }, gate_layout_id: 0, access_rules: [] },
+		custom_access: {
+			active: false,
+			metering: { enabled: false, count: 1, period: 'month' },
+			gate_layout_id: 0,
+			access_rules: [],
+			restricted_products: [],
+			restricted_product_categories: [],
+		},
 	};
 
 	const history = useHistory();
@@ -116,6 +123,22 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 			gatesRef.current = gates;
 		}
 	}, [ gates ] );
+
+	// An access rule with no value grants access to everyone, so it gates nothing.
+	const hasPopulatedAccessRules = customAccess.access_rules.some( ruleGroup =>
+		ruleGroup.some(
+			rule =>
+				( Array.isArray( rule.value ) && rule.value?.length > 0 ) ||
+				( ! Array.isArray( rule.value ) && rule.hasOwnProperty( 'value' ) )
+		)
+	);
+
+	// Purchase restriction is enforced only for an active paid-access gate whose access rules
+	// can actually exclude someone — matching Product_Purchase_Restriction::get_restricting_gates().
+	const restrictsPurchasing =
+		customAccess.active &&
+		hasPopulatedAccessRules &&
+		Boolean( customAccess.restricted_products?.length || customAccess.restricted_product_categories?.length );
 
 	const isDirty =
 		isNew ||
@@ -420,16 +443,12 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 					isFetching ||
 					! isDirty ||
 					! title ||
-					! contentRules.length ||
+					// A gate with no content rules gates no content, but it can still restrict
+					// purchasing of the products it lists (Content_Restriction_Control::get_post_gates()
+					// skips gates without content rules).
+					( ! contentRules.length && ! restrictsPurchasing ) ||
 					( ! registration.active && ! customAccess.active ) ||
-					( ! registration.active &&
-						! customAccess.access_rules.some( ruleGroup =>
-							ruleGroup.some(
-								rule =>
-									( Array.isArray( rule.value ) && rule.value?.length > 0 ) ||
-									( ! Array.isArray( rule.value ) && rule.hasOwnProperty( 'value' ) )
-							)
-						) ),
+					( ! registration.active && ! hasPopulatedAccessRules ),
 			},
 		];
 		if ( ! isNew ) {
@@ -479,6 +498,8 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 	}, [
 		contentRules.length,
 		customAccess.active,
+		hasPopulatedAccessRules,
+		restrictsPurchasing,
 		gate.id,
 		gate.status,
 		handleCreate,

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -127,9 +127,7 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 	// An access rule with no value grants access to everyone, so it gates nothing.
 	const hasPopulatedAccessRules = customAccess.access_rules.some( ruleGroup =>
 		ruleGroup.some(
-			rule =>
-				( Array.isArray( rule.value ) && rule.value?.length > 0 ) ||
-				( ! Array.isArray( rule.value ) && rule.hasOwnProperty( 'value' ) )
+			rule => ( Array.isArray( rule.value ) && rule.value?.length > 0 ) || ( ! Array.isArray( rule.value ) && rule.hasOwnProperty( 'value' ) )
 		)
 	);
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/restricted-products.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/restricted-products.tsx
@@ -16,13 +16,14 @@ import ContentRuleControlTokenField from './content-rule-control-tokenfield';
 
 // Defined at module scope so their identity is stable: the token field memoizes its
 // fetching on the config it receives, and a new object each render would refetch in a loop.
+const wizardApi = window.newspackAudienceContentGates?.api ?? '';
 const PRODUCTS_CONFIG = {
 	name: __( 'Products', 'newspack-plugin' ),
-	endpoint: `${ window.newspackAudienceContentGates.api }/products-search`,
+	endpoint: `${ wizardApi }/products-search`,
 };
 const PRODUCT_CATEGORIES_CONFIG = {
 	name: __( 'Product categories', 'newspack-plugin' ),
-	endpoint: `${ window.newspackAudienceContentGates.api }/product-categories-search`,
+	endpoint: `${ wizardApi }/product-categories-search`,
 };
 
 interface RestrictedProductsProps {

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/restricted-products.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/restricted-products.tsx
@@ -1,0 +1,79 @@
+/**
+ * Member-only purchasing: products a reader may only buy if they pass this gate's access rules.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack, BaseControl, CardBody } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useCallback, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ContentRuleControlTokenField from './content-rule-control-tokenfield';
+
+// Defined at module scope so their identity is stable: the token field memoizes its
+// fetching on the config it receives, and a new object each render would refetch in a loop.
+const PRODUCTS_CONFIG = {
+	name: __( 'Products', 'newspack-plugin' ),
+	endpoint: `${ window.newspackAudienceContentGates.api }/products-search`,
+};
+const PRODUCT_CATEGORIES_CONFIG = {
+	name: __( 'Product categories', 'newspack-plugin' ),
+	endpoint: `${ window.newspackAudienceContentGates.api }/product-categories-search`,
+};
+
+interface RestrictedProductsProps {
+	products: number[];
+	productCategories: number[];
+	onChange: ( value: { restricted_products?: number[]; restricted_product_categories?: number[] } ) => void;
+}
+
+export default function RestrictedProducts( { products, productCategories, onChange }: RestrictedProductsProps ) {
+	// The token field speaks strings; the gate stores IDs. Memoized because the token field
+	// re-fetches its saved items whenever the `value` identity changes, and this component
+	// re-renders on every edit elsewhere in the gate (title, access rules, metering).
+	const productTokens = useMemo( () => products.map( String ), [ products ] );
+	const productCategoryTokens = useMemo( () => productCategories.map( String ), [ productCategories ] );
+
+	const handleProductsChange = useCallback(
+		( value: string[] ) => onChange( { restricted_products: value.map( Number ) } ),
+		[ onChange ]
+	);
+	const handleProductCategoriesChange = useCallback(
+		( value: string[] ) => onChange( { restricted_product_categories: value.map( Number ) } ),
+		[ onChange ]
+	);
+
+	return (
+		<CardBody size="small">
+			<VStack spacing={ 4 }>
+				<div>
+					<BaseControl.VisualLabel>{ __( 'Member-only purchasing', 'newspack-plugin' ) }</BaseControl.VisualLabel>
+					<p className="components-base-control__help">
+						{ __(
+							'Readers who do not match this gate’s access rules can still view these products, but cannot purchase them. Restricting a product category also restricts its subcategories.',
+							'newspack-plugin'
+						) }
+					</p>
+				</div>
+				<ContentRuleControlTokenField
+					slug="restricted_products"
+					label={ PRODUCTS_CONFIG.name }
+					config={ PRODUCTS_CONFIG }
+					value={ productTokens }
+					onChange={ handleProductsChange }
+				/>
+				<ContentRuleControlTokenField
+					slug="restricted_product_categories"
+					label={ PRODUCT_CATEGORIES_CONFIG.name }
+					config={ PRODUCT_CATEGORIES_CONFIG }
+					value={ productCategoryTokens }
+					onChange={ handleProductCategoriesChange }
+				/>
+			</VStack>
+		</CardBody>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/restricted-products.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/restricted-products.tsx
@@ -38,10 +38,7 @@ export default function RestrictedProducts( { products, productCategories, onCha
 	const productTokens = useMemo( () => products.map( String ), [ products ] );
 	const productCategoryTokens = useMemo( () => productCategories.map( String ), [ productCategories ] );
 
-	const handleProductsChange = useCallback(
-		( value: string[] ) => onChange( { restricted_products: value.map( Number ) } ),
-		[ onChange ]
-	);
+	const handleProductsChange = useCallback( ( value: string[] ) => onChange( { restricted_products: value.map( Number ) } ), [ onChange ] );
 	const handleProductCategoriesChange = useCallback(
 		( value: string[] ) => onChange( { restricted_product_categories: value.map( Number ) } ),
 		[ onChange ]

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/gate-summary.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/gate-summary.tsx
@@ -6,7 +6,7 @@
 /**
  * WordPress dependencies.
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -121,6 +121,37 @@ export const getGateSummarySections = ( gate: Gate, isNewsletter = false ): Gate
 			</>
 		),
 	} );
+
+	// A gate can restrict purchasing without gating any content, so surface it — otherwise
+	// such a gate reads as doing nothing at all.
+	const restrictedProducts = gate.custom_access?.restricted_products?.length || 0;
+	const restrictedCategories = gate.custom_access?.restricted_product_categories?.length || 0;
+	if ( gate.custom_access?.active && restrictedProducts + restrictedCategories > 0 ) {
+		const restrictedCounts = [];
+		if ( restrictedProducts > 0 ) {
+			restrictedCounts.push(
+				sprintf(
+					// translators: %d: number of restricted products.
+					_n( '%d product', '%d products', restrictedProducts, 'newspack-plugin' ),
+					restrictedProducts
+				)
+			);
+		}
+		if ( restrictedCategories > 0 ) {
+			restrictedCounts.push(
+				sprintf(
+					// translators: %d: number of restricted product categories.
+					_n( '%d product category', '%d product categories', restrictedCategories, 'newspack-plugin' ),
+					restrictedCategories
+				)
+			);
+		}
+		sections.push( {
+			key: 'restricted_products',
+			label: __( 'Member-only purchasing', 'newspack-plugin' ),
+			content: <p>{ restrictedCounts.join( ', ' ) }</p>,
+		} );
+	}
 
 	return sections;
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -119,6 +119,9 @@ type CustomAccess = {
 	metering: Metering;
 	gate_layout_id: number;
 	access_rules: GateAccessRuleGroup[];
+	// Products (and product categories) that only readers passing the access rules above may purchase.
+	restricted_products: number[];
+	restricted_product_categories: number[];
 };
 
 type ContentGiftingConfig = {

--- a/plugins/newspack-plugin/src/wizards/types/window.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/window.d.ts
@@ -81,6 +81,7 @@ declare global {
 			// wp_localize_script() stringifies booleans ('1'/''); the wizard writes real booleans back.
 			presave_checks_enabled: boolean | string;
 			default_gate_status: GateStatus;
+			has_woocommerce: boolean | string;
 		};
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/product-purchase-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/product-purchase-restriction.php
@@ -1,0 +1,601 @@
+<?php
+/**
+ * Tests for restricting product purchases to readers who pass a gate's access rules.
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+namespace Newspack\Tests\Content_Gate;
+
+use Newspack\Content_Gate;
+use Newspack\Content_Gate_API;
+use Newspack\Product_Purchase_Restriction;
+use Newspack\Reader_Activation;
+
+/**
+ * Tests the WooCommerce Memberships purchase-restriction parity: a reader who
+ * fails a gate's access rules can still *see* a restricted product, but cannot
+ * *buy* it. Enforcement rides on `woocommerce_is_purchasable`, so these tests
+ * exercise the filter callback the same way WooCommerce does.
+ *
+ * The other two guards in `is_enforced()` — the NEWSPACK_CONTENT_GATES flag and
+ * WooCommerce Memberships being inactive — are verified at runtime rather than
+ * here: both are process-wide (a `define()` and a `class_exists()`), so faking
+ * either would leak into every test that runs afterwards in the same process.
+ *
+ * @group content-gate
+ * @group Product_Purchase_Restriction
+ */
+class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
+
+	/**
+	 * Reader whose email domain fails the gate's access rules.
+	 *
+	 * @var int
+	 */
+	private $blocked_reader_id;
+
+	/**
+	 * Reader whose (verified) email domain passes the gate's access rules.
+	 *
+	 * @var int
+	 */
+	private $member_reader_id;
+
+	/**
+	 * Enable the Content Gates feature flag and load the WooCommerce mocks.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Register the WooCommerce product post type and category taxonomy (the real
+	 * ones come from WooCommerce, which isn't loaded in the test suite), and
+	 * create the readers used across the assertions.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type(
+			'product',
+			[
+				'public' => true,
+				'label'  => 'Product',
+			]
+		);
+		register_taxonomy(
+			'product_cat',
+			'product',
+			[
+				'public'       => true,
+				'label'        => 'Product category',
+				'hierarchical' => true, // As WooCommerce registers it: restricting a category restricts its children.
+			]
+		);
+
+		$this->blocked_reader_id = $this->factory->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@public.test',
+			]
+		);
+		$this->member_reader_id = $this->factory->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@members.test',
+			]
+		);
+		Reader_Activation::set_reader_verified( $this->member_reader_id );
+	}
+
+	/**
+	 * Reset the per-request caches so each assertion re-evaluates the gates.
+	 */
+	public function tear_down() {
+		$this->reset_restriction_cache();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the memoized gate list and purchase decisions between assertions.
+	 */
+	private function reset_restriction_cache() {
+		foreach ( [
+			'blocking_gates'        => [],
+			'restricted_categories' => [],
+			'gate_access'           => [],
+			'rendered_notices'      => [],
+			'restricting_gates'     => null,
+		] as $cache_property => $empty_value ) {
+			$cache_property_reflection = new \ReflectionProperty( Product_Purchase_Restriction::class, $cache_property );
+			$cache_property_reflection->setAccessible( true );
+			$cache_property_reflection->setValue( null, $empty_value );
+		}
+
+		// Content_Restriction_Control memoizes the term-descendant lookups this class reuses.
+		$term_descendants_reflection = new \ReflectionProperty( \Newspack\Content_Restriction_Control::class, 'term_descendants_map' );
+		$term_descendants_reflection->setAccessible( true );
+		$term_descendants_reflection->setValue( null, [] );
+	}
+
+	/**
+	 * Create a published gate that restricts purchasing of the given products
+	 * and/or product categories to readers with a `members.test` email address.
+	 *
+	 * @param array $custom_access Custom access settings to override the defaults.
+	 *
+	 * @return array The gate, as returned by Content_Gate::get_gate().
+	 */
+	private function create_purchase_gate( $custom_access = [] ) {
+		$gate_id = $this->factory->post->create(
+			[
+				'post_type'   => Content_Gate::GATE_CPT,
+				'post_status' => $custom_access['status'] ?? 'publish',
+				'post_title'  => $custom_access['title'] ?? 'Members-only purchases',
+			]
+		);
+		update_post_meta(
+			$gate_id,
+			'custom_access',
+			[
+				'active'                        => $custom_access['active'] ?? true,
+				'access_rules'                  => $custom_access['access_rules'] ?? [
+					[
+						[
+							'slug'  => 'email_domain',
+							'value' => 'members.test',
+						],
+					],
+				],
+				'restricted_products'           => $custom_access['restricted_products'] ?? [],
+				'restricted_product_categories' => $custom_access['restricted_product_categories'] ?? [],
+			]
+		);
+		$this->reset_restriction_cache();
+		return Content_Gate::get_gate( $gate_id );
+	}
+
+	/**
+	 * Create a product as both a WP post (so it can carry product_cat terms) and
+	 * a mock WC_Product with the same ID (so it can be passed to the filter).
+	 *
+	 * @param array $data Mock product data, e.g. 'type' or 'parent_id'.
+	 *
+	 * @return \WC_Product The mock product.
+	 */
+	private function create_product( $data = [] ) {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'  => 'product',
+				'post_title' => $data['name'] ?? 'Tote bag',
+			]
+		);
+		return wc_create_mock_product( array_merge( [ 'id' => $product_id ], $data ) );
+	}
+
+	/**
+	 * Run the `woocommerce_is_purchasable` filter callback as the given user.
+	 *
+	 * @param \WC_Product $product The product.
+	 * @param int         $user_id The reader viewing the product.
+	 *
+	 * @return bool Whether the product is purchasable.
+	 */
+	private function is_purchasable( $product, $user_id = 0 ) {
+		wp_set_current_user( $user_id );
+		$this->reset_restriction_cache();
+		return Product_Purchase_Restriction::filter_is_purchasable( true, $product );
+	}
+
+	/**
+	 * A reader who fails the gate's access rules cannot purchase a restricted product.
+	 */
+	public function test_restricted_product_is_not_purchasable_for_blocked_reader() {
+		$product = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+
+		$this->assertFalse(
+			$this->is_purchasable( $product, $this->blocked_reader_id ),
+			'A reader failing the gate access rules should not be able to purchase a restricted product.'
+		);
+		$this->assertFalse(
+			$this->is_purchasable( $product, 0 ),
+			'An anonymous reader should not be able to purchase a restricted product.'
+		);
+	}
+
+	/**
+	 * A reader who passes the gate's access rules can purchase the product.
+	 */
+	public function test_restricted_product_is_purchasable_for_passing_reader() {
+		$product = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+
+		$this->assertTrue(
+			$this->is_purchasable( $product, $this->member_reader_id ),
+			'A reader passing the gate access rules should be able to purchase a restricted product.'
+		);
+	}
+
+	/**
+	 * Products the gate doesn't list are left alone.
+	 */
+	public function test_unlisted_product_is_purchasable() {
+		$restricted_product = $this->create_product();
+		$other_product      = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $restricted_product->get_id() ] ] );
+
+		$this->assertTrue(
+			$this->is_purchasable( $other_product, $this->blocked_reader_id ),
+			'A product not listed on any gate should stay purchasable.'
+		);
+	}
+
+	/**
+	 * A product in a restricted product category is blocked; one outside it is not.
+	 */
+	public function test_product_category_restriction() {
+		$category = $this->factory->term->create(
+			[
+				'taxonomy' => 'product_cat',
+				'name'     => 'Premium merch',
+			]
+		);
+		$categorized_product = $this->create_product();
+		wp_set_object_terms( $categorized_product->get_id(), [ $category ], 'product_cat' );
+		$uncategorized_product = $this->create_product();
+
+		$this->create_purchase_gate( [ 'restricted_product_categories' => [ $category ] ] );
+
+		$this->assertFalse(
+			$this->is_purchasable( $categorized_product, $this->blocked_reader_id ),
+			'A product in a restricted category should not be purchasable for a blocked reader.'
+		);
+		$this->assertTrue(
+			$this->is_purchasable( $uncategorized_product, $this->blocked_reader_id ),
+			'A product outside the restricted category should stay purchasable.'
+		);
+		$this->assertTrue(
+			$this->is_purchasable( $categorized_product, $this->member_reader_id ),
+			'A product in a restricted category should be purchasable for a passing reader.'
+		);
+	}
+
+	/**
+	 * `product_cat` is hierarchical, so restricting a parent category restricts
+	 * everything filed under it. Without this, a gate restricting "Premium" would
+	 * leave every product in "Premium > Merch" purchasable by anyone — the failure
+	 * mode is silent revenue leakage, not a visible break.
+	 */
+	public function test_restricted_category_cascades_to_child_categories() {
+		$parent_category = $this->factory->term->create(
+			[
+				'taxonomy' => 'product_cat',
+				'name'     => 'Premium',
+			]
+		);
+		$child_category = $this->factory->term->create(
+			[
+				'taxonomy' => 'product_cat',
+				'name'     => 'Premium merch',
+				'parent'   => $parent_category,
+			]
+		);
+
+		// The product sits only in the child category; the gate restricts the parent.
+		$product = $this->create_product();
+		wp_set_object_terms( $product->get_id(), [ $child_category ], 'product_cat' );
+		$this->create_purchase_gate( [ 'restricted_product_categories' => [ $parent_category ] ] );
+
+		$this->assertFalse(
+			$this->is_purchasable( $product, $this->blocked_reader_id ),
+			'A product in a child of a restricted category should not be purchasable for a blocked reader.'
+		);
+		$this->assertTrue(
+			$this->is_purchasable( $product, $this->member_reader_id ),
+			'A product in a child of a restricted category should be purchasable for a passing reader.'
+		);
+	}
+
+	/**
+	 * A purchase-only gate (products, no content rules) restricts purchasing without
+	 * gating any content. Product_Purchase_Restriction leans on this: it is what lets
+	 * a publisher restrict merch without also paywalling their articles.
+	 */
+	public function test_purchase_only_gate_does_not_gate_content() {
+		$product = $this->create_product();
+		$gate    = $this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+		update_post_meta( $gate['id'], 'content_rules', [] );
+
+		$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+
+		$this->assertFalse(
+			\Newspack\Content_Restriction_Control::is_post_restricted( false, $post_id, $this->blocked_reader_id ),
+			'A gate with no content rules should not restrict any content, only purchasing.'
+		);
+		$this->assertFalse(
+			$this->is_purchasable( $product, $this->blocked_reader_id ),
+			'The same gate should still block purchasing of its restricted product.'
+		);
+	}
+
+	/**
+	 * A variation inherits its parent product's restriction (WCM parity: rules
+	 * target the variable product, and Woo checks purchasability per variation).
+	 */
+	public function test_variation_inherits_parent_restriction() {
+		$parent    = $this->create_product( [ 'type' => 'variable' ] );
+		$variation = $this->create_product(
+			[
+				'type'      => 'variation',
+				'parent_id' => $parent->get_id(),
+			]
+		);
+		$this->create_purchase_gate( [ 'restricted_products' => [ $parent->get_id() ] ] );
+
+		$this->assertFalse(
+			$this->is_purchasable( $variation, $this->blocked_reader_id ),
+			'A variation of a restricted variable product should not be purchasable.'
+		);
+		$this->assertTrue(
+			$this->is_purchasable( $variation, $this->member_reader_id ),
+			'A variation of a restricted variable product should be purchasable for a passing reader.'
+		);
+	}
+
+	/**
+	 * A gate with no access rules grants access to everyone, so it can't block a
+	 * purchase — otherwise it would lock the product for every reader, forever.
+	 */
+	public function test_gate_without_access_rules_does_not_restrict() {
+		$product = $this->create_product();
+		$this->create_purchase_gate(
+			[
+				'access_rules'        => [],
+				'restricted_products' => [ $product->get_id() ],
+			]
+		);
+
+		$this->assertTrue(
+			$this->is_purchasable( $product, $this->blocked_reader_id ),
+			'A gate with no access rules should not block purchasing.'
+		);
+	}
+
+	/**
+	 * Only published gates with custom access active enforce.
+	 */
+	public function test_draft_or_inactive_gate_does_not_restrict() {
+		$draft_product = $this->create_product();
+		$this->create_purchase_gate(
+			[
+				'status'              => 'draft',
+				'restricted_products' => [ $draft_product->get_id() ],
+			]
+		);
+		$this->assertTrue(
+			$this->is_purchasable( $draft_product, $this->blocked_reader_id ),
+			'A draft gate should not block purchasing.'
+		);
+
+		$inactive_product = $this->create_product();
+		$this->create_purchase_gate(
+			[
+				'active'              => false,
+				'restricted_products' => [ $inactive_product->get_id() ],
+			]
+		);
+		$this->assertTrue(
+			$this->is_purchasable( $inactive_product, $this->blocked_reader_id ),
+			'A gate with custom access disabled should not block purchasing.'
+		);
+	}
+
+	/**
+	 * Shop managers (and admins) can always purchase, matching WCM, so that a
+	 * restriction can never lock a publisher out of their own store.
+	 */
+	public function test_shop_manager_can_always_purchase() {
+		$product = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+
+		// WooCommerce grants `manage_woocommerce` to administrators and shop managers; it isn't loaded here, so grant it as Woo would.
+		$shop_manager_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		get_user_by( 'id', $shop_manager_id )->add_cap( 'manage_woocommerce' );
+
+		$this->assertTrue(
+			$this->is_purchasable( $product, $shop_manager_id ),
+			'A user who can manage WooCommerce should always be able to purchase.'
+		);
+	}
+
+	/**
+	 * When several gates restrict the same product, the reader must pass all of
+	 * them (the OR logic lives inside a single gate's rule groups).
+	 */
+	public function test_reader_must_pass_every_gate_restricting_the_product() {
+		$product = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+		$this->create_purchase_gate(
+			[
+				'title'               => 'Staff only',
+				'access_rules'        => [
+					[
+						[
+							'slug'  => 'email_domain',
+							'value' => 'staff.test',
+						],
+					],
+				],
+				'restricted_products' => [ $product->get_id() ],
+			]
+		);
+
+		$this->assertFalse(
+			$this->is_purchasable( $product, $this->member_reader_id ),
+			'A reader passing one gate but failing another should not be able to purchase.'
+		);
+	}
+
+	/**
+	 * A product left unpurchasable by WooCommerce (out of stock, no price) stays
+	 * unpurchasable — the filter only ever removes access, never grants it.
+	 */
+	public function test_filter_never_makes_a_product_purchasable() {
+		$product = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+
+		wp_set_current_user( $this->member_reader_id );
+		$this->assertFalse(
+			Product_Purchase_Restriction::filter_is_purchasable( false, $product ),
+			'The filter should never turn a non-purchasable product into a purchasable one.'
+		);
+	}
+
+	/**
+	 * The restriction notice names the subscription products that unlock the
+	 * purchase, and is filterable.
+	 */
+	public function test_restricted_message() {
+		$subscription_product = $this->create_product( [ 'name' => 'Premium membership' ] );
+		$product              = $this->create_product();
+		$gate                 = $this->create_purchase_gate(
+			[
+				'access_rules'        => [
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ $subscription_product->get_id() ],
+						],
+					],
+				],
+				'restricted_products' => [ $product->get_id() ],
+			]
+		);
+
+		$message = Product_Purchase_Restriction::get_restricted_message( $product, $gate );
+		$this->assertStringContainsString( 'This product can only be purchased by members.', $message );
+		$this->assertStringContainsString( 'Premium membership', $message, 'The message should name the subscription product that unlocks the purchase.' );
+		$this->assertStringContainsString( get_permalink( $subscription_product->get_id() ), $message, 'The subscription product should be linked.' );
+
+		$generic_gate    = $this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+		$generic_message = Product_Purchase_Restriction::get_restricted_message( $product, $generic_gate );
+		$this->assertSame(
+			'This product can only be purchased by members.',
+			$generic_message,
+			'A gate with no subscription rule should fall back to the generic message.'
+		);
+
+		add_filter( 'newspack_product_purchase_restricted_message', '__return_empty_string' );
+		$this->assertSame( '', Product_Purchase_Restriction::get_restricted_message( $product, $generic_gate ), 'The message should be filterable.' );
+		remove_filter( 'newspack_product_purchase_restricted_message', '__return_empty_string' );
+	}
+
+	/**
+	 * Block themes never fire `woocommerce_single_product_summary`, so the notice
+	 * rides the add-to-cart block instead — otherwise the button just disappears
+	 * with no explanation.
+	 */
+	public function test_notice_renders_on_block_theme_product_template() {
+		$product = $this->create_product();
+		$this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+
+		$add_to_cart_block = [
+			'blockName' => 'woocommerce/add-to-cart-form',
+			'attrs'     => [ 'productId' => $product->get_id() ],
+		];
+
+		wp_set_current_user( $this->blocked_reader_id );
+		$this->reset_restriction_cache();
+		$blocked_output = Product_Purchase_Restriction::filter_add_to_cart_block( '<form class="cart"></form>', $add_to_cart_block );
+		$this->assertStringContainsString(
+			'newspack-product-purchase-restricted',
+			$blocked_output,
+			'A blocked reader should get the notice appended to the add-to-cart block.'
+		);
+
+		// Rendering the same product again must not repeat the notice.
+		$this->assertStringNotContainsString(
+			'newspack-product-purchase-restricted',
+			Product_Purchase_Restriction::filter_add_to_cart_block( '<form class="cart"></form>', $add_to_cart_block ),
+			'The notice should render at most once per product per request.'
+		);
+
+		wp_set_current_user( $this->member_reader_id );
+		$this->reset_restriction_cache();
+		$this->assertStringNotContainsString(
+			'newspack-product-purchase-restricted',
+			Product_Purchase_Restriction::filter_add_to_cart_block( '<form class="cart"></form>', $add_to_cart_block ),
+			'A passing reader should see the add-to-cart block untouched.'
+		);
+
+		// Blocks other than add-to-cart are left alone — the catalog stays as WooCommerce renders it.
+		$this->reset_restriction_cache();
+		wp_set_current_user( $this->blocked_reader_id );
+		$this->assertSame(
+			'<div>Grid</div>',
+			Product_Purchase_Restriction::filter_add_to_cart_block(
+				'<div>Grid</div>',
+				[
+					'blockName' => 'woocommerce/product-button',
+					'attrs'     => [ 'productId' => $product->get_id() ],
+				]
+			),
+			'Only the single-product add-to-cart block carries the notice.'
+		);
+	}
+
+	/**
+	 * Newsletter gates never restrict product purchasing.
+	 */
+	public function test_newsletter_gates_do_not_restrict() {
+		$product = $this->create_product();
+		$gate    = $this->create_purchase_gate( [ 'restricted_products' => [ $product->get_id() ] ] );
+		update_post_meta( $gate['id'], 'is_newsletter', true );
+
+		$this->assertTrue(
+			$this->is_purchasable( $product, $this->blocked_reader_id ),
+			'A newsletter gate should never restrict product purchasing.'
+		);
+	}
+
+	/**
+	 * The restricted product/category IDs round-trip through the REST sanitizer
+	 * and the gate meta whitelist.
+	 */
+	public function test_settings_round_trip() {
+		$sanitized = Content_Gate_API::sanitize_custom_access(
+			[
+				'active'                        => true,
+				'restricted_products'           => [ '12', 12, 0, '', 'not-an-id', 34 ],
+				'restricted_product_categories' => [ '7' ],
+			]
+		);
+		$this->assertSame( [ 12, 34 ], $sanitized['restricted_products'], 'Product IDs should be cast to unique, non-empty integers.' );
+		$this->assertSame( [ 7 ], $sanitized['restricted_product_categories'] );
+
+		$gate_id = $this->factory->post->create( [ 'post_type' => Content_Gate::GATE_CPT ] );
+		Content_Gate::update_custom_access_settings( $gate_id, $sanitized );
+		$settings = Content_Gate::get_custom_access_settings( $gate_id );
+		$this->assertSame( [ 12, 34 ], $settings['restricted_products'] );
+		$this->assertSame( [ 7 ], $settings['restricted_product_categories'] );
+
+		// An omitted key must not clobber the stored value.
+		Content_Gate::update_custom_access_settings( $gate_id, Content_Gate_API::sanitize_custom_access( [ 'active' => false ] ) );
+		$settings = Content_Gate::get_custom_access_settings( $gate_id );
+		$this->assertSame( [ 12, 34 ], $settings['restricted_products'], 'Saving without the products key should preserve the stored products.' );
+
+		// Gates saved before this feature existed default to empty arrays.
+		$legacy_gate_id = $this->factory->post->create( [ 'post_type' => Content_Gate::GATE_CPT ] );
+		update_post_meta( $legacy_gate_id, 'custom_access', [ 'active' => true ] );
+		$legacy_settings = Content_Gate::get_custom_access_settings( $legacy_gate_id );
+		$this->assertSame( [], $legacy_settings['restricted_products'] );
+		$this->assertSame( [], $legacy_settings['restricted_product_categories'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/product-purchase-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/product-purchase-restriction.php
@@ -598,4 +598,26 @@ class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
 		$this->assertSame( [], $legacy_settings['restricted_products'] );
 		$this->assertSame( [], $legacy_settings['restricted_product_categories'] );
 	}
+
+	/**
+	 * Meta written outside the REST API — a migration script, WP-CLI — doesn't pass
+	 * through the sanitizer, so the read path normalizes the IDs too. A stray 0 would
+	 * otherwise be compared against a real product ID.
+	 */
+	public function test_malformed_meta_is_normalized_on_read() {
+		$gate_id = $this->factory->post->create( [ 'post_type' => Content_Gate::GATE_CPT ] );
+		update_post_meta(
+			$gate_id,
+			'custom_access',
+			[
+				'active'                        => true,
+				'restricted_products'           => [ '12', 12, 0, -5, '', 'not-an-id', 34 ],
+				'restricted_product_categories' => [ '7', 7 ],
+			]
+		);
+
+		$settings = Content_Gate::get_custom_access_settings( $gate_id );
+		$this->assertSame( [ 12, 34 ], $settings['restricted_products'], 'Zeros, negatives, empties and duplicates should be dropped on read.' );
+		$this->assertSame( [ 7 ], $settings['restricted_product_categories'] );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce Memberships lets publishers restrict *purchasing* of a product to members. Access Control had no equivalent, which is the last feature gap blocking several publishers from migrating off Memberships.

This adds a native equivalent. A content gate can now list **restricted products** and **restricted product categories**; the gate's existing access rules decide who may buy them.

### Walkthroughs 

#### As an administrator

https://github.com/user-attachments/assets/79c46dd2-b3ff-4a80-8386-bf883cb0e19c

#### As a reader

https://github.com/user-attachments/assets/8c05e3bb-81e4-40fd-b29d-3ed31fcbaf2b

**Semantics (deliberate, matching Memberships' purchase restriction):**

* A reader who doesn't pass the gate still **sees** the product, its price, and the shop catalog — only the purchase is blocked. (View restriction is a separate Memberships feature and is out of scope.)
* A notice on the product page explains why, linking the subscription product that unlocks it. Subscriptions the reader also can't buy are left out of that list.
* Restricting a product category restricts its **subcategories** too (`product_cat` is hierarchical), reusing `Content_Restriction_Control::expand_hierarchical_terms()`.
* Variations are restricted through their parent product.
* Enforced only when `NEWSPACK_CONTENT_GATES` is on **and** WooCommerce Memberships is inactive, so a site mid-migration is never double-gated.
* Users with `manage_woocommerce` always keep purchasing rights, so a restriction can't lock a publisher out of their own store.
* A reader must pass **every** gate restricting a product ("any of these" is expressed within one gate, by its rule groups).
* Enforcement rides `woocommerce_is_purchasable` at priority 999 (as Memberships does), so a later callback — e.g. Subscriptions' renewal-cart limiter at 12 — can't hand a blocked purchase back.

**Notes:**

* A gate with restricted products but **no content rules** is valid: it restricts purchasing without gating any content. `Content_Restriction_Control::get_post_gates()` skips gates with no content rules, so this can't leak into content gating.
* No add-to-cart validation hook is needed: WooCommerce rejects non-purchasable adds, and `WC_Cart_Session::get_cart_from_session()` evicts an item that becomes non-purchasable (verified — see below).
* Follow-up filed: [NPPD-2036](https://linear.app/a8c/issue/NPPD-2036) — back `Content_Gate::get_gates()` with the object cache, so this (and every other caller) pays a cache hit rather than a query plus per-gate meta reads.

Two filters are exposed: `newspack_product_purchase_blocking_gate` and `newspack_product_purchase_restricted_message`.

Closes NPPD-1899.

### How to test the changes in this Pull Request:

1. On a site with WooCommerce active, `NEWSPACK_CONTENT_GATES` enabled and Reader Activation on, create a few products: one to restrict, one to leave free, a subscription product, and one in a product category (plus a product in a *sub*category of it).
2. Under **Audience → Access control**, edit or create a gate. In the **Paid access** card, enable it, add an access rule (e.g. Active subscription → the subscription product), then in **Member-only purchasing** add the product and the product category. Save.
3. In an incognito window, open the restricted product: the product and its price render, there is **no** Add to cart button, and a notice links the subscription. Same for the product in the *subcategory*.
4. Open the free product: Add to cart works as normal. Open the shop archive: every product is still listed at full price (restricted ones show "Read more" instead of "Add to cart", exactly as WooCommerce renders any non-purchasable product).
5. Log in as a reader who satisfies the access rule: Add to cart returns on the restricted product, and it can be added and checked out.
6. Put the restricted product in that reader's cart, then remove their access (change the gate's rules) and reload the cart: WooCommerce evicts it.
7. Activate WooCommerce Memberships, or turn off `NEWSPACK_CONTENT_GATES`: enforcement stands down entirely and the product is purchasable again.
8. Switch to a block theme (e.g. Twenty Twenty-Five) and repeat step 3 — the notice renders there too, exactly once.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verification:** 16 new unit tests (full suite green: 1992 tests, 5710 assertions); PHPCS clean; build clean. Every step above was exercised end to end in an isolated env with real WooCommerce + Subscriptions, on both a classic and a block theme.
