### PR TITLE
feat(insights): frame dataviews in cards and refine chart styling

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/style.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/style.scss
@@ -355,6 +355,21 @@
 		text-align: right;
 	}
 
+	// Core pulls the first column's header button left by 8px so its label sits
+	// flush to the cell edge, but ships no mirror for the last column — so a
+	// right-aligned (numeric) last header lands 8px shy of the edge, out of line
+	// with the values below it. Add the missing margin.
+	.dataviews-view-table tr th:last-child .dataviews-view-table-header-button,
+	.dataviews-view-table tr td:last-child .dataviews-view-table-header-button {
+		margin-right: -#{wp-vars.$grid-unit};
+	}
+
+	// The card (or wizard surface) supplies the background; keep the DataViews
+	// header cells transparent so it shows through instead of an opaque fill.
+	.dataviews-view-table thead th {
+		background: transparent;
+	}
+
 	// The `tbody` mirrors DataViews' own
 	// `.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper`
 	// nowrap rule so this out-specifies it and long values wrap in place
@@ -416,15 +431,35 @@
 	}
 }
 
-// When a dataview is the last thing in a card, drop the card body's bottom
-// padding so the table's final row sits flush at the card's bottom edge, and
-// clip the full-bleed table to the card's rounded corners.
-.newspack-insights__chart-card:has( .newspack-insights-dataview:last-child ) {
+// When a dataview is the last thing directly in a card body (a table-only card),
+// drop the body's bottom padding so the table's final row sits flush at the
+// card's bottom edge, and clip the full-bleed table to the rounded corners. The
+// direct-child guard keeps this off cards where the table is nested below a
+// title/caption (e.g. "Top articles that don't convert").
+.newspack-insights__chart-card:has( .newspack-card--core__body > .newspack-insights-dataview:last-child ) {
 	overflow: hidden;
 
 	.newspack-card--core__body {
 		padding-bottom: 0;
 	}
+}
+
+// Mirror of the above for a dataview that is the first thing directly in the
+// card body: drop the body's top padding so the header row sits flush at the
+// card's top edge, and clip to the rounded corners.
+.newspack-insights__chart-card:has( .newspack-card--core__body > .newspack-insights-dataview:first-child ) {
+	overflow: hidden;
+
+	.newspack-card--core__body {
+		padding-top: wp-vars.$grid-unit-20;
+	}
+}
+
+// A dataview that follows a title (i.e. not the card body's first child)
+// needs the 24px separation the removed body wrapper used to supply. The
+// dataview base rule locks `margin: 0 !important`, so this overrides in kind.
+.newspack-insights__chart-card .newspack-card--core__body > .newspack-insights-dataview:not(:first-child) {
+	margin-top: wp-vars.$grid-unit-20 !important;
 }
 
 // Opt-in sticky first column (Performance by prompt): a many-column table that

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-3 newspack-grid__gutter-16"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-4 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -230,7 +230,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-3 newspack-grid__gutter-16"
+          class="newspack-grid newspack-grid--no-margin newspack-grid__columns-4 newspack-grid__gutter-16"
         >
           <div
             class="components-surface components-card newspack-card--core newspack-insights__metric-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
@@ -1134,22 +1134,66 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           class="newspack-insights__prompts-convert-grid"
         >
           <div
-            class="newspack-insights__prompts-convert-col"
+            class="components-surface components-card newspack-card--core newspack-insights__chart-card newspack-insights__prompts-convert-col newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
-            <p
-              class="newspack-insights__section-empty"
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
             >
-              No funnel data yet. The funnel will populate once readers begin moving through your prompts.
-            </p>
+              <div
+                class="newspack-card--core__body"
+              >
+                <p
+                  class="newspack-insights__section-empty"
+                >
+                  No funnel data yet. The funnel will populate once readers begin moving through your prompts.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
           <div
-            class="newspack-insights__prompts-convert-col"
+            class="components-surface components-card newspack-card--core newspack-insights__chart-card newspack-insights__prompts-convert-col newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
-            <p
-              class="newspack-insights__section-empty"
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
             >
-              No distribution data yet. This will populate once readers begin converting.
-            </p>
+              <div
+                class="newspack-card--core__body"
+              >
+                <p
+                  class="newspack-insights__section-empty"
+                >
+                  No distribution data yet. This will populate once readers begin converting.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
           </div>
         </div>
       </section>
@@ -1183,61 +1227,133 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
           </div>
         </div>
         <div
-          class="newspack-insights__prompts-subsection"
+          class="components-flex components-h-stack components-v-stack css-j05iml-PolymorphicDiv-Flex-base-ItemsColumn e19lxcc00"
+          data-wp-c16t="true"
+          data-wp-component="VStack"
         >
-          <h3
-            class="newspack-insights__prompts-subsection-heading"
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__chart-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
-            Performance by prompt
-          </h3>
-          <p
-            class="newspack-insights__section-empty"
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <h3
+                  class="newspack-insights__chart-card-title"
+                >
+                  Performance by prompt
+                </h3>
+                <p
+                  class="newspack-insights__section-empty"
+                >
+                  No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.
+                </p>
+                <p
+                  class="newspack-insights__table-footnote"
+                >
+                  Showing the top 10 prompts by the sorted column; use “See more” to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__chart-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
-            No prompt data yet. Performance metrics will appear once readers begin interacting with your prompts.
-          </p>
-          <p
-            class="newspack-insights__prompts-subsection-note"
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <h3
+                  class="newspack-insights__chart-card-title"
+                >
+                  Performance by prompt intent
+                </h3>
+                <p
+                  class="newspack-insights__section-empty"
+                >
+                  No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.
+                </p>
+                <p
+                  class="newspack-insights__table-footnote"
+                >
+                  Answers 'are my donation prompts working better than my registration prompts?' at a glance.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
+          <div
+            class="components-surface components-card newspack-card--core newspack-insights__chart-card newspack-card--core__has-children css-1dj5kxo-PolymorphicDiv-Surface-getBorders-primary-Card-rounded e19lxcc00"
+            data-wp-c16t="true"
+            data-wp-component="Card"
           >
-            Showing the top 10 prompts by the sorted column; use “See more” to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear.
-          </p>
-        </div>
-        <div
-          class="newspack-insights__prompts-subsection"
-        >
-          <h3
-            class="newspack-insights__prompts-subsection-heading"
-          >
-            Performance by prompt intent
-          </h3>
-          <p
-            class="newspack-insights__section-empty"
-          >
-            No prompt data yet. Intent performance will appear once readers begin interacting with your prompts.
-          </p>
-          <p
-            class="newspack-insights__prompts-subsection-note"
-          >
-            Answers 'are my donation prompts working better than my registration prompts?' at a glance.
-          </p>
-        </div>
-        <div
-          class="newspack-insights__prompts-subsection"
-        >
-          <h3
-            class="newspack-insights__prompts-subsection-heading"
-          >
-            Performance by prompt placement
-          </h3>
-          <p
-            class="newspack-insights__section-empty"
-          >
-            No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.
-          </p>
-          <p
-            class="newspack-insights__prompts-subsection-note"
-          >
-            Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.
-          </p>
+            <div
+              class="css-7epkyb-PolymorphicDiv-Content e19lxcc00"
+            >
+              <div
+                class="newspack-card--core__body"
+              >
+                <h3
+                  class="newspack-insights__chart-card-title"
+                >
+                  Performance by prompt placement
+                </h3>
+                <p
+                  class="newspack-insights__section-empty"
+                >
+                  No prompt data yet. Placement performance will appear once readers begin interacting with your prompts.
+                </p>
+                <p
+                  class="newspack-insights__table-footnote"
+                >
+                  Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+            <div
+              aria-hidden="true"
+              class="components-elevation css-d8yggo-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+              data-wp-c16t="true"
+              data-wp-component="Elevation"
+            />
+          </div>
         </div>
       </section>
     </div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
@@ -19,6 +19,7 @@ import type { InsightsWindow } from '../../../api/advertising';
 import MetricTable from '../../components/MetricTable';
 import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
+import { Card } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -32,19 +33,21 @@ const SitePerformanceSection = ( { current }: SectionProps ) => (
 			title={ __( 'Performance by site', 'newspack-plugin' ) }
 			description={ __( 'How each site in your network is performing.', 'newspack-plugin' ) }
 		/>
-		<MetricTable
-			payload={ current.top_sites }
-			emptyMessage={ __( 'No per-site data in this timeframe.', 'newspack-plugin' ) }
-			expandable
-			defaultRowLimit={ 10 }
-			rowLimit={ 25 }
-			columns={ [
-				{ key: 'site', label: __( 'Site', 'newspack-plugin' ) },
-				{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-				{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-				{ key: 'ecpm', label: __( 'eCPM', 'newspack-plugin' ), format: 'currency', align: 'right' },
-			] }
-		/>
+		<Card __experimentalCoreCard className="newspack-insights__chart-card">
+			<MetricTable
+				payload={ current.top_sites }
+				emptyMessage={ __( 'No per-site data in this timeframe.', 'newspack-plugin' ) }
+				expandable
+				defaultRowLimit={ 10 }
+				rowLimit={ 25 }
+				columns={ [
+					{ key: 'site', label: __( 'Site', 'newspack-plugin' ) },
+					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					{ key: 'ecpm', label: __( 'eCPM', 'newspack-plugin' ), format: 'currency', align: 'right' },
+				] }
+			/>
+		</Card>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
@@ -22,6 +22,7 @@ import MetricTable from '../../components/MetricTable';
 import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import TabSections from '../../components/TabSections';
+import { Card } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -32,54 +33,60 @@ const TopPerformersSection = ( { current }: SectionProps ) => (
 	<TabSections>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
 			<SectionHeading id="newspack-insights-advertising-top-ad-units" title={ __( 'Top ad units', 'newspack-plugin' ) } />
-			<MetricTable
-				payload={ current.top_ad_units }
-				emptyMessage={ __( 'No ad unit data in this timeframe.', 'newspack-plugin' ) }
-				expandable
-				defaultRowLimit={ 5 }
-				columns={ [
-					{ key: 'ad_unit', label: __( 'Ad unit', 'newspack-plugin' ) },
-					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-				] }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<MetricTable
+					payload={ current.top_ad_units }
+					emptyMessage={ __( 'No ad unit data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'ad_unit', label: __( 'Ad unit', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-advertisers">
 			<SectionHeading id="newspack-insights-advertising-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
-			<MetricTable
-				payload={ current.top_advertisers }
-				emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
-				expandable
-				defaultRowLimit={ 5 }
-				columns={ [
-					{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
-					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-				] }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<MetricTable
+					payload={ current.top_advertisers }
+					emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
 			<SectionHeading id="newspack-insights-advertising-top-campaigns" title={ __( 'Top campaigns', 'newspack-plugin' ) } />
 			{ /* Direct-sold orders only — programmatic delivery is order-less and
 			     filtered server-side. */ }
-			<MetricTable
-				payload={ current.top_campaigns }
-				emptyMessage={ __( 'No campaign data in this timeframe.', 'newspack-plugin' ) }
-				expandable
-				defaultRowLimit={ 5 }
-				columns={ [
-					{ key: 'campaign', label: __( 'Campaign', 'newspack-plugin' ) },
-					{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
-					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-				] }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<MetricTable
+					payload={ current.top_campaigns }
+					emptyMessage={ __( 'No campaign data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'campaign', label: __( 'Campaign', 'newspack-plugin' ) },
+						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Card>
 		</Section>
 	</TabSections>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
@@ -31,48 +31,42 @@ const ContentPerformanceSection = ( { current }: SectionProps ) => (
 		/>
 		<VStack spacing={ 4 }>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
-				<VStack spacing={ 6 }>
-					<h3 className="newspack-insights__chart-card-title">{ __( 'Top articles', 'newspack-plugin' ) }</h3>
-					<MetricTable
-						payload={ current.top_pages }
-						emptyMessage={ __( 'No article data in this timeframe.', 'newspack-plugin' ) }
-						columns={ [
-							{ key: 'page_title', label: __( 'Article', 'newspack-plugin' ) },
-							{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-							{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
-						] }
-					/>
-				</VStack>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top articles', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ current.top_pages }
+					emptyMessage={ __( 'No article data in this timeframe.', 'newspack-plugin' ) }
+					columns={ [
+						{ key: 'page_title', label: __( 'Article', 'newspack-plugin' ) },
+						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
+					] }
+				/>
 			</Card>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
-				<VStack spacing={ 6 }>
-					<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by reader count', 'newspack-plugin' ) }</h3>
-					<MetricTable
-						payload={ current.top_authors_by_reader_count }
-						emptyMessage={ __( 'No author data in this timeframe.', 'newspack-plugin' ) }
-						columns={ [
-							{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
-							{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-							{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
-						] }
-					/>
-				</VStack>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by reader count', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ current.top_authors_by_reader_count }
+					emptyMessage={ __( 'No author data in this timeframe.', 'newspack-plugin' ) }
+					columns={ [
+						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
+						{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
+					] }
+				/>
 			</Card>
 			{ /* Top Categories is hidden_in_v1 (needs BQ UNNEST); it skip-renders until the BQ catalog ships. */ }
 			{ ! current.top_categories?.hidden_in_v1 && (
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">
-					<VStack spacing={ 6 }>
-						<h3 className="newspack-insights__chart-card-title">{ __( 'Top categories', 'newspack-plugin' ) }</h3>
-						<MetricTable
-							payload={ current.top_categories }
-							emptyMessage={ __( 'No category data in this timeframe.', 'newspack-plugin' ) }
-							columns={ [
-								{ key: 'category', label: __( 'Category', 'newspack-plugin' ) },
-								{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-								{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
-							] }
-						/>
-					</VStack>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Top categories', 'newspack-plugin' ) }</h3>
+					<MetricTable
+						payload={ current.top_categories }
+						emptyMessage={ __( 'No category data in this timeframe.', 'newspack-plugin' ) }
+						columns={ [
+							{ key: 'category', label: __( 'Category', 'newspack-plugin' ) },
+							{ key: 'unique_readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+							{ key: 'pageviews', label: __( 'Pageviews', 'newspack-plugin' ), format: 'number', align: 'right' },
+						] }
+					/>
 				</Card>
 			) }
 		</VStack>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/GeographicSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/GeographicSection.tsx
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -45,41 +44,37 @@ const GeographicSection = ( { current }: SectionProps ) => {
 			/>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">
-					<VStack spacing={ 6 }>
-						<h3 className="newspack-insights__chart-card-title">
-							{ __( 'Top regions / states', 'newspack-plugin' ) }
-							{ regionsScope && <ScopePill label={ regionsScope } /> }
-						</h3>
-						<MetricTable
-							payload={ current.top_regions }
-							emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
-							collapseColumn="country"
-							columns={ [
-								{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
-								{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
-								READERS_COL,
-							] }
-						/>
-					</VStack>
+					<h3 className="newspack-insights__chart-card-title">
+						{ __( 'Top regions / states', 'newspack-plugin' ) }
+						{ regionsScope && <ScopePill label={ regionsScope } /> }
+					</h3>
+					<MetricTable
+						payload={ current.top_regions }
+						emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
+						collapseColumn="country"
+						columns={ [
+							{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
+							{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
+							READERS_COL,
+						] }
+					/>
 				</Card>
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">
-					<VStack spacing={ 6 }>
-						<h3 className="newspack-insights__chart-card-title">
-							{ __( 'Top cities', 'newspack-plugin' ) }
-							{ citiesScope && <ScopePill label={ citiesScope } /> }
-						</h3>
-						<MetricTable
-							payload={ current.top_cities }
-							emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
-							collapseColumn="country"
-							columns={ [
-								{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
-								{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
-								{ key: 'city', label: __( 'City', 'newspack-plugin' ) },
-								READERS_COL,
-							] }
-						/>
-					</VStack>
+					<h3 className="newspack-insights__chart-card-title">
+						{ __( 'Top cities', 'newspack-plugin' ) }
+						{ citiesScope && <ScopePill label={ citiesScope } /> }
+					</h3>
+					<MetricTable
+						payload={ current.top_cities }
+						emptyMessage={ __( 'No data in this timeframe.', 'newspack-plugin' ) }
+						collapseColumn="country"
+						columns={ [
+							{ key: 'country', label: __( 'Country', 'newspack-plugin' ) },
+							{ key: 'region', label: __( 'Region', 'newspack-plugin' ) },
+							{ key: 'city', label: __( 'City', 'newspack-plugin' ) },
+							READERS_COL,
+						] }
+					/>
 				</Card>
 			</Grid>
 		</Section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
@@ -27,6 +27,21 @@ export interface SectionProps {
 	current: InsightsWindow;
 	previous: InsightsWindow | null;
 }
+
+// Short day-of-week labels for the bar chart. Keyed by the same translated full
+// names the API returns (`__( 'Monday' )` …), so the lookup matches in any
+// locale; the full name stays the accessible name (see BarChart `formatLabel`).
+const DAY_ABBREVIATIONS: Record< string, string > = {
+	[ __( 'Monday', 'newspack-plugin' ) ]: _x( 'Mon', 'Monday abbreviation', 'newspack-plugin' ),
+	[ __( 'Tuesday', 'newspack-plugin' ) ]: _x( 'Tue', 'Tuesday abbreviation', 'newspack-plugin' ),
+	[ __( 'Wednesday', 'newspack-plugin' ) ]: _x( 'Wed', 'Wednesday abbreviation', 'newspack-plugin' ),
+	[ __( 'Thursday', 'newspack-plugin' ) ]: _x( 'Thu', 'Thursday abbreviation', 'newspack-plugin' ),
+	[ __( 'Friday', 'newspack-plugin' ) ]: _x( 'Fri', 'Friday abbreviation', 'newspack-plugin' ),
+	[ __( 'Saturday', 'newspack-plugin' ) ]: _x( 'Sat', 'Saturday abbreviation', 'newspack-plugin' ),
+	[ __( 'Sunday', 'newspack-plugin' ) ]: _x( 'Sun', 'Sunday abbreviation', 'newspack-plugin' ),
+};
+
+const abbreviateDay = ( label: string ): string => DAY_ABBREVIATIONS[ label ] ?? label;
 
 const TimeTrendsSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-trends">
@@ -54,7 +69,7 @@ const TimeTrendsSection = ( { current }: SectionProps ) => (
 			</ChartCard>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				<ChartCard title={ __( 'Readership by day of week', 'newspack-plugin' ) } payload={ current.readership_by_day_of_week }>
-					<BarChart bars={ toSeries( current.readership_by_day_of_week, 'day_of_week', 'active_readers' ) } />
+					<BarChart bars={ toSeries( current.readership_by_day_of_week, 'day_of_week', 'active_readers' ) } formatLabel={ abbreviateDay } />
 				</ChartCard>
 				<ChartCard title={ __( 'Readership by hour of day', 'newspack-plugin' ) } payload={ current.readership_by_hour_of_day }>
 					<BarChart bars={ toSeries( current.readership_by_hour_of_day, 'hour', 'active_readers' ) } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/BarChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/BarChart.tsx
@@ -29,9 +29,14 @@ export interface BarChartProps {
 	bars: Bar[];
 	/** Render the hover value, e.g. "98 seconds". Defaults to a plain number. */
 	formatValue?: ( value: number ) => string;
+	/**
+	 * Abbreviate the visible label (e.g. "Monday" → "Mon"); the full label stays
+	 *  the accessible name and the hover tooltip. Defaults to the label as-is.
+	 */
+	formatLabel?: ( label: string ) => string;
 }
 
-const BarChart = ( { bars, formatValue = formatNumber }: BarChartProps ) => {
+const BarChart = ( { bars, formatValue = formatNumber, formatLabel }: BarChartProps ) => {
 	if ( bars.length === 0 ) {
 		return <p className="newspack-insights__chart-empty">{ __( 'No data in this timeframe.', 'newspack-plugin' ) }</p>;
 	}
@@ -69,7 +74,9 @@ const BarChart = ( { bars, formatValue = formatNumber }: BarChartProps ) => {
 							style={ { height: `${ Math.round( ( ( bar.value || 0 ) / max ) * 100 ) }%` } }
 						/>
 					</div>
-					<div className="newspack-insights__bar-label">{ bar.label }</div>
+					<div className="newspack-insights__bar-label" aria-label={ formatLabel ? bar.label : undefined }>
+						{ formatLabel ? formatLabel( bar.label ) : bar.label }
+					</div>
 				</div>
 			) ) }
 		</div>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/CohortHeatmap.tsx
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -106,7 +111,7 @@ const CohortHeatmap = ( {
 									return (
 										<td
 											key={ `${ cohort.label }-${ period }` }
-											className="newspack-insights__cohort-heatmap-cell"
+											className={ classnames( 'newspack-insights__cohort-heatmap-cell', { 'is-white': 0 === t } ) }
 											style={ cellStyle( t ) }
 										>
 											{ formatValue( value ) }
@@ -123,7 +128,7 @@ const CohortHeatmap = ( {
 					{ __( 'Lower', 'newspack-plugin' ) }
 					<span className="newspack-insights__cohort-heatmap-swatches" aria-hidden="true">
 						{ [ 0, 0.25, 0.5, 0.75, 1 ].map( t => (
-							<span key={ `sw-${ t }` } style={ cellStyle( t ) } />
+							<span key={ `sw-${ t }` } className={ classnames( { 'is-white': 0 === t } ) } style={ cellStyle( t ) } />
 						) ) }
 					</span>
 					{ __( 'Higher', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/DistributionTable.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/DistributionTable.test.tsx
@@ -52,6 +52,6 @@ describe( 'DistributionTable', () => {
 
 	it( 'omits the caption element when caption is not provided', () => {
 		const { container } = render( <DistributionTable buckets={ buckets } /> );
-		expect( container.querySelector( '.newspack-insights__distribution-caption' ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.newspack-insights__table-footnote' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/DistributionTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/DistributionTable.tsx
@@ -55,15 +55,15 @@ const DistributionTable = ( { buckets, caption }: DistributionTableProps ) => {
 	];
 
 	return (
-		<div className="newspack-insights__distribution">
+		<>
 			<InsightsDataView< DistributionBucket >
 				columns={ columns }
 				rows={ buckets }
 				getRowKey={ bucket => bucket.label }
 				emptyMessage={ __( 'No conversion distribution data in this timeframe.', 'newspack-plugin' ) }
 			/>
-			{ caption && <p className="newspack-insights__distribution-caption">{ caption }</p> }
-		</div>
+			{ caption && <p className="newspack-insights__table-footnote">{ caption }</p> }
+		</>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/InsightsDataView.tsx
@@ -31,6 +31,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Field, View } from '@wordpress/dataviews';
@@ -227,14 +228,14 @@ const InsightsDataView = < Row, >( {
 				search={ false }
 			/>
 			{ collapsible && (
-				<button
-					type="button"
+				<Button
+					variant="link"
 					className="newspack-insights__table-toggle"
 					aria-expanded={ expanded }
 					onClick={ () => setExpanded( ! expanded ) }
 				>
 					{ expanded ? __( 'See less', 'newspack-plugin' ) : __( 'See more', 'newspack-plugin' ) }
-				</button>
+				</Button>
 			) }
 		</>
 	);

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/LineChart.tsx
@@ -254,6 +254,7 @@ const LineChart = ( {
 					</div>
 				) }
 			</div>
+			{ xAxisLabel && <span className="newspack-insights__line-axis newspack-insights__line-axis--x">{ xAxisLabel }</span> }
 			{ isMulti ? (
 				<div className="newspack-insights__line-legend">
 					{ allSeries.map( ( s, si ) => (
@@ -272,7 +273,6 @@ const LineChart = ( {
 					<span>{ formatLabel( base[ n - 1 ].label ) }</span>
 				</div>
 			) }
-			{ xAxisLabel && <span className="newspack-insights__line-axis newspack-insights__line-axis--x">{ xAxisLabel }</span> }
 		</div>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -79,12 +79,12 @@
 			color: wp-colors.$gray-700;
 		}
 
-		// Chart body grows to fill the card; 24px separates it from the
+		// Chart body grows to fill the card; 16px separates it from the
 		// title/caption above.
 		&-body {
 			flex: 1 1 auto;
 			min-width: 0;
-			margin-top: wp-vars.$grid-unit-30;
+			margin-top: wp-vars.$grid-unit-20;
 		}
 	}
 
@@ -287,16 +287,15 @@
 
 	&__legend-swatch {
 		display: inline-block;
-		width: 20px;
-		height: 20px;
-		border-radius: wp-vars.$radius-full;
+		width: wp-vars.$grid-unit-20;
+		height: wp-vars.$grid-unit-15;
 		background: var( --series-color );
 		flex-shrink: 0;
 	}
 
 	// Label and value sit next to each other (not justified to opposite edges).
 	&__legend-label {
-		color: wp-colors.$gray-800;
+		color: wp-colors.$gray-700;
 	}
 
 	&__legend-value {
@@ -346,7 +345,7 @@
 	&__bar-label {
 		font-size: wp-vars.$font-size-small;
 		line-height: wp-vars.$default-line-height;
-		color: wp-colors.$gray-900;
+		color: wp-colors.$gray-700;
 		margin-top: wp-vars.$grid-unit-10;
 		white-space: nowrap;
 		overflow: hidden;
@@ -429,9 +428,10 @@
 	&__line-meta {
 		display: flex;
 		justify-content: space-between;
-		font-size: 11px;
+		font-size: wp-vars.$font-size-x-small;
+		line-height: wp-vars.$font-line-height-x-small;
 		color: wp-colors.$gray-700;
-		margin-top: 4px;
+		margin-top: calc(wp-vars.$grid-unit / 2);
 	}
 
 	// Axis titles naming what each axis represents (e.g. "Days since first
@@ -440,15 +440,16 @@
 	// text that would stretch.
 	&__line-axis {
 		display: block;
-		font-size: 11px;
+		font-size: wp-vars.$font-size-x-small;
+		line-height: wp-vars.$font-line-height-x-small;
 		color: wp-colors.$gray-700;
 
 		&--y {
-			margin-bottom: 6px;
+			margin-bottom: calc(wp-vars.$grid-unit / 2);
 		}
 
 		&--x {
-			margin-top: 6px;
+			margin-top: calc(wp-vars.$grid-unit / 2);
 			text-align: center;
 		}
 	}
@@ -458,20 +459,27 @@
 	// the value range); these rules own only structure. Horizontal scroll keeps a
 	// wide period axis from overflowing the card.
 	&__cohort-heatmap {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		gap: wp-vars.$grid-unit-30;
+		height: 100%;
 		overflow-x: auto;
 	}
 
 	&__cohort-heatmap-table {
 		border-collapse: separate;
-		border-spacing: 3px;
-		font-size: 12px;
+		border-spacing: wp-vars.$grid-unit-05;
+		font-size: wp-vars.$font-size-x-small;
+		line-height: wp-vars.$font-line-height-x-small;
 		font-variant-numeric: tabular-nums;
 
 		caption {
 			caption-side: top;
-			margin-bottom: 6px;
+			margin-bottom: calc(wp-vars.$grid-unit / 2);
 			text-align: left;
-			font-size: 11px;
+			font-size: wp-vars.$font-size-x-small;
+			line-height: wp-vars.$font-line-height-x-small;
 			color: wp-colors.$gray-700;
 		}
 	}
@@ -479,7 +487,7 @@
 	&__cohort-heatmap-corner,
 	&__cohort-heatmap-colhead {
 		padding: 0 6px 4px;
-		font-weight: 500;
+		font-weight: wp-vars.$font-weight-medium;
 		color: wp-colors.$gray-700;
 		text-align: center;
 	}
@@ -498,9 +506,8 @@
 	}
 
 	&__cohort-heatmap-cell {
-		min-width: 40px;
-		padding: 6px 10px;
-		border-radius: 4px;
+		min-width: calc(wp-vars.$grid-unit * 9);
+		padding: calc(wp-vars.$grid-unit / 2);
 		text-align: center;
 		font-variant-numeric: tabular-nums;
 		// Sequential ramp off the admin accent: mix the darker-20 base with white
@@ -510,30 +517,41 @@
 		&.is-empty {
 			background: transparent;
 		}
+
+		// A white cell (lowest value, no accent mix) would float against the
+		// white card; an inset hairline defines it without shifting the grid.
+		&.is-white {
+			box-shadow: inset 0 0 0 1px wp-colors.$gray-100;
+		}
 	}
 
 	&__cohort-heatmap-footer {
 		display: flex;
 		align-items: center;
-		gap: 16px;
-		margin-top: 10px;
-		font-size: 11px;
+		gap: wp-vars.$grid-unit;
+		margin: 0;
+		font-size: wp-vars.$font-size-x-small;
+		line-height: wp-vars.$font-line-height-x-small;
 		color: wp-colors.$gray-700;
 	}
 
 	&__cohort-heatmap-scale {
 		display: inline-flex;
 		align-items: center;
-		gap: 6px;
+		gap: wp-vars.$grid-unit;
 	}
 
 	&__cohort-heatmap-swatches {
 		display: inline-flex;
 
 		span {
-			width: 18px;
-			height: 12px;
+			width: wp-vars.$grid-unit-20;
+			height: wp-vars.$grid-unit-15;
 			background-color: color-mix( in srgb, var( --wp-admin-theme-color ) calc( var( --cell-t, 0 ) * 100% ), #{ wp-colors.$white } );
+
+			&.is-white {
+				box-shadow: inset 0 0 0 1px wp-colors.$gray-100;
+			}
 		}
 	}
 
@@ -622,10 +640,10 @@
 	&__line-legend {
 		display: flex;
 		flex-wrap: wrap;
-		gap: wp-vars.$grid-unit-20;
+		gap: wp-vars.$grid-unit-30;
 		margin-top: wp-vars.$grid-unit-30;
-		font-size: wp-vars.$font-size-small;
-		line-height: wp-vars.$default-line-height;
+		font-size: wp-vars.$font-size-x-small;
+		line-height: wp-vars.$font-line-height-x-small;
 		color: wp-colors.$gray-700;
 	}
 
@@ -633,23 +651,6 @@
 		display: flex;
 		align-items: center;
 		gap: wp-vars.$grid-unit-10;
-	}
-
-	// Distribution viz — shared across Gates (Tab 4) and Prompts (Tab 5).
-	// Wraps the canonical table chrome (`__table-wrap` / `__table`) and pins
-	// an optional caption below the table.
-	&__distribution {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-
-		&-caption {
-			margin: 0;
-			font-size: 13px;
-			font-weight: 400;
-			line-height: 1.5;
-			color: wp-colors.$gray-700;
-		}
 	}
 
 	// Funnel viz — shared across Gates, Prompts, and Conversion Journey tabs.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -291,32 +291,15 @@
 		border-radius: 4px;
 	}
 
-	// "See more" / "See less" toggle below an expandable MetricTable.
-	&__table-toggle {
-		display: inline-block;
-		// Hug the start when the toggle is a direct flex child (e.g. a full-width
-		// table rendered straight into a flex-column section) — otherwise it
-		// stretches full width and the button's default centered text drifts to
-		// the middle. A no-op where the toggle isn't a flex item.
-		align-self: flex-start;
-		margin-top: 8px;
-		padding: 0;
-		background: transparent;
-		border: 0;
-		cursor: pointer;
-		font-size: 13px;
-		font-weight: 600;
-		color: var( --wp-admin-theme-color );
-
-		&:hover {
-			text-decoration: underline;
-		}
-
-		// Match the canonical focus ring on its sibling `__sortable-table-more`.
-		&:focus-visible {
-			outline: 2px solid var( --wp-admin-theme-color );
-			outline-offset: 2px;
-		}
+	// "See more" / "See less" toggle below an expandable MetricTable. Rendered as
+	// a `Button variant="link"`, which supplies the link look, hover underline, and
+	// focus ring — only the layout is ours. Force block (the button is inline-flex,
+	// and its parent is often a plain block where a top margin wouldn't hold) and
+	// hug the content so it sits on its own line under the table.
+	&__table-toggle.components-button {
+		display: block;
+		width: fit-content;
+		margin-top: wp-vars.$grid-unit;
 	}
 
 	&__table {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -118,15 +118,23 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 			</Grid>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<h3 className="newspack-insights__chart-card-title">{ __( 'Top articles that don’t convert', 'newspack-plugin' ) }</h3>
-				<p className="newspack-insights__chart-card-caption">
-					{ __(
-						'These articles get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
-						'newspack-plugin'
+				<SectionState
+					state={ current.top_pages_no_conversion.state }
+					emptyMessage={ sprintf(
+						/* translators: %s: minimum pageview count for an article to qualify (formatted). */
+						__(
+							'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
+							'newspack-plugin'
+						),
+						formatNumber( current.top_pages_no_conversion.threshold_pageviews )
 					) }
-				</p>
-				<div className="newspack-insights__chart-card-body">
-					<SectionState
-						state={ current.top_pages_no_conversion.state }
+				>
+					<SortableTable
+						columns={ TOP_PAGES_COLUMNS }
+						rows={ current.top_pages_no_conversion.rows }
+						getRowKey={ row => row.post_id }
+						defaultSortKey="pageviews"
+						initialRowLimit={ TOP_PAGES_ROW_LIMIT }
 						emptyMessage={ sprintf(
 							/* translators: %s: minimum pageview count for an article to qualify (formatted). */
 							__(
@@ -135,24 +143,14 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 							),
 							formatNumber( current.top_pages_no_conversion.threshold_pageviews )
 						) }
-					>
-						<SortableTable
-							columns={ TOP_PAGES_COLUMNS }
-							rows={ current.top_pages_no_conversion.rows }
-							getRowKey={ row => row.post_id }
-							defaultSortKey="pageviews"
-							initialRowLimit={ TOP_PAGES_ROW_LIMIT }
-							emptyMessage={ sprintf(
-								/* translators: %s: minimum pageview count for an article to qualify (formatted). */
-								__(
-									'No qualifying articles yet. Articles with at least %s pageviews and a measurable conversion rate will appear here.',
-									'newspack-plugin'
-								),
-								formatNumber( current.top_pages_no_conversion.threshold_pageviews )
-							) }
-						/>
-					</SectionState>
-				</div>
+					/>
+				</SectionState>
+				<p className="newspack-insights__table-footnote">
+					{ __(
+						'These articles get traffic but don’t drive registrations. Consider adding a gate or prompt where engagement is high but conversion is low.',
+						'newspack-plugin'
+					) }
+				</p>
 			</Card>
 		</VStack>
 	</Section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
@@ -29,6 +29,7 @@ import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency, formatNumber } from '../components/format';
+import { Card } from '../../../../../packages/components/src';
 
 export interface CampaignSectionProps {
 	rows: DonorsCampaignRow[];
@@ -84,12 +85,14 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 					'newspack-plugin'
 				) }
 			/>
-			<InsightsDataView< DonorsCampaignRow >
-				columns={ columns }
-				rows={ rows }
-				getRowKey={ row => ( row.is_untagged ? '__untagged__' : `campaign:${ row.value }` ) }
-				emptyMessage={ __( 'No campaign-tagged donations in this window.', 'newspack-plugin' ) }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<InsightsDataView< DonorsCampaignRow >
+					columns={ columns }
+					rows={ rows }
+					getRowKey={ row => ( row.is_untagged ? '__untagged__' : `campaign:${ row.value }` ) }
+					emptyMessage={ __( 'No campaign-tagged donations in this window.', 'newspack-plugin' ) }
+				/>
+			</Card>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
@@ -40,6 +40,7 @@ import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { getPostEditUrl } from '../components/adminLinks';
 import { formatCurrency, formatNumber } from '../components/format';
+import { Card } from '../../../../../packages/components/src';
 
 export interface PerformanceSectionProps {
 	rows: DonorsTierRow[];
@@ -151,20 +152,22 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 					'newspack-plugin'
 				) }
 			/>
-			<InsightsDataView< FlatRow >
-				columns={ columns }
-				rows={ flatten( rows ) }
-				getRowKey={ item =>
-					item.kind === 'parent' ? `product:${ item.row.product_id }` : `${ item.parentId }-${ item.row.variation_id }`
-				}
-				emptyMessage={ __( 'No donation activity yet.', 'newspack-plugin' ) }
-			/>
-			<p className="newspack-insights__table-footnote">
-				{ __(
-					'“(no variation)”: Donations recorded at the product level without a specific variation — e.g. one-time or name-your-price gifts made against this product.',
-					'newspack-plugin'
-				) }
-			</p>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<InsightsDataView< FlatRow >
+					columns={ columns }
+					rows={ flatten( rows ) }
+					getRowKey={ item =>
+						item.kind === 'parent' ? `product:${ item.row.product_id }` : `${ item.parentId }-${ item.row.variation_id }`
+					}
+					emptyMessage={ __( 'No donation activity yet.', 'newspack-plugin' ) }
+				/>
+				<p className="newspack-insights__table-footnote">
+					{ __(
+						'“(no variation)”: Donations recorded at the product level without a specific variation — e.g. one-time or name-your-price gifts made against this product.',
+						'newspack-plugin'
+					) }
+				</p>
+			</Card>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -34,49 +34,43 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 		/>
 		<VStack spacing={ 4 }>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
-				<VStack spacing={ 6 }>
-					<h3 className="newspack-insights__chart-card-title">{ __( 'Most-engaged articles', 'newspack-plugin' ) }</h3>
-					<MetricTable
-						payload={ current.most_read_articles }
-						emptyMessage={ __( 'No article engagement data in this timeframe.', 'newspack-plugin' ) }
-						columns={ [
-							ARTICLE_COL,
-							{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-							{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
-						] }
-					/>
-				</VStack>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Most-engaged articles', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ current.most_read_articles }
+					emptyMessage={ __( 'No article engagement data in this timeframe.', 'newspack-plugin' ) }
+					columns={ [
+						ARTICLE_COL,
+						{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
+					] }
+				/>
 			</Card>
 			{ /* Completion is GA4-scroll-derived; hidden until scroll data flows. See ../constants. */ }
 			{ SHOW_COMPLETION_METRICS && (
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">
-					<VStack spacing={ 6 }>
-						<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by completion rate', 'newspack-plugin' ) }</h3>
-						<MetricTable
-							payload={ current.articles_by_completion_rate }
-							emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
-							columns={ [
-								ARTICLE_COL,
-								{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-								{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
-							] }
-						/>
-					</VStack>
+					<h3 className="newspack-insights__chart-card-title">{ __( 'Articles by completion rate', 'newspack-plugin' ) }</h3>
+					<MetricTable
+						payload={ current.articles_by_completion_rate }
+						emptyMessage={ __( 'No scroll-completion data in this timeframe.', 'newspack-plugin' ) }
+						columns={ [
+							ARTICLE_COL,
+							{ key: 'readers', label: __( 'Readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+							{ key: 'completion_rate', label: __( 'Read to end', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						] }
+					/>
 				</Card>
 			) }
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
-				<VStack spacing={ 6 }>
-					<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by avg engagement time', 'newspack-plugin' ) }</h3>
-					<MetricTable
-						payload={ current.top_authors_by_avg_engagement_time }
-						emptyMessage={ __( 'No author engagement data in this timeframe.', 'newspack-plugin' ) }
-						columns={ [
-							{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
-							{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
-							{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
-						] }
-					/>
-				</VStack>
+				<h3 className="newspack-insights__chart-card-title">{ __( 'Top authors by avg engagement time', 'newspack-plugin' ) }</h3>
+				<MetricTable
+					payload={ current.top_authors_by_avg_engagement_time }
+					emptyMessage={ __( 'No author engagement data in this timeframe.', 'newspack-plugin' ) }
+					columns={ [
+						{ key: 'author', label: __( 'Author', 'newspack-plugin' ) },
+						{ key: 'unique_readers', label: __( 'Engaged readers', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'avg_engagement_seconds', label: __( 'Avg time', 'newspack-plugin' ), format: 'duration', align: 'right' },
+					] }
+				/>
 			</Card>
 		</VStack>
 	</Section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/HowReadersConvertSection.tsx
@@ -24,6 +24,7 @@ import SectionHeading from '../components/SectionHeading';
 import Funnel from '../components/Funnel';
 import DistributionTable from '../components/DistributionTable';
 import SectionState from './SectionState';
+import { Card } from '../../../../../packages/components/src';
 
 export interface HowReadersConvertSectionProps {
 	current: GatesWindow;
@@ -40,7 +41,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 			) }
 		/>
 		<div className="newspack-insights__gates-convert-grid">
-			<div className="newspack-insights__gates-convert-col">
+			<Card __experimentalCoreCard className="newspack-insights__chart-card newspack-insights__gates-convert-col">
 				<SectionState
 					state={ current.conversion_funnel.state }
 					emptyMessage={ __(
@@ -50,8 +51,8 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 				>
 					<Funnel stages={ current.conversion_funnel.stages } />
 				</SectionState>
-			</div>
-			<div className="newspack-insights__gates-convert-col">
+			</Card>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card newspack-insights__gates-convert-col">
 				<SectionState
 					state={ current.exposures_distribution.state }
 					emptyMessage={ __( 'No distribution data yet. This will populate once readers begin converting.', 'newspack-plugin' ) }
@@ -61,7 +62,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 						caption={ __( 'Of readers who converted, this is how many gates they saw first.', 'newspack-plugin' ) }
 					/>
 				</SectionState>
-			</div>
+			</Card>
 		</div>
 	</Section>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
@@ -17,6 +17,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ import { formatNumber, formatPercent } from '../components/format';
 import Section from '../components/Section';
 import SectionHeading from '../components/SectionHeading';
 import { SECTION_ERROR_MESSAGE } from './SectionState';
+import { Card } from '../../../../../packages/components/src';
 
 export interface PerformanceByGateSectionProps {
 	data: GatesPerformanceTable;
@@ -50,7 +52,7 @@ const columns: InsightsColumn< GatesPerformanceRow >[] = [
 	{
 		key: 'gate_name',
 		label: __( 'Gate name', 'newspack-plugin' ),
-		render: row => <a href={ getPostEditUrl( row.gate_post_id ) }>{ row.gate_name }</a>,
+		render: row => <ExternalLink href={ getPostEditUrl( row.gate_post_id ) }>{ row.gate_name }</ExternalLink>,
 		sortValue: row => row.gate_name,
 	},
 	{
@@ -116,13 +118,15 @@ const PerformanceByGateSection = ( { data }: PerformanceByGateSectionProps ) => 
 				title={ __( 'Performance by gate', 'newspack-plugin' ) }
 				description={ __( 'Per-gate breakdown for the selected timeframe. Click any column to re-sort.', 'newspack-plugin' ) }
 			/>
-			<InsightsDataView< GatesPerformanceRow >
-				columns={ columns }
-				rows={ data.state === 'populated' ? data.rows : [] }
-				getRowKey={ row => String( row.gate_post_id ) }
-				defaultSortKey="impressions"
-				emptyMessage={ emptyMessage }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<InsightsDataView< GatesPerformanceRow >
+					columns={ columns }
+					rows={ data.state === 'populated' ? data.rows : [] }
+					getRowKey={ row => String( row.gate_post_id ) }
+					defaultSortKey="impressions"
+					emptyMessage={ emptyMessage }
+				/>
+			</Card>
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
@@ -24,6 +24,7 @@ import MetricTable from '../../components/MetricTable';
 import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 import TabSections from '../../components/TabSections';
+import { Card } from '../../../../../../packages/components/src';
 
 export interface SectionProps {
 	current: InsightsWindow;
@@ -51,52 +52,58 @@ const TablesSection = ( { current }: SectionProps ) => (
 	<TabSections>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-ads">
 			<SectionHeading id="newspack-insights-newsletter-ads-top-ads" title={ __( 'Top ads', 'newspack-plugin' ) } />
-			<MetricTable
-				payload={ current.top_ads }
-				emptyMessage={ __( 'No ad data in this timeframe.', 'newspack-plugin' ) }
-				expandable
-				defaultRowLimit={ 5 }
-				columns={ [
-					{ key: 'title', label: __( 'Ad', 'newspack-plugin' ) },
-					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-				] }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<MetricTable
+					payload={ current.top_ads }
+					emptyMessage={ __( 'No ad data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'title', label: __( 'Ad', 'newspack-plugin' ) },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-advertisers">
 			<SectionHeading id="newspack-insights-newsletter-ads-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
-			<MetricTable
-				payload={ current.top_advertisers }
-				emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
-				expandable
-				defaultRowLimit={ 5 }
-				columns={ [
-					{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
-					{ key: 'ads', label: __( 'Ads', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
-				] }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<MetricTable
+					payload={ current.top_advertisers }
+					emptyMessage={ __( 'No advertiser data in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'advertiser', label: __( 'Advertiser', 'newspack-plugin' ) },
+						{ key: 'ads', label: __( 'Ads', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'revenue', label: __( 'Revenue', 'newspack-plugin' ), format: 'currency', align: 'right' },
+					] }
+				/>
+			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-by-newsletter">
 			<SectionHeading id="newspack-insights-newsletter-ads-by-newsletter" title={ __( 'Ad performance by newsletter', 'newspack-plugin' ) } />
-			<MetricTable
-				payload={ withDisplayDates( current.by_newsletter ) }
-				emptyMessage={ __( 'No newsletters carried ads in this timeframe.', 'newspack-plugin' ) }
-				expandable
-				defaultRowLimit={ 5 }
-				columns={ [
-					{ key: 'title', label: __( 'Newsletter', 'newspack-plugin' ) },
-					{ key: 'sent_date', label: __( 'Sent date', 'newspack-plugin' ) },
-					{ key: 'ads', label: __( 'Ads carried', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
-					{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
-				] }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<MetricTable
+					payload={ withDisplayDates( current.by_newsletter ) }
+					emptyMessage={ __( 'No newsletters carried ads in this timeframe.', 'newspack-plugin' ) }
+					expandable
+					defaultRowLimit={ 5 }
+					columns={ [
+						{ key: 'title', label: __( 'Newsletter', 'newspack-plugin' ) },
+						{ key: 'sent_date', label: __( 'Sent date', 'newspack-plugin' ) },
+						{ key: 'ads', label: __( 'Ads carried', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'impressions', label: __( 'Impr.', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'clicks', label: __( 'Clicks', 'newspack-plugin' ), format: 'number', align: 'right' },
+						{ key: 'ctr', label: __( 'CTR', 'newspack-plugin' ), format: 'percent', align: 'right' },
+					] }
+				/>
+			</Card>
 		</Section>
 	</TabSections>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
@@ -22,6 +22,7 @@ import SectionHeading from '../components/SectionHeading';
 import Funnel from '../components/Funnel';
 import DistributionTable from '../components/DistributionTable';
 import SectionState from './SectionState';
+import { Card } from '../../../../../packages/components/src';
 
 export interface HowReadersConvertSectionProps {
 	current: PromptsWindow;
@@ -38,7 +39,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 			) }
 		/>
 		<div className="newspack-insights__prompts-convert-grid">
-			<div className="newspack-insights__prompts-convert-col">
+			<Card __experimentalCoreCard className="newspack-insights__chart-card newspack-insights__prompts-convert-col">
 				<SectionState
 					state={ current.conversion_funnel.state }
 					emptyMessage={ __(
@@ -48,8 +49,8 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 				>
 					<Funnel stages={ current.conversion_funnel.stages } />
 				</SectionState>
-			</div>
-			<div className="newspack-insights__prompts-convert-col">
+			</Card>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card newspack-insights__prompts-convert-col">
 				<SectionState
 					state={ current.exposures_distribution.state }
 					emptyMessage={ __( 'No distribution data yet. This will populate once readers begin converting.', 'newspack-plugin' ) }
@@ -59,7 +60,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 						caption={ __( 'Of readers who converted, this is how many prompts they saw first.', 'newspack-plugin' ) }
 					/>
 				</SectionState>
-			</div>
+			</Card>
 		</div>
 	</Section>
 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
@@ -11,6 +11,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -39,9 +40,11 @@ const PerformanceBreakdownSection = ( { current }: PerformanceBreakdownSectionPr
 				'newspack-plugin'
 			) }
 		/>
-		<PerformanceByPromptTable data={ current.performance_by_prompt } />
-		<PerformanceByIntentTable data={ current.performance_by_intent } />
-		<PerformanceByPlacementTable data={ current.performance_by_placement } />
+		<VStack spacing={ 4 }>
+			<PerformanceByPromptTable data={ current.performance_by_prompt } />
+			<PerformanceByIntentTable data={ current.performance_by_intent } />
+			<PerformanceByPlacementTable data={ current.performance_by_placement } />
+		</VStack>
 	</Section>
 );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
@@ -40,7 +40,7 @@ const PromptEngagementSection = ( { current, previous }: PromptEngagementSection
 				'newspack-plugin'
 			) }
 		/>
-		<Grid columns={ 3 } gutter={ 16 } noMargin>
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Click-Through Rate', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
@@ -42,7 +42,7 @@ const PromptExposureSection = ( { current, previous, lastUpdated }: PromptExposu
 			description={ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
-		<Grid columns={ 3 } gutter={ 16 } noMargin>
+		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
 				{ ...scalarToMetricCardProps( {
 					label: __( 'Total Prompt Impressions', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/prompts.scss
@@ -45,32 +45,6 @@
 		color: colors.$error-600;
 	}
 
-	// Section 7 — stacked breakdown sub-blocks.
-	&__prompts-subsection {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-
-		& + & {
-			margin-top: 24px;
-		}
-
-		&-heading {
-			margin: 0;
-			font-size: 15px;
-			font-weight: 600;
-			color: wp-colors.$gray-900;
-		}
-
-		&-note {
-			margin: 0;
-			font-size: 13px;
-			font-weight: 400;
-			line-height: 1.5;
-			color: wp-colors.$gray-700;
-		}
-	}
-
 }
 // Sortable-table sort affordances (See more/less toggle, empty row, sort chrome)
 // are now in tabs/components/_insights-charts.scss under __sortable-table-*.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByIntentTable.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../../packages/components/src';
 import type { PromptsPerformanceByIntentRow, PromptsPerformanceByIntentTable as TableData } from '../../../api/prompts';
 import { formatNumber } from '../../components/format';
 import SortableTable, { renderRate, type SortableColumn } from '../../components/SortableTable';
@@ -66,8 +67,8 @@ const columns: SortableColumn< PromptsPerformanceByIntentRow >[] = [
 ];
 
 const PerformanceByIntentTable = ( { data }: PerformanceByIntentTableProps ) => (
-	<div className="newspack-insights__prompts-subsection">
-		<h3 className="newspack-insights__prompts-subsection-heading">{ __( 'Performance by prompt intent', 'newspack-plugin' ) }</h3>
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ __( 'Performance by prompt intent', 'newspack-plugin' ) }</h3>
 		<SortableTable
 			columns={ columns }
 			rows={ data.rows }
@@ -79,10 +80,10 @@ const PerformanceByIntentTable = ( { data }: PerformanceByIntentTableProps ) => 
 			) }
 			errorMessage={ 'error' === data.state ? SECTION_ERROR_MESSAGE : undefined }
 		/>
-		<p className="newspack-insights__prompts-subsection-note">
+		<p className="newspack-insights__table-footnote">
 			{ __( "Answers 'are my donation prompts working better than my registration prompts?' at a glance.", 'newspack-plugin' ) }
 		</p>
-	</div>
+	</Card>
 );
 
 export default PerformanceByIntentTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPlacementTable.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../../packages/components/src';
 import type { PromptsPerformanceByPlacementRow, PromptsPerformanceByPlacementTable as TableData } from '../../../api/prompts';
 import { formatNumber } from '../../components/format';
 import SortableTable, { renderRate, type SortableColumn } from '../../components/SortableTable';
@@ -59,8 +60,8 @@ const columns: SortableColumn< PromptsPerformanceByPlacementRow >[] = [
 ];
 
 const PerformanceByPlacementTable = ( { data }: PerformanceByPlacementTableProps ) => (
-	<div className="newspack-insights__prompts-subsection">
-		<h3 className="newspack-insights__prompts-subsection-heading">{ __( 'Performance by prompt placement', 'newspack-plugin' ) }</h3>
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ __( 'Performance by prompt placement', 'newspack-plugin' ) }</h3>
 		<SortableTable
 			columns={ columns }
 			rows={ data.rows }
@@ -72,10 +73,10 @@ const PerformanceByPlacementTable = ( { data }: PerformanceByPlacementTableProps
 			) }
 			errorMessage={ 'error' === data.state ? SECTION_ERROR_MESSAGE : undefined }
 		/>
-		<p className="newspack-insights__prompts-subsection-note">
+		<p className="newspack-insights__table-footnote">
 			{ __( "Answers 'do my overlay prompts perform better than inline?' Useful for choosing placement defaults.", 'newspack-plugin' ) }
 		</p>
-	</div>
+	</Card>
 );
 
 export default PerformanceByPlacementTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/viz/PerformanceByPromptTable.tsx
@@ -19,10 +19,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { Card } from '../../../../../../packages/components/src';
 import type { PromptsPerformanceByPromptRow, PromptsPerformanceByPromptTable as TableData } from '../../../api/prompts';
 import { getPostEditUrl } from '../../components/adminLinks';
 import { formatNumber, formatPercent } from '../../components/format';
@@ -96,7 +98,7 @@ const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 		key: 'prompt_title',
 		label: __( 'Prompt', 'newspack-plugin' ),
 		numeric: false,
-		render: r => <a href={ getPostEditUrl( r.popup_id ) }>{ r.prompt_title }</a>,
+		render: r => <ExternalLink href={ getPostEditUrl( r.popup_id ) }>{ r.prompt_title }</ExternalLink>,
 		sortValue: r => r.prompt_title,
 	},
 	{
@@ -158,8 +160,8 @@ const columns: SortableColumn< PromptsPerformanceByPromptRow >[] = [
 ];
 
 const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => (
-	<div className="newspack-insights__prompts-subsection">
-		<h3 className="newspack-insights__prompts-subsection-heading">{ __( 'Performance by prompt', 'newspack-plugin' ) }</h3>
+	<Card __experimentalCoreCard className="newspack-insights__chart-card">
+		<h3 className="newspack-insights__chart-card-title">{ __( 'Performance by prompt', 'newspack-plugin' ) }</h3>
 		<SortableTable
 			columns={ columns }
 			rows={ data.rows }
@@ -173,13 +175,13 @@ const PerformanceByPromptTable = ( { data }: PerformanceByPromptTableProps ) => 
 			) }
 			errorMessage={ 'error' === data.state ? SECTION_ERROR_MESSAGE : undefined }
 		/>
-		<p className="newspack-insights__prompts-subsection-note">
+		<p className="newspack-insights__table-footnote">
 			{ __(
 				'Showing the top 10 prompts by the sorted column; use “See more” to reveal the rest. Capped at the top 50 prompts by impressions — lower-traffic prompts beyond that may not appear.',
 				'newspack-plugin'
 			) }
 		</p>
-	</div>
+	</Card>
 );
 
 export default PerformanceByPromptTable;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
@@ -29,6 +29,7 @@ import Section from '../components/Section';
 import SectionEmpty from '../components/SectionEmpty';
 import SectionHeading from '../components/SectionHeading';
 import { formatCurrency, formatNumber } from '../components/format';
+import { Card } from '../../../../../packages/components/src';
 
 export interface CampaignSectionProps {
 	rows: SubscribersCampaignRow[];
@@ -84,12 +85,14 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 					'newspack-plugin'
 				) }
 			/>
-			<InsightsDataView< SubscribersCampaignRow >
-				columns={ columns }
-				rows={ rows }
-				getRowKey={ row => ( row.is_untagged ? '__untagged__' : `campaign:${ row.value }` ) }
-				emptyMessage={ __( 'No campaign-tagged subscriptions in this window.', 'newspack-plugin' ) }
-			/>
+			<Card __experimentalCoreCard className="newspack-insights__chart-card">
+				<InsightsDataView< SubscribersCampaignRow >
+					columns={ columns }
+					rows={ rows }
+					getRowKey={ row => ( row.is_untagged ? '__untagged__' : `campaign:${ row.value }` ) }
+					emptyMessage={ __( 'No campaign-tagged subscriptions in this window.', 'newspack-plugin' ) }
+				/>
+			</Card>
 		</Section>
 	);
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Design polish pass on the Insights wizard, giving every data table a consistent card treatment and tightening the chart/table styling.

- **Every dataview now sits in a card.** All remaining uncarded tables (donors/subscribers campaigns, donors performance, advertising site performance + top performers, newsletter-ad tables, and the prompts performance breakdowns) are wrapped in the shared chart-card frame, matching the tables that were already carded. Cards whose only content is a table sit flush; cards with a title/footnote keep their padding.
- **Consistent card rhythm.** Removed the per-card inner `VStack` wrappers so a card's title, table, and footnote flow directly, driven by shared CSS (16px title-to-table spacing). Cohort-retention and opportunity-bucket groupings are unchanged.
- **Links over buttons.** Gate and prompt names now use `ExternalLink` (opens in a new tab); the table "See more / See less" control is now a link-style `Button`, dropping most of its bespoke CSS.
- **Chart/table refinements.** Line-chart legend and axis typography moved onto the shared x-small tokens; cohort heatmap cells restyled (square cells, transparent header, hairline on empty cells, wider min-width); DataViews header cells made transparent and last-column headers realigned; the distribution caption folded into the shared table-footnote treatment.
- All spacing/typography values use `@wordpress/base-styles` tokens rather than literals.

This PR targets the `feat/insights-rsm` integration branch. A follow-up (isolating the Insights DataViews onto `@wordpress/dataviews` 16.0.0) will come as a separate PR after this merges.

### How to test the changes in this Pull Request:

1. Build the plugin and open the Insights wizard.
2. Visit each tab (Audience, Engagement, Gates, Prompts, Donors, Subscribers, Advertising, Newsletter Ads, Conversion) and confirm every data table renders inside a card with consistent padding and title spacing.
3. On tables with more rows than the row limit, confirm the "See more / See less" toggle appears as a link, toggles the rows, and keeps its focus ring.
4. On "Performance by gate" and "Performance by prompt", confirm the gate/prompt name links show the external-link icon and open in a new tab.
5. On the Conversion tab, confirm the "Top articles that don't convert" card keeps its title padding on top and footnote padding on the bottom, and cohort heatmaps render with the updated cell styling.
6. Confirm `pnpm --filter newspack test` is green (aside from the pre-existing, unrelated `PrintDocumentMeta` failure), and `lint:js` / `lint:scss` pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?