### PR TITLE
feat(subscribers): audience wizard shell + read endpoints (NPPD-1753)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,10 @@ repos/*
 !repos/themes/.gitkeep
 logs
 html
-data
+# Anchored: this is the workspace-root database volume. Unanchored it also
+# swallowed source directories named `data/` inside plugins (e.g. a wizard's
+# data hooks), silently dropping new files there from commits.
+/data
 bin/secrets.json
 snapshots
 manager-html

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -200,6 +200,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-subscription-products.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-pricing-rules.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-integrations.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-subscribers-wizard.php';
 
 		// Network Wizard.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-network-wizard.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -74,6 +74,7 @@ class Wizards {
 			'audience-content-gates'  => new Audience_Content_Gates(),
 			'audience-donations'      => new Audience_Donations(),
 			'audience-integrations'   => new Audience_Integrations(),
+			'newspack-subscribers'    => new Subscribers_Wizard(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),

--- a/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
@@ -49,6 +49,21 @@ class Subscribers_Wizard extends Wizard {
 	const FILTER_INCLUDE_CAP = 10000;
 
 	/**
+	 * Upper bound on the number of avatars one /avatars request resolves. A single
+	 * list page needs at most `per_page` (≤100); the client batches larger sets.
+	 */
+	const AVATAR_BATCH_CAP = 200;
+
+	/**
+	 * How many subscriptions the filter scan hydrates at a time. The scan itself
+	 * is bounded by FILTER_INCLUDE_CAP, but WooCommerce returns fully hydrated
+	 * WC_Subscription objects and only their customer ID is needed here — walking
+	 * the set a page at a time keeps peak memory at one chunk rather than the
+	 * whole cap. See customer_ids_for_raw_statuses().
+	 */
+	const FILTER_SCAN_CHUNK = 500;
+
+	/**
 	 * Per-request memo of the site's group subscriptions (each with its resolved
 	 * settings). A single request can resolve these several times — once per active
 	 * filter set plus the group list itself — and each resolution hydrates every
@@ -66,6 +81,14 @@ class Subscribers_Wizard extends Wizard {
 	 * @var array<int,array<int,array>>|null
 	 */
 	private $group_membership_index = null;
