### PR TITLE
feat(insights): card-based dataviews and chart polish

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
@@ -21,7 +21,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { Button, ExternalLink } from '@wordpress/components';
-import { close } from '@wordpress/icons';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -74,7 +74,7 @@ const NextSteps = ( { links }: NextStepsProps ) => {
 				<span className="newspack-insights__next-steps-label">{ __( 'Next steps', 'newspack-plugin' ) }</span>
 				<Button
 					className="newspack-insights__next-steps-dismiss"
-					icon={ close }
+					icon={ closeSmall }
 					label={ __( 'Dismiss next steps', 'newspack-plugin' ) }
 					onClick={ dismiss }
 					size="small"

--- a/plugins/newspack-plugin/src/wizards/insights/components/_feedback.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_feedback.scss
@@ -8,6 +8,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .newspack-insights {
 
@@ -15,9 +16,9 @@
 	// body by a hairline rule. Hidden in print (the PDF export owns its own
 	// footer).
 	&__tab-footer {
-		margin-top: 32px;
-		padding-top: 16px;
-		border-top: 1px solid wp-colors.$gray-200;
+		margin-top: wp-vars.$grid-unit-80;
+		padding-top: wp-vars.$grid-unit-20;
+		border-top: 1px solid wp-colors.$gray-300;
 
 		@media print {
 			display: none;

--- a/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
@@ -47,9 +47,9 @@
 	// WP form-label treatment (DSGNEWS-188): 11px / 500 / uppercase, matching
 	// `.components-base-control__label`.
 	&__next-steps-label {
-		font-size: 11px;
-		font-weight: 500;
-		line-height: 1.4;
+		font-size: wp-vars.$font-size-x-small;
+		font-weight: wp-vars.$font-weight-medium;
+		line-height: wp-vars.$default-line-height;
 		text-transform: uppercase;
 		color: wp-colors.$gray-900;
 	}

--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -16,6 +16,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "tabs/components/sections";
 @use "components/feedback";
 @use "components/next-steps";
@@ -363,16 +364,17 @@
 		overflow-wrap: anywhere;
 	}
 
-	// Trim the 48px page-gutter edge padding so cell content aligns to the frame.
+	// Drop the page-gutter edge padding so cell content aligns flush to the frame
+	// (and, in a card, to the card's body padding and title).
 	.dataviews-view-table {
 		th:first-child,
 		td:first-child {
-			padding-left: 16px;
+			padding-left: 0;
 		}
 
 		th:last-child,
 		td:last-child {
-			padding-right: 16px;
+			padding-right: 0;
 		}
 	}
 }
@@ -381,6 +383,13 @@
 // supplies the border, and the narrow card needs the columns to fit rather than
 // overflow at DataViews' comfortable width — so pin the layout to the container.
 .newspack-insights__chart-card .newspack-insights-dataview {
+	// Full-bleed the table past the card's 24px body padding on both sides so the
+	// row hover/borders span edge to edge; the edge cells are re-inset below so
+	// text stays aligned to the title. !important beats the shared DataViews
+	// margin rule that otherwise wins on specificity.
+	width: calc(100% + #{wp-vars.$grid-unit-60});
+	margin-left: -#{wp-vars.$grid-unit-30} !important;
+	margin-right: -#{wp-vars.$grid-unit-30} !important;
 	border: 0;
 	border-radius: 0;
 
@@ -392,6 +401,29 @@
 		width: 100%;
 		min-width: 0;
 		table-layout: fixed;
+
+		// Re-inset the edge cells to the card body padding so content lines up
+		// with the title while the table frame stays full-bleed.
+		th:first-child,
+		td:first-child {
+			padding-left: wp-vars.$grid-unit-30;
+		}
+
+		th:last-child,
+		td:last-child {
+			padding-right: wp-vars.$grid-unit-30;
+		}
+	}
+}
+
+// When a dataview is the last thing in a card, drop the card body's bottom
+// padding so the table's final row sits flush at the card's bottom edge, and
+// clip the full-bleed table to the card's rounded corners.
+.newspack-insights__chart-card:has( .newspack-insights-dataview:last-child ) {
+	overflow: hidden;
+
+	.newspack-card--core__body {
+		padding-bottom: 0;
 	}
 }
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
@@ -6,10 +6,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import MetricTable from '../../components/MetricTable';
 import Section from '../../components/Section';
@@ -27,47 +29,53 @@ const ContentPerformanceSection = ( { current }: SectionProps ) => (
 			title={ __( 'Content performance', 'newspack-plugin' ) }
 			description={ __( "What's getting read.", 'newspack-plugin' ) }
 		/>
-		<div className="newspack-insights__table-grid">
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Top articles', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.top_pages }
-					emptyMessage={ __( 'No article data in this timeframe.', 'newspack-plugin' ) }
-					columns={ [
-						{ key: 'page_title', label: __( 'Article', 'newspack-plugin' ) },
-						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
-					] }
-				/>
-			</div>
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by reader count', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.top_authors_by_reader_count }
-					emptyMessage={ __( 'No author data in this timeframe.', 'newspack-plugin' ) }
-					columns={ [
-						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
-						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
-					] }
-				/>
-			</div>
-			{ /* Top Categories is hidden_in_v1 (needs BQ UNNEST); it skip-renders until the BQ catalog ships. */ }
-			{ ! current.top_categories?.hidden_in_v1 && (
-				<div>
-					<h3 className="newspack-insights__chart-card-title">{ __( 'Top categories', 'newspack-plugin' ) }</h3>
+		<VStack spacing={ 4 }>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<VStack spacing={ 6 }>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Top articles', 'newspack-plugin' ) }</h3>
 					<MetricTable
-						payload={ current.top_categories }
-						emptyMessage={ __( 'No category data in this timeframe.', 'newspack-plugin' ) }
+						payload={ current.top_pages }
+						emptyMessage={ __( 'No article data in this timeframe.', 'newspack-plugin' ) }
 						columns={ [
-							{ key: 'category', label: __( 'Category', 'newspack-plugin' ) },
+							{ key: 'page_title', label: __( 'Article', 'newspack-plugin' ) },
 							{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
 							{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
 						] }
 					/>
-				</div>
+				</VStack>
+			</Card>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<VStack spacing={ 6 }>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by reader count', 'newspack-plugin' ) }</h3>
+					<MetricTable
+						payload={ current.top_authors_by_reader_count }
+						emptyMessage={ __( 'No author data in this timeframe.', 'newspack-plugin' ) }
+						columns={ [
+							{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
+							{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+							{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
+						] }
+					/>
+				</VStack>
+			</Card>
+			{ /* Top Categories is hidden_in_v1 (needs BQ UNNEST); it skip-renders until the BQ catalog ships. */ }
+			{ ! current.top_categories?.hidden_in_v1 && (
+				<Card __experimentalCoreCard className="newspack-insights__chart-card">
+					<VStack spacing={ 6 }>
+						<h3 className="newspack-insights__chart-card-title">{ __( 'Top categories', 'newspack-plugin' ) }</h3>
+						<MetricTable
+							payload={ current.top_categories }
+							emptyMessage={ __( 'No category data in this timeframe.', 'newspack-plugin' ) }
+							columns={ [
+								{ key: 'category', label: __( 'Category', 'newspack-plugin' ) },
+								{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+								{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
+							] }
+						/>
+					</VStack>
+				</Card>
 			) }
-		</div>
+		</VStack>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/GeographicSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/GeographicSection.tsx
@@ -6,11 +6,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
-import { Grid } from '../../../../../../packages/components/src';
+import { Card, Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import type { MetricPayload } from '../../components/metrics';
 import { uniformValue } from '../../components/metrics';
@@ -43,39 +44,43 @@ const GeographicSection = ( { current }: SectionProps ) => {
 				description={ __( 'Where your readers are.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
-				<div>
-					<h3 className="newspack-insights__chart-card-title">
-						{ __( 'Top regions / states', 'newspack-plugin' ) }
-						{ regionsScope && <ScopePill label={ regionsScope } /> }
-					</h3>
-					<MetricTable
-						payload={ current.top_regions }
-						emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
-						collapseColumn="country"
-						columns={ [
-							{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
-							{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
-							READERS_COL,
-						] }
-					/>
-				</div>
-				<div>
-					<h3 className="newspack-insights__chart-card-title">
-						{ __( 'Top cities', 'newspack-plugin' ) }
-						{ citiesScope && <ScopePill label={ citiesScope } /> }
-					</h3>
-					<MetricTable
-						payload={ current.top_cities }
-						emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
-						collapseColumn="country"
-						columns={ [
-							{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
-							{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
-							{ key: 'city', label: __( 'City', 'newspack-plugin' ) },
-							READERS_COL,
-						] }
-					/>
-				</div>
+				<Card __experimentalCoreCard className="newspack-insights__chart-card">
+					<VStack spacing={ 6 }>
+						<h3 className="newspack-insights__chart-card-title">
+							{ __( 'Top regions / states', 'newspack-plugin' ) }
+							{ regionsScope && <ScopePill label={ regionsScope } /> }
+						</h3>
+						<MetricTable
+							payload={ current.top_regions }
+							emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
+							collapseColumn="country"
+							columns={ [
+								{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
+								{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
+								READERS_COL,
+							] }
+						/>
+					</VStack>
+				</Card>
+				<Card __experimentalCoreCard className="newspack-insights__chart-card">
+					<VStack spacing={ 6 }>
+						<h3 className="newspack-insights__chart-card-title">
+							{ __( 'Top cities', 'newspack-plugin' ) }
+							{ citiesScope && <ScopePill label={ citiesScope } /> }
+						</h3>
+						<MetricTable
+							payload={ current.top_cities }
+							emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
+							collapseColumn="country"
+							columns={ [
+								{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
+								{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
+								{ key: 'city', label: __( 'City', 'newspack-plugin' ) },
+								READERS_COL,
+							] }
+						/>
+					</VStack>
+				</Card>
 			</Grid>
 		</Section>
 	);

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
@@ -38,7 +38,7 @@ const TimeTrendsSection = ( { current }: SectionProps ) => (
 		{ /* New vs Returning takes the full width; the two day/hour bar charts share the row below. */ }
 		<VStack spacing={ 4 }>
 			<ChartCard
-				subhead={ __( 'Day to day', 'newspack-plugin' ) }
+				caption={ __( 'Day to day', 'newspack-plugin' ) }
 				title={ __( 'New vs returning over time', 'newspack-plugin' ) }
 				payload={ current.new_vs_returning_over_time }
 			>
@@ -48,21 +48,15 @@ const TimeTrendsSection = ( { current }: SectionProps ) => (
 						{ name: __( 'Returning', 'newspack-plugin' ), points: toSeries( current.new_vs_returning_over_time, 'date', 'returning' ) },
 					] }
 					formatLabel={ formatShortDate }
+					height={ 260 }
+					seriesColorIndices={ [ 0, 3 ] }
 				/>
 			</ChartCard>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
-				<ChartCard
-					subhead={ __( 'Day of week', 'newspack-plugin' ) }
-					title={ __( 'Readership by day of week', 'newspack-plugin' ) }
-					payload={ current.readership_by_day_of_week }
-				>
+				<ChartCard title={ __( 'Readership by day of week', 'newspack-plugin' ) } payload={ current.readership_by_day_of_week }>
 					<BarChart bars={ toSeries( current.readership_by_day_of_week, 'day_of_week', 'active_readers' ) } />
 				</ChartCard>
-				<ChartCard
-					subhead={ __( 'Hour of day', 'newspack-plugin' ) }
-					title={ __( 'Readership by hour of day', 'newspack-plugin' ) }
-					payload={ current.readership_by_hour_of_day }
-				>
+				<ChartCard title={ __( 'Readership by hour of day', 'newspack-plugin' ) } payload={ current.readership_by_hour_of_day }>
 					<BarChart bars={ toSeries( current.readership_by_hour_of_day, 'hour', 'active_readers' ) } />
 				</ChartCard>
 			</Grid>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/BarChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/BarChart.tsx
@@ -6,6 +6,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -32,9 +37,26 @@ const BarChart = ( { bars, formatValue = formatNumber }: BarChartProps ) => {
 	}
 	const max = Math.max( ...bars.map( b => b.value || 0 ), 1 );
 
+	// Colour encodes magnitude only for small categorical sets (<= 3 bars): the
+	// tallest takes the primary series colour, each shorter steps down the scale
+	// (8 shades, cycling to match PieChart). Larger sets (day-of-week, hour-of-day)
+	// stay a single series colour so the scale doesn't read as noise.
+	const seriesByIndex: number[] = bars.map( () => 0 );
+	if ( bars.length <= 3 ) {
+		bars.map( ( bar, index ) => ( { index, value: bar.value || 0 } ) )
+			.sort( ( a, b ) => b.value - a.value )
+			.forEach( ( item, rank ) => {
+				seriesByIndex[ item.index ] = rank % 8;
+			} );
+	}
+
 	return (
-		<div className="newspack-insights__bars" role="img" aria-label={ __( 'Bar chart', 'newspack-plugin' ) }>
-			{ bars.map( bar => (
+		<div
+			className={ classnames( 'newspack-insights__bars', { 'is-dense': bars.length > 3 } ) }
+			role="img"
+			aria-label={ __( 'Bar chart', 'newspack-plugin' ) }
+		>
+			{ bars.map( ( bar, index ) => (
 				<div className="newspack-insights__bar-col" key={ bar.label }>
 					{ /* Dark hover panel (NPPD-1649 fix #5), shown on column hover via CSS. */ }
 					<div className="newspack-insights__chart-tooltip newspack-insights__chart-tooltip--bar">
@@ -43,7 +65,7 @@ const BarChart = ( { bars, formatValue = formatNumber }: BarChartProps ) => {
 					</div>
 					<div className="newspack-insights__bar-track">
 						<div
-							className="newspack-insights__bar-fill is-series-0"
+							className={ `newspack-insights__bar-fill is-series-${ seriesByIndex[ index ] }` }
 							style={ { height: `${ Math.round( ( ( bar.value || 0 ) / max ) * 100 ) }%` } }
 						/>
 					</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ChartCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ChartCard.tsx
@@ -21,8 +21,6 @@ export interface ChartCardProps {
 	 * already names it (e.g. Revenue trend) omits this to avoid a duplicate title.
 	 */
 	title?: string;
-	/** Small temporal-scope subhead above the title (e.g. "Day to day"). */
-	subhead?: string;
 	caption?: string;
 	payload?: MetricPayload;
 	children: React.ReactNode;
@@ -30,7 +28,7 @@ export interface ChartCardProps {
 	style?: React.CSSProperties;
 }
 
-const ChartCard = ( { title, subhead, caption, payload, children, style }: ChartCardProps ) => {
+const ChartCard = ( { title, caption, payload, children, style }: ChartCardProps ) => {
 	if ( ! payload || payload.hidden_in_v1 ) {
 		return null;
 	}
@@ -48,7 +46,6 @@ const ChartCard = ( { title, subhead, caption, payload, children, style }: Chart
 
 	return (
 		<Card __experimentalCoreCard className="newspack-insights__chart-card" style={ style }>
-			{ subhead && <p className="newspack-insights__chart-card-subhead">{ subhead }</p> }
 			{ title && <h3 className="newspack-insights__chart-card-title">{ title }</h3> }
 			{ caption && <p className="newspack-insights__chart-card-caption">{ caption }</p> }
 			<div className="newspack-insights__chart-card-body">{ body }</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.tsx
@@ -73,10 +73,17 @@ export interface LineChartProps {
 	yMax?: number;
 	/** Empty-state copy shown when there's no data. Defaults to the generic line. */
 	emptyMessage?: string;
+	/** Plot height in px. Defaults to 160; full-width cards can go taller. */
+	height?: number;
+	/**
+	 * Map each series position to a palette index (`.is-series-N`). Defaults to
+	 * the series' own index. Use it to skip adjacent same-family shades that read
+	 * as one colour — e.g. `[ 0, 3 ]` pairs blue with orange for two series.
+	 */
+	seriesColorIndices?: number[];
 }
 
 const W = 600;
-const H = 160;
 const PAD = 8;
 
 const LineChart = ( {
@@ -89,7 +96,11 @@ const LineChart = ( {
 	referenceLine,
 	yMax,
 	emptyMessage,
+	height = 160,
+	seriesColorIndices,
 }: LineChartProps ) => {
+	const H = height;
+	const colorIndex = ( si: number ) => seriesColorIndices?.[ si ] ?? si;
 	const [ active, setActive ] = useState< number | null >( null );
 
 	const allSeries: LineSeries[] = series && series.length ? series : [ { name: '', points: points ?? [] } ];
@@ -139,6 +150,7 @@ const LineChart = ( {
 				<svg
 					viewBox={ `0 0 ${ W } ${ H }` }
 					className="newspack-insights__line-svg"
+					style={ { height: `${ H }px` } }
 					role="img"
 					aria-label={ __( 'Time-series chart', 'newspack-plugin' ) }
 					preserveAspectRatio="none"
@@ -168,17 +180,42 @@ const LineChart = ( {
 						const area = `${ PAD },${ H - PAD } ${ linePts } ${ xAt( n - 1 ).toFixed( 1 ) },${ H - PAD }`;
 						return (
 							<g key={ `series-${ si }` }>
-								{ ! isMulti && <polygon className={ `newspack-insights__line-area is-series-${ si }` } points={ area } /> }
-								<polyline className={ `newspack-insights__line-stroke is-series-${ si }` } points={ linePts } fill="none" />
-								{ coords.map( ( [ x, y ], i ) => (
-									<circle
-										key={ `pt-${ si }-${ i }` }
-										className={ `newspack-insights__line-point is-series-${ si }` }
-										cx={ x }
-										cy={ y }
-										r={ active === i ? 4.5 : 3 }
-									/>
-								) ) }
+								{ ! isMulti && (
+									<polygon className={ `newspack-insights__line-area is-series-${ colorIndex( si ) }` } points={ area } />
+								) }
+								<polyline
+									className={ `newspack-insights__line-stroke is-series-${ colorIndex( si ) }` }
+									points={ linePts }
+									fill="none"
+								/>
+								{ coords.map( ( [ x, y ], i ) => {
+									// Points are drawn as zero-length round-capped strokes with a
+									// non-scaling stroke width, so they stay perfectly circular even
+									// though the viewBox is stretched horizontally to fill the card
+									// (a plain <circle> fill would render as an oval). The white halo
+									// is a wider stroke behind the coloured dot.
+									const dot = active === i ? 9 : 6;
+									return (
+										<g key={ `pt-${ si }-${ i }` }>
+											<line
+												className="newspack-insights__line-point-halo"
+												x1={ x }
+												y1={ y }
+												x2={ x }
+												y2={ y }
+												strokeWidth={ dot + 2 }
+											/>
+											<line
+												className={ `newspack-insights__line-point is-series-${ colorIndex( si ) }` }
+												x1={ x }
+												y1={ y }
+												x2={ x }
+												y2={ y }
+												strokeWidth={ dot }
+											/>
+										</g>
+									);
+								} ) }
 							</g>
 						);
 					} ) }
@@ -204,7 +241,12 @@ const LineChart = ( {
 						<span className="newspack-insights__chart-tooltip-label">{ formatLabel( base[ active ].label ) }</span>
 						{ allSeries.map( ( s, si ) => (
 							<span key={ `tt-${ si }` } className="newspack-insights__chart-tooltip-row">
-								{ isMulti && <span className={ `newspack-insights__chart-tooltip-swatch is-series-${ si }` } aria-hidden="true" /> }
+								{ isMulti && (
+									<span
+										className={ `newspack-insights__chart-tooltip-swatch is-series-${ colorIndex( si ) }` }
+										aria-hidden="true"
+									/>
+								) }
 								{ isMulti && <span className="newspack-insights__chart-tooltip-name">{ s.name }</span> }
 								<span className="newspack-insights__chart-tooltip-value">{ formatValue( s.points[ active ]?.value ?? 0 ) }</span>
 							</span>
@@ -216,7 +258,7 @@ const LineChart = ( {
 				<div className="newspack-insights__line-legend">
 					{ allSeries.map( ( s, si ) => (
 						<span key={ `lg-${ si }` } className="newspack-insights__line-legend-item">
-							<span className={ `newspack-insights__legend-swatch is-series-${ si }` } aria-hidden="true" />
+							<span className={ `newspack-insights__legend-swatch is-series-${ colorIndex( si ) }` } aria-hidden="true" />
 							<span>{ s.name }</span>
 						</span>
 					) ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/PieChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/PieChart.tsx
@@ -53,7 +53,8 @@ const PieChart = ( { segments, centerLabel, emptyMessage, formatValue = formatNu
 		<div className="newspack-insights__pie">
 			{ /* Pie centered in the middle slot; legend anchored to the bottom (NPPD-1649 alignment). */ }
 			<div className="newspack-insights__pie-figure">
-				<svg viewBox="0 0 42 42" className="newspack-insights__pie-svg" role="img" aria-label={ __( 'Breakdown chart', 'newspack-plugin' ) }>
+				{ /* viewBox tightened to the ring's outer extent (r16 + strokeWidth8/2 = 20, centered at 21 → spans 1–41) so the donut sits flush to the svg box. */ }
+				<svg viewBox="1 1 40 40" className="newspack-insights__pie-svg" role="img" aria-label={ __( 'Breakdown chart', 'newspack-plugin' ) }>
 					<circle className="newspack-insights__pie-track" cx="21" cy="21" r={ RADIUS } />
 					{ segments.map( ( segment, i ) => {
 						const fraction = segment.value / total;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/ScopePill.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/ScopePill.tsx
@@ -1,7 +1,7 @@
 /**
  * ScopePill (NPPD-1649).
  *
- * Small inline badge rendered next to a table title to convey a uniform scope
+ * Muted inline note rendered next to a table title to convey a uniform scope
  * (e.g. "Showing: United States" when every row shares one country). Used by the
  * Geographic section in place of a free-floating caption, so the scope reads as
  * tied to the title.
@@ -12,11 +12,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { Badge } from '../../../../../packages/components/src';
-
 export interface ScopePillProps {
 	/** The uniform value to show (e.g. a country name). */
 	label: string;
@@ -24,13 +19,11 @@ export interface ScopePillProps {
 
 const ScopePill = ( { label }: ScopePillProps ) => (
 	<span className="newspack-insights__scope-pill">
-		<Badge
-			text={ sprintf(
-				/* translators: %s: the single value shared by every row (e.g. a country name). */
-				__( 'Showing: %s', 'newspack-plugin' ),
-				label
-			) }
-		/>
+		{ sprintf(
+			/* translators: %s: the single value shared by every row (e.g. a country name). */
+			__( 'Showing: %s', 'newspack-plugin' ),
+			label
+		) }
 	</span>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/TakeawayCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/TakeawayCard.tsx
@@ -3,9 +3,10 @@
  *
  * Replaces a dense comparison table with a scannable card: a one-line headline
  * comparison, a muted sub-line with the raw figures, and a small inline bar
- * chart. Matches the scorecard chrome (border, padding, top accent). Routes the
- * orchestrator payload's graceful-failure states through MetricNote, and shows a
- * muted note when there isn't enough data to compute a comparison.
+ * chart. Uses the shared CoreCard chrome (border, padding), same as the chart /
+ * metric cards. Routes the orchestrator payload's graceful-failure states
+ * through MetricNote, and shows a muted note when there isn't enough data to
+ * compute a comparison.
  */
 
 /**
@@ -16,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../packages/components/src';
 import MetricNote from './MetricNote';
 import type { MetricPayload } from './metrics';
 import BarChart from './BarChart';
@@ -61,10 +63,10 @@ const TakeawayCard = ( { title, payload, headline, sub, bars, formatValue }: Tak
 	}
 
 	return (
-		<div className="newspack-insights__takeaway-card">
+		<Card __experimentalCoreCard className="newspack-insights__takeaway-card">
 			<h3 className="newspack-insights__chart-card-title newspack-insights__takeaway-title">{ title }</h3>
 			{ body }
-		</div>
+		</Card>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -10,6 +10,7 @@
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "~@wordpress/base-styles/variables" as wp-vars;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
 @use "../../../../../packages/colors/colors.module" as colors;
 
 // Categorical series palette for charts (8 series): two monochrome families —
@@ -36,12 +37,6 @@
 		gap: 16px;
 	}
 
-	&__table-grid {
-		display: grid;
-		grid-template-columns: repeat( auto-fit, minmax( 320px, 1fr ) );
-		gap: 16px;
-	}
-
 	// Chart cell — CoreCard chrome (border + radius) to match the scorecards.
 	// Layout mirrors the metric card: title-as-label at the top, chart body
 	// grows, caption-as-description pinned to the bottom.
@@ -63,13 +58,15 @@
 			}
 		}
 
-		// Title matches the metric-card label (Core BaseControl label 1:1).
+		// Title matches the metric-card label. HStack so an optional scope note
+		// sits opposite the title text.
 		&-title {
+			@include wp-mixins.heading-large();
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: wp-vars.$grid-unit-10;
 			margin: 0;
-			font-size: wp-vars.$font-size-x-small;
-			font-weight: wp-vars.$font-weight-medium;
-			line-height: wp-vars.$default-line-height;
-			text-transform: uppercase;
 			color: wp-colors.$gray-900;
 		}
 
@@ -98,36 +95,36 @@
 		border-radius: 0;
 	}
 
-	// Inline scope pill next to a table title (e.g. "Showing: United States").
-	// Visual treatment is provided by the wrapped <Badge>; this wrapper only
-	// supplies positional rules so the pill flows inline with the title text.
+	// Inline scope note next to a table title (e.g. "Showing: United States").
+	// Muted, normal-case text opposite the uppercase title in the HStack.
 	&__scope-pill {
-		display: inline-block;
-		margin-left: 8px;
-		vertical-align: middle;
+		flex-shrink: 0;
 		white-space: nowrap;
-	}
-
-	// Temporal-scope subhead above a chart title (e.g. "Day to day").
-	&__chart-card-subhead {
-		margin: 0 0 2px;
-		font-size: 13px;
-		font-weight: 400;
+		font-size: inherit;
+		font-weight: wp-vars.$font-weight-regular;
+		text-transform: none;
 		color: wp-colors.$gray-700;
 	}
 
-	// Engagement Reader Segments takeaway cards — scorecard chrome (border,
-	// padding) with a headline / sub / bottom-pinned mini-bar layout. No top
-	// accent (DSGNEWS-188 — dropped the blanket brand-color bar).
+	// Engagement Reader Segments takeaway cards — shared CoreCard chrome (border,
+	// radius) with a headline / sub / bottom-pinned mini-bar layout. The layout
+	// lives on the inner body wrapper, matching the chart card.
 	&__takeaway-card {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-		min-height: 180px;
-		padding: 24px 28px;
-		background-color: wp-colors.$white;
-		border: 1px solid wp-colors.$gray-200;
-		border-radius: 4px;
+		height: 100%; // stretch to the row's tallest card
+		min-width: 0;
+
+		.newspack-card--core__body {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			min-height: 180px;
+			padding: wp-vars.$grid-unit-30;
+
+			// Zero CoreCard's default 16px 24px grandchild-div padding.
+			> div:not(.components-card__body):not(.components-card__media):not(.components-card__divider) {
+				padding: 0;
+			}
+		}
 	}
 
 	// Takeaway card title: persists across populated / empty / failure states so
@@ -135,21 +132,19 @@
 	// two-line min-height reservation (takeaway titles are single-line).
 	&__takeaway-title {
 		min-height: 0;
-		margin: 0 0 12px;
+		margin: 0 0 wp-vars.$grid-unit-10;
 	}
 
 	&__takeaway-headline {
+		@include wp-mixins.heading-x-large();
 		margin: 0;
-		font-size: 18px;
-		font-weight: 500;
-		line-height: 1.35;
-		color: wp-colors.$gray-900;
+		color: var(--wp-admin-theme-color);
 	}
 
 	&__takeaway-sub {
-		margin: 6px 0 0;
-		font-size: 13px;
-		color: wp-colors.$gray-700;
+		margin: calc(#{wp-vars.$grid-unit} / 2) 0 0;
+		font-size: inherit;
+		color: var(--wp-admin-theme-color);
 	}
 
 	&__takeaway-empty {
@@ -161,17 +156,12 @@
 	// Mini bar chart pinned to the card bottom (~60px tall).
 	&__takeaway-chart {
 		margin-top: auto;
-		padding-top: 16px;
+		// !important beats the CoreCard grandchild-div padding reset on the body.
+		padding-top: wp-vars.$grid-unit-30 !important;
 	}
 
 	&__takeaway-chart &__bars {
-		height: 60px;
-	}
-
-	// Standalone table heading (Geographic / Content performance, where each
-	// table has its own title above the canonical table-wrap).
-	&__table-grid &__chart-card-title {
-		margin-bottom: 8px;
+		height: calc(#{wp-vars.$grid-unit} * 16);
 	}
 
 	// Shared graceful-failure note: informational, not code — muted sans-serif
@@ -229,8 +219,9 @@
 	}
 
 	&__pie-svg {
+		display: block; // kill the inline baseline gap so the svg sits flush
 		width: 100%;
-		max-width: calc(#{wp-vars.$grid-unit} * 32);
+		max-width: calc(#{wp-vars.$grid-unit} * 25);
 		height: auto;
 		aspect-ratio: 1 / 1;
 		// No rotate: segments already start at 12 o'clock via the component's
@@ -260,16 +251,11 @@
 		fill: wp-colors.$gray-900;
 	}
 
-	// Bottom slot: legend anchored to the card bottom, left-aligned, full width.
+	// Bottom slot: legend anchored to the card bottom, left-aligned.
+	// `margin-top: auto` pins it to the bottom edge of the card body.
 	&__pie-legend {
 		list-style: none;
-		// Full-bleed top divider: stretch past the card's 24px body padding so
-		// the hairline spans edge to edge, then re-inset the legend content.
-		// `margin-top: auto` pins the legend to the card bottom.
-		width: calc(100% + #{wp-vars.$grid-unit-60});
-		margin: auto 0 0 -#{wp-vars.$grid-unit-30};
-		padding: wp-vars.$grid-unit-30 wp-vars.$grid-unit-30 0;
-		border-top: 1px solid wp-colors.$gray-100;
+		margin: auto 0 0;
 
 		li {
 			display: flex;
@@ -309,8 +295,8 @@
 	&__bars {
 		display: flex;
 		align-items: flex-end;
-		gap: 3px;
-		height: 160px;
+		gap: calc(#{wp-vars.$grid-unit} / 2);
+		height: calc(#{wp-vars.$grid-unit} * 20);
 		// flex:1 1 0 + min-width:0 on the columns keeps the 24 hour-of-day bars
 		// inside the card; overflow stays visible so hover tooltips aren't clipped.
 	}
@@ -345,13 +331,21 @@
 	}
 
 	&__bar-label {
-		font-size: 9px;
-		color: wp-colors.$gray-700;
-		margin-top: 4px;
+		font-size: wp-vars.$font-size-small;
+		line-height: wp-vars.$default-line-height;
+		color: wp-colors.$gray-900;
+		margin-top: wp-vars.$grid-unit-10;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: 100%;
+	}
+
+	// Dense sets (day-of-week, hour-of-day) get a smaller label so the tightly
+	// packed columns don't crowd.
+	&__bars.is-dense &__bar-label {
+		font-size: wp-vars.$font-size-x-small;
+		line-height: wp-vars.$font-line-height-x-small;
 	}
 
 	// Line.
@@ -367,7 +361,7 @@
 
 	&__line-svg {
 		width: 100%;
-		height: 160px;
+		height: calc(#{wp-vars.$grid-unit} * 20);
 		display: block;
 	}
 
@@ -402,14 +396,21 @@
 		vector-effect: non-scaling-stroke;
 	}
 
+	// Points are zero-length round-capped strokes (see LineChart.tsx) so they stay
+	// circular under the stretched viewBox. Stroke width (the dot diameter) is set
+	// inline; the halo is a wider white stroke drawn behind.
 	&__line-point {
-		fill: var( --series-color );
-		stroke: wp-colors.$white;
-		stroke-width: 1;
+		fill: none;
+		stroke: var( --series-color );
+		stroke-linecap: round;
+		vector-effect: non-scaling-stroke;
+	}
 
-		&:hover {
-			stroke-width: 2;
-		}
+	&__line-point-halo {
+		fill: none;
+		stroke: wp-colors.$white;
+		stroke-linecap: round;
+		vector-effect: non-scaling-stroke;
 	}
 
 	&__line-meta {
@@ -599,19 +600,22 @@
 	}
 
 	// Legend below a multi-series line chart.
+	// Match the pie legend: Core help-text type, 20px circular swatches, and a
+	// 24px gap above the plot.
 	&__line-legend {
 		display: flex;
 		flex-wrap: wrap;
-		gap: 16px;
-		margin-top: 8px;
-		font-size: 12px;
+		gap: wp-vars.$grid-unit-20;
+		margin-top: wp-vars.$grid-unit-30;
+		font-size: wp-vars.$font-size-small;
+		line-height: wp-vars.$default-line-height;
 		color: wp-colors.$gray-700;
 	}
 
 	&__line-legend-item {
 		display: flex;
 		align-items: center;
-		gap: 6px;
+		gap: wp-vars.$grid-unit-10;
 	}
 
 	// Distribution viz — shared across Gates (Tab 4) and Prompts (Tab 5).

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -13,6 +13,7 @@
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "~@wordpress/base-styles/variables" as wp-vars;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
 
 .newspack-insights {
 
@@ -131,6 +132,7 @@
 			display: flex;
 			flex-direction: column;
 			height: 100%;
+			min-height: 167px;
 			padding: wp-vars.$grid-unit-30;
 
 			// Match CoreCard's own selector to win the cascade — it
@@ -148,12 +150,7 @@
 		}
 
 		&-label {
-			// Match Core's BaseControl label typography 1:1 (baseLabelTypography):
-			// 11px / medium (499) / 1.4 line-height / uppercase, no letter-spacing.
-			font-size: wp-vars.$font-size-x-small;
-			font-weight: wp-vars.$font-weight-medium;
-			line-height: wp-vars.$default-line-height;
-			text-transform: uppercase;
+			@include wp-mixins.heading-large();
 			color: wp-colors.$gray-900;
 		}
 
@@ -171,23 +168,15 @@
 
 		&-value {
 			margin: 0;
-			// Explicit font stack + lockdown to prevent the wp-admin chrome's
-			// inherited font from flipping between cards (the bug was: digits
-			// in "35" rendered slim, "$738.33" rendered heavier with a slight
-			// optical slant — different chars resolving in different
-			// fallback fonts because no explicit family was declared). Uses
-			// @wordpress/base-styles' admin body font token.
-			font-family: wp-vars.$default-font;
 			// Cap at the 44px design size, but scale down with the card width so a
 			// long formatted number (e.g. "1,392,000") can't overflow a narrow
 			// tile. `container-type` is set on `&__metric-card`.
 			font-size: 44px; // fallback where container-query units aren't supported.
 			font-size: min( 44px, 14cqi );
-			font-weight: 500;
+			font-weight: wp-vars.$font-weight-medium;
 			font-style: normal;
-			line-height: 1.05;
-			letter-spacing: -0.01em;
-			color: wp-colors.$gray-900;
+			line-height: 1;
+			color: var(--wp-admin-theme-color);
 			font-variant-numeric: tabular-nums;
 			font-feature-settings: "tnum" 1;
 			font-synthesis: none;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import MetricTable from '../../components/MetricTable';
 import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import { SHOW_COMPLETION_METRICS } from '../constants';
-import { Grid } from '../../../../../../packages/components/src';
+import { Card } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -31,51 +32,53 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 			title={ __( 'Content engagement', 'newspack-plugin' ) }
 			description={ __( 'What holds reader attention.', 'newspack-plugin' ) }
 		/>
-		{ /* 2-col grid. With completion shown: Most-Engaged + Completion share row 1
-		     and Top Authors wraps to row 2 (one column, ~50%, left-aligned). With
-		     completion hidden (SHOW_COMPLETION_METRICS=false) the two remaining
-		     tables fill row 1 as a clean 2-up — no full-width stretch. */ }
-		<Grid columns={ 2 } gutter={ 16 } noMargin>
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-engaged articles', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.most_read_articles }
-					emptyMessage={ __( 'No article engagement data in this timeframe.', 'newspack-plugin' ) }
-					columns={ [
-						ARTICLE_COL,
-						{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
-					] }
-				/>
-			</div>
-			{ /* Completion is GA4-scroll-derived; hidden until scroll data flows. See ../constants. */ }
-			{ SHOW_COMPLETION_METRICS && (
-				<div>
-					<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by completion rate', 'newspack-plugin' ) }</h3>
+		<VStack spacing={ 4 }>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<VStack spacing={ 6 }>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Most-engaged articles', 'newspack-plugin' ) }</h3>
 					<MetricTable
-						payload={ current.articles_by_completion_rate }
-						emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
+						payload={ current.most_read_articles }
+						emptyMessage={ __( 'No article engagement data in this timeframe.', 'newspack-plugin' ) }
 						columns={ [
 							ARTICLE_COL,
-							{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-							{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
+							{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+							{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
 						] }
 					/>
-				</div>
+				</VStack>
+			</Card>
+			{ /* Completion is GA4-scroll-derived; hidden until scroll data flows. See ../constants. */ }
+			{ SHOW_COMPLETION_METRICS && (
+				<Card __experimentalCoreCard className="newspack-insights__chart-card">
+					<VStack spacing={ 6 }>
+						<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by completion rate', 'newspack-plugin' ) }</h3>
+						<MetricTable
+							payload={ current.articles_by_completion_rate }
+							emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
+							columns={ [
+								ARTICLE_COL,
+								{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+								{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
+							] }
+						/>
+					</VStack>
+				</Card>
 			) }
-			<div>
-				<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by avg engagement time', 'newspack-plugin' ) }</h3>
-				<MetricTable
-					payload={ current.top_authors_by_avg_engagement_time }
-					emptyMessage={ __( 'No author engagement data in this timeframe.', 'newspack-plugin' ) }
-					columns={ [
-						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
-						{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
-					] }
-				/>
-			</div>
-		</Grid>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<VStack spacing={ 6 }>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by avg engagement time', 'newspack-plugin' ) }</h3>
+					<MetricTable
+						payload={ current.top_authors_by_avg_engagement_time }
+						emptyMessage={ __( 'No author engagement data in this timeframe.', 'newspack-plugin' ) }
+						columns={ [
+							{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
+							{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+							{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
+						] }
+					/>
+				</VStack>
+			</Card>
+		</VStack>
 	</Section>
 );
 


### PR DESCRIPTION
Design polish for the Insights wizard, stacking on \`feat/insights-rsm\`.

### Cards & dataviews
- Wrap the Content performance, Content engagement, and Geographic tables in CoreCards; title + dataview grouped in a \`VStack\` (24px).
- Content performance / Content engagement switched from 2-col grids to a single-column \`VStack\` (16px); Geographic stays 2-up.
- Dataviews in a card now full-bleed the table (\`width: 100% + 48px\`, \`-24px\` margins) with edge cells re-inset to 24px so text still lines up with the title.
- Cards ending in a dataview drop their bottom padding and clip the table to their rounded corners.
- \`TakeawayCard\` is now a CoreCard instead of a hand-rolled bordered div.

### Typography
- \`metric-card-label\` and \`chart-card-title\` use the \`heading-large()\` mixin (15px, no uppercase).
- \`takeaway-headline\` uses \`heading-x-large()\`; headline/sub/metric value now use \`var(--wp-admin-theme-color)\`.
- Scope pill is plain muted text (no Badge), in an HStack title with the label opposite.

### Charts
- Line-chart points render as non-scaling round-capped strokes so they stay circular under the stretched viewBox.
- New vs returning uses a blue+orange series pair (\`seriesColorIndices\`) and a taller 260px plot.
- Bar-fill colour steps down the scale for small sets (≤3 bars); dense sets stay flat with smaller labels.
- Pie donut flushed (tightened viewBox), legend matches the line legend.

### Misc
- Next-steps dismiss uses \`closeSmall\`; assorted spacing/token cleanups.