### PR TITLE
refactor(insights): shared Section/Grid/CoreCard, card typography

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -11,7 +11,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
     >
       <section
         aria-labelledby="newspack-insights-prompts-exposure-heading"
-        class="newspack-insights__section newspack-insights__section--exposure"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--exposure css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-insights__section-header-container"
@@ -41,7 +43,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-3 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -204,7 +206,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
       />
       <section
         aria-labelledby="newspack-insights-prompts-engagement-heading"
-        class="newspack-insights__section newspack-insights__section--engagement"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--engagement css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-section-header__container newspack-insights__section-heading"
@@ -226,7 +230,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-3 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -389,7 +393,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
       />
       <section
         aria-labelledby="newspack-insights-prompts-free-heading"
-        class="newspack-insights__section newspack-insights__section--free-reader"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--free-reader css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-section-header__container newspack-insights__section-heading"
@@ -625,7 +631,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
       />
       <section
         aria-labelledby="newspack-insights-prompts-paid-heading"
-        class="newspack-insights__section newspack-insights__section--paid-reader"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--paid-reader css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-section-header__container newspack-insights__section-heading"
@@ -861,7 +869,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
       />
       <section
         aria-labelledby="newspack-insights-prompts-revenue-heading"
-        class="newspack-insights__section newspack-insights__section--revenue"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--revenue css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-section-header__container newspack-insights__section-heading"
@@ -1097,7 +1107,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
       />
       <section
         aria-labelledby="newspack-insights-prompts-convert-heading"
-        class="newspack-insights__section newspack-insights__section--convert"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--convert css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-section-header__container newspack-insights__section-heading"
@@ -1147,7 +1159,9 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
       />
       <section
         aria-labelledby="newspack-insights-prompts-performance-heading"
-        class="newspack-insights__section newspack-insights__section--performance"
+        class="components-flex components-h-stack components-v-stack newspack-insights__section newspack-insights__section--performance css-tovjn5-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+        data-wp-c16t="true"
+        data-wp-component="VStack"
       >
         <div
           class="newspack-section-header__container newspack-insights__section-heading"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ChannelDeviceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ChannelDeviceSection.tsx
@@ -22,9 +22,11 @@ import { __ } from '@wordpress/i18n';
 import type { InsightsWindow } from '../../../api/advertising';
 import ChartCard from '../../components/ChartCard';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { toSeries } from '../../components/metrics';
 import PieChart from '../../components/PieChart';
