### PR TITLE
feat(insights): live Broadstreet reporting for Tab 8 (NPPD-2045)

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/api/class-advertising-rest-controller.php
@@ -119,6 +119,9 @@ class Advertising_REST_Controller extends WP_REST_Controller {
 		if ( defined( 'NEWSPACK_INSIGHTS_FIXTURE_MODE' ) && NEWSPACK_INSIGHTS_FIXTURE_MODE ) {
 			$compare  = $compare_start && $compare_end;
 			$variant  = (string) ( $request->get_param( '_fixture_state' ) ?? 'populated' );
+			// Provider variant (NPPD-2045): _fixture_provider=broadstreet renders the
+			// impressions-only Broadstreet envelope; defaults to the GAM shape.
+			$provider = 'broadstreet' === $request->get_param( '_fixture_provider' ) ? 'broadstreet' : 'gam';
 			$response = rest_ensure_response(
 				[
 					'cache' => [
@@ -126,7 +129,7 @@ class Advertising_REST_Controller extends WP_REST_Controller {
 						'computed_at'    => gmdate( 'Y-m-d\TH:i:s\Z' ),
 						'cooldown_until' => null,
 					],
-					'data'  => Advertising_Metric::get_fixture( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), $compare, $variant ),
+					'data'  => Advertising_Metric::get_fixture( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), $compare, $variant, $provider ),
 				]
 			);
 			$response->header( 'Cache-Control', 'no-store, private' );

--- a/plugins/newspack-plugin/includes/wizards/insights/broadstreet/class-client.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/broadstreet/class-client.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Newspack Insights — Broadstreet reporting client (NPPD-2045).
+ *
+ * Generic, metric-agnostic primitives for reading Broadstreet ad reporting that
+ * power Tab 8 (Advertising) when Broadstreet — rather than Google Ad Manager —
+ * is the site's active ad server. The Advertising metric orchestrator
+ * ({@see \Newspack\Insights\Advertising_Metric}) builds metric-specific reports
+ * on top of the single {@see self::report()} primitive.
+ *
+ * Unlike GAM (async SOAP report jobs), Broadstreet exposes a synchronous REST
+ * rollup: a single `GET /api/1/records?type=custom` returns every advertiser (or
+ * zone) row for the whole network over a date range in one call — no fan-out. So
+ * this client is a thin `wp_remote_get` wrapper; the orchestrator computes the
+ * Broadstreet window synchronously (no Action Scheduler).
+ *
+ * IMPORTANT — read before modifying:
+ *
+ *  - The Broadstreet v1 API has NO revenue / RPM / eCPM / cost anywhere
+ *    (confirmed live). Broadstreet is an impressions-side provider only; every
+ *    revenue-derived Tab 8 metric is GAM-only.
+ *  - Credentials come from the Broadstreet plugin via newspack-ads' guarded
+ *    accessors ({@see \Broadstreet_Utility::getApiKey()} / `getNetworkId()`).
+ *    Every access is `class_exists`/`method_exists`-guarded so Insights never
+ *    hard-depends on the Broadstreet plugin being installed.
+ *  - Insights owns the HTTP call here (via `wp_remote_get`); the newspack-ads
+ *    Broadstreet provider is used only for the active-server detection signal.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Insights\Broadstreet;
+
+use Newspack\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Broadstreet reporting client.
+ */
+final class Client {
+
+	/**
+	 * Broadstreet API base (v1).
+	 *
+	 * @var string
+	 */
+	const API_BASE = 'https://api.broadstreetads.com/api/1';
+
+	/**
+	 * Logger header for this client.
+	 *
+	 * @var string
+	 */
+	const LOGGER_HEADER = 'NEWSPACK-INSIGHTS-BROADSTREET';
+
+	/**
+	 * Whether Broadstreet is the site's active ad server. Prefers the detection
+	 * newspack-ads already ships ({@see \Newspack_Ads\Providers\Broadstreet_Provider::is_active()}
+	 * — plugin present + API key + network id); falls back to replicating that
+	 * check directly against the Broadstreet plugin's utility when the provider
+	 * class isn't available. Guarded so Insights never hard-depends on either
+	 * plugin being loaded. Local/cheap — no remote calls.
+	 *
+	 * @return bool
+	 */
+	public static function is_active(): bool {
+		if ( class_exists( '\Newspack_Ads\Providers\Broadstreet_Provider' ) ) {
+			return ( new \Newspack_Ads\Providers\Broadstreet_Provider() )->is_active();
+		}
+		// Fallback: replicate the provider's own is_active() check.
+		return '' !== self::get_access_token() && '' !== self::get_network_id();
+	}
+
+	/**
+	 * The Broadstreet network id, or '' when unavailable.
+	 *
+	 * @return string
+	 */
+	public static function get_network_id(): string {
+		if ( class_exists( '\Broadstreet_Utility' ) && method_exists( '\Broadstreet_Utility', 'getNetworkId' ) ) {
+			return (string) \Broadstreet_Utility::getNetworkId();
+		}
+		return '';
+	}
+
+	/**
+	 * The Broadstreet API access token (key), or '' when unavailable.
+	 *
+	 * @return string
+	 */
+	public static function get_access_token(): string {
+		if ( class_exists( '\Broadstreet_Utility' ) && method_exists( '\Broadstreet_Utility', 'getApiKey' ) ) {
+			return (string) \Broadstreet_Utility::getApiKey();
+		}
+		return '';
+	}
+
+	/**
+	 * Run a network-rollup records report. One synchronous call returns every
+	 * grouped row for the whole network over the date range.
+	 *
+	 * @param string   $group  Grouping dimension: network|advertiser|zone|campaign.
+	 * @param string[] $select Fields to select, e.g. [ 'advertiser.name', 'count(view)', 'count(click)' ].
+	 *                         `count(view)` is impressions; `count(click)` is clicks.
+	 * @param string   $start  Inclusive window start, YYYY-MM-DD.
+	 * @param string   $end    Inclusive window end, YYYY-MM-DD.
+	 * @return array<int,array<string,mixed>> The `records` rows, or [] on any failure (degrade).
+	 */
+	public static function report( string $group, array $select, string $start, string $end ): array {
+		$token      = self::get_access_token();
+		$network_id = self::get_network_id();
+		if ( '' === $token || '' === $network_id ) {
+			return [];
+		}
+
+		// add_query_arg() URL-encodes each value exactly once, so the `select` list's
+		// parens and commas (count(view),count(click),advertiser.name) are encoded
+		// safely. Do NOT pre-encode with rawurlencode() — that double-encodes and
+		// breaks the request.
+		$url = add_query_arg(
+			[
+				'access_token' => $token,
+				'type'         => 'custom',
+				'network_id'   => $network_id,
+				'select'       => implode( ',', $select ),
+				'group'        => $group,
+				'start_date'   => $start,
+				'end_date'     => $end,
+			],
+			self::API_BASE . '/records'
+		);
+
+		$decoded = self::request( $url );
+		if ( ! is_array( $decoded ) || ! isset( $decoded['records'] ) || ! is_array( $decoded['records'] ) ) {
+			return [];
+		}
+		return $decoded['records'];
+	}
+
+	/**
+	 * The HTTP boundary: fetch a Broadstreet API URL and JSON-decode it. Isolated
+	 * so the network-touching path is the single point that reads the wire (and so
+	 * it can be stubbed in isolation). Returns the decoded array, or null on any
+	 * transport / non-200 / decode failure — the caller degrades to [] rather than
+	 * surfacing an error, so a Broadstreet outage never breaks the tab.
+	 *
+	 * @param string $url The fully-built request URL.
+	 * @return array<string,mixed>|null Decoded JSON, or null on failure.
+	 */
+	protected static function request( string $url ) {
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get, WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout -- Broadstreet reporting reads hit the publisher's own ad server off a transient-cached path; a slightly longer timeout tolerates a cold rollup, and any failure degrades to an empty result rather than blocking.
+		$response = wp_remote_get( $url, [ 'timeout' => 10 ] );
+		if ( is_wp_error( $response ) ) {
+			if ( class_exists( '\Newspack\Logger' ) ) {
+				Logger::error( 'Broadstreet API request failed: ' . $response->get_error_message(), self::LOGGER_HEADER );
+			}
+			return null;
+		}
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			if ( class_exists( '\Newspack\Logger' ) ) {
+				Logger::error( 'Broadstreet API returned a non-200 response.', self::LOGGER_HEADER );
+			}
+			return null;
+		}
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+		return is_array( $decoded ) ? $decoded : null;
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/class-insights-section-advertising.php
@@ -59,6 +59,7 @@ class Insights_Section_Advertising {
 	private static function load_dependencies(): void {
 		$base = NEWSPACK_ABSPATH . 'includes/wizards/insights/';
 		include_once $base . 'derived/class-cross-system-metrics.php';
+		include_once $base . 'broadstreet/class-client.php';
 		include_once $base . 'metrics/class-advertising-metric.php';
 		include_once $base . 'api/class-advertising-rest-controller.php';
 	}

--- a/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/fixtures/advertising-fixture.php
@@ -27,11 +27,131 @@
 
 defined( 'ABSPATH' ) || exit;
 
-return function ( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated' ): array {
+return function ( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated', string $provider = 'gam' ): array {
 	$tz         = wp_timezone();
 	$today      = new DateTimeImmutable( 'today', $tz );
 	$data_as_of = $today->modify( '-7 days' )->format( 'Y-m-d' );
 	$est_start  = $today->modify( '-7 days' )->format( 'Y-m-d' );
+
+	// Broadstreet variant (NPPD-2045): impressions-only envelope. Broadstreet's API
+	// carries no revenue, so this variant omits RPM / revenue / eCPM / fill /
+	// viewability / revenue-mix entirely and surfaces only the doable signals —
+	// total impressions, impressions per session (the provider-agnostic cross-system
+	// join), overall CTR, mobile share, and top advertisers / top zones / top
+	// campaigns (impressions + clicks + CTR, no revenue). Fake advertiser/zone/
+	// campaign names only. Sessions are held flat across windows so the comparison
+	// toggle produces a visible impressions-per-session delta.
+	if ( 'broadstreet' === $provider ) {
+		$bs_sessions   = 800000;
+		$bs_data_as_of = $today->modify( '-1 day' )->format( 'Y-m-d' );
+
+		$bs_table = function ( array $names, string $label_key, float $scale ): array {
+			$rows  = [];
+			$count = count( $names );
+			foreach ( $names as $i => $name ) {
+				$weight      = $count - $i;
+				$impressions = (int) round( ( 2400000 / 55 ) * $weight * $scale );
+				$ctr         = round( 0.004 - ( $i * 0.0002 ), 4 );
+				$rows[]      = [
+					$label_key    => $name,
+					'impressions' => $impressions,
+					'clicks'      => (int) round( $impressions * $ctr ),
+					'ctr'         => $impressions > 0 ? $ctr : null,
+				];
+			}
+			return $rows;
+		};
+
+		$bs_advertisers = [ 'Hometown Hardware', 'Riverside Credit Union', 'Maple & Main Bistro', 'Cedar Grove Realty', 'Bluebird Books', 'Sunrise Dental', 'Prairie Wind Outfitters', 'Lakeside Auto Care' ];
+		$bs_zones       = [ 'Homepage Leaderboard', 'Article Sidebar', 'In-Content Rectangle', 'Footer Banner', 'Newsletter Sponsor', 'Mobile Sticky' ];
+		$bs_campaigns   = [ 'Hometown Hardware — Spring Flight', 'Riverside Credit Union — Summer', 'Maple & Main Bistro — Weekend Brunch', 'Cedar Grove Realty — Open House Push', 'Bluebird Books — Summer Reading', 'Sunrise Dental — New Patient Special' ];
+
+		// A rate scorecard mirroring Advertising_Metric::broadstreet_rate(): non-computable
+		// (→ em-dash, never a fake 0%) when there are no impressions to divide by.
+		$bs_rate = function ( int $numerator, int $denominator ): array {
+			return [
+				'value'       => $denominator > 0 ? $numerator / $denominator : 0.0,
+				'computable'  => $denominator > 0,
+				'type'        => 'rate',
+				'numerator'   => $numerator,
+				'denominator' => $denominator,
+			];
+		};
+
+		$bs_window = function ( float $scale ) use ( $bs_sessions, $bs_data_as_of, $bs_table, $bs_rate, $bs_advertisers, $bs_zones, $bs_campaigns ): array {
+			$impressions  = (int) round( 2400000 * $scale );
+			$impr_payload = [
+				'value'      => $impressions,
+				'computable' => true,
+				'type'       => 'count',
+			];
+			// Live-shaped ratios (Richland network): ~0.18% overall CTR, ~63% mobile share.
+			$clicks = (int) round( $impressions * 0.0018 );
+			$mobile = (int) round( $impressions * 0.63 );
+			return [
+				'window'                      => null,
+				'active_provider'             => 'broadstreet',
+				'is_tab_visible'              => true,
+				'is_report_ready'             => true,
+				'is_network_member'           => false,
+				'readiness_issues'            => [],
+				'metrics'                     => [
+					'total_impressions'           => $impr_payload,
+					'avg_impressions_per_session' => \Newspack\Insights\Derived\Cross_System_Metrics::avg_impressions_per_session( $impr_payload, $bs_sessions ),
+					'overall_ctr'                 => $bs_rate( $clicks, $impressions ),
+					'mobile_share'                => $bs_rate( $mobile, $impressions ),
+					'top_advertisers'             => [
+						'rows'       => $bs_table( $bs_advertisers, 'advertiser', $scale ),
+						'computable' => true,
+						'type'       => 'table',
+					],
+					'top_zones'                   => [
+						'rows'       => $bs_table( $bs_zones, 'zone', $scale ),
+						'computable' => true,
+						'type'       => 'table',
+					],
+					'top_campaigns'               => [
+						'rows'       => $bs_table( $bs_campaigns, 'campaign', $scale ),
+						'computable' => true,
+						'type'       => 'table',
+					],
+				],
+				'has_window_activity'         => $impressions > 0,
+				'data_as_of'                  => $bs_data_as_of,
+				'has_estimated_data'          => false,
+				'estimated_window_start_date' => null,
+			];
+		};
+
+		$current           = $bs_window( 1.0 );
+		$current['window'] = [
+			'start' => $start_date,
+			'end'   => $end_date,
+		];
+		$previous = null;
+		if ( $compare ) {
+			try {
+				$bs_start  = new DateTimeImmutable( $start_date, $tz );
+				$bs_end    = new DateTimeImmutable( $end_date, $tz );
+				$bs_len    = (int) $bs_start->diff( $bs_end )->format( '%a' ) + 1;
+				$bs_pend   = $bs_start->modify( '-1 day' );
+				$bs_pstart = $bs_pend->modify( '-' . ( $bs_len - 1 ) . ' days' );
+			} catch ( Exception $e ) {
+				$bs_pstart = $start_date;
+				$bs_pend   = $end_date;
+			}
+			$previous           = $bs_window( 0.85 );
+			$previous['window'] = [
+				'start' => $bs_pstart instanceof DateTimeImmutable ? $bs_pstart->format( 'Y-m-d' ) : $bs_pstart,
+				'end'   => $bs_pend instanceof DateTimeImmutable ? $bs_pend->format( 'Y-m-d' ) : $bs_pend,
+			];
+		}
+
+		return [
+			'current'  => $current,
+			'previous' => $previous,
+		];
+	}
 
 	/**
 	 * Build a single window's metric set, scaled so comparison windows can
@@ -466,6 +586,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 				'start' => $start_date,
 				'end'   => $end_date,
 			],
+			'active_provider'             => 'gam',
 			'is_tab_visible'              => true,
 			'is_report_ready'             => false,
 			'is_network_member'           => false,
@@ -503,6 +624,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 					'start' => $start_date,
 					'end'   => $end_date,
 				],
+				'active_provider'   => 'gam',
 				'is_tab_visible'    => true,
 				'is_report_ready'   => true,
 				'is_network_member' => false,
@@ -583,6 +705,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 			'start' => $start_date,
 			'end'   => $end_date,
 		],
+		'active_provider'             => 'gam',
 		'is_tab_visible'              => true,
 		'is_report_ready'             => true,
 		'is_network_member'           => $is_network,
@@ -640,6 +763,7 @@ return function ( string $start_date, string $end_date, bool $compare = false, s
 				'start' => $prior_start instanceof DateTimeImmutable ? $prior_start->format( 'Y-m-d' ) : $prior_start,
 				'end'   => $prior_end instanceof DateTimeImmutable ? $prior_end->format( 'Y-m-d' ) : $prior_end,
 			],
+			'active_provider'             => 'gam',
 			'is_tab_visible'              => true,
 			'is_report_ready'             => true,
 			'is_network_member'           => $is_network,

--- a/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
+++ b/plugins/newspack-plugin/includes/wizards/insights/metrics/class-advertising-metric.php
@@ -40,6 +40,7 @@ namespace Newspack\Insights;
 use Newspack\Insights\GAM\Client;
 use Newspack\Insights\GAM\Report_Query;
 use Newspack\Insights\GAM\Report_Job_Status;
+use Newspack\Insights\Broadstreet\Client as Broadstreet_Client;
 use Newspack\Insights\Derived\Cross_System_Metrics;
 use Newspack\Logger;
 
@@ -59,6 +60,14 @@ class Advertising_Metric {
 	const CACHE_FRESH_TTL  = 15 * MINUTE_IN_SECONDS;
 	const CACHE_HARD_TTL   = DAY_IN_SECONDS;
 	const CACHE_RETRY_TTL  = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Broadstreet window cache. The Broadstreet rollup is synchronous and cheap, so
+	 * unlike GAM there's no stale-while-revalidate / Action Scheduler machinery — the
+	 * envelope is simply computed on a miss and cached for a short window.
+	 */
+	const BROADSTREET_CACHE_KEY_PREFIX = 'newspack_insights_advertising_broadstreet_v1:';
+	const BROADSTREET_CACHE_TTL        = 15 * MINUTE_IN_SECONDS;
 
 	const REFRESH_ACTION = 'newspack_insights_advertising_refresh';
 	const REFRESH_GROUP  = 'newspack-insights';
@@ -160,12 +169,44 @@ class Advertising_Metric {
 	 */
 
 	/**
-	 * Whether Tab 8 should be visible: Google Ad Manager active on the site.
+	 * The active ad-server provider backing Tab 8, or null when neither is
+	 * configured. GAM wins when both are active (a placement-count tiebreaker is a
+	 * later concern). Detection is local/cheap — no remote calls — so it's safe to
+	 * call repeatedly per request.
+	 *
+	 * @return string|null 'gam' | 'broadstreet' | null.
+	 */
+	public static function active_provider(): ?string {
+		if ( Client::is_gam_active() ) {
+			return 'gam';
+		}
+		if ( static::is_broadstreet_active() ) {
+			return 'broadstreet';
+		}
+		return null;
+	}
+
+	/**
+	 * Whether Broadstreet is the site's active ad server. A `protected` seam over
+	 * {@see \Newspack\Insights\Broadstreet\Client::is_active()} (plugin present +
+	 * API key + network id) so tests can force it without stubbing the optional
+	 * Broadstreet plugin. Called via `static::` from {@see self::active_provider()}
+	 * so a test subclass's override takes effect.
+	 *
+	 * @return bool
+	 */
+	protected static function is_broadstreet_active(): bool {
+		return Broadstreet_Client::is_active();
+	}
+
+	/**
+	 * Whether Tab 8 should be visible: a supported ad server (Google Ad Manager or
+	 * Broadstreet) is active on the site.
 	 *
 	 * @return bool
 	 */
 	public static function is_tab_visible(): bool {
-		return Client::is_gam_active();
+		return null !== static::active_provider();
 	}
 
 	/**
@@ -191,6 +232,20 @@ class Advertising_Metric {
 	 * @return bool
 	 */
 	public static function is_report_ready(): bool {
+		$provider = static::active_provider();
+
+		// Broadstreet reporting is a synchronous REST rollup (no OAuth scope, no
+		// network-code readiness dance, no async job): if Broadstreet is the active
+		// provider it's immediately ready to report.
+		if ( 'broadstreet' === $provider ) {
+			return true;
+		}
+
+		// Any non-GAM provider (including none) can't run a GAM report.
+		if ( 'gam' !== $provider ) {
+			return false;
+		}
+
 		if ( null === self::$can_run_memo ) {
 			self::$can_run_memo = Client::can_run_reports();
 		}
@@ -288,11 +343,13 @@ class Advertising_Metric {
 	 * @return array
 	 */
 	public static function get_all( string $start_date, string $end_date, bool $compare = false ): array {
+		$provider = self::active_provider();
 		$envelope = [
 			'window'            => [
 				'start' => $start_date,
 				'end'   => $end_date,
 			],
+			'active_provider'   => $provider,
 			'is_tab_visible'    => self::is_tab_visible(),
 			'is_report_ready'   => self::is_report_ready(),
 			'is_network_member' => self::is_network_member(),
@@ -304,6 +361,18 @@ class Advertising_Metric {
 		// schedule a refresh that would just be skipped.
 		if ( ! $envelope['is_tab_visible'] || ! $envelope['is_report_ready'] ) {
 			return array_merge( $envelope, self::empty_window( $start_date, $end_date ), [ 'is_report_ready' => $envelope['is_report_ready'] ] );
+		}
+
+		// Broadstreet: a synchronous, impressions-only rollup (no revenue in the v1
+		// API, no async job). Computed inline and transient-cached — never through the
+		// GAM stale-while-revalidate / Action Scheduler path.
+		if ( 'broadstreet' === $provider ) {
+			$envelope = array_merge( $envelope, self::read_broadstreet_window( $start_date, $end_date ) );
+			if ( $compare ) {
+				[ $prior_start, $prior_end ] = self::prior_period( $start_date, $end_date );
+				$envelope['compare']         = self::read_broadstreet_window( $prior_start, $prior_end );
+			}
+			return $envelope;
 		}
 
 		$window = self::read_window( $start_date, $end_date );
@@ -326,11 +395,13 @@ class Advertising_Metric {
 	 * @param string $end_date   YYYY-MM-DD.
 	 * @param bool   $compare    Whether to attach the comparison payload.
 	 * @param string $variant    Render-path variant: populated|not_ready|zero|no_viewability.
+	 * @param string $provider   Ad-server variant: gam|broadstreet (NPPD-2045). Broadstreet
+	 *                           renders the impressions-only envelope (no revenue/RPM).
 	 * @return array
 	 */
-	public static function get_fixture( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated' ): array {
+	public static function get_fixture( string $start_date, string $end_date, bool $compare = false, string $variant = 'populated', string $provider = 'gam' ): array {
 		$fixture = require NEWSPACK_ABSPATH . 'includes/wizards/insights/fixtures/advertising-fixture.php';
-		return $fixture( $start_date, $end_date, $compare, $variant );
+		return $fixture( $start_date, $end_date, $compare, $variant, $provider );
 	}
 
 	/**
@@ -1186,6 +1257,248 @@ class Advertising_Metric {
 			$host = preg_replace( '#^https?://#', '', $value );
 		}
 		return (string) preg_replace( '#^www\.#', '', (string) $host );
+	}
+
+	/*
+	 * Broadstreet (NPPD-2045) — synchronous, impressions-only window.
+	 *
+	 * Broadstreet's v1 API has no revenue/RPM/eCPM/cost, so this path emits only
+	 * impressions-side metrics: total impressions, overall CTR, mobile share, top
+	 * advertisers, top zones, top campaigns, plus the provider-agnostic avg
+	 * impressions/session cross-system join (added at the read layer). Every
+	 * revenue/inventory metric GAM produces is deliberately absent.
+	 */
+
+	/**
+	 * Read a Broadstreet window: transient-cached synchronous compute (no Action
+	 * Scheduler). The avg-impressions-per-session cross-system scorecard and the
+	 * derived empty-state signal are layered on AFTER the cache — matching the GAM
+	 * read layer — so sessions track the Audience cache rather than the ad cache.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array Window payload.
+	 */
+	private static function read_broadstreet_window( string $start_date, string $end_date ): array {
+		$cache_key = self::broadstreet_cache_key( $start_date, $end_date );
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) && isset( $cached['metrics'] ) && is_array( $cached['metrics'] ) ) {
+			$window = $cached;
+		} else {
+			$window = self::compute_broadstreet_window( $start_date, $end_date );
+			set_transient( $cache_key, $window, self::BROADSTREET_CACHE_TTL );
+		}
+
+		// Cross-system derived scorecard (provider-agnostic): impressions per session,
+		// joining this window's Broadstreet impressions with fresh GA4 sessions.
+		$metrics  = $window['metrics'] ?? [];
+		$sessions = Cross_System_Metrics::sessions_for_window( $start_date, $end_date );
+		$window['metrics']['avg_impressions_per_session'] = Cross_System_Metrics::avg_impressions_per_session(
+			$metrics['total_impressions'] ?? [],
+			$sessions
+		);
+
+		// Derived empty-state signal (NPPD-1697): Broadstreet has no revenue, so
+		// impressions are the only activity signal. Set only when the volume metric is
+		// computable, so an errored/absent metric doesn't collapse the section.
+		$imp = $metrics['total_impressions'] ?? [];
+		if ( ! empty( $imp['computable'] ) ) {
+			$window['has_window_activity'] = self::window_activity_signal( (int) ( $imp['value'] ?? 0 ), 0.0 );
+		}
+
+		return $window;
+	}
+
+	/**
+	 * Compute a Broadstreet window's metrics (the report-touching path). Cheap and
+	 * synchronous — a single rollup call per metric, no fan-out.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return array Window payload (window + metrics + minimal lag info).
+	 */
+	private static function compute_broadstreet_window( string $start_date, string $end_date ): array {
+		// A SINGLE group=network call yields three scorecards (impressions, CTR,
+		// mobile share); the advertiser/zone/campaign groups are one call each.
+		$network = self::broadstreet_network_metrics( $start_date, $end_date );
+		return [
+			'window'                      => [
+				'start' => $start_date,
+				'end'   => $end_date,
+			],
+			'metrics'                     => [
+				'total_impressions' => $network['total_impressions'],
+				'overall_ctr'       => $network['overall_ctr'],
+				'mobile_share'      => $network['mobile_share'],
+				'top_advertisers'   => self::broadstreet_top_advertisers( $start_date, $end_date ),
+				'top_zones'         => self::broadstreet_top_zones( $start_date, $end_date ),
+				'top_campaigns'     => self::broadstreet_top_campaigns( $start_date, $end_date ),
+			],
+			// Broadstreet reports settle without GAM's multi-day AdX estimate lag, so
+			// there's no estimated-data window; the UI hides the lag indicator anyway.
+			'data_as_of'                  => ( new \DateTimeImmutable( 'today', wp_timezone() ) )->modify( '-1 day' )->format( 'Y-m-d' ),
+			'has_estimated_data'          => false,
+			'estimated_window_start_date' => null,
+		];
+	}
+
+	/**
+	 * Broadstreet network-rollup scorecards — a SINGLE `group=network` call
+	 * selecting `count(view)`, `count(click)`, and `count(mobile_view)`, from which
+	 * three scorecards are derived without any extra requests:
+	 *   - total_impressions : sum of `count(view)`.
+	 *   - overall_ctr       : clicks ÷ impressions (rate).
+	 *   - mobile_share      : mobile views ÷ impressions (rate).
+	 *
+	 * `count(mobile_view)` is Broadstreet's ONLY device signal — a mobile-vs-total
+	 * split, not a full device breakdown (desktop/tablet counts don't exist in the
+	 * v1 API), so there's deliberately no device table.
+	 *
+	 * @param string $s Start date.
+	 * @param string $e End date.
+	 * @return array{total_impressions:array,overall_ctr:array,mobile_share:array}
+	 */
+	public static function broadstreet_network_metrics( string $s, string $e ): array {
+		$rows        = static::run_broadstreet_report( 'network', [ 'count(view)', 'count(click)', 'count(mobile_view)' ], $s, $e );
+		$impressions = 0.0;
+		$clicks      = 0.0;
+		$mobile      = 0.0;
+		foreach ( $rows as $row ) {
+			$impressions += self::cell_number( $row, 'count(view)' );
+			$clicks      += self::cell_number( $row, 'count(click)' );
+			$mobile      += self::cell_number( $row, 'count(mobile_view)' );
+		}
+		return [
+			'total_impressions' => self::scalar_count( $impressions ),
+			'overall_ctr'       => self::broadstreet_rate( $clicks, $impressions ),
+			'mobile_share'      => self::broadstreet_rate( $mobile, $impressions ),
+		];
+	}
+
+	/**
+	 * Shape a Broadstreet rate scorecard: numerator ÷ denominator, carrying the raw
+	 * counts. Not computable (→ em-dash, never a misleading 0%) when the denominator
+	 * is zero, so an empty/degraded rollup reads as "no data", not a real zero rate.
+	 *
+	 * @param float $numerator   Rate numerator (clicks, or mobile views).
+	 * @param float $denominator Rate denominator (impressions).
+	 * @return array
+	 */
+	private static function broadstreet_rate( float $numerator, float $denominator ): array {
+		return [
+			'value'       => $denominator > 0 ? $numerator / $denominator : 0.0,
+			'computable'  => $denominator > 0,
+			'type'        => 'rate',
+			'numerator'   => (int) $numerator,
+			'denominator' => (int) $denominator,
+		];
+	}
+
+	/**
+	 * Broadstreet top advertisers by impressions — `group=advertiser`. Rows carry
+	 * impressions, clicks, and CTR (clicks / impressions, null when impressions are
+	 * zero). Top 10 by impressions. No revenue — the Broadstreet API has none.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function broadstreet_top_advertisers( string $s, string $e, int $limit = 10 ): array {
+		$rows = static::run_broadstreet_report( 'advertiser', [ 'advertiser.name', 'count(view)', 'count(click)' ], $s, $e );
+		$out  = [];
+		foreach ( $rows as $row ) {
+			$impressions = (int) self::cell_number( $row, 'count(view)' );
+			$clicks      = (int) self::cell_number( $row, 'count(click)' );
+			$out[]       = [
+				'advertiser'  => (string) self::cell( $row, 'advertiser.name' ),
+				'impressions' => $impressions,
+				'clicks'      => $clicks,
+				'ctr'         => self::ctr( $clicks, $impressions ),
+			];
+		}
+		return self::rank_table( $out, 'impressions', $limit );
+	}
+
+	/**
+	 * Broadstreet top zones by impressions — `group=zone`. Rows carry impressions,
+	 * clicks, and CTR (null when impressions are zero). Top 10 by impressions.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function broadstreet_top_zones( string $s, string $e, int $limit = 10 ): array {
+		$rows = static::run_broadstreet_report( 'zone', [ 'zone.name', 'count(view)', 'count(click)' ], $s, $e );
+		$out  = [];
+		foreach ( $rows as $row ) {
+			$impressions = (int) self::cell_number( $row, 'count(view)' );
+			$clicks      = (int) self::cell_number( $row, 'count(click)' );
+			$out[]       = [
+				'zone'        => (string) self::cell( $row, 'zone.name' ),
+				'impressions' => $impressions,
+				'clicks'      => $clicks,
+				'ctr'         => self::ctr( $clicks, $impressions ),
+			];
+		}
+		return self::rank_table( $out, 'impressions', $limit );
+	}
+
+	/**
+	 * Broadstreet top campaigns by impressions — `group=campaign`. Rows carry
+	 * impressions, clicks, and CTR (clicks / impressions, null when impressions are
+	 * zero). Top 10 by impressions. No revenue — the Broadstreet API has none. Unlike
+	 * the GAM top-campaigns metric (direct-sold ORDER_NAME rows), Broadstreet's
+	 * `campaign` group is a first-class reporting dimension with real named campaigns.
+	 *
+	 * @param string $s     Start date.
+	 * @param string $e     End date.
+	 * @param int    $limit Max rows.
+	 * @return array
+	 */
+	public static function broadstreet_top_campaigns( string $s, string $e, int $limit = 10 ): array {
+		$rows = static::run_broadstreet_report( 'campaign', [ 'campaign.name', 'count(view)', 'count(click)' ], $s, $e );
+		$out  = [];
+		foreach ( $rows as $row ) {
+			$impressions = (int) self::cell_number( $row, 'count(view)' );
+			$clicks      = (int) self::cell_number( $row, 'count(click)' );
+			$out[]       = [
+				'campaign'    => (string) self::cell( $row, 'campaign.name' ),
+				'impressions' => $impressions,
+				'clicks'      => $clicks,
+				'ctr'         => self::ctr( $clicks, $impressions ),
+			];
+		}
+		return self::rank_table( $out, 'impressions', $limit );
+	}
+
+	/**
+	 * Run a Broadstreet rollup report. The mockable seam (mirrors GAM's
+	 * {@see self::run_gam_report()}): tests subclass and override this to inject
+	 * canned `records` rows without touching the network. Returns the raw rows, or
+	 * [] on any degrade.
+	 *
+	 * @param string   $group  Grouping dimension (network|advertiser|zone|campaign).
+	 * @param string[] $select Fields to select.
+	 * @param string   $s      Start date, YYYY-MM-DD.
+	 * @param string   $e      End date, YYYY-MM-DD.
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected static function run_broadstreet_report( string $group, array $select, string $s, string $e ): array {
+		return Broadstreet_Client::report( $group, $select, $s, $e );
+	}
+
+	/**
+	 * Broadstreet window cache key, scoped to the network id so a reconnect to a
+	 * different Broadstreet network never serves a stale payload.
+	 *
+	 * @param string $start_date YYYY-MM-DD.
+	 * @param string $end_date   YYYY-MM-DD.
+	 * @return string
+	 */
+	private static function broadstreet_cache_key( string $start_date, string $end_date ): string {
+		return self::BROADSTREET_CACHE_KEY_PREFIX . md5( Broadstreet_Client::get_network_id() . '|' . $start_date . '|' . $end_date );
 	}
 
 	/*

--- a/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/api/advertising.ts
@@ -30,11 +30,16 @@ export interface ReadinessIssue {
 	remediation_url: string;
 }
 
+/** The ad server backing this tab. Broadstreet omits revenue-based metrics (NPPD-2045). */
+export type AdvertisingProvider = 'gam' | 'broadstreet';
+
 /**
  * One window's full Advertising envelope (the orchestrator's `get_all()` shape).
  */
 export interface AdvertisingWindow {
 	window?: { start: string; end: string };
+	/** Which ad server produced this envelope, or null when neither is active. */
+	active_provider?: AdvertisingProvider | null;
 	is_tab_visible: boolean;
 	is_report_ready: boolean;
 	/** Newspack Network member (NPPD-1671): gates the per-site breakdown (`metrics.top_sites`). */
@@ -88,9 +93,16 @@ const queryString = ( query: InsightsQuery ): string => {
 	// A no-op in production: the server ignores it unless
 	// NEWSPACK_INSIGHTS_FIXTURE_MODE is enabled.
 	if ( typeof window !== 'undefined' ) {
-		const fixtureState = new URLSearchParams( window.location.search ).get( '_fixture_state' );
+		const search = new URLSearchParams( window.location.search );
+		const fixtureState = search.get( '_fixture_state' );
 		if ( fixtureState ) {
 			params.set( '_fixture_state', fixtureState );
+		}
+		// Provider variant (NPPD-2045): `_fixture_provider=broadstreet` renders the
+		// impressions-only Broadstreet envelope for smoke testing. No-op in production.
+		const fixtureProvider = search.get( '_fixture_provider' );
+		if ( fixtureProvider ) {
+			params.set( '_fixture_provider', fixtureProvider );
 		}
 	}
 	return params.toString();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
@@ -220,4 +220,58 @@ describe( 'AdvertisingTab', () => {
 		render( <AdvertisingTab range={ range } previousRange={ null } /> );
 		expect( screen.queryByText( 'Performance by site' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'renders the impressions-only Broadstreet variant, hiding every revenue/GAM section (NPPD-2045)', () => {
+		mockData(
+			baseWindow( {
+				active_provider: 'broadstreet',
+				metrics: {
+					total_impressions: { value: 2400000, computable: true, type: 'count' },
+					avg_impressions_per_session: { value: 3, computable: true, type: 'count' },
+					overall_ctr: { value: 0.0018, computable: true, type: 'rate', numerator: 4320, denominator: 2400000 },
+					mobile_share: { value: 0.63, computable: true, type: 'rate', numerator: 1512000, denominator: 2400000 },
+					top_advertisers: {
+						type: 'table',
+						computable: true,
+						rows: [ { advertiser: 'Hometown Hardware', impressions: 120000, clicks: 480, ctr: 0.004 } ],
+					},
+					top_zones: {
+						type: 'table',
+						computable: true,
+						rows: [ { zone: 'Homepage Leaderboard', impressions: 90000, clicks: 360, ctr: 0.004 } ],
+					},
+					top_campaigns: {
+						type: 'table',
+						computable: true,
+						rows: [ { campaign: 'Riverside Credit Union — Summer', impressions: 70000, clicks: 280, ctr: 0.004 } ],
+					},
+				},
+			} )
+		);
+		const { container } = render( <AdvertisingTab range={ range } previousRange={ null } /> );
+
+		// Impressions-side sections render.
+		expect( screen.getByText( 'Reach' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Impressions per session' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top advertisers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Hometown Hardware' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top zones' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Homepage Leaderboard' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top campaigns' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Riverside Credit Union — Summer' ) ).toBeInTheDocument();
+
+		// GAM-only sections + the revenue card are absent (no revenue in Broadstreet).
+		expect( screen.queryByText( 'Reach & revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'RPM' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Average eCPM' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Impressions by type' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Performance by device' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top ad units' ) ).not.toBeInTheDocument();
+		// The GAM data-lag note is hidden for Broadstreet. Scope to the render
+		// container — the global a11y-speak region (document.body) can retain stale
+		// announcements from earlier tests in this suite.
+		expect( container ).not.toHaveTextContent( /Data as of/ );
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -72,6 +72,13 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 	// Fixture mode returns a `previous` window unconditionally, so gate here.
 	const previous = previousRange ? data?.previous?.metrics ?? null : null;
 
+	// Broadstreet has no revenue in its API (NPPD-2045), so its variant is
+	// impressions-only: a provider-aware Reach section and a Top performers section
+	// with zones + advertisers + campaigns. The GAM-only sections (revenue/inventory
+	// scorecards, revenue trend, channel/device, per-site) and the GAM data-lag note
+	// are hidden.
+	const isBroadstreet = current?.active_provider === 'broadstreet';
+
 	return (
 		<TabStateView
 			status={ status }
@@ -82,21 +89,29 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 		>
 			{ current && (
 				<>
-					<DataLagIndicator dataAsOf={ current.data_as_of } hasEstimatedData={ current.has_estimated_data } />
+					{ /* GAM-specific AdX data-lag note; Broadstreet has no estimate lag. */ }
+					{ ! isBroadstreet && <DataLagIndicator dataAsOf={ current.data_as_of } hasEstimatedData={ current.has_estimated_data } /> }
 					<TabSections>
 						<ReachRevenueSection
 							current={ current.metrics }
 							previous={ previous }
 							hasWindowActivity={ current.has_window_activity }
+							activeProvider={ current.active_provider }
 							lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
 						/>
-						<RevenueTrendSection current={ current.metrics } previous={ previous } />
-						{ /* Channel pie + device table: after the trend, before the per-site and
-						     top-performer tables. */ }
-						<ChannelDeviceSection current={ current.metrics } previous={ previous } />
-						{ /* Per-site breakdown: network members only; absent otherwise. */ }
-						{ current.is_network_member && <SitePerformanceSection current={ current.metrics } previous={ previous } /> }
-						<TopPerformersSection current={ current.metrics } previous={ previous } />
+						{ /* Revenue/inventory sections are GAM-only — Broadstreet's API has no
+						     revenue, channels, devices, or per-site custom dimension. */ }
+						{ ! isBroadstreet && (
+							<>
+								<RevenueTrendSection current={ current.metrics } previous={ previous } />
+								{ /* Channel pie + device table: after the trend, before the per-site and
+								     top-performer tables. */ }
+								<ChannelDeviceSection current={ current.metrics } previous={ previous } />
+								{ /* Per-site breakdown: network members only; absent otherwise. */ }
+								{ current.is_network_member && <SitePerformanceSection current={ current.metrics } previous={ previous } /> }
+							</>
+						) }
+						<TopPerformersSection current={ current.metrics } previous={ previous } activeProvider={ current.active_provider } />
 					</TabSections>
 				</>
 			) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -42,7 +42,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components'; // eslin
 /**
  * Internal dependencies
  */
-import type { InsightsWindow } from '../../../api/advertising';
+import type { AdvertisingProvider, InsightsWindow } from '../../../api/advertising';
 import { Grid } from '../../../../../../packages/components/src';
 import EmptyMetricSection from '../../components/EmptyMetricSection';
 import MetricCard from '../../components/MetricCard';
@@ -60,12 +60,75 @@ export interface SectionProps {
 	 */
 	hasWindowActivity?: boolean;
 	lastUpdated?: ReactNode;
+	/** Ad server backing the tab. Broadstreet is impressions-only (NPPD-2045). */
+	activeProvider?: AdvertisingProvider | null;
 }
 
 const TITLE = __( 'Reach & revenue', 'newspack-plugin' );
 const CAPTION = __( 'Volume, revenue, and inventory quality for the period.', 'newspack-plugin' );
 
-const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdated }: SectionProps ) => {
+// Broadstreet has no revenue in its API (NPPD-2045), so its variant is impressions-only.
+const BROADSTREET_TITLE = __( 'Reach', 'newspack-plugin' );
+const BROADSTREET_CAPTION = __( 'Ad impressions in this timeframe', 'newspack-plugin' );
+
+const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdated, activeProvider }: SectionProps ) => {
+	// Broadstreet variant (NPPD-2045): impressions-only. Broadstreet's API carries no
+	// revenue, so this renders four doable cards — total impressions, impressions per
+	// session, overall CTR, and mobile share — with no revenue / RPM / eCPM / fill /
+	// viewability. Overall CTR and mobile share are rate cards (percent, em-dash when
+	// there were no impressions to divide by).
+	if ( 'broadstreet' === activeProvider ) {
+		if ( hasWindowActivity === false ) {
+			return (
+				<EmptyMetricSection
+					title={ BROADSTREET_TITLE }
+					caption={ BROADSTREET_CAPTION }
+					state="no_opportunity"
+					body={ __(
+						'No ad impressions in this timeframe. Worth expanding the date range or checking your Broadstreet zone setup.',
+						'newspack-plugin'
+					) }
+				/>
+			);
+		}
+		return (
+			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-reach-revenue">
+				<SectionHeading
+					id="newspack-insights-advertising-reach-revenue"
+					title={ BROADSTREET_TITLE }
+					description={ BROADSTREET_CAPTION }
+					actions={ lastUpdated }
+				/>
+				<Grid columns={ 4 } gutter={ 16 } noMargin>
+					<Scorecard
+						label={ __( 'Impressions', 'newspack-plugin' ) }
+						description={ __( 'Total ad impressions served on your site', 'newspack-plugin' ) }
+						current={ current.total_impressions }
+						previous={ previous?.total_impressions }
+					/>
+					<Scorecard
+						label={ __( 'Impressions per session', 'newspack-plugin' ) }
+						description={ __( 'Avg ad impressions a reader sees each session', 'newspack-plugin' ) }
+						current={ current.avg_impressions_per_session }
+						previous={ previous?.avg_impressions_per_session }
+					/>
+					<Scorecard
+						label={ __( 'Overall CTR', 'newspack-plugin' ) }
+						description={ __( 'Clicks per impression across all ads', 'newspack-plugin' ) }
+						current={ current.overall_ctr }
+						previous={ previous?.overall_ctr }
+					/>
+					<Scorecard
+						label={ __( 'Mobile share', 'newspack-plugin' ) }
+						description={ __( 'Share of impressions served to mobile', 'newspack-plugin' ) }
+						current={ current.mobile_share }
+						previous={ previous?.mobile_share }
+					/>
+				</Grid>
+			</Section>
+		);
+	}
+
 	// Whole-section empty: the report resolved with no ad activity. Collapse the
 	// grid to a single callout. Strict `=== false` so the absent-while-loading /
 	// absent-on-error cases fall through to the normal render.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { InsightsWindow } from '../../../api/advertising';
+import type { AdvertisingProvider, InsightsWindow } from '../../../api/advertising';
 import MetricTable from '../../components/MetricTable';
 import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
@@ -26,23 +26,29 @@ import TabSections from '../../components/TabSections';
 export interface SectionProps {
 	current: InsightsWindow;
 	previous: InsightsWindow | null;
+	/** Ad server backing the tab. Broadstreet is impressions-only (NPPD-2045). */
+	activeProvider?: AdvertisingProvider | null;
 }
 
-const TopPerformersSection = ( { current }: SectionProps ) => (
+// Broadstreet variant (NPPD-2045): Top zones + Top advertisers + Top campaigns,
+// impressions-side only (impressions, clicks, CTR — no revenue). Order mirrors GAM
+// (ad units → advertisers → campaigns): a Broadstreet zone is the ad-unit analog, so
+// it leads. Broadstreet has no ad-unit concept, so that GAM table is absent; its
+// `campaign` group, unlike GAM's direct-sold orders, is a first-class named dimension.
+const BroadstreetTopPerformers = ( { current }: SectionProps ) => (
 	<TabSections>
-		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
-			<SectionHeading id="newspack-insights-advertising-top-ad-units" title={ __( 'Top ad units', 'newspack-plugin' ) } />
+		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-zones">
+			<SectionHeading id="newspack-insights-advertising-top-zones" title={ __( 'Top zones', 'newspack-plugin' ) } />
 			<MetricTable
-				payload={ current.top_ad_units }
-				emptyMessage={ __( 'No ad unit data in this timeframe.', 'newspack-plugin' ) }
+				payload={ current.top_zones }
+				emptyMessage={ __( 'No zone data in this timeframe.', 'newspack-plugin' ) }
 				expandable
 				defaultRowLimit={ 5 }
 				columns={ [
-					{ key: 'ad_unit', label: __( 'Ad unit', 'newspack-plugin' ) },
+					{ key: 'zone', label: __( 'Zone', 'newspack-plugin' ) },
 					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
 					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
 					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
 		</Section>
@@ -58,14 +64,11 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
 					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
 					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
 			<SectionHeading id="newspack-insights-advertising-top-campaigns" title={ __( 'Top campaigns', 'newspack-plugin' ) } />
-			{ /* Direct-sold orders only — programmatic delivery is order-less and
-			     filtered server-side. */ }
 			<MetricTable
 				payload={ current.top_campaigns }
 				emptyMessage={ __( 'No campaign data in this timeframe.', 'newspack-plugin' ) }
@@ -73,15 +76,74 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 				defaultRowLimit={ 5 }
 				columns={ [
 					{ key: 'campaign', label: __( 'Campaign', 'newspack-plugin' ) },
-					{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
 					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
 					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
 					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
 				] }
 			/>
 		</Section>
 	</TabSections>
 );
+
+const TopPerformersSection = ( { current, previous, activeProvider }: SectionProps ) => {
+	if ( 'broadstreet' === activeProvider ) {
+		return <BroadstreetTopPerformers current={ current } previous={ previous } />;
+	}
+	return (
+		<TabSections>
+			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
+				<SectionHeading id="newspack-insights-advertising-top-ad-units" title={ __( 'Top ad units', 'newspack-plugin' ) } />
+				<MetricTable
+					payload={ current.top_ad_units }
+					emptyMessage={ __( 'No ad unit data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'ad_unit', label: __( 'Ad unit', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Section>
+			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-advertisers">
+				<SectionHeading id="newspack-insights-advertising-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
+				<MetricTable
+					payload={ current.top_advertisers }
+					emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Section>
+			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
+				<SectionHeading id="newspack-insights-advertising-top-campaigns" title={ __( 'Top campaigns', 'newspack-plugin' ) } />
+				{ /* Direct-sold orders only — programmatic delivery is order-less and
+			     filtered server-side. */ }
+				<MetricTable
+					payload={ current.top_campaigns }
+					emptyMessage={ __( 'No campaign data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'campaign', label: __( 'Campaign', 'newspack-plugin' ) },
+						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Section>
+		</TabSections>
+	);
+};
 
 export default TopPerformersSection;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/sections.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/sections.test.tsx
@@ -224,3 +224,93 @@ describe( 'Advertising sections', () => {
 		expect( screen.getByText( '$0.00' ) ).toBeInTheDocument();
 	} );
 } );
+
+describe( 'Advertising Broadstreet variant (NPPD-2045)', () => {
+	const broadstreetMetrics: InsightsWindow = {
+		total_impressions: { value: 2400000, computable: true, type: 'count' },
+		avg_impressions_per_session: { value: 3, computable: true, type: 'count' },
+		// Overall CTR + mobile share are rate cards derived from the single network call.
+		overall_ctr: { value: 0.0018, computable: true, type: 'rate', numerator: 4320, denominator: 2400000 },
+		mobile_share: { value: 0.63, computable: true, type: 'rate', numerator: 1512000, denominator: 2400000 },
+		top_advertisers: {
+			type: 'table',
+			computable: true,
+			rows: [ { advertiser: 'Hometown Hardware', impressions: 120000, clicks: 480, ctr: 0.004 } ],
+		},
+		top_zones: {
+			type: 'table',
+			computable: true,
+			rows: [
+				{ zone: 'Homepage Leaderboard', impressions: 90000, clicks: 360, ctr: 0.004 },
+				{ zone: 'Article Sidebar', impressions: 40000, clicks: 0, ctr: null },
+			],
+		},
+		top_campaigns: {
+			type: 'table',
+			computable: true,
+			rows: [
+				{ campaign: 'Riverside Credit Union — Summer', impressions: 70000, clicks: 280, ctr: 0.004 },
+				{ campaign: 'Bluebird Books — Summer Reading', impressions: 20000, clicks: 0, ctr: null },
+			],
+		},
+	};
+
+	it( 'ReachRevenueSection renders the four Reach cards — impressions, per session, CTR, mobile share — and no revenue/RPM/eCPM', () => {
+		render( <ReachRevenueSection current={ broadstreetMetrics } previous={ null } hasWindowActivity activeProvider="broadstreet" /> );
+
+		expect( screen.getByText( 'Impressions' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Impressions per session' ) ).toBeInTheDocument();
+		expect( screen.getByText( '3' ) ).toBeInTheDocument();
+		// The two new rate cards render as percents.
+		expect( screen.getByText( 'Overall CTR' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Mobile share' ) ).toBeInTheDocument();
+		expect( screen.getByText( '63%' ) ).toBeInTheDocument();
+
+		// Revenue-derived cards are omitted entirely (Broadstreet has no revenue).
+		expect( screen.queryByText( 'Revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'RPM' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Average eCPM' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Viewability Rate' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'Overall CTR and Mobile share em-dash (never 0%) when there are no impressions', () => {
+		const noImpressions: InsightsWindow = {
+			...broadstreetMetrics,
+			overall_ctr: { value: 0, computable: false, type: 'rate', numerator: 0, denominator: 0 },
+			mobile_share: { value: 0, computable: false, type: 'rate', numerator: 0, denominator: 0 },
+		};
+		render( <ReachRevenueSection current={ noImpressions } previous={ null } hasWindowActivity activeProvider="broadstreet" /> );
+		expect( screen.getByText( 'Overall CTR' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Mobile share' ) ).toBeInTheDocument();
+		// Non-computable rate → em-dash, never a misleading 0%.
+		expect( screen.queryByText( '0%' ) ).not.toBeInTheDocument();
+		expect( screen.getAllByText( '—' ).length ).toBeGreaterThanOrEqual( 2 );
+	} );
+
+	it( 'ReachRevenueSection collapses to no_opportunity when Broadstreet has no impressions', () => {
+		const { container } = render(
+			<ReachRevenueSection current={ broadstreetMetrics } previous={ null } hasWindowActivity={ false } activeProvider="broadstreet" />
+		);
+		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Impressions per session' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'TopPerformersSection renders Top advertisers + Top zones + Top campaigns, no revenue column or GAM ad-units table', () => {
+		render( <TopPerformersSection current={ broadstreetMetrics } previous={ null } activeProvider="broadstreet" /> );
+
+		expect( screen.getByText( 'Top advertisers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Hometown Hardware' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top zones' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Homepage Leaderboard' ) ).toBeInTheDocument();
+		// Top campaigns is a first-class Broadstreet table (impressions/clicks/CTR, no revenue).
+		expect( screen.getByText( 'Top campaigns' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Riverside Credit Union — Summer' ) ).toBeInTheDocument();
+		// Null CTR (no impressions basis) renders an em-dash, never 0%.
+		expect( screen.getAllByText( '—' ).length ).toBeGreaterThanOrEqual( 1 );
+
+		// No revenue column, and the GAM-only ad-units table is absent.
+		expect( screen.queryByText( 'Revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top ad units' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
+++ b/plugins/newspack-plugin/tests/unit-tests/insights-advertising-metric.php
@@ -32,6 +32,31 @@ class Insights_Advertising_Test_Metric extends Advertising_Metric {
 	public static $next_site_key_id = 42;
 
 	/**
+	 * Canned Broadstreet rollup rows keyed by group (NPPD-2045), so the
+	 * network/advertiser/zone reports each get their own injected rows.
+	 *
+	 * @var array<string,array>
+	 */
+	public static $next_broadstreet = [];
+
+	/**
+	 * Force Broadstreet to read as the active ad server (NPPD-2045), without
+	 * stubbing the optional Broadstreet plugin.
+	 *
+	 * @var bool
+	 */
+	public static $broadstreet_active = false;
+
+	/**
+	 * Override the Broadstreet active-server detection with the injected flag.
+	 *
+	 * @return bool
+	 */
+	protected static function is_broadstreet_active(): bool {
+		return static::$broadstreet_active;
+	}
+
+	/**
 	 * Override the GAM-touching seam with the injected result.
 	 *
 	 * @param Report_Query $query The query (ignored).
@@ -48,6 +73,20 @@ class Insights_Advertising_Test_Metric extends Advertising_Metric {
 	 */
 	protected static function resolve_site_key_id(): ?int {
 		return static::$next_site_key_id;
+	}
+
+	/**
+	 * Override the Broadstreet HTTP seam with canned rows for the given group
+	 * (NPPD-2045) — no network is touched.
+	 *
+	 * @param string   $group  Grouping dimension.
+	 * @param string[] $select Selected fields (ignored).
+	 * @param string   $s      Start date (ignored).
+	 * @param string   $e      End date (ignored).
+	 * @return array
+	 */
+	protected static function run_broadstreet_report( string $group, array $select, string $s, string $e ): array {
+		return static::$next_broadstreet[ $group ] ?? [];
 	}
 }
 
@@ -77,6 +116,8 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 	public function tear_down() {
 		Insights_Advertising_Test_Metric::$next_report      = [ 'rows' => [] ];
 		Insights_Advertising_Test_Metric::$next_site_key_id = 42;
+		Insights_Advertising_Test_Metric::$next_broadstreet   = [];
+		Insights_Advertising_Test_Metric::$broadstreet_active = false;
 		Advertising_Metric::reset_readiness_cache();
 		parent::tear_down();
 	}
@@ -885,5 +926,271 @@ class Newspack_Test_Insights_Advertising_Metric extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'previous', $payload );
 		$this->assertSame( '2026-01-31', $payload['previous']['window']['end'] );
 		$this->assertNotSame( $payload['current']['window']['start'], $payload['previous']['window']['start'] );
+	}
+
+	/*
+	 * Provider detection + Broadstreet reporting (NPPD-2045).
+	 */
+
+	/**
+	 * With no ad server configured (clean test env: GAM inactive, Broadstreet
+	 * inactive), there's no active provider and the tab stays hidden.
+	 */
+	public function test_no_provider_hides_tab() {
+		$this->assertNull( Insights_Advertising_Test_Metric::active_provider() );
+		$this->assertFalse( Insights_Advertising_Test_Metric::is_tab_visible() );
+		$this->assertFalse( Insights_Advertising_Test_Metric::is_report_ready() );
+	}
+
+	/**
+	 * When Broadstreet is the active provider, it wins tab visibility and is
+	 * immediately report-ready (synchronous rollup — no OAuth/network-code dance).
+	 */
+	public function test_broadstreet_only_is_visible_and_ready() {
+		Insights_Advertising_Test_Metric::$broadstreet_active = true;
+
+		$this->assertSame( 'broadstreet', Insights_Advertising_Test_Metric::active_provider() );
+		$this->assertTrue( Insights_Advertising_Test_Metric::is_tab_visible() );
+		$this->assertTrue( Insights_Advertising_Test_Metric::is_report_ready() );
+	}
+
+	/**
+	 * GAM wins when both providers are active. GAM is inactive in the test env
+	 * (newspack-ads absent), so with Broadstreet forced active the resolved
+	 * provider is Broadstreet; the GAM-precedence leg is exercised via the fixture,
+	 * whose GAM envelope always declares 'gam' — the field the UI branches on.
+	 */
+	public function test_gam_fixture_declares_provider() {
+		$fixture = Advertising_Metric::get_fixture( '2026-06-01', '2026-06-30', false, 'populated', 'gam' );
+		$this->assertSame( 'gam', $fixture['current']['active_provider'] );
+	}
+
+	/**
+	 * The single network rollup yields three scorecards from one call: total
+	 * impressions (sum of `count(view)`), overall CTR (clicks ÷ impressions), and
+	 * mobile share (mobile views ÷ impressions), each carrying its raw counts.
+	 */
+	public function test_broadstreet_network_metrics_derives_three_scorecards() {
+		Insights_Advertising_Test_Metric::$next_broadstreet = [
+			'network' => [
+				[
+					'count(view)'        => 2400000,
+					'count(click)'       => 12000,
+					'count(mobile_view)' => 1512000,
+				],
+			],
+		];
+		$metrics = Insights_Advertising_Test_Metric::broadstreet_network_metrics( '2026-01-01', '2026-01-31' );
+
+		$this->assertSame( 2400000, $metrics['total_impressions']['value'] );
+		$this->assertTrue( $metrics['total_impressions']['computable'] );
+		$this->assertSame( 'count', $metrics['total_impressions']['type'] );
+
+		// Overall CTR = clicks / impressions, carrying numerator/denominator.
+		$this->assertSame( 'rate', $metrics['overall_ctr']['type'] );
+		$this->assertTrue( $metrics['overall_ctr']['computable'] );
+		$this->assertSame( 12000 / 2400000, $metrics['overall_ctr']['value'] );
+		$this->assertSame( 12000, $metrics['overall_ctr']['numerator'] );
+		$this->assertSame( 2400000, $metrics['overall_ctr']['denominator'] );
+
+		// Mobile share = mobile views / impressions.
+		$this->assertSame( 'rate', $metrics['mobile_share']['type'] );
+		$this->assertSame( 1512000 / 2400000, $metrics['mobile_share']['value'] );
+		$this->assertSame( 1512000, $metrics['mobile_share']['numerator'] );
+	}
+
+	/**
+	 * Overall CTR / mobile share are NOT computable (→ em-dash, never a fake 0%)
+	 * when the window served no impressions to divide by.
+	 */
+	public function test_broadstreet_rates_not_computable_on_zero_impressions() {
+		Insights_Advertising_Test_Metric::$next_broadstreet = [
+			'network' => [
+				[
+					'count(view)'        => 0,
+					'count(click)'       => 0,
+					'count(mobile_view)' => 0,
+				],
+			],
+		];
+		$metrics = Insights_Advertising_Test_Metric::broadstreet_network_metrics( '2026-01-01', '2026-01-31' );
+		$this->assertFalse( $metrics['overall_ctr']['computable'] );
+		$this->assertFalse( $metrics['mobile_share']['computable'] );
+	}
+
+	/**
+	 * Broadstreet top advertisers shape rows with impressions/clicks/CTR (null CTR
+	 * on zero views), rank by impressions desc, and carry NO revenue.
+	 */
+	public function test_broadstreet_top_advertisers_shape_and_ctr() {
+		Insights_Advertising_Test_Metric::$next_broadstreet = [
+			'advertiser' => [
+				[
+					'advertiser.name' => 'Hometown Hardware',
+					'count(view)'     => 1000,
+					'count(click)'    => 4,
+				],
+				[
+					'advertiser.name' => 'Riverside Credit Union',
+					'count(view)'     => 5000,
+					'count(click)'    => 25,
+				],
+				[
+					'advertiser.name' => 'No Delivery Inc',
+					'count(view)'     => 0,
+					'count(click)'    => 0,
+				],
+			],
+		];
+		$payload = Insights_Advertising_Test_Metric::broadstreet_top_advertisers( '2026-01-01', '2026-01-31' );
+
+		$this->assertSame( 'table', $payload['type'] );
+		// Ranked by impressions desc: Riverside (5000) first.
+		$this->assertSame( 'Riverside Credit Union', $payload['rows'][0]['advertiser'] );
+		$this->assertSame( 5000, $payload['rows'][0]['impressions'] );
+		$this->assertSame( 25, $payload['rows'][0]['clicks'] );
+		$this->assertSame( 0.005, $payload['rows'][0]['ctr'] );
+
+		$by_name = array_column( $payload['rows'], null, 'advertiser' );
+		$this->assertSame( 0.004, $by_name['Hometown Hardware']['ctr'] );
+		// CTR is null — never 0% — when the advertiser served no impressions.
+		$this->assertNull( $by_name['No Delivery Inc']['ctr'] );
+
+		// No revenue anywhere in the Broadstreet API.
+		foreach ( $payload['rows'] as $row ) {
+			$this->assertArrayNotHasKey( 'revenue', $row );
+		}
+	}
+
+	/**
+	 * Broadstreet top zones shape rows with impressions/clicks/CTR and rank by
+	 * impressions.
+	 */
+	public function test_broadstreet_top_zones_shape() {
+		Insights_Advertising_Test_Metric::$next_broadstreet = [
+			'zone' => [
+				[
+					'zone.name'    => 'Article Sidebar',
+					'count(view)'  => 200,
+					'count(click)' => 1,
+				],
+				[
+					'zone.name'    => 'Homepage Leaderboard',
+					'count(view)'  => 900,
+					'count(click)' => 9,
+				],
+			],
+		];
+		$payload = Insights_Advertising_Test_Metric::broadstreet_top_zones( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 'Homepage Leaderboard', $payload['rows'][0]['zone'] );
+		$this->assertSame( 900, $payload['rows'][0]['impressions'] );
+		$this->assertSame( 0.01, $payload['rows'][0]['ctr'] );
+	}
+
+	/**
+	 * A degraded (empty) Broadstreet rollup yields zero impressions, computably —
+	 * the graceful-degrade contract (an outage reads as no activity, not an error) —
+	 * while the derived rates stay non-computable rather than reading as 0%.
+	 */
+	public function test_broadstreet_network_metrics_degrades_to_zero() {
+		Insights_Advertising_Test_Metric::$next_broadstreet = [ 'network' => [] ];
+		$metrics = Insights_Advertising_Test_Metric::broadstreet_network_metrics( '2026-01-01', '2026-01-31' );
+		$this->assertSame( 0, $metrics['total_impressions']['value'] );
+		$this->assertTrue( $metrics['total_impressions']['computable'] );
+		$this->assertFalse( $metrics['overall_ctr']['computable'] );
+		$this->assertFalse( $metrics['mobile_share']['computable'] );
+	}
+
+	/**
+	 * Broadstreet top campaigns shape rows with impressions/clicks/CTR (null CTR on
+	 * zero views), rank by impressions desc, and carry NO revenue.
+	 */
+	public function test_broadstreet_top_campaigns_shape_and_ctr() {
+		Insights_Advertising_Test_Metric::$next_broadstreet = [
+			'campaign' => [
+				[
+					'campaign.name' => 'Hometown Hardware — Spring Flight',
+					'count(view)'   => 1000,
+					'count(click)'  => 4,
+				],
+				[
+					'campaign.name' => 'Riverside Credit Union — Summer',
+					'count(view)'   => 5000,
+					'count(click)'  => 25,
+				],
+				[
+					'campaign.name' => 'Bluebird Books — Summer Reading',
+					'count(view)'   => 0,
+					'count(click)'  => 0,
+				],
+			],
+		];
+		$payload = Insights_Advertising_Test_Metric::broadstreet_top_campaigns( '2026-01-01', '2026-01-31' );
+
+		$this->assertSame( 'table', $payload['type'] );
+		// Ranked by impressions desc: Riverside (5000) first.
+		$this->assertSame( 'Riverside Credit Union — Summer', $payload['rows'][0]['campaign'] );
+		$this->assertSame( 5000, $payload['rows'][0]['impressions'] );
+		$this->assertSame( 25, $payload['rows'][0]['clicks'] );
+		$this->assertSame( 0.005, $payload['rows'][0]['ctr'] );
+
+		$by_name = array_column( $payload['rows'], null, 'campaign' );
+		$this->assertSame( 0.004, $by_name['Hometown Hardware — Spring Flight']['ctr'] );
+		// CTR is null — never 0% — when the campaign served no impressions.
+		$this->assertNull( $by_name['Bluebird Books — Summer Reading']['ctr'] );
+
+		// No revenue anywhere in the Broadstreet API.
+		foreach ( $payload['rows'] as $row ) {
+			$this->assertArrayNotHasKey( 'revenue', $row );
+		}
+	}
+
+	/**
+	 * The Broadstreet fixture envelope is impressions-only: it declares the
+	 * provider, carries total impressions + a computable impressions-per-session +
+	 * top advertisers/zones, and omits every revenue-derived metric.
+	 */
+	public function test_broadstreet_fixture_is_impressions_only() {
+		$fixture = Advertising_Metric::get_fixture( '2026-06-01', '2026-06-30', false, 'populated', 'broadstreet' );
+		$current = $fixture['current'];
+		$metrics = $current['metrics'];
+
+		$this->assertSame( 'broadstreet', $current['active_provider'] );
+		$this->assertTrue( $current['is_report_ready'] );
+
+		$this->assertArrayHasKey( 'total_impressions', $metrics );
+		$this->assertTrue( $metrics['total_impressions']['computable'] );
+		$this->assertArrayHasKey( 'avg_impressions_per_session', $metrics );
+		$this->assertTrue( $metrics['avg_impressions_per_session']['computable'] );
+		$this->assertSame( 'count', $metrics['avg_impressions_per_session']['type'] );
+		// Overall CTR + mobile share are computable rate scorecards (NPPD-2045 add 1).
+		$this->assertArrayHasKey( 'overall_ctr', $metrics );
+		$this->assertSame( 'rate', $metrics['overall_ctr']['type'] );
+		$this->assertTrue( $metrics['overall_ctr']['computable'] );
+		$this->assertArrayHasKey( 'mobile_share', $metrics );
+		$this->assertSame( 'rate', $metrics['mobile_share']['type'] );
+		$this->assertTrue( $metrics['mobile_share']['computable'] );
+		$this->assertArrayHasKey( 'top_advertisers', $metrics );
+		$this->assertArrayHasKey( 'top_zones', $metrics );
+		// Top campaigns is a first-class Broadstreet table (NPPD-2045 add 2).
+		$this->assertArrayHasKey( 'top_campaigns', $metrics );
+		$this->assertTrue( $metrics['top_campaigns']['computable'] );
+
+		// No revenue in the Broadstreet API → none of these render.
+		foreach ( [ 'total_revenue', 'rpm', 'avg_ecpm', 'fill_rate', 'viewability_rate', 'direct_vs_programmatic', 'by_channel', 'by_device', 'top_ad_units', 'revenue_by_day' ] as $absent ) {
+			$this->assertArrayNotHasKey( $absent, $metrics, "$absent must be absent on the Broadstreet variant" );
+		}
+	}
+
+	/**
+	 * The Broadstreet comparison window holds sessions flat, so impressions per
+	 * session differs between windows and the delta renders.
+	 */
+	public function test_broadstreet_fixture_comparison_has_impressions_delta() {
+		$fixture = Advertising_Metric::get_fixture( '2026-06-01', '2026-06-30', true, 'populated', 'broadstreet' );
+		$this->assertNotNull( $fixture['previous'] );
+		$current = $fixture['current']['metrics']['avg_impressions_per_session']['value'];
+		$prior   = $fixture['previous']['metrics']['avg_impressions_per_session']['value'];
+		$this->assertGreaterThan( $prior, $current );
 	}
 }


### PR DESCRIPTION
## Summary

Brings Insights Tab 8 (Advertising) to Broadstreet publishers — currently GAM-only, so the tab is invisible for the ~10 sites on Broadstreet. Adds a live Broadstreet reporting client and a provider abstraction so Tab 8 renders an impressions-side variant for Broadstreet while the GAM path is untouched.

Ticket: NPPD-2045. Unblocked by the NPPD-1665 correction: the Broadstreet **v1** API (`/api/1/records?type=custom`) has a network-wide rollup — one call returns impressions/clicks aggregated over a date range, groupable by advertiser/zone/campaign. The earlier "~7k fan-out, not feasible" conclusion was a `/api/0` artifact; the v1 rollup is live-verified against a real network.

## What's built

- **`Newspack\Insights\Broadstreet\Client`** (`includes/wizards/insights/broadstreet/class-client.php`) — thin `wp_remote_get` wrapper over `/api/1/records?type=custom` (auth = `access_token`, creds from the Broadstreet plugin, guarded). `request()` seam; degrades to `[]` on WP_Error/non-200/bad JSON.
- **Provider abstraction in `Advertising_Metric`** — `active_provider(): 'gam'|'broadstreet'|null` (GAM wins if both active), `is_tab_visible()` = provider ≠ null, envelope carries `active_provider`. Broadstreet compute is **synchronous** (the rollup is cheap — no Action Scheduler), transient-cached, `is_report_ready` true when active. Metrics from a single `group=network` call plus two grouped calls:
  - `total_impressions`, `overall_ctr`, `mobile_share` — one `group=network` call selecting `count(view),count(click),count(mobile_view)`.
  - `avg_impressions_per_session` — via the existing provider-agnostic `Cross_System_Metrics` (÷ GA4 sessions).
  - `top_advertisers` / `top_zones` / `top_campaigns` — `group=advertiser|zone|campaign`.
- **No revenue / RPM / eCPM** — the Broadstreet v1 API has zero revenue fields (verified across the spec). Those cards/sections are GAM-only.
- **Frontend** — `AdvertisingTab` forks on `active_provider`. Broadstreet renders: a **Reach** section (Impressions, Impressions per session, Overall CTR, Mobile share — rates render em-dash, never a fake 0%) and three full-width tables in GAM-parallel order (**Top zones → Top advertisers → Top campaigns**). Hides the GAM-only sections (revenue/eCPM/fill/viewability scorecards, revenue trend, channel pie, device table, per-site, ad units, data-lag).
- **Fixture** — `_fixture_provider=broadstreet` variant (obviously-fake names).

### Metric-selection notes (grounded in live data from a real network)
- **Mobile share** is surfaced as a single stat, not a device table: the API exposes only `mobile_view` (a mobile-vs-total split) — no `desktop_view`/`tablet_view`/`mobile_click`, so a device *table* would over-promise granularity GAM has and Broadstreet doesn't.
- **Conversions** (`count(conversion)`) omitted — zero on the tested network; revisit gated on non-zero data.
- **Daily trend** omitted — no date dimension on the rollup (it groups by entity), so a trend would cost ~1 call/day rather than being free; deferred.

## Test plan
- PHPUnit `--group insights,insights_advertising`: **882 tests** green (new Broadstreet coverage: provider precedence, network-metrics bundle incl. non-computable rates on zero impressions, degrade-to-empty, advertiser/zone/campaign shaping with null-CTR-on-zero-views, no-revenue envelope, ready-when-active).
- Jest full suite: **840** green (Broadstreet ReachRevenue 4-card + em-dash-on-zero, TopPerformers three tables, tab-level provider fork).
- Root `phpcs.xml` clean; eslint clean; tsc clean on touched files.
- Verified live in fixture mode (`?_fixture_provider=broadstreet`) and confirmed the GAM default is unchanged; zero console errors.