### PR TITLE
feat(insights): card + Grid layout for scorecards and conversion

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -417,7 +417,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-insights__metric-grid"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-4 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -655,7 +655,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-insights__metric-grid"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-4 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -893,7 +893,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-insights__metric-grid"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-4 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { MetricPayload } from '../../components/metrics';
 import MetricCard from '../../components/MetricCard';
 import Section from '../../components/Section';
@@ -45,7 +46,7 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 				title={ __( 'Newsletter subscriber value', 'newspack-plugin' ) }
 				description={ __( 'What your newsletter audience is worth as future reader revenue.', 'newspack-plugin' ) }
 			/>
-			<div className="newspack-insights__metric-grid">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					label={ __( 'Value per newsletter subscriber', 'newspack-plugin' ) }
 					value={ amount ?? 0 }
@@ -63,7 +64,7 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 						'newspack-plugin'
 					) }
 				/>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.tsx
@@ -43,15 +43,12 @@ export interface CohortHeatmapProps {
 	emptyMessage?: string;
 }
 
-// Sequential blue ramp endpoints (light → dark), matching the tab's chart palette.
-const LIGHT: [ number, number, number ] = [ 230, 241, 251 ]; // #E6F1FB
-const DARK: [ number, number, number ] = [ 24, 95, 165 ]; // #185FA5
-
-const lerp = ( a: number, b: number, t: number ): number => Math.round( a + ( b - a ) * t );
-
-/** Cell background for a normalized value `t` in [0, 1]. */
-const cellColor = ( t: number ): string =>
-	`rgb(${ lerp( LIGHT[ 0 ], DARK[ 0 ], t ) }, ${ lerp( LIGHT[ 1 ], DARK[ 1 ], t ) }, ${ lerp( LIGHT[ 2 ], DARK[ 2 ], t ) })`;
+// The sequential ramp keys off the admin accent: each cell mixes
+// `--wp-admin-theme-color` with white by its normalized value `t` (in [0, 1])
+// via color-mix in the stylesheet. Cells expose `t` as the `--cell-t` custom
+// property and dark cells flip to white text.
+const cellStyle = ( t: number ): React.CSSProperties =>
+	( { '--cell-t': t, color: t > 0.55 ? '#fff' : 'var(--wp-admin-theme-color)' } ) as React.CSSProperties;
 
 const CohortHeatmap = ( {
 	cohorts,
@@ -110,7 +107,7 @@ const CohortHeatmap = ( {
 										<td
 											key={ `${ cohort.label }-${ period }` }
 											className="newspack-insights__cohort-heatmap-cell"
-											style={ { backgroundColor: cellColor( t ), color: t > 0.55 ? '#fff' : '#0c447c' } }
+											style={ cellStyle( t ) }
 										>
 											{ formatValue( value ) }
 										</td>
@@ -126,7 +123,7 @@ const CohortHeatmap = ( {
 					{ __( 'Lower', 'newspack-plugin' ) }
 					<span className="newspack-insights__cohort-heatmap-swatches" aria-hidden="true">
 						{ [ 0, 0.25, 0.5, 0.75, 1 ].map( t => (
-							<span key={ `sw-${ t }` } style={ { backgroundColor: cellColor( t ) } } />
+							<span key={ `sw-${ t }` } style={ cellStyle( t ) } />
 						) ) }
 					</span>
 					{ __( 'Higher', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/PieChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/PieChart.tsx
@@ -53,34 +53,40 @@ const PieChart = ( { segments, centerLabel, emptyMessage, formatValue = formatNu
 		<div className="newspack-insights__pie">
 			{ /* Pie centered in the middle slot; legend anchored to the bottom (NPPD-1649 alignment). */ }
 			<div className="newspack-insights__pie-figure">
-				{ /* viewBox tightened to the ring's outer extent (r16 + strokeWidth8/2 = 20, centered at 21 → spans 1–41) so the donut sits flush to the svg box. */ }
-				<svg viewBox="1 1 40 40" className="newspack-insights__pie-svg" role="img" aria-label={ __( 'Breakdown chart', 'newspack-plugin' ) }>
-					<circle className="newspack-insights__pie-track" cx="21" cy="21" r={ RADIUS } />
-					{ segments.map( ( segment, i ) => {
-						const fraction = segment.value / total;
-						const dash = fraction * CIRCUMFERENCE;
-						// No hover tooltip on pie segments — the legend already shows
-						// label + value + percent (NPPD-1649 fix #6).
-						const circle = (
-							<circle
-								key={ segment.label }
-								className={ `newspack-insights__pie-segment is-series-${ i % 8 }` }
-								cx="21"
-								cy="21"
-								r={ RADIUS }
-								strokeDasharray={ `${ dash } ${ CIRCUMFERENCE - dash }` }
-								strokeDashoffset={ CIRCUMFERENCE / 4 - offset }
-							/>
-						);
-						offset += dash;
-						return circle;
-					} ) }
-					{ centerLabel && (
-						<text className="newspack-insights__pie-center" x="21" y="21" textAnchor="middle" dominantBaseline="central">
-							{ centerLabel }
-						</text>
-					) }
-				</svg>
+				{ /* The donut wraps the svg and the HTML center label so the label
+				     can be a real HTML element (heading-scale px), overlaid on the
+				     svg center rather than sized in svg user units. */ }
+				<div className="newspack-insights__pie-donut">
+					{ /* viewBox tightened to the ring's outer extent (r16 + strokeWidth8/2 = 20, centered at 21 → spans 1–41) so the donut sits flush to the svg box. */ }
+					<svg
+						viewBox="1 1 40 40"
+						className="newspack-insights__pie-svg"
+						role="img"
+						aria-label={ __( 'Breakdown chart', 'newspack-plugin' ) }
+					>
+						<circle className="newspack-insights__pie-track" cx="21" cy="21" r={ RADIUS } />
+						{ segments.map( ( segment, i ) => {
+							const fraction = segment.value / total;
+							const dash = fraction * CIRCUMFERENCE;
+							// No hover tooltip on pie segments — the legend already shows
+							// label + value + percent (NPPD-1649 fix #6).
+							const circle = (
+								<circle
+									key={ segment.label }
+									className={ `newspack-insights__pie-segment is-series-${ i % 8 }` }
+									cx="21"
+									cy="21"
+									r={ RADIUS }
+									strokeDasharray={ `${ dash } ${ CIRCUMFERENCE - dash }` }
+									strokeDashoffset={ CIRCUMFERENCE / 4 - offset }
+								/>
+							);
+							offset += dash;
+							return circle;
+						} ) }
+					</svg>
+					{ centerLabel && <span className="newspack-insights__pie-center">{ centerLabel }</span> }
+				</div>
 			</div>
 			<ul className="newspack-insights__pie-legend">
 				{ segments.map( ( segment, i ) => (

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -218,15 +218,22 @@
 		padding: 0 0 wp-vars.$grid-unit-30;
 	}
 
+	// Positioning context for the svg + the HTML center label overlaid on it,
+	// capped to the donut's rendered width so the label centers on the hole.
+	&__pie-donut {
+		position: relative;
+		width: 100%;
+		max-width: calc(#{wp-vars.$grid-unit} * 25);
+	}
+
 	&__pie-svg {
 		display: block; // kill the inline baseline gap so the svg sits flush
 		width: 100%;
-		max-width: calc(#{wp-vars.$grid-unit} * 25);
 		height: auto;
 		aspect-ratio: 1 / 1;
 		// No rotate: segments already start at 12 o'clock via the component's
 		// stroke-dashoffset (CIRCUMFERENCE / 4). Rotating the <svg> here would
-		// re-offset every segment and turn the center-label text sideways.
+		// re-offset every segment.
 	}
 
 	// Donut band thickness. The chart is a stroked circle (r=16 in a 42 viewBox),
@@ -244,11 +251,17 @@
 		stroke-width: 8;
 	}
 
-	// Center label text inside the donut (e.g. the window total — NPPD-1609).
+	// Center label inside the donut (e.g. the window total — NPPD-1609): an HTML
+	// element absolutely centered over the svg hole, so it renders at the real
+	// heading scale in the admin accent color rather than in svg user units.
 	&__pie-center {
-		font-size: 6px;
-		font-weight: 600;
-		fill: wp-colors.$gray-900;
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		@include wp-mixins.heading-x-large();
+		color: var( --wp-admin-theme-color );
 	}
 
 	// Bottom slot: legend anchored to the card bottom, left-aligned.
@@ -490,6 +503,9 @@
 		border-radius: 4px;
 		text-align: center;
 		font-variant-numeric: tabular-nums;
+		// Sequential ramp off the admin accent: mix the darker-20 base with white
+		// by the cell's normalized value (--cell-t, set inline in [0, 1]).
+		background-color: color-mix( in srgb, var( --wp-admin-theme-color ) calc( var( --cell-t, 0 ) * 100% ), #{ wp-colors.$white } );
 
 		&.is-empty {
 			background: transparent;
@@ -517,6 +533,7 @@
 		span {
 			width: 18px;
 			height: 12px;
+			background-color: color-mix( in srgb, var( --wp-admin-theme-color ) calc( var( --cell-t, 0 ) * 100% ), #{ wp-colors.$white } );
 		}
 	}
 
@@ -648,14 +665,12 @@
 		// connector never ends up narrower than the min-width section beneath it.
 		$funnel-min-band-width: 80px;
 
+		// Chrome (border, background, radius, padding) is supplied by the enclosing
+		// chart-card CoreCard — the funnel itself is just the stepped layout.
 		width: 100%;
 		margin: 0 auto;
-		padding: wp-vars.$grid-unit-10;
 		box-sizing: border-box;
 		list-style: none;
-		background-color: wp-colors.$white;
-		border: 1px solid wp-colors.$gray-200;
-		border-radius: wp-vars.$radius-medium;
 
 		&-step {
 			position: relative;
@@ -937,16 +952,4 @@
 // is intentionally NOT defined in this per-tab partial so the callout can't
 // look different depending on which tab-chunk CSS happens to be loaded.
 
-// Section grid column modifier — the only fixed-column grid still authored in
-// CSS. QualitySection drops to 3 even columns when the completion card is
-// hidden (see QualitySection.tsx); every other fixed-column grid now uses the
-// shared <Grid> component. Compound selector (0,2,0) so it wins over the
-// single-class base rule regardless of stylesheet load order.
-.newspack-insights__metric-grid.newspack-insights__metric-grid--cols-3 {
-	grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
-
-	@media ( max-width: 782px ) {
-		grid-template-columns: 1fr;
-	}
-}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -74,14 +74,8 @@
 		color: wp-colors.$gray-700;
 	}
 
-	// Scorecard grid — responsive: auto-fill with a 220px minimum per
-	// column. Each card stretches to fill its column.
-
-	&__metric-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-		gap: 16px;
-	}
+	// Scorecards now lay out with the shared <Grid columns={ 4 }>; the metric
+	// card chrome + internal layout below still applies to each tile.
 
 	// Card chrome (white background, gray-200 border, 4px radius) is
 	// provided by the newspack Card component (rendered via
@@ -152,6 +146,7 @@
 		&-label {
 			@include wp-mixins.heading-large();
 			color: wp-colors.$gray-900;
+			text-wrap: pretty;
 		}
 
 		&-body {
@@ -264,6 +259,7 @@
 				// admin default paragraph size.
 				font: inherit;
 				color: inherit;
+				text-wrap: balance;
 			}
 		}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -14,10 +14,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../packages/components/src';
 import type { ConversionCohortData } from '../../api/conversion';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
@@ -41,26 +43,28 @@ interface CohortChartProps {
 }
 
 const CohortChart = ( { title, data, caption, referenceLabel }: CohortChartProps ) => (
-	<div className="newspack-insights__conversion-cohort-cell">
-		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
-		<p className="newspack-insights__conversion-subcaption">{ caption }</p>
-		<SectionState
-			state={ data.state }
-			comingSoonMessage={ __(
-				'Cohort data is being prepared. Check back in a few minutes, then click Refresh now to load it.',
-				'newspack-plugin'
-			) }
-			emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
-		>
-			<CohortHeatmap
-				cohorts={ data.cohorts }
-				formatValue={ formatPercent }
-				columnsLabel={ __( 'Months since cohort start', 'newspack-plugin' ) }
-				referenceLabel={ referenceLabel }
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ title }</h3>
+		<p className="newspack-insights__chart-card-caption">{ caption }</p>
+		<div className="newspack-insights__chart-card-body">
+			<SectionState
+				state={ data.state }
+				comingSoonMessage={ __(
+					'Cohort data is being prepared. Check back in a few minutes, then click Refresh now to load it.',
+					'newspack-plugin'
+				) }
 				emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
-			/>
-		</SectionState>
-	</div>
+			>
+				<CohortHeatmap
+					cohorts={ data.cohorts }
+					formatValue={ formatPercent }
+					columnsLabel={ __( 'Months since cohort start', 'newspack-plugin' ) }
+					referenceLabel={ referenceLabel }
+					emptyMessage={ __( 'No cohort data available yet.', 'newspack-plugin' ) }
+				/>
+			</SectionState>
+		</div>
+	</Card>
 );
 
 const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
@@ -76,7 +80,7 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__conversion-cohort-stack">
+		<VStack spacing={ 4 }>
 			<CohortChart
 				/*
 				 * TODO: default a self-relative reference callout here — the median
@@ -101,7 +105,7 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => (
 				data={ current.subscriber_retention_cohort }
 				referenceLabel={ current.subscriber_retention_cohort.reference_line?.label }
 			/>
-		</div>
+		</VStack>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../packages/components/src';
 import type { ConversionWeekPoint, ConversionWeeklyTrendsData } from '../../api/conversion';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
@@ -69,7 +70,7 @@ const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionPr
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__conversion-rate-trends-cell">
+		<Card __experimentalCoreCard className="newspack-insights__chart-card">
 			<SectionState
 				state={ current.weekly_conversion_rates.state }
 				emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
@@ -83,7 +84,7 @@ const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionPr
 					emptyMessage={ __( 'Weekly trends will appear once the timeframe contains at least 4 weeks of data.', 'newspack-plugin' ) }
 				/>
 			</SectionState>
-		</div>
+		</Card>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { ConversionWindow } from '../../api/conversion';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -42,7 +43,7 @@ const CrossTabInfluencedAttributionSection = ( { current, previous }: CrossTabIn
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Influenced Registration Rate', 'newspack-plugin' ),
@@ -78,7 +79,7 @@ const CrossTabInfluencedAttributionSection = ( { current, previous }: CrossTabIn
 					previous: previous?.influenced_newsletter_rate_7d,
 				} ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card, Grid, Notice } from '../../../../../packages/components/src';
 import type { ConversionCumulativeMulti, ConversionCumulativePoint, ConversionWindow } from '../../api/conversion';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
@@ -47,11 +48,11 @@ interface CurveCellProps {
 }
 
 const CurveCell = ( { title, caption, children }: CurveCellProps ) => (
-	<div className="newspack-insights__conversion-curve-cell">
-		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
-		{ caption && <p className="newspack-insights__conversion-subcaption">{ caption }</p> }
-		{ children }
-	</div>
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ title }</h3>
+		{ caption && <p className="newspack-insights__chart-card-caption">{ caption }</p> }
+		<div className="newspack-insights__chart-card-body">{ children }</div>
+	</Card>
 );
 
 const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSectionProps ) => {
@@ -70,7 +71,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					'newspack-plugin'
 				) }
 			/>
-			<div className="newspack-insights__conversion-curve-grid">
+			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				{ /* 4.1 — time to register: Phase A, state-gated */ }
 				<CurveCell title={ __( 'Time to register', 'newspack-plugin' ) }>
 					<SectionState
@@ -125,9 +126,14 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 				{ /* 4.4 — subscriber → donor lag: Phase B, coming_soon + visibility gate */ }
 				<CurveCell title={ __( 'Subscriber → donor lag', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					{ lag.visibility === 'hidden' ? (
-						<p className="newspack-insights__conversion-gated-note">
-							{ __( 'Subscriber-to-donor lag appears when at least 50 readers have both subscribed and donated.', 'newspack-plugin' ) }
-						</p>
+						<Notice
+							isWarning
+							className="newspack-insights__conversion-notice"
+							noticeText={ __(
+								'Subscriber-to-donor lag appears when at least 50 readers have both subscribed and donated.',
+								'newspack-plugin'
+							) }
+						/>
 					) : (
 						<SectionState
 							state={ lag.state }
@@ -145,7 +151,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 						</SectionState>
 					) }
 				</CurveCell>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -16,10 +16,12 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
+import { Card, Grid } from '../../../../../packages/components/src';
 import type { ConversionTopPageRow, ConversionWindow } from '../../api/conversion';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -90,65 +92,69 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid">
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Stale Registered Readers', 'newspack-plugin' ),
-					description: __( 'Registered but never converted, no activity in 90 days', 'newspack-plugin' ),
-					current: current.stale_registered_count,
-				} ) }
-			/>
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'At-Risk Subscribers', 'newspack-plugin' ),
-					description: __( 'Active subscribers with a failed-payment retry scheduled', 'newspack-plugin' ),
-					current: current.at_risk_subscriber_count,
-				} ) }
-			/>
-			<MetricCard
-				{ ...scalarToMetricCardProps( {
-					label: __( 'Lapsed Donors', 'newspack-plugin' ),
-					description: __( 'Donors with no donation in the last 365 days', 'newspack-plugin' ),
-					current: current.lapsed_donor_count,
-				} ) }
-			/>
-		</div>
-		<div className="newspack-insights__conversion-top-pages">
-			<h3 className="newspack-insights__conversion-subheading">{ __( 'Top articles that don’t convert', 'newspack-plugin' ) }</h3>
-			<SectionState
-				state={ current.top_pages_no_conversion.state }
-				emptyMessage={ sprintf(
-					/* translators: %s: minimum pageview count for an article to qualify (formatted). */
-					__(
-						'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
-						'newspack-plugin'
-					),
-					formatNumber( current.top_pages_no_conversion.threshold_pageviews )
-				) }
-			>
-				<SortableTable
-					columns={ TOP_PAGES_COLUMNS }
-					rows={ current.top_pages_no_conversion.rows }
-					getRowKey={ row => row.post_id }
-					defaultSortKey="pageviews"
-					initialRowLimit={ TOP_PAGES_ROW_LIMIT }
-					emptyMessage={ sprintf(
-						/* translators: %s: minimum pageview count for an article to qualify (formatted). */
-						__(
-							'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
-							'newspack-plugin'
-						),
-						formatNumber( current.top_pages_no_conversion.threshold_pageviews )
-					) }
+		<VStack spacing={ 4 }>
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Stale Registered Readers', 'newspack-plugin' ),
+						description: __( 'Registered but never converted, no activity in 90 days', 'newspack-plugin' ),
+						current: current.stale_registered_count,
+					} ) }
 				/>
-			</SectionState>
-			<p className="newspack-insights__conversion-top-pages-note">
-				{ __(
-					'These articles get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
-					'newspack-plugin'
-				) }
-			</p>
-		</div>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'At-Risk Subscribers', 'newspack-plugin' ),
+						description: __( 'Active subscribers with a failed-payment retry scheduled', 'newspack-plugin' ),
+						current: current.at_risk_subscriber_count,
+					} ) }
+				/>
+				<MetricCard
+					{ ...scalarToMetricCardProps( {
+						label: __( 'Lapsed Donors', 'newspack-plugin' ),
+						description: __( 'Donors with no donation in the last 365 days', 'newspack-plugin' ),
+						current: current.lapsed_donor_count,
+					} ) }
+				/>
+			</Grid>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top articles that don’t convert', 'newspack-plugin' ) }</h3>
+				<p className="newspack-insights__chart-card-caption">
+					{ __(
+						'These articles get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
+						'newspack-plugin'
+					) }
+				</p>
+				<div className="newspack-insights__chart-card-body">
+					<SectionState
+						state={ current.top_pages_no_conversion.state }
+						emptyMessage={ sprintf(
+							/* translators: %s: minimum pageview count for an article to qualify (formatted). */
+							__(
+								'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
+								'newspack-plugin'
+							),
+							formatNumber( current.top_pages_no_conversion.threshold_pageviews )
+						) }
+					>
+						<SortableTable
+							columns={ TOP_PAGES_COLUMNS }
+							rows={ current.top_pages_no_conversion.rows }
+							getRowKey={ row => row.post_id }
+							defaultSortKey="pageviews"
+							initialRowLimit={ TOP_PAGES_ROW_LIMIT }
+							emptyMessage={ sprintf(
+								/* translators: %s: minimum pageview count for an article to qualify (formatted). */
+								__(
+									'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
+									'newspack-plugin'
+								),
+								formatNumber( current.top_pages_no_conversion.threshold_pageviews )
+							) }
+						/>
+					</SectionState>
+				</div>
+			</Card>
+		</VStack>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -35,6 +35,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card, Grid, Notice } from '../../../../../packages/components/src';
 import type { ConversionGatedFunnelData, ConversionWindow } from '../../api/conversion';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