+import { Grid } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -32,13 +34,13 @@ export interface SectionProps {
 }
 
 const ChannelDeviceSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-channel-device">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-channel-device">
 		<SectionHeading
 			id="newspack-insights-advertising-channel-device"
 			title={ __( 'Ad types & devices', 'newspack-plugin' ) }
 			description={ __( 'How inventory and revenue split across ad types and devices.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
 				title={ __( 'Impressions by type', 'newspack-plugin' ) }
 				caption={ __( 'How your ad inventory is allocated — including unpaid house ads', 'newspack-plugin' ) }
@@ -65,8 +67,8 @@ const ChannelDeviceSection = ( { current }: SectionProps ) => (
 					] }
 				/>
 			</ChartCard>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default ChannelDeviceSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -47,6 +47,7 @@ import { Grid } from '../../../../../../packages/components/src';
 import EmptyMetricSection from '../../components/EmptyMetricSection';
 import MetricCard from '../../components/MetricCard';
 import Scorecard from '../../components/Scorecard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { formatNumber } from '../../components/format';
 
@@ -90,7 +91,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 	const noRevenue = !! impressions?.computable && !! revenue?.computable && ( impressions?.value ?? 0 ) > 0 && ( revenue?.value ?? 0 ) === 0;
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
 			<SectionHeading id="newspack-insights-advertising-reach-revenue" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
 			<VStack spacing={ 4 }>
 				{ /* Row 1: the four headline scorecards. Volume + revenue (raw), then the
@@ -162,7 +163,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 					/>
 				</Grid>
 			</VStack>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/advertising';
 import ChartCard from '../../components/ChartCard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import LineChart from '../../components/LineChart';
 import { toSeries } from '../../components/metrics';
@@ -42,7 +43,7 @@ const RevenueTrendSection = ( { current, previous }: SectionProps ) => {
 	];
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-revenue-trend">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-revenue-trend">
 			<SectionHeading
 				id="newspack-insights-advertising-revenue-trend"
 				title={ __( 'Revenue trend', 'newspack-plugin' ) }
@@ -56,7 +57,7 @@ const RevenueTrendSection = ( { current, previous }: SectionProps ) => {
 					yAxisLabel={ __( 'Revenue', 'newspack-plugin' ) }
 				/>
 			</ChartCard>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/advertising';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface SectionProps {
@@ -25,7 +26,7 @@ export interface SectionProps {
 }
 
 const SitePerformanceSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-site-performance">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-site-performance">
 		<SectionHeading
 			id="newspack-insights-advertising-site-performance"
 			title={ __( 'Performance by site', 'newspack-plugin' ) }
@@ -44,7 +45,7 @@ const SitePerformanceSection = ( { current }: SectionProps ) => (
 				{ key: 'ecpm', label: __( 'eCPM', 'newspack-plugin' ), format: 'currency', align: 'right' },
 			] }
 		/>
-	</section>
+	</Section>
 );
 
 export default SitePerformanceSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/advertising';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import TabSections from '../../components/TabSections';
 
@@ -29,7 +30,7 @@ export interface SectionProps {
 
 const TopPerformersSection = ( { current }: SectionProps ) => (
 	<TabSections>
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
 			<SectionHeading id="newspack-insights-advertising-top-ad-units" title={ __( 'Top ad units', 'newspack-plugin' ) } />
 			<MetricTable
 				payload={ current.top_ad_units }
@@ -44,8 +45,8 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
-		</section>
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-advertisers">
+		</Section>
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-advertisers">
 			<SectionHeading id="newspack-insights-advertising-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
 			<MetricTable
 				payload={ current.top_advertisers }
@@ -60,8 +61,8 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
-		</section>
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
+		</Section>
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
 			<SectionHeading id="newspack-insights-advertising-top-campaigns" title={ __( 'Top campaigns', 'newspack-plugin' ) } />
 			{ /* Direct-sold orders only — programmatic delivery is order-less and
 			     filtered server-side. */ }
@@ -79,7 +80,7 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
-		</section>
+		</Section>
 	</TabSections>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
@@ -17,9 +17,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { AppMetrics } from '../../api/app';
+import { Grid } from '../../../../../packages/components/src';
 import { toSeries } from '../components/metrics';
 import ChartCard from '../components/ChartCard';
 import PieChart from '../components/PieChart';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 
 export interface CompositionSectionProps {
@@ -41,13 +43,13 @@ const humanizeStatus = ( label: string ): string => {
 };
 
 const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-composition-heading">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-composition-heading">
 		<SectionHeading
 			id="newspack-insights-app-composition-heading"
 			title={ __( 'Audience & access', 'newspack-plugin' ) }
 			description={ __( 'The subscriber mix of your app audience and the free-vs-paid content they read.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
 				title={ __( 'Subscriber mix', 'newspack-plugin' ) }
 				caption={ __( 'Active users by subscriber status', 'newspack-plugin' ) }
@@ -67,8 +69,8 @@ const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
 			>
 				<PieChart segments={ toSeries( metrics.content_cost, 'cost', 'views' ) } />
 			</ChartCard>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default CompositionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
@@ -22,8 +22,10 @@ import { SelectControl } from '@wordpress/components';
  * Internal dependencies
  */
 import type { AppMetrics } from '../../api/app';
+import { Grid } from '../../../../../packages/components/src';
 import ChartCard from '../components/ChartCard';
 import MetricTable from '../components/MetricTable';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { collectionValues, titleCase, topByCollection } from './collections';
 
@@ -62,14 +64,14 @@ const ContentSection = ( { metrics }: ContentSectionProps ) => {
 	) : undefined;
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-content-heading">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-content-heading">
 			<SectionHeading
 				id="newspack-insights-app-content-heading"
 				title={ __( 'Content', 'newspack-plugin' ) }
 				description={ __( 'The sections and authors readers engage with most in the app.', 'newspack-plugin' ) }
 				actions={ selector }
 			/>
-			<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				<ChartCard
 					title={ __( 'Top sections', 'newspack-plugin' ) }
 					caption={ __( 'Screen views by section', 'newspack-plugin' ) }
@@ -98,8 +100,8 @@ const ContentSection = ( { metrics }: ContentSectionProps ) => {
 						emptyMessage={ __( 'No author data for this timeframe.', 'newspack-plugin' ) }
 					/>
 				</ChartCard>
-			</div>
-		</section>
+			</Grid>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/DownloadsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/DownloadsSection.tsx
@@ -23,9 +23,11 @@ import { __ } from '@wordpress/i18n';
  */
 import type { AppMetrics } from '../../api/app';
 import type { MetricPayload } from '../components/metrics';
+import { Grid } from '../../../../../packages/components/src';
 import Scorecard from '../components/Scorecard';
 import ChartCard from '../components/ChartCard';
 import MetricTable from '../components/MetricTable';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { titleCase } from './collections';
 
@@ -45,13 +47,13 @@ const DownloadsSection = ( { metrics, previous }: DownloadsSectionProps ) => {
 			: null;
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-downloads-heading">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-downloads-heading">
 			<SectionHeading
 				id="newspack-insights-app-downloads-heading"
 				title={ __( 'Downloads', 'newspack-plugin' ) }
 				description={ __( 'How readers download your stories to read offline.', 'newspack-plugin' ) }
 			/>
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+			<Grid columns={ 3 } gutter={ 16 } noMargin>
 				<Scorecard
 					label={ __( 'Downloads started', 'newspack-plugin' ) }
 					description={ __( 'Downloads readers began', 'newspack-plugin' ) }
@@ -70,7 +72,7 @@ const DownloadsSection = ( { metrics, previous }: DownloadsSectionProps ) => {
 					current={ metrics.download_completion_rate }
 					previous={ previous?.download_completion_rate }
 				/>
-			</div>
+			</Grid>
 			{ byPublication && (
 				<div className="newspack-insights__chart-grid">
 					<ChartCard
@@ -89,7 +91,7 @@ const DownloadsSection = ( { metrics, previous }: DownloadsSectionProps ) => {
 					</ChartCard>
 				</div>
 			) }
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
@@ -16,7 +16,9 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { AppMetrics } from '../../api/app';
+import { Grid } from '../../../../../packages/components/src';
 import Scorecard from '../components/Scorecard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 
 export interface EngagementSectionProps {
@@ -25,13 +27,13 @@ export interface EngagementSectionProps {
 }
 
 const EngagementSection = ( { metrics, previous }: EngagementSectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-engagement-heading">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-engagement-heading">
 		<SectionHeading
 			id="newspack-insights-app-engagement-heading"
 			title={ __( 'Engagement', 'newspack-plugin' ) }
 			description={ __( 'How deeply people use your app.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<Scorecard
 				label={ __( 'Avg. engagement time', 'newspack-plugin' ) }
 				description={ __( 'Average time in the app per session — app readers tend to stay far longer than on the web', 'newspack-plugin' ) }
@@ -62,8 +64,8 @@ const EngagementSection = ( { metrics, previous }: EngagementSectionProps ) => (
 				current={ metrics.screen_views }
 				previous={ previous?.screen_views }
 			/>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default EngagementSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
@@ -15,7 +15,9 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { AppMetrics } from '../../api/app';
+import { Grid } from '../../../../../packages/components/src';
 import Scorecard from '../components/Scorecard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 
 export interface NotificationsSectionProps {
@@ -24,13 +26,13 @@ export interface NotificationsSectionProps {
 }
 
 const NotificationsSection = ( { metrics, previous }: NotificationsSectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-notifications-heading">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-notifications-heading">
 		<SectionHeading
 			id="newspack-insights-app-notifications-heading"
 			title={ __( 'Notifications', 'newspack-plugin' ) }
 			description={ __( 'How your push notifications perform.', 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<Scorecard
 				label={ __( 'Notification open rate', 'newspack-plugin' ) }
 				description={ __( 'Share of received push notifications that were opened', 'newspack-plugin' ) }
@@ -49,8 +51,8 @@ const NotificationsSection = ( { metrics, previous }: NotificationsSectionProps 
 				current={ metrics.notification_opt_changes }
 				previous={ previous?.notification_opt_changes }
 			/>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default NotificationsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
@@ -21,10 +21,12 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { AppMetrics } from '../../api/app';
+import { Grid } from '../../../../../packages/components/src';
 import { toSeries } from '../components/metrics';
 import Scorecard from '../components/Scorecard';
 import ChartCard from '../components/ChartCard';
 import PieChart from '../components/PieChart';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 
 export interface ReachSectionProps {
@@ -35,14 +37,14 @@ export interface ReachSectionProps {
 }
 
 const ReachSection = ( { metrics, previous, lastUpdated }: ReachSectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-reach-heading">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-reach-heading">
 		<SectionHeading
 			id="newspack-insights-app-reach-heading"
 			title={ __( 'Reach', 'newspack-plugin' ) }
 			description={ __( 'How many people use your app, and on what.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<Scorecard
 				label={ __( 'Active users', 'newspack-plugin' ) }
 				description={ __( 'Distinct people who opened the app', 'newspack-plugin' ) }
@@ -61,8 +63,8 @@ const ReachSection = ( { metrics, previous, lastUpdated }: ReachSectionProps ) =
 				current={ metrics.sessions }
 				previous={ previous?.sessions }
 			/>
-		</div>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+		</Grid>
+		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
 				title={ __( 'By platform', 'newspack-plugin' ) }
 				caption={ __( 'Active users by operating system', 'newspack-plugin' ) }
@@ -77,8 +79,8 @@ const ReachSection = ( { metrics, previous, lastUpdated }: ReachSectionProps ) =
 			>
 				<PieChart segments={ toSeries( metrics.app_version, 'app_version', 'active_users' ) } />
 			</ChartCard>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default ReachSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/RetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/RetentionSection.tsx
@@ -16,6 +16,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import type { AppMetrics } from '../../api/app';
 import type { MetricPayload } from '../components/metrics';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import ChartCard from '../components/ChartCard';
 import LineChart from '../components/LineChart';
@@ -33,7 +34,7 @@ export interface RetentionSectionProps {
 }
 
 const RetentionSection = ( { metrics }: RetentionSectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-app-retention-heading">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-retention-heading">
 		<SectionHeading
 			id="newspack-insights-app-retention-heading"
 			title={ __( 'Retention', 'newspack-plugin' ) }
@@ -60,7 +61,7 @@ const RetentionSection = ( { metrics }: RetentionSectionProps ) => (
 				emptyMessage={ __( 'Retention will appear once there are enough weekly cohorts of data.', 'newspack-plugin' ) }
 			/>
 		</ChartCard>
-	</section>
+	</Section>
 );
 
 export default RetentionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/CompositionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/CompositionSection.tsx
@@ -12,8 +12,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import ChartCard from '../../components/ChartCard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { toSeries } from '../../components/metrics';
 import PieChart from '../../components/PieChart';
@@ -24,13 +26,13 @@ export interface SectionProps {
 }
 
 const CompositionSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-composition">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-composition">
 		<SectionHeading
 			id="newspack-insights-audience-composition"
 			title={ __( 'Audience composition', 'newspack-plugin' ) }
 			description={ __( "Who's reading your stories.", 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-4">
+		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
 				title={ __( 'Newsletter subscriber composition', 'newspack-plugin' ) }
 				caption={ __( 'Your newsletter subscribers vs the rest', 'newspack-plugin' ) }
@@ -59,8 +61,8 @@ const CompositionSection = ( { current }: SectionProps ) => (
 			>
 				<PieChart segments={ toSeries( current.supporter_type, 'label', 'value' ) } />
 			</ChartCard>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default CompositionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/audience';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface SectionProps {
@@ -20,7 +21,7 @@ export interface SectionProps {
 }
 
 const ContentPerformanceSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-content">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-content">
 		<SectionHeading
 			id="newspack-insights-audience-content"
 			title={ __( 'Content performance', 'newspack-plugin' ) }
@@ -67,7 +68,7 @@ const ContentPerformanceSection = ( { current }: SectionProps ) => (
 				</div>
 			) }
 		</div>
-	</section>
+	</Section>
 );
 
 export default ContentPerformanceSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/GeographicSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/GeographicSection.tsx
@@ -10,11 +10,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import type { MetricPayload } from '../../components/metrics';
 import { uniformValue } from '../../components/metrics';
 import MetricTable from '../../components/MetricTable';
 import ScopePill from '../../components/ScopePill';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface SectionProps {
@@ -34,13 +36,13 @@ const GeographicSection = ( { current }: SectionProps ) => {
 	const citiesScope = countryScope( current.top_cities );
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-geo">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-geo">
 			<SectionHeading
 				id="newspack-insights-audience-geo"
 				title={ __( 'Geographic', 'newspack-plugin' ) }
 				description={ __( 'Where your readers are.', 'newspack-plugin' ) }
 			/>
-			<div className="newspack-insights__table-grid newspack-insights__table-grid--cols-2">
+			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				<div>
 					<h3 className="newspack-insights__chart-card-title">
 						{ __( 'Top regions / states', 'newspack-plugin' ) }
@@ -74,8 +76,8 @@ const GeographicSection = ( { current }: SectionProps ) => {
 						] }
 					/>
 				</div>
-			</div>
-		</section>
+			</Grid>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { MetricPayload } from '../../components/metrics';
 import MetricCard from '../../components/MetricCard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface NewsletterValueSectionProps {
@@ -38,7 +39,7 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 	const warming = value?.state === 'warming';
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-newsletter-value">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-newsletter-value">
 			<SectionHeading
 				id="newspack-insights-audience-newsletter-value"
 				title={ __( 'Newsletter subscriber value', 'newspack-plugin' ) }
@@ -63,7 +64,7 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 					) }
 				/>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ReachSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ReachSection.tsx
@@ -17,8 +17,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import Scorecard from '../../components/Scorecard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface SectionProps {
@@ -28,14 +30,14 @@ export interface SectionProps {
 }
 
 const ReachSection = ( { current, previous, lastUpdated }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-reach">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-reach">
 		<SectionHeading
 			id="newspack-insights-audience-reach"
 			title={ __( 'Reach', 'newspack-plugin' ) }
 			description={ __( 'Your reach this period.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-4">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<Scorecard
 				label={ __( 'Active Readers', 'newspack-plugin' ) }
 				description={ __( 'How many people read you', 'newspack-plugin' ) }
@@ -60,8 +62,8 @@ const ReachSection = ( { current, previous, lastUpdated }: SectionProps ) => (
 				current={ current.newsletter_signups }
 				previous={ previous?.newsletter_signups }
 			/>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default ReachSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx
@@ -29,8 +29,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { MetricPayload, RegisteredReaders } from '../../../api/audience';
 import MetricCard from '../../components/MetricCard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface RegisteredReadersSectionProps {
@@ -56,13 +58,13 @@ const RegisteredReadersSection = ( { registeredReaders, showComparison }: Regist
 	const previousNew = showComparison && newCount !== 0 ? readCount( newReaders.previous ) : null;
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-registered-readers">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-registered-readers">
 			<SectionHeading
 				id="newspack-insights-audience-registered-readers"
 				title={ __( 'Registered readers', 'newspack-plugin' ) }
 				description={ __( 'People who registered on your site — the known-reader population behind the segments below.', 'newspack-plugin' ) }
 			/>
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-2">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					label={ __( 'Total registered readers', 'newspack-plugin' ) }
 					value={ totalCount ?? 0 }
@@ -79,8 +81,8 @@ const RegisteredReadersSection = ( { registeredReaders, showComparison }: Regist
 					notComputableMessage={ newCount === null ? UNAVAILABLE_MESSAGE : undefined }
 					description={ __( 'Registrations created in this timeframe', 'newspack-plugin' ) }
 				/>
-			</div>
-		</section>
+			</Grid>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
@@ -8,12 +8,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import ChartCard from '../../components/ChartCard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { toSeries } from '../../components/metrics';
 import { formatShortDate } from '../../components/format';
@@ -26,43 +29,45 @@ export interface SectionProps {
 }
 
 const TimeTrendsSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-trends">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-trends">
 		<SectionHeading
 			id="newspack-insights-audience-trends"
 			title={ __( 'Time trends', 'newspack-plugin' ) }
 			description={ __( 'When your readers show up across the period, by day of week, and by hour of day.', 'newspack-plugin' ) }
 		/>
 		{ /* New vs Returning takes the full width; the two day/hour bar charts share the row below. */ }
-		<ChartCard
-			subhead={ __( 'Day to day', 'newspack-plugin' ) }
-			title={ __( 'New vs returning over time', 'newspack-plugin' ) }
-			payload={ current.new_vs_returning_over_time }
-		>
-			<LineChart
-				series={ [
-					{ name: __( 'New', 'newspack-plugin' ), points: toSeries( current.new_vs_returning_over_time, 'date', 'new' ) },
-					{ name: __( 'Returning', 'newspack-plugin' ), points: toSeries( current.new_vs_returning_over_time, 'date', 'returning' ) },
-				] }
-				formatLabel={ formatShortDate }
-			/>
-		</ChartCard>
-		<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-2">
+		<VStack spacing={ 4 }>
 			<ChartCard
-				subhead={ __( 'Day of week', 'newspack-plugin' ) }
-				title={ __( 'Readership by day of week', 'newspack-plugin' ) }
-				payload={ current.readership_by_day_of_week }
+				subhead={ __( 'Day to day', 'newspack-plugin' ) }
+				title={ __( 'New vs returning over time', 'newspack-plugin' ) }
+				payload={ current.new_vs_returning_over_time }
 			>
-				<BarChart bars={ toSeries( current.readership_by_day_of_week, 'day_of_week', 'active_readers' ) } />
+				<LineChart
+					series={ [
+						{ name: __( 'New', 'newspack-plugin' ), points: toSeries( current.new_vs_returning_over_time, 'date', 'new' ) },
+						{ name: __( 'Returning', 'newspack-plugin' ), points: toSeries( current.new_vs_returning_over_time, 'date', 'returning' ) },
+					] }
+					formatLabel={ formatShortDate }
+				/>
 			</ChartCard>
-			<ChartCard
-				subhead={ __( 'Hour of day', 'newspack-plugin' ) }
-				title={ __( 'Readership by hour of day', 'newspack-plugin' ) }
-				payload={ current.readership_by_hour_of_day }
-			>
-				<BarChart bars={ toSeries( current.readership_by_hour_of_day, 'hour', 'active_readers' ) } />
-			</ChartCard>
-		</div>
-	</section>
+			<Grid columns={ 2 } gutter={ 16 } noMargin>
+				<ChartCard
+					subhead={ __( 'Day of week', 'newspack-plugin' ) }
+					title={ __( 'Readership by day of week', 'newspack-plugin' ) }
+					payload={ current.readership_by_day_of_week }
+				>
+					<BarChart bars={ toSeries( current.readership_by_day_of_week, 'day_of_week', 'active_readers' ) } />
+				</ChartCard>
+				<ChartCard
+					subhead={ __( 'Hour of day', 'newspack-plugin' ) }
+					title={ __( 'Readership by hour of day', 'newspack-plugin' ) }
+					payload={ current.readership_by_hour_of_day }
+				>
+					<BarChart bars={ toSeries( current.readership_by_hour_of_day, 'hour', 'active_readers' ) } />
+				</ChartCard>
+			</Grid>
+		</VStack>
+	</Section>
 );
 
 export default TimeTrendsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TrafficSourcesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TrafficSourcesSection.tsx
@@ -10,10 +10,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import type { MetricPayload } from '../../components/metrics';
 import ChartCard from '../../components/ChartCard';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { toSeries, isNotSet } from '../../components/metrics';
 import PieChart from '../../components/PieChart';
@@ -48,19 +50,19 @@ const TrafficSourcesSection = ( { current }: SectionProps ) => {
 	const campaigns = withoutUnattributedRows( current.top_campaigns );
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-traffic">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-traffic">
 			<SectionHeading
 				id="newspack-insights-audience-traffic"
 				title={ __( 'Traffic sources', 'newspack-plugin' ) }
 				description={ __( 'Where your readers come from.', 'newspack-plugin' ) }
 			/>
-			{ /* Channel breakdown (left ~35%) reads as a unit with the campaigns
-			     driving each channel (right ~65%) — NPPD-1649 fix #3. */ }
-			<div className="newspack-insights__traffic-grid">
+			{ /* Channel breakdown (1 column) reads as a unit with the campaigns
+			     driving each channel (spans the other 2 columns) — NPPD-1649 fix #3. */ }
+			<Grid columns={ 3 } gutter={ 16 } noMargin>
 				<ChartCard title={ __( 'Traffic sources breakdown', 'newspack-plugin' ) } payload={ current.traffic_sources_breakdown }>
 					<PieChart segments={ toSeries( current.traffic_sources_breakdown, 'channel', 'readers' ) } />
 				</ChartCard>
-				<ChartCard title={ __( 'Top campaigns', 'newspack-plugin' ) } payload={ campaigns }>
+				<ChartCard title={ __( 'Top campaigns', 'newspack-plugin' ) } payload={ campaigns } style={ { gridColumn: 'span 2' } }>
 					<MetricTable
 						payload={ campaigns }
 						emptyMessage={ __( 'No campaign traffic in this timeframe.', 'newspack-plugin' ) }
@@ -73,8 +75,8 @@ const TrafficSourcesSection = ( { current }: SectionProps ) => {
 						] }
 					/>
 				</ChartCard>
-			</div>
-		</section>
+			</Grid>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ChartCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ChartCard.tsx
@@ -11,6 +11,7 @@
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../packages/components/src';
 import MetricNote from './MetricNote';
 import type { MetricPayload } from './metrics';
 
@@ -25,9 +26,11 @@ export interface ChartCardProps {
 	caption?: string;
 	payload?: MetricPayload;
 	children: React.ReactNode;
+	/** Inline style forwarded to the underlying CoreCard (e.g. a grid-column span). */
+	style?: React.CSSProperties;
 }
 
-const ChartCard = ( { title, subhead, caption, payload, children }: ChartCardProps ) => {
+const ChartCard = ( { title, subhead, caption, payload, children, style }: ChartCardProps ) => {
 	if ( ! payload || payload.hidden_in_v1 ) {
 		return null;
 	}
@@ -44,12 +47,12 @@ const ChartCard = ( { title, subhead, caption, payload, children }: ChartCardPro
 	}
 
 	return (
-		<div className="newspack-insights__chart-card">
+		<Card __experimentalCoreCard className="newspack-insights__chart-card" style={ style }>
 			{ subhead && <p className="newspack-insights__chart-card-subhead">{ subhead }</p> }
 			{ title && <h3 className="newspack-insights__chart-card-title">{ title }</h3> }
 			{ caption && <p className="newspack-insights__chart-card-caption">{ caption }</p> }
-			{ body }
-		</div>
+			<div className="newspack-insights__chart-card-body">{ body }</div>
+		</Card>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.tsx
@@ -26,6 +26,7 @@ import { Notice } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import Section from './Section';
 import SectionHeading from './SectionHeading';
 import { formatNumber } from './format';
 
@@ -69,12 +70,12 @@ const interpolate = ( body: string, signalCount?: number ): string =>
 const EmptyMetricSection = ( { title, caption, state, body, signalCount }: EmptyMetricSectionProps ) => {
 	const id = headingId( title );
 	return (
-		<section className="newspack-insights__section newspack-insights__empty-metric-section" aria-labelledby={ id } data-empty-state={ state }>
+		<Section className="newspack-insights__section newspack-insights__empty-metric-section" aria-labelledby={ id } data-empty-state={ state }>
 			<SectionHeading id={ id } title={ title } description={ caption } />
 			<Notice status="info" isDismissible={ false } className="newspack-insights__empty-metric-section-callout">
 				<p>{ interpolate( body, signalCount ) }</p>
 			</Notice>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/Section.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/Section.tsx
@@ -1,0 +1,16 @@
+/**
+ * Section
+ *
+ * Shared wrapper for an Insights section: a semantic `<section>` laid out as a
+ * vertical stack. Centralizes the inter-element spacing (VStack `spacing={ 8 }`
+ * = 32px) so every section matches and the value changes in one place.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+const Section = ( props: React.ComponentPropsWithoutRef< 'section' > ) => <VStack as="section" spacing={ 8 } { ...props } />;
+
+export default Section;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -42,29 +42,52 @@
 		gap: 16px;
 	}
 
+	// Chart cell — CoreCard chrome (border + radius) to match the scorecards.
+	// Layout mirrors the metric card: title-as-label at the top, chart body
+	// grows, caption-as-description pinned to the bottom.
 	&__chart-card {
-		display: flex;
-		flex-direction: column;
 		height: 100%; // stretch to the row's tallest card so pies can center
-		border: 1px solid wp-colors.$gray-200;
-		border-radius: 4px;
-		padding: 16px;
 		min-width: 0; // let charts shrink inside grid cells instead of overflowing
 
-		&-title {
-			font-size: 14px;
-			font-weight: 600;
-			line-height: 1.3;
-			margin: 0 0 4px;
-			color: wp-colors.$gray-900;
-			// Reserve two lines so single- and two-line titles align across a row.
-			min-height: calc( 14px * 1.3 * 2 );
+		// CoreCard wraps children in `.newspack-card--core__body`; the flex
+		// column and the 24px padding live there, matching the metric card.
+		.newspack-card--core__body {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			padding: wp-vars.$grid-unit-30;
+
+			// Zero CoreCard's default 16px 24px grandchild-div padding.
+			> div:not(.components-card__body):not(.components-card__media):not(.components-card__divider) {
+				padding: 0;
+			}
 		}
 
+		// Title matches the metric-card label (Core BaseControl label 1:1).
+		&-title {
+			margin: 0;
+			font-size: wp-vars.$font-size-x-small;
+			font-weight: wp-vars.$font-weight-medium;
+			line-height: wp-vars.$default-line-height;
+			text-transform: uppercase;
+			color: wp-colors.$gray-900;
+		}
+
+		// Caption matches the metric-card description (Core help text), sitting
+		// directly under the title.
 		&-caption {
-			font-size: 13px;
+			margin: wp-vars.$grid-unit-10 0 0;
+			font-size: wp-vars.$font-size-small;
+			font-style: normal;
 			color: wp-colors.$gray-700;
-			margin: 0 0 12px;
+		}
+
+		// Chart body grows to fill the card; 24px separates it from the
+		// title/caption above.
+		&-body {
+			flex: 1 1 auto;
+			min-width: 0;
+			margin-top: wp-vars.$grid-unit-30;
 		}
 	}
 
@@ -192,21 +215,22 @@
 		flex: 1;
 		flex-direction: column;
 		min-height: 0;
+		height: 100%;
 	}
 
 	// Middle slot: pie centered both axes in the remaining space.
 	&__pie-figure {
-		flex: 1;
+		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		min-height: 0;
-		padding: 12px 0;
+		padding: 0 0 wp-vars.$grid-unit-30;
 	}
 
 	&__pie-svg {
 		width: 100%;
-		max-width: 150px;
+		max-width: calc(#{wp-vars.$grid-unit} * 32);
 		height: auto;
 		aspect-ratio: 1 / 1;
 		// No rotate: segments already start at 12 o'clock via the component's
@@ -239,16 +263,22 @@
 	// Bottom slot: legend anchored to the card bottom, left-aligned, full width.
 	&__pie-legend {
 		list-style: none;
-		margin: auto 0 0;
-		padding: 0;
-		width: 100%;
+		// Full-bleed top divider: stretch past the card's 24px body padding so
+		// the hairline spans edge to edge, then re-inset the legend content.
+		// `margin-top: auto` pins the legend to the card bottom.
+		width: calc(100% + #{wp-vars.$grid-unit-60});
+		margin: auto 0 0 -#{wp-vars.$grid-unit-30};
+		padding: wp-vars.$grid-unit-30 wp-vars.$grid-unit-30 0;
+		border-top: 1px solid wp-colors.$gray-100;
 
 		li {
 			display: flex;
 			align-items: center;
-			gap: 8px;
-			font-size: 12px;
-			margin-bottom: 6px;
+			gap: wp-vars.$grid-unit-10;
+			// Match Core's help text: 12px with the shared 1.4 line-height.
+			font-size: wp-vars.$font-size-small;
+			line-height: wp-vars.$default-line-height;
+			margin-bottom: wp-vars.$grid-unit-10;
 		}
 
 		li:last-child {
@@ -258,9 +288,9 @@
 
 	&__legend-swatch {
 		display: inline-block;
-		width: 12px;
-		height: 12px;
-		border-radius: 2px;
+		width: 20px;
+		height: 20px;
+		border-radius: wp-vars.$radius-full;
 		background: var( --series-color );
 		flex-shrink: 0;
 	}
@@ -903,37 +933,11 @@
 // is intentionally NOT defined in this per-tab partial so the callout can't
 // look different depending on which tab-chunk CSS happens to be loaded.
 
-// Per-section grid column modifiers. Compound selectors (0,2,0) so they win
-// over the single-class base rules regardless of stylesheet load order. Max 4
-// cards per row anywhere (NPPD-1649 fix #1).
-// Shared column patterns. cols-2 and cols-4 use the same breakpoints across
-// every grid variant; cols-3 differs (metric collapses at 782px, chart at
-// 1100px) so it stays per-grid.
-%insights-grid-cols-2 {
-	grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
-
-	@media ( max-width: 782px ) {
-		grid-template-columns: 1fr;
-	}
-}
-
-%insights-grid-cols-4 {
-	grid-template-columns: repeat( 4, minmax( 0, 1fr ) );
-
-	@media ( max-width: 1100px ) {
-		grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
-	}
-
-	@media ( max-width: 600px ) {
-		grid-template-columns: 1fr;
-	}
-}
-
-.newspack-insights__metric-grid.newspack-insights__metric-grid--cols-4,
-.newspack-insights__chart-grid.newspack-insights__chart-grid--cols-4 {
-	@extend %insights-grid-cols-4;
-}
-
+// Section grid column modifier — the only fixed-column grid still authored in
+// CSS. QualitySection drops to 3 even columns when the completion card is
+// hidden (see QualitySection.tsx); every other fixed-column grid now uses the
+// shared <Grid> component. Compound selector (0,2,0) so it wins over the
+// single-class base rule regardless of stylesheet load order.
 .newspack-insights__metric-grid.newspack-insights__metric-grid--cols-3 {
 	grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
 
@@ -942,30 +946,3 @@
 	}
 }
 
-.newspack-insights__chart-grid.newspack-insights__chart-grid--cols-3 {
-	grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
-
-	@media ( max-width: 1100px ) {
-		grid-template-columns: 1fr;
-	}
-}
-
-.newspack-insights__metric-grid.newspack-insights__metric-grid--cols-2,
-.newspack-insights__chart-grid.newspack-insights__chart-grid--cols-2,
-.newspack-insights__table-grid.newspack-insights__table-grid--cols-2 {
-	@extend %insights-grid-cols-2;
-}
-
-// Traffic sources: channel-breakdown pie (~40%) reads as a unit with the
-// campaigns table (~60%) — NPPD-1649 fix #3.
-.newspack-insights__traffic-grid {
-	display: grid;
-	// Pie card ~35% (stacked, narrower-and-taller), campaigns table ~65%.
-	grid-template-columns: minmax( 0, 35fr ) minmax( 0, 65fr );
-	gap: 16px;
-	align-items: stretch;
-
-	@media ( max-width: 782px ) {
-		grid-template-columns: 1fr;
-	}
-}

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -54,15 +54,6 @@
 		}
 	}
 
-	// Sections are pure spacing — no background, no border. The cards
-	// inside them carry the chrome (per spec).
-
-	&__section {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
 	// Wraps a tab's sections; the interleaved full-width Dividers supply all the
 	// inter-section spacing via their own margins, so no gap here (a gap would
 	// stack with the divider margins).
@@ -89,20 +80,6 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 		gap: 16px;
-	}
-
-	// The Prompts conversion sections carry longer scorecard titles (e.g.
-	// "Registration Conversion (Influenced, 7d)") that wrap to three lines, while
-	// the default label reserves two — so cards with a 3-line title push their
-	// hero value/em-dash down and the row reads as staggered. Reserve a third line
-	// in just these sections so every hero aligns; exposure/engagement titles fit
-	// in two lines and keep the tighter default.
-	&__section--free-reader,
-	&__section--paid-reader,
-	&__section--revenue {
-		.newspack-insights__metric-card-label {
-			min-height: calc(12px * 1.4 * 3);
-		}
 	}
 
 	// Card chrome (white background, gray-200 border, 4px radius) is
@@ -153,35 +130,31 @@
 		.newspack-card--core__body {
 			display: flex;
 			flex-direction: column;
-			padding: 24px 28px;
-			min-height: 180px;
+			height: 100%;
+			padding: wp-vars.$grid-unit-30;
 
 			// Match CoreCard's own selector to win the cascade — it
 			// pads non-CardBody/Media/Divider grandchild divs at
 			// 16px 24px by default; our outer padding above already
 			// owns the spacing. The body sub-region gets its own
-			// 16px top padding re-applied at matching specificity.
+			// 8px top padding re-applied at matching specificity.
 			> div:not(.components-card__body):not(.components-card__media):not(.components-card__divider) {
 				padding: 0;
 
 				&.newspack-insights__metric-card-body {
-					padding: 16px 0 0;
+					padding: wp-vars.$grid-unit-10 0 0;
 				}
 			}
 		}
 
 		&-label {
-			font-size: 12px;
-			font-weight: 600;
-			line-height: 1.4;
-			letter-spacing: 0.05em;
+			// Match Core's BaseControl label typography 1:1 (baseLabelTypography):
+			// 11px / medium (499) / 1.4 line-height / uppercase, no letter-spacing.
+			font-size: wp-vars.$font-size-x-small;
+			font-weight: wp-vars.$font-weight-medium;
+			line-height: wp-vars.$default-line-height;
 			text-transform: uppercase;
-			color: wp-colors.$gray-700;
-			// Reserve two lines of vertical space so a long label that
-			// wraps ("MONTHLY RECURRING REVENUE") doesn't push its hero
-			// number down relative to neighboring cards whose labels fit
-			// on one line. 12px font × 1.4 line-height × 2 lines.
-			min-height: calc(12px * 1.4 * 2);
+			color: wp-colors.$gray-900;
 		}
 
 		&-body {
@@ -289,12 +262,20 @@
 		}
 
 		&-description {
-			margin: 16px 0 0;
-			font-size: 13px;
-			font-weight: 400;
-			line-height: 1.4;
+			margin: wp-vars.$grid-unit-30 0 0;
+			// Match Core's help text (StyledHelp): 12px / normal style / gray-700.
+			font-size: wp-vars.$font-size-small;
+			font-style: normal;
 			color: wp-colors.$gray-700;
 			text-align: left;
+
+			p {
+				margin: 0;
+				// Inherit the description's help-text typography instead of the
+				// admin default paragraph size.
+				font: inherit;
+				color: inherit;
+			}
 		}
 
 		// Empty-state variant: same card chrome as a populated metric

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionCohortData } from '../../api/conversion';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import CohortHeatmap from '../components/CohortHeatmap';
 import { formatPercent } from '../components/format';
@@ -63,7 +64,7 @@ const CohortChart = ( { title, data, caption, referenceLabel }: CohortChartProps
 );
 
 const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--cohort-retention"
 		aria-labelledby="newspack-insights-conversion-cohort-heading"
 	>
@@ -101,7 +102,7 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
 				referenceLabel={ current.subscriber_retention_cohort.reference_line?.label }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default CohortRetentionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionWeekPoint, ConversionWeeklyTrendsData } from '../../api/conversion';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import LineChart, { type LineSeries } from '../components/LineChart';
 import { formatPercent } from '../components/format';
@@ -56,7 +57,7 @@ const toTrendSeries = ( data: ConversionWeeklyTrendsData ): LineSeries[] =>
 		} ) );
 
 const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--rate-trends"
 		aria-labelledby="newspack-insights-conversion-rate-trends-heading"
 	>
@@ -83,7 +84,7 @@ const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionPr
 				/>
 			</SectionState>
 		</div>
-	</section>
+	</Section>
 );
 
 export default ConversionRateTrendsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { ConversionWindow } from '../../api/conversion';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { scalarToMetricCardProps } from './scalarToCard';
 
@@ -29,7 +30,7 @@ export interface CrossTabInfluencedAttributionSectionProps {
 }
 
 const CrossTabInfluencedAttributionSection = ( { current, previous }: CrossTabInfluencedAttributionSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--influenced-attribution"
 		aria-labelledby="newspack-insights-conversion-influenced-heading"
 	>
@@ -78,7 +79,7 @@ const CrossTabInfluencedAttributionSection = ( { current, previous }: CrossTabIn
 				} ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default CrossTabInfluencedAttributionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -21,6 +21,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionCumulativeMulti, ConversionCumulativePoint, ConversionWindow } from '../../api/conversion';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { sourceLabel, dayLabel } from './labels';
 import { formatPercent } from '../components/format';
@@ -57,7 +58,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 	const lag = current.subscriber_to_donor_lag_distribution;
 	const snapshotCaption = __( 'This view always uses all available history, regardless of the selected date range.', 'newspack-plugin' );
 	return (
-		<section
+		<Section
 			className="newspack-insights__section newspack-insights__section--time-to-convert"
 			aria-labelledby="newspack-insights-conversion-time-to-convert-heading"
 		>
@@ -145,7 +146,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					) }
 				</CurveCell>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -22,6 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import type { ConversionTopPageRow, ConversionWindow } from '../../api/conversion';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { formatNumber, formatPercent } from '../components/format';
 import { scalarToMetricCardProps } from './scalarToCard';
@@ -77,7 +78,7 @@ const TOP_PAGES_COLUMNS: SortableColumn< ConversionTopPageRow >[] = [
 ];
 
 const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--opportunity-buckets"
 		aria-labelledby="newspack-insights-conversion-opportunity-heading"
 	>
@@ -148,7 +149,7 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 				) }
 			</p>
 		</div>
-	</section>
+	</Section>
 );
 
 export default OpportunityBucketsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -36,6 +36,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionGatedFunnelData, ConversionWindow } from '../../api/conversion';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import SectionEmpty from '../components/SectionEmpty';
 import { formatNumber } from '../components/format';
@@ -153,7 +154,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 	const donationVisible = current.registered_to_donor_funnel.visibility !== 'hidden';
 
 	return (
-		<section
+		<Section
 			className="newspack-insights__section newspack-insights__section--per-journey-funnels"
 			aria-labelledby="newspack-insights-conversion-per-journey-heading"
 		>
@@ -246,7 +247,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 					/>
 				</JourneyFunnel>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionWindow } from '../../api/conversion';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import Funnel from '../components/Funnel';
 import SectionState from './SectionState';
@@ -30,7 +31,7 @@ export interface ReaderLifecycleSectionProps {
 }
 
 const ReaderLifecycleSection = ( { current, lastUpdated }: ReaderLifecycleSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--reader-lifecycle"
 		aria-labelledby="newspack-insights-conversion-lifecycle-heading"
 	>
@@ -49,7 +50,7 @@ const ReaderLifecycleSection = ( { current, lastUpdated }: ReaderLifecycleSectio
 		>
 			<Funnel stages={ current.reader_lifecycle_funnel.stages } />
 		</SectionState>
-	</section>
+	</Section>
 );
 
 export default ReaderLifecycleSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ConversionSourceMixData } from '../../api/conversion';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { formatNumber } from '../components/format';
 import { sourceLabel } from './labels';
@@ -52,7 +53,7 @@ const SourcePie = ( { title, data, emptyMessage }: SourcePieProps ) => (
 );
 
 const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--source-mix"
 		aria-labelledby="newspack-insights-conversion-source-mix-heading"
 	>
@@ -81,7 +82,7 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 				emptyMessage={ __( 'Source data will appear once donations occur in this timeframe.', 'newspack-plugin' ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default WhereConversionsComeFromSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
@@ -25,6 +25,7 @@ import { __ } from '@wordpress/i18n';
 import type { DonorsCampaignRow } from '../../api/donors';
 import InsightsDataView from '../components/InsightsDataView';
 import type { InsightsColumn } from '../components/InsightsDataView';
+import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency, formatNumber } from '../components/format';
@@ -66,15 +67,15 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 	const hasTagged = rows.some( row => ! row.is_untagged );
 	if ( ! hasTagged ) {
 		return (
-			<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+			<Section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
 				<SectionHeading id={ HEADING_ID } title={ title } />
 				<SectionEmpty>{ __( 'No campaign-tagged donations in this window.', 'newspack-plugin' ) }</SectionEmpty>
-			</section>
+			</Section>
 		);
 	}
 
 	return (
-		<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+		<Section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
 			<SectionHeading
 				id={ HEADING_ID }
 				title={ title }
@@ -89,7 +90,7 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 				getRowKey={ row => ( row.is_untagged ? '__untagged__' : `campaign:${ row.value }` ) }
 				emptyMessage={ __( 'No campaign-tagged donations in this window.', 'newspack-plugin' ) }
 			/>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
@@ -35,6 +35,7 @@ import { __ } from '@wordpress/i18n';
 import type { DonorsTierRow, DonorsTierVariationRow } from '../../api/donors';
 import InsightsDataView from '../components/InsightsDataView';
 import type { InsightsColumn } from '../components/InsightsDataView';
+import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { getPostEditUrl } from '../components/adminLinks';
@@ -127,18 +128,18 @@ const columns: InsightsColumn< FlatRow >[] = [
 const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 	if ( rows.length === 0 ) {
 		return (
-			<section
+			<Section
 				className="newspack-insights__section newspack-insights__section--performance"
 				aria-labelledby="newspack-insights-donors-performance-heading"
 			>
 				<SectionHeading id="newspack-insights-donors-performance-heading" title={ __( 'Donations by tier', 'newspack-plugin' ) } />
 				<SectionEmpty>{ __( 'No donation activity yet.', 'newspack-plugin' ) }</SectionEmpty>
-			</section>
+			</Section>
 		);
 	}
 
 	return (
-		<section
+		<Section
 			className="newspack-insights__section newspack-insights__section--performance"
 			aria-labelledby="newspack-insights-donors-performance-heading"
 		>
@@ -164,7 +165,7 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 					'newspack-plugin'
 				) }
 			</p>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
@@ -35,6 +35,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import type { DonorsRateValue, DonorsWindow } from '../../api/donors';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { formatNumber } from '../components/format';
@@ -74,7 +75,7 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 
 	if ( ! recovery.computable && ! retention.computable ) {
 		return (
-			<section { ...sectionProps }>
+			<Section { ...sectionProps }>
 				{ heading }
 				<SectionEmpty>
 					{ __(
@@ -82,12 +83,12 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 						'newspack-plugin'
 					) }
 				</SectionEmpty>
-			</section>
+			</Section>
 		);
 	}
 
 	return (
-		<section { ...sectionProps }>
+		<Section { ...sectionProps }>
 			{ heading }
 			<div className="newspack-insights__metric-grid">
 				{ recovery.computable ? (
@@ -125,7 +126,7 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 					</div>
 				) }
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -24,6 +24,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import type { DonorsSnapshot } from '../../api/donors';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency, formatNumber } from '../components/format';
 
@@ -33,7 +34,7 @@ export interface ScorecardSectionProps {
 }
 
 const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--scorecard"
 		aria-labelledby="newspack-insights-donors-scorecard-heading"
 	>
@@ -114,7 +115,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Donation subscriptions set to end in the next 30 days', 'newspack-plugin' ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default ScorecardSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -36,6 +36,7 @@ import type { DonorsWindow } from '../../api/donors';
 import type { DateRange } from '../../state/useDateRange';
 import EmptyMetricSection from '../components/EmptyMetricSection';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency, formatNumber } from '../components/format';
 
@@ -143,7 +144,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 	const oneTimeGiftsLabel = __( 'one-time gifts', 'newspack-plugin' );
 
 	return (
-		<section
+		<Section
 			className="newspack-insights__section newspack-insights__section--windowed"
 			aria-labelledby="newspack-insights-donors-windowed-heading"
 		>
@@ -202,7 +203,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					description={ __( 'Mean order total across one-time donation orders in this timeframe', 'newspack-plugin' ) }
 				/>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -12,8 +12,10 @@ import { __ } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/audience';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { SHOW_COMPLETION_METRICS } from '../constants';
+import { Grid } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -23,7 +25,7 @@ export interface SectionProps {
 const ARTICLE_COL = { key: 'page_title', label: __( 'Article', 'newspack-plugin' ) };
 
 const ContentEngagementSection = ( { current }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-content">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-content">
 		<SectionHeading
 			id="newspack-insights-engagement-content"
 			title={ __( 'Content engagement', 'newspack-plugin' ) }
@@ -33,7 +35,7 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 		     and Top Authors wraps to row 2 (one column, ~50%, left-aligned). With
 		     completion hidden (SHOW_COMPLETION_METRICS=false) the two remaining
 		     tables fill row 1 as a clean 2-up — no full-width stretch. */ }
-		<div className="newspack-insights__table-grid newspack-insights__table-grid--cols-2">
+		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<div>
 				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-engaged articles', 'newspack-plugin' ) }</h3>
 				<MetricTable
@@ -73,8 +75,8 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 					] }
 				/>
 			</div>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default ContentEngagementSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { InsightsWindow } from '../../../api/audience';
 import Scorecard from '../../components/Scorecard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { SHOW_COMPLETION_METRICS } from '../constants';
 
@@ -27,7 +28,7 @@ export interface SectionProps {
 }
 
 const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-quality">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-quality">
 		<SectionHeading
 			id="newspack-insights-engagement-quality"
 			title={ __( 'Overall engagement quality', 'newspack-plugin' ) }
@@ -70,7 +71,7 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 				/>
 			) }
 		</div>
-	</section>
+	</Section>
 );
 
 export default QualitySection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
@@ -17,8 +17,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import type { InsightsWindow } from '../../../api/audience';
 import type { MetricPayload, MetricRow } from '../../components/metrics';
 import { formatDecimal, formatDuration, formatNumber } from '../../components/format';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import TakeawayCard from '../../components/TakeawayCard';
+import { Grid } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -193,13 +195,13 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 	const trafficSource = trafficSourceTakeaway( current.engagement_by_traffic_source );
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-segments">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-segments">
 			<SectionHeading
 				id="newspack-insights-engagement-segments"
 				title={ __( 'Reader segments', 'newspack-plugin' ) }
 				description={ __( 'How engagement varies by segment.', 'newspack-plugin' ) }
 			/>
-			<div className="newspack-insights__chart-grid newspack-insights__chart-grid--cols-3">
+			<Grid columns={ 3 } gutter={ 16 } noMargin>
 				<TakeawayCard
 					title={ __( 'Engagement by device', 'newspack-plugin' ) }
 					payload={ current.engagement_by_device_type }
@@ -224,8 +226,8 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					bars={ trafficSource.bars }
 					formatValue={ formatSeconds }
 				/>
-			</div>
-		</section>
+			</Grid>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
@@ -39,6 +39,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import EmptyMetricSection from '../components/EmptyMetricSection';
 import { scalarToMetricCardProps } from './scalarToCard';
@@ -111,7 +112,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 	}
 
 	return (
-		<section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby={ HEADING_ID }>
+		<Section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby={ HEADING_ID }>
 			<SectionHeading id={ HEADING_ID } title={ title } description={ caption } />
 			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--pair">
 				<MetricCard
@@ -151,7 +152,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					} ) }
 				/>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/GateExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/GateExposureSection.tsx
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { scalarToMetricCardProps } from './scalarToCard';
 
@@ -34,7 +35,7 @@ export interface GateExposureSectionProps {
 }
 
 const GateExposureSection = ( { current, previous, lastUpdated }: GateExposureSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-gates-exposure-heading">
+	<Section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-gates-exposure-heading">
 		<SectionHeading
 			id="newspack-insights-gates-exposure-heading"
 			title={ __( 'Gate exposure', 'newspack-plugin' ) }
@@ -75,7 +76,7 @@ const GateExposureSection = ( { current, previous, lastUpdated }: GateExposureSe
 				} ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default GateExposureSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/HowReadersConvertSection.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { GatesWindow } from '../../api/gates';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import Funnel from '../components/Funnel';
 import DistributionTable from '../components/DistributionTable';
@@ -29,7 +30,7 @@ export interface HowReadersConvertSectionProps {
 }
 
 const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-gates-convert-heading">
+	<Section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-gates-convert-heading">
 		<SectionHeading
 			id="newspack-insights-gates-convert-heading"
 			title={ __( 'How readers convert', 'newspack-plugin' ) }
@@ -62,7 +63,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 				</SectionState>
 			</div>
 		</div>
-	</section>
+	</Section>
 );
 
 export default HowReadersConvertSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -31,6 +31,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import EmptyMetricSection from '../components/EmptyMetricSection';
 import { scalarToMetricCardProps } from './scalarToCard';
@@ -96,7 +97,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 	}
 
 	return (
-		<section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby={ HEADING_ID }>
+		<Section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby={ HEADING_ID }>
 			<SectionHeading id={ HEADING_ID } title={ title } description={ caption } />
 			<div className="newspack-insights__metric-grid">
 				<MetricCard
@@ -170,7 +171,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					} ) }
 				/>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
@@ -26,6 +26,7 @@ import InsightsDataView from '../components/InsightsDataView';
 import type { InsightsColumn } from '../components/InsightsDataView';
 import { getPostEditUrl } from '../components/adminLinks';
 import { formatNumber, formatPercent } from '../components/format';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { SECTION_ERROR_MESSAGE } from './SectionState';
 
@@ -106,7 +107,7 @@ const PerformanceByGateSection = ( { data }: PerformanceByGateSectionProps ) => 
 			: __( 'No gate data yet. Performance metrics will appear once readers begin interacting with your gates.', 'newspack-plugin' );
 
 	return (
-		<section
+		<Section
 			className="newspack-insights__section newspack-insights__section--performance"
 			aria-labelledby="newspack-insights-gates-performance-heading"
 		>
@@ -122,7 +123,7 @@ const PerformanceByGateSection = ( { data }: PerformanceByGateSectionProps ) => 
 				defaultSortKey="impressions"
 				emptyMessage={ emptyMessage }
 			/>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
@@ -31,6 +31,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components'; // eslin
 import type { InsightsWindow } from '../../../api/newsletter_ads';
 import EmptyMetricSection from '../../components/EmptyMetricSection';
 import Scorecard from '../../components/Scorecard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { Grid } from '../../../../../../packages/components/src';
 
@@ -77,7 +78,7 @@ const OverviewSection = ( { current, previous, hasWindowActivity, lastUpdated }:
 	const excludedAds = current.revenue_excluded_ads?.computable ? current.revenue_excluded_ads?.value ?? 0 : 0;
 
 	return (
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-overview">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-overview">
 			<SectionHeading id="newspack-insights-newsletter-ads-overview" title={ TITLE } description={ CAPTION } actions={ lastUpdated } />
 			<VStack spacing={ 4 }>
 				{ /* Row 1: the four timeframe headline scorecards. */ }
@@ -160,7 +161,7 @@ const OverviewSection = ( { current, previous, hasWindowActivity, lastUpdated }:
 					) }
 				</p>
 			) }
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
@@ -21,6 +21,7 @@ import type { ByNewsletterRow, InsightsWindow } from '../../../api/newsletter_ad
 import type { MetricPayload } from '../../components/metrics';
 import { formatShortDate } from '../../components/format';
 import MetricTable from '../../components/MetricTable';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import TabSections from '../../components/TabSections';
 
@@ -48,7 +49,7 @@ const withDisplayDates = ( payload?: MetricPayload ): MetricPayload | undefined 
 
 const TablesSection = ( { current }: SectionProps ) => (
 	<TabSections>
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-ads">
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-ads">
 			<SectionHeading id="newspack-insights-newsletter-ads-top-ads" title={ __( 'Top ads', 'newspack-plugin' ) } />
 			<MetricTable
 				payload={ current.top_ads }
@@ -63,8 +64,8 @@ const TablesSection = ( { current }: SectionProps ) => (
 					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
-		</section>
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-advertisers">
+		</Section>
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-advertisers">
 			<SectionHeading id="newspack-insights-newsletter-ads-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
 			<MetricTable
 				payload={ current.top_advertisers }
@@ -79,8 +80,8 @@ const TablesSection = ( { current }: SectionProps ) => (
 					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
-		</section>
-		<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-by-newsletter">
+		</Section>
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-by-newsletter">
 			<SectionHeading id="newspack-insights-newsletter-ads-by-newsletter" title={ __( 'Ad performance by newsletter', 'newspack-plugin' ) } />
 			<MetricTable
 				payload={ withDisplayDates( current.by_newsletter ) }
@@ -96,7 +97,7 @@ const TablesSection = ( { current }: SectionProps ) => (
 					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
 				] }
 			/>
-		</section>
+		</Section>
 	</TabSections>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
@@ -22,6 +22,7 @@ import { __experimentalHStack as HStack, FlexBlock } from '@wordpress/components
  */
 import type { InsightsWindow } from '../../../api/newsletter_ads';
 import ChartCard from '../../components/ChartCard';
+import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import LineChart from '../../components/LineChart';
 import { toSeries } from '../../components/metrics';
@@ -46,7 +47,7 @@ const buildSeries = ( current: InsightsWindow, previous: InsightsWindow | null, 
 };
 
 const TrendSection = ( { current, previous }: SectionProps ) => (
-	<section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-trend">
+	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-trend">
 		<SectionHeading
 			id="newspack-insights-newsletter-ads-trend"
 			title={ __( 'Performance trend', 'newspack-plugin' ) }
@@ -64,7 +65,7 @@ const TrendSection = ( { current, previous }: SectionProps ) => (
 				</ChartCard>
 			</FlexBlock>
 		</HStack>
-	</section>
+	</Section>
 );
 
 export default TrendSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
 import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
@@ -33,7 +34,7 @@ export interface FreeReaderConversionSectionProps {
 }
 
 const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversionSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby="newspack-insights-prompts-free-heading">
+	<Section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby="newspack-insights-prompts-free-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-free-heading"
 			title={ __( 'Free reader conversion', 'newspack-plugin' ) }
@@ -96,7 +97,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				} ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default FreeReaderConversionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { PromptsWindow } from '../../api/prompts';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import Funnel from '../components/Funnel';
 import DistributionTable from '../components/DistributionTable';
@@ -27,7 +28,7 @@ export interface HowReadersConvertSectionProps {
 }
 
 const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-prompts-convert-heading">
+	<Section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-prompts-convert-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-convert-heading"
 			title={ __( 'How readers convert', 'newspack-plugin' ) }
@@ -60,7 +61,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 				</SectionState>
 			</div>
 		</div>
-	</section>
+	</Section>
 );
 
 export default HowReadersConvertSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -23,6 +23,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
 import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
@@ -34,7 +35,7 @@ export interface PaidReaderConversionSectionProps {
 }
 
 const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversionSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby="newspack-insights-prompts-paid-heading">
+	<Section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby="newspack-insights-prompts-paid-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-paid-heading"
 			title={ __( 'Paid reader conversion', 'newspack-plugin' ) }
@@ -100,7 +101,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				} ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default PaidReaderConversionSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { PromptsWindow } from '../../api/prompts';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import PerformanceByPromptTable from './viz/PerformanceByPromptTable';
 import PerformanceByIntentTable from './viz/PerformanceByIntentTable';
@@ -26,7 +27,7 @@ export interface PerformanceBreakdownSectionProps {
 }
 
 const PerformanceBreakdownSection = ( { current }: PerformanceBreakdownSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--performance"
 		aria-labelledby="newspack-insights-prompts-performance-heading"
 	>
@@ -41,7 +42,7 @@ const PerformanceBreakdownSection = ( { current }: PerformanceBreakdownSectionPr
 		<PerformanceByPromptTable data={ current.performance_by_prompt } />
 		<PerformanceByIntentTable data={ current.performance_by_intent } />
 		<PerformanceByPlacementTable data={ current.performance_by_placement } />
-	</section>
+	</Section>
 );
 
 export default PerformanceBreakdownSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
@@ -15,10 +15,12 @@ import { __ } from '@wordpress/i18n';
  */
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
 import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
 import { scalarToMetricCardProps } from './scalarToCard';
+import { Grid } from '../../../../../packages/components/src';
 
 export interface PromptEngagementSectionProps {
 	current: PromptsWindow;
@@ -26,7 +28,7 @@ export interface PromptEngagementSectionProps {
 }
 
 const PromptEngagementSection = ( { current, previous }: PromptEngagementSectionProps ) => (
-	<section
+	<Section
 		className="newspack-insights__section newspack-insights__section--engagement"
 		aria-labelledby="newspack-insights-prompts-engagement-heading"
 	>
@@ -38,7 +40,7 @@ const PromptEngagementSection = ( { current, previous }: PromptEngagementSection
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Click-Through Rate', 'newspack-plugin' ),
@@ -65,8 +67,8 @@ const PromptEngagementSection = ( { current, previous }: PromptEngagementSection
 					previous: previous?.dismissal_rate,
 				} ) }
 			/>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default PromptEngagementSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
@@ -23,8 +23,10 @@ import { __ } from '@wordpress/i18n';
  */
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { scalarToMetricCardProps } from './scalarToCard';
+import { Grid } from '../../../../../packages/components/src';
 
 export interface PromptExposureSectionProps {
 	current: PromptsWindow;
@@ -33,14 +35,14 @@ export interface PromptExposureSectionProps {
 }
 
 const PromptExposureSection = ( { current, previous, lastUpdated }: PromptExposureSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-prompts-exposure-heading">
+	<Section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-prompts-exposure-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-exposure-heading"
 			title={ __( 'Prompt exposure', 'newspack-plugin' ) }
 			description={ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid newspack-insights__metric-grid--cols-3">
+		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Total Prompt Impressions', 'newspack-plugin' ),
@@ -65,8 +67,8 @@ const PromptExposureSection = ( { current, previous, lastUpdated }: PromptExposu
 					previous: previous?.avg_prompts_per_reader,
 				} ) }
 			/>
-		</div>
-	</section>
+		</Grid>
+	</Section>
 );
 
 export default PromptExposureSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { NOT_CAPABLE_COPY } from './notCapableCopy';
 import { NOT_COMPUTABLE_COPY } from './notComputableCopy';
@@ -33,7 +34,7 @@ export interface RevenueFromPromptsSectionProps {
 }
 
 const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--revenue" aria-labelledby="newspack-insights-prompts-revenue-heading">
+	<Section className="newspack-insights__section newspack-insights__section--revenue" aria-labelledby="newspack-insights-prompts-revenue-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-revenue-heading"
 			title={ __( 'Revenue from prompts', 'newspack-plugin' ) }
@@ -99,7 +100,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 				} ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default RevenueFromPromptsSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
@@ -25,6 +25,7 @@ import { __ } from '@wordpress/i18n';
 import type { SubscribersCampaignRow } from '../../api/subscribers';
 import InsightsDataView from '../components/InsightsDataView';
 import type { InsightsColumn } from '../components/InsightsDataView';
+import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency, formatNumber } from '../components/format';
@@ -66,15 +67,15 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 	const hasTagged = rows.some( row => ! row.is_untagged );
 	if ( ! hasTagged ) {
 		return (
-			<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+			<Section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
 				<SectionHeading id={ HEADING_ID } title={ title } />
 				<SectionEmpty>{ __( 'No campaign-tagged subscriptions in this window.', 'newspack-plugin' ) }</SectionEmpty>
-			</section>
+			</Section>
 		);
 	}
 
 	return (
-		<section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
+		<Section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
 			<SectionHeading
 				id={ HEADING_ID }
 				title={ title }
@@ -89,7 +90,7 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 				getRowKey={ row => ( row.is_untagged ? '__untagged__' : `campaign:${ row.value }` ) }
 				emptyMessage={ __( 'No campaign-tagged subscriptions in this window.', 'newspack-plugin' ) }
 			/>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
@@ -22,6 +22,7 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import type { PerformanceRow } from '../../api/subscribers';
+import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { getPostEditUrl } from '../components/adminLinks';
@@ -34,18 +35,18 @@ export interface PerformanceSectionProps {
 const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 	if ( rows.length === 0 ) {
 		return (
-			<section
+			<Section
 				className="newspack-insights__section newspack-insights__section--performance"
 				aria-labelledby="newspack-insights-performance-heading"
 			>
 				<SectionHeading id="newspack-insights-performance-heading" title={ __( 'Subscriptions by product', 'newspack-plugin' ) } />
 				<SectionEmpty>{ __( 'No subscription products configured yet.', 'newspack-plugin' ) }</SectionEmpty>
-			</section>
+			</Section>
 		);
 	}
 
 	return (
-		<section
+		<Section
 			className="newspack-insights__section newspack-insights__section--performance"
 			aria-labelledby="newspack-insights-performance-heading"
 		>
@@ -136,7 +137,7 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 					'newspack-plugin'
 				) }
 			</p>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -27,6 +27,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import type { SubscribersSnapshot } from '../../api/subscribers';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency } from '../components/format';
 
@@ -36,7 +37,7 @@ export interface ScorecardSectionProps {
 }
 
 const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) => (
-	<section className="newspack-insights__section newspack-insights__section--scorecard" aria-labelledby="newspack-insights-scorecard-heading">
+	<Section className="newspack-insights__section newspack-insights__section--scorecard" aria-labelledby="newspack-insights-scorecard-heading">
 		<SectionHeading
 			id="newspack-insights-scorecard-heading"
 			title={ __( 'Subscribers at a glance', 'newspack-plugin' ) }
@@ -109,7 +110,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Subscriptions set to end in the next 30 days', 'newspack-plugin' ) }
 			/>
 		</div>
-	</section>
+	</Section>
 );
 
 export default ScorecardSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/TenureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/TenureSection.tsx
@@ -20,6 +20,7 @@ import { useMemo } from '@wordpress/element';
  */
 import type { TenureDistributionRow } from '../../api/subscribers';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 
@@ -59,10 +60,10 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 
 	if ( ! stats ) {
 		return (
-			<section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
+			<Section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
 				<SectionHeading id="newspack-insights-tenure-heading" title={ __( 'Subscriber tenure', 'newspack-plugin' ) } />
 				<SectionEmpty>{ __( 'No subscribers yet — tenure data will appear once subscriptions exist.', 'newspack-plugin' ) }</SectionEmpty>
-			</section>
+			</Section>
 		);
 	}
 
@@ -95,7 +96,7 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 	const narrative = showSecondSentence ? `${ medianSentence } ${ p75Sentence }` : medianSentence;
 
 	return (
-		<section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
+		<Section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
 			<SectionHeading id="newspack-insights-tenure-heading" title={ __( 'Subscriber tenure', 'newspack-plugin' ) } description={ narrative } />
 			<div className="newspack-insights__metric-grid">
 				<MetricCard
@@ -117,7 +118,7 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 					secondary={ _n( 'day', 'days', stats.p75, 'newspack-plugin' ) }
 				/>
 			</div>
-		</section>
+		</Section>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -42,6 +42,7 @@ import type { SubscribersRateValue, SubscribersWindow } from '../../api/subscrib
 import type { DateRange } from '../../state/useDateRange';
 import EmptyMetricSection from '../components/EmptyMetricSection';
 import MetricCard from '../components/MetricCard';
+import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { formatNumber } from '../components/format';
 
@@ -162,7 +163,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 	const retryPrevious = previous?.failed_payment_retry_rate?.computable ? previous.failed_payment_retry_rate.value : null;
 
 	return (
-		<section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
+		<Section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
 			<SectionHeading id="newspack-insights-windowed-heading" title={ getHeading( range ) } />
 			<div className="newspack-insights__metric-grid">
 				<MetricCard
@@ -234,7 +235,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'Recovered retries ÷ retry attempts', 'newspack-plugin' ) }
 				/>
 			</div>
-		</section>
+		</Section>
 	);
 };
 


### PR DESCRIPTION
Design refinements across the Insights wizard, iterated live on the review env.

## Layout
- **Shared `<Section>` wrapper** — new component renders `<VStack as="section" spacing={ 8 }>` (32px); swept all ~57 section wrappers onto it and removed the `.newspack-insights__section` CSS rule so section spacing lives in one place.
- **`<Grid>` for fixed-column grids** — replaced the custom `--cols-2/3/4` grid classes with the Newspack `Grid` component (`gutter={ 16 }`, `noMargin`); removed the now-unused `--cols` SCSS.
- **Traffic sources** — 3-col Grid with the campaigns/DataViews card spanning 2 columns (via a forwarded `style` prop on `ChartCard`).
- **Time trends** — grouped the line card + day/hour bar grid in a nested `VStack spacing={ 4 }` (16px).

## Cards
- **`ChartCard` now uses the CoreCard** (same chrome/layout as the scorecards); title styled as the label, caption as the description sitting under the title, chart body below.
- **Card typography matched 1:1 to Core** using wp-vars tokens — label = `BaseControl` label (`$font-size-x-small` / `$font-weight-medium` / `$default-line-height` / uppercase / `$gray-900`); description = help text (`$font-size-small`, `$gray-700`).
- Padding/spacing tokenized to `$grid-unit-*` throughout; pie chart, legend, and swatch styling refined.

## Notes
- `PromptsTab` snapshot regenerated (VStack output).
- Lint (ESLint + Stylelint), `tsc`, and build all clean. Full JS suite passes (the one `PrintDocumentMeta` date-range failure is pre-existing and unrelated).