### PR TITLE
fix(content-gate): keep institutional-access check URL host-relative

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
@@ -439,8 +439,13 @@ class IP_Access_Rule {
 	 * Get the URL to redirect to from the dedicated endpoint.
 	 *
 	 * Checks redirect_to param, then Referer header, then falls back to homepage.
+	 * Returned host-relative (see get_check_url()) so the loading page's
+	 * client-side redirect resolves against the document (proxy) origin. Under a
+	 * rewriting proxy (e.g. a library EZproxy) an absolute URL would send the
+	 * just-verified reader back to the canonical host — off the proxy, without
+	 * the proxied IP — and re-lock the content. See NPPD-2039.
 	 *
-	 * @return string The redirect URL.
+	 * @return string Host-relative redirect URL (path and query, without scheme or host).
 	 */
 	private static function get_dedicated_redirect_url() {
 		$home = home_url( '/' );
@@ -448,16 +453,16 @@ class IP_Access_Rule {
 		if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
 			$url = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
 			if ( wp_validate_redirect( $url, $home ) !== $home || $url === $home ) {
-				return $url;
+				return wp_make_link_relative( $url );
 			}
 		}
 
 		$referer = wp_get_referer();
 		if ( $referer && wp_validate_redirect( $referer, $home ) !== $home ) {
-			return $referer;
+			return wp_make_link_relative( $referer );
 		}
 
-		return $home;
+		return wp_make_link_relative( $home );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
@@ -461,6 +461,29 @@ class IP_Access_Rule {
 	}
 
 	/**
+	 * Build the host-relative URL for the institutional-access check endpoint.
+	 *
+	 * The loading page's fetch must resolve against the document origin rather
+	 * than an absolute canonical host. When the page is served through a
+	 * rewriting reverse proxy (e.g. a library EZproxy), that origin is the
+	 * proxy host, so a host-relative URL stays proxied and the origin sees the
+	 * proxy's whitelisted IP. An absolute URL is left unrewritten inside the
+	 * inline script, so the browser fetches it directly from the reader's real
+	 * IP — bypassing the proxy and defeating institutional IP access. See NPPD-2039.
+	 *
+	 * @param int|null $institution_id Optional. Institution post ID to scope the check.
+	 *
+	 * @return string Host-relative REST URL (path and query, without scheme or host).
+	 */
+	private static function get_check_url( $institution_id = null ) {
+		$url = rest_url( NEWSPACK_API_NAMESPACE . self::REST_ROUTE );
+		if ( $institution_id ) {
+			$url = add_query_arg( 'institution_id', $institution_id, $url );
+		}
+		return wp_make_link_relative( $url );
+	}
+
+	/**
 	 * Render the loading page for access verification.
 	 *
 	 * Outputs a standalone HTML page with a loading spinner that performs
@@ -473,10 +496,7 @@ class IP_Access_Rule {
 	 */
 	public static function render_loading_page( $institution_id = null ) {
 		$redirect_url = self::get_dedicated_redirect_url();
-		$rest_url     = rest_url( NEWSPACK_API_NAMESPACE . self::REST_ROUTE );
-		if ( $institution_id ) {
-			$rest_url = add_query_arg( 'institution_id', $institution_id, $rest_url );
-		}
+		$rest_url     = self::get_check_url( $institution_id );
 		$result_param = self::RESULT_PARAM;
 		$site_name    = get_bloginfo( 'name' );
 		$timeout_ms   = 10000;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -720,4 +720,38 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 
 		remove_all_filters( 'newspack_content_gate_ip_allowlist' );
 	}
+
+	/**
+	 * Test the loading-page check URL is host-relative.
+	 *
+	 * The dedicated endpoint's loading page verifies via a client-side fetch.
+	 * Under a rewriting reverse proxy (e.g. a library EZproxy) an absolute URL
+	 * is left unrewritten inside the inline script, so the fetch goes direct
+	 * from the reader's real IP and bypasses the proxy. A host-relative URL
+	 * resolves against the document origin (the proxy host) and stays proxied,
+	 * so the origin sees the proxy's whitelisted IP. See NPPD-2039.
+	 */
+	public function test_check_url_is_host_relative() {
+		$method = new ReflectionMethod( IP_Access_Rule::class, 'get_check_url' );
+		$method->setAccessible( true );
+
+		$url = $method->invoke( null, null );
+
+		$this->assertStringStartsWith( '/', $url, 'Check URL should be host-relative.' );
+		$this->assertStringNotContainsString( '://', $url, 'Check URL should not contain a scheme or host.' );
+		$this->assertStringContainsString( 'institutional-access/check', $url );
+	}
+
+	/**
+	 * Test the check URL carries the institution scope and stays host-relative.
+	 */
+	public function test_check_url_includes_institution_id() {
+		$method = new ReflectionMethod( IP_Access_Rule::class, 'get_check_url' );
+		$method->setAccessible( true );
+
+		$url = $method->invoke( null, 4242 );
+
+		$this->assertStringNotContainsString( '://', $url, 'Check URL should not contain a scheme or host.' );
+		$this->assertStringContainsString( 'institution_id=4242', $url );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -186,7 +186,7 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$method->setAccessible( true );
 		$url = $method->invoke( null );
 
-		$this->assertSame( home_url( '/target-page/' ), $url );
+		$this->assertSame( '/target-page/', $url );
 
 		$_GET = [];
 	}
@@ -201,7 +201,7 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$method->setAccessible( true );
 		$url = $method->invoke( null );
 
-		$this->assertSame( home_url( '/' ), $url );
+		$this->assertSame( '/', $url );
 
 		$_GET = [];
 	}
@@ -216,7 +216,7 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$method->setAccessible( true );
 		$url = $method->invoke( null );
 
-		$this->assertSame( home_url( '/' ), $url );
+		$this->assertSame( '/', $url );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Institutional readers reaching a site through a library off-campus proxy (e.g. EZproxy) were rejected at the institutional-access page with "We couldn't verify your location," even though the proxy's IP is whitelisted.

The dedicated `/institutional-access/<slug>/` loading page verifies access with a client-side `fetch()` to the check REST endpoint, and that URL was emitted as an absolute canonical URL. A rewriting reverse proxy like EZproxy leaves the (slash-escaped, JS-embedded) absolute URL unrewritten, so the browser sends the check request **directly to the canonical host, bypassing the proxy** — and the origin then sees the reader's real off-campus IP instead of the whitelisted proxy IP.

This emits the check URL **host-relative** so it resolves against the document origin. When the page is served through the proxy, the fetch stays on the proxy host and is proxied, so the origin sees the proxy's whitelisted IP and access is granted. Direct (on-campus / no-proxy) visitors are unaffected — the relative URL still resolves to the canonical host.

No REST endpoints change; the server-to-server `POST` check used by mobile apps (Pugpig Bolt, NPPD-1395) is untouched.

Closes NPPD-2039.

### How to test the changes in this Pull Request:

1. Load `/institutional-access/` (or `/institutional-access/<institution-slug>/`) directly. View source and confirm the inline `fetch(...)` URL is now **host-relative** — `"/wp-json/newspack/v1/institutional-access/check"` — not an absolute `https://<host>/wp-json/...` URL.
2. Confirm normal (non-proxy) verification still works: with an Institution (Audience → Access Control) whitelisting your IP, the page grants access and sets the `wp_nocache_ip` cookie.
3. Put a reverse proxy in front of the site under a **different host** (simulating EZproxy) and load the institutional-access page through it. In the browser Network panel, confirm the `/wp-json/newspack/v1/institutional-access/check` request goes to the **proxy** host (not the canonical host).
4. With the proxy's egress IP whitelisted on an Institution, confirm the proxied check returns `{"valid":true,...}` and sets `wp_nocache_ip` — i.e. the reader is granted access through the proxy.
5. Confirm the server-to-server `POST /wp-json/newspack/v1/institutional-access/check` (body `{"ip":"..."}`) still returns `show_paywall` as before (unchanged).
6. Run the PHPUnit `Access_Rules` group — `test_check_url_is_host_relative` and `test_check_url_includes_institution_id` pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
