### PR TITLE
fix(components): balance section-header description text-wrap

### DIFF
--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -12,6 +12,9 @@
 
 	&__container {
 		position: relative;
+		p {
+			text-wrap: balance;
+		}
 		&:not(:first-child) {
 			margin-top: 48px;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Applies `text-wrap: balance` to description paragraphs inside the `SectionHeader` component (`newspack-components` package). Multi-line section descriptions wrap with visually even line lengths instead of leaving a short orphan word on the last line. Single-line descriptions are unaffected, and browsers without `text-wrap: balance` support simply ignore it (progressive enhancement, no fallback needed).

Extracted from #315 so the component change can land on `main` independently of the Insights work.

### How to test the changes in this Pull Request:

1. Open any wizard screen that renders a `SectionHeader` with a description long enough to wrap onto two or more lines (e.g. narrow the viewport).
2. Verify the description's lines are visually balanced in length rather than leaving one word dangling on the final line.
3. Verify single-line descriptions and headings render unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
