### PR TITLE
fix(subscriptions): keep group owner sub on member delete (NPPM-3021)

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -63,6 +63,12 @@ class Group_Subscription_MyAccount {
 		add_action( 'template_redirect', [ __CLASS__, 'redirect_legacy_manage_members' ] );
 		add_filter( 'wcs_get_users_subscriptions', [ __CLASS__, 'inject_member_group_subscriptions' ], 15, 2 );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'grant_group_member_view_order_cap' ], 15, 4 );
+		// Remove a departing user from their group memberships before WooCommerce
+		// Subscriptions' `delete_user` cascade (priority 10) force-deletes their
+		// subscriptions, so the cascade never sees a group owner's subscription as
+		// belonging to the member being deleted. See NPPM-3021.
+		add_action( 'delete_user', [ __CLASS__, 'remove_deleted_user_from_groups' ], 5 );
+		add_action( 'wpmu_delete_user', [ __CLASS__, 'remove_deleted_user_from_groups' ], 5 );
 		add_filter( 'wcs_view_subscription_actions', [ __CLASS__, 'view_subscription_actions' ], 13, 3 );
 		add_action( 'admin_post_' . self::INVITE_NONCE_ACTION, [ __CLASS__, 'handle_invite_member' ] );
 		add_action( 'admin_post_' . self::CANCEL_INVITE_NONCE_ACTION, [ __CLASS__, 'handle_cancel_invite' ] );