@@ -54,11 +55,11 @@ interface JourneyFunnelProps {
 }
 
 const JourneyFunnel = ( { title, caption, children }: JourneyFunnelProps ) => (
-	<div className="newspack-insights__conversion-journey-cell">
-		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
-		<p className="newspack-insights__conversion-subcaption">{ caption }</p>
-		{ children }
-	</div>
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ title }</h3>
+		<p className="newspack-insights__chart-card-caption">{ caption }</p>
+		<div className="newspack-insights__chart-card-body">{ children }</div>
+	</Card>
 );
 
 interface GatedFunnelCellProps {
@@ -70,12 +71,14 @@ interface GatedFunnelCellProps {
 const GatedFunnelCell = ( { data, emptyMessage }: GatedFunnelCellProps ) => {
 	if ( data.visibility === 'hidden' ) {
 		return (
-			<p className="newspack-insights__conversion-gated-note">
-				{ __(
+			<Notice
+				isWarning
+				className="newspack-insights__conversion-notice"
+				noticeText={ __(
 					'Cross-upsell view appears when both subscription and donation programs have at least 50 active participants.',
 					'newspack-plugin'
 				) }
-			</p>
+			/>
 		);
 	}
 	return (
@@ -131,7 +134,11 @@ const ConversionLegCell = ( { data, emptyMessage, noOpportunityMessage, noConver
 			return (
 				<>
 					<Funnel stages={ data.stages } />
-					<p className="newspack-insights__conversion-gated-note">{ interpolateCount( noConversionsBody, priorStage ) }</p>
+					<Notice
+						isWarning
+						className="newspack-insights__conversion-notice"
+						noticeText={ interpolateCount( noConversionsBody, priorStage ) }
+					/>
 				</>
 			);
 		}
@@ -166,7 +173,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 					'newspack-plugin'
 				) }
 			/>
-			<div className="newspack-insights__conversion-journey-grid">
+			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				<JourneyFunnel
 					title={ __( 'Anonymous → Registered', 'newspack-plugin' ) }
 					caption={ __(
@@ -246,7 +253,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 						emptyMessage={ __( 'No cross-upsell data yet. This will populate once cross-upsell conversions occur.', 'newspack-plugin' ) }
 					/>
 				</JourneyFunnel>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../packages/components/src';
 import type { ConversionWindow } from '../../api/conversion';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
@@ -44,12 +45,14 @@ const ReaderLifecycleSection = ( { current, lastUpdated }: ReaderLifecycleSectio
 			) }
 			actions={ lastUpdated }
 		/>
-		<SectionState
-			state={ current.reader_lifecycle_funnel.state }
-			emptyMessage={ __( 'No funnel data yet. The funnel will populate once readers begin moving through your site.', 'newspack-plugin' ) }
-		>
-			<Funnel stages={ current.reader_lifecycle_funnel.stages } />
-		</SectionState>
+		<Card __experimentalCoreCard className="newspack-insights__chart-card">
+			<SectionState
+				state={ current.reader_lifecycle_funnel.state }
+				emptyMessage={ __( 'No funnel data yet. The funnel will populate once readers begin moving through your site.', 'newspack-plugin' ) }
+			>
+				<Funnel stages={ current.reader_lifecycle_funnel.stages } />
+			</SectionState>
+		</Card>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card, Grid } from '../../../../../packages/components/src';
 import type { ConversionSourceMixData } from '../../api/conversion';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
@@ -40,16 +41,18 @@ interface SourcePieProps {
 }
 
 const SourcePie = ( { title, data, emptyMessage }: SourcePieProps ) => (
-	<div className="newspack-insights__conversion-pie-cell">
-		<h3 className="newspack-insights__conversion-subheading">{ title }</h3>
-		<SectionState state={ data.state } emptyMessage={ emptyMessage }>
-			<PieChart
-				segments={ data.slices.map( slice => ( { label: sourceLabel( slice.source ), value: slice.count } ) ) }
-				centerLabel={ formatNumber( data.total ) }
-				emptyMessage={ emptyMessage }
-			/>
-		</SectionState>
-	</div>
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ title }</h3>
+		<div className="newspack-insights__chart-card-body">
+			<SectionState state={ data.state } emptyMessage={ emptyMessage }>
+				<PieChart
+					segments={ data.slices.map( slice => ( { label: sourceLabel( slice.source ), value: slice.count } ) ) }
+					centerLabel={ formatNumber( data.total ) }
+					emptyMessage={ emptyMessage }
+				/>
+			</SectionState>
+		</div>
+	</Card>
 );
 
 const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromSectionProps ) => (
@@ -65,7 +68,7 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__conversion-pie-row">
+		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<SourcePie
 				title={ __( 'New registrations', 'newspack-plugin' ) }
 				data={ current.source_mix_registrations }
@@ -81,7 +84,7 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 				data={ current.source_mix_donors }
 				emptyMessage={ __( 'Source data will appear once donations occur in this timeframe.', 'newspack-plugin' ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/conversion.scss
@@ -17,21 +17,6 @@
 @use "../../../../../packages/colors/colors.module" as colors;
 @use "../components/insights-charts";
 
-// Shared card chrome for this tab's chart cells (pie / curve / cohort / rate
-// trends). Matches the funnel + scorecard + Audience-tab chart-card treatment
-// (white fill, gray-200 hairline, 4px radius, 16px padding) so every section
-// reads as the same bounded card instead of a chart floating on the page.
-// `height: 100%` lets cards in a row stretch to the tallest, keeping row edges
-// aligned.
-@mixin conversion-chart-card {
-	min-width: 0;
-	height: 100%;
-	padding: 16px;
-	background-color: wp-colors.$white;
-	border: 1px solid wp-colors.$gray-200;
-	border-radius: 4px;
-}
-
 .newspack-insights {
 	&__conversion-tab {
 		display: flex;
@@ -64,7 +49,14 @@
 		color: wp-colors.$gray-700;
 	}
 
-	// Per-viz subheading + caption used inside the multi-cell sections.
+	// Gate/no-conversion warning notices sit flush inside a funnel card — drop the
+	// notice's default block margins. Compound selector to beat the base rule.
+	&__conversion-notice.newspack-notice {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+
+	// Per-viz subheading still used by the Opportunity buckets section (Section 7).
 	&__conversion-subheading {
 		margin: 0 0 4px;
 		font-size: 15px;
@@ -72,102 +64,8 @@
 		color: wp-colors.$gray-900;
 	}
 
-	&__conversion-subcaption {
-		margin: 0 0 12px;
-		font-size: 13px;
-		font-weight: 400;
-		line-height: 1.5;
-		color: wp-colors.$gray-700;
-	}
-
-	// Empty-state note shown when a visibility-gated viz (Section 2.4 funnel,
-	// Section 4.4 lag curve) is hidden.
-	&__conversion-gated-note {
-		margin: 0;
-		padding: 32px 20px;
-		text-align: center;
-		font-size: 13px;
-		color: wp-colors.$gray-700;
-	}
-
-	// Section 2 — four per-journey funnels in a 2-column grid, stacking under
-	// ~720px container width. Cells stretch so a shorter funnel (e.g. the 2-stage
-	// cross-upsell) matches the height of its taller row-mate.
-	&__conversion-journey-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-		gap: 24px;
-		align-items: stretch;
-	}
-
-	&__conversion-journey-cell {
-		display: flex;
-		flex-direction: column;
-		min-width: 0;
-
-		// The funnel is the cell's last child; grow it to fill the stretched cell.
-		.newspack-insights__funnel {
-			flex: 1 1 auto;
-		}
-	}
-
-	// Section 3 — three source-mix pies side by side.
-	&__conversion-pie-row {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-		gap: 24px;
-		align-items: stretch;
-	}
-
-	&__conversion-pie-cell {
-		@include conversion-chart-card;
-	}
-
-	// Section 4 — 2×2 grid of cumulative-distribution curves.
-	&__conversion-curve-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-		gap: 24px;
-		align-items: stretch;
-	}
-
-	&__conversion-curve-cell {
-		@include conversion-chart-card;
-	}
-
-	// Section 5 — two cohort heatmaps, each on its own full-width row.
-	// (DSGNEWS-188: side-by-side cut off the rightmost month columns on the
-	// wider heatmaps — full width gives each room to show every column.)
-	&__conversion-cohort-stack {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
-	&__conversion-cohort-cell {
-		@include conversion-chart-card;
-	}
-
-	// Section 6 — single full-width weekly rate-trends curve.
-	&__conversion-rate-trends-cell {
-		@include conversion-chart-card;
-	}
-
-	// Section 8.4 — top-pages table block.
-	&__conversion-top-pages {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-		margin-top: 24px;
-	}
-
-	&__conversion-top-pages-note {
-		margin: 0;
-		font-size: 13px;
-		font-weight: 400;
-		line-height: 1.5;
-		color: wp-colors.$gray-700;
-	}
+	// Section 8.4 — top-pages table now sits in a chart-card CoreCard; the
+	// explanatory line moved to the card caption (chart-card-caption).
 
 }
 // Sortable-table sort affordances (See more/less toggle, empty row, sort chrome)

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
@@ -33,6 +33,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { DonorsRateValue, DonorsWindow } from '../../api/donors';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -90,7 +91,7 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 	return (
 		<Section { ...sectionProps }>
 			{ heading }
-			<div className="newspack-insights__metric-grid">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				{ recovery.computable ? (
 					<MetricCard
 						label={ RECOVERY_LABEL() }
@@ -125,7 +126,7 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 						</p>
 					</div>
 				) }
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -22,6 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { DonorsSnapshot } from '../../api/donors';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -44,7 +45,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 			description={ __( 'Current state and recurring revenue, independent of selected timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				label={ __( 'Active donors', 'newspack-plugin' ) }
 				value={ snapshot.active_donors }
@@ -114,7 +115,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				lowerIsBetter
 				description={ __( 'Donation subscriptions set to end in the next 30 days', 'newspack-plugin' ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -32,6 +32,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { DonorsWindow } from '../../api/donors';
 import type { DateRange } from '../../state/useDateRange';
 import EmptyMetricSection from '../components/EmptyMetricSection';
@@ -149,7 +150,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 			aria-labelledby="newspack-insights-donors-windowed-heading"
 		>
 			<SectionHeading id="newspack-insights-donors-windowed-heading" title={ getHeading( range ) } />
-			<div className="newspack-insights__metric-grid">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					label={ __( 'New donors', 'newspack-plugin' ) }
 					value={ current.new_donors }
@@ -202,7 +203,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					}
 					description={ __( 'Mean order total across one-time donation orders in this timeframe', 'newspack-plugin' ) }
 				/>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../../packages/components/src';
 import type { InsightsWindow } from '../../../api/audience';
 import Scorecard from '../../components/Scorecard';
 import Section from '../../components/Section';
@@ -37,7 +38,7 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 		/>
 		{ /* Drop to 3 even columns when the completion card is hidden so the row
 		     doesn't leave a trailing gap under the base auto-fill grid. */ }
-		<div className={ `newspack-insights__metric-grid${ SHOW_COMPLETION_METRICS ? '' : ' newspack-insights__metric-grid--cols-3' }` }>
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<Scorecard
 				label={ __( 'Avg Pages per Session', 'newspack-plugin' ) }
 				description={ __( 'Pages viewed per visit', 'newspack-plugin' ) }
@@ -70,7 +71,7 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 					previous={ previous?.article_completion_rate }
 				/>
 			) }
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/FreeReaderConversionSection.tsx
@@ -37,6 +37,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -114,7 +115,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 	return (
 		<Section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby={ HEADING_ID }>
 			<SectionHeading id={ HEADING_ID } title={ title } description={ caption } />
-			<div className="newspack-insights__metric-grid newspack-insights__metric-grid--pair">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
 						label: __( 'Registered access gate Conversion (Direct)', 'newspack-plugin' ),
@@ -151,7 +152,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 						},
 					} ) }
 				/>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/GateExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/GateExposureSection.tsx
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -42,7 +43,7 @@ const GateExposureSection = ( { current, previous, lastUpdated }: GateExposureSe
 			description={ __( 'Top of the funnel. How many readers see gates in this timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Total Gate Impressions', 'newspack-plugin' ),
@@ -75,7 +76,7 @@ const GateExposureSection = ( { current, previous, lastUpdated }: GateExposureSe
 					previous: previous?.sessions_with_gate,
 				} ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PaidReaderConversionSection.tsx
@@ -29,6 +29,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { GatesWindow } from '../../api/gates';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -99,7 +100,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 	return (
 		<Section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby={ HEADING_ID }>
 			<SectionHeading id={ HEADING_ID } title={ title } description={ caption } />
-			<div className="newspack-insights__metric-grid">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					{ ...scalarToMetricCardProps( {
 						label: __( 'Paid access gate Conversion (Direct)', 'newspack-plugin' ),
@@ -170,7 +171,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 						},
 					} ) }
 				/>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/gates.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/gates.scss
@@ -27,13 +27,6 @@
 	// different thing for regwall (same-session) than for paywall (checkout
 	// through the gate), so the mechanism is described per-metric instead.
 
-	// Two-card row (Section 2). The shared metric-grid is auto-fill
-	// with a 220px minimum; for the dedicated two-card sections we
-	// cap at two equal columns instead of letting more squeeze in.
-	&__metric-grid--pair {
-		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-	}
-
 	// Section 4 — funnel + distribution side-by-side at equal width,
 	// stacking under 720px container width.
 	&__gates-convert-grid {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -43,7 +44,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Registration Conversion (Direct)', 'newspack-plugin' ),
@@ -96,7 +97,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 					notComputableMessage: NOT_COMPUTABLE_COPY.newsletterInfluenced,
 				} ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -21,6 +21,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -44,7 +45,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Donation Conversion (Direct)', 'newspack-plugin' ),
@@ -100,7 +101,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 					notComputableMessage: NOT_COMPUTABLE_COPY.subscriptionInfluenced,
 				} ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { PromptsWindow } from '../../api/prompts';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -43,7 +44,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 				'newspack-plugin'
 			) }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Donation Revenue (Direct)', 'newspack-plugin' ),
@@ -99,7 +100,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 					notComputableMessage: NOT_COMPUTABLE_COPY.subscription,
 				} ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -25,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { SubscribersSnapshot } from '../../api/subscribers';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -44,7 +45,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 			description={ __( 'Current state and recurring revenue, independent of selected timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<div className="newspack-insights__metric-grid">
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				label={ __( 'Active subscribers', 'newspack-plugin' ) }
 				value={ snapshot.active_subscribers }
@@ -109,7 +110,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				lowerIsBetter
 				description={ __( 'Subscriptions set to end in the next 30 days', 'newspack-plugin' ) }
 			/>
-		</div>
+		</Grid>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/TenureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/TenureSection.tsx
@@ -18,6 +18,7 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { TenureDistributionRow } from '../../api/subscribers';
 import MetricCard from '../components/MetricCard';
 import Section from '../components/Section';
@@ -98,7 +99,7 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 	return (
 		<Section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
 			<SectionHeading id="newspack-insights-tenure-heading" title={ __( 'Subscriber tenure', 'newspack-plugin' ) } description={ narrative } />
-			<div className="newspack-insights__metric-grid">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					label={ __( 'Median tenure', 'newspack-plugin' ) }
 					value={ stats.median }
@@ -117,7 +118,7 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 					format="number"
 					secondary={ _n( 'day', 'days', stats.p75, 'newspack-plugin' ) }
 				/>
-			</div>
+			</Grid>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -38,6 +38,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Grid } from '../../../../../packages/components/src';
 import type { SubscribersRateValue, SubscribersWindow } from '../../api/subscribers';
 import type { DateRange } from '../../state/useDateRange';
 import EmptyMetricSection from '../components/EmptyMetricSection';
@@ -165,7 +166,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 	return (
 		<Section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
 			<SectionHeading id="newspack-insights-windowed-heading" title={ getHeading( range ) } />
-			<div className="newspack-insights__metric-grid">
+			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
 					label={ __( 'New subscribers', 'newspack-plugin' ) }
 					value={ current.new_subscribers }
@@ -234,7 +235,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					notComputableMessage={ retryEmptyMessage }
 					description={ __( 'Recovered retries ÷ retry attempts', 'newspack-plugin' ) }
 				/>
-			</div>
+			</Grid>
 		</Section>
 	);
 };


### PR DESCRIPTION
Standardizes the Insights UI on the shared card + grid primitives.

## Conversion tab
- Every section (reader-lifecycle funnel, per-journey funnels, source-mix pies, distribution curves, cohort heatmaps, rate trends, opportunity buckets, top-pages table) is now wrapped in a chart-card `CoreCard`.
- Multi-viz layouts use the shared `<Grid>` (per-journey funnels 2-col, source pies 3-col, curves 2-col) or `<VStack>` (cohorts, opportunity buckets) at 16px spacing.
- Visibility-gate notes ("appears when…") and the no-conversions annotation are now warning `<Notice>`s (flush, no block margin) instead of plain paragraphs.
- Top-pages explanatory line moved to the card caption.

## Scorecards (Gates, Prompts, Donors, Subscribers, Conversion, Audience, Engagement)
- `newspack-insights__metric-grid` replaced with `<Grid columns={ 4 } gutter={ 16 }>` across 16 sections. The bespoke `--pair` (2-col) and `--cols-3` variants are dropped in favour of the uniform 4-column grid.

## Charts
- Pie center label rendered as an HTML overlay at `heading-x-large()` in the admin accent (was SVG text).
- Cohort heatmap shading rebased on `--wp-admin-theme-color` via `color-mix`.
- `metric-card-label` uses `text-wrap: pretty`; description uses `text-wrap: balance`.

Dead grid/cell/mixin SCSS removed. `PromptsTab` snapshot regenerated for the new Grid markup; full JS suite passes (the lone `PrintDocumentMeta` date-range failure is pre-existing and unrelated).