### PR TITLE
feat(insights): title case, section copy, and layout polish

### DIFF
--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
@@ -84,9 +84,7 @@ const NextSteps = ( { links }: NextStepsProps ) => {
 				<ul className="newspack-insights__next-steps-list">
 					{ safeLinks.map( link => (
 						<li key={ link.url }>
-							<ExternalLink className="newspack-insights__next-steps-link" href={ link.url }>
-								{ link.label }
-							</ExternalLink>
+							<ExternalLink href={ link.url }>{ link.label }</ExternalLink>
 						</li>
 					) ) }
 				</ul>

--- a/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/components/NextSteps.tsx
@@ -20,7 +20,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { closeSmall } from '@wordpress/icons';
 
 /**
@@ -69,27 +69,36 @@ const NextSteps = ( { links }: NextStepsProps ) => {
 	};
 
 	return (
-		<nav className="newspack-insights__next-steps" aria-label={ __( 'Next steps', 'newspack-plugin' ) }>
-			<div className="newspack-insights__next-steps-header">
-				<span className="newspack-insights__next-steps-label">{ __( 'Next steps', 'newspack-plugin' ) }</span>
-				<Button
-					className="newspack-insights__next-steps-dismiss"
-					icon={ closeSmall }
-					label={ __( 'Dismiss next steps', 'newspack-plugin' ) }
-					onClick={ dismiss }
-					size="small"
-				/>
-			</div>
-			<ul className="newspack-insights__next-steps-list">
-				{ safeLinks.map( link => (
-					<li key={ link.url }>
-						<ExternalLink className="newspack-insights__next-steps-link" href={ link.url }>
-							{ link.label }
-						</ExternalLink>
-					</li>
-				) ) }
-			</ul>
-		</nav>
+		<HStack
+			as="nav"
+			className="newspack-insights__next-steps"
+			aria-label={ __( 'Next steps', 'newspack-plugin' ) }
+			spacing={ 4 }
+			alignment="center"
+			justify="space-between"
+		>
+			<VStack spacing={ 2 }>
+				<div className="newspack-insights__next-steps-header">
+					<span className="newspack-insights__next-steps-label">{ __( 'Next steps', 'newspack-plugin' ) }</span>
+				</div>
+				<ul className="newspack-insights__next-steps-list">
+					{ safeLinks.map( link => (
+						<li key={ link.url }>
+							<ExternalLink className="newspack-insights__next-steps-link" href={ link.url }>
+								{ link.label }
+							</ExternalLink>
+						</li>
+					) ) }
+				</ul>
+			</VStack>
+			<Button
+				className="newspack-insights__next-steps-dismiss"
+				icon={ closeSmall }
+				label={ __( 'Dismiss next steps', 'newspack-plugin' ) }
+				onClick={ dismiss }
+				size="small"
+			/>
+		</HStack>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
@@ -17,18 +17,15 @@
 	// Sits above tab content but below the WP admin bar and any modals.
 	&__next-steps {
 		position: fixed;
-		right: 24px;
-		bottom: 24px;
+		right: wp-vars.$grid-unit-30;
+		bottom: wp-vars.$grid-unit-30;
 		z-index: 100;
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 6px;
-		max-width: 260px;
-		padding: 12px 16px;
+		max-width: calc( #{wp-vars.$grid-unit-80} * 4 + #{wp-vars.$grid-unit-05} ); // 260px
+		padding: wp-vars.$grid-unit-20;
 		background: wp-colors.$white;
 		border: 1px solid wp-colors.$gray-200;
-		border-radius: 6px;
+		// Match the Snackbar's radius + elevation ($radius-medium / $elevation-small).
+		border-radius: wp-vars.$radius-medium;
 		box-shadow: wp-vars.$elevation-small;
 
 		@media print {
@@ -40,7 +37,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		gap: 8px;
+		gap: wp-vars.$grid-unit-10;
 		width: 100%;
 	}
 
@@ -56,8 +53,8 @@
 
 	// Compact close button; the WP Button supplies the focus ring + hover.
 	&__next-steps-dismiss.components-button.has-icon {
-		min-width: 24px;
-		height: 24px;
+		min-width: wp-vars.$grid-unit-30;
+		height: wp-vars.$grid-unit-30;
 		padding: 0;
 		color: wp-colors.$gray-700;
 	}
@@ -65,17 +62,21 @@
 	&__next-steps-list {
 		display: flex;
 		flex-direction: column;
-		gap: 6px;
+		gap: wp-vars.$grid-unit-10;
 		margin: 0;
 		padding: 0;
 		list-style: none;
+
+		> li {
+			margin: 0;
+		}
 	}
 
 	// ExternalLink (`.components-external-link`) supplies the new-tab icon, the
 	// screen-reader "(opens in a new tab)" text, the correct rel, and focus
 	// styling; we only set the type scale here.
 	&__next-steps-link.components-external-link {
-		font-size: 13px;
-		font-weight: 500;
+		font-size: 13px; // No 13px token; $font-size-small is 12px.
+		font-weight: wp-vars.$font-weight-medium;
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/components/_next-steps.scss
@@ -71,12 +71,4 @@
 			margin: 0;
 		}
 	}
-
-	// ExternalLink (`.components-external-link`) supplies the new-tab icon, the
-	// screen-reader "(opens in a new tab)" text, the correct rel, and focus
-	// styling; we only set the type scale here.
-	&__next-steps-link.components-external-link {
-		font-size: 13px; // No 13px token; $font-size-small is 12px.
-		font-weight: wp-vars.$font-weight-medium;
-	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/state/useDateRange.ts
@@ -35,6 +35,29 @@ export const DATE_RANGE_PRESETS: DateRangePresetDef[] = [
 	{ key: 'custom', label: __( 'Custom', 'newspack-plugin' ) },
 ];
 
+/**
+ * Human "when" phrase for a range, for embedding in metric descriptions
+ * (e.g. `Registrations created {phrase}` → "…in the last 30 days"). Each preset
+ * reads naturally in that slot with its preposition baked in where one is
+ * needed; custom falls back to the generic "in this timeframe".
+ */
+export const rangeWhenPhrase = ( range: DateRange ): string => {
+	switch ( range.preset ) {
+		case 'last-7':
+			return __( 'in the last 7 days', 'newspack-plugin' );
+		case 'last-30':
+			return __( 'in the last 30 days', 'newspack-plugin' );
+		case 'last-90':
+			return __( 'in the last 90 days', 'newspack-plugin' );
+		case 'this-month':
+			return __( 'this month', 'newspack-plugin' );
+		case 'last-month':
+			return __( 'last month', 'newspack-plugin' );
+		default:
+			return __( 'in this timeframe', 'newspack-plugin' );
+	}
+};
+
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.test.tsx
@@ -78,7 +78,7 @@ describe( 'AdvertisingTab', () => {
 		expect( screen.getByText( 'Reconnect Google to grant the Ad Manager scope.' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'No Google Ad Manager network is configured.' ) ).toBeInTheDocument();
 		// No section content while not ready.
-		expect( screen.queryByText( 'Reach & revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Reach & Revenue' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows the progressive GAM messages while a ready window is still being cached', () => {
@@ -98,10 +98,10 @@ describe( 'AdvertisingTab', () => {
 
 		expect( screen.getByText( 'Loading ad performance…' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /No ad impressions in this timeframe/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Reach & revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Reach & Revenue' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'collapses the Reach & revenue section to no_opportunity on a resolved zero window', () => {
+	it( 'collapses the Reach & Revenue section to no_opportunity on a resolved zero window', () => {
 		mockData(
 			baseWindow( {
 				has_window_activity: false,
@@ -133,7 +133,7 @@ describe( 'AdvertisingTab', () => {
 		);
 		render( <AdvertisingTab range={ range } previousRange={ null } /> );
 
-		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Reach & Revenue' ) ).toBeInTheDocument();
 		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument(); // 7-digit impressions abbreviate (NPPD-1684)
 		expect( screen.getByText( '$4,200' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Sidebar' ) ).toBeInTheDocument();
@@ -211,14 +211,14 @@ describe( 'AdvertisingTab', () => {
 			} )
 		);
 		render( <AdvertisingTab range={ range } previousRange={ null } /> );
-		expect( screen.getByText( 'Performance by site' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance by Site' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'almanacnews.com' ) ).toBeInTheDocument();
 	} );
 
 	it( 'hides the per-site breakdown for non-network publishers', () => {
 		mockData( baseWindow( { is_network_member: false } ) );
 		render( <AdvertisingTab range={ range } previousRange={ null } /> );
-		expect( screen.queryByText( 'Performance by site' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Performance by Site' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the impressions-only Broadstreet variant, hiding every revenue/GAM section (NPPD-2045)', () => {
@@ -253,22 +253,22 @@ describe( 'AdvertisingTab', () => {
 		// Impressions-side sections render.
 		expect( screen.getByText( 'Reach' ) ).toBeInTheDocument();
 		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Impressions per session' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top advertisers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Impressions per Session' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Advertisers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Hometown Hardware' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top zones' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Zones' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Homepage Leaderboard' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top campaigns' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Campaigns' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Riverside Credit Union — Summer' ) ).toBeInTheDocument();
 
 		// GAM-only sections + the revenue card are absent (no revenue in Broadstreet).
-		expect( screen.queryByText( 'Reach & revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Reach & Revenue' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Revenue' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'RPM' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Average eCPM' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Impressions by type' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Performance by device' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Top ad units' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Impressions by Type' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Performance by Device' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top Ad Units' ) ).not.toBeInTheDocument();
 		// The GAM data-lag note is hidden for Broadstreet. Scope to the render
 		// container — the global a11y-speak region (document.body) can retain stale
 		// announcements from earlier tests in this suite.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AdvertisingTab.tsx
@@ -100,16 +100,16 @@ const AdvertisingTab = ( { range, previousRange }: AdvertisingTabProps ) => {
 							lastUpdated={ <LastUpdated tab="advertising" range={ range } previousRange={ previousRange } /> }
 						/>
 						{ /* Revenue/inventory sections are GAM-only — Broadstreet's API has no
-						     revenue, channels, devices, or per-site custom dimension. */ }
-						{ ! isBroadstreet && (
-							<>
-								<RevenueTrendSection current={ current.metrics } previous={ previous } />
-								{ /* Channel pie + device table: after the trend, before the per-site and
-								     top-performer tables. */ }
-								<ChannelDeviceSection current={ current.metrics } previous={ previous } />
-								{ /* Per-site breakdown: network members only; absent otherwise. */ }
-								{ current.is_network_member && <SitePerformanceSection current={ current.metrics } previous={ previous } /> }
-							</>
+						     revenue, channels, devices, or per-site custom dimension. Kept as
+						     direct TabSections children (not wrapped in a Fragment) so a
+						     full-width divider is drawn between each rendered section. */ }
+						{ ! isBroadstreet && <RevenueTrendSection current={ current.metrics } previous={ previous } /> }
+						{ /* Channel pie + device table: after the trend, before the per-site and
+						     top-performer tables. */ }
+						{ ! isBroadstreet && <ChannelDeviceSection current={ current.metrics } previous={ previous } /> }
+						{ /* Per-site breakdown: network members only; absent otherwise. */ }
+						{ ! isBroadstreet && current.is_network_member && (
+							<SitePerformanceSection current={ current.metrics } previous={ previous } />
 						) }
 						<TopPerformersSection current={ current.metrics } previous={ previous } activeProvider={ current.active_provider } />
 					</TabSections>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.test.tsx
@@ -178,24 +178,24 @@ describe( 'AppTab', () => {
 		expect( await screen.findByText( 'Reach' ) ).toBeInTheDocument();
 		// The property-context line names the property the tab is reading.
 		expect( screen.getByText( /App property: YubaNet → yubanetapp \(533212292\)/ ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Active users' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Active Users' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Engagement' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Avg. engagement time' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Avg. Engagement Time' ) ).toBeInTheDocument();
 		// Assert later sections by a unique card label (the section titles like
-		// "Notifications" collide with card labels such as "Notifications received"
+		// "Notifications" collide with card labels such as "Notifications Received"
 		// under the text matcher).
-		expect( screen.getByText( 'Weekly retention' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Notification open rate' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Download completion rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Weekly Retention' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Notification Open Rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Download Completion Rate' ) ).toBeInTheDocument();
 		// Tier-2a content + composition sections (unique card titles).
-		expect( screen.getByText( 'Top sections' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top authors' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Subscriber mix' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Free vs. paid content' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Sections' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Authors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Subscriber Mix' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Free vs. Paid Content' ) ).toBeInTheDocument();
 		// Raw KG status values are humanized for display ("ExistingSubscriber" → "Existing subscriber").
 		expect( screen.getByText( 'Existing subscriber' ) ).toBeInTheDocument();
 		// Multi-property apps get the downloads-by-publication table, title-cased.
-		expect( screen.getByText( 'Downloads by publication' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Downloads by Publication' ) ).toBeInTheDocument();
 		// "Example City" renders both as a downloads-table row and a selector option.
 		expect( screen.getAllByText( 'Example City' ).length ).toBeGreaterThanOrEqual( 2 );
 		// ...and the Content section's per-publication selector (2+ collections).
@@ -210,7 +210,7 @@ describe( 'AppTab', () => {
 		renderTab();
 
 		// "All publications" initially → the app-wide top author.
-		expect( await screen.findByText( 'Top authors' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Top Authors' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Alex Rivera' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Sam Okafor' ) ).not.toBeInTheDocument();
 
@@ -251,8 +251,8 @@ describe( 'AppTab', () => {
 		renderTab();
 
 		// The section titles still render (the cards are present, just gated).
-		expect( await screen.findByText( 'Top sections' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Subscriber mix' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Top Sections' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Subscriber Mix' ) ).toBeInTheDocument();
 		expect( screen.getAllByText( /Not configured for this site/i ).length ).toBeGreaterThanOrEqual( 2 );
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AppTab.tsx
@@ -87,7 +87,7 @@ const PropertyPicker = ( { config, onSaved }: { config: AppConfig; onSaved: ( ne
 	return (
 		<WizardsActionCard
 			isMedium
-			title={ __( 'App analytics property', 'newspack-plugin' ) }
+			title={ __( 'App Analytics Property', 'newspack-plugin' ) }
 			description={ __(
 				'Choose the Google Analytics property that receives your app’s data. It may be in a different account than your website.',
 				'newspack-plugin'
@@ -101,7 +101,7 @@ const PropertyPicker = ( { config, onSaved }: { config: AppConfig; onSaved: ( ne
 		>
 			<Grid noMargin rowGap={ 16 }>
 				<SelectControl
-					label={ __( 'App analytics property', 'newspack-plugin' ) }
+					label={ __( 'App Analytics Property', 'newspack-plugin' ) }
 					hideLabelFromVision
 					value={ value }
 					options={ options }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/AudienceTab.tsx
@@ -69,7 +69,7 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 						<ConnectBanner text={ data.banner_text } />
 						<TabSections>
 							{ registeredReaders && (
-								<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
+								<RegisteredReadersSection registeredReaders={ registeredReaders } range={ range } showComparison={ showComparison } />
 							) }
 							{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
 						</TabSections>
@@ -84,7 +84,7 @@ const AudienceTab = ( { range, previousRange }: AudienceTabProps ) => {
 								lastUpdated={ <LastUpdated tab="audience" range={ range } previousRange={ previousRange } /> }
 							/>
 							{ registeredReaders && (
-								<RegisteredReadersSection registeredReaders={ registeredReaders } showComparison={ showComparison } />
+								<RegisteredReadersSection registeredReaders={ registeredReaders } range={ range } showComparison={ showComparison } />
 							) }
 							{ newsletterSubscriberValue && <NewsletterValueSection value={ newsletterSubscriberValue } /> }
 							<CompositionSection current={ current } previous={ previous } />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/ConversionTab.test.tsx
@@ -69,14 +69,14 @@ describe( 'ConversionTab', () => {
 		mockSuccess();
 		render( <ConversionTab range={ range } previousRange={ null } /> );
 
-		expect( screen.getByText( 'The reader lifecycle' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Per-journey conversion funnels' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Where conversions come from' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How long conversions take' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Cohort retention' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Conversion rate trends' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Cross-tab influenced attribution' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Opportunity buckets' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'The Reader Lifecycle' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Per-Journey Conversion Funnels' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Where Conversions Come From' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'How Long Conversions Take' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Cohort Retention' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Conversion Rate Trends' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Cross-Tab Influenced Attribution' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Opportunity Buckets' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the LastUpdated chrome stub in the first section', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/EngagementTab.test.tsx
@@ -40,7 +40,7 @@ describe( 'EngagementTab', () => {
 		render( <EngagementTab range={ range } previousRange={ null } /> );
 
 		expect( screen.getByText( 'Connect Google Analytics.' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Overall engagement quality' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Overall Engagement Quality' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders sections with values on success', () => {
@@ -61,7 +61,7 @@ describe( 'EngagementTab', () => {
 
 		render( <EngagementTab range={ range } previousRange={ null } /> );
 
-		expect( screen.getByText( 'Overall engagement quality' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Overall Engagement Quality' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Avg Pages per Session' ) ).toBeInTheDocument();
 		expect( screen.getByText( '3.2' ) ).toBeInTheDocument();
 	} );
@@ -92,7 +92,7 @@ describe( 'EngagementTab', () => {
 
 		// The three non-completion quality cards still render.
 		expect( screen.getByText( 'Avg Pages per Session' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Avg Engaged Session Duration' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Avg Engaged Time' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Bounce Rate' ) ).toBeInTheDocument();
 		// The two remaining content tables still render.
 		expect( screen.getByText( 'Most-engaged articles' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/NewsletterAdsTab.test.tsx
@@ -130,16 +130,16 @@ describe( 'NewsletterAdsTab', () => {
 		expect( screen.getByText( 'Newsletter ad statistics have not been recorded yet.' ) ).toBeInTheDocument();
 		// …but — unlike AdvertisingTab — the tab body is NOT replaced: the Overview
 		// section renders with the all-time lifetime cards.
-		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'All-time impressions' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Reach & Revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'All-Time Impressions' ) ).toBeInTheDocument();
 		expect( screen.getByText( '950,000' ) ).toBeInTheDocument();
 		expect( screen.getByText( '12,400' ) ).toBeInTheDocument();
 		// The non-computable timeframe cards render the em-dash treatment with the
 		// remediation copy — never fake zeros.
 		expect( screen.getAllByText( 'Requires the latest Newspack Newsletters plugin.' ).length ).toBeGreaterThan( 0 );
 		// The timeframe-scoped sections stay withheld…
-		expect( screen.queryByText( 'Performance trend' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Top ads' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Performance Trend' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top Ads' ) ).not.toBeInTheDocument();
 		// …and the absent has_window_activity signal must NOT collapse the
 		// Overview into the empty state (the lifetime cards carry the signal).
 		expect( document.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
@@ -163,20 +163,20 @@ describe( 'NewsletterAdsTab', () => {
 		// Not presented as a "finish connecting" blocker…
 		expect( screen.queryByText( 'Finish setting up newsletter ad tracking to see timeframe data' ) ).not.toBeInTheDocument();
 		// …and every section still renders.
-		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top ads' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Ad performance by newsletter' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Reach & Revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance Trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Ads' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Ad Performance by Newsletter' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders all sections with values when ready', () => {
 		mockData( baseWindow() );
 		render( <NewsletterAdsTab range={ range } previousRange={ null } /> );
 
-		expect( screen.getByText( 'Reach & revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Reach & Revenue' ) ).toBeInTheDocument();
 		expect( screen.getByText( '84,000' ) ).toBeInTheDocument();
 		expect( screen.getByText( '$4,200' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance Trend' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Summer Sale' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Weekly Digest' ) ).toBeInTheDocument();
 		// No "About this data / data as of" callout: this tab reads local data

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/PromptsTab.test.tsx
@@ -119,13 +119,13 @@ describe( 'PromptsTab', () => {
 		// The tab-level Direct vs Influenced explainer was removed: Direct means a
 		// different thing per metric, so each card describes its own mechanism.
 		expect( screen.queryByText( 'About Direct vs Influenced conversion' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Prompt exposure' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Prompt engagement' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Free reader conversion' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Paid reader conversion' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Revenue from prompts' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How readers convert' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Performance breakdown' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Prompt Exposure' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Prompt Engagement' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Free Reader Conversion' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Paid Reader Conversion' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Revenue From Prompts' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'How Readers Convert' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance Breakdown' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders scorecard titles across the four format types', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/__snapshots__/PromptsTab.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   class="newspack-section-header__title-container"
                 >
                   <h2>
-                    Prompt exposure
+                    Prompt Exposure
                   </h2>
                 </div>
                 <p>
@@ -221,7 +221,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               class="newspack-section-header__title-container"
             >
               <h2>
-                Prompt engagement
+                Prompt Engagement
               </h2>
             </div>
             <p>
@@ -408,7 +408,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               class="newspack-section-header__title-container"
             >
               <h2>
-                Free reader conversion
+                Free Reader Conversion
               </h2>
             </div>
             <p>
@@ -436,7 +436,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Registration Conversion (Direct)
+                    Registration Conversion
+(Direct)
                   </span>
                 </div>
                 <div
@@ -487,7 +488,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Registration Conversion (Influenced, 7d)
+                    Registration Conversion
+(Influenced, 7d)
                   </span>
                 </div>
                 <div
@@ -538,7 +540,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Newsletter Signup Conversion (Direct)
+                    Newsletter Signup Conversion
+(Direct)
                   </span>
                 </div>
                 <div
@@ -589,7 +592,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Newsletter Signup Conversion (Influenced, 7d)
+                    Newsletter Signup Conversion
+(Influenced, 7d)
                   </span>
                 </div>
                 <div
@@ -646,7 +650,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               class="newspack-section-header__title-container"
             >
               <h2>
-                Paid reader conversion
+                Paid Reader Conversion
               </h2>
             </div>
             <p>
@@ -674,7 +678,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Donation Conversion (Direct)
+                    Donation Conversion
+(Direct)
                   </span>
                 </div>
                 <div
@@ -725,7 +730,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Donation Conversion (Influenced, 14d)
+                    Donation Conversion
+(Influenced, 14d)
                   </span>
                 </div>
                 <div
@@ -776,7 +782,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Subscription Conversion (Direct)
+                    Subscription Conversion
+(Direct)
                   </span>
                 </div>
                 <div
@@ -827,7 +834,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Subscription Conversion (Influenced, 14d)
+                    Subscription Conversion
+(Influenced, 14d)
                   </span>
                 </div>
                 <div
@@ -884,7 +892,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               class="newspack-section-header__title-container"
             >
               <h2>
-                Revenue from prompts
+                Revenue From Prompts
               </h2>
             </div>
             <p>
@@ -912,7 +920,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Donation Revenue (Direct)
+                    Donation Revenue
+(Direct)
                   </span>
                 </div>
                 <div
@@ -963,7 +972,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Donation Revenue (Influenced, 14d)
+                    Donation Revenue
+(Influenced, 14d)
                   </span>
                 </div>
                 <div
@@ -1014,7 +1024,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Subscription Revenue (Direct)
+                    Subscription Revenue
+(Direct)
                   </span>
                 </div>
                 <div
@@ -1065,7 +1076,8 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
                   data-wp-component="HStack"
                 >
                   <span>
-                    Subscription Revenue (Influenced, 14d)
+                    Subscription Revenue
+(Influenced, 14d)
                   </span>
                 </div>
                 <div
@@ -1122,7 +1134,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               class="newspack-section-header__title-container"
             >
               <h2>
-                How readers convert
+                How Readers Convert
               </h2>
             </div>
             <p>
@@ -1218,7 +1230,7 @@ exports[`PromptsTab matches the full-tab placeholder snapshot 1`] = `
               class="newspack-section-header__title-container"
             >
               <h2>
-                Performance breakdown
+                Performance Breakdown
               </h2>
             </div>
             <p>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ChannelDeviceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ChannelDeviceSection.tsx
@@ -37,12 +37,12 @@ const ChannelDeviceSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-channel-device">
 		<SectionHeading
 			id="newspack-insights-advertising-channel-device"
-			title={ __( 'Ad types & devices', 'newspack-plugin' ) }
+			title={ __( 'Ad Types & Devices', 'newspack-plugin' ) }
 			description={ __( 'How inventory and revenue split across ad types and devices.', 'newspack-plugin' ) }
 		/>
 		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
-				title={ __( 'Impressions by type', 'newspack-plugin' ) }
+				title={ __( 'Impressions by Type', 'newspack-plugin' ) }
 				caption={ __( 'How your ad inventory is allocated — including unpaid house ads', 'newspack-plugin' ) }
 				payload={ current.by_channel }
 			>
@@ -52,7 +52,7 @@ const ChannelDeviceSection = ( { current }: SectionProps ) => (
 				/>
 			</ChartCard>
 			<ChartCard
-				title={ __( 'Performance by device', 'newspack-plugin' ) }
+				title={ __( 'Performance by Device', 'newspack-plugin' ) }
 				caption={ __( 'Where your impressions and revenue land', 'newspack-plugin' ) }
 				payload={ current.by_device }
 			>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.test.tsx
@@ -112,8 +112,8 @@ describe( 'ReachRevenueSection cross-system scorecards (NPPD-1675)', () => {
 		expect( screen.getByText( 'RPM' ) ).toBeInTheDocument();
 		expect( cardValueByLabel( container, 'RPM' ) ).toBe( '$5.25' );
 
-		expect( screen.getByText( 'Impressions per session' ) ).toBeInTheDocument();
-		expect( cardValueByLabel( container, 'Impressions per session' ) ).toBe( '3' );
+		expect( screen.getByText( 'Impressions per Session' ) ).toBeInTheDocument();
+		expect( cardValueByLabel( container, 'Impressions per Session' ) ).toBe( '3' );
 	} );
 
 	it( 'shows period deltas on the derived scorecards under comparison', () => {
@@ -130,7 +130,7 @@ describe( 'ReachRevenueSection cross-system scorecards (NPPD-1675)', () => {
 				?.querySelector( '.newspack-insights__metric-card-delta' );
 
 		expect( deltaByLabel( 'RPM' ) ).not.toBeNull();
-		expect( deltaByLabel( 'Impressions per session' ) ).not.toBeNull();
+		expect( deltaByLabel( 'Impressions per Session' ) ).not.toBeNull();
 	} );
 
 	it( 'renders the data-unavailable overlay when sessions are missing', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/ReachRevenueSection.tsx
@@ -64,7 +64,7 @@ export interface SectionProps {
 	activeProvider?: AdvertisingProvider | null;
 }
 
-const TITLE = __( 'Reach & revenue', 'newspack-plugin' );
+const TITLE = __( 'Reach & Revenue', 'newspack-plugin' );
 const CAPTION = __( 'Volume, revenue, and inventory quality for the period.', 'newspack-plugin' );
 
 // Broadstreet has no revenue in its API (NPPD-2045), so its variant is impressions-only.
@@ -107,7 +107,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 						previous={ previous?.total_impressions }
 					/>
 					<Scorecard
-						label={ __( 'Impressions per session', 'newspack-plugin' ) }
+						label={ __( 'Impressions per Session', 'newspack-plugin' ) }
 						description={ __( 'Avg ad impressions a reader sees each session', 'newspack-plugin' ) }
 						current={ current.avg_impressions_per_session }
 						previous={ previous?.avg_impressions_per_session }
@@ -119,7 +119,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 						previous={ previous?.overall_ctr }
 					/>
 					<Scorecard
-						label={ __( 'Mobile share', 'newspack-plugin' ) }
+						label={ __( 'Mobile Share', 'newspack-plugin' ) }
 						description={ __( 'Share of impressions served to mobile', 'newspack-plugin' ) }
 						current={ current.mobile_share }
 						previous={ previous?.mobile_share }
@@ -196,7 +196,7 @@ const ReachRevenueSection = ( { current, previous, hasWindowActivity, lastUpdate
 						previous={ previous?.rpm }
 					/>
 					<Scorecard
-						label={ __( 'Impressions per session', 'newspack-plugin' ) }
+						label={ __( 'Impressions per Session', 'newspack-plugin' ) }
 						description={ __( 'Avg ad impressions a reader sees each session', 'newspack-plugin' ) }
 						current={ current.avg_impressions_per_session }
 						previous={ previous?.avg_impressions_per_session }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.test.tsx
@@ -29,7 +29,7 @@ describe( 'RevenueTrendSection', () => {
 	it( 'renders the revenue trend section with a chart', () => {
 		const { container } = render( <RevenueTrendSection current={ metrics() } previous={ null } /> );
 
-		expect( screen.getByText( 'Revenue trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Revenue Trend' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Daily revenue across the selected period.' ) ).toBeInTheDocument();
 		// One series → one line stroke.
 		expect( container.querySelectorAll( '.newspack-insights__line-stroke' ) ).toHaveLength( 1 );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/RevenueTrendSection.tsx
@@ -46,7 +46,7 @@ const RevenueTrendSection = ( { current, previous }: SectionProps ) => {
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-revenue-trend">
 			<SectionHeading
 				id="newspack-insights-advertising-revenue-trend"
-				title={ __( 'Revenue trend', 'newspack-plugin' ) }
+				title={ __( 'Revenue Trend', 'newspack-plugin' ) }
 				description={ __( 'Daily revenue across the selected period.', 'newspack-plugin' ) }
 			/>
 			<ChartCard payload={ current.revenue_by_day }>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.test.tsx
@@ -28,7 +28,7 @@ describe( 'SitePerformanceSection', () => {
 	it( 'renders the per-site table with one row per network site', () => {
 		render( <SitePerformanceSection current={ metrics() } previous={ null } /> );
 
-		expect( screen.getByText( 'Performance by site' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance by Site' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'almanacnews.com' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'mv-voice.com' ) ).toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/SitePerformanceSection.tsx
@@ -30,7 +30,7 @@ const SitePerformanceSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-site-performance">
 		<SectionHeading
 			id="newspack-insights-advertising-site-performance"
-			title={ __( 'Performance by site', 'newspack-plugin' ) }
+			title={ __( 'Performance by Site', 'newspack-plugin' ) }
 			description={ __( 'How each site in your network is performing.', 'newspack-plugin' ) }
 		/>
 		<Card __experimentalCoreCard className="newspack-insights__chart-card">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/TopPerformersSection.tsx
@@ -39,7 +39,11 @@ export interface SectionProps {
 const BroadstreetTopPerformers = ( { current }: SectionProps ) => (
 	<TabSections>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-zones">
-			<SectionHeading id="newspack-insights-advertising-top-zones" title={ __( 'Top zones', 'newspack-plugin' ) } />
+			<SectionHeading
+				id="newspack-insights-advertising-top-zones"
+				title={ __( 'Top Zones', 'newspack-plugin' ) }
+				description={ __( 'Your ad placements ranked by impressions and clicks.', 'newspack-plugin' ) }
+			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<MetricTable
 					payload={ current.top_zones }
@@ -56,7 +60,11 @@ const BroadstreetTopPerformers = ( { current }: SectionProps ) => (
 			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-advertisers">
-			<SectionHeading id="newspack-insights-advertising-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
+			<SectionHeading
+				id="newspack-insights-advertising-top-advertisers"
+				title={ __( 'Top Advertisers', 'newspack-plugin' ) }
+				description={ __( 'The advertisers delivering the most impressions on your site.', 'newspack-plugin' ) }
+			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<MetricTable
 					payload={ current.top_advertisers }
@@ -73,7 +81,11 @@ const BroadstreetTopPerformers = ( { current }: SectionProps ) => (
 			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
-			<SectionHeading id="newspack-insights-advertising-top-campaigns" title={ __( 'Top campaigns', 'newspack-plugin' ) } />
+			<SectionHeading
+				id="newspack-insights-advertising-top-campaigns"
+				title={ __( 'Top Campaigns', 'newspack-plugin' ) }
+				description={ __( 'Direct-sold orders ranked by delivery.', 'newspack-plugin' ) }
+			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<MetricTable
 					payload={ current.top_campaigns }
@@ -99,7 +111,11 @@ const TopPerformersSection = ( { current, previous, activeProvider }: SectionPro
 	return (
 		<TabSections>
 			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-ad-units">
-				<SectionHeading id="newspack-insights-advertising-top-ad-units" title={ __( 'Top ad units', 'newspack-plugin' ) } />
+				<SectionHeading
+					id="newspack-insights-advertising-top-ad-units"
+					title={ __( 'Top Ad Units', 'newspack-plugin' ) }
+					description={ __( 'Your highest-earning ad units this timeframe.', 'newspack-plugin' ) }
+				/>
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">
 					<MetricTable
 						payload={ current.top_ad_units }
@@ -117,7 +133,11 @@ const TopPerformersSection = ( { current, previous, activeProvider }: SectionPro
 				</Card>
 			</Section>
 			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-advertisers">
-				<SectionHeading id="newspack-insights-advertising-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
+				<SectionHeading
+					id="newspack-insights-advertising-top-advertisers"
+					title={ __( 'Top Advertisers', 'newspack-plugin' ) }
+					description={ __( 'The advertisers delivering the most impressions on your site.', 'newspack-plugin' ) }
+				/>
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">
 					<MetricTable
 						payload={ current.top_advertisers }
@@ -135,7 +155,11 @@ const TopPerformersSection = ( { current, previous, activeProvider }: SectionPro
 				</Card>
 			</Section>
 			<Section className="newspack-insights__section" aria-labelledby="newspack-insights-advertising-top-campaigns">
-				<SectionHeading id="newspack-insights-advertising-top-campaigns" title={ __( 'Top campaigns', 'newspack-plugin' ) } />
+				<SectionHeading
+					id="newspack-insights-advertising-top-campaigns"
+					title={ __( 'Top Campaigns', 'newspack-plugin' ) }
+					description={ __( 'Direct-sold orders ranked by delivery.', 'newspack-plugin' ) }
+				/>
 				{ /* Direct-sold orders only — programmatic delivery is order-less and
 				     filtered server-side. */ }
 				<Card __experimentalCoreCard className="newspack-insights__chart-card">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/sections.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/advertising/sections/sections.test.tsx
@@ -114,7 +114,7 @@ describe( 'Advertising sections', () => {
 		expect( screen.getByText( 'Acme Co' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Hometown Hardware — Spring Flight' ) ).toBeInTheDocument();
 		// The device breakdown lives in ChannelDeviceSection, not here.
-		expect( screen.queryByText( 'Performance by device' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Performance by Device' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Smartphone' ) ).not.toBeInTheDocument();
 		// The ad-units table no longer carries an eCPM column (payload field is
 		// still present but unrendered).
@@ -133,7 +133,7 @@ describe( 'Advertising sections', () => {
 
 	it( 'Top campaigns lists direct-sold orders and em-dashes a null CTR', () => {
 		render( <TopPerformersSection current={ metrics } previous={ null } /> );
-		expect( screen.getByText( 'Top campaigns' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Campaigns' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Riverside Credit Union' ) ).toBeInTheDocument();
 		expect( screen.getByText( '$350.00' ) ).toBeInTheDocument();
 		// Null CTR (no impressions basis) renders an em-dash, never 0%.
@@ -180,7 +180,7 @@ describe( 'Advertising sections', () => {
 
 	it( 'ChannelDeviceSection renders impressions-weighted ad-type slices with plain-number legend values', () => {
 		render( <ChannelDeviceSection current={ metrics } previous={ null } /> );
-		expect( screen.getByText( 'Impressions by type' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Impressions by Type' ) ).toBeInTheDocument();
 		// One legend entry per ad-type bucket, impressions-weighted with plain
 		// numbers — no currency, since house inventory is unpaid by definition.
 		expect( screen.getByText( 'Programmatic' ) ).toBeInTheDocument();
@@ -196,7 +196,7 @@ describe( 'Advertising sections', () => {
 
 	it( 'ChannelDeviceSection renders the device table with eCPM (em-dash when no impressions)', () => {
 		render( <ChannelDeviceSection current={ metrics } previous={ null } /> );
-		expect( screen.getByText( 'Performance by device' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance by Device' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Smartphone' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Desktop' ) ).toBeInTheDocument();
 		expect( screen.getByText( '1,392,000' ) ).toBeInTheDocument();
@@ -260,11 +260,11 @@ describe( 'Advertising Broadstreet variant (NPPD-2045)', () => {
 
 		expect( screen.getByText( 'Impressions' ) ).toBeInTheDocument();
 		expect( screen.getByText( '2.4M' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Impressions per session' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Impressions per Session' ) ).toBeInTheDocument();
 		expect( screen.getByText( '3' ) ).toBeInTheDocument();
 		// The two new rate cards render as percents.
 		expect( screen.getByText( 'Overall CTR' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Mobile share' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Mobile Share' ) ).toBeInTheDocument();
 		expect( screen.getByText( '63%' ) ).toBeInTheDocument();
 
 		// Revenue-derived cards are omitted entirely (Broadstreet has no revenue).
@@ -282,7 +282,7 @@ describe( 'Advertising Broadstreet variant (NPPD-2045)', () => {
 		};
 		render( <ReachRevenueSection current={ noImpressions } previous={ null } hasWindowActivity activeProvider="broadstreet" /> );
 		expect( screen.getByText( 'Overall CTR' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Mobile share' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Mobile Share' ) ).toBeInTheDocument();
 		// Non-computable rate → em-dash, never a misleading 0%.
 		expect( screen.queryByText( '0%' ) ).not.toBeInTheDocument();
 		expect( screen.getAllByText( '—' ).length ).toBeGreaterThanOrEqual( 2 );
@@ -293,24 +293,24 @@ describe( 'Advertising Broadstreet variant (NPPD-2045)', () => {
 			<ReachRevenueSection current={ broadstreetMetrics } previous={ null } hasWindowActivity={ false } activeProvider="broadstreet" />
 		);
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Impressions per session' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Impressions per Session' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'TopPerformersSection renders Top advertisers + Top zones + Top campaigns, no revenue column or GAM ad-units table', () => {
 		render( <TopPerformersSection current={ broadstreetMetrics } previous={ null } activeProvider="broadstreet" /> );
 
-		expect( screen.getByText( 'Top advertisers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Advertisers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Hometown Hardware' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Top zones' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Zones' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Homepage Leaderboard' ) ).toBeInTheDocument();
 		// Top campaigns is a first-class Broadstreet table (impressions/clicks/CTR, no revenue).
-		expect( screen.getByText( 'Top campaigns' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Top Campaigns' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Riverside Credit Union — Summer' ) ).toBeInTheDocument();
 		// Null CTR (no impressions basis) renders an em-dash, never 0%.
 		expect( screen.getAllByText( '—' ).length ).toBeGreaterThanOrEqual( 1 );
 
 		// No revenue column, and the GAM-only ad-units table is absent.
 		expect( screen.queryByText( 'Revenue' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Top ad units' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Top Ad Units' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/CompositionSection.tsx
@@ -46,12 +46,12 @@ const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-app-composition-heading">
 		<SectionHeading
 			id="newspack-insights-app-composition-heading"
-			title={ __( 'Audience & access', 'newspack-plugin' ) }
+			title={ __( 'Audience & Access', 'newspack-plugin' ) }
 			description={ __( 'The subscriber mix of your app audience and the free-vs-paid content they read.', 'newspack-plugin' ) }
 		/>
 		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
-				title={ __( 'Subscriber mix', 'newspack-plugin' ) }
+				title={ __( 'Subscriber Mix', 'newspack-plugin' ) }
 				caption={ __( 'Active users by subscriber status', 'newspack-plugin' ) }
 				payload={ metrics.subscriber_mix }
 			>
@@ -63,7 +63,7 @@ const CompositionSection = ( { metrics }: CompositionSectionProps ) => (
 				/>
 			</ChartCard>
 			<ChartCard
-				title={ __( 'Free vs. paid content', 'newspack-plugin' ) }
+				title={ __( 'Free vs. Paid Content', 'newspack-plugin' ) }
 				caption={ __( 'Screen views by content access level', 'newspack-plugin' ) }
 				payload={ metrics.content_cost }
 			>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ContentSection.tsx
@@ -73,7 +73,7 @@ const ContentSection = ( { metrics }: ContentSectionProps ) => {
 			/>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				<ChartCard
-					title={ __( 'Top sections', 'newspack-plugin' ) }
+					title={ __( 'Top Sections', 'newspack-plugin' ) }
 					caption={ __( 'Screen views by section', 'newspack-plugin' ) }
 					payload={ sections }
 				>
@@ -87,7 +87,7 @@ const ContentSection = ( { metrics }: ContentSectionProps ) => {
 					/>
 				</ChartCard>
 				<ChartCard
-					title={ __( 'Top authors', 'newspack-plugin' ) }
+					title={ __( 'Top Authors', 'newspack-plugin' ) }
 					caption={ __( 'Screen views by author', 'newspack-plugin' ) }
 					payload={ authors }
 				>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/DownloadsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/DownloadsSection.tsx
@@ -55,19 +55,19 @@ const DownloadsSection = ( { metrics, previous }: DownloadsSectionProps ) => {
 			/>
 			<Grid columns={ 3 } gutter={ 16 } noMargin>
 				<Scorecard
-					label={ __( 'Downloads started', 'newspack-plugin' ) }
+					label={ __( 'Downloads Started', 'newspack-plugin' ) }
 					description={ __( 'Downloads readers began', 'newspack-plugin' ) }
 					current={ metrics.downloads_started }
 					previous={ previous?.downloads_started }
 				/>
 				<Scorecard
-					label={ __( 'Downloads completed', 'newspack-plugin' ) }
+					label={ __( 'Downloads Completed', 'newspack-plugin' ) }
 					description={ __( 'Downloads that finished successfully', 'newspack-plugin' ) }
 					current={ metrics.downloads_completed }
 					previous={ previous?.downloads_completed }
 				/>
 				<Scorecard
-					label={ __( 'Download completion rate', 'newspack-plugin' ) }
+					label={ __( 'Download Completion Rate', 'newspack-plugin' ) }
 					description={ __( 'Share of started downloads that completed', 'newspack-plugin' ) }
 					current={ metrics.download_completion_rate }
 					previous={ previous?.download_completion_rate }
@@ -76,7 +76,7 @@ const DownloadsSection = ( { metrics, previous }: DownloadsSectionProps ) => {
 			{ byPublication && (
 				<div className="newspack-insights__chart-grid">
 					<ChartCard
-						title={ __( 'Downloads by publication', 'newspack-plugin' ) }
+						title={ __( 'Downloads by Publication', 'newspack-plugin' ) }
 						caption={ __( 'Completed downloads across the titles your app serves', 'newspack-plugin' ) }
 						payload={ byPublication }
 					>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/EngagementSection.tsx
@@ -35,31 +35,31 @@ const EngagementSection = ( { metrics, previous }: EngagementSectionProps ) => (
 		/>
 		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<Scorecard
-				label={ __( 'Avg. engagement time', 'newspack-plugin' ) }
+				label={ __( 'Avg. Engagement Time', 'newspack-plugin' ) }
 				description={ __( 'Average time in the app per session — app readers tend to stay far longer than on the web', 'newspack-plugin' ) }
 				current={ metrics.avg_engagement_time }
 				previous={ previous?.avg_engagement_time }
 			/>
 			<Scorecard
-				label={ __( 'Engagement rate', 'newspack-plugin' ) }
+				label={ __( 'Engagement Rate', 'newspack-plugin' ) }
 				description={ __( 'Share of sessions that were engaged (meaningful time, a conversion, or multiple screens)', 'newspack-plugin' ) }
 				current={ metrics.engagement_rate }
 				previous={ previous?.engagement_rate }
 			/>
 			<Scorecard
-				label={ __( 'Engaged sessions', 'newspack-plugin' ) }
+				label={ __( 'Engaged Sessions', 'newspack-plugin' ) }
 				description={ __( 'Sessions that lasted 10+ seconds, had a key event, or viewed 2+ screens', 'newspack-plugin' ) }
 				current={ metrics.engaged_sessions }
 				previous={ previous?.engaged_sessions }
 			/>
 			<Scorecard
-				label={ __( 'Screens per session', 'newspack-plugin' ) }
+				label={ __( 'Screens per Session', 'newspack-plugin' ) }
 				description={ __( 'Average screens viewed per app session', 'newspack-plugin' ) }
 				current={ metrics.screens_per_session }
 				previous={ previous?.screens_per_session }
 			/>
 			<Scorecard
-				label={ __( 'Screen views', 'newspack-plugin' ) }
+				label={ __( 'Screen Views', 'newspack-plugin' ) }
 				description={ __( 'Total app screens viewed', 'newspack-plugin' ) }
 				current={ metrics.screen_views }
 				previous={ previous?.screen_views }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/NotificationsSection.tsx
@@ -34,19 +34,19 @@ const NotificationsSection = ( { metrics, previous }: NotificationsSectionProps 
 		/>
 		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<Scorecard
-				label={ __( 'Notification open rate', 'newspack-plugin' ) }
+				label={ __( 'Notification Open Rate', 'newspack-plugin' ) }
 				description={ __( 'Share of received push notifications that were opened', 'newspack-plugin' ) }
 				current={ metrics.notification_open_rate }
 				previous={ previous?.notification_open_rate }
 			/>
 			<Scorecard
-				label={ __( 'Notifications received', 'newspack-plugin' ) }
+				label={ __( 'Notifications Received', 'newspack-plugin' ) }
 				description={ __( 'Push notifications delivered to app users', 'newspack-plugin' ) }
 				current={ metrics.notifications_received }
 				previous={ previous?.notifications_received }
 			/>
 			<Scorecard
-				label={ __( 'Opt-in changes', 'newspack-plugin' ) }
+				label={ __( 'Opt-in Changes', 'newspack-plugin' ) }
 				description={ __( 'Times users changed their push-notification permission', 'newspack-plugin' ) }
 				current={ metrics.notification_opt_changes }
 				previous={ previous?.notification_opt_changes }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/ReachSection.tsx
@@ -46,13 +46,13 @@ const ReachSection = ( { metrics, previous, lastUpdated }: ReachSectionProps ) =
 		/>
 		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<Scorecard
-				label={ __( 'Active users', 'newspack-plugin' ) }
+				label={ __( 'Active Users', 'newspack-plugin' ) }
 				description={ __( 'Distinct people who opened the app', 'newspack-plugin' ) }
 				current={ metrics.active_users }
 				previous={ previous?.active_users }
 			/>
 			<Scorecard
-				label={ __( 'New users', 'newspack-plugin' ) }
+				label={ __( 'New Users', 'newspack-plugin' ) }
 				description={ __( 'First-time app users', 'newspack-plugin' ) }
 				current={ metrics.new_users }
 				previous={ previous?.new_users }
@@ -66,14 +66,14 @@ const ReachSection = ( { metrics, previous, lastUpdated }: ReachSectionProps ) =
 		</Grid>
 		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
-				title={ __( 'By platform', 'newspack-plugin' ) }
+				title={ __( 'By Platform', 'newspack-plugin' ) }
 				caption={ __( 'Active users by operating system', 'newspack-plugin' ) }
 				payload={ metrics.platform }
 			>
 				<PieChart segments={ toSeries( metrics.platform, 'platform', 'active_users' ) } />
 			</ChartCard>
 			<ChartCard
-				title={ __( 'By app version', 'newspack-plugin' ) }
+				title={ __( 'By App Version', 'newspack-plugin' ) }
 				caption={ __( 'Active users by app version', 'newspack-plugin' ) }
 				payload={ metrics.app_version }
 			>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/app/RetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/app/RetentionSection.tsx
@@ -41,7 +41,7 @@ const RetentionSection = ( { metrics }: RetentionSectionProps ) => (
 			description={ __( 'How many new app users come back in the weeks after their first open.', 'newspack-plugin' ) }
 		/>
 		<ChartCard
-			title={ __( 'Weekly retention', 'newspack-plugin' ) }
+			title={ __( 'Weekly Retention', 'newspack-plugin' ) }
 			caption={ __( 'Share of new users still active N weeks after first open', 'newspack-plugin' ) }
 			payload={ metrics.retention }
 		>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/CompositionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/CompositionSection.tsx
@@ -29,33 +29,33 @@ const CompositionSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-composition">
 		<SectionHeading
 			id="newspack-insights-audience-composition"
-			title={ __( 'Audience composition', 'newspack-plugin' ) }
+			title={ __( 'Audience Composition', 'newspack-plugin' ) }
 			description={ __( "Who's reading your stories.", 'newspack-plugin' ) }
 		/>
 		<Grid columns={ 2 } gutter={ 16 } noMargin>
 			<ChartCard
-				title={ __( 'Newsletter subscriber composition', 'newspack-plugin' ) }
+				title={ __( 'Newsletter Subscriber Composition', 'newspack-plugin' ) }
 				caption={ __( 'Your newsletter subscribers vs the rest', 'newspack-plugin' ) }
 				payload={ current.newsletter_subscriber_composition }
 			>
 				<PieChart segments={ toSeries( current.newsletter_subscriber_composition, 'label', 'value' ) } />
 			</ChartCard>
 			<ChartCard
-				title={ __( 'Logged-in vs anonymous', 'newspack-plugin' ) }
+				title={ __( 'Logged-in vs Anonymous', 'newspack-plugin' ) }
 				caption={ __( "Who's signed in", 'newspack-plugin' ) }
 				payload={ current.logged_in_vs_anonymous_composition }
 			>
 				<PieChart segments={ toSeries( current.logged_in_vs_anonymous_composition, 'label', 'value' ) } />
 			</ChartCard>
 			<ChartCard
-				title={ __( 'Device breakdown', 'newspack-plugin' ) }
+				title={ __( 'Device Breakdown', 'newspack-plugin' ) }
 				caption={ __( 'What devices your readers use', 'newspack-plugin' ) }
 				payload={ current.device_breakdown }
 			>
 				<PieChart segments={ toSeries( current.device_breakdown, 'device', 'readers' ) } />
 			</ChartCard>
 			<ChartCard
-				title={ __( 'Supporter type', 'newspack-plugin' ) }
+				title={ __( 'Supporter Type', 'newspack-plugin' ) }
 				caption={ __( 'Subscribers, donors, and registered readers among your logged-in audience.', 'newspack-plugin' ) }
 				payload={ current.supporter_type }
 			>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/ContentPerformanceSection.tsx
@@ -26,7 +26,7 @@ const ContentPerformanceSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-content">
 		<SectionHeading
 			id="newspack-insights-audience-content"
-			title={ __( 'Content performance', 'newspack-plugin' ) }
+			title={ __( 'Content Performance', 'newspack-plugin' ) }
 			description={ __( "What's getting read.", 'newspack-plugin' ) }
 		/>
 		<VStack spacing={ 4 }>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.test.tsx
@@ -16,25 +16,25 @@ import NewsletterValueSection from './NewsletterValueSection';
 describe( 'Audience NewsletterValueSection', () => {
 	it( 'renders the modeled value when computable', () => {
 		render( <NewsletterValueSection value={ { value: 27.3, computable: true, denominator: 1200 } } /> );
-		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Value per Newsletter Subscriber' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders an em-dash with explanatory copy when not computable', () => {
 		render( <NewsletterValueSection value={ { value: 0, computable: false, denominator: 0 } } /> );
-		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Value per Newsletter Subscriber' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough newsletter or supporter history to model yet.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'suppresses the insufficient-history copy when the payload carries an error', () => {
 		render( <NewsletterValueSection value={ { value: 0, computable: false, error: 'Hub unavailable' } } /> );
-		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Value per Newsletter Subscriber' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows the warming note when the hub snapshot is still backfilling (NEWS-2603)', () => {
 		render( <NewsletterValueSection value={ { value: 0, computable: false, state: 'warming' } } /> );
-		expect( screen.getByText( 'Value per newsletter subscriber' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Value per Newsletter Subscriber' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter or supporter history to model yet.' ) ).not.toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/NewsletterValueSection.tsx
@@ -43,12 +43,12 @@ const NewsletterValueSection = ( { value }: NewsletterValueSectionProps ) => {
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-newsletter-value">
 			<SectionHeading
 				id="newspack-insights-audience-newsletter-value"
-				title={ __( 'Newsletter subscriber value', 'newspack-plugin' ) }
+				title={ __( 'Newsletter Subscriber Value', 'newspack-plugin' ) }
 				description={ __( 'What your newsletter audience is worth as future reader revenue.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
-					label={ __( 'Value per newsletter subscriber', 'newspack-plugin' ) }
+					label={ __( 'Value per Newsletter Subscriber', 'newspack-plugin' ) }
 					value={ amount ?? 0 }
 					format="currency"
 					error={ value?.error }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.test.tsx
@@ -15,6 +15,7 @@ import { render, screen } from '@testing-library/react';
  */
 import RegisteredReadersSection from './RegisteredReadersSection';
 import type { MetricPayload, RegisteredReaders } from '../../../api/audience';
+import type { DateRange } from '../../../state/useDateRange';
 
 const count = ( value: number | null, computable = true ): MetricPayload => ( { value, computable, type: 'count' } );
 
@@ -23,37 +24,60 @@ const make = ( total: MetricPayload, current: MetricPayload, previous: MetricPay
 	new: { current, previous },
 } );
 
+const RANGE: DateRange = { preset: 'last-30', start: '2026-05-20', end: '2026-06-18' };
+
 describe( 'RegisteredReadersSection', () => {
 	it( 'renders the heading and both cards with formatted counts', () => {
-		render( <RegisteredReadersSection registeredReaders={ make( count( 24680 ), count( 412 ), count( 357 ) ) } showComparison /> );
-		expect( screen.getByRole( 'heading', { name: 'Registered readers' } ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Total registered readers' ) ).toBeInTheDocument();
+		render(
+			<RegisteredReadersSection registeredReaders={ make( count( 24680 ), count( 412 ), count( 357 ) ) } range={ RANGE } showComparison />
+		);
+		expect( screen.getByRole( 'heading', { name: 'Registered Readers' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total Registered Readers' ) ).toBeInTheDocument();
 		expect( screen.getByText( '24,680' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'New registered readers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Registered Readers' ) ).toBeInTheDocument();
 		expect( screen.getByText( '412' ) ).toBeInTheDocument();
 	} );
 
+	it( 'names the active timeframe in the new-readers description', () => {
+		render(
+			<RegisteredReadersSection registeredReaders={ make( count( 24680 ), count( 412 ), count( 357 ) ) } range={ RANGE } showComparison />
+		);
+		expect( screen.getByText( 'Registrations created in the last 30 days' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to the generic phrase for a custom range', () => {
+		const custom: DateRange = { preset: 'custom', start: '2026-01-01', end: '2026-02-01' };
+		render(
+			<RegisteredReadersSection registeredReaders={ make( count( 24680 ), count( 412 ), count( 357 ) ) } range={ custom } showComparison />
+		);
+		expect( screen.getByText( 'Registrations created in this timeframe' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders a new-publisher zero as an honest 0 with no period delta', () => {
-		render( <RegisteredReadersSection registeredReaders={ make( count( 0 ), count( 0 ), count( 0 ) ) } showComparison /> );
+		render( <RegisteredReadersSection registeredReaders={ make( count( 0 ), count( 0 ), count( 0 ) ) } range={ RANGE } showComparison /> );
 		expect( screen.getAllByText( '0' ).length ).toBeGreaterThanOrEqual( 2 );
 		expect( screen.queryByText( '↑' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( '↓' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the not-computable em-dash + line when a count fails server-side', () => {
-		render( <RegisteredReadersSection registeredReaders={ make( count( null, false ), count( null, false ), null ) } showComparison /> );
+		render(
+			<RegisteredReadersSection registeredReaders={ make( count( null, false ), count( null, false ), null ) } range={ RANGE } showComparison />
+		);
 		expect( screen.getAllByLabelText( 'Not applicable' ) ).toHaveLength( 2 );
 		expect( screen.getAllByText( 'Registered reader count is unavailable right now.' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'suppresses the new-readers delta when none were created this timeframe', () => {
-		render( <RegisteredReadersSection registeredReaders={ make( count( 100 ), count( 0 ), count( 40 ) ) } showComparison /> );
+		render( <RegisteredReadersSection registeredReaders={ make( count( 100 ), count( 0 ), count( 40 ) ) } range={ RANGE } showComparison /> );
 		// A real prior value exists, but an honest zero must not render "↓100%".
 		expect( screen.queryByText( '↓' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'omits the new-readers delta when the comparison toggle is off', () => {
-		render( <RegisteredReadersSection registeredReaders={ make( count( 100 ), count( 60 ), count( 40 ) ) } showComparison={ false } /> );
+		render(
+			<RegisteredReadersSection registeredReaders={ make( count( 100 ), count( 60 ), count( 40 ) ) } range={ RANGE } showComparison={ false } />
+		);
 		expect( screen.queryByText( '↑' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( '↓' ) ).not.toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/RegisteredReadersSection.tsx
@@ -24,19 +24,22 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { Grid } from '../../../../../../packages/components/src';
 import type { MetricPayload, RegisteredReaders } from '../../../api/audience';
+import { rangeWhenPhrase, type DateRange } from '../../../state/useDateRange';
 import MetricCard from '../../components/MetricCard';
 import Section from '../../components/Section';
 import SectionHeading from '../../components/SectionHeading';
 
 export interface RegisteredReadersSectionProps {
 	registeredReaders: RegisteredReaders;
+	/** Active date range — drives the "new" card's timeframe-aware description. */
+	range: DateRange;
 	/** Whether the comparison toggle is on — gates the "new" card's period delta. */
 	showComparison: boolean;
 }
@@ -47,7 +50,7 @@ const readCount = ( payload: MetricPayload | null | undefined ): number | null =
 
 const UNAVAILABLE_MESSAGE = __( 'Registered reader count is unavailable right now.', 'newspack-plugin' );
 
-const RegisteredReadersSection = ( { registeredReaders, showComparison }: RegisteredReadersSectionProps ) => {
+const RegisteredReadersSection = ( { registeredReaders, range, showComparison }: RegisteredReadersSectionProps ) => {
 	const { total, new: newReaders } = registeredReaders;
 
 	const totalCount = readCount( total );
@@ -61,12 +64,12 @@ const RegisteredReadersSection = ( { registeredReaders, showComparison }: Regist
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-registered-readers">
 			<SectionHeading
 				id="newspack-insights-audience-registered-readers"
-				title={ __( 'Registered readers', 'newspack-plugin' ) }
+				title={ __( 'Registered Readers', 'newspack-plugin' ) }
 				description={ __( 'People who registered on your site — the known-reader population behind the segments below.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
-					label={ __( 'Total registered readers', 'newspack-plugin' ) }
+					label={ __( 'Total Registered Readers', 'newspack-plugin' ) }
 					value={ totalCount ?? 0 }
 					format="number"
 					// Window-independent snapshot: never a period delta.
@@ -74,12 +77,16 @@ const RegisteredReadersSection = ( { registeredReaders, showComparison }: Regist
 					description={ __( 'All-time registrations on your site', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'New registered readers', 'newspack-plugin' ) }
+					label={ __( 'New Registered Readers', 'newspack-plugin' ) }
 					value={ newCount ?? 0 }
 					format="number"
 					previousValue={ previousNew }
 					notComputableMessage={ newCount === null ? UNAVAILABLE_MESSAGE : undefined }
-					description={ __( 'Registrations created in this timeframe', 'newspack-plugin' ) }
+					description={ sprintf(
+						/* translators: %s is a timeframe phrase, e.g. "in the last 30 days" or "this month". */
+						__( 'Registrations created %s', 'newspack-plugin' ),
+						rangeWhenPhrase( range )
+					) }
 				/>
 			</Grid>
 		</Section>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TimeTrendsSection.tsx
@@ -47,14 +47,14 @@ const TimeTrendsSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-trends">
 		<SectionHeading
 			id="newspack-insights-audience-trends"
-			title={ __( 'Time trends', 'newspack-plugin' ) }
+			title={ __( 'Time Trends', 'newspack-plugin' ) }
 			description={ __( 'When your readers show up across the period, by day of week, and by hour of day.', 'newspack-plugin' ) }
 		/>
 		{ /* New vs Returning takes the full width; the two day/hour bar charts share the row below. */ }
 		<VStack spacing={ 4 }>
 			<ChartCard
 				caption={ __( 'Day to day', 'newspack-plugin' ) }
-				title={ __( 'New vs returning over time', 'newspack-plugin' ) }
+				title={ __( 'New vs Returning Over Time', 'newspack-plugin' ) }
 				payload={ current.new_vs_returning_over_time }
 			>
 				<LineChart
@@ -68,10 +68,10 @@ const TimeTrendsSection = ( { current }: SectionProps ) => (
 				/>
 			</ChartCard>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
-				<ChartCard title={ __( 'Readership by day of week', 'newspack-plugin' ) } payload={ current.readership_by_day_of_week }>
+				<ChartCard title={ __( 'Readership by Day of Week', 'newspack-plugin' ) } payload={ current.readership_by_day_of_week }>
 					<BarChart bars={ toSeries( current.readership_by_day_of_week, 'day_of_week', 'active_readers' ) } formatLabel={ abbreviateDay } />
 				</ChartCard>
-				<ChartCard title={ __( 'Readership by hour of day', 'newspack-plugin' ) } payload={ current.readership_by_hour_of_day }>
+				<ChartCard title={ __( 'Readership by Hour of Day', 'newspack-plugin' ) } payload={ current.readership_by_hour_of_day }>
 					<BarChart bars={ toSeries( current.readership_by_hour_of_day, 'hour', 'active_readers' ) } />
 				</ChartCard>
 			</Grid>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TrafficSourcesSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TrafficSourcesSection.test.tsx
@@ -71,7 +71,7 @@ describe( 'TrafficSourcesSection — Top campaigns row filtering', () => {
 		);
 		expect( screen.getByText( 'No campaign traffic in this timeframe.' ) ).toBeInTheDocument();
 		// Section + breakdown stay visible.
-		expect( screen.getByText( 'Traffic sources' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Traffic sources breakdown' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Traffic Sources' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Traffic Sources Breakdown' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TrafficSourcesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/audience/sections/TrafficSourcesSection.tsx
@@ -53,16 +53,16 @@ const TrafficSourcesSection = ( { current }: SectionProps ) => {
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-audience-traffic">
 			<SectionHeading
 				id="newspack-insights-audience-traffic"
-				title={ __( 'Traffic sources', 'newspack-plugin' ) }
+				title={ __( 'Traffic Sources', 'newspack-plugin' ) }
 				description={ __( 'Where your readers come from.', 'newspack-plugin' ) }
 			/>
 			{ /* Channel breakdown (1 column) reads as a unit with the campaigns
 			     driving each channel (spans the other 2 columns) — NPPD-1649 fix #3. */ }
 			<Grid columns={ 3 } gutter={ 16 } noMargin>
-				<ChartCard title={ __( 'Traffic sources breakdown', 'newspack-plugin' ) } payload={ current.traffic_sources_breakdown }>
+				<ChartCard title={ __( 'Traffic Sources Breakdown', 'newspack-plugin' ) } payload={ current.traffic_sources_breakdown }>
 					<PieChart segments={ toSeries( current.traffic_sources_breakdown, 'channel', 'readers' ) } />
 				</ChartCard>
-				<ChartCard title={ __( 'Top campaigns', 'newspack-plugin' ) } payload={ campaigns } style={ { gridColumn: 'span 2' } }>
+				<ChartCard title={ __( 'Top Campaigns', 'newspack-plugin' ) } payload={ campaigns } style={ { gridColumn: 'span 2' } }>
 					<MetricTable
 						payload={ campaigns }
 						emptyMessage={ __( 'No campaign traffic in this timeframe.', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/DataLagIndicator.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/DataLagIndicator.tsx
@@ -4,26 +4,49 @@
  * Reporting-freshness context near the top of a tab body: when the displayed
  * figures were last finalized ("Data as of …"), plus — when the window includes
  * recent days the ad server hasn't cleared yet — a note that those recent
- * figures are estimated and may shift. Renders via the shared {@see InfoCallout}
- * and is deliberately NOT dismissible: the content varies with the selected date
- * range, so the publisher should see it on every window.
+ * figures are estimated and may shift. Renders as a plain `@wordpress/components`
+ * warning `Notice`, portaled to the top of the wizard body, and is deliberately
+ * NOT dismissible: the content varies with the selected date range, so the
+ * publisher should see it on every window.
  */
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import InfoCallout from './InfoCallout';
+import { createPortal, useLayoutEffect, useState } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 export interface DataLagIndicatorProps {
 	/** ISO YYYY-MM-DD of the most recent finalized data, or null/undefined. */
 	dataAsOf?: string | null;
 	hasEstimatedData?: boolean;
 }
+
+/**
+ * A host node inserted as the first child of `.newspack-wizard__main` — inside
+ * the wizard body but above (outside) `.newspack-wizard__content` — so the
+ * callout reads as a page-level notice while still living in the routed tab (and
+ * keeping its per-tab data). Returns null when the wizard chrome isn't present
+ * (e.g. isolated tests), so the caller falls back to an inline render.
+ */
+const useWizardMainHost = (): HTMLElement | null => {
+	const [ host, setHost ] = useState< HTMLElement | null >( null );
+	useLayoutEffect( () => {
+		const main = document.querySelector< HTMLElement >( '.newspack-wizard__main' );
+		if ( ! main ) {
+			return;
+		}
+		const el = document.createElement( 'div' );
+		el.className = 'newspack-insights__page-notice';
+		main.insertBefore( el, main.firstChild );
+		setHost( el );
+		return () => {
+			el.remove();
+		};
+	}, [] );
+	return host;
+};
 
 const dateFormatter = new Intl.DateTimeFormat( undefined, {
 	month: 'short',
@@ -45,6 +68,8 @@ const formatIsoDate = ( iso?: string | null ): string => {
 };
 
 const DataLagIndicator = ( { dataAsOf, hasEstimatedData }: DataLagIndicatorProps ) => {
+	// Called unconditionally (hooks rules) before the early return below.
+	const host = useWizardMainHost();
 	const asOf = formatIsoDate( dataAsOf );
 
 	// Nothing to say only when there's neither an as-of date nor an estimate
@@ -70,11 +95,15 @@ const DataLagIndicator = ( { dataAsOf, hasEstimatedData }: DataLagIndicatorProps
 		text = __( 'Recent days are estimated and may shift until Google finalizes.', 'newspack-plugin' );
 	}
 
-	return (
-		<InfoCallout heading={ __( 'About this data', 'newspack-plugin' ) } dismissible={ false }>
-			<p>{ text }</p>
-		</InfoCallout>
+	const callout = (
+		<Notice status="warning" isDismissible={ false }>
+			{ text }
+		</Notice>
 	);
+
+	// Portal into the wizard body (above the routed content) when available;
+	// otherwise render inline (isolated tests, or before the host is ready).
+	return host ? createPortal( callout, host ) : callout;
 };
 
 export default DataLagIndicator;

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/EmptyMetricSection.test.tsx
@@ -26,20 +26,20 @@ describe( 'EmptyMetricSection', () => {
 		// normalization (NPPD-1698). Don't "sync" them.
 		const { container } = render(
 			<EmptyMetricSection
-				title="Paid reader conversion"
+				title="Paid Reader Conversion"
 				caption="How effectively paid access gates convert visitors."
 				state="no_opportunity"
 				body="No paid access gate attempts in this window."
 			/>
 		);
-		expect( container ).toHaveTextContent( 'Paid reader conversion' );
+		expect( container ).toHaveTextContent( 'Paid Reader Conversion' );
 		expect( container ).toHaveTextContent( 'How effectively paid access gates convert visitors.' );
 		expect( container ).toHaveTextContent( 'No paid access gate attempts in this window.' );
 	} );
 
 	it( 'omits the caption when none is passed', () => {
 		const { container } = render(
-			<EmptyMetricSection title="Free reader conversion" state="no_opportunity" body="No registration impressions." />
+			<EmptyMetricSection title="Free Reader Conversion" state="no_opportunity" body="No registration impressions." />
 		);
 		expect( container ).not.toHaveTextContent( 'How effectively paid access gates convert visitors.' );
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.test.tsx
@@ -212,7 +212,7 @@ describe( 'MetricCard notCapableMessage (NPPD-1720)', () => {
 
 describe( 'MetricCard warming (NEWS-2603)', () => {
 	it( 'renders the "still calculating" note in place of the value', () => {
-		render( <MetricCard label="Newsletter → subscription" value={ 0 } format="percent" warming /> );
+		render( <MetricCard label="Newsletter → Subscription" value={ 0 } format="percent" warming /> );
 		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
 		// Not the generic non-computable / em-dash note.
 		expect( screen.queryByLabelText( 'Not applicable' ) ).not.toBeInTheDocument();
@@ -220,7 +220,7 @@ describe( 'MetricCard warming (NEWS-2603)', () => {
 	} );
 
 	it( 'yields to the error treatment (error wins over warming)', () => {
-		render( <MetricCard label="Newsletter → subscription" error="boom" warming /> );
+		render( <MetricCard label="Newsletter → Subscription" error="boom" warming /> );
 		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Still calculating — check back shortly.' ) ).not.toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/MetricCard.tsx
@@ -171,6 +171,13 @@ const tieredFormat = ( v: number, fmt: MetricFormat ): FormattedCurrency | null 
 // card renders it in the value region's own type scale.
 const EM_DASH = '—';
 
+// A trailing "(qualifier)" — e.g. "(Direct)", "(Influenced, 7d)", "(30d)" — is
+// dropped to its own line so the metric name reads first and its scope sits
+// beneath it. Done at render time (not in the copy) so each label stays a
+// single translatable string; the newline renders via `white-space: pre-line`
+// on the label and normalizes back to a space for the accessible name.
+const dropQualifierToNewLine = ( label: string ): string => label.replace( / (\([^)]*\))$/, '\n$1' );
+
 const MetricCard = ( props: MetricCardProps ) => {
 	const {
 		label,
@@ -258,7 +265,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 		return (
 			<Card __experimentalCoreCard className="newspack-insights__metric-card newspack-insights__metric-card--note">
 				<HStack className="newspack-insights__metric-card-label" alignment="top" justify="space-between" spacing={ 2 }>
-					<span>{ label }</span>
+					<span>{ dropQualifierToNewLine( label ) }</span>
 					{ secondary && (
 						<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ secondary }>
 							<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />
@@ -348,7 +355,7 @@ const MetricCard = ( props: MetricCardProps ) => {
 	return (
 		<Card __experimentalCoreCard className="newspack-insights__metric-card">
 			<HStack className="newspack-insights__metric-card-label" alignment="top" justify="space-between" spacing={ 2 }>
-				<span>{ label }</span>
+				<span>{ dropQualifierToNewLine( label ) }</span>
 				{ ( fallbackSecondary ?? secondary ) && (
 					<Tooltip delay={ 250 } hideOnClick={ false } placement="bottom-start" text={ fallbackSecondary ?? secondary }>
 						<Button icon={ info } className="newspack-insights__metric-card-info-icon" variant="tertiary" />

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/TakeawayCard.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/TakeawayCard.test.tsx
@@ -20,7 +20,7 @@ describe( 'TakeawayCard', () => {
 	it( 'renders the title alongside the headline when populated', () => {
 		render(
 			<TakeawayCard
-				title="Engagement by device"
+				title="Engagement by Device"
 				payload={ populated }
 				headline="Desktop readers spend 40% longer per session"
 				sub="than mobile readers (2:00 vs 1:25)"
@@ -30,19 +30,19 @@ describe( 'TakeawayCard', () => {
 				] }
 			/>
 		);
-		expect( screen.getByText( 'Engagement by device' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Engagement by Device' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Desktop readers spend 40% longer per session' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the title even in the empty state (no headline / no bars)', () => {
-		render( <TakeawayCard title="Engagement by traffic source" payload={ { computable: true, type: 'table', rows: [] } } bars={ [] } /> );
-		expect( screen.getByText( 'Engagement by traffic source' ) ).toBeInTheDocument();
+		render( <TakeawayCard title="Engagement by Traffic Source" payload={ { computable: true, type: 'table', rows: [] } } bars={ [] } /> );
+		expect( screen.getByText( 'Engagement by Traffic Source' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough data in this timeframe.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders nothing for a hidden_in_v1 metric', () => {
 		const { container } = render(
-			<TakeawayCard title="Engagement by device" payload={ { value: null, computable: false, hidden_in_v1: true } } bars={ [] } />
+			<TakeawayCard title="Engagement by Device" payload={ { value: null, computable: false, hidden_in_v1: true } } bars={ [] } />
 		);
 		expect( container ).toBeEmptyDOMElement();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/_insights-charts.scss
@@ -79,12 +79,12 @@
 			color: wp-colors.$gray-700;
 		}
 
-		// Chart body grows to fill the card; 16px separates it from the
+		// Chart body grows to fill the card; 24px separates it from the
 		// title/caption above.
 		&-body {
 			flex: 1 1 auto;
 			min-width: 0;
-			margin-top: wp-vars.$grid-unit-20;
+			margin-top: wp-vars.$grid-unit-30;
 		}
 	}
 

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/advertising-ui.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/advertising-ui.test.tsx
@@ -46,16 +46,16 @@ describe( 'FinishConnectingDiagnostic', () => {
 } );
 
 describe( 'DataLagIndicator', () => {
-	// `@wordpress/components` Notice (via InfoCallout) renders both visible
-	// content and a hidden a11y-speak region with the same text. Scope queries
-	// to the visible notice element to avoid duplicate matches.
+	// `@wordpress/components` Notice renders both visible content and a hidden
+	// a11y-speak region with the same text. Scope queries to the visible notice
+	// element to avoid duplicate matches.
 	const getCallout = ( container: HTMLElement ): HTMLElement | null => container.querySelector( '.components-notice' );
 
-	it( 'renders the as-of date in an info callout, not dismissible', () => {
+	it( 'renders the as-of date in a warning notice, not dismissible', () => {
 		const { container } = render( <DataLagIndicator dataAsOf="2026-05-30" hasEstimatedData={ false } /> );
 		const callout = getCallout( container );
 		expect( callout ).not.toBeNull();
-		expect( callout ).toHaveTextContent( 'About this data' );
+		expect( callout ).toHaveClass( 'is-warning' );
 		expect( callout ).toHaveTextContent( /Data as of/ );
 		// Not dismissible — no close button.
 		expect( callout!.querySelector( 'button' ) ).toBeNull();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/format.ts
@@ -150,17 +150,19 @@ export const formatPercent = ( fraction: number ): string => {
 	return percentFormatter.format( fraction );
 };
 
-/** Format a duration in seconds as m:ss (or h:mm:ss past an hour): 142 -> "2:22". */
+/** Format a duration in seconds with unit suffixes: 142 -> "2m 22s", 9573 -> "2h 39m 33s", 5 -> "5s". */
 export const formatDuration = ( seconds: number ): string => {
 	const total = Math.max( 0, Math.round( seconds ) );
 	const hrs = Math.floor( total / 3600 );
 	const mins = Math.floor( ( total % 3600 ) / 60 );
 	const secs = total % 60;
-	const pad = ( n: number ): string => String( n ).padStart( 2, '0' );
 	if ( hrs > 0 ) {
-		return `${ hrs }:${ pad( mins ) }:${ pad( secs ) }`;
+		return `${ hrs }h ${ mins }m ${ secs }s`;
 	}
-	return `${ mins }:${ pad( secs ) }`;
+	if ( mins > 0 ) {
+		return `${ mins }m ${ secs }s`;
+	}
+	return `${ secs }s`;
 };
 
 /**

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.test.ts
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/metrics.test.ts
@@ -98,10 +98,10 @@ describe( 'payloadToCard', () => {
 
 	it( 'renders a warming metric as { warming: true }, not a value card (NEWS-2603)', () => {
 		const card = payloadToCard( {
-			label: 'Newsletter → subscription',
+			label: 'Newsletter → Subscription',
 			current: { state: 'warming', computable: false },
 		} );
-		expect( card ).toEqual( { label: 'Newsletter → subscription', description: undefined, warming: true } );
+		expect( card ).toEqual( { label: 'Newsletter → Subscription', description: undefined, warming: true } );
 		expect( card ).not.toHaveProperty( 'value' );
 	} );
 
@@ -155,12 +155,13 @@ describe( 'toSeries', () => {
 } );
 
 describe( 'formatDuration', () => {
-	it( 'formats seconds as m:ss', () => {
-		expect( formatDuration( 142 ) ).toBe( '2:22' );
-		expect( formatDuration( 5 ) ).toBe( '0:05' );
+	it( 'formats seconds with m/s suffixes', () => {
+		expect( formatDuration( 142 ) ).toBe( '2m 22s' );
+		expect( formatDuration( 5 ) ).toBe( '5s' );
 	} );
 
-	it( 'formats past an hour as h:mm:ss', () => {
-		expect( formatDuration( 3661 ) ).toBe( '1:01:01' );
+	it( 'formats past an hour with h/m/s suffixes', () => {
+		expect( formatDuration( 3661 ) ).toBe( '1h 1m 1s' );
+		expect( formatDuration( 9573 ) ).toBe( '2h 39m 33s' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/components/sections.scss
@@ -126,7 +126,7 @@
 			display: flex;
 			flex-direction: column;
 			height: 100%;
-			min-height: 167px;
+			min-height: calc( 21 * #{wp-vars.$grid-unit} ); // 168px
 			padding: wp-vars.$grid-unit-30;
 
 			// Match CoreCard's own selector to win the cascade — it
@@ -147,6 +147,9 @@
 			@include wp-mixins.heading-large();
 			color: wp-colors.$gray-900;
 			text-wrap: pretty;
+			// Honor the newline MetricCard injects before a trailing "(qualifier)"
+			// so the scope drops to its own line; no effect on labels without one.
+			white-space: pre-line;
 		}
 
 		&-body {
@@ -398,6 +401,11 @@
 
 		& + & {
 			margin-top: 4px;
+		}
+
+		// As a VStack row the stack gap owns the spacing, so drop the top margin.
+		.components-v-stack > & {
+			margin-top: 0;
 		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.test.tsx
@@ -37,9 +37,9 @@ const populatedCohort = ( referenceLine: ConversionReferenceLine | null ): Conve
 describe( 'CohortRetentionSection', () => {
 	it( 'renders the heading and both cohort titles', () => {
 		render( <CohortRetentionSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'Cohort retention' } ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Registration → conversion' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Subscriber retention' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Cohort Retention' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Registration → Conversion' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Subscriber Retention' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the cohort coming_soon message for both charts', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CohortRetentionSection.tsx
@@ -113,7 +113,7 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => {
 				 * For now 5.1 shows no target; the hardcoded 15% was removed because no
 				 * fixed-% default fits the network (publisher models diverge widely).
 				 */
-				title={ __( 'Registration → conversion', 'newspack-plugin' ) }
+				title={ __( 'Registration → Conversion', 'newspack-plugin' ) }
 				caption={ __(
 					'Of the readers who registered each month, the share who had become a paying subscriber or donor by that many months later. Starts at 0% and climbs.',
 					'newspack-plugin'
@@ -121,7 +121,7 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => {
 				data={ current.registration_to_conversion_cohort }
 			/>
 			<CohortChart
-				title={ __( 'Subscriber retention', 'newspack-plugin' ) }
+				title={ __( 'Subscriber Retention', 'newspack-plugin' ) }
 				caption={ __(
 					'Of the subscribers who started each month, the share still subscribed that many months later. Starts at 100% and declines.',
 					'newspack-plugin'
@@ -139,7 +139,7 @@ const CohortRetentionSection = ( { current }: CohortRetentionSectionProps ) => {
 		>
 			<SectionHeading
 				id="newspack-insights-conversion-cohort-heading"
-				title={ __( 'Cohort retention', 'newspack-plugin' ) }
+				title={ __( 'Cohort Retention', 'newspack-plugin' ) }
 				description={ __(
 					'Each row is a monthly cohort; each column is months since that cohort started. Read down a column to compare cohorts at the same age, and across a row to watch one cohort over time. Updated weekly.',
 					'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.test.tsx
@@ -18,7 +18,7 @@ import { makeConversionWindow } from './fixtures';
 describe( 'ConversionRateTrendsSection', () => {
 	it( 'renders the heading', () => {
 		render( <ConversionRateTrendsSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'Conversion rate trends' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Conversion Rate Trends' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the empty treatment when state is empty', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ConversionRateTrendsSection.tsx
@@ -64,7 +64,7 @@ const ConversionRateTrendsSection = ( { current }: ConversionRateTrendsSectionPr
 	>
 		<SectionHeading
 			id="newspack-insights-conversion-rate-trends-heading"
-			title={ __( 'Conversion rate trends', 'newspack-plugin' ) }
+			title={ __( 'Conversion Rate Trends', 'newspack-plugin' ) }
 			description={ __(
 				'Weekly conversion rates across the selected timeframe. Useful for spotting acceleration, plateaus, or seasonality.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.test.tsx
@@ -32,7 +32,7 @@ const errorScalar = (): ConversionScalarMetric => ( {
 describe( 'CrossTabInfluencedAttributionSection', () => {
 	it( 'renders the heading and the four influenced-rate scorecards', () => {
 		render( <CrossTabInfluencedAttributionSection current={ makeConversionWindow() } previous={ null } /> );
-		expect( screen.getByRole( 'heading', { name: 'Cross-tab influenced attribution' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Cross-Tab Influenced Attribution' } ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Influenced Registration Rate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Influenced Subscription Rate' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Influenced Donation Rate' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/CrossTabInfluencedAttributionSection.tsx
@@ -37,7 +37,7 @@ const CrossTabInfluencedAttributionSection = ( { current, previous }: CrossTabIn
 	>
 		<SectionHeading
 			id="newspack-insights-conversion-influenced-heading"
-			title={ __( 'Cross-tab influenced attribution', 'newspack-plugin' ) }
+			title={ __( 'Cross-Tab Influenced Attribution', 'newspack-plugin' ) }
 			description={ __(
 				'Influenced conversion rates from your Gates and Prompts tabs, centralized so you don’t have to bounce between tabs to compare. Influenced means the reader saw a gate or prompt in the lookback window before converting in a later session.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.test.tsx
@@ -23,11 +23,11 @@ import { makeConversionWindow } from './fixtures';
 describe( 'HowLongConversionsTakeSection', () => {
 	it( 'renders the heading and all four curve titles', () => {
 		render( <HowLongConversionsTakeSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'How long conversions take' } ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Time to register' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Time to subscribe' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Time to donate' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Subscriber → donor lag' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'How Long Conversions Take' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Time to Register' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Time to Subscribe' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Time to Donate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Subscriber → Donor Lag' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders 4.1 empty treatment when time-to-register state is empty', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/HowLongConversionsTakeSection.tsx
@@ -65,7 +65,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 		>
 			<SectionHeading
 				id="newspack-insights-conversion-time-to-convert-heading"
-				title={ __( 'How long conversions take', 'newspack-plugin' ) }
+				title={ __( 'How Long Conversions Take', 'newspack-plugin' ) }
 				description={ __(
 					'Cumulative conversion curves per cohort. Each line shows what percentage of readers had converted by day N. Steeper early curves mean faster conversion; flatter curves mean longer tails. Median is where the line crosses 50%.',
 					'newspack-plugin'
@@ -73,7 +73,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 			/>
 			<Grid columns={ 2 } gutter={ 16 } noMargin>
 				{ /* 4.1 — time to register: Phase A, state-gated */ }
-				<CurveCell title={ __( 'Time to register', 'newspack-plugin' ) }>
+				<CurveCell title={ __( 'Time to Register', 'newspack-plugin' ) }>
 					<SectionState
 						state={ current.time_to_register_distribution.state }
 						emptyMessage={ __( 'Time-to-register data will appear once registrations occur in this timeframe.', 'newspack-plugin' ) }
@@ -90,7 +90,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					</SectionState>
 				</CurveCell>
 				{ /* 4.2 — time to subscribe: Phase B, coming_soon */ }
-				<CurveCell title={ __( 'Time to subscribe', 'newspack-plugin' ) } caption={ snapshotCaption }>
+				<CurveCell title={ __( 'Time to Subscribe', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					<SectionState
 						state={ current.time_to_subscribe_distribution.state }
 						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
@@ -107,7 +107,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					</SectionState>
 				</CurveCell>
 				{ /* 4.3 — time to donate: Phase B, coming_soon */ }
-				<CurveCell title={ __( 'Time to donate', 'newspack-plugin' ) } caption={ snapshotCaption }>
+				<CurveCell title={ __( 'Time to Donate', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					<SectionState
 						state={ current.time_to_donate_distribution.state }
 						emptyMessage={ __( 'Time-to-convert data will appear once conversions occur in this timeframe.', 'newspack-plugin' ) }
@@ -124,7 +124,7 @@ const HowLongConversionsTakeSection = ( { current }: HowLongConversionsTakeSecti
 					</SectionState>
 				</CurveCell>
 				{ /* 4.4 — subscriber → donor lag: Phase B, coming_soon + visibility gate */ }
-				<CurveCell title={ __( 'Subscriber → donor lag', 'newspack-plugin' ) } caption={ snapshotCaption }>
+				<CurveCell title={ __( 'Subscriber → Donor Lag', 'newspack-plugin' ) } caption={ snapshotCaption }>
 					{ lag.visibility === 'hidden' ? (
 						<Notice
 							isWarning

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.test.tsx
@@ -19,7 +19,7 @@ import { makeConversionWindow } from './fixtures';
 describe( 'OpportunityBucketsSection', () => {
 	it( 'renders the heading and the three opportunity scorecards', () => {
 		render( <OpportunityBucketsSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'Opportunity buckets' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Opportunity Buckets' } ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Stale Registered Readers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'At-Risk Subscribers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Lapsed Donors' ) ).toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/OpportunityBucketsSection.tsx
@@ -86,7 +86,7 @@ const OpportunityBucketsSection = ( { current }: OpportunityBucketsSectionProps 
 	>
 		<SectionHeading
 			id="newspack-insights-conversion-opportunity-heading"
-			title={ __( 'Opportunity buckets', 'newspack-plugin' ) }
+			title={ __( 'Opportunity Buckets', 'newspack-plugin' ) }
 			description={ __(
 				'Where the funnel has slack. These are diagnostic counts and underperforming articles — readers and content that could move with attention.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.test.tsx
@@ -22,11 +22,11 @@ const heading = ( name: string ) => screen.queryByRole( 'heading', { name } );
 describe( 'PerJourneyConversionFunnelsSection', () => {
 	it( 'renders the heading and all four journey funnel titles', () => {
 		render( <PerJourneyConversionFunnelsSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'Per-journey conversion funnels' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Per-Journey Conversion Funnels' } ) ).toBeInTheDocument();
 		expect( heading( 'Anonymous → Registered' ) ).toBeInTheDocument();
 		expect( heading( 'Registered → Subscriber' ) ).toBeInTheDocument();
 		expect( heading( 'Registered → Donor' ) ).toBeInTheDocument();
-		expect( heading( 'Subscriber → Donor (cross-upsell)' ) ).toBeInTheDocument();
+		expect( heading( 'Subscriber → Donor (Cross-Upsell)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the cross-upsell gated note when 2.4 visibility is hidden', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/PerJourneyConversionFunnelsSection.tsx
@@ -167,7 +167,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 		>
 			<SectionHeading
 				id="newspack-insights-conversion-per-journey-heading"
-				title={ __( 'Per-journey conversion funnels', 'newspack-plugin' ) }
+				title={ __( 'Per-Journey Conversion Funnels', 'newspack-plugin' ) }
 				description={ __(
 					'Focused conversion paths. Each funnel shows where readers drop off within a specific journey — anonymous to registered, registered to paid, paid to donor.',
 					'newspack-plugin'
@@ -245,7 +245,7 @@ const PerJourneyConversionFunnelsSection = ( { current }: PerJourneyConversionFu
 					</JourneyFunnel>
 				) }
 				<JourneyFunnel
-					title={ __( 'Subscriber → Donor (cross-upsell)', 'newspack-plugin' ) }
+					title={ __( 'Subscriber → Donor (Cross-Upsell)', 'newspack-plugin' ) }
 					caption={ __( 'Cross-upsell visibility for publishers running both subscriptions and donations.', 'newspack-plugin' ) }
 				>
 					<GatedFunnelCell

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.test.tsx
@@ -18,7 +18,7 @@ import { makeConversionWindow } from './fixtures';
 describe( 'ReaderLifecycleSection', () => {
 	it( 'renders the heading', () => {
 		render( <ReaderLifecycleSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'The reader lifecycle' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'The Reader Lifecycle' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the funnel when state is populated', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/ReaderLifecycleSection.tsx
@@ -38,7 +38,7 @@ const ReaderLifecycleSection = ( { current, lastUpdated }: ReaderLifecycleSectio
 	>
 		<SectionHeading
 			id="newspack-insights-conversion-lifecycle-heading"
-			title={ __( 'The reader lifecycle', 'newspack-plugin' ) }
+			title={ __( 'The Reader Lifecycle', 'newspack-plugin' ) }
 			description={ __(
 				'The marquee view. How readers progress from first-time visitor through engagement, registration, and newsletter signup to becoming a supporter.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.test.tsx
@@ -18,10 +18,10 @@ import { makeConversionWindow } from './fixtures';
 describe( 'WhereConversionsComeFromSection', () => {
 	it( 'renders the heading and the three pie titles', () => {
 		render( <WhereConversionsComeFromSection current={ makeConversionWindow() } /> );
-		expect( screen.getByRole( 'heading', { name: 'Where conversions come from' } ) ).toBeInTheDocument();
-		expect( screen.getByText( 'New registrations' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'New subscribers' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'New donors' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Where Conversions Come From' } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Registrations' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Donors' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the empty treatment when state is empty', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/conversion/WhereConversionsComeFromSection.tsx
@@ -62,7 +62,7 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 	>
 		<SectionHeading
 			id="newspack-insights-conversion-source-mix-heading"
-			title={ __( 'Where conversions come from', 'newspack-plugin' ) }
+			title={ __( 'Where Conversions Come From', 'newspack-plugin' ) }
 			description={ __(
 				'Source attribution for new conversions in this timeframe. Gate, prompt, or direct (standalone form) — which surfaces drive your registrations, subscriptions, and donations?',
 				'newspack-plugin'
@@ -70,17 +70,17 @@ const WhereConversionsComeFromSection = ( { current }: WhereConversionsComeFromS
 		/>
 		<Grid columns={ 3 } gutter={ 16 } noMargin>
 			<SourcePie
-				title={ __( 'New registrations', 'newspack-plugin' ) }
+				title={ __( 'New Registrations', 'newspack-plugin' ) }
 				data={ current.source_mix_registrations }
 				emptyMessage={ __( 'Source data will appear once registrations occur in this timeframe.', 'newspack-plugin' ) }
 			/>
 			<SourcePie
-				title={ __( 'New subscribers', 'newspack-plugin' ) }
+				title={ __( 'New Subscribers', 'newspack-plugin' ) }
 				data={ current.source_mix_subscribers }
 				emptyMessage={ __( 'Source data will appear once subscriptions occur in this timeframe.', 'newspack-plugin' ) }
 			/>
 			<SourcePie
-				title={ __( 'New donors', 'newspack-plugin' ) }
+				title={ __( 'New Donors', 'newspack-plugin' ) }
 				data={ current.source_mix_donors }
 				emptyMessage={ __( 'Source data will appear once donations occur in this timeframe.', 'newspack-plugin' ) }
 			/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/CampaignSection.tsx
@@ -69,7 +69,11 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 	if ( ! hasTagged ) {
 		return (
 			<Section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
-				<SectionHeading id={ HEADING_ID } title={ title } />
+				<SectionHeading
+					id={ HEADING_ID }
+					title={ title }
+					description={ __( 'Which campaigns bring in the most donations.', 'newspack-plugin' ) }
+				/>
 				<SectionEmpty>{ __( 'No campaign-tagged donations in this window.', 'newspack-plugin' ) }</SectionEmpty>
 			</Section>
 		);

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/PerformanceSection.tsx
@@ -133,7 +133,11 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 				className="newspack-insights__section newspack-insights__section--performance"
 				aria-labelledby="newspack-insights-donors-performance-heading"
 			>
-				<SectionHeading id="newspack-insights-donors-performance-heading" title={ __( 'Donations by tier', 'newspack-plugin' ) } />
+				<SectionHeading
+					id="newspack-insights-donors-performance-heading"
+					title={ __( 'Donations by Tier', 'newspack-plugin' ) }
+					description={ __( 'Recurring, one-time, and lifetime revenue broken out by donation tier.', 'newspack-plugin' ) }
+				/>
 				<SectionEmpty>{ __( 'No donation activity yet.', 'newspack-plugin' ) }</SectionEmpty>
 			</Section>
 		);
@@ -146,7 +150,7 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 		>
 			<SectionHeading
 				id="newspack-insights-donors-performance-heading"
-				title={ __( 'Donations by tier', 'newspack-plugin' ) }
+				title={ __( 'Donations by Tier', 'newspack-plugin' ) }
 				description={ __(
 					'Current state plus activity in the selected timeframe. Lifetime revenue is the all-time total per product.',
 					'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/RetentionSection.tsx
@@ -72,7 +72,13 @@ const RetentionSection = ( { current, previous }: RetentionSectionProps ) => {
 		'aria-labelledby': 'newspack-insights-donors-retention-heading',
 	};
 
-	const heading = <SectionHeading id="newspack-insights-donors-retention-heading" title={ __( 'Retention', 'newspack-plugin' ) } />;
+	const heading = (
+		<SectionHeading
+			id="newspack-insights-donors-retention-heading"
+			title={ __( 'Retention', 'newspack-plugin' ) }
+			description={ __( 'Whether donors keep giving, and where they lapse.', 'newspack-plugin' ) }
+		/>
+	);
 
 	if ( ! recovery.computable && ! retention.computable ) {
 		return (

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.test.tsx
@@ -29,20 +29,20 @@ const makeSnapshot = ( over: Partial< DonorsSnapshot > = {} ): DonorsSnapshot =>
 describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
 	it( 'renders the modeled CLV and newsletter-conversion cards when computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot() } /> );
-		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( '3-Year Supporter Value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Donation' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough recurring-donor history to model yet.' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the CLV card as an em-dash with explanatory copy when not computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot( { supporter_clv_3yr: { value: 0, computable: false, denominator: 0 } } ) } /> );
-		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.getByText( '3-Year Supporter Value' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough recurring-donor history to model yet.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the newsletter-conversion card as an em-dash when the cohort is not yet mature', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0 } } ) } /> );
-		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Donation' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough newsletter signups with a full year of history yet.' ) ).toBeInTheDocument();
 	} );
 
@@ -52,7 +52,7 @@ describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
 				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'error' } } ) }
 			/>
 		);
-		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Donation' ) ).toBeInTheDocument();
 		// The card enters MetricCard's shared error-note state, not the em-dash/value path.
 		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
@@ -64,7 +64,7 @@ describe( 'Donors ScorecardSection — at-a-glance snapshot cards', () => {
 				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'warming' } } ) }
 			/>
 		);
-		expect( screen.getByText( 'Newsletter → donation' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Donation' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/ScorecardSection.tsx
@@ -41,13 +41,13 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 	>
 		<SectionHeading
 			id="newspack-insights-donors-scorecard-heading"
-			title={ __( 'Donors at a glance', 'newspack-plugin' ) }
+			title={ __( 'Donors at a Glance', 'newspack-plugin' ) }
 			description={ __( 'Current state and recurring revenue, independent of selected timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
 		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
-				label={ __( 'Active donors', 'newspack-plugin' ) }
+				label={ __( 'Active Donors', 'newspack-plugin' ) }
 				value={ snapshot.active_donors }
 				format="number"
 				secondary={ sprintf(
@@ -69,7 +69,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Active recurring donations normalized to a monthly rate', 'newspack-plugin' ) }
 			/>
 			<MetricCard
-				label={ __( '3-year supporter value', 'newspack-plugin' ) }
+				label={ __( '3-Year Supporter Value', 'newspack-plugin' ) }
 				value={ snapshot.supporter_clv_3yr.value }
 				format="currency"
 				notComputableMessage={
@@ -81,7 +81,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				) }
 			/>
 			<MetricCard
-				label={ __( 'Newsletter → donation', 'newspack-plugin' ) }
+				label={ __( 'Newsletter → Donation', 'newspack-plugin' ) }
 				value={ snapshot.newsletter_conversion.value }
 				format="percent"
 				// A hub proxy failure is an error state, not "insufficient history" —
@@ -103,13 +103,13 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Share of newsletter signups who became a donor within 12 months.', 'newspack-plugin' ) }
 			/>
 			<MetricCard
-				label={ __( 'Upcoming renewals (30d)', 'newspack-plugin' ) }
+				label={ __( 'Upcoming Renewals (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_donation_renewals_30d.count }
 				format="number"
 				description={ __( 'Active recurring donations due to renew in the next 30 days', 'newspack-plugin' ) }
 			/>
 			<MetricCard
-				label={ __( 'Upcoming endings (30d)', 'newspack-plugin' ) }
+				label={ __( 'Upcoming Endings (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_donation_cancellations_30d.count }
 				format="number"
 				lowerIsBetter

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.test.tsx
@@ -46,7 +46,7 @@ const makeWindow = ( over: Partial< DonorsWindow > = {} ): DonorsWindow => ( {
  */
 const revenueBreakdownText = ( container: HTMLElement ): string => {
 	const label = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) ).find(
-		el => el.textContent === 'Total donation revenue'
+		el => el.textContent === 'Total Donation Revenue'
 	);
 	const card = label?.closest( '.newspack-insights__metric-card' );
 	return card?.querySelector( '.newspack-insights__metric-card-secondary' )?.textContent ?? '';
@@ -70,8 +70,8 @@ describe( 'WindowedSection empty states', () => {
 		// global live-region, so a screen-level text query would match twice.
 		expect( container ).toHaveTextContent( 'No donations in this timeframe' );
 		// The grid (and its cards) is gone.
-		expect( screen.queryByText( 'Lapsed donors' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Total donation revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Lapsed Donors' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Total Donation Revenue' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the per-card no-acquisition state on New donors without collapsing the section', () => {
@@ -84,8 +84,8 @@ describe( 'WindowedSection empty states', () => {
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( '42 active donors, but none new this timeframe' ) ).toBeInTheDocument();
 		// The real revenue cards are still present.
-		expect( screen.getByText( 'Total donation revenue' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Lapsed donors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total Donation Revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Lapsed Donors' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does NOT show the no-acquisition line when there are no active donors either', () => {
@@ -103,7 +103,7 @@ describe( 'WindowedSection empty states', () => {
 		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeDonors={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'New donors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Donors' ) ).toBeInTheDocument();
 
 		const breakdown = revenueBreakdownText( container );
 		expect( breakdown ).toMatch( /one-time/ );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/donors/WindowedSection.tsx
@@ -149,10 +149,14 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 			className="newspack-insights__section newspack-insights__section--windowed"
 			aria-labelledby="newspack-insights-donors-windowed-heading"
 		>
-			<SectionHeading id="newspack-insights-donors-windowed-heading" title={ getHeading( range ) } />
+			<SectionHeading
+				id="newspack-insights-donors-windowed-heading"
+				title={ getHeading( range ) }
+				description={ __( 'New donors, lapsed donors, and the revenue they generated.', 'newspack-plugin' ) }
+			/>
 			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
-					label={ __( 'New donors', 'newspack-plugin' ) }
+					label={ __( 'New Donors', 'newspack-plugin' ) }
 					value={ current.new_donors }
 					format="number"
 					// Drop the period delta when there are no new donors: a "↓ 100%" against
@@ -171,7 +175,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					description={ __( 'First-time donors in selected timeframe', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Lapsed donors', 'newspack-plugin' ) }
+					label={ __( 'Lapsed Donors', 'newspack-plugin' ) }
 					value={ current.lapsed_donors }
 					format="number"
 					previousValue={ previous?.lapsed_donors }
@@ -179,7 +183,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					description={ __( 'Donors who stopped recurring giving in this timeframe', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Total donation revenue', 'newspack-plugin' ) }
+					label={ __( 'Total Donation Revenue', 'newspack-plugin' ) }
 					value={ current.total_revenue }
 					format="currency"
 					previousValue={ previous?.total_revenue }
@@ -192,7 +196,7 @@ const WindowedSection = ( { range, current, previous, activeDonors }: WindowedSe
 					description={ __( 'One-time gifts + recurring renewals in this timeframe', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Average one-time gift', 'newspack-plugin' ) }
+					label={ __( 'Average One-Time Gift', 'newspack-plugin' ) }
 					value={ current.average_gift }
 					format="currency"
 					previousValue={ previous?.average_gift }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ContentEngagementSection.tsx
@@ -29,7 +29,7 @@ const ContentEngagementSection = ( { current }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-content">
 		<SectionHeading
 			id="newspack-insights-engagement-content"
-			title={ __( 'Content engagement', 'newspack-plugin' ) }
+			title={ __( 'Content Engagement', 'newspack-plugin' ) }
 			description={ __( 'What holds reader attention.', 'newspack-plugin' ) }
 		/>
 		<VStack spacing={ 4 }>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/QualitySection.tsx
@@ -32,7 +32,7 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-quality">
 		<SectionHeading
 			id="newspack-insights-engagement-quality"
-			title={ __( 'Overall engagement quality', 'newspack-plugin' ) }
+			title={ __( 'Overall Engagement Quality', 'newspack-plugin' ) }
 			description={ __( 'How deeply readers engage.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
@@ -46,7 +46,7 @@ const QualitySection = ( { current, previous, lastUpdated }: SectionProps ) => (
 				previous={ previous?.avg_pages_per_session }
 			/>
 			<Scorecard
-				label={ __( 'Avg Engaged Session Duration', 'newspack-plugin' ) }
+				label={ __( 'Avg Engaged Time', 'newspack-plugin' ) }
 				description={ __( 'Time spent per visit', 'newspack-plugin' ) }
 				current={ current.avg_engaged_session_duration }
 				previous={ previous?.avg_engaged_session_duration }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.test.tsx
@@ -31,7 +31,7 @@ const windowOf = ( engagement_by_traffic_source: unknown ): InsightsWindow => ( 
 
 /** The card body is a sibling of the title within the same takeaway card. */
 const trafficSourceCard = (): HTMLElement => {
-	const title = screen.getByText( 'Engagement by traffic source' );
+	const title = screen.getByText( 'Engagement by Traffic Source' );
 	return title.closest( '.newspack-insights__takeaway-card' ) as HTMLElement;
 };
 
@@ -41,7 +41,7 @@ describe( 'ReaderSegmentsSection — traffic source card', () => {
 		const card = trafficSourceCard();
 		// 98s vs 49s → newsletter leads by 100%.
 		expect( within( card ).getByText( 'Newsletter traffic engages 100% longer than other sources' ) ).toBeInTheDocument();
-		expect( within( card ).getByText( '1:38 per session vs 0:49' ) ).toBeInTheDocument();
+		expect( within( card ).getByText( '1m 38s per session vs 49s' ) ).toBeInTheDocument();
 		expect( within( card ).queryByText( 'Not enough data in this timeframe.' ) ).not.toBeInTheDocument();
 		// Bar-hover values carry the "seconds" unit.
 		expect( within( card ).getByText( '98 seconds' ) ).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe( 'ReaderSegmentsSection — traffic source card', () => {
 		// 98s vs 49s → other leads by 100%; phrased as "longer" with other as the subject.
 		expect( within( card ).getByText( 'Other sources engage 100% longer than newsletter traffic' ) ).toBeInTheDocument();
 		// Sub leads with the subject (other) too.
-		expect( within( card ).getByText( '1:38 per session vs 0:49' ) ).toBeInTheDocument();
+		expect( within( card ).getByText( '1m 38s per session vs 49s' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the needs-data state when the newsletter cohort is below the floor', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/engagement/sections/ReaderSegmentsSection.tsx
@@ -198,12 +198,12 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-engagement-segments">
 			<SectionHeading
 				id="newspack-insights-engagement-segments"
-				title={ __( 'Reader segments', 'newspack-plugin' ) }
+				title={ __( 'Reader Segments', 'newspack-plugin' ) }
 				description={ __( 'How engagement varies by segment.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 3 } gutter={ 16 } noMargin>
 				<TakeawayCard
-					title={ __( 'Engagement by device', 'newspack-plugin' ) }
+					title={ __( 'Engagement by Device', 'newspack-plugin' ) }
 					payload={ current.engagement_by_device_type }
 					headline={ device.headline }
 					sub={ device.sub }
@@ -211,7 +211,7 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					formatValue={ formatSeconds }
 				/>
 				<TakeawayCard
-					title={ __( 'New vs returning readers', 'newspack-plugin' ) }
+					title={ __( 'New vs Returning Readers', 'newspack-plugin' ) }
 					payload={ current.engagement_by_returning_vs_new }
 					headline={ returning.headline }
 					sub={ returning.sub }
@@ -219,7 +219,7 @@ const ReaderSegmentsSection = ( { current }: SectionProps ) => {
 					formatValue={ formatPages }
 				/>
 				<TakeawayCard
-					title={ __( 'Engagement by traffic source', 'newspack-plugin' ) }
+					title={ __( 'Engagement by Traffic Source', 'newspack-plugin' ) }
 					payload={ current.engagement_by_traffic_source }
 					headline={ trafficSource.headline }
 					sub={ trafficSource.sub }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/GateExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/GateExposureSection.tsx
@@ -39,7 +39,7 @@ const GateExposureSection = ( { current, previous, lastUpdated }: GateExposureSe
 	<Section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-gates-exposure-heading">
 		<SectionHeading
 			id="newspack-insights-gates-exposure-heading"
-			title={ __( 'Gate exposure', 'newspack-plugin' ) }
+			title={ __( 'Gate Exposure', 'newspack-plugin' ) }
 			description={ __( 'Top of the funnel. How many readers see gates in this timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/HowReadersConvertSection.tsx
@@ -34,7 +34,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 	<Section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-gates-convert-heading">
 		<SectionHeading
 			id="newspack-insights-gates-convert-heading"
-			title={ __( 'How readers convert', 'newspack-plugin' ) }
+			title={ __( 'How Readers Convert', 'newspack-plugin' ) }
 			description={ __(
 				'The journey from gate impression to conversion. The funnel shows where readers drop off; the distribution shows how many touches it typically takes before conversion.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/gates/PerformanceByGateSection.tsx
@@ -115,7 +115,7 @@ const PerformanceByGateSection = ( { data }: PerformanceByGateSectionProps ) => 
 		>
 			<SectionHeading
 				id="newspack-insights-gates-performance-heading"
-				title={ __( 'Performance by gate', 'newspack-plugin' ) }
+				title={ __( 'Performance by Gate', 'newspack-plugin' ) }
 				description={ __( 'Per-gate breakdown for the selected timeframe. Click any column to re-sort.', 'newspack-plugin' ) }
 			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.test.tsx
@@ -44,8 +44,8 @@ describe( 'OverviewSection', () => {
 		expect( screen.getByText( '$50.00' ) ).toBeInTheDocument(); // eCPM keeps cents below $1K.
 		expect( screen.getByText( '1.4%' ) ).toBeInTheDocument(); // CTR as a percent.
 		// All-time cards, clearly labeled, values from the lifetime counters.
-		expect( cardByLabel( container, 'All-time impressions' ) ).toHaveTextContent( '950,000' );
-		expect( cardByLabel( container, 'All-time clicks' ) ).toHaveTextContent( '12,400' );
+		expect( cardByLabel( container, 'All-Time Impressions' ) ).toHaveTextContent( '950,000' );
+		expect( cardByLabel( container, 'All-Time Clicks' ) ).toHaveTextContent( '12,400' );
 	} );
 
 	it( 'never renders a delta on the lifetime cards, even under comparison', () => {
@@ -55,8 +55,8 @@ describe( 'OverviewSection', () => {
 		// The timeframe impressions card compares normally…
 		expect( cardByLabel( container, 'Impressions' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).not.toBeNull();
 		// …but the cumulative all-time cards never carry a delta.
-		expect( cardByLabel( container, 'All-time impressions' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
-		expect( cardByLabel( container, 'All-time clicks' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+		expect( cardByLabel( container, 'All-Time Impressions' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
+		expect( cardByLabel( container, 'All-Time Clicks' )?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
 	} );
 
 	it( 'renders the em-dash treatment for a non-computable CTR — never 0%', () => {

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/OverviewSection.tsx
@@ -51,7 +51,7 @@ export interface SectionProps {
 // section mixes timeframe cards with the two all-time cards, so a windowed
 // "In the last N days" heading would sit above cards it doesn't describe. The
 // page-level date picker carries the timeframe.
-const TITLE = __( 'Reach & revenue', 'newspack-plugin' );
+const TITLE = __( 'Reach & Revenue', 'newspack-plugin' );
 const CAPTION = __( 'Newsletter ad volume and revenue, plus all-time totals.', 'newspack-plugin' );
 // Timeframe metrics are non-computable only when dated ad tracking is
 // unavailable (the not-ready state) — mirror the diagnostic's remediation.
@@ -129,38 +129,38 @@ const OverviewSection = ( { current, previous, hasWindowActivity, lastUpdated }:
 						notComputableMessage={ __( 'Requires both revenue and impressions in this timeframe to calculate.', 'newspack-plugin' ) }
 					/>
 					<Scorecard
-						label={ __( 'Active ads', 'newspack-plugin' ) }
+						label={ __( 'Active Ads', 'newspack-plugin' ) }
 						description={ __( 'Ads that ran in newsletters', 'newspack-plugin' ) }
 						current={ current.active_ads }
 						previous={ previous?.active_ads }
 						notComputableMessage={ NOT_TRACKED_MESSAGE }
 					/>
 					<Scorecard
-						label={ __( 'All-time impressions', 'newspack-plugin' ) }
+						label={ __( 'All-Time Impressions', 'newspack-plugin' ) }
 						description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
 						current={ current.lifetime_impressions }
 					/>
 					<Scorecard
-						label={ __( 'All-time clicks', 'newspack-plugin' ) }
+						label={ __( 'All-Time Clicks', 'newspack-plugin' ) }
 						description={ __( 'Cumulative total since tracking began', 'newspack-plugin' ) }
 						current={ current.lifetime_clicks }
 					/>
 				</Grid>
+				{ excludedAds > 0 && (
+					<p className="newspack-insights__table-footnote">
+						{ sprintf(
+							/* translators: %d: count of ads excluded from the revenue totals. */
+							_n(
+								'%d ad excluded from revenue (missing price or flight dates)',
+								'%d ads excluded from revenue (missing price or flight dates)',
+								excludedAds,
+								'newspack-plugin'
+							),
+							excludedAds
+						) }
+					</p>
+				) }
 			</VStack>
-			{ excludedAds > 0 && (
-				<p className="newspack-insights__table-footnote">
-					{ sprintf(
-						/* translators: %d: count of ads excluded from the revenue totals. */
-						_n(
-							'%d ad excluded from revenue (missing price or flight dates)',
-							'%d ads excluded from revenue (missing price or flight dates)',
-							excludedAds,
-							'newspack-plugin'
-						),
-						excludedAds
-					) }
-				</p>
-			) }
 		</Section>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TablesSection.tsx
@@ -51,7 +51,11 @@ const withDisplayDates = ( payload?: MetricPayload ): MetricPayload | undefined 
 const TablesSection = ( { current }: SectionProps ) => (
 	<TabSections>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-ads">
-			<SectionHeading id="newspack-insights-newsletter-ads-top-ads" title={ __( 'Top ads', 'newspack-plugin' ) } />
+			<SectionHeading
+				id="newspack-insights-newsletter-ads-top-ads"
+				title={ __( 'Top Ads', 'newspack-plugin' ) }
+				description={ __( 'Your best-performing newsletter ads by clicks and revenue.', 'newspack-plugin' ) }
+			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<MetricTable
 					payload={ current.top_ads }
@@ -69,7 +73,11 @@ const TablesSection = ( { current }: SectionProps ) => (
 			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-top-advertisers">
-			<SectionHeading id="newspack-insights-newsletter-ads-top-advertisers" title={ __( 'Top advertisers', 'newspack-plugin' ) } />
+			<SectionHeading
+				id="newspack-insights-newsletter-ads-top-advertisers"
+				title={ __( 'Top Advertisers', 'newspack-plugin' ) }
+				description={ __( 'The advertisers buying the most newsletter inventory.', 'newspack-plugin' ) }
+			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<MetricTable
 					payload={ current.top_advertisers }
@@ -87,7 +95,11 @@ const TablesSection = ( { current }: SectionProps ) => (
 			</Card>
 		</Section>
 		<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-by-newsletter">
-			<SectionHeading id="newspack-insights-newsletter-ads-by-newsletter" title={ __( 'Ad performance by newsletter', 'newspack-plugin' ) } />
+			<SectionHeading
+				id="newspack-insights-newsletter-ads-by-newsletter"
+				title={ __( 'Ad Performance by Newsletter', 'newspack-plugin' ) }
+				description={ __( 'How ad performance compares across your newsletters.', 'newspack-plugin' ) }
+			/>
 			<Card __experimentalCoreCard className="newspack-insights__chart-card">
 				<MetricTable
 					payload={ withDisplayDates( current.by_newsletter ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.test.tsx
@@ -30,7 +30,7 @@ describe( 'TrendSection', () => {
 	it( 'renders impressions and clicks as two separate charts', () => {
 		const { container } = render( <TrendSection current={ metrics() } previous={ null } /> );
 
-		expect( screen.getByText( 'Performance trend' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Performance Trend' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Impressions' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Clicks' ) ).toBeInTheDocument();
 		// One series per chart without comparison → two line strokes total.

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/newsletter_ads/sections/TrendSection.tsx
@@ -50,7 +50,7 @@ const TrendSection = ( { current, previous }: SectionProps ) => (
 	<Section className="newspack-insights__section" aria-labelledby="newspack-insights-newsletter-ads-trend">
 		<SectionHeading
 			id="newspack-insights-newsletter-ads-trend"
-			title={ __( 'Performance trend', 'newspack-plugin' ) }
+			title={ __( 'Performance Trend', 'newspack-plugin' ) }
 			description={ __( 'Daily impressions and clicks across the selected timeframe.', 'newspack-plugin' ) }
 		/>
 		<HStack spacing={ 4 } alignment="stretch" wrap>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/FreeReaderConversionSection.tsx
@@ -38,7 +38,7 @@ const FreeReaderConversionSection = ( { current, previous }: FreeReaderConversio
 	<Section className="newspack-insights__section newspack-insights__section--free-reader" aria-labelledby="newspack-insights-prompts-free-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-free-heading"
-			title={ __( 'Free reader conversion', 'newspack-plugin' ) }
+			title={ __( 'Free Reader Conversion', 'newspack-plugin' ) }
 			description={ __(
 				'How effectively prompts convert readers into registered readers and newsletter subscribers. Direct counts conversions submitted through a prompt’s own form. Influenced counts conversions in a later session within 7 days of seeing a prompt.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/HowReadersConvertSection.tsx
@@ -32,7 +32,7 @@ const HowReadersConvertSection = ( { current }: HowReadersConvertSectionProps ) 
 	<Section className="newspack-insights__section newspack-insights__section--convert" aria-labelledby="newspack-insights-prompts-convert-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-convert-heading"
-			title={ __( 'How readers convert', 'newspack-plugin' ) }
+			title={ __( 'How Readers Convert', 'newspack-plugin' ) }
 			description={ __(
 				'The journey from prompt impression to conversion. The funnel shows where readers drop off; the distribution shows how many touches it typically takes before conversion.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PaidReaderConversionSection.tsx
@@ -39,7 +39,7 @@ const PaidReaderConversionSection = ( { current, previous }: PaidReaderConversio
 	<Section className="newspack-insights__section newspack-insights__section--paid-reader" aria-labelledby="newspack-insights-prompts-paid-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-paid-heading"
-			title={ __( 'Paid reader conversion', 'newspack-plugin' ) }
+			title={ __( 'Paid Reader Conversion', 'newspack-plugin' ) }
 			description={ __(
 				'How effectively prompts convert readers into donors and subscribers. Direct counts conversions completed through a prompt’s own donation block or checkout button. Influenced counts conversions in a later session within 14 days of seeing a prompt.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PerformanceBreakdownSection.tsx
@@ -34,7 +34,7 @@ const PerformanceBreakdownSection = ( { current }: PerformanceBreakdownSectionPr
 	>
 		<SectionHeading
 			id="newspack-insights-prompts-performance-heading"
-			title={ __( 'Performance breakdown', 'newspack-plugin' ) }
+			title={ __( 'Performance Breakdown', 'newspack-plugin' ) }
 			description={ __(
 				'Per-prompt, per-intent, and per-placement breakdowns for the selected timeframe. Click any column to re-sort.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptEngagementSection.tsx
@@ -34,7 +34,7 @@ const PromptEngagementSection = ( { current, previous }: PromptEngagementSection
 	>
 		<SectionHeading
 			id="newspack-insights-prompts-engagement-heading"
-			title={ __( 'Prompt engagement', 'newspack-plugin' ) }
+			title={ __( 'Prompt Engagement', 'newspack-plugin' ) }
 			description={ __(
 				'How readers respond to prompts they see. Engagement is any interaction beyond just seeing the prompt.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/PromptExposureSection.tsx
@@ -38,7 +38,7 @@ const PromptExposureSection = ( { current, previous, lastUpdated }: PromptExposu
 	<Section className="newspack-insights__section newspack-insights__section--exposure" aria-labelledby="newspack-insights-prompts-exposure-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-exposure-heading"
-			title={ __( 'Prompt exposure', 'newspack-plugin' ) }
+			title={ __( 'Prompt Exposure', 'newspack-plugin' ) }
 			description={ __( 'Top of the funnel. How many readers see prompts in this timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/prompts/RevenueFromPromptsSection.tsx
@@ -38,7 +38,7 @@ const RevenueFromPromptsSection = ( { current, previous }: RevenueFromPromptsSec
 	<Section className="newspack-insights__section newspack-insights__section--revenue" aria-labelledby="newspack-insights-prompts-revenue-heading">
 		<SectionHeading
 			id="newspack-insights-prompts-revenue-heading"
-			title={ __( 'Revenue from prompts', 'newspack-plugin' ) }
+			title={ __( 'Revenue From Prompts', 'newspack-plugin' ) }
 			description={ __(
 				'Donation and subscription revenue completed after a prompt impression. Direct totals Woo order revenue from conversions completed through a prompt’s own block. Influenced totals checkout revenue from later-session completions within 14 days of seeing a prompt.',
 				'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/CampaignSection.tsx
@@ -69,7 +69,11 @@ const CampaignSection = ( { rows }: CampaignSectionProps ) => {
 	if ( ! hasTagged ) {
 		return (
 			<Section className="newspack-insights__section newspack-insights__section--performance" aria-labelledby={ HEADING_ID }>
-				<SectionHeading id={ HEADING_ID } title={ title } />
+				<SectionHeading
+					id={ HEADING_ID }
+					title={ title }
+					description={ __( 'Which campaigns bring in the most subscriptions.', 'newspack-plugin' ) }
+				/>
 				<SectionEmpty>{ __( 'No campaign-tagged subscriptions in this window.', 'newspack-plugin' ) }</SectionEmpty>
 			</Section>
 		);

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/PerformanceSection.tsx
@@ -39,7 +39,11 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 				className="newspack-insights__section newspack-insights__section--performance"
 				aria-labelledby="newspack-insights-performance-heading"
 			>
-				<SectionHeading id="newspack-insights-performance-heading" title={ __( 'Subscriptions by product', 'newspack-plugin' ) } />
+				<SectionHeading
+					id="newspack-insights-performance-heading"
+					title={ __( 'Subscriptions by Product', 'newspack-plugin' ) }
+					description={ __( 'Active subscribers and revenue broken out by subscription product.', 'newspack-plugin' ) }
+				/>
 				<SectionEmpty>{ __( 'No subscription products configured yet.', 'newspack-plugin' ) }</SectionEmpty>
 			</Section>
 		);
@@ -52,7 +56,7 @@ const PerformanceSection = ( { rows }: PerformanceSectionProps ) => {
 		>
 			<SectionHeading
 				id="newspack-insights-performance-heading"
-				title={ __( 'Subscriptions by product', 'newspack-plugin' ) }
+				title={ __( 'Subscriptions by Product', 'newspack-plugin' ) }
 				description={ __(
 					'Active subscriptions per product (subscriptions, not unique customers). New and churned subs reflect the selected timeframe; active counts and value are current, and lifetime revenue is the all-time total per product.',
 					'newspack-plugin'

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.test.tsx
@@ -29,20 +29,20 @@ const makeSnapshot = ( over: Partial< SubscribersSnapshot > = {} ): SubscribersS
 describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
 	it( 'renders the modeled CLV and newsletter-conversion cards when computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot() } /> );
-		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( '3-Year Supporter Value' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Subscription' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough subscription history to model yet.' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the CLV card as an em-dash with explanatory copy when not computable', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot( { supporter_clv_3yr: { value: 0, computable: false, denominator: 0 } } ) } /> );
-		expect( screen.getByText( '3-year supporter value' ) ).toBeInTheDocument();
+		expect( screen.getByText( '3-Year Supporter Value' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough subscription history to model yet.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the newsletter-conversion card as an em-dash when the cohort is not yet mature', () => {
 		render( <ScorecardSection snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0 } } ) } /> );
-		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Subscription' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Not enough newsletter signups with a full year of history yet.' ) ).toBeInTheDocument();
 	} );
 
@@ -52,7 +52,7 @@ describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
 				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'error' } } ) }
 			/>
 		);
-		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Subscription' ) ).toBeInTheDocument();
 		// The card enters MetricCard's shared error-note state, not the em-dash/value path.
 		expect( screen.getByText( 'Data temporarily unavailable.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
@@ -64,7 +64,7 @@ describe( 'Subscribers ScorecardSection — at-a-glance snapshot cards', () => {
 				snapshot={ makeSnapshot( { newsletter_conversion: { value: 0, computable: false, denominator: 0, state: 'warming' } } ) }
 			/>
 		);
-		expect( screen.getByText( 'Newsletter → subscription' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Newsletter → Subscription' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Still calculating — check back shortly.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Not enough newsletter signups with a full year of history yet.' ) ).not.toBeInTheDocument();
 	} );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/ScorecardSection.tsx
@@ -41,13 +41,13 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 	<Section className="newspack-insights__section newspack-insights__section--scorecard" aria-labelledby="newspack-insights-scorecard-heading">
 		<SectionHeading
 			id="newspack-insights-scorecard-heading"
-			title={ __( 'Subscribers at a glance', 'newspack-plugin' ) }
+			title={ __( 'Subscribers at a Glance', 'newspack-plugin' ) }
 			description={ __( 'Current state and recurring revenue, independent of selected timeframe.', 'newspack-plugin' ) }
 			actions={ lastUpdated }
 		/>
 		<Grid columns={ 4 } gutter={ 16 } noMargin>
 			<MetricCard
-				label={ __( 'Active subscribers', 'newspack-plugin' ) }
+				label={ __( 'Active Subscribers', 'newspack-plugin' ) }
 				value={ snapshot.active_subscribers }
 				format="number"
 				description={ __( 'Distinct readers with at least one active subscription', 'newspack-plugin' ) }
@@ -64,7 +64,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Normalized across billing periods', 'newspack-plugin' ) }
 			/>
 			<MetricCard
-				label={ __( '3-year supporter value', 'newspack-plugin' ) }
+				label={ __( '3-Year Supporter Value', 'newspack-plugin' ) }
 				value={ snapshot.supporter_clv_3yr.value }
 				format="currency"
 				notComputableMessage={
@@ -76,7 +76,7 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				) }
 			/>
 			<MetricCard
-				label={ __( 'Newsletter → subscription', 'newspack-plugin' ) }
+				label={ __( 'Newsletter → Subscription', 'newspack-plugin' ) }
 				value={ snapshot.newsletter_conversion.value }
 				format="percent"
 				// A hub proxy failure is an error state, not "insufficient history" —
@@ -98,13 +98,13 @@ const ScorecardSection = ( { snapshot, lastUpdated }: ScorecardSectionProps ) =>
 				description={ __( 'Share of newsletter signups who became a paid subscriber within 12 months.', 'newspack-plugin' ) }
 			/>
 			<MetricCard
-				label={ __( 'Upcoming renewals (30d)', 'newspack-plugin' ) }
+				label={ __( 'Upcoming Renewals (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_renewals_30d.count }
 				format="number"
 				description={ __( 'Active subscriptions due to renew in the next 30 days', 'newspack-plugin' ) }
 			/>
 			<MetricCard
-				label={ __( 'Upcoming endings (30d)', 'newspack-plugin' ) }
+				label={ __( 'Upcoming Endings (30d)', 'newspack-plugin' ) }
 				value={ snapshot.upcoming_cancellations_30d.count }
 				format="number"
 				lowerIsBetter

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/TenureSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/TenureSection.tsx
@@ -62,7 +62,11 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 	if ( ! stats ) {
 		return (
 			<Section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
-				<SectionHeading id="newspack-insights-tenure-heading" title={ __( 'Subscriber tenure', 'newspack-plugin' ) } />
+				<SectionHeading
+					id="newspack-insights-tenure-heading"
+					title={ __( 'Subscriber Tenure', 'newspack-plugin' ) }
+					description={ __( 'Median subscription length, plus the 25th and 75th percentiles.', 'newspack-plugin' ) }
+				/>
 				<SectionEmpty>{ __( 'No subscribers yet — tenure data will appear once subscriptions exist.', 'newspack-plugin' ) }</SectionEmpty>
 			</Section>
 		);
@@ -98,22 +102,22 @@ const TenureSection = ( { rows }: TenureSectionProps ) => {
 
 	return (
 		<Section className="newspack-insights__section newspack-insights__section--tenure" aria-labelledby="newspack-insights-tenure-heading">
-			<SectionHeading id="newspack-insights-tenure-heading" title={ __( 'Subscriber tenure', 'newspack-plugin' ) } description={ narrative } />
+			<SectionHeading id="newspack-insights-tenure-heading" title={ __( 'Subscriber Tenure', 'newspack-plugin' ) } description={ narrative } />
 			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
-					label={ __( 'Median tenure', 'newspack-plugin' ) }
+					label={ __( 'Median Tenure', 'newspack-plugin' ) }
 					value={ stats.median }
 					format="number"
 					secondary={ _n( 'day', 'days', stats.median, 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( '25th percentile', 'newspack-plugin' ) }
+					label={ __( '25th Percentile', 'newspack-plugin' ) }
 					value={ stats.p25 }
 					format="number"
 					secondary={ _n( 'day', 'days', stats.p25, 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( '75th percentile', 'newspack-plugin' ) }
+					label={ __( '75th Percentile', 'newspack-plugin' ) }
 					value={ stats.p75 }
 					format="number"
 					secondary={ _n( 'day', 'days', stats.p75, 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.test.tsx
@@ -59,8 +59,8 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		expect( container.querySelector( '[data-empty-state="no_opportunity"]' ) ).toBeInTheDocument();
 		// Assert on the container — the Notice's speak() duplicates copy into a live-region.
 		expect( container ).toHaveTextContent( 'No subscription activity in this timeframe' );
-		expect( screen.queryByText( 'Churned subscribers' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Gross revenue' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Churned Subscribers' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Gross Revenue' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the per-card no-acquisition state on New subscribers without collapsing the section', () => {
@@ -72,12 +72,12 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		// The misleading period delta is suppressed even though `previous` has a real
 		// prior count — a "↓ 100%" would misread an honest zero.
 		const newCard = Array.from( container.querySelectorAll( '.newspack-insights__metric-card-label' ) )
-			.find( el => el.textContent === 'New subscribers' )
+			.find( el => el.textContent === 'New Subscribers' )
 			?.closest( '.newspack-insights__metric-card' );
 		expect( newCard?.querySelector( '.newspack-insights__metric-card-delta' ) ).toBeNull();
 		// Real cards still render.
-		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Gross revenue' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Churned Subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Gross Revenue' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does NOT show the no-acquisition line when there are no active subscribers either', () => {
@@ -94,8 +94,8 @@ describe( 'Subscribers WindowedSection empty states', () => {
 
 		// Section is NOT collapsed and the churn card is a real card showing 0.
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
-		expect( cardValueByLabel( container, 'Churned subscribers' ) ).toBe( '0' );
+		expect( screen.getByText( 'Churned Subscribers' ) ).toBeInTheDocument();
+		expect( cardValueByLabel( container, 'Churned Subscribers' ) ).toBe( '0' );
 	} );
 
 	it( 'GOOD ZERO: zero failed payments reframes positively (NPPD-1726), section intact', () => {
@@ -118,7 +118,7 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		expect( screen.getByText( 'No refund requests in this timeframe.' ) ).toBeInTheDocument();
 		// Distinct from the no-orders message, and the hero is the em-dash, not "0%".
 		expect( screen.queryByText( 'No subscription orders in this timeframe.' ) ).not.toBeInTheDocument();
-		expect( cardValueByLabel( container, 'Refund rate' ) ).toBe( '—' );
+		expect( cardValueByLabel( container, 'Refund Rate' ) ).toBe( '—' );
 	} );
 
 	it( 'D5: Refund rate and Failed payment recovery good-zeros share the em-dash treatment', () => {
@@ -135,8 +135,8 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		} );
 		const { container } = render( <WindowedSection range={ RANGE } current={ current } previous={ null } activeSubscribers={ 200 } /> );
 
-		expect( cardValueByLabel( container, 'Refund rate' ) ).toBe( '—' );
-		expect( cardValueByLabel( container, 'Failed payment recovery' ) ).toBe( '—' );
+		expect( cardValueByLabel( container, 'Refund Rate' ) ).toBe( '—' );
+		expect( cardValueByLabel( container, 'Failed Payment Recovery' ) ).toBe( '—' );
 		expect( screen.getByText( 'No failed payments in this timeframe.' ) ).toBeInTheDocument();
 		// The old bespoke empty-note element no longer renders for these cards.
 		expect( container.querySelectorAll( '.newspack-insights__metric-card--empty' ).length ).toBe( 0 );
@@ -162,9 +162,9 @@ describe( 'Subscribers WindowedSection empty states', () => {
 		const { container } = render( <WindowedSection range={ RANGE } current={ makeWindow() } previous={ null } activeSubscribers={ 200 } /> );
 
 		expect( container.querySelector( '[data-empty-state]' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'New subscribers' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Churned subscribers' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Refund rate' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Failed payment recovery' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Churned Subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Refund Rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Failed Payment Recovery' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
+++ b/plugins/newspack-plugin/src/wizards/insights/tabs/subscribers/WindowedSection.tsx
@@ -165,10 +165,14 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 
 	return (
 		<Section className="newspack-insights__section newspack-insights__section--windowed" aria-labelledby="newspack-insights-windowed-heading">
-			<SectionHeading id="newspack-insights-windowed-heading" title={ getHeading( range ) } />
+			<SectionHeading
+				id="newspack-insights-windowed-heading"
+				title={ getHeading( range ) }
+				description={ __( 'New subscribers, win-backs, churn, and the revenue behind them.', 'newspack-plugin' ) }
+			/>
 			<Grid columns={ 4 } gutter={ 16 } noMargin>
 				<MetricCard
-					label={ __( 'New subscribers', 'newspack-plugin' ) }
+					label={ __( 'New Subscribers', 'newspack-plugin' ) }
 					value={ current.new_subscribers }
 					format="number"
 					// Drop the period delta when there are no new subscribers: a "↓ 100%"
@@ -186,14 +190,14 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'First-time subscribers', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Win-backs', 'newspack-plugin' ) }
+					label={ __( 'Win-Backs', 'newspack-plugin' ) }
 					value={ current.winback_subscribers }
 					format="number"
 					previousValue={ previous?.winback_subscribers }
 					description={ __( 'Previously churned subscribers who resubscribed', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Churned subscribers', 'newspack-plugin' ) }
+					label={ __( 'Churned Subscribers', 'newspack-plugin' ) }
 					value={ current.churned_subscribers }
 					format="number"
 					previousValue={ previous?.churned_subscribers }
@@ -201,7 +205,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'Subscribers who churned in this timeframe', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Gross revenue', 'newspack-plugin' ) }
+					label={ __( 'Gross Revenue', 'newspack-plugin' ) }
 					value={ current.revenue_gross }
 					format="currency"
 					previousValue={ previous?.revenue_gross }
@@ -209,7 +213,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'Subscription orders before refunds', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Net revenue', 'newspack-plugin' ) }
+					label={ __( 'Net Revenue', 'newspack-plugin' ) }
 					value={ current.revenue_net }
 					format="currency"
 					previousValue={ previous?.revenue_net }
@@ -217,7 +221,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'Gross minus refunds processed', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Refund rate', 'newspack-plugin' ) }
+					label={ __( 'Refund Rate', 'newspack-plugin' ) }
 					value={ refund.computable ? refund.value : 0 }
 					format="percent"
 					previousValue={ refundEmptyMessage ? undefined : refundPrevious }
@@ -227,7 +231,7 @@ const WindowedSection = ( { range, current, previous, activeSubscribers }: Windo
 					description={ __( 'Refunds ÷ subscription orders', 'newspack-plugin' ) }
 				/>
 				<MetricCard
-					label={ __( 'Failed payment recovery', 'newspack-plugin' ) }
+					label={ __( 'Failed Payment Recovery', 'newspack-plugin' ) }
 					value={ retry.computable ? retry.value : 0 }
 					format="percent"
 					previousValue={ retryEmptyMessage ? undefined : retryPrevious }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A design-polish pass over the Insights wizard, tightening copy and layout consistency across every tab. Targets the `feat/insights-rsm` integration branch.

**Copy**

* Section/chart headings and metric-card labels now use consistent **Title Case** (previously a mix of sentence and title case). Minor words stay lowercase (`per`, `by`, `to`, `vs`, `of`…) and acronyms/units are preserved (`eCPM`, `CTR`, `RPM`, `MRR`, `7d`/`14d`/`30d`, `→`, `&`).
* Every section heading now has a one-line **description** — filled in the ~15 that were missing one (Top Zones, Top Ad Units, Top Advertisers, Top Campaigns, Top Ads, Ad Performance by Newsletter, Donations by Tier, Retention, Subscriptions by Product, Subscriber Tenure, the two "by campaign" tables, and the donor/subscriber windowed sections) so headings read consistently.
* The "New registered readers" description now **names the active timeframe** ("Registrations created in the last 30 days") instead of a generic "in this timeframe".
* Durations render with **unit suffixes** (`2m 22s`, `2h 39m 33s`) instead of clock notation (`2:22`), everywhere a duration appears.
* "Avg Engaged Session Duration" is shortened to **"Avg Engaged Time"**.
* A trailing scope qualifier on a metric label — `(Direct)`, `(Influenced, 7d)`, `(30d)` — now sits on its **own line** beneath the metric name.

**Layout**

* The data-freshness note ("Data as of…") is now a **warning notice pinned to the top of the page**, above the tab content, rather than a custom info box inside it.
* The Advertising tab now shows a **divider between each section** (e.g. Revenue Trend and Ad Types & Devices), matching the rest of the tabs.
* Assorted spacing/consistency fixes: the Newsletter Ads "ads excluded" footnote sits tighter under its cards; the floating "Next steps" card was restructured for cleaner alignment; and a few card spacing values were normalized.

### How to test the changes in this Pull Request:

1. Build the plugin and open **Insights** (`wp-admin` → Newspack → Insights).
2. Walk each tab (Audience, Engagement, Conversion Journey, Gates, Campaigns, Subscribers, Donors, Advertising, Newsletter Ads, App) and confirm section headings and scorecard labels read in consistent Title Case, with acronyms (`eCPM`, `CTR`, `RPM`), units (`7d`, `30d`) and symbols (`→`, `&`, `vs`) intact.
3. Confirm every section heading now has a description line beneath it — spot-check the previously-bare ones on Advertising (Top Zones / Ad Units / Advertisers / Campaigns), Newsletter Ads (Top Ads / Advertisers / Ad Performance by Newsletter), Donors and Subscribers.
4. On **Audience**, change the Date Range and confirm the "New registered readers" description tracks it ("…in the last 7 days", "…this month", etc.), and that a custom range falls back to "…in this timeframe".
5. On **Engagement**, confirm the engagement-time metric reads "Avg Engaged Time" and its value uses `Xm Ys` (or `Xh Ym Zs`) format; check any duration columns render the same way.
6. On **Gates** / **Campaigns**, confirm conversion labels drop their `(Direct)` / `(Influenced, 7d)` qualifier to a second line, and the values across a row still align.
7. On **Advertising** (GAM), confirm the "Data as of…" warning notice appears at the very top of the page (above the date picker/content), and that a full-width divider separates each section.
8. On **Newsletter Ads**, confirm the "N ads excluded from revenue" footnote sits directly under the scorecards with no extra gap.
9. Confirm the floating "Next steps" card (bottom-right, on tabs that have playbook links) is laid out correctly and dismisses.
10. Run the JS suite (`pnpm --filter newspack test`) — green except the pre-existing, unrelated `PrintDocumentMeta` date-range assertion on this branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?