@@ -465,7 +471,23 @@ class Group_Subscription_MyAccount {
 	 * @return array
 	 */
 	public static function inject_member_group_subscriptions( $subscriptions, $user_id ) {
+		// Never inject during a user-deletion cascade. WCS's trash_users_subscriptions()
+		// is hooked on `delete_user` and force-deletes every subscription that
+		// wcs_get_users_subscriptions() returns; because self-service account deletion
+		// runs on the My Account page (is_account_page() is true), injecting a member's
+		// group subscription here would feed the *owner's* subscription into that cascade
+		// and permanently delete it. See NPPM-3021.
+		if ( doing_action( 'delete_user' ) || doing_action( 'wpmu_delete_user' ) ) {
+			return $subscriptions;
+		}
 		if ( ! function_exists( 'is_account_page' ) || ! \is_account_page() ) {
+			return $subscriptions;
+		}
+		// Only augment the list when a member is viewing their OWN account. This keeps the
+		// member-injection out of any wcs_get_users_subscriptions( $other_user ) call that
+		// runs in an account-page request (admin/cross-user reads, or a contact sync), which
+		// must only ever see the subscriptions the user actually owns. See NPPM-3021.
+		if ( (int) $user_id !== \get_current_user_id() ) {
 			return $subscriptions;
 		}
 		// The legacy/core My Account UI has no member-safe templates, so don't surface
@@ -498,6 +520,31 @@ class Group_Subscription_MyAccount {
 	}
 
 	/**
+	 * Remove a user from every group they are a member of before the user is deleted.
+	 *
+	 * Hooked on `delete_user` (and `wpmu_delete_user`) at priority 5 — ahead of
+	 * WooCommerce Subscriptions' WC_Subscriptions_Manager::trash_users_subscriptions()
+	 * at the default priority 10, which force-deletes every subscription that
+	 * wcs_get_users_subscriptions() returns for the deleted user. Clearing the
+	 * departing member's group membership here means the cascade no longer resolves a
+	 * group owner's subscription as one of the member's own. This is the primary fix;
+	 * the doing_action( 'delete_user' ) guards in inject_member_group_subscriptions()
+	 * and grant_group_member_view_order_cap() are defense-in-depth. See NPPM-3021.
+	 *
+	 * Deleting only the membership meta (not going through update_members()) avoids
+	 * that method's side effects, e.g. re-enabling a disabled group subscription.
+	 *
+	 * @param int $user_id The ID of the user being deleted.
+	 */
+	public static function remove_deleted_user_from_groups( $user_id ) {
+		$group_ids = Group_Subscription::get_group_subscriptions_for_user( $user_id, true );
+		foreach ( $group_ids as $subscription_id ) {
+			\delete_user_meta( $user_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $subscription_id );
+			\delete_user_meta( $user_id, Group_Subscription::get_member_joined_meta_key( $subscription_id ) );
+		}
+	}
+
+	/**
 	 * Grant the `view_order` capability to group subscription members on My Account pages.
 	 *
 	 * WCS checks current_user_can( 'view_order', $subscription->get_id() ) before rendering
@@ -512,6 +559,11 @@ class Group_Subscription_MyAccount {
 	 * @return string[]
 	 */
 	public static function grant_group_member_view_order_cap( $caps, $cap, $user_id, $args ) {
+		// Don't elevate caps during a user-deletion cascade (defense-in-depth alongside the
+		// same guard in inject_member_group_subscriptions()). See NPPM-3021.
+		if ( doing_action( 'delete_user' ) || doing_action( 'wpmu_delete_user' ) ) {
+			return $caps;
+		}
 		if ( 'view_order' !== $cap || ! function_exists( 'is_account_page' ) || ! \is_account_page() ) {
 			return $caps;
 		}

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-woocommerce.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-woocommerce.php
@@ -107,6 +107,9 @@ class WooCommerce {
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
 			function( $acc, $subscription_id ) use ( $user_id ) {
 				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( ! $subscription ) {
+					return $acc;
+				}
 				// Skip group subscriptions the user is only a *member* of (not the owner);
 				// the My Account member-injection filter can surface these on account pages,
 				// but the contact's "current product" must reflect a subscription they own.

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-woocommerce.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-woocommerce.php
@@ -8,6 +8,7 @@
 namespace Newspack\Reader_Activation\Sync;
 
 use Newspack\Donations;
+use Newspack\Group_Subscription;
 use Newspack\WooCommerce_Connection;
 use Newspack\WooCommerce_Order_UTM;
 use Newspack\Subscriptions_Meta;
@@ -104,8 +105,15 @@ class WooCommerce {
 		}
 		$subscriptions = array_reduce(
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
-			function( $acc, $subscription_id ) {
+			function( $acc, $subscription_id ) use ( $user_id ) {
 				$subscription = \wcs_get_subscription( $subscription_id );
+				// Skip group subscriptions the user is only a *member* of (not the owner);
+				// the My Account member-injection filter can surface these on account pages,
+				// but the contact's "current product" must reflect a subscription they own.
+				// Group access syncs separately via Content Access Group/Source. See NPPM-3021.
+				if ( Group_Subscription::user_is_member( $user_id, $subscription ) ) {
+					return $acc;
+				}
 				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 
 					// Only donation subscriptions that have at least one completed order are considered.

--- a/plugins/newspack-plugin/includes/reader-activation/sync/contact-metadata/class-subscription.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/contact-metadata/class-subscription.php
@@ -8,6 +8,7 @@
 namespace Newspack\Reader_Activation\Sync\Contact_Metadata;
 
 use Newspack\Donations;
+use Newspack\Group_Subscription;
 use Newspack\Subscriptions_Meta;
 use Newspack\WooCommerce_Connection;
 use Newspack\Reader_Activation\Sync\Contact_Metadata;
@@ -139,6 +140,14 @@ class Subscription extends Contact_Metadata {
 
 		$all_subscriptions = \wcs_get_users_subscriptions( $this->user->ID );
 		foreach ( $all_subscriptions as $subscription ) {
+			// Skip group subscriptions the user is only a *member* of (not the owner). On
+			// account pages, wcs_get_users_subscriptions() can surface these via the My
+			// Account member-injection filter, but a member's subscription metadata must
+			// reflect only subscriptions they own; their group access is synced separately
+			// through the Content Access Group / Content Access Source fields. See NPPM-3021.
+			if ( Group_Subscription::user_is_member( $this->user->ID, $subscription ) ) {
+				continue;
+			}
 			if ( $this->is_relevant_subscription( $subscription ) ) {
 				$this->user_subscriptions_cache[] = $subscription;
 			}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -172,6 +172,8 @@ class Test_Group_Subscription_MyAccount extends WP_UnitTestCase {
 		$member_id = $this->create_reader_user();
 		$group_sub = $this->create_group_subscription( $owner_id );
 		$this->add_member( $member_id, $group_sub );
+		// Injection only augments the current viewer's own account.
+		wp_set_current_user( $member_id );
 
 		// Start with an empty list (member has no owned subscriptions).
 		$result = Group_Subscription_MyAccount::inject_member_group_subscriptions( [], $member_id );
@@ -191,6 +193,7 @@ class Test_Group_Subscription_MyAccount extends WP_UnitTestCase {
 		$member_id = $this->create_reader_user();
 		$group_sub = $this->create_group_subscription( $owner_id );
 		$this->add_member( $member_id, $group_sub );
+		wp_set_current_user( $member_id );
 
 		// Pre-populate $existing with the group sub — simulates the sub already being present.
 		$existing = [ $group_sub->get_id() => $group_sub ];
@@ -232,6 +235,7 @@ class Test_Group_Subscription_MyAccount extends WP_UnitTestCase {
 		);
 		$trashed_sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
 		$this->add_member( $member_id, $trashed_sub );
+		wp_set_current_user( $member_id );
 
 		$result = Group_Subscription_MyAccount::inject_member_group_subscriptions( [], $member_id );
 
@@ -255,6 +259,7 @@ class Test_Group_Subscription_MyAccount extends WP_UnitTestCase {
 			$member_id = $this->create_reader_user();
 			$group_sub = $this->create_group_subscription( $owner_id );
 			$this->add_member( $member_id, $group_sub );
+			wp_set_current_user( $member_id );
 
 			$result = Group_Subscription_MyAccount::inject_member_group_subscriptions( [], $member_id );
 		} finally {
@@ -262,6 +267,114 @@ class Test_Group_Subscription_MyAccount extends WP_UnitTestCase {
 		}
 
 		$this->assertEmpty( $result, 'Should not inject on the legacy My Account UI' );
+	}
+
+	/**
+	 * Regression (NPPM-3021): injection only augments the *current viewer's* own account.
+	 *
+	 * A wcs_get_users_subscriptions( $other_user ) call that runs in an account-page
+	 * request (an admin view, a cross-user read, or a contact sync) must return only the
+	 * subscriptions that user actually owns — never a group sub they are merely a member of.
+	 */
+	public function test_inject_skipped_for_non_current_user() {
+		$owner_id  = $this->create_reader_user();
+		$member_id = $this->create_reader_user();
+		$viewer_id = $this->create_reader_user();
+		$group_sub = $this->create_group_subscription( $owner_id );
+		$this->add_member( $member_id, $group_sub );
+
+		// A different user is the current viewer while the member's subscriptions are fetched.
+		wp_set_current_user( $viewer_id );
+
+		$result = Group_Subscription_MyAccount::inject_member_group_subscriptions( [], $member_id );
+
+		$this->assertEmpty(
+			$result,
+			'Member group sub must not be injected when fetched for a non-current user'
+		);
+	}
+
+	/**
+	 * Regression (NPPM-3021): the member-injection filter must NOT run during a
+	 * user-deletion cascade.
+	 *
+	 * WCS's WC_Subscriptions_Manager::trash_users_subscriptions() is hooked on
+	 * `delete_user` and force-deletes every subscription that
+	 * wcs_get_users_subscriptions() returns. Because self-service account deletion
+	 * runs on the My Account page (is_account_page() true), injecting a member's
+	 * group subscription here would feed the *owner's* subscription into that
+	 * cascade and permanently delete it. Fix A guards the filter with
+	 * doing_action( 'delete_user' ). Captured at priority 1 to isolate the guard
+	 * from the priority-5 membership cleanup (fix B).
+	 */
+	public function test_inject_skipped_during_user_deletion_cascade() {
+		$owner_id  = $this->create_reader_user();
+		$member_id = $this->create_reader_user();
+		$group_sub = $this->create_group_subscription( $owner_id );
+		$this->add_member( $member_id, $group_sub );
+		// Faithful self-service deletion: the member is the current user and on an account
+		// page, so both is_account_page() and the current-user allowlist pass — the
+		// delete_user guard is what must stop the injection here.
+		wp_set_current_user( $member_id );
+		$GLOBALS['newspack_test_is_account_page'] = true;
+
+		$captured = null;
+		$capture  = function () use ( &$captured, $member_id ) {
+			$captured = Group_Subscription_MyAccount::inject_member_group_subscriptions( [], $member_id );
+		};
+		add_action( 'delete_user', $capture, 1 );
+		try {
+			wp_delete_user( $member_id );
+		} finally {
+			remove_action( 'delete_user', $capture, 1 );
+		}
+
+		$this->assertSame(
+			[],
+			$captured,
+			'Owner group subscription must not be injected during the delete_user cascade'
+		);
+	}
+
+	/**
+	 * Regression (NPPM-3021): a deleted user is removed from the groups they are a
+	 * member of *before* WCS's deletion cascade runs.
+	 *
+	 * Fix B hooks `delete_user` at priority 5 (ahead of WCS's
+	 * trash_users_subscriptions at priority 10) and clears the departing user's
+	 * membership meta, so by the time the cascade queries their subscriptions the
+	 * owner's group sub is no longer associated with them. Captured at priority 8:
+	 * after the cleanup, before the cascade.
+	 */
+	public function test_user_deletion_removes_group_memberships_before_cascade() {
+		$owner_id  = $this->create_reader_user();
+		$member_id = $this->create_reader_user();
+		$group_sub = $this->create_group_subscription( $owner_id );
+		$this->add_member( $member_id, $group_sub );
+
+		// Wire the cleanup exactly as Group_Subscription_MyAccount::init() does. init() is
+		// gated behind the Access Control feature flag (off in the test bootstrap), so
+		// register it here to exercise the priority-5 ordering against WCS's delete_user
+		// cascade (priority 10).
+		$cleanup = [ Group_Subscription_MyAccount::class, 'remove_deleted_user_from_groups' ];
+		add_action( 'delete_user', $cleanup, 5 );
+
+		$still_member_at_cascade_time = null;
+		$capture                      = function () use ( &$still_member_at_cascade_time, $member_id, $group_sub ) {
+			$still_member_at_cascade_time = Group_Subscription::user_is_member( $member_id, $group_sub );
+		};
+		add_action( 'delete_user', $capture, 8 );
+		try {
+			wp_delete_user( $member_id );
+		} finally {
+			remove_action( 'delete_user', $capture, 8 );
+			remove_action( 'delete_user', $cleanup, 5 );
+		}
+
+		$this->assertFalse(
+			$still_member_at_cascade_time,
+			'Deleted user should be removed from their groups before the WCS deletion cascade'
+		);
 	}
 
 	// ---- grant_group_member_view_order_cap tests ----

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync/class-test-subscription-metadata.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync/class-test-subscription-metadata.php
@@ -6,6 +6,8 @@
  */
 
 use Newspack\Subscriptions_Meta;
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Settings;
 use Newspack\Reader_Activation\Sync\Contact_Metadata\Subscription;
 
 require_once __DIR__ . '/../../mocks/wc-mocks.php';
@@ -145,6 +147,35 @@ class Test_Subscription_Metadata extends WP_UnitTestCase {
 
 		$metadata = ( new Subscription( self::$user_id ) )->get_metadata();
 		$this->assertSame( 2, $metadata['Active_Subscription_Count'] );
+	}
+
+	public function test_metadata_excludes_group_member_subscriptions() {
+		// A group subscription owned by a *different* user that self::$user_id only belongs
+		// to as a member. The My Account member-injection filter can surface it in the
+		// member's wcs_get_users_subscriptions() results on account pages; it must not feed
+		// the member's own subscription metadata — group access is synced separately via the
+		// Content Access Group / Content Access Source fields. See NPPM-3021.
+		$owner_id  = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$group_sub = $this->create_subscription( [ 'customer_id' => $owner_id ] );
+		$group_sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		add_user_meta( self::$user_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $group_sub->get_id() );
+
+		// Simulate the My Account injection surfacing the owner's group sub for the member.
+		$inject = function ( $subs, $user_id ) use ( $group_sub ) {
+			if ( (int) $user_id === (int) self::$user_id ) {
+				$subs[ $group_sub->get_id() ] = $group_sub;
+			}
+			return $subs;
+		};
+		add_filter( 'wcs_get_users_subscriptions', $inject, 15, 2 );
+		try {
+			$metadata = ( new Subscription( self::$user_id ) )->get_metadata();
+		} finally {
+			remove_filter( 'wcs_get_users_subscriptions', $inject, 15 );
+		}
+
+		$this->assertSame( 0, $metadata['Active_Subscription_Count'], 'A group-member sub must not count toward the member.' );
+		$this->assertSame( '', $metadata['Subscriber_Status'], 'A group-member sub must not set the member Subscriber Status.' );
 	}
 
 	public function test_pending_cancel_counted_as_active() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a data-loss bug: a **member** of a group subscription who deletes their own reader account (self-service **My Account → Delete Account**) would also permanently delete the **group owner's** subscription — cutting off access for the entire group. The owner's subscription was force-deleted (not trashed), leaving orphaned renewal orders.

Root cause: Newspack surfaces a group subscription to its members by filtering `wcs_get_users_subscriptions()`, guarded only by `is_account_page()`. WooCommerce Subscriptions' `delete_user` cascade (`WC_Subscriptions_Manager::trash_users_subscriptions()`) calls that same function and `->delete( true )`s everything it returns. Because self-service deletion runs on the My Account page, the member's group-owner subscription was injected into the cascade and hard-deleted.

This PR:

- **(primary fix)** Removes a departing user from their group memberships on `delete_user` / `wpmu_delete_user` (priority 5, ahead of WCS's cascade), so the cascade only ever deletes subscriptions the user actually owns.
- Hardens the member-injection filter to bail during a user-deletion cascade and to only augment the **current viewer's own** account, so cross-user reads (admin views, contact syncs) see owner-only subscriptions.
- Excludes group subscriptions the user is only a **member** of from the ESP contact-sync subscription metadata and "current product" resolution, so a member's ESP subscription fields reflect only subscriptions they own. Group access continues to sync via the **Content Access Group / Content Access Source** fields. Gifted subscriptions are preserved.

No public API/hook signatures change.

Closes NPPM-3021.

### How to test the changes in this Pull Request:

Prerequisites: Access Control feature flag on, v1 My Account active, WooCommerce + WooCommerce Subscriptions active, WC Memberships **not** active.

1. As an admin, create a group subscription owned by **User A** and add **User B** as a member (e.g. via `Group_Subscription::update_members()` or the group-management UI). Confirm User B has group access.
2. Log in as **User B** → **My Account → Edit Account → Delete Account**; complete the email-confirmation flow to delete User B's account.
3. Verify **User A's group subscription still exists** (WooCommerce → Subscriptions) and is unchanged, and that other group members still have access. (Before this fix, User A's subscription would be gone.)
4. Confirm User B's own subscriptions (if any) are still cleaned up when their account is deleted.
5. Delete a group **member** from **wp-admin → Users** — confirm the owner's subscription is likewise unaffected.
6. ESP metadata: for a reader who is only a **member** of a group subscription (owning none of their own), trigger a contact sync and confirm the subscription metadata fields (Subscriber Status, Active Subscription Count, etc.) are empty/zero — the group is reflected via **Content Access Group / Content Access Source**, not the subscription fields.
7. Regression: a group **owner** viewing **My Account → Subscriptions** still sees and can manage their group subscription; a member still sees the group subscription in their account per existing behavior.

Automated: `n test-php` for `newspack-plugin` passes (1678 tests). New regression tests cover the delete cascade, the current-user allowlist, the membership-cleanup ordering, and the ESP-metadata exclusion.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