+
+	/**
+	 * Per-request memo of customer IDs keyed by the sorted status set they were
+	 * resolved for. See customer_ids_for_raw_statuses().
+	 *
+	 * @var array<string,int[]>
+	 */
+	private $raw_status_ids_cache = [];
 
 	/**
 	 * Constructor.
@@ -133,9 +156,14 @@ class Subscribers_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'emails' => [
-						'type'     => 'array',
-						'required' => true,
-						'items'    => [ 'type' => 'string' ],
+						'type'              => 'array',
+						'required'          => true,
+						'items'             => [ 'type' => 'string' ],
+						// Sanitized declaratively, like the sibling `size` arg. Invalid
+						// entries are dropped rather than failing the whole request:
+						// one malformed address shouldn't blank a page of avatars.
+						'sanitize_callback' => [ __CLASS__, 'sanitize_emails_arg' ],
+						'validate_callback' => 'rest_validate_request_arg',
 					],
 					'size'   => [
 						'type'              => 'integer',
@@ -211,10 +239,27 @@ class Subscribers_Wizard extends Wizard {
 						'type'              => 'array',
 						'items'             => [ 'type' => 'string' ],
 						'sanitize_callback' => 'rest_sanitize_request_arg',
+						'validate_callback' => 'rest_validate_request_arg',
 					],
 				],
 			]
 		);
+	}
+
+	/**
+	 * Sanitize the /avatars `emails` arg: valid addresses only, deduplicated and
+	 * bounded to AVATAR_BATCH_CAP.
+	 *
+	 * Invalid entries are dropped rather than rejected so a single malformed
+	 * address can't fail the whole batch.
+	 *
+	 * @param mixed $emails The raw `emails` request arg.
+	 *
+	 * @return string[] Sanitized, unique, capped email addresses.
+	 */
+	public static function sanitize_emails_arg( $emails ) {
+		$sanitized = array_filter( array_map( 'sanitize_email', (array) $emails ) );
+		return array_values( array_slice( array_unique( $sanitized ), 0, self::AVATAR_BATCH_CAP ) );
 	}
 
 	/**
@@ -257,6 +302,7 @@ class Subscribers_Wizard extends Wizard {
 	public function api_get_groups() {
 		$this->group_subscriptions_cache = null;
 		$this->group_membership_index    = null;
+		$this->raw_status_ids_cache      = [];
 		$items                           = [];
 		foreach ( $this->get_group_subscriptions() as $group ) {
 			$items[] = $this->prepare_group( $group['subscription'], $group['settings'] );
@@ -363,9 +409,10 @@ class Subscribers_Wizard extends Wizard {
 	public function api_get_subscribers( $request ) {
 		$this->group_subscriptions_cache = null;
 		$this->group_membership_index    = null;
+		$this->raw_status_ids_cache      = [];
 		$per_page                        = (int) $request->get_param( 'per_page' );
-		$page     = (int) $request->get_param( 'page' );
-		$search   = trim( (string) $request->get_param( 'search' ) );
+		$page                            = (int) $request->get_param( 'page' );
+		$search                          = trim( (string) $request->get_param( 'search' ) );
 
 		$query_args = [
 			'role__in'    => Reader_Activation::get_reader_roles(),
@@ -418,6 +465,19 @@ class Subscribers_Wizard extends Wizard {
 
 	/**
 	 * Shape a reader user for the admin subscriber list.
+	 *
+	 * Cost note: group memberships are indexed once per request
+	 * (get_group_membership_index), but two lookups here are inherently per-row —
+	 * wcs_get_users_subscriptions() and last_payment_date()'s wc_get_orders() —
+	 * so a page costs ~2 × `per_page` (≤100) WooCommerce queries. Both are
+	 * "newest/owned rows for one customer" lookups that WooCommerce can't answer
+	 * per-customer in a single batched query: batching last_payment_date() over
+	 * the page's customer IDs would need either an unbounded `limit => -1` (worse
+	 * peak memory than the bounded per-row queries) or a truncated scan that
+	 * silently blanks the last payment of a reader whose most recent order falls
+	 * outside it. The bounded per-row shape is the correct trade-off here, and
+	 * matches the existing convention elsewhere in the plugin
+	 * (Sync\Contact_Metadata\Engagement::get_latest_order).
 	 *
 	 * @param \WP_User $user The reader user.
 	 *
@@ -567,6 +627,22 @@ class Subscribers_Wizard extends Wizard {
 	 * dropped whenever any live status remains. Empty when they have no
 	 * subscription at all (a free reader shows no status badge).
 	 *
+	 * SOURCE OF TRUTH for the status-reduction rule. The rule is:
+	 *
+	 *   Rank statuses active → pending → on-hold → cancelled, and drop
+	 *   `cancelled` entirely whenever the reader still holds any live
+	 *   (non-cancelled) subscription; a reader with no subscription at all has
+	 *   no status.
+	 *
+	 * It is re-encoded in three other places, each of which points back here and
+	 * must be changed in step or the endpoint's filter will contradict the badge
+	 * it filters on:
+	 *   - customer_ids_for_statuses() below — the endpoint's `status` filter.
+	 *   - displayStatuses() in src/wizards/subscribers/status.js — the row's
+	 *     status badges.
+	 *   - visiblePlanEntries in src/wizards/subscribers/screens/SubscriberList.jsx
+	 *     — the Subscription column.
+	 *
 	 * @param array $subscriptions Individual subscription entries.
 	 * @param array $groups        Group membership entries.
 	 *
@@ -667,8 +743,9 @@ class Subscribers_Wizard extends Wizard {
 
 	/**
 	 * Customer IDs whose displayed status matches any of the given prototype
-	 * statuses, mirroring the list's badge reduction (see reduced_status /
-	 * displayStatuses): a live status always qualifies, but `cancelled` matches
+	 * statuses, mirroring the list's badge reduction (reduced_status() above is
+	 * the documented source of truth for that rule): a live status always
+	 * qualifies, but `cancelled` matches
 	 * only fully-churned readers — anyone who also holds a live (active/pending/
 	 * on-hold) subscription is dropped, since the badge hides cancelled while a
 	 * live plan remains. Without this the Cancelled filter would surface readers
@@ -711,21 +788,39 @@ class Subscribers_Wizard extends Wizard {
 		if ( empty( $prototype_statuses ) ) {
 			return [];
 		}
+		// Memoized per status set: customer_ids_for_statuses() asks for up to three
+		// overlapping sets per request (and a filter like ['active','cancelled']
+		// asks for `active` twice), each of which would otherwise repeat the full
+		// subscription scan below.
+		sort( $prototype_statuses );
+		$cache_key = implode( ',', $prototype_statuses );
+		if ( isset( $this->raw_status_ids_cache[ $cache_key ] ) ) {
+			return $this->raw_status_ids_cache[ $cache_key ];
+		}
 		$ids = [];
 
 		// Individual + owned subscriptions in a matching WCS status (HPOS-safe).
 		// Bounded to the same ceiling the include set is capped at, so the filter
-		// path can't load an unbounded number of subscription objects on a large store.
+		// path can't load an unbounded number of subscription objects on a large
+		// store, and walked a chunk at a time: WooCommerce hands back fully
+		// hydrated WC_Subscription objects and only the customer ID is read here,
+		// so paging keeps peak memory at one chunk instead of the whole cap.
 		$wcs_statuses = $this->wcs_statuses_for( $prototype_statuses );
 		if ( ! empty( $wcs_statuses ) && function_exists( 'wcs_get_subscriptions' ) ) {
-			$subs = \wcs_get_subscriptions(
-				[
-					'subscriptions_per_page' => self::FILTER_INCLUDE_CAP,
-					'subscription_status'    => $wcs_statuses,
-				]
-			);
-			foreach ( $subs as $subscription ) {
-				$ids[] = (int) $subscription->get_customer_id();
+			for ( $page = 1; ( $page - 1 ) * self::FILTER_SCAN_CHUNK < self::FILTER_INCLUDE_CAP; $page++ ) {
+				$subs = \wcs_get_subscriptions(
+					[
+						'subscriptions_per_page' => self::FILTER_SCAN_CHUNK,
+						'paged'                  => $page,
+						'subscription_status'    => $wcs_statuses,
+					]
+				);
+				foreach ( $subs as $subscription ) {
+					$ids[] = (int) $subscription->get_customer_id();
+				}
+				if ( count( $subs ) < self::FILTER_SCAN_CHUNK ) {
+					break;
+				}
 			}
 		}
 
@@ -736,7 +831,8 @@ class Subscribers_Wizard extends Wizard {
 			}
 		}
 
-		return array_values( array_unique( array_filter( $ids ) ) );
+		$this->raw_status_ids_cache[ $cache_key ] = array_values( array_unique( array_filter( $ids ) ) );
+		return $this->raw_status_ids_cache[ $cache_key ];
 	}
 
 	/**
@@ -858,14 +954,10 @@ class Subscribers_Wizard extends Wizard {
 		// displays (list: 32px → 64, profile: 64px → 128).
 		$size    = $request->get_param( 'size' );
 		$avatars = [];
-		// A single list page resolves at most `per_page` (≤100) avatars; bound the
-		// batch so an oversized payload can't fan out into unbounded get_avatar_url() calls.
-		$emails = array_slice( (array) $request->get_param( 'emails' ), 0, 200 );
-		foreach ( $emails as $email ) {
-			$email = sanitize_email( $email );
-			if ( '' === $email ) {
-				continue;
-			}
+		// Already sanitized, deduplicated and capped at AVATAR_BATCH_CAP by the
+		// arg's sanitize_callback (sanitize_emails_arg), so an oversized payload
+		// can't fan out into unbounded get_avatar_url() calls.
+		foreach ( (array) $request->get_param( 'emails' ) as $email ) {
 			$avatars[ $email ] = get_avatar_url( $email, [ 'size' => $size ] );
 		}
 		return rest_ensure_response(

--- a/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
@@ -1,0 +1,932 @@
+<?php
+/**
+ * Newspack Subscribers management wizard.
+ *
+ * The admin-side, people-first view of the site's subscribers and group
+ * subscriptions. Ported from the signed-off i2 design prototype; it lives under
+ * the Audience menu and is visible to any admin who can `manage_options`.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Subscribers wizard.
+ */
+class Subscribers_Wizard extends Wizard {
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-subscribers';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * The parent menu slug this wizard hangs under.
+	 *
+	 * @var string
+	 */
+	protected $parent_slug = 'newspack-audience';
+
+	/**
+	 * Upper bound on the number of customer IDs a subscription-status/plan filter
+	 * resolves to. Keeps both the subscription scan and the WP_User_Query IN()
+	 * clause bounded on very large stores. See resolve_filter_include().
+	 */
+	const FILTER_INCLUDE_CAP = 10000;
+
+	/**
+	 * Per-request memo of the site's group subscriptions (each with its resolved
+	 * settings). A single request can resolve these several times — once per active
+	 * filter set plus the group list itself — and each resolution hydrates every
+	 * group subscription, so it's cached for the life of the (per-request) wizard.
+	 *
+	 * @var array<int,array{subscription:\WC_Subscription,settings:array}>|null
+	 */
+	private $group_subscriptions_cache = null;
+
+	/**
+	 * Per-request memo mapping each user ID to their group memberships
+	 * ({ id, plan, status, role }), built once from the site's groups so the
+	 * subscriber list doesn't re-resolve group roles per row.
+	 *
+	 * @var array<int,array<int,array>>|null
+	 */
+	private $group_membership_index = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $args Optional arguments.
+	 */
+	public function __construct( $args = [] ) {
+		parent::__construct( $args );
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Whether this wizard is available.
+	 *
+	 * The subscribers surface is the admin face of the group-subscription / Access
+	 * Control feature, so it rides the same flag the rest of that code gates on
+	 * rather than introducing a new one — a site without Access Control has no
+	 * group data to manage here.
+	 *
+	 * @return bool
+	 */
+	public function is_feature_enabled() {
+		return Content_Gate::is_newspack_feature_enabled();
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return esc_html__( 'Audience Management / Subscribers', 'newspack-plugin' );
+	}
+
+	/**
+	 * Add the Subscribers subpage under the Audience menu.
+	 */
+	public function add_page() {
+		if ( ! $this->is_feature_enabled() ) {
+			return;
+		}
+		add_submenu_page(
+			$this->parent_slug,
+			$this->get_name(),
+			esc_html__( 'Subscribers', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
+	}
+
+	/**
+	 * Register REST endpoints.
+	 */
+	public function register_api_endpoints() {
+		if ( ! $this->is_feature_enabled() ) {
+			return;
+		}
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/avatars',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'api_get_avatars' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'emails' => [
+						'type'     => 'array',
+						'required' => true,
+						'items'    => [ 'type' => 'string' ],
+					],
+					'size'   => [
+						'type'              => 'integer',
+						'default'           => 64,
+						'minimum'           => 16,
+						'maximum'           => 512,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+				],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/groups',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_groups' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/subscribers',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_subscribers' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'page'     => [
+						'type'              => 'integer',
+						'default'           => 1,
+						'minimum'           => 1,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'per_page' => [
+						'type'              => 'integer',
+						'default'           => 20,
+						'minimum'           => 1,
+						'maximum'           => 100,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'search'   => [
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'orderby'  => [
+						'type'              => 'string',
+						'enum'              => [ 'name', 'memberSince' ],
+						'default'           => 'memberSince',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'order'    => [
+						'type'              => 'string',
+						'enum'              => [ 'asc', 'desc' ],
+						'default'           => 'desc',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'status'   => [
+						'type'              => 'array',
+						'items'             => [
+							'type' => 'string',
+							'enum' => [ 'active', 'pending', 'on-hold', 'cancelled' ],
+						],
+						'sanitize_callback' => 'rest_sanitize_request_arg',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'plan'     => [
+						'type'              => 'array',
+						'items'             => [ 'type' => 'string' ],
+						'sanitize_callback' => 'rest_sanitize_request_arg',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Map a WooCommerce Subscriptions status onto the prototype's status
+	 * vocabulary (active / pending / on-hold / cancelled).
+	 *
+	 * The admin UI was designed against these four values; WCS carries a handful
+	 * more that collapse cleanly onto them:
+	 *   - active, pending-cancel → active (still entitled)
+	 *   - pending               → pending (awaiting first payment)
+	 *   - on-hold               → on-hold (failed/paused renewal)
+	 *   - cancelled, expired    → cancelled (no longer entitled)
+	 * Anything unrecognised is treated as on-hold, the safe "needs attention"
+	 * bucket, rather than surfacing a raw WCS slug the UI has no label for.
+	 *
+	 * @param string $wcs_status The WooCommerce Subscriptions status slug.
+	 *
+	 * @return string One of 'active' | 'pending' | 'on-hold' | 'cancelled'.
+	 */
+	public static function map_subscription_status( $wcs_status ) {
+		return match ( $wcs_status ) {
+			'active', 'pending-cancel' => 'active',
+			'pending'                  => 'pending',
+			'cancelled', 'expired'     => 'cancelled',
+			default                    => 'on-hold',
+		};
+	}
+
+	/**
+	 * GET the site's group subscriptions, hydrated for the admin group list.
+	 *
+	 * Returns the `{ items, total, pages }` envelope the wizard's data hooks
+	 * expect. Groups are returned in full (the group list paginates client-side),
+	 * so `pages` is always 1. Each group carries the owner-inclusive member count
+	 * and the seat limit so the list can render "used / limit" without a second
+	 * round-trip.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function api_get_groups() {
+		$this->group_subscriptions_cache = null;
+		$this->group_membership_index    = null;
+		$items                           = [];
+		foreach ( $this->get_group_subscriptions() as $group ) {
+			$items[] = $this->prepare_group( $group['subscription'], $group['settings'] );
+		}
+
+		return rest_ensure_response(
+			[
+				'items' => $items,
+				'total' => count( $items ),
+				'pages' => 1,
+			]
+		);
+	}
+
+	/**
+	 * Every group-enabled subscription on the site, each paired with its resolved
+	 * settings, keyed by subscription ID. Memoized for the request.
+	 *
+	 * The HPOS-safe site-wide query get_group_subscription_ids() can over-report
+	 * under product inheritance, so each candidate is re-checked against its own
+	 * settings — the authority on group membership.
+	 *
+	 * @return array<int,array{subscription:\WC_Subscription,settings:array}>
+	 */
+	private function get_group_subscriptions() {
+		if ( null !== $this->group_subscriptions_cache ) {
+			return $this->group_subscriptions_cache;
+		}
+		$groups = [];
+		if ( class_exists( '\Newspack\Group_Subscription_Settings' ) && function_exists( 'wcs_get_subscription' ) ) {
+			foreach ( Group_Subscription_Settings::get_group_subscription_ids() as $subscription_id ) {
+				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( ! $subscription ) {
+					continue;
+				}
+				$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+				if ( empty( $settings['enabled'] ) ) {
+					continue;
+				}
+				$groups[ (int) $subscription->get_id() ] = [
+					'subscription' => $subscription,
+					'settings'     => $settings,
+				];
+			}
+		}
+		$this->group_subscriptions_cache = $groups;
+		return $groups;
+	}
+
+	/**
+	 * Shape a group subscription for the admin group list.
+	 *
+	 * @param \WC_Subscription $subscription The group subscription.
+	 * @param array            $settings     Its resolved group settings (name + limit).
+	 *
+	 * @return array
+	 */
+	private function prepare_group( $subscription, $settings ) {
+		$owner_id   = (int) $subscription->get_user_id();
+		$owner      = $owner_id ? get_userdata( $owner_id ) : false;
+		$created    = $subscription->get_date_created();
+		$created_at = $created ? gmdate( 'Y-m-d', $created->getTimestamp() ) : null;
+
+		return [
+			'id'          => (int) $subscription->get_id(),
+			'ownerId'     => $owner_id,
+			'owner'       => $owner ? [
+				'id'    => $owner_id,
+				'name'  => $owner->display_name,
+				'email' => $owner->user_email,
+			] : null,
+			'plan'        => (string) $settings['name'],
+			'status'      => self::map_subscription_status( $subscription->get_status() ),
+			// The configured limit is owner-inclusive (0 = unlimited); the member
+			// count is likewise owner-inclusive, so "members / seatLimit" reads true.
+			'seatLimit'   => (int) $settings['limit'],
+			'members'     => Group_Subscription::get_member_count( $subscription ),
+			'createdAt'   => $created_at,
+			// Interim click-through target: the WooCommerce subscription edit
+			// screen (HPOS-safe), until the in-wizard group detail lands (PR 4).
+			'editUrl'     => method_exists( $subscription, 'get_edit_order_url' ) ? $subscription->get_edit_order_url() : '',
+			// Seat requests are surfaced in a later slice (NPPD-1753 PR 7).
+			'seatRequest' => null,
+		];
+	}
+
+	/**
+	 * GET a paginated page of subscribers (reader-role users), hydrated for the
+	 * admin subscriber list.
+	 *
+	 * The list is server-paginated: filtering, sorting and paging all run against
+	 * the database rather than a client-side array. Returns the
+	 * `{ items, total, pages }` envelope the wizard's data hooks expect.
+	 *
+	 * Subscription-status and plan filters can't be expressed as user-table
+	 * columns, so they run inverted: an HPOS-safe subscription query resolves the
+	 * matching customer IDs, which are then intersected into the user query's
+	 * `include` set. See resolve_filter_include().
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function api_get_subscribers( $request ) {
+		$this->group_subscriptions_cache = null;
+		$this->group_membership_index    = null;
+		$per_page                        = (int) $request->get_param( 'per_page' );
+		$page     = (int) $request->get_param( 'page' );
+		$search   = trim( (string) $request->get_param( 'search' ) );
+
+		$query_args = [
+			'role__in'    => Reader_Activation::get_reader_roles(),
+			'number'      => $per_page,
+			'paged'       => $page,
+			'orderby'     => 'name' === $request->get_param( 'orderby' ) ? 'display_name' : 'registered',
+			'order'       => 'asc' === $request->get_param( 'order' ) ? 'ASC' : 'DESC',
+			'count_total' => true,
+			'fields'      => 'all',
+		];
+
+		if ( '' !== $search ) {
+			$query_args['search']         = '*' . $search . '*';
+			$query_args['search_columns'] = [ 'user_login', 'user_email', 'display_name' ];
+		}
+
+		// Invert subscription-status / plan filters into an `include` set. Tri-state:
+		// null = no filter applied; [] = filter active but matched nobody (short-circuit
+		// to an empty page); a populated list = restrict the query to those users.
+		$include = $this->resolve_filter_include( $request );
+		if ( is_array( $include ) ) {
+			if ( empty( $include ) ) {
+				return rest_ensure_response(
+					[
+						'items' => [],
+						'total' => 0,
+						'pages' => 0,
+					]
+				);
+			}
+			$query_args['include'] = $include;
+		}
+
+		$user_query = new \WP_User_Query( $query_args );
+		$total      = (int) $user_query->get_total();
+
+		$items = [];
+		foreach ( $user_query->get_results() as $user ) {
+			$items[] = $this->prepare_subscriber( $user );
+		}
+
+		return rest_ensure_response(
+			[
+				'items' => $items,
+				'total' => $total,
+				'pages' => (int) ceil( $total / $per_page ),
+			]
+		);
+	}
+
+	/**
+	 * Shape a reader user for the admin subscriber list.
+	 *
+	 * @param \WP_User $user The reader user.
+	 *
+	 * @return array
+	 */
+	private function prepare_subscriber( $user ) {
+		$user_id = (int) $user->ID;
+		// Resolve the user's own subscriptions once and reuse them, so hydration
+		// doesn't fetch the same list twice per row.
+		$owned_subscriptions = function_exists( 'wcs_get_users_subscriptions' ) ? \wcs_get_users_subscriptions( $user_id ) : [];
+		$subscriptions       = $this->get_individual_subscriptions( $user_id, $owned_subscriptions );
+		$groups              = $this->get_group_memberships( $user_id );
+
+		// user_registered can be a zero date ('0000-00-00 …'), which is truthy but
+		// unparseable; guard on the parsed timestamp so it degrades to null, not 1970.
+		$registered = $user->user_registered ? strtotime( $user->user_registered ) : false;
+
+		return [
+			'id'            => $user_id,
+			'name'          => $user->display_name,
+			'email'         => $user->user_email,
+			// Interim click-through target: the native user-edit screen (self edits
+			// resolve to profile.php), until the in-wizard person profile lands (PR 5).
+			'editUrl'       => get_edit_user_link( $user_id ),
+			'status'        => $this->reduced_status( $subscriptions, $groups ),
+			'memberSince'   => $registered ? gmdate( 'Y-m-d', $registered ) : null,
+			'lastPayment'   => $this->last_payment_date( $user_id ),
+			// Wired to reader activity in a later slice; the column is hidden by default.
+			'lastSeen'      => null,
+			'subscriptions' => $subscriptions,
+			'groups'        => $groups,
+			// Tags and newsletters are populated in a later slice (NPPD-1753 PR 7).
+			'tags'          => [],
+			'newsletters'   => [],
+		];
+	}
+
+	/**
+	 * A reader's own (non-group) subscriptions, shaped as { id, plan, status }.
+	 *
+	 * The wcs_get_users_subscriptions() list is filtered to also surface subs the
+	 * user is only a member of; those are excluded here (they belong to
+	 * get_group_memberships()) by keeping only subs the user actually owns and
+	 * that are not group-enabled.
+	 *
+	 * @param int                $user_id      The reader user ID.
+	 * @param \WC_Subscription[] $owned_subscriptions The user's subscriptions, already fetched by the caller.
+	 *
+	 * @return array<int,array>
+	 */
+	private function get_individual_subscriptions( $user_id, $owned_subscriptions ) {
+		$out = [];
+		foreach ( $owned_subscriptions as $subscription ) {
+			if ( ! $subscription instanceof \WC_Subscription || (int) $subscription->get_customer_id() !== $user_id ) {
+				continue;
+			}
+			$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+			if ( ! empty( $settings['enabled'] ) ) {
+				continue; // Group subscriptions are surfaced via get_group_memberships().
+			}
+			$out[] = [
+				'id'     => (int) $subscription->get_id(),
+				'plan'   => $this->individual_plan_name( $subscription ),
+				'status' => self::map_subscription_status( $subscription->get_status() ),
+			];
+		}
+		return $out;
+	}
+
+	/**
+	 * Resolve the display name of an individual subscription's plan (its product name).
+	 *
+	 * @param \WC_Subscription $subscription The subscription.
+	 *
+	 * @return string The product name, or '' when it can't be resolved.
+	 */
+	private function individual_plan_name( $subscription ) {
+		if ( ! class_exists( '\Newspack\WooCommerce_Subscriptions' ) || ! function_exists( 'wc_get_product' ) ) {
+			return '';
+		}
+		$product_id = WooCommerce_Subscriptions::get_subscription_product_id( $subscription );
+		$product    = $product_id ? \wc_get_product( $product_id ) : false;
+		return $product ? (string) $product->get_name() : '';
+	}
+
+	/**
+	 * A reader's group memberships, shaped as { id, plan, status, role }.
+	 *
+	 * Read from the per-request membership index rather than re-querying the
+	 * user's owned/managed/member subscriptions per row.
+	 *
+	 * @param int $user_id The reader user ID.
+	 *
+	 * @return array<int,array>
+	 */
+	private function get_group_memberships( $user_id ) {
+		$index = $this->get_group_membership_index();
+		return $index[ $user_id ] ?? [];
+	}
+
+	/**
+	 * Build (once per request) a map of user ID → their group memberships, each
+	 * shaped as { id, plan, status, role }.
+	 *
+	 * Iterating the site's (few, memoized) groups and reading each group's people
+	 * once is far cheaper than resolving every subscriber's owned/managed/member
+	 * subscriptions individually while paginating a large reader list. Role
+	 * precedence matches the per-group display: owner (the subscription customer),
+	 * else manager (in get_managers), else member.
+	 *
+	 * @return array<int,array<int,array>> User ID → list of membership entries.
+	 */
+	private function get_group_membership_index() {
+		if ( null !== $this->group_membership_index ) {
+			return $this->group_membership_index;
+		}
+		$index = [];
+		if ( class_exists( '\Newspack\Group_Subscription' ) ) {
+			foreach ( $this->get_group_subscriptions() as $group ) {
+				$subscription = $group['subscription'];
+				$owner_id     = (int) $subscription->get_user_id();
+				$managers     = array_map( 'intval', Group_Subscription::get_managers( $subscription ) );
+				$entry        = [
+					'id'     => (int) $subscription->get_id(),
+					'plan'   => (string) $group['settings']['name'],
+					'status' => self::map_subscription_status( $subscription->get_status() ),
+				];
+				foreach ( array_map( 'intval', Group_Subscription::get_all_members( $subscription ) ) as $member_id ) {
+					if ( $member_id === $owner_id ) {
+						$role = 'owner';
+					} elseif ( in_array( $member_id, $managers, true ) ) {
+						$role = 'manager';
+					} else {
+						$role = 'member';
+					}
+					$index[ $member_id ][] = array_merge( $entry, [ 'role' => $role ] );
+				}
+			}
+		}
+		$this->group_membership_index = $index;
+		return $index;
+	}
+
+	/**
+	 * Reduce a reader's many subscription statuses to a single subscriber-level
+	 * status, mirroring the list's badge logic: active-first, with cancelled
+	 * dropped whenever any live status remains. Empty when they have no
+	 * subscription at all (a free reader shows no status badge).
+	 *
+	 * @param array $subscriptions Individual subscription entries.
+	 * @param array $groups        Group membership entries.
+	 *
+	 * @return string One of 'active' | 'pending' | 'on-hold' | 'cancelled' | ''.
+	 */
+	private function reduced_status( $subscriptions, $groups ) {
+		$statuses = array_values(
+			array_unique(
+				array_filter(
+					array_merge(
+						array_column( $subscriptions, 'status' ),
+						array_column( $groups, 'status' )
+					)
+				)
+			)
+		);
+		if ( empty( $statuses ) ) {
+			return '';
+		}
+		$rank = [
+			'active'    => 0,
+			'pending'   => 1,
+			'on-hold'   => 2,
+			'cancelled' => 3,
+		];
+		$live = array_filter( $statuses, fn( $status ) => 'cancelled' !== $status );
+		if ( ! empty( $live ) ) {
+			$statuses = $live;
+		}
+		usort( $statuses, fn( $a, $b ) => ( $rank[ $a ] ?? 99 ) - ( $rank[ $b ] ?? 99 ) );
+		return reset( $statuses );
+	}
+
+	/**
+	 * The date of a reader's most recent completed/processing order, or null.
+	 *
+	 * @param int $user_id The reader user ID.
+	 *
+	 * @return string|null 'YYYY-MM-DD', or null when they have no paid order.
+	 */
+	private function last_payment_date( $user_id ) {
+		if ( ! function_exists( 'wc_get_orders' ) ) {
+			return null;
+		}
+		$orders = \wc_get_orders(
+			[
+				'customer_id' => $user_id,
+				'status'      => [ 'wc-completed', 'wc-processing' ],
+				'limit'       => 1,
+				'orderby'     => 'date',
+				'order'       => 'DESC',
+			]
+		);
+		if ( empty( $orders ) ) {
+			return null;
+		}
+		$paid = $orders[0]->get_date_paid();
+		return $paid ? gmdate( 'Y-m-d', $paid->getTimestamp() ) : null;
+	}
+
+	/**
+	 * Resolve the `include` user-ID set for the active subscription-status / plan
+	 * filters, or null when neither is present.
+	 *
+	 * Each active filter resolves to a set of customer IDs; the sets are
+	 * intersected so multiple filters narrow (AND) rather than widen. The result
+	 * is capped at FILTER_INCLUDE_CAP to keep the WP_User_Query IN() clause bounded
+	 * on large stores. Above that ceiling the extras are dropped, so the reported
+	 * total/pages under-count — an accepted trade-off at a scale (10k+ filtered
+	 * subscribers) where pixel-accurate paging matters less than not OOMing.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return int[]|null Customer IDs to include, or null when no filter applies.
+	 */
+	private function resolve_filter_include( $request ) {
+		$status_filter = array_filter( array_map( 'sanitize_text_field', (array) $request->get_param( 'status' ) ) );
+		$plan_filter   = array_filter( array_map( 'sanitize_text_field', (array) $request->get_param( 'plan' ) ) );
+		if ( empty( $status_filter ) && empty( $plan_filter ) ) {
+			return null;
+		}
+
+		$sets = [];
+		if ( ! empty( $status_filter ) ) {
+			$sets[] = $this->customer_ids_for_statuses( $status_filter );
+		}
+		if ( ! empty( $plan_filter ) ) {
+			$sets[] = $this->customer_ids_for_plans( $plan_filter );
+		}
+
+		$include = array_shift( $sets );
+		foreach ( $sets as $set ) {
+			$include = array_intersect( $include, $set );
+		}
+
+		return array_values( array_unique( array_slice( $include, 0, self::FILTER_INCLUDE_CAP ) ) );
+	}
+
+	/**
+	 * Customer IDs whose displayed status matches any of the given prototype
+	 * statuses, mirroring the list's badge reduction (see reduced_status /
+	 * displayStatuses): a live status always qualifies, but `cancelled` matches
+	 * only fully-churned readers — anyone who also holds a live (active/pending/
+	 * on-hold) subscription is dropped, since the badge hides cancelled while a
+	 * live plan remains. Without this the Cancelled filter would surface readers
+	 * whose row still reads Active.
+	 *
+	 * The live-subscription scan backing that exclusion is itself bounded by
+	 * FILTER_INCLUDE_CAP, so on a store past that ceiling a reader whose only live
+	 * plan sits beyond the cap could slip into the Cancelled set — an accepted
+	 * edge at a scale where exact filtering matters less than a bounded query.
+	 *
+	 * @param string[] $prototype_statuses Prototype statuses (active/pending/on-hold/cancelled).
+	 *
+	 * @return int[]
+	 */
+	private function customer_ids_for_statuses( array $prototype_statuses ) {
+		// Non-cancelled statuses are always displayed, so any matching subscription
+		// qualifies the reader.
+		$ids = $this->customer_ids_for_raw_statuses( array_values( array_diff( $prototype_statuses, [ 'cancelled' ] ) ) );
+
+		// Cancelled matches only readers with no live plan.
+		if ( in_array( 'cancelled', $prototype_statuses, true ) ) {
+			$cancelled_ids = $this->customer_ids_for_raw_statuses( [ 'cancelled' ] );
+			$live_ids      = $this->customer_ids_for_raw_statuses( [ 'active', 'pending', 'on-hold' ] );
+			$ids           = array_merge( $ids, array_diff( $cancelled_ids, $live_ids ) );
+		}
+
+		return array_values( array_unique( array_filter( $ids ) ) );
+	}
+
+	/**
+	 * Customer IDs holding a subscription (individual or group) in any of the
+	 * given prototype statuses, without the display reduction — a raw status
+	 * match. customer_ids_for_statuses() layers the cancelled reduction on top.
+	 *
+	 * @param string[] $prototype_statuses Prototype statuses (active/pending/on-hold/cancelled).
+	 *
+	 * @return int[]
+	 */
+	private function customer_ids_for_raw_statuses( array $prototype_statuses ) {
+		if ( empty( $prototype_statuses ) ) {
+			return [];
+		}
+		$ids = [];
+
+		// Individual + owned subscriptions in a matching WCS status (HPOS-safe).
+		// Bounded to the same ceiling the include set is capped at, so the filter
+		// path can't load an unbounded number of subscription objects on a large store.
+		$wcs_statuses = $this->wcs_statuses_for( $prototype_statuses );
+		if ( ! empty( $wcs_statuses ) && function_exists( 'wcs_get_subscriptions' ) ) {
+			$subs = \wcs_get_subscriptions(
+				[
+					'subscriptions_per_page' => self::FILTER_INCLUDE_CAP,
+					'subscription_status'    => $wcs_statuses,
+				]
+			);
+			foreach ( $subs as $subscription ) {
+				$ids[] = (int) $subscription->get_customer_id();
+			}
+		}
+
+		// Group members inherit their group's status.
+		foreach ( $this->get_group_subscriptions() as $group ) {
+			if ( in_array( self::map_subscription_status( $group['subscription']->get_status() ), $prototype_statuses, true ) ) {
+				$ids = array_merge( $ids, array_map( 'intval', Group_Subscription::get_all_members( $group['subscription'] ) ) );
+			}
+		}
+
+		return array_values( array_unique( array_filter( $ids ) ) );
+	}
+
+	/**
+	 * Customer IDs holding a subscription (individual or group) on any of the
+	 * named plans.
+	 *
+	 * @param string[] $plan_names Plan display names.
+	 *
+	 * @return int[]
+	 */
+	private function customer_ids_for_plans( array $plan_names ) {
+		$ids = [];
+
+		// Group plans, matched by the group's configured name.
+		foreach ( $this->get_group_subscriptions() as $group ) {
+			if ( in_array( (string) $group['settings']['name'], $plan_names, true ) ) {
+				$ids = array_merge( $ids, array_map( 'intval', Group_Subscription::get_all_members( $group['subscription'] ) ) );
+			}
+		}
+
+		// Individual plans, matched by product name → subscriptions for that product.
+		$product_ids = $this->product_ids_for_names( $plan_names );
+		if ( ! empty( $product_ids ) && function_exists( 'wcs_get_subscriptions_for_product' ) && function_exists( 'wcs_get_subscription' ) ) {
+			$subscription_ids = [];
+			foreach ( $product_ids as $product_id ) {
+				foreach ( array_keys( \wcs_get_subscriptions_for_product( $product_id ) ) as $subscription_id ) {
+					$subscription_ids[] = (int) $subscription_id;
+				}
+			}
+			// Bound the number of subscription objects hydrated, mirroring the
+			// status path's cap so a plan on a very popular product can't load an
+			// unbounded set into memory.
+			$subscription_ids = array_slice( array_unique( $subscription_ids ), 0, self::FILTER_INCLUDE_CAP );
+			foreach ( $subscription_ids as $subscription_id ) {
+				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( $subscription ) {
+					$ids[] = (int) $subscription->get_customer_id();
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $ids ) ) );
+	}
+
+	/**
+	 * Resolve product IDs whose title exactly matches any of the given names.
+	 *
+	 * @param string[] $names Product names.
+	 *
+	 * @return int[] Matching product IDs.
+	 */
+	private function product_ids_for_names( array $names ) {
+		$ids = [];
+		foreach ( array_unique( $names ) as $name ) {
+			// Product titles aren't unique, so collect every published product that
+			// carries this exact name rather than just the first match.
+			$query = new \WP_Query(
+				[
+					'post_type'              => [ 'product', 'product_variation' ],
+					'post_status'            => 'publish',
+					'title'                  => $name,
+					// Bounded to the filter cap; product titles collide rarely, so
+					// this ceiling is only a runaway guard.
+					'posts_per_page'         => self::FILTER_INCLUDE_CAP,
+					'fields'                 => 'ids',
+					'no_found_rows'          => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				]
+			);
+			foreach ( $query->posts as $post_id ) {
+				$ids[] = (int) $post_id;
+			}
+		}
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Map prototype statuses onto the WooCommerce Subscriptions statuses that
+	 * collapse into them (the inverse of map_subscription_status()).
+	 *
+	 * @param string[] $prototype_statuses Prototype statuses.
+	 *
+	 * @return string[] Distinct WCS status slugs.
+	 */
+	private function wcs_statuses_for( array $prototype_statuses ) {
+		// on-hold is the catch-all display bucket in map_subscription_status(), so its
+		// inverse carries the extra WCS statuses that also render as on-hold (e.g. a
+		// mid-switch 'switched' subscription) to keep display and filter in step. Truly
+		// unknown/custom statuses still can't be enumerated here — they display as
+		// on-hold but aren't reachable by the individual-subscription filter scan.
+		$map = [
+			'active'    => [ 'active', 'pending-cancel' ],
+			'pending'   => [ 'pending' ],
+			'on-hold'   => [ 'on-hold', 'switched' ],
+			'cancelled' => [ 'cancelled', 'expired' ],
+		];
+		$wcs = [];
+		foreach ( $prototype_statuses as $status ) {
+			if ( isset( $map[ $status ] ) ) {
+				$wcs = array_merge( $wcs, $map[ $status ] );
+			}
+		}
+		return array_values( array_unique( $wcs ) );
+	}
+
+	/**
+	 * Resolve avatar URLs for a set of emails via core get_avatar_url(), which
+	 * honors the Settings → Discussion avatar options and any avatar plugin.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
+	 */
+	public function api_get_avatars( $request ) {
+		if ( ! get_option( 'show_avatars', true ) ) {
+			return rest_ensure_response( [ 'show' => false ] );
+		}
+		// Callers request 2x their render size so avatars stay crisp on high-DPR
+		// displays (list: 32px → 64, profile: 64px → 128).
+		$size    = $request->get_param( 'size' );
+		$avatars = [];
+		// A single list page resolves at most `per_page` (≤100) avatars; bound the
+		// batch so an oversized payload can't fan out into unbounded get_avatar_url() calls.
+		$emails = array_slice( (array) $request->get_param( 'emails' ), 0, 200 );
+		foreach ( $emails as $email ) {
+			$email = sanitize_email( $email );
+			if ( '' === $email ) {
+				continue;
+			}
+			$avatars[ $email ] = get_avatar_url( $email, [ 'size' => $size ] );
+		}
+		return rest_ensure_response(
+			[
+				'show'    => true,
+				'avatars' => $avatars,
+			]
+		);
+	}
+
+	/**
+	 * Enqueue Subscribers wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( ! $this->is_wizard_page() || ! $this->is_feature_enabled() ) {
+			return;
+		}
+
+		// Fall back gracefully when the built asset manifest is absent (fresh
+		// checkout before a build, or a partial deploy) rather than emitting warnings.
+		$asset_path = NEWSPACK_ABSPATH . 'dist/subscribers.asset.php';
+		$asset      = file_exists( $asset_path ) ? include $asset_path : [];
+
+		wp_enqueue_script(
+			'newspack-subscribers',
+			Newspack::plugin_url() . '/dist/subscribers.js',
+			$asset['dependencies'] ?? [],
+			$asset['version'] ?? NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+
+		// Mirror the publisher's configurable group/team label so the wizard stays
+		// consistent with the Audience → Setup "Group labels" override.
+		$group_label_singular = class_exists( '\Newspack\Group_Subscription' )
+			? Group_Subscription::get_label( 'singular' )
+			: __( 'Group', 'newspack-plugin' );
+		$group_label_plural = class_exists( '\Newspack\Group_Subscription' )
+			? Group_Subscription::get_label( 'plural' )
+			: __( 'Groups', 'newspack-plugin' );
+
+		wp_add_inline_script(
+			'newspack-subscribers',
+			'window.newspackSubscribers = ' . wp_json_encode(
+				[
+					'groupLabel'       => $group_label_singular,
+					'groupLabelPlural' => $group_label_plural,
+					// Drives the column layout synchronously; the avatar URLs
+					// themselves come from the /avatars REST endpoint.
+					'showAvatars'      => (bool) get_option( 'show_avatars', true ),
+				]
+			) . ';',
+			'before'
+		);
+
+		wp_enqueue_style(
+			'newspack-subscribers',
+			Newspack::plugin_url() . '/dist/subscribers.css',
+			[ 'wp-components' ],
+			NEWSPACK_PLUGIN_VERSION
+		);
+	}
+}

--- a/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
@@ -370,9 +370,12 @@ class Subscribers_Wizard extends Wizard {
 			'id'          => (int) $subscription->get_id(),
 			'ownerId'     => $owner_id,
 			'owner'       => $owner ? [
-				'id'    => $owner_id,
-				'name'  => $owner->display_name,
-				'email' => $owner->user_email,
+				'id'      => $owner_id,
+				'name'    => $owner->display_name,
+				'email'   => $owner->user_email,
+				// The owner's name links to the person, not to the subscription —
+				// see the group list's `editUrl` for the subscription itself.
+				'editUrl' => (string) get_edit_user_link( $owner_id ),
 			] : null,
 			'plan'        => (string) $settings['name'],
 			'status'      => self::map_subscription_status( $subscription->get_status() ),
@@ -383,10 +386,25 @@ class Subscribers_Wizard extends Wizard {
 			'createdAt'   => $created_at,
 			// Interim click-through target: the WooCommerce subscription edit
 			// screen (HPOS-safe), until the in-wizard group detail lands (PR 4).
-			'editUrl'     => method_exists( $subscription, 'get_edit_order_url' ) ? $subscription->get_edit_order_url() : '',
+			'editUrl'     => $this->subscription_edit_url( $subscription ),
 			// Seat requests are surfaced in a later slice (NPPD-1753 PR 7).
 			'seatRequest' => null,
 		];
+	}
+
+	/**
+	 * The admin edit-screen URL for a subscription (HPOS-safe).
+	 *
+	 * Every subscription the wizard surfaces — a group, a group membership, or an
+	 * individual plan — carries this so a plan name always links to that plan,
+	 * while a person's name always links to that person.
+	 *
+	 * @param \WC_Subscription $subscription The subscription.
+	 *
+	 * @return string The edit URL, or '' when it can't be resolved.
+	 */
+	private function subscription_edit_url( $subscription ) {
+		return method_exists( $subscription, 'get_edit_order_url' ) ? (string) $subscription->get_edit_order_url() : '';
 	}
 
 	/**
@@ -516,7 +534,7 @@ class Subscribers_Wizard extends Wizard {
 	}
 
 	/**
-	 * A reader's own (non-group) subscriptions, shaped as { id, plan, status }.
+	 * A reader's own (non-group) subscriptions, shaped as { id, plan, status, editUrl }.
 	 *
 	 * The wcs_get_users_subscriptions() list is filtered to also surface subs the
 	 * user is only a member of; those are excluded here (they belong to
@@ -539,9 +557,10 @@ class Subscribers_Wizard extends Wizard {
 				continue; // Group subscriptions are surfaced via get_group_memberships().
 			}
 			$out[] = [
-				'id'     => (int) $subscription->get_id(),
-				'plan'   => $this->individual_plan_name( $subscription ),
-				'status' => self::map_subscription_status( $subscription->get_status() ),
+				'id'      => (int) $subscription->get_id(),
+				'plan'    => $this->individual_plan_name( $subscription ),
+				'status'  => self::map_subscription_status( $subscription->get_status() ),
+				'editUrl' => $this->subscription_edit_url( $subscription ),
 			];
 		}
 		return $out;
@@ -564,7 +583,7 @@ class Subscribers_Wizard extends Wizard {
 	}
 
 	/**
-	 * A reader's group memberships, shaped as { id, plan, status, role }.
+	 * A reader's group memberships, shaped as { id, plan, status, role, editUrl }.
 	 *
 	 * Read from the per-request membership index rather than re-querying the
 	 * user's owned/managed/member subscriptions per row.
@@ -580,7 +599,7 @@ class Subscribers_Wizard extends Wizard {
 
 	/**
 	 * Build (once per request) a map of user ID → their group memberships, each
-	 * shaped as { id, plan, status, role }.
+	 * shaped as { id, plan, status, role, editUrl }.
 	 *
 	 * Iterating the site's (few, memoized) groups and reading each group's people
 	 * once is far cheaper than resolving every subscriber's owned/managed/member
@@ -601,9 +620,10 @@ class Subscribers_Wizard extends Wizard {
 				$owner_id     = (int) $subscription->get_user_id();
 				$managers     = array_map( 'intval', Group_Subscription::get_managers( $subscription ) );
 				$entry        = [
-					'id'     => (int) $subscription->get_id(),
-					'plan'   => (string) $group['settings']['name'],
-					'status' => self::map_subscription_status( $subscription->get_status() ),
+					'id'      => (int) $subscription->get_id(),
+					'plan'    => (string) $group['settings']['name'],
+					'status'  => self::map_subscription_status( $subscription->get_status() ),
+					'editUrl' => $this->subscription_edit_url( $subscription ),
 				];
 				foreach ( array_map( 'intval', Group_Subscription::get_all_members( $subscription ) ) as $member_id ) {
 					if ( $member_id === $owner_id ) {

--- a/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-subscribers-wizard.php
@@ -825,13 +825,21 @@ class Subscribers_Wizard extends Wizard {
 		// store, and walked a chunk at a time: WooCommerce hands back fully
 		// hydrated WC_Subscription objects and only the customer ID is read here,
 		// so paging keeps peak memory at one chunk instead of the whole cap.
+		//
+		// The walk pages with `offset`, not `paged`: wcs_get_subscriptions()
+		// declares `paged` among its own defaults, so it is stripped from the
+		// extra args and never reaches the WC_Order_Query — passing it would
+		// re-scan the first chunk on every iteration. `orderby => ID` gives the
+		// walk a deterministic tiebreak; the default start-date sort can shuffle
+		// rows sharing a date across a chunk boundary and skip a customer.
 		$wcs_statuses = $this->wcs_statuses_for( $prototype_statuses );
 		if ( ! empty( $wcs_statuses ) && function_exists( 'wcs_get_subscriptions' ) ) {
 			for ( $page = 1; ( $page - 1 ) * self::FILTER_SCAN_CHUNK < self::FILTER_INCLUDE_CAP; $page++ ) {
 				$subs = \wcs_get_subscriptions(
 					[
 						'subscriptions_per_page' => self::FILTER_SCAN_CHUNK,
-						'paged'                  => $page,
+						'offset'                 => ( $page - 1 ) * self::FILTER_SCAN_CHUNK,
+						'orderby'                => 'ID',
 						'subscription_status'    => $wcs_statuses,
 					]
 				);
@@ -1029,6 +1037,11 @@ class Subscribers_Wizard extends Wizard {
 					// Drives the column layout synchronously; the avatar URLs
 					// themselves come from the /avatars REST endpoint.
 					'showAvatars'      => (bool) get_option( 'show_avatars', true ),
+					// The /avatars endpoint truncates anything past this cap rather
+					// than erroring, so the client must batch to the same number. It
+					// is published here so there is one authority instead of two
+					// constants that can drift apart silently.
+					'avatarBatchCap'   => self::AVATAR_BATCH_CAP,
 				]
 			) . ';',
 			'before'

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.js
@@ -18,9 +18,13 @@ const config = ( typeof window !== 'undefined' && window.newspackSubscribers ) |
 
 export const SHOW_AVATARS = config.showAvatars !== false;
 
-// The endpoint caps each request at this many emails; the hook batches larger
-// sets so nothing is silently dropped (e.g. a site with many groups).
-const AVATAR_BATCH_SIZE = 200;
+// The endpoint caps each request at this many emails and silently truncates the
+// overflow, so the batch size has to match it exactly — the wizard localizes its
+// own AVATAR_BATCH_CAP so there is one authority rather than two constants that
+// can drift apart. Read at call time, not at import, so the value doesn't depend
+// on this module loading after the inline config script. The fallback only
+// applies if the config never loaded at all.
+const avatarBatchSize = () => Number( window?.newspackSubscribers?.avatarBatchCap ) || 200;
 
 /**
  * Resolve avatar URLs for a list of emails from the wizard's REST endpoint.
@@ -53,9 +57,10 @@ export function useAvatars( emails, { size } = {} ) {
 		setAvatars( {} );
 		// Batch to the endpoint's per-request cap and merge, so a set larger than
 		// one batch still resolves fully instead of dropping the overflow.
+		const batchSize = avatarBatchSize();
 		const batches = [];
-		for ( let i = 0; i < list.length; i += AVATAR_BATCH_SIZE ) {
-			batches.push( list.slice( i, i + AVATAR_BATCH_SIZE ) );
+		for ( let i = 0; i < list.length; i += batchSize ) {
+			batches.push( list.slice( i, i + batchSize ) );
 		}
 		Promise.all(
 			batches.map( batch =>

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.js
@@ -58,11 +58,11 @@ export function useAvatars( emails, { size } = {} ) {
 			batches.push( list.slice( i, i + AVATAR_BATCH_SIZE ) );
 		}
 		Promise.all(
-			batches.map( emails =>
+			batches.map( batch =>
 				apiFetch( {
 					path: '/newspack/v1/wizard/newspack-subscribers/avatars',
 					method: 'POST',
-					data: size ? { emails, size } : { emails },
+					data: size ? { emails: batch, size } : { emails: batch },
 				} ).catch( () => null )
 			)
 		)

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.js
@@ -1,0 +1,98 @@
+/**
+ * Shared avatar resolution for the Subscribers wizard.
+ *
+ * SHOW_AVATARS mirrors the publisher's "Show avatars" setting (Settings →
+ * Discussion), localized onto window by the wizard PHP so the column layout can
+ * be decided synchronously (no flash). useAvatars fetches the /avatars REST
+ * endpoint once for a set of emails and returns them keyed by email; callers
+ * map that onto their own keys (subscriber id, group id, single profile).
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+const config = ( typeof window !== 'undefined' && window.newspackSubscribers ) || {};
+
+export const SHOW_AVATARS = config.showAvatars !== false;
+
+// The endpoint caps each request at this many emails; the hook batches larger
+// sets so nothing is silently dropped (e.g. a site with many groups).
+const AVATAR_BATCH_SIZE = 200;
+
+/**
+ * Resolve avatar URLs for a list of emails from the wizard's REST endpoint.
+ *
+ * @param {string[]} emails         Emails to resolve (falsy entries are ignored).
+ * @param {Object}   [options]
+ * @param {number}   [options.size] Source size in px (defaults to the endpoint default).
+ * @return {{ avatars: Object, loading: boolean }} Map of email → URL, plus loading state.
+ */
+export function useAvatars( emails, { size } = {} ) {
+	const [ avatars, setAvatars ] = useState( {} );
+	const [ loading, setLoading ] = useState( SHOW_AVATARS );
+	// Join into a stable key so the effect re-runs only when the set of emails
+	// actually changes (callers pass a freshly built array each render).
+	const key = ( emails || [] ).filter( Boolean ).join( ',' );
+	useEffect( () => {
+		if ( ! SHOW_AVATARS ) {
+			return undefined;
+		}
+		const list = key ? key.split( ',' ) : [];
+		if ( ! list.length ) {
+			setAvatars( {} );
+			setLoading( false );
+			return undefined;
+		}
+		let cancelled = false;
+		// Reset so a previous result doesn't linger across hops, and keep the
+		// spinner up until this set resolves (no flash-in).
+		setLoading( true );
+		setAvatars( {} );
+		// Batch to the endpoint's per-request cap and merge, so a set larger than
+		// one batch still resolves fully instead of dropping the overflow.
+		const batches = [];
+		for ( let i = 0; i < list.length; i += AVATAR_BATCH_SIZE ) {
+			batches.push( list.slice( i, i + AVATAR_BATCH_SIZE ) );
+		}
+		Promise.all(
+			batches.map( emails =>
+				apiFetch( {
+					path: '/newspack/v1/wizard/newspack-subscribers/avatars',
+					method: 'POST',
+					data: size ? { emails, size } : { emails },
+				} ).catch( () => null )
+			)
+		)
+			.then( responses => {
+				if ( cancelled ) {
+					return;
+				}
+				// Honor the endpoint's own avatars-off signal rather than relying
+				// solely on the client SHOW_AVATARS flag (they can disagree if the
+				// Discussion setting is toggled between page load and this fetch).
+				if ( responses.some( response => response?.show === false ) ) {
+					setAvatars( {} );
+					return;
+				}
+				const merged = {};
+				responses.forEach( response => {
+					if ( response?.avatars ) {
+						Object.assign( merged, response.avatars );
+					}
+				} );
+				setAvatars( merged );
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ key, size ] );
+	return { avatars, loading };
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.test.js
@@ -17,7 +17,8 @@ import { useAvatars } from './use-avatars';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-// The endpoint caps each request at 200 emails; the hook batches past that.
+// The endpoint's cap, which the wizard localizes onto window as `avatarBatchCap`.
+// With no config present (as in these tests) the hook falls back to the same 200.
 const BATCH_SIZE = 200;
 
 const emailsFor = count => Array.from( { length: count }, ( _, i ) => `reader${ i }@test.com` );
@@ -64,6 +65,27 @@ describe( 'useAvatars', () => {
 		expect( Object.keys( result.current.avatars ) ).toHaveLength( BATCH_SIZE + 50 );
 		expect( result.current.avatars[ emails[ 0 ] ] ).toBe( `https://avatar.test/${ emails[ 0 ] }` );
 		expect( result.current.avatars[ emails[ emails.length - 1 ] ] ).toBe( `https://avatar.test/${ emails[ emails.length - 1 ] }` );
+	} );
+
+	it( 'batches to the cap the server localized, not a client-side copy of it', async () => {
+		// The endpoint silently truncates anything past its own cap, so a client
+		// batching to a larger number loses the overflow with no error anywhere.
+		// A hook holding its own hard-coded 200 would send one batch of 12 here.
+		const serverCap = 5;
+		window.newspackSubscribers = { avatarBatchCap: serverCap };
+		const emails = emailsFor( 12 );
+		apiFetch.mockImplementation( ( { data } ) => Promise.resolve( avatarsResponseFor( data.emails ) ) );
+
+		const { result } = renderHook( () => useAvatars( emails ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].data.emails ).toHaveLength( serverCap );
+		expect( apiFetch.mock.calls[ 2 ][ 0 ].data.emails ).toHaveLength( 2 );
+		expect( Object.keys( result.current.avatars ) ).toHaveLength( 12 );
+
+		delete window.newspackSubscribers;
 	} );
 
 	it( 'honors the server saying avatars are off, even for one batch of many', async () => {

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-avatars.test.js
@@ -1,0 +1,113 @@
+// @jest-environment jsdom
+
+/**
+ * External dependencies
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { useAvatars } from './use-avatars';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// The endpoint caps each request at 200 emails; the hook batches past that.
+const BATCH_SIZE = 200;
+
+const emailsFor = count => Array.from( { length: count }, ( _, i ) => `reader${ i }@test.com` );
+
+// One response shaped like the endpoint's, resolving every email it was sent.
+const avatarsResponseFor = emails => ( {
+	show: true,
+	avatars: Object.fromEntries( emails.map( email => [ email, `https://avatar.test/${ email }` ] ) ),
+} );
+
+describe( 'useAvatars', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'resolves a single batch and keys the result by email', async () => {
+		apiFetch.mockImplementation( ( { data } ) => Promise.resolve( avatarsResponseFor( data.emails ) ) );
+
+		const { result } = renderHook( () => useAvatars( [ 'a@test.com', 'b@test.com' ] ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.avatars ).toEqual( {
+			'a@test.com': 'https://avatar.test/a@test.com',
+			'b@test.com': 'https://avatar.test/b@test.com',
+		} );
+	} );
+
+	it( 'batches past the endpoint cap and merges every batch', async () => {
+		// The reason the hook exists: a set larger than one batch must resolve in
+		// full rather than silently dropping the overflow.
+		const emails = emailsFor( BATCH_SIZE + 50 );
+		apiFetch.mockImplementation( ( { data } ) => Promise.resolve( avatarsResponseFor( data.emails ) ) );
+
+		const { result } = renderHook( () => useAvatars( emails ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].data.emails ).toHaveLength( BATCH_SIZE );
+		expect( apiFetch.mock.calls[ 1 ][ 0 ].data.emails ).toHaveLength( 50 );
+		// Merged, not last-batch-wins.
+		expect( Object.keys( result.current.avatars ) ).toHaveLength( BATCH_SIZE + 50 );
+		expect( result.current.avatars[ emails[ 0 ] ] ).toBe( `https://avatar.test/${ emails[ 0 ] }` );
+		expect( result.current.avatars[ emails[ emails.length - 1 ] ] ).toBe( `https://avatar.test/${ emails[ emails.length - 1 ] }` );
+	} );
+
+	it( 'honors the server saying avatars are off, even for one batch of many', async () => {
+		// The Discussion setting can be toggled between page load (which sets the
+		// client SHOW_AVATARS flag) and this fetch; the server is the authority.
+		const emails = emailsFor( BATCH_SIZE + 1 );
+		apiFetch.mockResolvedValueOnce( avatarsResponseFor( emails.slice( 0, BATCH_SIZE ) ) ).mockResolvedValueOnce( { show: false } );
+
+		const { result } = renderHook( () => useAvatars( emails ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( result.current.avatars ).toEqual( {} );
+	} );
+
+	it( 'keeps the batches that resolved when one request fails', async () => {
+		const emails = emailsFor( BATCH_SIZE + 1 );
+		apiFetch.mockRejectedValueOnce( new Error( 'boom' ) ).mockResolvedValueOnce( avatarsResponseFor( emails.slice( BATCH_SIZE ) ) );
+
+		const { result } = renderHook( () => useAvatars( emails ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( result.current.avatars ).toEqual( {
+			[ emails[ BATCH_SIZE ] ]: `https://avatar.test/${ emails[ BATCH_SIZE ] }`,
+		} );
+	} );
+
+	it( 'skips the request entirely for an empty set', async () => {
+		const { result } = renderHook( () => useAvatars( [ undefined, '' ] ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( result.current.avatars ).toEqual( {} );
+	} );
+
+	it( 'passes an explicit size through to the endpoint', async () => {
+		apiFetch.mockImplementation( ( { data } ) => Promise.resolve( avatarsResponseFor( data.emails ) ) );
+
+		const { result } = renderHook( () => useAvatars( [ 'a@test.com' ], { size: 128 } ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].data ).toEqual( { emails: [ 'a@test.com' ], size: 128 } );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.js
@@ -10,7 +10,8 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 const PATH = '/newspack/v1/wizard/newspack-subscribers/groups';
@@ -18,23 +19,34 @@ const PATH = '/newspack/v1/wizard/newspack-subscribers/groups';
 /**
  * Fetch every group subscription on the site, hydrated for the group list.
  *
- * @return {{ groups: Array, loading: boolean }} The full group set plus loading state.
+ * A failed request is reported as `error` rather than collapsing into an empty
+ * set, so the screen can tell "this site has no groups" apart from "we could not
+ * read them" and offer `reload` as a retry.
+ *
+ * @return {{ groups: Array, loading: boolean, error: string, reload: Function }} The full group set plus loading/error state.
  */
 export function useGroups() {
 	const [ groups, setGroups ] = useState( [] );
 	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState( '' );
+	const [ attempt, setAttempt ] = useState( 0 );
+
+	const reload = useCallback( () => setAttempt( n => n + 1 ), [] );
 
 	useEffect( () => {
 		let cancelled = false;
+		setLoading( true );
 		apiFetch( { path: PATH } )
 			.then( response => {
 				if ( ! cancelled ) {
 					setGroups( response?.items || [] );
+					setError( '' );
 				}
 			} )
-			.catch( () => {
+			.catch( e => {
 				if ( ! cancelled ) {
 					setGroups( [] );
+					setError( e?.message || __( 'Something went wrong.', 'newspack-plugin' ) );
 				}
 			} )
 			.finally( () => {
@@ -45,7 +57,7 @@ export function useGroups() {
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ attempt ] );
 
-	return { groups, loading };
+	return { groups, loading, error, reload };
 }

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.js
@@ -1,0 +1,51 @@
+/**
+ * Site-wide group list.
+ *
+ * The group/team subscriptions on a site are few relative to readers, so the
+ * endpoint returns them all in one response and the list filters, sorts and
+ * paginates client-side (mirroring the prototype). This hook fetches that full
+ * set once and returns it with a loading flag.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+const PATH = '/newspack/v1/wizard/newspack-subscribers/groups';
+
+/**
+ * Fetch every group subscription on the site, hydrated for the group list.
+ *
+ * @return {{ groups: Array, loading: boolean }} The full group set plus loading state.
+ */
+export function useGroups() {
+	const [ groups, setGroups ] = useState( [] );
+	const [ loading, setLoading ] = useState( true );
+
+	useEffect( () => {
+		let cancelled = false;
+		apiFetch( { path: PATH } )
+			.then( response => {
+				if ( ! cancelled ) {
+					setGroups( response?.items || [] );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setGroups( [] );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	return { groups, loading };
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.test.js
@@ -1,0 +1,48 @@
+// @jest-environment jsdom
+
+/**
+ * External dependencies
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { useGroups } from './use-groups';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'useGroups', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'fetches the full group set once and returns it', async () => {
+		apiFetch.mockResolvedValue( { items: [ { id: 1 }, { id: 2 } ], total: 2, pages: 1 } );
+
+		const { result } = renderHook( () => useGroups() );
+
+		expect( result.current.loading ).toBe( true );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toBe( '/newspack/v1/wizard/newspack-subscribers/groups' );
+		expect( result.current.groups ).toEqual( [ { id: 1 }, { id: 2 } ] );
+	} );
+
+	it( 'degrades to an empty list when the request fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'boom' ) );
+
+		const { result } = renderHook( () => useGroups() );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( result.current.groups ).toEqual( [] );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-groups.test.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -36,13 +36,36 @@ describe( 'useGroups', () => {
 		expect( result.current.groups ).toEqual( [ { id: 1 }, { id: 2 } ] );
 	} );
 
-	it( 'degrades to an empty list when the request fails', async () => {
+	it( 'surfaces the failure instead of passing an empty list off as the answer', async () => {
+		// An empty list alone would render as "this site has no groups". The error
+		// is what lets the screen say the read failed, so it is the contract here —
+		// not just the empty list beside it.
 		apiFetch.mockRejectedValue( new Error( 'boom' ) );
 
 		const { result } = renderHook( () => useGroups() );
 
 		await waitFor( () => expect( result.current.loading ).toBe( false ) );
 
+		expect( result.current.error ).toBeTruthy();
 		expect( result.current.groups ).toEqual( [] );
+	} );
+
+	it( 'clears the error and refetches on reload', async () => {
+		// The retry button in the error notice calls reload(); a retry that left
+		// the error set would keep showing the notice over good data.
+		apiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
+
+		const { result } = renderHook( () => useGroups() );
+
+		await waitFor( () => expect( result.current.error ).toBeTruthy() );
+
+		apiFetch.mockResolvedValue( { items: [ { id: 1 } ], total: 1, pages: 1 } );
+		act( () => result.current.reload() );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( result.current.error ).toBeFalsy();
+		expect( result.current.groups ).toEqual( [ { id: 1 } ] );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.js
@@ -12,7 +12,8 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -53,12 +54,20 @@ export const viewToParams = view => {
 /**
  * Fetch one server-paginated page of subscribers for the given view.
  *
+ * A failed request is reported as `error` rather than collapsing into an empty
+ * page, so the screen can tell "this site has no subscribers" apart from "we
+ * could not read them" and offer `reload` as a retry.
+ *
  * @param {Object} view The DataViews view (page, perPage, sort, search, filters).
- * @return {{ items: Array, total: number, pages: number, loading: boolean }} The page.
+ * @return {{ items: Array, total: number, pages: number, loading: boolean, error: string, reload: Function }} The page.
  */
 export function useSubscribers( view ) {
 	const [ result, setResult ] = useState( { items: [], total: 0, pages: 0 } );
 	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState( '' );
+	const [ attempt, setAttempt ] = useState( 0 );
+
+	const reload = useCallback( () => setAttempt( n => n + 1 ), [] );
 
 	// Serialize the params so the effect re-runs only when a query-affecting bit
 	// of the view actually changes (the view object is a fresh reference each
@@ -79,10 +88,12 @@ export function useSubscribers( view ) {
 					total: response?.total || 0,
 					pages: response?.pages || 0,
 				} );
+				setError( '' );
 			} )
-			.catch( () => {
+			.catch( e => {
 				if ( ! cancelled ) {
 					setResult( { items: [], total: 0, pages: 0 } );
+					setError( e?.message || __( 'Something went wrong.', 'newspack-plugin' ) );
 				}
 			} )
 			.finally( () => {
@@ -93,7 +104,7 @@ export function useSubscribers( view ) {
 		return () => {
 			cancelled = true;
 		};
-	}, [ key ] );
+	}, [ key, attempt ] );
 
-	return { ...result, loading };
+	return { ...result, loading, error, reload };
 }

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.js
@@ -1,0 +1,99 @@
+/**
+ * Server-side subscriber list.
+ *
+ * The subscriber list is server-paginated: unlike the group list (which loads
+ * in full and filters client-side), the reader table can run to tens of
+ * thousands of rows, so filtering, sorting and paging all happen in the REST
+ * endpoint. This hook translates the DataViews `view` object into query params
+ * and returns the `{ items, total, pages }` envelope the list renders, plus a
+ * loading flag while a page is in flight.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const PATH = '/newspack/v1/wizard/newspack-subscribers/subscribers';
+
+// Only name and member-since are server-sortable in this slice; any other sort
+// field falls back to member-since so the request stays valid (the endpoint
+// enums orderby to these two).
+const SORTABLE_FIELDS = [ 'name', 'memberSince' ];
+
+/**
+ * Translate the DataViews view into the endpoint's query params. Filters are
+ * matched by field id — `status` maps to the subscription-status filter; the
+ * plan / group-role / tag / newsletter filters arrive in later slices and are
+ * ignored here.
+ *
+ * @param {Object} view The DataViews view.
+ * @return {Object} Query params for the subscribers endpoint.
+ */
+export const viewToParams = view => {
+	const params = {
+		page: view.page || 1,
+		per_page: view.perPage || 20,
+		orderby: SORTABLE_FIELDS.includes( view.sort?.field ) ? view.sort.field : 'memberSince',
+		order: 'asc' === view.sort?.direction ? 'asc' : 'desc',
+	};
+	const search = ( view.search || '' ).trim();
+	if ( search ) {
+		params.search = search;
+	}
+	const statusFilter = ( view.filters || [] ).find( f => 'status' === f.field );
+	if ( statusFilter?.value?.length ) {
+		params.status = statusFilter.value;
+	}
+	return params;
+};
+
+/**
+ * Fetch one server-paginated page of subscribers for the given view.
+ *
+ * @param {Object} view The DataViews view (page, perPage, sort, search, filters).
+ * @return {{ items: Array, total: number, pages: number, loading: boolean }} The page.
+ */
+export function useSubscribers( view ) {
+	const [ result, setResult ] = useState( { items: [], total: 0, pages: 0 } );
+	const [ loading, setLoading ] = useState( true );
+
+	// Serialize the params so the effect re-runs only when a query-affecting bit
+	// of the view actually changes (the view object is a fresh reference each
+	// time DataViews reports a change). Rebuilt from the key inside the effect so
+	// the effect closes over no unstable object.
+	const key = useMemo( () => JSON.stringify( viewToParams( view ) ), [ view ] );
+
+	useEffect( () => {
+		let cancelled = false;
+		setLoading( true );
+		apiFetch( { path: addQueryArgs( PATH, JSON.parse( key ) ) } )
+			.then( response => {
+				if ( cancelled ) {
+					return;
+				}
+				setResult( {
+					items: response?.items || [],
+					total: response?.total || 0,
+					pages: response?.pages || 0,
+				} );
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setResult( { items: [], total: 0, pages: 0 } );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ key ] );
+
+	return { ...result, loading };
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.test.js
@@ -1,0 +1,114 @@
+// @jest-environment jsdom
+
+/**
+ * External dependencies
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { useSubscribers, viewToParams } from './use-subscribers';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const baseView = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'memberSince', direction: 'desc' },
+	search: '',
+	filters: [],
+};
+
+describe( 'viewToParams', () => {
+	it( 'maps page, perPage and the default sort', () => {
+		expect( viewToParams( baseView ) ).toEqual( {
+			page: 1,
+			per_page: 20,
+			orderby: 'memberSince',
+			order: 'desc',
+		} );
+	} );
+
+	it( 'passes through the name sort with ascending order', () => {
+		const params = viewToParams( { ...baseView, sort: { field: 'name', direction: 'asc' } } );
+		expect( params.orderby ).toBe( 'name' );
+		expect( params.order ).toBe( 'asc' );
+	} );
+
+	it( 'falls back to memberSince for a sort field the endpoint cannot honor', () => {
+		// lastPayment is a display-only column this slice; sorting on it must not
+		// produce an invalid orderby (the endpoint enums to name / memberSince).
+		const params = viewToParams( { ...baseView, sort: { field: 'lastPayment', direction: 'asc' } } );
+		expect( params.orderby ).toBe( 'memberSince' );
+	} );
+
+	it( 'trims a non-empty search and omits an empty one', () => {
+		expect( viewToParams( { ...baseView, search: '  alice ' } ).search ).toBe( 'alice' );
+		expect( viewToParams( { ...baseView, search: '   ' } ) ).not.toHaveProperty( 'search' );
+	} );
+
+	it( 'extracts the status filter, ignoring unsupported filters', () => {
+		const params = viewToParams( {
+			...baseView,
+			filters: [
+				{ field: 'status', operator: 'isAny', value: [ 'active', 'on-hold' ] },
+				{ field: 'groupRole', operator: 'isAny', value: [ 'owner' ] },
+			],
+		} );
+		expect( params.status ).toEqual( [ 'active', 'on-hold' ] );
+		expect( params ).not.toHaveProperty( 'groupRole' );
+	} );
+
+	it( 'omits the status param when the filter is present but empty', () => {
+		const params = viewToParams( {
+			...baseView,
+			filters: [ { field: 'status', operator: 'isAny', value: [] } ],
+		} );
+		expect( params ).not.toHaveProperty( 'status' );
+	} );
+} );
+
+describe( 'useSubscribers', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'requests the endpoint with the view params and returns the envelope', async () => {
+		apiFetch.mockResolvedValue( { items: [ { id: 7 } ], total: 42, pages: 3 } );
+
+		const { result } = renderHook( () => useSubscribers( baseView ) );
+
+		expect( result.current.loading ).toBe( true );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		const { path } = apiFetch.mock.calls[ 0 ][ 0 ];
+		expect( path ).toContain( '/newspack/v1/wizard/newspack-subscribers/subscribers' );
+		expect( path ).toContain( 'orderby=memberSince' );
+		expect( path ).toContain( 'per_page=20' );
+
+		expect( result.current.items ).toEqual( [ { id: 7 } ] );
+		expect( result.current.total ).toBe( 42 );
+		expect( result.current.pages ).toBe( 3 );
+	} );
+
+	it( 'degrades to an empty page when the request fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'boom' ) );
+
+		const { result } = renderHook( () => useSubscribers( baseView ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( result.current.items ).toEqual( [] );
+		expect( result.current.total ).toBe( 0 );
+		expect( result.current.pages ).toBe( 0 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/data/use-subscribers.test.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -100,15 +100,38 @@ describe( 'useSubscribers', () => {
 		expect( result.current.pages ).toBe( 3 );
 	} );
 
-	it( 'degrades to an empty page when the request fails', async () => {
+	it( 'surfaces the failure instead of passing an empty page off as the answer', async () => {
+		// An empty envelope alone would render as "this site has no subscribers".
+		// The error is what lets the screen say the read failed, so it is the
+		// contract here — not just the empty page beside it.
 		apiFetch.mockRejectedValue( new Error( 'boom' ) );
 
 		const { result } = renderHook( () => useSubscribers( baseView ) );
 
 		await waitFor( () => expect( result.current.loading ).toBe( false ) );
 
+		expect( result.current.error ).toBeTruthy();
 		expect( result.current.items ).toEqual( [] );
 		expect( result.current.total ).toBe( 0 );
 		expect( result.current.pages ).toBe( 0 );
+	} );
+
+	it( 'clears the error and refetches on reload', async () => {
+		// The retry button in the error notice calls reload(); a retry that left
+		// the error set would keep showing the notice over good data.
+		apiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
+
+		const { result } = renderHook( () => useSubscribers( baseView ) );
+
+		await waitFor( () => expect( result.current.error ).toBeTruthy() );
+
+		apiFetch.mockResolvedValue( { items: [ { id: 7 } ], total: 1, pages: 1 } );
+		act( () => result.current.reload() );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( result.current.error ).toBeFalsy();
+		expect( result.current.items ).toEqual( [ { id: 7 } ] );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/subscribers/format.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/format.js
@@ -1,0 +1,25 @@
+/**
+ * Shared formatting helpers for the Subscribers wizard.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { gmdateI18n, getSettings, humanTimeDiff } from '@wordpress/date';
+
+// "2 days ago" — defers to core's localized relative-time formatting (the same
+// helper wp-admin uses) rather than a bespoke ladder.
+export const fmtRelative = date => ( date ? humanTimeDiff( date ) : '' );
+
+// Calendar-date presentation, using the publisher's WordPress date format. The
+// wizard stores dates as date-only strings (YYYY-MM-DD) with no time or zone, so
+// they are anchored at UTC midnight and formatted in UTC: this keeps the shown
+// day stable no matter the viewer's timezone (a browser ahead of the site's zone
+// would otherwise roll a bare date back to the previous day).
+export const fmtDate = value => {
+	if ( ! value ) {
+		return '';
+	}
+	const anchored = /^\d{4}-\d{2}-\d{2}$/.test( value ) ? `${ value }T00:00:00+00:00` : value;
+	return gmdateI18n( getSettings().formats.date, anchored );
+};

--- a/plugins/newspack-plugin/src/wizards/subscribers/index.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/index.js
@@ -1,0 +1,50 @@
+import '../../shared/js/public-path';
+
+/**
+ * Subscribers — people-first subscriber management.
+ *
+ * Entry point: mounts a Wizard with the two L0 lists — the subscriber list and
+ * the group list (both full-width). Row click-through currently opens the
+ * native admin screens; the in-wizard person profile and group detail arrive in
+ * later slices (NPPD-1753 PR 4/5).
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { render } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { Wizard } from '../../../packages/components/src';
+import SubscriberList from './screens/SubscriberList';
+import GroupList from './screens/GroupList';
+import { GROUP_LABEL_PLURAL } from './labels';
+
+function SubscribersApp() {
+	return (
+		<Wizard
+			headerText={ __( 'Audience Management', 'newspack-plugin' ) }
+			sections={ [
+				{
+					label: __( 'Subscribers', 'newspack-plugin' ),
+					path: '/',
+					exact: true,
+					fullWidth: true,
+					render: SubscriberList,
+				},
+				{
+					label: GROUP_LABEL_PLURAL,
+					path: '/groups',
+					exact: true,
+					fullWidth: true,
+					render: GroupList,
+				},
+			] }
+		/>
+	);
+}
+
+render( <SubscribersApp />, document.getElementById( 'newspack-subscribers' ) );

--- a/plugins/newspack-plugin/src/wizards/subscribers/labels.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/labels.js
@@ -13,7 +13,6 @@ const cfg = ( typeof window !== 'undefined' && window.newspackSubscribers ) || {
 
 export const GROUP_LABEL = cfg.groupLabel || __( 'Group', 'newspack-plugin' );
 export const GROUP_LABEL_PLURAL = cfg.groupLabelPlural || __( 'Groups', 'newspack-plugin' );
-export const GROUP_LABEL_PLURAL_LOWER = GROUP_LABEL_PLURAL.toLowerCase();
 
 // A group member's role within their group. The group is the owner's, held by
 // exactly one owner; any number of managers maintain it; everyone else is a

--- a/plugins/newspack-plugin/src/wizards/subscribers/labels.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/labels.js
@@ -1,0 +1,25 @@
+/**
+ * Publisher-configurable group/team label and group-role labels.
+ *
+ * The group label mirrors the Audience → Setup "Group labels" override
+ * (newspack_group_subscription_label_singular / _plural options, surfaced by
+ * Group_Subscription::get_label), localized onto window by the wizard's PHP
+ * enqueue. Falls back to the default "Group" / "Groups" when unset.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+const cfg = ( typeof window !== 'undefined' && window.newspackSubscribers ) || {};
+
+export const GROUP_LABEL = cfg.groupLabel || __( 'Group', 'newspack-plugin' );
+export const GROUP_LABEL_PLURAL = cfg.groupLabelPlural || __( 'Groups', 'newspack-plugin' );
+export const GROUP_LABEL_PLURAL_LOWER = GROUP_LABEL_PLURAL.toLowerCase();
+
+// A group member's role within their group. The group is the owner's, held by
+// exactly one owner; any number of managers maintain it; everyone else is a
+// plain member.
+export const ROLE_LABELS = {
+	owner: __( 'Owner', 'newspack-plugin' ),
+	manager: __( 'Manager', 'newspack-plugin' ),
+	member: __( 'Member', 'newspack-plugin' ),
+};

--- a/plugins/newspack-plugin/src/wizards/subscribers/links.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/links.jsx
@@ -9,13 +9,22 @@
 /**
  * Link a plan/subscription name to that subscription's admin edit screen.
  *
- * Renders the name unlinked when the endpoint couldn't resolve an edit URL (no
- * WooCommerce, or an admin without the capability), so the column never shows a
- * dead link — and likewise when the name itself is empty (a subscription whose
- * product has since been deleted), which would otherwise leave an invisible link
- * with no accessible name. The click is stopped from bubbling: both lists
- * delegate row clicks to the person, and a plan name must not resolve to two
- * destinations at once.
+ * Renders the name unlinked when the endpoint couldn't resolve an edit URL —
+ * which in practice means WooCommerce is absent, since WC_Order's
+ * get_edit_order_url() performs no capability check of its own — so the column
+ * never shows a dead link. Likewise when the name itself is empty (a
+ * subscription whose product has since been deleted), which would otherwise
+ * leave an invisible link with no accessible name.
+ *
+ * The click is stopped from bubbling: both lists delegate row clicks to the
+ * person, and a plan name must not resolve to two destinations at once.
+ *
+ * Keydown needs no equivalent guard, but only because of where this is used:
+ * always an ordinary cell, never the DataViews title cell. That cell's
+ * ItemClickWrapper fires its onClickItem on Enter/Space without checking that
+ * the key originated on the wrapper itself, so a link nested there would
+ * navigate to the row's target as well as its own. Keep it out of title cells —
+ * see the owner field in GroupList.
  *
  * @param {Object} props          Component props.
  * @param {string} props.href     The subscription edit URL, if any.

--- a/plugins/newspack-plugin/src/wizards/subscribers/links.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/links.jsx
@@ -1,0 +1,33 @@
+/**
+ * Click-through targets shared by the subscriber and group lists.
+ *
+ * The rule both tabs follow: a person's name goes to that person, a plan name
+ * goes to that plan. Names are the DataViews title cell, so their target is the
+ * list's `onClickItem`; plan names are ordinary cells and carry their own link.
+ */
+
+/**
+ * Link a plan/subscription name to that subscription's admin edit screen.
+ *
+ * Renders the name unlinked when the endpoint couldn't resolve an edit URL (no
+ * WooCommerce, or an admin without the capability), so the column never shows a
+ * dead link — and likewise when the name itself is empty (a subscription whose
+ * product has since been deleted), which would otherwise leave an invisible link
+ * with no accessible name. The click is stopped from bubbling: both lists
+ * delegate row clicks to the person, and a plan name must not resolve to two
+ * destinations at once.
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.href     The subscription edit URL, if any.
+ * @param {*}      props.children The plan name.
+ */
+export const SubscriptionLink = ( { href, children } ) => {
+	if ( ! href || ! children ) {
+		return children;
+	}
+	return (
+		<a href={ href } onClick={ event => event.stopPropagation() }>
+			{ children }
+		</a>
+	);
+};

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -4,9 +4,11 @@
  *
  * Admin-facing list of every group/team subscription on the site. Unlike the
  * subscriber list, the group set is small enough to load in full and filter,
- * sort and paginate client-side. Filterable by status and plan, sortable,
- * click-through to the native subscription edit screen until the in-wizard group
- * detail lands (NPPD-1753 PR 4).
+ * sort and paginate client-side. Filterable by status and plan, sortable. Click
+ * targets follow the rule both tabs share: the row (and the owner name in it)
+ * opens that person's user-edit screen, while the plan name — under the owner and
+ * in the Subscription column — opens that group's subscription. Both are the
+ * native admin screens until the in-wizard group detail lands (NPPD-1753 PR 4).
  */
 
 /**
@@ -29,6 +31,7 @@ import { useGroups } from '../data/use-groups';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { STATUS_LABELS, STATUS_BADGE_LEVEL } from '../status';
 import { GROUP_LABEL_PLURAL } from '../labels';
+import { SubscriptionLink } from '../links';
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -52,11 +55,16 @@ export default function GroupList() {
 
 	const { groups, loading: groupsLoading, error, reload } = useGroups();
 
-	const openGroup = item => {
-		if ( item?.editUrl ) {
-			window.location.href = item.editUrl;
+	// The row's title is the owner, so the row resolves to that person. The group
+	// itself is reachable from the plan name, which links to its subscription.
+	// A group whose owner no longer exists has nothing to open, so its row is not
+	// clickable (isItemClickable below) rather than silently doing nothing.
+	const openOwner = item => {
+		if ( item?.owner?.editUrl ) {
+			window.location.href = item.owner.editUrl;
 		}
 	};
+	const hasOwnerLink = item => !! item?.owner?.editUrl;
 
 	// Resolve owner avatar URLs, keyed by group id. The table renders immediately
 	// with the avatar placeholder and each avatar fills in as it resolves.
@@ -101,7 +109,9 @@ export default function GroupList() {
 									/>
 								) }
 							</HStack>
-							<div className="newspack-subscribers__email">{ item.plan }</div>
+							<div className="newspack-subscribers__email">
+								<SubscriptionLink href={ item.editUrl }>{ item.plan }</SubscriptionLink>
+							</div>
 						</div>
 					);
 					if ( ! SHOW_AVATARS ) {
@@ -126,7 +136,7 @@ export default function GroupList() {
 				elements: planElements,
 				filterBy: { operators: [ 'isAny' ] },
 				getValue: ( { item } ) => item.plan,
-				render: ( { item } ) => <span>{ item.plan }</span>,
+				render: ( { item } ) => <SubscriptionLink href={ item.editUrl }>{ item.plan }</SubscriptionLink>,
 				enableSorting: false,
 			},
 			{
@@ -166,7 +176,9 @@ export default function GroupList() {
 
 	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( groups, view, fields ), [ groups, view, fields ] );
 
-	// Whole-row click → subscription edit (DataViews only wires up the title cell).
+	// Whole-row click → the owner's user edit (DataViews only wires up the title
+	// cell). The plan name inside the row is a real link and is skipped by the
+	// `a` guard below, so it keeps its own subscription target.
 	//
 	// DEPENDS ON DATAVIEWS INTERNAL MARKUP: the row is located by the
 	// `dataviews-view-table__row` class, which DataViews owns and could rename on
@@ -186,7 +198,7 @@ export default function GroupList() {
 		const id = row.querySelector( '[data-group-id]' )?.getAttribute( 'data-group-id' );
 		const item = groups.find( g => String( g.id ) === String( id ) );
 		if ( item ) {
-			openGroup( item );
+			openOwner( item );
 		}
 	};
 
@@ -240,7 +252,8 @@ export default function GroupList() {
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ { table: {} } }
 				getItemId={ item => item.id }
-				onClickItem={ openGroup }
+				onClickItem={ openOwner }
+				isItemClickable={ hasOwnerLink }
 				search
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -6,9 +6,9 @@
  * subscriber list, the group set is small enough to load in full and filter,
  * sort and paginate client-side. Filterable by status and plan, sortable. Click
  * targets follow the rule both tabs share: the row (and the owner name in it)
- * opens that person's user-edit screen, while the plan name — under the owner and
- * in the Subscription column — opens that group's subscription. Both are the
- * native admin screens until the in-wizard group detail lands (NPPD-1753 PR 4).
+ * opens that person's user-edit screen, while the plan name in the Subscription
+ * column opens that group's subscription. Both are the native admin screens until
+ * the in-wizard group detail lands (NPPD-1753 PR 4).
  */
 
 /**
@@ -39,7 +39,10 @@ const DEFAULT_VIEW = {
 	perPage: 20,
 	sort: { field: 'createdAt', direction: 'desc' },
 	search: '',
-	fields: [ 'members', 'status', 'createdAt' ],
+	// `plan` is visible by default because it is the only place a group's
+	// subscription is reachable — see the owner field below for why the title
+	// cell can't carry that link.
+	fields: [ 'plan', 'members', 'status', 'createdAt' ],
 	// Hide cancelled groups by default: they add noise with little value. Still
 	// reachable by ticking "Cancelled" in the Status filter (or clearing it).
 	// A group awaiting its first payment sits in `pending`, so it stays visible.
@@ -93,6 +96,14 @@ export default function GroupList() {
 				label: __( 'Owner', 'newspack-plugin' ),
 				enableGlobalSearch: true,
 				getValue: ( { item } ) => item.owner?.name || '',
+				// The secondary line is the owner's email, mirroring the subscriber
+				// list's title cell — not the plan. This is the DataViews title
+				// field, which ColumnPrimary wraps in an ItemClickWrapper: a
+				// role="button" whose own Enter/Space handler fires onClickItem
+				// regardless of where the key originated, so a link nested here
+				// resolves to two destinations at once, and ARIA treats descendants
+				// of role="button" as presentational. The plan's link lives in the
+				// `plan` column below, outside the wrapper.
 				render: ( { item } ) => {
 					const details = (
 						<div data-group-id={ item.id }>
@@ -109,9 +120,7 @@ export default function GroupList() {
 									/>
 								) }
 							</HStack>
-							<div className="newspack-subscribers__email">
-								<SubscriptionLink href={ item.editUrl }>{ item.plan }</SubscriptionLink>
-							</div>
+							<div className="newspack-subscribers__email">{ item.owner?.email }</div>
 						</div>
 					);
 					if ( ! SHOW_AVATARS ) {

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -28,7 +28,7 @@ import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { useGroups } from '../data/use-groups';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { GROUP_STATUS_LABELS, GROUP_STATUS_BADGE_LEVEL } from '../status';
-import { GROUP_LABEL_PLURAL, GROUP_LABEL_PLURAL_LOWER } from '../labels';
+import { GROUP_LABEL_PLURAL } from '../labels';
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -133,9 +133,13 @@ export default function GroupList() {
 				label: __( 'Members', 'newspack-plugin' ),
 				// The endpoint returns the owner-inclusive member count directly.
 				getValue: ( { item } ) => item.members,
+				// A seat limit of 0 means the group is uncapped, so there is no
+				// denominator to show against the count.
 				render: ( { item } ) => (
 					<span>
-						{ item.members } / { item.seatLimit }
+						{ item.seatLimit > 0
+							? `${ item.members } / ${ item.seatLimit }`
+							: sprintf( __( '%s / Unlimited', 'newspack-plugin' ), item.members ) }
 					</span>
 				),
 				enableSorting: true,
@@ -188,7 +192,7 @@ export default function GroupList() {
 					{ GROUP_LABEL_PLURAL }{ ' ' }
 					<span
 						className="newspack-subscribers__header-count"
-						aria-label={ sprintf( __( '%1$s %2$s total', 'newspack-plugin' ), total.toLocaleString(), GROUP_LABEL_PLURAL_LOWER ) }
+						aria-label={ sprintf( __( '%1$s %2$s total', 'newspack-plugin' ), total.toLocaleString(), GROUP_LABEL_PLURAL ) }
 					>
 						{ `(${ total.toLocaleString() })` }
 					</span>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -21,13 +21,13 @@ import { __experimentalHStack as HStack } from '@wordpress/components'; // eslin
 /**
  * Internal dependencies.
  */
-import { Badge, DataViews, Waiting } from '../../../../packages/components/src';
+import { Badge, Button, DataViews, Notice, Waiting } from '../../../../packages/components/src';
 import { fmtDate } from '../format';
 import './style.scss';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { useGroups } from '../data/use-groups';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
-import { GROUP_STATUS_LABELS, GROUP_STATUS_BADGE_LEVEL } from '../status';
+import { STATUS_LABELS, STATUS_BADGE_LEVEL } from '../status';
 import { GROUP_LABEL_PLURAL } from '../labels';
 
 const DEFAULT_VIEW = {
@@ -39,7 +39,8 @@ const DEFAULT_VIEW = {
 	fields: [ 'members', 'status', 'createdAt' ],
 	// Hide cancelled groups by default: they add noise with little value. Still
 	// reachable by ticking "Cancelled" in the Status filter (or clearing it).
-	filters: [ { field: 'status', operator: 'isAny', value: [ 'active', 'on-hold' ] } ],
+	// A group awaiting its first payment sits in `pending`, so it stays visible.
+	filters: [ { field: 'status', operator: 'isAny', value: [ 'active', 'pending', 'on-hold' ] } ],
 	layout: {},
 	titleField: 'owner',
 };
@@ -49,7 +50,7 @@ export default function GroupList() {
 
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
-	const { groups, loading: groupsLoading } = useGroups();
+	const { groups, loading: groupsLoading, error, reload } = useGroups();
 
 	const openGroup = item => {
 		if ( item?.editUrl ) {
@@ -57,10 +58,10 @@ export default function GroupList() {
 		}
 	};
 
-	// Resolve owner avatar URLs once, keyed by group id. The list is held behind
-	// a spinner until they resolve so the avatars don't flash in after the table.
+	// Resolve owner avatar URLs, keyed by group id. The table renders immediately
+	// with the avatar placeholder and each avatar fills in as it resolves.
 	const ownerEmails = useMemo( () => groups.map( g => g.owner?.email ), [ groups ] );
-	const { avatars: avatarsByEmail, loading: avatarsLoading } = useAvatars( ownerEmails );
+	const { avatars: avatarsByEmail } = useAvatars( ownerEmails );
 	const avatars = useMemo( () => {
 		const byId = {};
 		groups.forEach( g => {
@@ -147,10 +148,10 @@ export default function GroupList() {
 			{
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
-				elements: Object.entries( GROUP_STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+				elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
 				filterBy: { operators: [ 'isAny' ] },
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <Badge level={ GROUP_STATUS_BADGE_LEVEL[ item.status ] } text={ GROUP_STATUS_LABELS[ item.status ] } />,
+				render: ( { item } ) => <Badge level={ STATUS_BADGE_LEVEL[ item.status ] } text={ STATUS_LABELS[ item.status ] } />,
 			},
 			{
 				id: 'createdAt',
@@ -166,6 +167,13 @@ export default function GroupList() {
 	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( groups, view, fields ), [ groups, view, fields ] );
 
 	// Whole-row click → subscription edit (DataViews only wires up the title cell).
+	//
+	// DEPENDS ON DATAVIEWS INTERNAL MARKUP: the row is located by the
+	// `dataviews-view-table__row` class, which DataViews owns and could rename on
+	// upgrade — whole-row click-through would then silently stop working (grep for
+	// "DEPENDS ON DATAVIEWS INTERNAL MARKUP" when bumping @wordpress/dataviews).
+	// Keyboard users are unaffected either way: the title cell is a real button
+	// wired to the same handler, which is the accessible path here.
 	const onRowClick = event => {
 		if ( event.target.closest( 'a, button, input, label, [role="button"], [role="checkbox"]' ) ) {
 			return;
@@ -201,11 +209,23 @@ export default function GroupList() {
 		} );
 	}, [ setHeaderData, total ] );
 
-	if ( groupsLoading || avatarsLoading ) {
+	if ( groupsLoading ) {
 		return (
 			<div className="newspack-subscribers__loading">
 				<Waiting isCenter />
 			</div>
+		);
+	}
+
+	// A failed read must not read as "this site has no groups": say so, and offer
+	// a retry.
+	if ( error ) {
+		return (
+			<Notice isError noticeText={ sprintf( __( 'Could not load %1$s: %2$s', 'newspack-plugin' ), GROUP_LABEL_PLURAL, error ) }>
+				<Button variant="link" onClick={ reload }>
+					{ __( 'Retry', 'newspack-plugin' ) }
+				</Button>
+			</Notice>
 		);
 	}
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -1,0 +1,224 @@
+/* eslint-disable @wordpress/i18n-translator-comments, no-bitwise */
+/**
+ * L0 — Group list (DataViews, full-width).
+ *
+ * Admin-facing list of every group/team subscription on the site. Unlike the
+ * subscriber list, the group set is small enough to load in full and filter,
+ * sort and paginate client-side. Filterable by status and plan, sortable,
+ * click-through to the native subscription edit screen until the in-wizard group
+ * detail lands (NPPD-1753 PR 4).
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+/**
+ * Internal dependencies.
+ */
+import { Badge, DataViews, Waiting } from '../../../../packages/components/src';
+import { fmtDate } from '../format';
+import './style.scss';
+import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
+import { useGroups } from '../data/use-groups';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import { GROUP_STATUS_LABELS, GROUP_STATUS_BADGE_LEVEL } from '../status';
+import { GROUP_LABEL_PLURAL, GROUP_LABEL_PLURAL_LOWER } from '../labels';
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'createdAt', direction: 'desc' },
+	search: '',
+	fields: [ 'members', 'status', 'createdAt' ],
+	// Hide cancelled groups by default: they add noise with little value. Still
+	// reachable by ticking "Cancelled" in the Status filter (or clearing it).
+	filters: [ { field: 'status', operator: 'isAny', value: [ 'active', 'on-hold' ] } ],
+	layout: {},
+	titleField: 'owner',
+};
+
+export default function GroupList() {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	const { groups, loading: groupsLoading } = useGroups();
+
+	const openGroup = item => {
+		if ( item?.editUrl ) {
+			window.location.href = item.editUrl;
+		}
+	};
+
+	// Resolve owner avatar URLs once, keyed by group id. The list is held behind
+	// a spinner until they resolve so the avatars don't flash in after the table.
+	const ownerEmails = useMemo( () => groups.map( g => g.owner?.email ), [ groups ] );
+	const { avatars: avatarsByEmail, loading: avatarsLoading } = useAvatars( ownerEmails );
+	const avatars = useMemo( () => {
+		const byId = {};
+		groups.forEach( g => {
+			const email = g.owner?.email;
+			byId[ g.id ] = email ? avatarsByEmail[ email ] : undefined;
+		} );
+		return byId;
+	}, [ groups, avatarsByEmail ] );
+
+	// Plan filter options come from the loaded groups (the plans endpoint arrives
+	// in a later slice); distinct, in first-seen order.
+	const planElements = useMemo(
+		() => [ ...new Set( groups.map( g => g.plan ).filter( Boolean ) ) ].map( n => ( { value: n, label: n } ) ),
+		[ groups ]
+	);
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'owner',
+				label: __( 'Owner', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => item.owner?.name || '',
+				render: ( { item } ) => {
+					const details = (
+						<div data-group-id={ item.id }>
+							<HStack spacing={ 2 } justify="flex-start" alignment="center" expanded={ false }>
+								{ item.owner ? <span>{ item.owner.name }</span> : <span>—</span> }
+								{ item.seatRequest && (
+									<Badge
+										level="warning"
+										text={
+											item.seatRequest.status === 'awaiting-payment'
+												? __( 'Awaiting payment', 'newspack-plugin' )
+												: __( 'Seat increase requested', 'newspack-plugin' )
+										}
+									/>
+								) }
+							</HStack>
+							<div className="newspack-subscribers__email">{ item.plan }</div>
+						</div>
+					);
+					if ( ! SHOW_AVATARS ) {
+						return details;
+					}
+					return (
+						<HStack spacing={ 3 } justify="flex-start" alignment="center">
+							{ avatars[ item.id ] ? (
+								<img className="newspack-subscribers__avatar" src={ avatars[ item.id ] } alt="" width={ 32 } height={ 32 } />
+							) : (
+								<span className="newspack-subscribers__avatar" aria-hidden="true" />
+							) }
+							{ details }
+						</HStack>
+					);
+				},
+				enableSorting: true,
+			},
+			{
+				id: 'plan',
+				label: __( 'Subscription', 'newspack-plugin' ),
+				elements: planElements,
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) => item.plan,
+				render: ( { item } ) => <span>{ item.plan }</span>,
+				enableSorting: false,
+			},
+			{
+				id: 'members',
+				label: __( 'Members', 'newspack-plugin' ),
+				// The endpoint returns the owner-inclusive member count directly.
+				getValue: ( { item } ) => item.members,
+				render: ( { item } ) => (
+					<span>
+						{ item.members } / { item.seatLimit }
+					</span>
+				),
+				enableSorting: true,
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				elements: Object.entries( GROUP_STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) => item.status,
+				render: ( { item } ) => <Badge level={ GROUP_STATUS_BADGE_LEVEL[ item.status ] } text={ GROUP_STATUS_LABELS[ item.status ] } />,
+			},
+			{
+				id: 'createdAt',
+				label: __( 'Created', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.createdAt,
+				render: ( { item } ) => <span>{ fmtDate( item.createdAt ) }</span>,
+				enableSorting: true,
+			},
+		],
+		[ avatars, planElements ]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( groups, view, fields ), [ groups, view, fields ] );
+
+	// Whole-row click → subscription edit (DataViews only wires up the title cell).
+	const onRowClick = event => {
+		if ( event.target.closest( 'a, button, input, label, [role="button"], [role="checkbox"]' ) ) {
+			return;
+		}
+		const row = event.target.closest( 'tbody tr.dataviews-view-table__row' );
+		if ( ! row ) {
+			return;
+		}
+		// Resolve by the id stamped on the owner cell, not the row's DOM position.
+		const id = row.querySelector( '[data-group-id]' )?.getAttribute( 'data-group-id' );
+		const item = groups.find( g => String( g.id ) === String( id ) );
+		if ( item ) {
+			openGroup( item );
+		}
+	};
+
+	const total = paginationInfo?.totalItems ?? 0;
+
+	// Surface the group count in the header breadcrumb, e.g. "/ Groups (14)".
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: (
+				<>
+					{ GROUP_LABEL_PLURAL }{ ' ' }
+					<span
+						className="newspack-subscribers__header-count"
+						aria-label={ sprintf( __( '%1$s %2$s total', 'newspack-plugin' ), total.toLocaleString(), GROUP_LABEL_PLURAL_LOWER ) }
+					>
+						{ `(${ total.toLocaleString() })` }
+					</span>
+				</>
+			),
+		} );
+	}, [ setHeaderData, total ] );
+
+	if ( groupsLoading || avatarsLoading ) {
+		return (
+			<div className="newspack-subscribers__loading">
+				<Waiting isCenter />
+			</div>
+		);
+	}
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div className="newspack-subscribers__clickable-rows" onClick={ onRowClick }>
+			<DataViews
+				data={ processedData }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ { table: {} } }
+				getItemId={ item => item.id }
+				onClickItem={ openGroup }
+				search
+			/>
+		</div>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -201,7 +201,7 @@ export default function SubscriberList() {
 				// translators: %s: singular group label (publisher-customisable).
 				label: sprintf( __( '%s role', 'newspack-plugin' ), GROUP_LABEL ),
 				// Hidden by default (not in DEFAULT_VIEW fields). Display-only until
-				// the endpoint gains a group-role filter (a later slice). One line per
+				// the endpoint gains a group-role filter (NPPD-2111). One line per
 				// group, plan-qualified only when the reader belongs to more than one.
 				enableSorting: false,
 				render: ( { item } ) => {

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -31,7 +31,7 @@ import { useSubscribers } from '../data/use-subscribers';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { GROUP_LABEL, ROLE_LABELS } from '../labels';
 import { SubscriptionLink } from '../links';
-import { STATUS_LABELS, STATUS_BADGE_LEVEL, STATUS_RANK, displayStatuses } from '../status';
+import { STATUS_LABELS, STATUS_BADGE_LEVEL, displayStatuses, statusRank } from '../status';
 
 // A subscriber's group memberships, in the shape the column helpers expect
 // ([{ group, role }]). The endpoint embeds them flat on the item as
@@ -56,7 +56,7 @@ const planEntries = ( item, groupEntries ) => {
 		role: null,
 	} ) );
 	// Active subscriptions list first, then on-hold, then cancelled.
-	return [ ...cohorts, ...individual ].sort( ( a, b ) => STATUS_RANK[ a.status ] - STATUS_RANK[ b.status ] );
+	return [ ...cohorts, ...individual ].sort( ( a, b ) => statusRank( a.status ) - statusRank( b.status ) );
 };
 
 // Plan entries to show in the Subscription column: a cancelled plan is dropped
@@ -119,6 +119,11 @@ export default function SubscriberList() {
 			window.location.href = item.editUrl;
 		}
 	};
+	// A subscriber the current admin can't edit has no edit URL (get_edit_user_link()
+	// returns '' without the `edit_user` capability, which is reachable on
+	// multisite), so their row is not clickable rather than focusable-but-inert.
+	// Mirrors hasOwnerLink in GroupList.
+	const hasSubscriberLink = item => !! item?.editUrl;
 
 	const fields = useMemo(
 		() => [
@@ -354,6 +359,7 @@ export default function SubscriberList() {
 				defaultLayouts={ { table: {} } }
 				getItemId={ item => item.id }
 				onClickItem={ openSubscriber }
+				isItemClickable={ hasSubscriberLink }
 				search
 			/>
 		</div>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -21,7 +21,7 @@ import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '
 /**
  * Internal dependencies.
  */
-import { Badge, DataViews, Waiting } from '../../../../packages/components/src';
+import { Badge, Button, DataViews, Notice, Waiting } from '../../../../packages/components/src';
 import './style.scss';
 import { fmtRelative, fmtDate } from '../format';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
@@ -55,8 +55,10 @@ const planEntries = ( item, groupEntries ) => {
 };
 
 // Plan entries to show in the Subscription column: a cancelled plan is dropped
-// whenever the reader still has a live (active/on-hold) one, since it's no longer
-// what they're paying for. A fully churned reader keeps their cancelled plans.
+// whenever the reader still has a live one, since it's no longer what they're
+// paying for. A fully churned reader keeps their cancelled plans. This is one of
+// the four copies of that invariant — see the SOURCE OF TRUTH note on
+// displayStatuses in status.js before changing it.
 const visiblePlanEntries = entries => {
 	const hasLive = entries.some( e => e.status !== 'cancelled' );
 	return hasLive ? entries.filter( e => e.status !== 'cancelled' ) : entries;
@@ -91,12 +93,14 @@ export default function SubscriberList() {
 	// The server owns filter/sort/paginate; this page's rows come back already
 	// narrowed. Group-role, tag, newsletter and plan filters arrive in later
 	// slices (the endpoint honors status here); sorting is name / member-since.
-	const { items, total, pages, loading: subscribersLoading } = useSubscribers( view );
+	const { items, total, pages, loading: subscribersLoading, error, reload } = useSubscribers( view );
 
 	// Resolve avatar URLs for the current page, keyed by subscriber id. The table
-	// is held behind a spinner until they resolve so the avatars don't flash in.
+	// renders immediately with the avatar placeholder and each avatar fills in as
+	// it resolves — blanking the whole table on every page/sort/filter change
+	// would be a far heavier flash than the one it avoids.
 	const emails = useMemo( () => items.map( s => s.email ), [ items ] );
-	const { avatars: avatarsByEmail, loading: avatarsLoading } = useAvatars( emails );
+	const { avatars: avatarsByEmail } = useAvatars( emails );
 	const avatars = useMemo( () => {
 		const byId = {};
 		items.forEach( s => {
@@ -271,6 +275,13 @@ export default function SubscriberList() {
 	// DataViews only makes the title cell clickable; delegate clicks from the
 	// rest of the row to the same target, ignoring genuinely interactive elements
 	// (the title button, selection checkbox, links).
+	//
+	// DEPENDS ON DATAVIEWS INTERNAL MARKUP: the row is located by the
+	// `dataviews-view-table__row` class, which DataViews owns and could rename on
+	// upgrade — whole-row click-through would then silently stop working (grep for
+	// "DEPENDS ON DATAVIEWS INTERNAL MARKUP" when bumping @wordpress/dataviews).
+	// Keyboard users are unaffected either way: the title cell is a real button
+	// wired to the same handler, which is the accessible path here.
 	const onRowClick = event => {
 		if ( event.target.closest( 'a, button, input, label, [role="button"], [role="checkbox"]' ) ) {
 			return;
@@ -304,11 +315,23 @@ export default function SubscriberList() {
 		} );
 	}, [ setHeaderData, total ] );
 
-	if ( subscribersLoading || avatarsLoading ) {
+	if ( subscribersLoading ) {
 		return (
 			<div className="newspack-subscribers__loading">
 				<Waiting isCenter />
 			</div>
+		);
+	}
+
+	// A failed read must not read as "this site has no subscribers": say so, and
+	// offer a retry.
+	if ( error ) {
+		return (
+			<Notice isError noticeText={ sprintf( __( 'Could not load subscribers: %s', 'newspack-plugin' ), error ) }>
+				<Button variant="link" onClick={ reload }>
+					{ __( 'Retry', 'newspack-plugin' ) }
+				</Button>
+			</Notice>
 		);
 	}
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -1,0 +1,331 @@
+/* eslint-disable @wordpress/i18n-translator-comments, no-bitwise */
+/**
+ * L0 — Subscriber list (DataViews, full-width).
+ *
+ * Server-paginated: filtering, sorting, search and paging run against the REST
+ * endpoint (via useSubscribers), not a client-side array, so the table scales to
+ * large reader bases. Each row's group memberships arrive embedded on the item
+ * (item.groups), so the Status/Subscription/Group-role columns resolve without a
+ * second lookup. Row click-through opens the native user-edit screen until the
+ * in-wizard person profile lands (NPPD-1753 PR 5).
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+/**
+ * Internal dependencies.
+ */
+import { Badge, DataViews, Waiting } from '../../../../packages/components/src';
+import './style.scss';
+import { fmtRelative, fmtDate } from '../format';
+import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
+import { useSubscribers } from '../data/use-subscribers';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import { GROUP_LABEL, ROLE_LABELS } from '../labels';
+import { STATUS_LABELS, STATUS_BADGE_LEVEL, STATUS_RANK, displayStatuses } from '../status';
+
+// A subscriber's group memberships, in the shape the column helpers expect
+// ([{ group, role }]). The endpoint embeds them flat on the item as
+// item.groups = [{ id, plan, status, role }].
+const groupEntriesOf = item => ( item.groups || [] ).map( g => ( { group: { plan: g.plan, status: g.status }, role: g.role } ) );
+
+// Every subscription a subscriber has, group and individual alike: cohorts they
+// own or belong to (tagged by role) plus their own individual subscriptions.
+// Each entry carries its own status so the column can show them independently.
+// `groupEntries` is the subscriber's [{ group, role }] memberships.
+const planEntries = ( item, groupEntries ) => {
+	const cohorts = ( groupEntries || [] ).map( ( { group, role } ) => ( {
+		plan: group.plan,
+		status: group.status,
+		role,
+	} ) );
+	const individual = ( item.subscriptions || [] ).map( s => ( {
+		plan: s.plan,
+		status: s.status,
+		role: null,
+	} ) );
+	// Active subscriptions list first, then on-hold, then cancelled.
+	return [ ...cohorts, ...individual ].sort( ( a, b ) => STATUS_RANK[ a.status ] - STATUS_RANK[ b.status ] );
+};
+
+// Plan entries to show in the Subscription column: a cancelled plan is dropped
+// whenever the reader still has a live (active/on-hold) one, since it's no longer
+// what they're paying for. A fully churned reader keeps their cancelled plans.
+const visiblePlanEntries = entries => {
+	const hasLive = entries.some( e => e.status !== 'cancelled' );
+	return hasLive ? entries.filter( e => e.status !== 'cancelled' ) : entries;
+};
+
+// The status badge(s) a subscriber gets in the list: every distinct status
+// across all their subscriptions, active-first, with cancelled hidden when any
+// live plan remains. See displayStatuses.
+const subscriberStatuses = ( item, groupEntries ) =>
+	displayStatuses(
+		planEntries( item, groupEntries ).map( e => e.status ),
+		item.status
+	);
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'memberSince', direction: 'desc' },
+	search: '',
+	fields: [ 'status', 'plans', 'lastPayment', 'memberSince' ],
+	filters: [],
+	layout: {},
+	titleField: 'name',
+};
+
+export default function SubscriberList() {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	// The server owns filter/sort/paginate; this page's rows come back already
+	// narrowed. Group-role, tag, newsletter and plan filters arrive in later
+	// slices (the endpoint honors status here); sorting is name / member-since.
+	const { items, total, pages, loading: subscribersLoading } = useSubscribers( view );
+
+	// Resolve avatar URLs for the current page, keyed by subscriber id. The table
+	// is held behind a spinner until they resolve so the avatars don't flash in.
+	const emails = useMemo( () => items.map( s => s.email ), [ items ] );
+	const { avatars: avatarsByEmail, loading: avatarsLoading } = useAvatars( emails );
+	const avatars = useMemo( () => {
+		const byId = {};
+		items.forEach( s => {
+			byId[ s.id ] = avatarsByEmail[ s.email ];
+		} );
+		return byId;
+	}, [ items, avatarsByEmail ] );
+
+	const openSubscriber = item => {
+		if ( item?.editUrl ) {
+			window.location.href = item.editUrl;
+		}
+	};
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'name',
+				label: __( 'Subscriber', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				enableSorting: true,
+				getValue: ( { item } ) => `${ item.name } ${ item.email }`,
+				render: ( { item } ) => {
+					const details = (
+						<div>
+							<div>{ item.name }</div>
+							<div className="newspack-subscribers__email">{ item.email }</div>
+						</div>
+					);
+					if ( ! SHOW_AVATARS ) {
+						return <div data-subscriber-id={ item.id }>{ details }</div>;
+					}
+					return (
+						<HStack data-subscriber-id={ item.id } spacing={ 3 } justify="flex-start" alignment="center">
+							{ avatars[ item.id ] ? (
+								<img className="newspack-subscribers__avatar" src={ avatars[ item.id ] } alt="" width={ 32 } height={ 32 } />
+							) : (
+								<span className="newspack-subscribers__avatar" aria-hidden="true" />
+							) }
+							{ details }
+						</HStack>
+					);
+				},
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+				filterBy: { operators: [ 'isAny' ] },
+				enableSorting: false,
+				// The Cancelled filter means fully churned: the endpoint resolves it
+				// against the same reduced display set the badges use, so cancelled is
+				// hidden while any active or on-hold plan remains.
+				getValue: ( { item } ) => subscriberStatuses( item, groupEntriesOf( item ) ),
+				render: ( { item } ) => (
+					<HStack spacing={ 2 } justify="flex-start" alignment="center" wrap>
+						{ subscriberStatuses( item, groupEntriesOf( item ) ).map( status => (
+							<Badge key={ status } level={ STATUS_BADGE_LEVEL[ status ] } text={ STATUS_LABELS[ status ] } />
+						) ) }
+					</HStack>
+				),
+			},
+			{
+				id: 'plans',
+				label: __( 'Subscription', 'newspack-plugin' ),
+				// Plan filtering waits on the plans endpoint (NPPD-1753 PR 6); this is
+				// a display-only column for now.
+				enableSorting: false,
+				render: ( { item } ) => {
+					const entries = visiblePlanEntries( planEntries( item, groupEntriesOf( item ) ) );
+					if ( entries.length === 0 ) {
+						return <span>—</span>;
+					}
+					// 8px between subscriptions so each reads as a distinct block. A
+					// group entry is tagged "(Group)"; the subscriber's role in it is
+					// L1 information (profile card, group members table).
+					return (
+						<VStack spacing={ 2 } alignment="left">
+							{ entries.map( ( e, i ) => (
+								<div key={ i }>
+									{ e.plan }
+									{ e.role && <>&nbsp;{ `(${ GROUP_LABEL })` }</> }
+								</div>
+							) ) }
+						</VStack>
+					);
+				},
+			},
+			{
+				id: 'groupRole',
+				// translators: %s: singular group label (publisher-customisable).
+				label: sprintf( __( '%s role', 'newspack-plugin' ), GROUP_LABEL ),
+				// Hidden by default (not in DEFAULT_VIEW fields). Display-only until
+				// the endpoint gains a group-role filter (a later slice). One line per
+				// group, plan-qualified only when the reader belongs to more than one.
+				enableSorting: false,
+				render: ( { item } ) => {
+					const entries = groupEntriesOf( item );
+					if ( entries.length === 0 ) {
+						return <span>—</span>;
+					}
+					return (
+						<VStack spacing={ 2 } alignment="left">
+							{ entries.map( ( e, i ) => (
+								<div key={ i }>{ entries.length > 1 ? `${ ROLE_LABELS[ e.role ] } (${ e.group.plan })` : ROLE_LABELS[ e.role ] }</div>
+							) ) }
+						</VStack>
+					);
+				},
+			},
+			{
+				id: 'lastPayment',
+				label: __( 'Last payment', 'newspack-plugin' ),
+				// Not server-sortable in this slice.
+				enableSorting: false,
+				render: ( { item } ) => <span>{ item.lastPayment ? fmtDate( item.lastPayment ) : '—' }</span>,
+			},
+			{
+				id: 'memberSince',
+				label: __( 'Member since', 'newspack-plugin' ),
+				enableSorting: true,
+				getValue: ( { item } ) => item.memberSince,
+				render: ( { item } ) =>
+					item.memberSince ? (
+						<div>
+							<div>{ fmtDate( item.memberSince ) }</div>
+							<div className="newspack-subscribers__muted">{ fmtRelative( item.memberSince ) }</div>
+						</div>
+					) : (
+						<span>—</span>
+					),
+			},
+			{
+				id: 'lastSeen',
+				label: __( 'Last seen', 'newspack-plugin' ),
+				// Wired to reader activity in a later slice; hidden by default.
+				enableSorting: false,
+				render: ( { item } ) =>
+					item.lastSeen ? (
+						<div>
+							<div>{ fmtDate( item.lastSeen ) }</div>
+							<div className="newspack-subscribers__muted">{ fmtRelative( item.lastSeen ) }</div>
+						</div>
+					) : (
+						<span>—</span>
+					),
+			},
+			{
+				id: 'tags',
+				label: __( 'Tags', 'newspack-plugin' ),
+				// Populated in a later slice (NPPD-1753 PR 7); hidden by default.
+				enableSorting: false,
+				render: ( { item } ) => (
+					<HStack spacing={ 1 } justify="flex-start" wrap>
+						{ ( item.tags || [] ).map( t => (
+							<Badge key={ t } text={ t } />
+						) ) }
+					</HStack>
+				),
+			},
+			{
+				id: 'newsletters',
+				label: __( 'Newsletters', 'newspack-plugin' ),
+				// Populated in a later slice (NPPD-1753 PR 7); hidden by default.
+				enableSorting: false,
+				render: ( { item } ) => <div>{ ( item.newsletters || [] ).join( ', ' ) }</div>,
+			},
+		],
+		[ avatars ]
+	);
+
+	// DataViews only makes the title cell clickable; delegate clicks from the
+	// rest of the row to the same target, ignoring genuinely interactive elements
+	// (the title button, selection checkbox, links).
+	const onRowClick = event => {
+		if ( event.target.closest( 'a, button, input, label, [role="button"], [role="checkbox"]' ) ) {
+			return;
+		}
+		const row = event.target.closest( 'tbody tr.dataviews-view-table__row' );
+		if ( ! row ) {
+			return;
+		}
+		// Resolve by the id stamped on the name cell, not the row's DOM position.
+		const id = row.querySelector( '[data-subscriber-id]' )?.getAttribute( 'data-subscriber-id' );
+		const item = items.find( s => String( s.id ) === String( id ) );
+		if ( item ) {
+			openSubscriber( item );
+		}
+	};
+
+	// Surface the subscriber count in the header breadcrumb, e.g. "/ Subscribers (85)".
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: (
+				<>
+					{ __( 'Subscribers', 'newspack-plugin' ) }{ ' ' }
+					<span
+						className="newspack-subscribers__header-count"
+						aria-label={ sprintf( __( '%s subscribers total', 'newspack-plugin' ), total.toLocaleString() ) }
+					>
+						{ `(${ total.toLocaleString() })` }
+					</span>
+				</>
+			),
+		} );
+	}, [ setHeaderData, total ] );
+
+	if ( subscribersLoading || avatarsLoading ) {
+		return (
+			<div className="newspack-subscribers__loading">
+				<Waiting isCenter />
+			</div>
+		);
+	}
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div className="newspack-subscribers__clickable-rows" onClick={ onRowClick }>
+			<DataViews
+				data={ items }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				paginationInfo={ { totalItems: total, totalPages: pages } }
+				defaultLayouts={ { table: {} } }
+				getItemId={ item => item.id }
+				onClickItem={ openSubscriber }
+				search
+			/>
+		</div>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -6,8 +6,10 @@
  * endpoint (via useSubscribers), not a client-side array, so the table scales to
  * large reader bases. Each row's group memberships arrive embedded on the item
  * (item.groups), so the Status/Subscription/Group-role columns resolve without a
- * second lookup. Row click-through opens the native user-edit screen until the
- * in-wizard person profile lands (NPPD-1753 PR 5).
+ * second lookup. Click targets follow the rule both tabs share: the row (and the
+ * subscriber name in it) opens that person's user-edit screen, while a plan name
+ * in the Subscription column opens that subscription. Both are the native admin
+ * screens until the in-wizard person profile lands (NPPD-1753 PR 5).
  */
 
 /**
@@ -28,12 +30,13 @@ import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { useSubscribers } from '../data/use-subscribers';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { GROUP_LABEL, ROLE_LABELS } from '../labels';
+import { SubscriptionLink } from '../links';
 import { STATUS_LABELS, STATUS_BADGE_LEVEL, STATUS_RANK, displayStatuses } from '../status';
 
 // A subscriber's group memberships, in the shape the column helpers expect
 // ([{ group, role }]). The endpoint embeds them flat on the item as
-// item.groups = [{ id, plan, status, role }].
-const groupEntriesOf = item => ( item.groups || [] ).map( g => ( { group: { plan: g.plan, status: g.status }, role: g.role } ) );
+// item.groups = [{ id, plan, status, role, editUrl }].
+const groupEntriesOf = item => ( item.groups || [] ).map( g => ( { group: { plan: g.plan, status: g.status, editUrl: g.editUrl }, role: g.role } ) );
 
 // Every subscription a subscriber has, group and individual alike: cohorts they
 // own or belong to (tagged by role) plus their own individual subscriptions.
@@ -43,11 +46,13 @@ const planEntries = ( item, groupEntries ) => {
 	const cohorts = ( groupEntries || [] ).map( ( { group, role } ) => ( {
 		plan: group.plan,
 		status: group.status,
+		editUrl: group.editUrl,
 		role,
 	} ) );
 	const individual = ( item.subscriptions || [] ).map( s => ( {
 		plan: s.plan,
 		status: s.status,
+		editUrl: s.editUrl,
 		role: null,
 	} ) );
 	// Active subscriptions list first, then on-hold, then cancelled.
@@ -176,12 +181,14 @@ export default function SubscriberList() {
 					}
 					// 8px between subscriptions so each reads as a distinct block. A
 					// group entry is tagged "(Group)"; the subscriber's role in it is
-					// L1 information (profile card, group members table).
+					// L1 information (profile card, group members table). The plan
+					// name links to that subscription while the row resolves to the
+					// person, so the two affordances stay distinct — see links.jsx.
 					return (
 						<VStack spacing={ 2 } alignment="left">
 							{ entries.map( ( e, i ) => (
 								<div key={ i }>
-									{ e.plan }
+									<SubscriptionLink href={ e.editUrl }>{ e.plan }</SubscriptionLink>
 									{ e.role && <>&nbsp;{ `(${ GROUP_LABEL })` }</> }
 								</div>
 							) ) }

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/style.scss
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/style.scss
@@ -1,0 +1,460 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/breakpoints" as wp-breakpoints;
+
+.newspack-wizard__header .newspack-section-header p {
+	white-space: pre-line !important;
+}
+
+.newspack-subscribers__snackbar {
+	bottom: wp-vars.$grid-unit-15;
+	left: 50%;
+	position: fixed;
+	transform: translateX( -50% );
+	z-index: 100000;
+}
+
+.newspack-subscribers__card-icon {
+	width: wp-vars.$grid-unit-40;
+	height: auto;
+	display: block;
+}
+
+// Active, non-default payment cards keep their status badge but hide it: it
+// reserves the badge's (taller-than-text) height so promoting a card to default
+// doesn't shift the row. Hidden from view and, via aria-hidden, screen readers.
+.newspack-subscribers__badge-placeholder {
+	visibility: hidden;
+}
+
+.newspack-subscribers__email,
+.newspack-subscribers__muted {
+	color: wp-colors.$gray-700;
+	font-size: wp-vars.$helptext-font-size;
+	line-height: wp-vars.$default-line-height;
+	font-weight: normal;
+}
+
+.newspack-subscribers__header-count {
+	color: wp-colors.$gray-700;
+	font-weight: normal;
+}
+
+// Center the loading spinner in the content area while data resolves.
+.newspack-subscribers__loading {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	min-height: 50vh;
+}
+
+// Whole-row click affordance for the subscriber list.
+.newspack-subscribers__clickable-rows {
+	.dataviews-view-table tbody tr.dataviews-view-table__row {
+		cursor: pointer;
+
+		&:hover {
+			background: rgba( wp-colors.$gray-100, 0.5 );
+		}
+	}
+}
+
+.newspack-subscribers__avatar {
+	width: wp-vars.$grid-unit-40;
+	height: wp-vars.$grid-unit-40;
+	border-radius: 50%;
+	flex-shrink: 0;
+	object-fit: cover;
+	background: wp-colors.$gray-100;
+}
+
+// Profile header avatar, portaled into the wizard section header, top-right.
+.newspack-wizard__section-header.newspack-subscribers__has-avatar {
+	position: relative;
+}
+
+.newspack-subscribers__profile-avatar {
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: wp-vars.$grid-unit-80;
+	height: wp-vars.$grid-unit-80;
+	border-radius: 50%;
+	object-fit: cover;
+	background: wp-colors.$gray-100;
+}
+
+// Spinner placeholder shown in the avatar circle until the URL resolves.
+.newspack-subscribers__profile-avatar--loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+// Full-width notices hosted below the wizard header/tabs (inserted as the first
+// child of .newspack-wizard__main), spanning wider than the content column.
+.newspack-subscribers__notices:not(:empty) {
+	margin-bottom: wp-vars.$grid-unit-20;
+}
+
+// Modal flow body: rely on the stack's gap for vertical rhythm, so reset the
+// default top/bottom margins on its direct children (paragraphs, controls).
+.newspack-subscribers__flow > * {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.newspack-subscribers__notices-inner {
+	background: wp-colors.$gray-300;
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	padding-bottom: 1px;
+
+	.components-notice {
+		margin: 0;
+	}
+}
+
+// Inline name button rendered as plain dark text, matching the un-linked
+// names in the Subscribers/Groups lists. Used for table row names.
+.newspack-subscribers__rowlink {
+	background: none;
+	border: 0;
+	color: wp-colors.$gray-900;
+	cursor: pointer;
+	padding: 0;
+	text-align: left;
+
+	&:hover {
+		color: var( --wp-admin-theme-color );
+	}
+
+	&:focus-visible {
+		outline: var( --wp-admin-border-width-focus, 1.5px ) solid var( --wp-admin-theme-color );
+		outline-offset: 2px;
+	}
+}
+
+// Custom section header row: heading (+ light-gray seat count) on the left,
+// actions on the right. Matches the SectionHeader title type scale.
+.newspack-subscribers__section-head {
+	margin-block: wp-vars.$grid-unit-30 wp-vars.$grid-unit-15;
+}
+
+.newspack-subscribers__section-title {
+	font-size: wp-vars.$font-size-x-large;
+	font-weight: wp-vars.$font-weight-medium;
+	line-height: wp-vars.$font-line-height-x-large;
+	margin: 0;
+}
+
+// A standalone section heading (no surrounding flex row) carries both classes;
+// this beats section-title's margin reset so section-head's block spacing applies.
+.newspack-subscribers__section-title.newspack-subscribers__section-head {
+	margin-block: wp-vars.$grid-unit-30 wp-vars.$grid-unit-15;
+}
+
+// Seat count beside the "Members" heading: same size/line-height as the title,
+// lighter weight and gray so it reads as secondary.
+.newspack-subscribers__seat-count {
+	color: wp-colors.$gray-700;
+	font-size: wp-vars.$font-size-x-large;
+	font-weight: normal;
+	line-height: wp-vars.$font-line-height-x-large;
+}
+
+.newspack-subscribers__note-card.newspack-card--core {
+	background-color: wp-colors.$gray-100;
+	overflow: hidden;
+
+	.components-card__body,
+	.newspack-card--core__body {
+		background-color: transparent;
+	}
+}
+
+.newspack-subscribers__profile {
+	.components-notice__actions {
+		margin-top: wp-vars.$grid-unit-15;
+
+		.components-button {
+			height: wp-vars.$grid-unit-40;
+			line-height: 1;
+			margin-left: 0;
+			margin-right: 0;
+			padding: 0 wp-vars.$grid-unit-15;
+		}
+	}
+
+	.components-card__header,
+	.newspack-card--core__header {
+		padding: wp-vars.$grid-unit-20;
+	}
+	// The Dropdown wrapper ships as inline-block, whose line box is ~0.2px taller
+	// than the button; flex collapses it to the button's exact height. Pinning the
+	// flex basis keeps it from shrinking below the button when the row is tight.
+	.newspack-subscribers__card-menu {
+		display: flex;
+		flex: 0 0 wp-vars.$button-size-compact;
+	}
+	// The compact kebab is taller than the header's text row, so pull it in by
+	// half the difference to keep the card header at its text-only height.
+	.newspack-subscribers__card-menu-toggle {
+		$kebab-pull: calc( ( 20px - #{wp-vars.$button-size-compact} ) / 2 );
+
+		margin-top: $kebab-pull;
+		margin-bottom: $kebab-pull;
+	}
+	// A group card's title doubles as a link to the group page; keep it looking
+	// like the heading and only reveal the link affordance on hover/focus.
+	.newspack-subscribers__card-title-link.components-button.is-link {
+		color: inherit;
+		font: inherit;
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			color: var(--wp-admin-theme-color);
+		}
+	}
+	.components-card__body,
+	.newspack-card--core__body {
+		padding: wp-vars.$grid-unit-20;
+
+		> * {
+			margin: 0 !important;
+			padding: 0 !important;
+		}
+	}
+}
+
+// DataViews ships its search input and footer page-select as `.components-base-control`,
+// which adds `margin-bottom: 16px`. That throws their parent HStacks out of vertical
+// alignment with the buttons next to them. Drop the bottom margin so the toolbar and
+// footer collapse to a single line.
+.dataviews-wrapper {
+	.dataviews__search .components-base-control,
+	.dataviews-pagination .components-base-control {
+		margin-bottom: 0;
+	}
+}
+
+.newspack-subscribers__orders-wrapper {
+	.dataviews-view-table {
+		tr td:first-child,
+		tr th:first-child {
+			padding-left: wp-vars.$grid-unit-15 !important;
+		}
+		tr td:last-child,
+		tr th:last-child {
+			padding-right: wp-vars.$grid-unit-15 !important;
+		}
+		tr:hover {
+			background: rgba( wp-colors.$gray-100, 0.5 );
+		}
+	}
+}
+
+.newspack-subscribers__profile {
+	// Inline (non-full-width) DataViews inherit a -48px horizontal bleed from the
+	// wizard content style; cancel it so the member/invitation tables align with
+	// the rest of the section.
+	.newspack-dataviews {
+		margin-left: 0 !important;
+		margin-right: 0 !important;
+	}
+
+	// Tighten the default 48px edge padding on the group detail tables.
+	.dataviews-view-table {
+		tr td:first-child,
+		tr th:first-child {
+			padding-left: wp-vars.$grid-unit-15 !important;
+		}
+		tr td:last-child,
+		tr th:last-child {
+			padding-right: wp-vars.$grid-unit-15 !important;
+		}
+	}
+
+	// The footer ships its own 48px horizontal padding; tighten it to match the
+	// table cells so the pagination and bulk-action bar line up with the content.
+	.dataviews-footer {
+		padding-left: wp-vars.$grid-unit-15 !important;
+		padding-right: wp-vars.$grid-unit-15 !important;
+	}
+
+	// These fixed profile tables have no search or actions, so drop the now-empty
+	// DataViews view-actions toolbar. Column-header sorting still works. The
+	// members table opts back in below, since it has search.
+	.dataviews__view-actions {
+		display: none;
+	}
+}
+
+// The members table enables search, so restore its view-actions toolbar (hidden
+// for the other fixed profile tables above) and drop its horizontal padding so
+// the search field lines up with the table edge.
+.newspack-subscribers__members-dataviews .dataviews__view-actions {
+	display: flex;
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+.newspack-subscribers__modal-text {
+	margin: 0;
+}
+
+.newspack-subscribers__nowrap {
+	white-space: nowrap;
+}
+
+// "View subscription" drawer: a read-only, right-edge slide-in panel that
+// mirrors the newsletters quick-edit look. Built on @wordpress/components Modal
+// with custom overlay/frame classes so it anchors to the right instead of
+// rendering centered.
+.newspack-subscribers__sub-detail-overlay {
+	align-items: stretch;
+	justify-content: flex-end;
+	padding: 0;
+}
+
+.components-modal__frame.newspack-subscribers__sub-detail-modal {
+	animation: 0.2s ease-out forwards newspack-subscribers__sub-detail-slide-in;
+	border-radius: 0;
+	box-shadow: -1px 0 16px rgb( 0 0 0 / 8% );
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	margin: 0;
+	max-height: 100vh;
+	width: 350px;
+
+	@media ( max-width: wp-breakpoints.$break-small ) {
+		width: 100vw;
+	}
+
+	// Drop the modal's built-in content padding so the header/content classes
+	// below own the spacing (matching the newsletters quick-edit), and let the
+	// inner wrappers flex so the content area scrolls within the full height.
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+	}
+
+	.components-modal__children-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+	}
+}
+
+@keyframes newspack-subscribers__sub-detail-slide-in {
+	from {
+		transform: translateX( 100% );
+	}
+
+	to {
+		transform: translateX( 0 );
+	}
+}
+
+@keyframes newspack-subscribers__sub-detail-slide-out {
+	from {
+		transform: translateX( 0 );
+	}
+
+	to {
+		transform: translateX( 100% );
+	}
+}
+
+// Mirror the slide-in with a slide-out on close. @wp/components' Modal adds
+// `is-animating-out` and keeps the panel mounted until an animationend fires
+// (which bubbles up from the frame), so animating the frame is enough. Suppress
+// the overlay's default disappear animation so the motion stays a slide, not a
+// fade. The compound selector outweighs the base frame rule in the cascade.
+.components-modal__screen-overlay.newspack-subscribers__sub-detail-overlay.is-animating-out {
+	animation: none;
+}
+
+.components-modal__screen-overlay.newspack-subscribers__sub-detail-overlay.is-animating-out .components-modal__frame {
+	animation: 0.2s ease-in forwards newspack-subscribers__sub-detail-slide-out;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.newspack-subscribers__sub-detail-overlay,
+	.components-modal__frame.newspack-subscribers__sub-detail-modal,
+	.components-modal__screen-overlay.newspack-subscribers__sub-detail-overlay.is-animating-out .components-modal__frame {
+		animation: none;
+	}
+}
+
+.newspack-subscribers__sub-detail-header {
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-30 wp-vars.$grid-unit-30 0;
+}
+
+.newspack-subscribers__sub-detail-title {
+	flex: 1;
+	font-size: inherit;
+	font-weight: wp-vars.$font-weight-medium;
+	margin: 0;
+}
+
+.newspack-subscribers__sub-detail-content {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	padding: wp-vars.$grid-unit-30;
+}
+
+// Match the WordPress control label (e.g. TextControl): 11px, medium weight,
+// uppercase, gray-900.
+.newspack-subscribers__sub-detail-label {
+	color: wp-colors.$gray-900;
+	font-size: wp-vars.$font-size-x-small;
+	font-weight: wp-vars.$font-weight-medium;
+	text-transform: uppercase;
+}
+
+.newspack-subscribers__sub-detail-value {
+	// The Badge ships display: block, so it would stretch to the full row width
+	// here; keep it hugging its label (e.g. the status pill).
+	.newspack-badge {
+		display: inline-block;
+	}
+}
+
+// Pinned action bar at the bottom of the drawer: the same subscription CTAs as
+// the person-profile group card. Mirrors the newspack-newsletters quick-edit
+// footer (white, sticky, no divider, buttons split 50/50).
+.newspack-subscribers__sub-detail-footer {
+	background: wp-colors.$white;
+	bottom: 0;
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-20 wp-vars.$grid-unit-30;
+	position: sticky;
+	z-index: 1;
+
+	.components-button {
+		flex: 1;
+		justify-content: center;
+	}
+}
+
+// Labeled label/value rows on the subscription and payment-method cards,
+// reusing the quick-edit drawer's label style.
+.newspack-subscribers__card-row {
+	display: flex;
+	flex-direction: column;
+	gap: wp-vars.$grid-unit-05;
+}
+
+.newspack-subscribers__card-label {
+	color: wp-colors.$gray-900;
+	font-size: wp-vars.$font-size-x-small;
+	font-weight: wp-vars.$font-weight-medium;
+	text-transform: uppercase;
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.js
@@ -1,0 +1,64 @@
+/**
+ * Shared subscription-status helpers for the Subscribers wizard.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+export const STATUS_LABELS = {
+	active: __( 'Active', 'newspack-plugin' ),
+	pending: __( 'Pending', 'newspack-plugin' ),
+	'on-hold': __( 'On hold', 'newspack-plugin' ),
+	cancelled: __( 'Cancelled', 'newspack-plugin' ),
+};
+
+export const STATUS_BADGE_LEVEL = {
+	active: 'success',
+	pending: 'info',
+	'on-hold': 'warning',
+	cancelled: 'error',
+};
+
+// Active first, then pending, then on-hold, then cancelled.
+export const STATUS_RANK = { active: 0, pending: 1, 'on-hold': 2, cancelled: 3 };
+
+// Group subscriptions never sit in the 'pending' (awaiting-first-payment) bucket,
+// so the group status filter/badges use the three statuses a group can hold.
+export const GROUP_STATUS_LABELS = {
+	active: STATUS_LABELS.active,
+	'on-hold': STATUS_LABELS[ 'on-hold' ],
+	cancelled: STATUS_LABELS.cancelled,
+};
+
+export const GROUP_STATUS_BADGE_LEVEL = {
+	active: STATUS_BADGE_LEVEL.active,
+	'on-hold': STATUS_BADGE_LEVEL[ 'on-hold' ],
+	cancelled: STATUS_BADGE_LEVEL.cancelled,
+};
+
+/**
+ * Reduce a subscriber's many subscription statuses to the badge(s) we show.
+ *
+ * Distinct statuses, ordered active-first. A cancelled subscription is hidden
+ * whenever the subscriber still has any live (non-cancelled) one, since a past
+ * cancellation alongside an active or on-hold plan is just noise; cancelled
+ * only shows when every subscription is cancelled. Falls back to the stored
+ * status when there are none on file.
+ *
+ * @param {string[]} statuses Per-subscription statuses (group and individual).
+ * @param {string}   fallback Stored status to use when there are none.
+ * @return {string[]} Ordered, distinct statuses to display.
+ */
+export const displayStatuses = ( statuses, fallback ) => {
+	const present = ( statuses || [] ).filter( Boolean );
+	if ( ! present.length ) {
+		return fallback ? [ fallback ] : [];
+	}
+	let distinct = [ ...new Set( present ) ];
+	if ( distinct.some( s => s !== 'cancelled' ) ) {
+		distinct = distinct.filter( s => s !== 'cancelled' );
+	}
+	return distinct.sort( ( a, b ) => STATUS_RANK[ a ] - STATUS_RANK[ b ] );
+};

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.js
@@ -24,20 +24,6 @@ export const STATUS_BADGE_LEVEL = {
 // Active first, then pending, then on-hold, then cancelled.
 export const STATUS_RANK = { active: 0, pending: 1, 'on-hold': 2, cancelled: 3 };
 
-// Group subscriptions never sit in the 'pending' (awaiting-first-payment) bucket,
-// so the group status filter/badges use the three statuses a group can hold.
-export const GROUP_STATUS_LABELS = {
-	active: STATUS_LABELS.active,
-	'on-hold': STATUS_LABELS[ 'on-hold' ],
-	cancelled: STATUS_LABELS.cancelled,
-};
-
-export const GROUP_STATUS_BADGE_LEVEL = {
-	active: STATUS_BADGE_LEVEL.active,
-	'on-hold': STATUS_BADGE_LEVEL[ 'on-hold' ],
-	cancelled: STATUS_BADGE_LEVEL.cancelled,
-};
-
 /**
  * Reduce a subscriber's many subscription statuses to the badge(s) we show.
  *
@@ -46,6 +32,15 @@ export const GROUP_STATUS_BADGE_LEVEL = {
  * cancellation alongside an active or on-hold plan is just noise; cancelled
  * only shows when every subscription is cancelled. Falls back to the stored
  * status when there are none on file.
+ *
+ * SOURCE OF TRUTH — the "cancelled is dropped whenever a live status remains"
+ * invariant is documented once, on the PHP side, in
+ * Subscribers_Wizard::reduced_status(). It is re-encoded in three other places
+ * that must stay in lockstep with it, each carrying a pointer back:
+ * Subscribers_Wizard::customer_ids_for_statuses() (the endpoint's status
+ * filter), this function (the row's status badges), and `visiblePlanEntries`
+ * in SubscriberList.jsx (the Subscription column). Change one, change all four,
+ * or the filter will contradict the badge it filters on.
  *
  * @param {string[]} statuses Per-subscription statuses (group and individual).
  * @param {string}   fallback Stored status to use when there are none.

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.js
@@ -24,6 +24,11 @@ export const STATUS_BADGE_LEVEL = {
 // Active first, then pending, then on-hold, then cancelled.
 export const STATUS_RANK = { active: 0, pending: 1, 'on-hold': 2, cancelled: 3 };
 
+// Rank of a status, with anything outside the four sorting last instead of
+// yielding NaN (which leaves the comparator's order implementation-defined).
+// Mirrors the `?? 99` guard in Subscribers_Wizard::reduced_status().
+export const statusRank = status => STATUS_RANK[ status ] ?? 99;
+
 /**
  * Reduce a subscriber's many subscription statuses to the badge(s) we show.
  *
@@ -55,5 +60,5 @@ export const displayStatuses = ( statuses, fallback ) => {
 	if ( distinct.some( s => s !== 'cancelled' ) ) {
 		distinct = distinct.filter( s => s !== 'cancelled' );
 	}
-	return distinct.sort( ( a, b ) => STATUS_RANK[ a ] - STATUS_RANK[ b ] );
+	return distinct.sort( ( a, b ) => statusRank( a ) - statusRank( b ) );
 };

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.test.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { displayStatuses, STATUS_LABELS } from './status';
+
+// The status-reduction rule these assertions pin is documented on the PHP side,
+// in Subscribers_Wizard::reduced_status(); the endpoint's `status` filter
+// resolves against the same rule, so the badge and the filter must agree.
+describe( 'displayStatuses', () => {
+	it( 'orders distinct statuses active-first', () => {
+		expect( displayStatuses( [ 'on-hold', 'active', 'pending' ], '' ) ).toEqual( [ 'active', 'pending', 'on-hold' ] );
+	} );
+
+	it( 'collapses duplicates', () => {
+		expect( displayStatuses( [ 'active', 'active' ], '' ) ).toEqual( [ 'active' ] );
+	} );
+
+	it( 'hides cancelled while any live subscription remains', () => {
+		expect( displayStatuses( [ 'cancelled', 'active' ], '' ) ).toEqual( [ 'active' ] );
+		expect( displayStatuses( [ 'cancelled', 'on-hold' ], '' ) ).toEqual( [ 'on-hold' ] );
+		expect( displayStatuses( [ 'cancelled', 'pending' ], '' ) ).toEqual( [ 'pending' ] );
+	} );
+
+	it( 'shows cancelled only for a fully churned reader', () => {
+		expect( displayStatuses( [ 'cancelled', 'cancelled' ], '' ) ).toEqual( [ 'cancelled' ] );
+	} );
+
+	it( 'falls back to the stored status when no subscription statuses are on file', () => {
+		expect( displayStatuses( [], 'active' ) ).toEqual( [ 'active' ] );
+		// A free reader has neither, and gets no badge at all.
+		expect( displayStatuses( [], '' ) ).toEqual( [] );
+	} );
+
+	it( 'ignores falsy entries', () => {
+		expect( displayStatuses( [ '', null, 'active' ], 'cancelled' ) ).toEqual( [ 'active' ] );
+	} );
+
+	it( 'labels every status a group or individual subscription can hold', () => {
+		// A group awaiting its first payment is `pending`, so the badge must have a
+		// label for it — an unlabeled badge renders empty.
+		expect( Object.keys( STATUS_LABELS ) ).toEqual( [ 'active', 'pending', 'on-hold', 'cancelled' ] );
+		Object.values( STATUS_LABELS ).forEach( label => expect( label ).toBeTruthy() );
+	} );
+} );

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -912,19 +912,51 @@ function wcs_get_users_subscriptions( $user_id ) {
 	return apply_filters( 'wcs_get_users_subscriptions', $user_subscriptions, $user_id );
 }
 function wcs_get_subscriptions( $args = [] ) {
-	// Minimal mock: implements only the `customer_id` filter, the sole arg the code
-	// under test passes. If a future test needs status/paging args
-	// (subscription_status, subscriptions_per_page, paged, offset), extend the filter
-	// here rather than relying on this returning the full set.
+	// Minimal mock: implements the `customer_id` and `subscription_status` filters —
+	// the args the code under test passes. `subscription_status` accepts a single
+	// status or an array; 'any' (or unset) means no status filter. `meta_query` and
+	// paging args (subscriptions_per_page, paged, offset) are still ignored — extend
+	// here rather than relying on this returning the full set if a test needs them.
 	global $subscriptions_database;
 	$customer_id = $args['customer_id'] ?? null;
-	$matches     = [];
+	$statuses    = $args['subscription_status'] ?? 'any';
+	if ( 'any' === $statuses ) {
+		$statuses = null;
+	} elseif ( null !== $statuses ) {
+		$statuses = (array) $statuses;
+	}
+	$matches = [];
 	foreach ( $subscriptions_database as $id => $subscription ) {
-		if ( null === $customer_id || $subscription->get_customer_id() === $customer_id ) {
-			$matches[ $id ] = $subscription;
+		if ( null !== $customer_id && $subscription->get_customer_id() !== $customer_id ) {
+			continue;
 		}
+		if ( null !== $statuses && ! in_array( $subscription->get_status(), $statuses, true ) ) {
+			continue;
+		}
+		$matches[ $id ] = $subscription;
 	}
 	return $matches;
+}
+function wcs_get_subscriptions_for_product( $product_ids, $fields = 'ids', $args = [] ) {
+	// Minimal mock mirroring the real return shape: subscriptions keyed by their
+	// ID (so array_keys() yields subscription IDs), matched via WC_Subscription's
+	// `products` array (has_product()). `subscription_status`/paging args are
+	// ignored — extend here if a test needs them.
+	global $subscriptions_database;
+	$product_ids   = array_map( 'absint', (array) $product_ids );
+	$subscriptions = [];
+	foreach ( $subscriptions_database as $id => $subscription ) {
+		if ( ! method_exists( $subscription, 'has_product' ) ) {
+			continue;
+		}
+		foreach ( $product_ids as $product_id ) {
+			if ( $subscription->has_product( $product_id ) ) {
+				$subscriptions[ $id ] = ( 'ids' !== $fields ) ? $subscription : $id;
+				break;
+			}
+		}
+	}
+	return $subscriptions;
 }
 function wcs_get_canonical_product_id( $item ) {
 	if ( is_object( $item ) && method_exists( $item, 'get_product_id' ) ) {

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -913,16 +913,20 @@ function wcs_get_users_subscriptions( $user_id ) {
 }
 function wcs_get_subscriptions( $args = [] ) {
 	// Minimal mock: implements the `customer_id` and `subscription_status` filters
-	// plus `subscriptions_per_page`/`paged` paging — the args the code under test
+	// plus `subscriptions_per_page`/`offset` paging — the args the code under test
 	// passes. `subscription_status` accepts a single status or an array; 'any' (or
-	// unset) means no status filter. `meta_query` and `offset` are still ignored —
+	// unset) means no status filter. `meta_query` and `orderby` are still ignored —
 	// extend here rather than relying on this returning the full set if a test
 	// needs them.
+	//
+	// `paged` is deliberately NOT implemented: the real wcs_get_subscriptions()
+	// declares it among its own defaults and strips it before building the query,
+	// so a mock that honored it would make a broken caller look correct.
 	global $subscriptions_database;
 	$customer_id = $args['customer_id'] ?? null;
 	$statuses    = $args['subscription_status'] ?? 'any';
 	$per_page    = isset( $args['subscriptions_per_page'] ) ? (int) $args['subscriptions_per_page'] : 0;
-	$paged       = isset( $args['paged'] ) ? max( 1, (int) $args['paged'] ) : 1;
+	$offset      = isset( $args['offset'] ) ? max( 0, (int) $args['offset'] ) : 0;
 	if ( 'any' === $statuses ) {
 		$statuses = null;
 	} elseif ( null !== $statuses ) {
@@ -938,8 +942,8 @@ function wcs_get_subscriptions( $args = [] ) {
 		}
 		$matches[ $id ] = $subscription;
 	}
-	if ( $per_page > 0 ) {
-		$matches = array_slice( $matches, ( $paged - 1 ) * $per_page, $per_page, true );
+	if ( $per_page > 0 || $offset > 0 ) {
+		$matches = array_slice( $matches, $offset, $per_page > 0 ? $per_page : null, true );
 	}
 	return $matches;
 }

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -912,14 +912,17 @@ function wcs_get_users_subscriptions( $user_id ) {
 	return apply_filters( 'wcs_get_users_subscriptions', $user_subscriptions, $user_id );
 }
 function wcs_get_subscriptions( $args = [] ) {
-	// Minimal mock: implements the `customer_id` and `subscription_status` filters —
-	// the args the code under test passes. `subscription_status` accepts a single
-	// status or an array; 'any' (or unset) means no status filter. `meta_query` and
-	// paging args (subscriptions_per_page, paged, offset) are still ignored — extend
-	// here rather than relying on this returning the full set if a test needs them.
+	// Minimal mock: implements the `customer_id` and `subscription_status` filters
+	// plus `subscriptions_per_page`/`paged` paging — the args the code under test
+	// passes. `subscription_status` accepts a single status or an array; 'any' (or
+	// unset) means no status filter. `meta_query` and `offset` are still ignored —
+	// extend here rather than relying on this returning the full set if a test
+	// needs them.
 	global $subscriptions_database;
 	$customer_id = $args['customer_id'] ?? null;
 	$statuses    = $args['subscription_status'] ?? 'any';
+	$per_page    = isset( $args['subscriptions_per_page'] ) ? (int) $args['subscriptions_per_page'] : 0;
+	$paged       = isset( $args['paged'] ) ? max( 1, (int) $args['paged'] ) : 1;
 	if ( 'any' === $statuses ) {
 		$statuses = null;
 	} elseif ( null !== $statuses ) {
@@ -934,6 +937,9 @@ function wcs_get_subscriptions( $args = [] ) {
 			continue;
 		}
 		$matches[ $id ] = $subscription;
+	}
+	if ( $per_page > 0 ) {
+		$matches = array_slice( $matches, ( $paged - 1 ) * $per_page, $per_page, true );
 	}
 	return $matches;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-groups-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-groups-endpoint.php
@@ -197,14 +197,47 @@ class Test_Subscribers_Wizard_Groups_Endpoint extends WP_UnitTestCase {
 	}
 
 	/**
-	 * WCS statuses collapse to the prototype vocabulary (active / on-hold / cancelled).
+	 * WCS statuses collapse onto the four values the list has labels and badges for
+	 * (active / pending / on-hold / cancelled).
+	 *
+	 * A group awaiting its first payment is a real, reachable state, and it is the
+	 * one that bites: it maps to `pending`, so both the status badge and the list's
+	 * default status filter have to know about it, or such a group renders with an
+	 * empty status — or is hidden outright.
 	 */
 	public function test_maps_wcs_status_to_prototype_vocabulary() {
 		wp_set_current_user( $this->create_reader_user( 'administrator' ) );
-		$this->create_group_subscription( $this->create_reader_user(), 3, 'cancelled' );
+
+		$prototype_status_by_wcs_status = [
+			'active'         => 'active',
+			// Cancelled at period end, but still entitled until then.
+			'pending-cancel' => 'active',
+			'pending'        => 'pending',
+			'on-hold'        => 'on-hold',
+			'cancelled'      => 'cancelled',
+			'expired'        => 'cancelled',
+			// An unrecognised WCS slug lands in the "needs attention" bucket rather
+			// than reaching the UI as a status it cannot label.
+			'switched'       => 'on-hold',
+		];
+
+		$wcs_status_by_group_id = [];
+		foreach ( array_keys( $prototype_status_by_wcs_status ) as $wcs_status ) {
+			$group = $this->create_group_subscription( $this->create_reader_user(), 3, $wcs_status );
+
+			$wcs_status_by_group_id[ $group->get_id() ] = $wcs_status;
+		}
 
 		$data = $this->dispatch()->get_data();
-		$this->assertSame( 'cancelled', $data['items'][0]['status'] );
+		$this->assertCount( count( $prototype_status_by_wcs_status ), $data['items'] );
+		foreach ( $data['items'] as $group ) {
+			$wcs_status = $wcs_status_by_group_id[ $group['id'] ];
+			$this->assertSame(
+				$prototype_status_by_wcs_status[ $wcs_status ],
+				$group['status'],
+				sprintf( 'WCS status "%s" should surface as "%s".', $wcs_status, $prototype_status_by_wcs_status[ $wcs_status ] )
+			);
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-groups-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-groups-endpoint.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Tests for the Subscribers wizard groups read endpoint.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ * @group subscribers-wizard
+ */
+
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * GET /wizard/newspack-subscribers/groups.
+ */
+class Test_Subscribers_Wizard_Groups_Endpoint extends WP_UnitTestCase {
+
+	const ROUTE = '/newspack/v1/wizard/newspack-subscribers/groups';
+
+	/**
+	 * Track created user IDs for cleanup.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = [];
+
+	/**
+	 * Include the WC mocks before the class boots.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 3 ) . '/mocks/wc-mocks.php';
+		// The wizard rides the Access Control feature flag; enable it so its routes register.
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Reset the mock databases and register REST routes.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$this->user_ids         = [];
+		Group_Subscription::reset_cache();
+		Group_Subscription_Settings::clear_group_subscription_ids_cache();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Tear down: reset databases and delete users.
+	 */
+	public function tear_down() {
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = [];
+		Group_Subscription_Settings::clear_group_subscription_ids_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a reader user and track it for cleanup.
+	 *
+	 * @param string $role Optional role. Defaults to subscriber.
+	 *
+	 * @return int The new user ID.
+	 */
+	private function create_reader_user( string $role = 'subscriber' ): int {
+		$suffix  = wp_generate_password( 6, false );
+		$user_id = wp_insert_user(
+			[
+				'user_login'   => 'reader-' . $suffix,
+				'user_pass'    => wp_generate_password(),
+				'user_email'   => 'reader-' . $suffix . '@test.com',
+				'display_name' => 'Reader ' . $suffix,
+				'role'         => $role,
+			]
+		);
+		update_user_meta( $user_id, '_newspack_reader', true );
+		$this->user_ids[] = $user_id;
+		return $user_id;
+	}
+
+	/**
+	 * Create a group subscription owned by $owner_id, enabled with a seat limit.
+	 *
+	 * @param int    $owner_id The owner user ID.
+	 * @param int    $limit    Seat limit (owner-inclusive).
+	 * @param string $status   Subscription status.
+	 *
+	 * @return WC_Subscription
+	 */
+	private function create_group_subscription( int $owner_id, int $limit, string $status = 'active' ): WC_Subscription {
+		$sub = wcs_create_subscription(
+			[
+				'customer_id'    => $owner_id,
+				'status'         => $status,
+				'billing_period' => 'month',
+			]
+		);
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', (string) $limit );
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'name', 'Acme Team' );
+		return $sub;
+	}
+
+	/**
+	 * Add $member_id as a plain member of $subscription.
+	 *
+	 * @param int             $member_id    The member user ID.
+	 * @param WC_Subscription $subscription The group subscription.
+	 */
+	private function add_member( int $member_id, WC_Subscription $subscription ): void {
+		add_user_meta( $member_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $subscription->get_id() );
+	}
+
+	/**
+	 * Dispatch the groups endpoint as the current user.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function dispatch(): WP_REST_Response {
+		return rest_get_server()->dispatch( new WP_REST_Request( 'GET', self::ROUTE ) );
+	}
+
+	/**
+	 * An admin gets the group list in the { items, total, pages } envelope, with each
+	 * group hydrated with owner, plan, status, seat limit, owner-inclusive member count
+	 * and created date.
+	 */
+	public function test_returns_hydrated_groups_for_admin() {
+		wp_set_current_user( $this->create_reader_user( 'administrator' ) );
+
+		$owner_id  = $this->create_reader_user();
+		$member_id = $this->create_reader_user();
+		$sub       = $this->create_group_subscription( $owner_id, 5 );
+		$this->add_member( $member_id, $sub );
+
+		$response = $this->dispatch();
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'items', $data );
+		$this->assertArrayHasKey( 'total', $data );
+		$this->assertArrayHasKey( 'pages', $data );
+		$this->assertSame( 1, $data['total'] );
+		$this->assertCount( 1, $data['items'] );
+
+		$group = $data['items'][0];
+		$this->assertSame( $sub->get_id(), $group['id'] );
+		$this->assertSame( $owner_id, $group['ownerId'] );
+		$this->assertSame( $owner_id, $group['owner']['id'] );
+		$this->assertSame( 'Acme Team', $group['plan'] );
+		$this->assertSame( 'active', $group['status'] );
+		$this->assertSame( 5, $group['seatLimit'] );
+		// Owner + one member.
+		$this->assertSame( 2, $group['members'] );
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2}$/', $group['createdAt'] );
+		// The interim click-through target is always present (empty when the
+		// subscription object can't resolve an edit URL, e.g. under the mock).
+		$this->assertArrayHasKey( 'editUrl', $group );
+		$this->assertIsString( $group['editUrl'] );
+		$this->assertNull( $group['seatRequest'] );
+	}
+
+	/**
+	 * A subscription that is not group-enabled is excluded, even though the test mock's
+	 * get_group_subscription_ids() over-returns (it ignores the meta_query).
+	 */
+	public function test_excludes_non_group_subscriptions() {
+		wp_set_current_user( $this->create_reader_user( 'administrator' ) );
+
+		$owner_id = $this->create_reader_user();
+		$this->create_group_subscription( $owner_id, 3 );
+
+		// A plain, non-group subscription.
+		wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader_user(),
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+
+		$data = $this->dispatch()->get_data();
+		$this->assertSame( 1, $data['total'], 'Only the group-enabled subscription should be listed.' );
+	}
+
+	/**
+	 * WCS statuses collapse to the prototype vocabulary (active / on-hold / cancelled).
+	 */
+	public function test_maps_wcs_status_to_prototype_vocabulary() {
+		wp_set_current_user( $this->create_reader_user( 'administrator' ) );
+		$this->create_group_subscription( $this->create_reader_user(), 3, 'cancelled' );
+
+		$data = $this->dispatch()->get_data();
+		$this->assertSame( 'cancelled', $data['items'][0]['status'] );
+	}
+
+	/**
+	 * A non-admin reader is refused.
+	 */
+	public function test_forbidden_for_non_admin() {
+		wp_set_current_user( $this->create_reader_user( 'subscriber' ) );
+		$this->create_group_subscription( $this->create_reader_user(), 3 );
+
+		$response = $this->dispatch();
+		$this->assertSame( 403, $response->get_status() );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-groups-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-groups-endpoint.php
@@ -167,6 +167,9 @@ class Test_Subscribers_Wizard_Groups_Endpoint extends WP_UnitTestCase {
 		// subscription object can't resolve an edit URL, e.g. under the mock).
 		$this->assertArrayHasKey( 'editUrl', $group );
 		$this->assertIsString( $group['editUrl'] );
+		// The owner carries their own target: a person's name links to the person,
+		// the plan name links to the subscription above.
+		$this->assertStringContainsString( 'user_id=' . $owner_id, $group['owner']['editUrl'] );
 		$this->assertNull( $group['seatRequest'] );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * Tests for the Subscribers wizard subscribers read endpoint.
+ *
+ * @package Newspack\Tests
+ * @group WooCommerce_Subscriptions_Integration
+ * @group subscribers-wizard
+ */
+
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * GET /wizard/newspack-subscribers/subscribers.
+ */
+class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
+
+	const ROUTE = '/newspack/v1/wizard/newspack-subscribers/subscribers';
+
+	/**
+	 * A token shared by every reader this test creates, so list queries can be
+	 * scoped to just them regardless of other users in the fixture database.
+	 *
+	 * @var string
+	 */
+	private $scope_token;
+
+	/**
+	 * Track created user IDs for cleanup.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = [];
+
+	/**
+	 * Include the WC mocks before the class boots.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 3 ) . '/mocks/wc-mocks.php';
+		// The wizard rides the Access Control feature flag; enable it so its routes register.
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Reset the mock databases and register REST routes.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database, $orders_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$orders_database        = [];
+		$this->user_ids         = [];
+		$this->scope_token      = 'scope' . wp_generate_password( 8, false );
+		Group_Subscription::reset_cache();
+		Group_Subscription_Settings::clear_group_subscription_ids_cache();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Tear down: reset databases and delete users.
+	 */
+	public function tear_down() {
+		global $subscriptions_database, $products_database, $orders_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		$orders_database        = [];
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = [];
+		Group_Subscription_Settings::clear_group_subscription_ids_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a reader user (display name carries the scope token) and track it.
+	 *
+	 * @param string $name Human name, prefixed with the scope token in display_name.
+	 * @param string $role Optional role.
+	 *
+	 * @return int The new user ID.
+	 */
+	private function create_reader( string $name = 'Reader', string $role = 'subscriber' ): int {
+		$suffix  = wp_generate_password( 6, false );
+		$user_id = wp_insert_user(
+			[
+				'user_login'   => 'reader-' . $suffix,
+				'user_pass'    => wp_generate_password(),
+				'user_email'   => 'reader-' . $suffix . '@test.com',
+				'display_name' => $this->scope_token . ' ' . $name,
+				'role'         => $role,
+			]
+		);
+		update_user_meta( $user_id, '_newspack_reader', true );
+		$this->user_ids[] = $user_id;
+		return $user_id;
+	}
+
+	/**
+	 * Create an admin and make it the current user.
+	 *
+	 * @return int The admin user ID.
+	 */
+	private function login_admin(): int {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->user_ids[] = $admin_id;
+		wp_set_current_user( $admin_id );
+		return $admin_id;
+	}
+
+	/**
+	 * Create a group subscription owned by $owner_id.
+	 *
+	 * @param int    $owner_id The owner user ID.
+	 * @param int    $limit    Seat limit.
+	 * @param string $status   Subscription status.
+	 *
+	 * @return WC_Subscription
+	 */
+	private function create_group_subscription( int $owner_id, int $limit = 5, string $status = 'active' ): WC_Subscription {
+		$sub = wcs_create_subscription(
+			[
+				'customer_id'    => $owner_id,
+				'status'         => $status,
+				'billing_period' => 'month',
+			]
+		);
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', (string) $limit );
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'name', 'Acme Team' );
+		return $sub;
+	}
+
+	/**
+	 * Create a plain (non-group) individual subscription owned by $owner_id.
+	 *
+	 * @param int    $owner_id   The owner user ID.
+	 * @param string $status     Subscription status.
+	 * @param int    $product_id Optional product ID to link (so the plan filter can
+	 *                           match it via wcs_get_subscriptions_for_product).
+	 *
+	 * @return WC_Subscription
+	 */
+	private function create_individual_subscription( int $owner_id, string $status = 'active', int $product_id = 0 ): WC_Subscription {
+		$data = [
+			'customer_id'    => $owner_id,
+			'status'         => $status,
+			'billing_period' => 'month',
+		];
+		if ( $product_id ) {
+			$data['products'] = [ $product_id ];
+		}
+		return wcs_create_subscription( $data );
+	}
+
+	/**
+	 * Dispatch the subscribers endpoint, scoped to this test's readers via search.
+	 *
+	 * @param array $params Extra query params (page, per_page, orderby, order, status, plan, search).
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function dispatch( array $params = [] ): WP_REST_Response {
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		if ( ! array_key_exists( 'search', $params ) ) {
+			$params['search'] = $this->scope_token;
+		}
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * An admin gets the paginated envelope with each reader hydrated with the L0 fields.
+	 */
+	public function test_returns_hydrated_subscribers_for_admin() {
+		$this->login_admin();
+		$this->create_reader( 'Alice' );
+
+		$response = $this->dispatch();
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'items', $data );
+		$this->assertArrayHasKey( 'total', $data );
+		$this->assertArrayHasKey( 'pages', $data );
+		$this->assertSame( 1, $data['total'] );
+
+		$item = $data['items'][0];
+		foreach ( [ 'id', 'name', 'email', 'editUrl', 'status', 'memberSince', 'lastPayment', 'lastSeen', 'subscriptions', 'groups', 'tags', 'newsletters' ] as $key ) {
+			$this->assertArrayHasKey( $key, $item, "Missing key: $key" );
+		}
+		$this->assertStringContainsString( 'Alice', $item['name'] );
+		// The interim click-through target resolves to a native edit URL for an admin.
+		$this->assertStringContainsString( 'user_id=' . $item['id'], $item['editUrl'] );
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2}$/', $item['memberSince'] );
+	}
+
+	/**
+	 * The list paginates: total counts the whole scoped set; items are one page.
+	 */
+	public function test_paginates() {
+		$this->login_admin();
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->create_reader( 'R' . $i );
+		}
+
+		$page1 = $this->dispatch(
+			[
+				'per_page' => 2,
+				'page'     => 1,
+			] 
+		)->get_data();
+		$this->assertSame( 5, $page1['total'] );
+		$this->assertSame( 3, $page1['pages'] );
+		$this->assertCount( 2, $page1['items'] );
+
+		$page3 = $this->dispatch(
+			[
+				'per_page' => 2,
+				'page'     => 3,
+			] 
+		)->get_data();
+		$this->assertCount( 1, $page3['items'] );
+	}
+
+	/**
+	 * Sorting by name is honoured server-side.
+	 */
+	public function test_sorts_by_name() {
+		$this->login_admin();
+		$this->create_reader( 'Charlie' );
+		$this->create_reader( 'Alice' );
+		$this->create_reader( 'Bob' );
+
+		$names = array_map(
+			fn( $item ) => $item['name'],
+			$this->dispatch(
+				[
+					'orderby' => 'name',
+					'order'   => 'asc',
+				] 
+			)->get_data()['items']
+		);
+		$sorted = $names;
+		sort( $sorted );
+		$this->assertSame( $sorted, $names );
+	}
+
+	/**
+	 * Search narrows the result set to matching readers.
+	 */
+	public function test_search_narrows_results() {
+		$this->login_admin();
+		$needle_id = $this->create_reader( 'Zephyr' );
+		$this->create_reader( 'Someone' );
+
+		$data = $this->dispatch( [ 'search' => 'Zephyr' ] )->get_data();
+		$this->assertSame( 1, $data['total'] );
+		$this->assertSame( $needle_id, $data['items'][0]['id'] );
+	}
+
+	/**
+	 * Group memberships are hydrated with role, plan and status; the owner reads as
+	 * owner and a plain member reads as member. Group subs do not leak into the
+	 * individual `subscriptions` array.
+	 */
+	public function test_hydrates_group_roles() {
+		$this->login_admin();
+		$owner_id  = $this->create_reader( 'Owner' );
+		$member_id = $this->create_reader( 'Member' );
+		$sub       = $this->create_group_subscription( $owner_id );
+		add_user_meta( $member_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $sub->get_id() );
+
+		$items = $this->dispatch()->get_data()['items'];
+		$by_id = [];
+		foreach ( $items as $item ) {
+			$by_id[ $item['id'] ] = $item;
+		}
+
+		$this->assertCount( 1, $by_id[ $owner_id ]['groups'] );
+		$this->assertSame( 'owner', $by_id[ $owner_id ]['groups'][0]['role'] );
+		$this->assertSame( 'Acme Team', $by_id[ $owner_id ]['groups'][0]['plan'] );
+		$this->assertSame( 'active', $by_id[ $owner_id ]['groups'][0]['status'] );
+		$this->assertEmpty( $by_id[ $owner_id ]['subscriptions'], 'A group sub is not an individual subscription.' );
+
+		$this->assertCount( 1, $by_id[ $member_id ]['groups'] );
+		$this->assertSame( 'member', $by_id[ $member_id ]['groups'][0]['role'] );
+	}
+
+	/**
+	 * A plain individual subscription is hydrated into `subscriptions` with its
+	 * mapped status, and does not appear as a group.
+	 */
+	public function test_hydrates_individual_subscription() {
+		$this->login_admin();
+		$reader_id = $this->create_reader( 'Solo' );
+		wcs_create_subscription(
+			[
+				'customer_id'    => $reader_id,
+				'status'         => 'on-hold',
+				'billing_period' => 'month',
+			]
+		);
+
+		$data  = $this->dispatch( [ 'search' => $this->scope_token . ' Solo' ] )->get_data();
+		$item  = $data['items'][0];
+		$this->assertCount( 1, $item['subscriptions'] );
+		$this->assertSame( 'on-hold', $item['subscriptions'][0]['status'] );
+		$this->assertArrayHasKey( 'plan', $item['subscriptions'][0] );
+		$this->assertEmpty( $item['groups'] );
+	}
+
+	/**
+	 * A status filter inverts to just the readers holding an individual
+	 * subscription in a matching status; others are excluded via the include set.
+	 */
+	public function test_status_filter_inverts_to_matching_readers() {
+		$this->login_admin();
+		$active_id    = $this->create_reader( 'Active' );
+		$cancelled_id = $this->create_reader( 'Cancelled' );
+		$this->create_individual_subscription( $active_id, 'active' );
+		$this->create_individual_subscription( $cancelled_id, 'cancelled' );
+
+		$data = $this->dispatch( [ 'status' => [ 'cancelled' ] ] )->get_data();
+		$this->assertSame( 1, $data['total'] );
+		$this->assertSame( $cancelled_id, $data['items'][0]['id'] );
+	}
+
+	/**
+	 * A status filter also matches readers who only inherit that status through a
+	 * group they belong to (owner and members alike).
+	 */
+	public function test_status_filter_matches_group_members_via_inheritance() {
+		$this->login_admin();
+		$owner_id  = $this->create_reader( 'GroupOwner' );
+		$member_id = $this->create_reader( 'GroupMember' );
+		$outsider  = $this->create_reader( 'Outsider' );
+		$sub       = $this->create_group_subscription( $owner_id, 5, 'on-hold' );
+		add_user_meta( $member_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $sub->get_id() );
+		$this->create_individual_subscription( $outsider, 'active' );
+
+		$ids = array_column( $this->dispatch( [ 'status' => [ 'on-hold' ] ] )->get_data()['items'], 'id' );
+		sort( $ids );
+		$expected = [ $owner_id, $member_id ];
+		sort( $expected );
+		$this->assertSame( $expected, $ids, 'Owner and member inherit the on-hold group status; the active outsider is excluded.' );
+	}
+
+	/**
+	 * A plan filter inverts to the members of the matching group.
+	 */
+	public function test_plan_filter_inverts_to_group_members() {
+		$this->login_admin();
+		$owner_id  = $this->create_reader( 'PlanOwner' );
+		$member_id = $this->create_reader( 'PlanMember' );
+		$other_id  = $this->create_reader( 'OtherPlan' );
+		$sub       = $this->create_group_subscription( $owner_id, 5 ); // plan name "Acme Team".
+		add_user_meta( $member_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $sub->get_id() );
+		$this->create_individual_subscription( $other_id, 'active' );
+
+		$ids = array_column( $this->dispatch( [ 'plan' => [ 'Acme Team' ] ] )->get_data()['items'], 'id' );
+		sort( $ids );
+		$expected = [ $owner_id, $member_id ];
+		sort( $expected );
+		$this->assertSame( $expected, $ids );
+	}
+
+	/**
+	 * A plan filter also inverts to the holders of a matching individual
+	 * subscription: the plan name resolves to its product, and every reader with a
+	 * subscription on that product is included (the product-name branch, distinct
+	 * from the group-plan branch above).
+	 */
+	public function test_plan_filter_matches_individual_product_subscribers() {
+		$this->login_admin();
+		$product_id = self::factory()->post->create(
+			[
+				'post_type'   => 'product',
+				'post_title'  => 'Digital Monthly',
+				'post_status' => 'publish',
+			]
+		);
+		$digital_id = $this->create_reader( 'DigitalReader' );
+		$this->create_individual_subscription( $digital_id, 'active', $product_id );
+
+		// A reader on a different, unnamed product must not match.
+		$other_id = $this->create_reader( 'OtherReader' );
+		$this->create_individual_subscription( $other_id, 'active' );
+
+		$ids = array_column( $this->dispatch( [ 'plan' => [ 'Digital Monthly' ] ] )->get_data()['items'], 'id' );
+		$this->assertSame( [ $digital_id ], $ids, 'Only the reader on the named product matches the plan filter.' );
+	}
+
+	/**
+	 * Combining status and plan filters narrows (AND): only readers matching both.
+	 */
+	public function test_combined_filters_narrow_with_and_semantics() {
+		$this->login_admin();
+		$acme_owner  = $this->create_reader( 'AcmeOwner' );
+		$acme_member = $this->create_reader( 'AcmeMember' );
+		$beta_member = $this->create_reader( 'BetaMember' );
+
+		$acme = $this->create_group_subscription( $acme_owner, 5, 'active' ); // "Acme Team".
+		add_user_meta( $acme_member, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $acme->get_id() );
+
+		// A second active group on a different plan — matches the status axis but not the plan axis.
+		$beta = $this->create_group_subscription( $this->create_reader( 'BetaOwner' ), 5, 'active' );
+		$beta->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'name', 'Beta Team' );
+		add_user_meta( $beta_member, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $beta->get_id() );
+
+		// A cancelled group on the SAME Acme plan — matches the plan axis but not the status axis.
+		$cancelled_acme        = $this->create_group_subscription( $this->create_reader( 'CancelledAcmeOwner' ), 5, 'cancelled' );
+		$cancelled_acme_member = $this->create_reader( 'CancelledAcmeMember' );
+		add_user_meta( $cancelled_acme_member, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $cancelled_acme->get_id() );
+
+		$ids = array_column(
+			$this->dispatch(
+				[
+					'status' => [ 'active' ],
+					'plan'   => [ 'Acme Team' ],
+				]
+			)->get_data()['items'],
+			'id'
+		);
+		$this->assertContains( $acme_owner, $ids );
+		$this->assertContains( $acme_member, $ids );
+		$this->assertNotContains( $beta_member, $ids, 'A Beta-Team member is active but not on the Acme plan, so the AND filter excludes them (plan axis narrows).' );
+		$this->assertNotContains( $cancelled_acme_member, $ids, 'A cancelled Acme member is on the plan but not active, so the AND filter excludes them (status axis narrows).' );
+	}
+
+	/**
+	 * A filter that matches nobody short-circuits to an empty envelope (total 0,
+	 * pages 0) rather than falling through to an unfiltered query.
+	 */
+	public function test_filter_matching_nobody_returns_empty_envelope() {
+		$this->login_admin();
+		$this->create_individual_subscription( $this->create_reader( 'Active' ), 'active' );
+
+		$data = $this->dispatch( [ 'status' => [ 'pending' ] ] )->get_data();
+		$this->assertSame( [], $data['items'] );
+		$this->assertSame( 0, $data['total'] );
+		$this->assertSame( 0, $data['pages'] );
+	}
+
+	/**
+	 * The subscriber-level status reduces across all a reader's subscriptions:
+	 * a live status wins over a cancelled one, cancelled-only reads cancelled,
+	 * and a reader with no subscription has no status.
+	 */
+	public function test_reduced_status_prefers_live_over_cancelled() {
+		$this->login_admin();
+
+		$mixed_id = $this->create_reader( 'Mixed' );
+		$this->create_individual_subscription( $mixed_id, 'active' );
+		$this->create_individual_subscription( $mixed_id, 'cancelled' );
+
+		$churned_id = $this->create_reader( 'Churned' );
+		$this->create_individual_subscription( $churned_id, 'cancelled' );
+
+		$free_id = $this->create_reader( 'Free' );
+
+		$by_id = [];
+		foreach ( $this->dispatch()->get_data()['items'] as $item ) {
+			$by_id[ $item['id'] ] = $item;
+		}
+
+		$this->assertSame( 'active', $by_id[ $mixed_id ]['status'], 'A live plan wins over a cancelled one.' );
+		$this->assertSame( 'cancelled', $by_id[ $churned_id ]['status'], 'A fully churned reader reads cancelled.' );
+		$this->assertSame( '', $by_id[ $free_id ]['status'], 'A reader with no subscription has no status.' );
+	}
+
+	/**
+	 * The avatars endpoint short-circuits when avatars are disabled and otherwise
+	 * returns a per-email URL map, ignoring blank/invalid addresses.
+	 */
+	public function test_avatars_endpoint() {
+		$this->login_admin();
+
+		update_option( 'show_avatars', false );
+		$off_request = new WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-subscribers/avatars' );
+		$off_request->set_param( 'emails', [ 'reader@test.com' ] );
+		$this->assertFalse( rest_get_server()->dispatch( $off_request )->get_data()['show'] );
+
+		update_option( 'show_avatars', true );
+		$on_request = new WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-subscribers/avatars' );
+		$on_request->set_param( 'emails', [ 'reader@test.com', '' ] );
+		$data = rest_get_server()->dispatch( $on_request )->get_data();
+		$this->assertTrue( $data['show'] );
+		$this->assertArrayHasKey( 'reader@test.com', $data['avatars'] );
+		$this->assertArrayNotHasKey( '', $data['avatars'], 'Blank emails are dropped.' );
+	}
+
+	/**
+	 * The Cancelled filter matches only fully-churned readers: a reader who holds
+	 * both a cancelled and a live subscription reads as live (the badge hides
+	 * cancelled), so the filter must not surface them — otherwise the results
+	 * contradict the displayed status.
+	 */
+	public function test_cancelled_filter_excludes_readers_with_a_live_plan() {
+		$this->login_admin();
+
+		$mixed_id = $this->create_reader( 'MixedChurn' );
+		$this->create_individual_subscription( $mixed_id, 'active' );
+		$this->create_individual_subscription( $mixed_id, 'cancelled' );
+
+		$churned_id = $this->create_reader( 'FullyChurned' );
+		$this->create_individual_subscription( $churned_id, 'cancelled' );
+
+		$cancelled_ids = array_column( $this->dispatch( [ 'status' => [ 'cancelled' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $churned_id, $cancelled_ids, 'A fully-churned reader matches the Cancelled filter.' );
+		$this->assertNotContains( $mixed_id, $cancelled_ids, 'A reader with a live plan is excluded from Cancelled, matching the badge display.' );
+
+		// The same reader still matches the Active filter (the live axis is unaffected).
+		$active_ids = array_column( $this->dispatch( [ 'status' => [ 'active' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $mixed_id, $active_ids );
+	}
+
+	/**
+	 * A non-admin reader is refused.
+	 */
+	public function test_forbidden_for_non_admin() {
+		wp_set_current_user( $this->create_reader( 'Nope', 'subscriber' ) );
+		$response = $this->dispatch();
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * The avatars endpoint enforces the same manage_options gate as the list
+	 * endpoints.
+	 */
+	public function test_avatars_forbidden_for_non_admin() {
+		wp_set_current_user( $this->create_reader( 'NopeAvatar', 'subscriber' ) );
+		$request = new WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-subscribers/avatars' );
+		$request->set_param( 'emails', [ 'reader@test.com' ] );
+		$this->assertSame( 403, rest_get_server()->dispatch( $request )->get_status() );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
@@ -79,21 +79,27 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 	/**
 	 * Create a reader user (display name carries the scope token) and track it.
 	 *
-	 * @param string $name Human name, prefixed with the scope token in display_name.
-	 * @param string $role Optional role.
+	 * @param string $name       Human name, prefixed with the scope token in display_name.
+	 * @param string $role       Optional role.
+	 * @param string $registered Optional 'Y-m-d H:i:s' registration date. Fixture users
+	 *                           otherwise all register in the same second, which makes
+	 *                           member-since ordering unobservable.
 	 *
 	 * @return int The new user ID.
 	 */
-	private function create_reader( string $name = 'Reader', string $role = 'subscriber' ): int {
+	private function create_reader( string $name = 'Reader', string $role = 'subscriber', string $registered = '' ): int {
 		$suffix  = wp_generate_password( 6, false );
 		$user_id = wp_insert_user(
-			[
-				'user_login'   => 'reader-' . $suffix,
-				'user_pass'    => wp_generate_password(),
-				'user_email'   => 'reader-' . $suffix . '@test.com',
-				'display_name' => $this->scope_token . ' ' . $name,
-				'role'         => $role,
-			]
+			array_filter(
+				[
+					'user_login'      => 'reader-' . $suffix,
+					'user_pass'       => wp_generate_password(),
+					'user_email'      => 'reader-' . $suffix . '@test.com',
+					'display_name'    => $this->scope_token . ' ' . $name,
+					'role'            => $role,
+					'user_registered' => $registered,
+				]
+			)
 		);
 		update_user_meta( $user_id, '_newspack_reader', true );
 		$this->user_ids[] = $user_id;
@@ -250,6 +256,27 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 		$sorted = $names;
 		sort( $sorted );
 		$this->assertSame( $sorted, $names );
+	}
+
+	/**
+	 * Sorting by member-since is honoured server-side — and it is the endpoint's
+	 * default order, so the list's out-of-the-box ordering rides on it.
+	 */
+	public function test_sorts_by_member_since_by_default() {
+		$this->login_admin();
+		$oldest_id = $this->create_reader( 'Oldest', 'subscriber', '2020-01-01 00:00:00' );
+		$middle_id = $this->create_reader( 'Middle', 'subscriber', '2022-06-15 00:00:00' );
+		$newest_id = $this->create_reader( 'Newest', 'subscriber', '2024-11-30 00:00:00' );
+
+		// No orderby/order params: the registered defaults are memberSince / desc.
+		$descending = array_column( $this->dispatch()->get_data()['items'], 'id' );
+		$this->assertSame( [ $newest_id, $middle_id, $oldest_id ], $descending );
+
+		$ascending = array_column( $this->dispatch( [ 'order' => 'asc' ] )->get_data()['items'], 'id' );
+		$this->assertSame( [ $oldest_id, $middle_id, $newest_id ], $ascending );
+
+		// memberSince is hydrated from the same column.
+		$this->assertSame( '2024-11-30', $this->dispatch()->get_data()['items'][0]['memberSince'] );
 	}
 
 	/**
@@ -494,6 +521,42 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 		$this->assertTrue( $data['show'] );
 		$this->assertArrayHasKey( 'reader@test.com', $data['avatars'] );
 		$this->assertArrayNotHasKey( '', $data['avatars'], 'Blank emails are dropped.' );
+	}
+
+	/**
+	 * The avatars endpoint bounds its inputs: `size` is enumerated to 16–512 (so a
+	 * caller can't ask core for an arbitrarily large render) and the email batch is
+	 * capped, so an oversized payload can't fan out into unbounded avatar lookups.
+	 */
+	public function test_avatars_endpoint_bounds_its_inputs() {
+		$this->login_admin();
+		update_option( 'show_avatars', true );
+
+		foreach ( [ 8, 1024 ] as $out_of_range_size ) {
+			$request = new WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-subscribers/avatars' );
+			$request->set_param( 'emails', [ 'reader@test.com' ] );
+			$request->set_param( 'size', $out_of_range_size );
+			$this->assertSame(
+				400,
+				rest_get_server()->dispatch( $request )->get_status(),
+				"A size of $out_of_range_size is outside the 16-512 range the endpoint accepts."
+			);
+		}
+
+		$in_range = new WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-subscribers/avatars' );
+		$in_range->set_param( 'emails', [ 'reader@test.com' ] );
+		$in_range->set_param( 'size', 128 );
+		$this->assertSame( 200, rest_get_server()->dispatch( $in_range )->get_status() );
+
+		// One over the cap: the overflow is dropped rather than resolved. The
+		// client batches larger sets, so nothing is lost end to end.
+		$cap      = \Newspack\Subscribers_Wizard::AVATAR_BATCH_CAP;
+		$oversize = new WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-subscribers/avatars' );
+		$oversize->set_param( 'emails', array_map( fn( $i ) => "reader$i@test.com", range( 0, $cap ) ) );
+		$avatars = rest_get_server()->dispatch( $oversize )->get_data()['avatars'];
+		$this->assertCount( $cap, $avatars );
+		$this->assertArrayHasKey( 'reader0@test.com', $avatars );
+		$this->assertArrayNotHasKey( "reader$cap@test.com", $avatars, 'Emails past the cap are dropped.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
@@ -88,19 +88,21 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 	 * @return int The new user ID.
 	 */
 	private function create_reader( string $name = 'Reader', string $role = 'subscriber', string $registered = '' ): int {
-		$suffix  = wp_generate_password( 6, false );
-		$user_id = wp_insert_user(
-			array_filter(
-				[
-					'user_login'      => 'reader-' . $suffix,
-					'user_pass'       => wp_generate_password(),
-					'user_email'      => 'reader-' . $suffix . '@test.com',
-					'display_name'    => $this->scope_token . ' ' . $name,
-					'role'            => $role,
-					'user_registered' => $registered,
-				]
-			)
-		);
+		$suffix = wp_generate_password( 6, false );
+		$args   = [
+			'user_login'   => 'reader-' . $suffix,
+			'user_pass'    => wp_generate_password(),
+			'user_email'   => 'reader-' . $suffix . '@test.com',
+			'display_name' => $this->scope_token . ' ' . $name,
+			'role'         => $role,
+		];
+		// Set only when given, key by key rather than with a blanket array_filter():
+		// that would equally drop a deliberately-empty `role`, which is the
+		// documented way to create a role-less user.
+		if ( $registered ) {
+			$args['user_registered'] = $registered;
+		}
+		$user_id = wp_insert_user( $args );
 		update_user_meta( $user_id, '_newspack_reader', true );
 		$this->user_ids[] = $user_id;
 		return $user_id;
@@ -587,6 +589,90 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 		// The same reader still matches the Active filter (the live axis is unaffected).
 		$active_ids = array_column( $this->dispatch( [ 'status' => [ 'active' ] ] )->get_data()['items'], 'id' );
 		$this->assertContains( $mixed_id, $active_ids );
+	}
+
+	/**
+	 * The filter-side status map is the inverse of the display-side one, and both
+	 * have to stay in step or a filter contradicts the badge it filters on. The
+	 * display direction is pinned in test_reduced_status_prefers_live_over_cancelled;
+	 * this pins the inverse, positively — deleting an entry from wcs_statuses_for()'s
+	 * map must fail a test, not just narrow the results silently.
+	 */
+	public function test_status_filter_maps_wcs_statuses_positively() {
+		$this->login_admin();
+
+		// 'pending' => [ 'pending' ], via an individual subscription and via group
+		// inheritance (a member holds no subscription of their own).
+		$pending_individual = $this->create_reader( 'PendingIndividual' );
+		$this->create_individual_subscription( $pending_individual, 'pending' );
+
+		$pending_group  = $this->create_group_subscription( $this->create_reader( 'PendingGroupOwner' ), 5, 'pending' );
+		$pending_member = $this->create_reader( 'PendingGroupMember' );
+		add_user_meta( $pending_member, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $pending_group->get_id() );
+
+		// 'on-hold' => [ 'on-hold', 'switched' ]: a mid-switch subscription displays
+		// as on-hold, so the On hold filter has to reach it too.
+		$switched = $this->create_reader( 'Switched' );
+		$this->create_individual_subscription( $switched, 'switched' );
+
+		// Active also covers pending-cancel, and Cancelled also covers expired.
+		$pending_cancel = $this->create_reader( 'PendingCancel' );
+		$this->create_individual_subscription( $pending_cancel, 'pending-cancel' );
+
+		$expired = $this->create_reader( 'Expired' );
+		$this->create_individual_subscription( $expired, 'expired' );
+
+		$pending_ids = array_column( $this->dispatch( [ 'status' => [ 'pending' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $pending_individual, $pending_ids );
+		$this->assertContains( $pending_member, $pending_ids, 'A member of a pending group inherits its status on the filter axis too.' );
+
+		$on_hold_ids = array_column( $this->dispatch( [ 'status' => [ 'on-hold' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $switched, $on_hold_ids, 'A switched subscription displays as on-hold, so On hold must match it.' );
+
+		$active_ids = array_column( $this->dispatch( [ 'status' => [ 'active' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $pending_cancel, $active_ids, 'A pending-cancel subscription is still live until it lapses.' );
+
+		$cancelled_ids = array_column( $this->dispatch( [ 'status' => [ 'cancelled' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $expired, $cancelled_ids, 'An expired subscription displays as cancelled, so Cancelled must match it.' );
+	}
+
+	/**
+	 * The status filter scans subscriptions a chunk at a time. The walk has to
+	 * advance: wcs_get_subscriptions() strips a `paged` argument before building
+	 * its query, so paging with it silently re-scans the first chunk forever —
+	 * readers past the chunk boundary vanish from the results, and (worse) a
+	 * reader whose only live plan sits past it is wrongly reported as churned.
+	 *
+	 * Seeds one full chunk of active filler, then two readers whose live plans can
+	 * only be found in the second chunk, so a walk that doesn't advance fails both
+	 * assertions rather than merely returning fewer rows.
+	 */
+	public function test_status_filter_scan_advances_past_the_first_chunk() {
+		$this->login_admin();
+
+		// Filler subscriptions are owned by customer IDs with no user behind them:
+		// the scan only reads get_customer_id(), and skipping 500 user inserts keeps
+		// this test cheap. They fill the first chunk of the live-status scan.
+		for ( $i = 0; $i < \Newspack\Subscribers_Wizard::FILTER_SCAN_CHUNK; $i++ ) {
+			$this->create_individual_subscription( 900000 + $i, 'active' );
+		}
+
+		// Only subscription is active and sits in the second chunk.
+		$late_active = $this->create_reader( 'LateActive' );
+		$this->create_individual_subscription( $late_active, 'active' );
+
+		// Cancelled plan in reach, live plan past the boundary. The Cancelled filter
+		// means fully churned, so finding the live plan is what excludes them — miss
+		// it and a paying reader is reported as churned.
+		$late_mixed = $this->create_reader( 'LateMixed' );
+		$this->create_individual_subscription( $late_mixed, 'cancelled' );
+		$this->create_individual_subscription( $late_mixed, 'active' );
+
+		$active_ids = array_column( $this->dispatch( [ 'status' => [ 'active' ] ] )->get_data()['items'], 'id' );
+		$this->assertContains( $late_active, $active_ids, 'A reader whose only subscription sits past the first chunk still matches Active.' );
+
+		$cancelled_ids = array_column( $this->dispatch( [ 'status' => [ 'cancelled' ] ] )->get_data()['items'], 'id' );
+		$this->assertNotContains( $late_mixed, $cancelled_ids, 'A live plan past the chunk boundary still disqualifies the reader from Cancelled.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscribers/class-subscribers-endpoint.php
@@ -314,6 +314,7 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 		$this->assertSame( 'owner', $by_id[ $owner_id ]['groups'][0]['role'] );
 		$this->assertSame( 'Acme Team', $by_id[ $owner_id ]['groups'][0]['plan'] );
 		$this->assertSame( 'active', $by_id[ $owner_id ]['groups'][0]['status'] );
+		$this->assertArrayHasKey( 'editUrl', $by_id[ $owner_id ]['groups'][0], 'A group membership carries the subscription click target.' );
 		$this->assertEmpty( $by_id[ $owner_id ]['subscriptions'], 'A group sub is not an individual subscription.' );
 
 		$this->assertCount( 1, $by_id[ $member_id ]['groups'] );
@@ -340,6 +341,10 @@ class Test_Subscribers_Wizard_Subscribers_Endpoint extends WP_UnitTestCase {
 		$this->assertCount( 1, $item['subscriptions'] );
 		$this->assertSame( 'on-hold', $item['subscriptions'][0]['status'] );
 		$this->assertArrayHasKey( 'plan', $item['subscriptions'][0] );
+		// The plan name is its own click target, distinct from the row's person
+		// target; always present, empty when no edit URL resolves (as under the mock).
+		$this->assertArrayHasKey( 'editUrl', $item['subscriptions'][0] );
+		$this->assertIsString( $item['subscriptions'][0]['editUrl'] );
 		$this->assertEmpty( $item['groups'] );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Part of NPPD-1753 (Subscribers management surface). **PR 3 of the series** – the first user-visible slice. Adds the Audience → Subscribers wizard shell, its read-only REST endpoints, and both level-0 list screens.

Depends on #608 (group-subscription backend), which has merged; this branch is rebased onto `main` so the diff is just this slice. Later slices – the in-wizard group detail and person profile, the plans endpoint, and the tags/newsletters columns – follow in their own PRs, so NPPD-1753 stays open after this merges.

**Backend (`class-subscribers-wizard.php`)**
- Registers the `newspack-subscribers` wizard under the Audience menu, riding the existing Access Control feature flag (no new flag).
- Three read endpoints under `newspack/v1/wizard/newspack-subscribers/`: `subscribers` (server-side paginated / filtered / sorted), `groups` (full set), `avatars` (batched email→avatar lookup). All gated by `manage_options`.
- Subscription status / plan filters resolve to customer IDs HPOS-safely and invert into a capped `WP_User_Query` include. The `cancelled` status filter matches only fully-churned readers – a reader who still holds a live plan is excluded.
- Per-row group memberships are built once per request from the site's groups (no N+1).

**Frontend (`src/wizards/subscribers/`)**
- A ~1:1 port of the signed-off prototype's presentation layer; only the `data/` hooks are new, wired to the endpoints above.
- **Subscribers** list: controlled server-side DataViews – pagination / sort / status filter round-trip to the endpoint.
- **Groups** list: loads the full (small) set and filters / sorts / paginates client-side.
- Interim click-through to the native admin edit screens (via server-provided `editUrl`s) until the in-wizard detail views land in a later slice. Both tabs follow the same rule: a person's name (and the row around it) opens that person's user-edit screen, while a plan name opens that subscription.

### How to test the changes in this Pull Request:

1. On a site with WooCommerce Subscriptions and the Access Control feature enabled, build the plugin: `n build newspack-plugin`.
2. Seed several subscribers and at least one group/team subscription (owner + managers + members).
3. Go to **Audience → Subscribers**. Confirm the Subscribers list paginates, sorts, searches, and filters by status/plan **server-side** (network tab hits `.../wizard/newspack-subscribers/subscribers` with the matching params).
4. Tick **Cancelled** in the status filter – only fully-churned readers should appear (a reader holding a live plan alongside a cancelled one must *not* show).
5. Open the **Groups** tab; confirm owner-inclusive member counts and seat limits render, and the status/plan filters work. A group awaiting its first payment (WCS status `pending`) stays visible in the default view and carries a **Pending** badge.
6. Check the click targets in both tabs: clicking a row (or the subscriber / group-owner name in it) opens that person's user-edit screen, while clicking a plan name – in the Subscribers tab's Subscription column, or under the owner in the Groups tab – opens that subscription's edit screen.
7. Run the tests: from `plugins/newspack-plugin`, `n test-php` (subscribers endpoint + groups endpoint suites) and `n test-js` (the `use-subscribers` / `use-groups` hook tests).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
