### PR TITLE
refactor(audience): split the configure-view draft from its retry buffer

### DIFF
--- a/packages/components/DEVELOPMENT.md
+++ b/packages/components/DEVELOPMENT.md
@@ -100,7 +100,7 @@ When building a screen, use the **spacing scale** (8px unit: 16, 24, 32, 48, 64)
 - **`Notice`** – Use for outcome feedback (success/error/warning) or short contextual messages. Vertical margin is 32px so notices don’t collide with cards; keep one primary message per area when possible.
 - **`Waiting`** – Loading state indicator.
 - **`ProgressBar`** – Progress indicator.
-- **`Accordion`** – Collapsible content sections.
+- **`Accordion`** / **`AccordionPanel`** – Container for one or more collapsible panels.
 - **`StepsList`** / **`StepsListItem`** – Step-by-step list components.
 - **`StyleCard`** – Style preview card.
 

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { __experimentalVStack as VStack, PanelBody } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Children, Fragment, cloneElement } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -12,22 +12,34 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Divider from '../divider';
 import './style.scss';
 
-const Accordion = ( { children, title, defaultOpen = false } ) => {
-	const [ isOpen, setIsOpen ] = useState( defaultOpen );
+export const AccordionPanel = ( { children, className, title, defaultOpen = false } ) => (
+	<PanelBody className={ className } title={ title } initialOpen={ defaultOpen }>
+		{ children }
+	</PanelBody>
+);
+
+const Accordion = ( { children, className, hideSingleTitle = false, spacing = 6 } ) => {
+	const panels = Children.toArray( children );
+	// With nothing to collapse against, a lone panel can render open and untitled.
+	if ( hideSingleTitle && panels.length === 1 ) {
+		return (
+			<div className={ classNames( 'newspack-accordion', className ) }>
+				{ cloneElement( panels[ 0 ], { defaultOpen: true, title: undefined } ) }
+			</div>
+		);
+	}
 	return (
-		<details
-			className={ classNames( 'newspack-accordion', { 'newspack-accordion--is-open': isOpen } ) }
-			open={ isOpen }
-			onToggle={ e => setIsOpen( e.currentTarget.open ) }
-		>
-			<summary>
-				{ title }
-				<Icon className="newspack-accordion__icon" icon={ chevronRight } size={ 24 } />
-			</summary>
-			<div className="newspack-accordion__content">{ children }</div>
-		</details>
+		<VStack className={ classNames( 'newspack-accordion', className ) } spacing={ spacing }>
+			{ panels.map( ( panel, index ) => (
+				<Fragment key={ panel.key }>
+					{ panel }
+					{ index < panels.length - 1 && <Divider variant="secondary" marginBottom={ 0 } marginTop={ 0 } /> }
+				</Fragment>
+			) ) }
+		</VStack>
 	);
 };
 

--- a/packages/components/src/accordion/index.test.js
+++ b/packages/components/src/accordion/index.test.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Accordion, { AccordionPanel } from './index';
+
+const renderPanels = ( count, props = {} ) =>
+	render(
+		<Accordion { ...props }>
+			{ Array.from( { length: count }, ( _, i ) => (
+				<AccordionPanel key={ i } title={ `Panel ${ i }` }>
+					content
+				</AccordionPanel>
+			) ) }
+		</Accordion>
+	);
+
+const dividers = container => container.querySelectorAll( '.newspack-divider' );
+
+describe( 'Accordion dividers', () => {
+	it( 'renders no divider for a single panel', () => {
+		const { container } = renderPanels( 1 );
+		expect( container.querySelectorAll( '.components-panel__body' ) ).toHaveLength( 1 );
+		expect( dividers( container ) ).toHaveLength( 0 );
+	} );
+
+	it( 'renders a divider between panels but not after the last', () => {
+		const { container } = renderPanels( 3 );
+		expect( container.querySelectorAll( '.components-panel__body' ) ).toHaveLength( 3 );
+		expect( dividers( container ) ).toHaveLength( 2 );
+		expect( container.querySelector( '.newspack-accordion' ).lastElementChild ).not.toHaveClass( 'newspack-divider' );
+	} );
+
+	it( 'renders secondary dividers', () => {
+		const { container } = renderPanels( 2 );
+		expect( dividers( container )[ 0 ] ).toHaveClass( 'newspack-divider--variant-secondary' );
+	} );
+} );
+
+describe( 'Accordion hideSingleTitle', () => {
+	it( 'keeps the title on a lone panel by default', () => {
+		renderPanels( 1 );
+		expect( screen.getByRole( 'button', { name: 'Panel 0' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'drops the title and opens a lone panel when set', () => {
+		const { container } = renderPanels( 1, { hideSingleTitle: true } );
+		expect( screen.queryByRole( 'button', { name: 'Panel 0' } ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-panel__body' ) ).toHaveClass( 'is-opened' );
+		expect( screen.getByText( 'content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves titles alone when there is more than one panel', () => {
+		renderPanels( 2, { hideSingleTitle: true } );
+		expect( screen.getByRole( 'button', { name: 'Panel 0' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Panel 1' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/accordion/style.scss
+++ b/packages/components/src/accordion/style.scss
@@ -1,31 +1,35 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
+// Sit flush with the surrounding column: core insets panels horizontally, which
+// would misalign them against the section they belong to.
 .newspack-accordion {
-	border: 1px solid wp-colors.$gray-300;
+	.components-panel__body {
+		border: 0;
 
-	&__icon {
-		transition: transform 200ms ease-out;
-		transform: rotate(90deg);
-	}
-
-	&--is-open {
-		.newspack-accordion {
-			&__icon {
-				transform: rotate(-90deg);
-			}
+		> .components-panel__body-title:hover {
+			background: none;
 		}
 	}
-	summary {
-		padding: 16px 32px;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		cursor: pointer;
-		font-size: 14px;
-		font-weight: bold;
+
+	.components-panel__body.is-opened {
+		padding: 0;
+
+		> .components-panel__body-title {
+			margin: 0 0 wp-vars.$grid-unit-30;
+		}
 	}
 
-	&__content {
-		padding: 16px 32px;
+	.components-panel__body-toggle.components-button {
+		@include wp-mixins.heading-large();
+		padding: 0;
+
+		.components-panel__arrow {
+			right: 0;
+		}
+
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+		}
 	}
 }

--- a/packages/components/src/card-feature/README.md
+++ b/packages/components/src/card-feature/README.md
@@ -11,7 +11,7 @@ A card component for presenting a named feature or setting with a predictable, s
 
 | State | Condition | Button | Dropdown | Badge |
 |---|---|---|---|---|
-| **Unmet requirements** | `requirements` is set | "Enable" — disabled (clickable if `requirementsActionable`) | Hidden | Error badge with `requirements` text |
+| **Unmet requirements** | `requirements` is set | "Enable" — disabled (clickable if `requirementsActionable`) | Shown if `enabled` and `requirementsActionable` (and `moreControls` provided); otherwise hidden | Error badge with `requirements` text |
 | **Disabled** | `!enabled`, no requirements | "Enable" | Hidden | None |
 | **Enabled** | `enabled`, no requirements | "Configure" | Shown if `moreControls` provided | Success badge ("Enabled") |
 
@@ -155,12 +155,12 @@ import { __ } from '@wordpress/i18n';
 | `icon` | `CardFeatureIcon` | — | Icon displayed on the right. See `CardFeatureIcon` below. |
 | `enabled` | `boolean` | `false` | Whether the feature is currently enabled |
 | `requirements` | `string` | — | When set, enters the unmet-requirements state; value is used as the error badge text |
-| `requirementsActionable` | `boolean` | `false` | When `requirements` is set, keep the primary button clickable so it can remediate the unmet requirement |
+| `requirementsActionable` | `boolean` | `false` | When `requirements` is set, keep the primary button clickable so it can remediate the unmet requirement, and keep the "More" dropdown visible on an enabled card (degraded but still operable) |
 | `enableLabel` | `string` | `"Enable"` | Primary button label when not enabled |
 | `configureLabel` | `string` | `"Configure"` | Primary button label when enabled |
 | `onEnable` | `() => void` | — | Called when the primary button is clicked and the feature is not enabled |
 | `onConfigure` | `() => void` | — | Called when the primary button is clicked and the feature is enabled |
-| `moreControls` | `MoreControl[]` | — | Items for the "More" dropdown, shown only when enabled |
+| `moreControls` | `MoreControl[]` | — | Items for the "More" dropdown. Shown when `enabled` and either there are no `requirements` or `requirementsActionable` is set |
 | `badgeText` | `string` | `"Enabled"` | Badge text shown when enabled |
 | `badgeLevel` | `BadgeLevel` | `"success"` | Badge level shown when enabled |
 | `className` | `string` | — | Additional class name applied to the card element |

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -58,7 +58,9 @@ type CardFeatureProps = {
 	requirements?: string;
 	/**
 	 * When `requirements` is set, keep the primary button clickable so the
-	 * user can remediate the unmet requirement from this card.
+	 * user can remediate the unmet requirement from this card, and keep the
+	 * "More" dropdown available — the feature is degraded but still operable
+	 * (e.g. can be disabled), unlike a hard-locked requirement.
 	 */
 	requirementsActionable?: boolean;
 	/** Primary button label when not enabled. Default: "Enable". */
@@ -71,7 +73,7 @@ type CardFeatureProps = {
 	onEnable?: () => void;
 	/** Called when the primary button is clicked and the feature is enabled. */
 	onConfigure?: () => void;
-	/** Controls rendered inside the "More" dropdown, shown only when enabled. */
+	/** Controls rendered inside the "More" dropdown, shown when enabled — including the unmet-requirements state when `requirementsActionable`. */
 	moreControls?: MoreControl[];
 	/** Badge text shown when enabled. Default: "Enabled". */
 	badgeText?: string;
@@ -118,6 +120,7 @@ const CardFeature = ( {
 
 	const isConfigureState = enabled && ! requirements;
 	const buttonLabel = isConfigureState ? configureLabel ?? __( 'Configure', 'newspack-plugin' ) : enableLabel ?? __( 'Enable', 'newspack-plugin' );
+	const showMoreControls = enabled && !! moreControls?.length && ( ! requirements || requirementsActionable );
 
 	const handleButtonClick = () => {
 		if ( isConfigureState ) {
@@ -174,7 +177,7 @@ const CardFeature = ( {
 								>
 									{ buttonLabel }
 								</Button>
-								{ isConfigureState && !! moreControls?.length && (
+								{ showMoreControls && (
 									<DropdownMenu
 										icon={ moreVertical }
 										label={ __( 'More', 'newspack-plugin' ) }

--- a/packages/components/src/divider/style.scss
+++ b/packages/components/src/divider/style.scss
@@ -34,7 +34,7 @@
 	// Variant
 
 	&--variant-default {
-		background-color: wp-colors.$gray-300;
+		background-color: var( --wpds-color-stroke-surface-neutral, #{wp-colors.$gray-300} );
 	}
 
 	&--variant-primary {

--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -61,6 +61,11 @@
 		grid-row-gap: 16px;
 	}
 
+	// Row Gap 24
+	&__row-gap-24 {
+		grid-row-gap: 24px;
+	}
+
 	// Row Gap 32
 	&__row-gap-32 {
 		grid-row-gap: 32px;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,4 +1,4 @@
-export { default as Accordion } from './accordion';
+export { default as Accordion, AccordionPanel } from './accordion';
 export { default as ActionCard } from './action-card';
 export { default as AutocompleteTokenField } from './autocomplete-tokenfield';
 export { default as AutocompleteWithSuggestions } from './autocomplete-with-suggestions';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -35,12 +35,9 @@
 // Checkboxes
 .newspack-checkbox-control {
 	margin-top: 0 !important;
-	.components-checkbox-control__label {
-		font-weight: 600;
-	}
 
 	.components-base-control__help {
-		margin-left: 32px;
+		margin-left: calc(var(--checkbox-input-size) + var(--checkbox-input-margin));
 		margin-top: 0;
 	}
 }

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -46,7 +46,7 @@
 	}
 
 	&__main {
-		overflow-x: hidden;
+		overflow: hidden;
 		padding-bottom: 1px; /* Prevents borders from being cut off */
 	}
 

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -220,9 +220,9 @@ h1 {
 		margin-top: 8px;
 
 		// Match the width of a single card in the 2-column CardFeature grid
-		// (grid has 16px gutter; falls back to 1 column below 744px viewport).
+		// (grid has 32px gutter; falls back to 1 column below 744px viewport).
 		@media screen and ( min-width: 744px ) {
-			max-width: calc((100% - 16px) / 2);
+			max-width: calc((100% - 32px) / 2);
 		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/card-feature-more-menu.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/card-feature-more-menu.test.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { CardFeature } from '../../../../../packages/components/src';
+
+// packages/components has no test runner and is outside the `--filter newspack`
+// suite, so CardFeature's More-menu gating is exercised here against the real
+// component. Do NOT mock @wordpress/data — mocking it breaks the real
+// @wordpress/components barrel (its @wordpress/rich-text dependency runs
+// combineReducers() at module load).
+
+const defaultControls = [ { title: 'Disable', onClick: jest.fn() } ];
+
+const renderCard = props => render( <CardFeature title="Newsletter ESP" moreControls={ defaultControls } { ...props } /> );
+
+const moreMenu = () => screen.queryByRole( 'button', { name: 'More' } );
+
+describe( 'CardFeature More menu gating', () => {
+	it( 'shows the More menu when enabled with no requirements', () => {
+		renderCard( { enabled: true } );
+		expect( moreMenu() ).toBeInTheDocument();
+	} );
+
+	it( 'shows the More menu when enabled with an actionable requirement', () => {
+		renderCard( { enabled: true, requirements: 'Requires an API-based ESP', requirementsActionable: true } );
+		expect( moreMenu() ).toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when the requirement is not actionable (locked)', () => {
+		renderCard( { enabled: true, requirements: 'Managed by site configuration', requirementsActionable: false } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when not enabled', () => {
+		renderCard( { enabled: false } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when not enabled even with an actionable requirement', () => {
+		renderCard( { enabled: false, requirements: 'Requires an API-based ESP', requirementsActionable: true } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when there are no controls', () => {
+		renderCard( { enabled: true, moreControls: [] } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -9,7 +9,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Accordion, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
+import { Accordion, AccordionPanel, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../wizards-tab';
 import { SettingsField } from './settings-field';
@@ -214,91 +214,87 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	return (
 		<>
 			{ navBlockDialog }
-			<WizardsTab isFetching={ loading }>
-				<div className="newspack-configure-view">
-					{ /* Section 1: Settings */ }
-					{ settingsFields.length > 0 && (
-						<Grid columns={ 2 } gutter={ 32 }>
-							<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
-							<Grid columns={ 1 } rowGap={ 16 }>
-								{ settingsFields.filter( fieldIsVisible ).map( field => (
-									<SettingsField
-										key={ field.key }
-										field={ field }
-										value={ getFieldValue( field ) }
-										onChange={ val => handleFieldChange( field.key, val ) }
-									/>
-								) ) }
+			<div className="newspack-configure-view">
+				{ /* Section 1: Settings */ }
+				{ settingsFields.length > 0 && (
+					<Grid columns={ 2 } gutter={ 32 }>
+						<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
+						<Grid columns={ 1 } gutter={ 24 }>
+							{ settingsFields.filter( fieldIsVisible ).map( field => (
+								<SettingsField
+									key={ field.key }
+									field={ field }
+									value={ getFieldValue( field ) }
+									onChange={ val => handleFieldChange( field.key, val ) }
+								/>
+							) ) }
+						</Grid>
+					</Grid>
+				) }
+
+				{ /* Section 2: Inbound */ }
+				{ inboundField && (
+					<>
+						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
+						<Grid columns={ 2 } gutter={ 32 } noMargin>
+							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
+							<Grid columns={ 1 } rowGap={ 8 } noMargin>
+								{ ( inboundField.options || [] ).map( option => {
+									// Framework injects options as { value, label } objects
+									// (see class-integration.php:get_settings_config()), but accepts bare strings
+									// for backward compatibility.
+									const optionValue = typeof option === 'string' ? option : option.value;
+									const optionLabel = typeof option === 'string' ? option : option.label || option.value;
+									const currentValue = getFieldValue( inboundField );
+									const selected = Array.isArray( currentValue ) ? currentValue : [];
+									return (
+										<CheckboxControl
+											className="newspack-checkbox-control"
+											key={ optionValue }
+											label={ optionLabel }
+											checked={ selected.includes( optionValue ) }
+											onChange={ checked => handleCheckboxListChange( inboundField.key, currentValue, optionValue, checked ) }
+										/>
+									);
+								} ) }
 							</Grid>
 						</Grid>
-					) }
+					</>
+				) }
 
-					{ /* Section 2: Inbound */ }
-					{ inboundField && (
-						<>
-							<Divider alignment="full-width" variant="tertiary" marginTop={ 32 } marginBottom={ 32 } />
-							<Grid columns={ 2 } gutter={ 32 } noMargin>
-								<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
-								<Grid columns={ 1 } rowGap={ 8 } noMargin>
-									{ ( inboundField.options || [] ).map( option => {
-										// Framework injects options as { value, label } objects
-										// (see class-integration.php:get_settings_config()), but accepts bare strings
-										// for backward compatibility.
-										const optionValue = typeof option === 'string' ? option : option.value;
-										const optionLabel = typeof option === 'string' ? option : option.label || option.value;
-										const currentValue = getFieldValue( inboundField );
-										const selected = Array.isArray( currentValue ) ? currentValue : [];
-										return (
-											<CheckboxControl
-												className="newspack-checkbox-control"
-												key={ optionValue }
-												label={ optionLabel }
-												checked={ selected.includes( optionValue ) }
-												onChange={ checked =>
-													handleCheckboxListChange( inboundField.key, currentValue, optionValue, checked )
-												}
-											/>
-										);
-									} ) }
-								</Grid>
-							</Grid>
-						</>
-					) }
-
-					{ /* Section 3: Outbound */ }
-					{ outboundField && (
-						<>
-							<Divider alignment="full-width" variant="tertiary" marginTop={ 32 } marginBottom={ 32 } />
-							<Grid columns={ 2 } gutter={ 32 } noMargin>
-								<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
-								<div>
-									{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
-										const currentValue = getFieldValue( outboundField );
-										const selected = Array.isArray( currentValue ) ? currentValue : [];
-										return (
-											<Accordion key={ group.section } title={ group.section } defaultOpen={ index === 0 }>
-												<Grid columns={ 1 } rowGap={ 8 } noMargin>
-													{ group.fields.map( fieldName => (
-														<CheckboxControl
-															className="newspack-checkbox-control"
-															key={ fieldName }
-															label={ fieldName }
-															checked={ selected.includes( fieldName ) }
-															onChange={ checked =>
-																handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
-															}
-														/>
-													) ) }
-												</Grid>
-											</Accordion>
-										);
-									} ) }
-								</div>
-							</Grid>
-						</>
-					) }
-				</div>
-			</WizardsTab>
+				{ /* Section 3: Outbound */ }
+				{ outboundField && (
+					<>
+						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
+						<Grid columns={ 2 } gutter={ 32 } noMargin>
+							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
+							<Accordion hideSingleTitle>
+								{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
+									const currentValue = getFieldValue( outboundField );
+									const selected = Array.isArray( currentValue ) ? currentValue : [];
+									return (
+										<AccordionPanel key={ `${ index }-${ group.section }` } title={ group.section } defaultOpen={ index === 0 }>
+											<Grid columns={ 1 } rowGap={ 8 } noMargin>
+												{ group.fields.map( fieldName => (
+													<CheckboxControl
+														className="newspack-checkbox-control"
+														key={ fieldName }
+														label={ fieldName }
+														checked={ selected.includes( fieldName ) }
+														onChange={ checked =>
+															handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
+														}
+													/>
+												) ) }
+											</Grid>
+										</AccordionPanel>
+									);
+								} ) }
+							</Accordion>
+						</Grid>
+					</>
+				) }
+			</div>
 		</>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,38 +16,37 @@ import { SettingsField } from './settings-field';
 
 import './configure-view.scss';
 
-export const ConfigureView = ( { integrations, loading, pendingChanges, saving, onFieldChange, onDiscardChanges, onSave, match } ) => {
+// Remount the inner view when the integration id changes so the local draft is
+// per-integration. Switching integrations (same Route, new params) and leaving
+// the view both reset the draft structurally — no unmount cleanup effect needed.
+export const ConfigureView = props => <ConfigureViewInner key={ props.match?.params?.integrationId } { ...props } />;
+
+const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, onSave, match } ) => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	const integrationId = match?.params?.integrationId;
 	const integration = integrations[ integrationId ];
 
-	const hasPending = pendingChanges[ integrationId ] && Object.keys( pendingChanges[ integrationId ] ).length > 0;
+	// The live draft is local to the view. Seeded from the request layer's retry
+	// buffer so returning to an integration whose last save failed re-shows the
+	// unsaved edit. Dies at unmount — that is the discard.
+	const [ draft, setDraft ] = useState( () => inFlightChanges?.[ integrationId ] || {} );
+
+	// Header Save action is registered once per hasPending/saving transition, so
+	// its closure reads the latest draft through a ref rather than a stale copy.
+	const draftRef = useRef( draft );
+	draftRef.current = draft;
+
+	const hasPending = Object.keys( draft ).length > 0;
 	const integrationSaving = saving[ integrationId ];
 
 	const { confirmDialog: navBlockDialog } = useUnsavedChangesDialog( {
-		when: !! hasPending && ! integrationSaving && !! integration,
+		when: hasPending && ! integrationSaving && !! integration,
 	} );
 
-	// A save in flight owns its integration's pending changes: handleSave
-	// clears them itself on success, and on failure they are the user's only
-	// copy. The ref holds the whole `saving` map (not the pre-indexed
-	// `integrationSaving` scalar) so the cleanup can read the latest state for
-	// the integration it owns — on an integrationId change, ConfigureView
-	// doesn't unmount (same route, new params), so the cleanup must check the
-	// id it closed over, not whichever id rendered last. Must run for every
-	// render path — placed above the early returns.
-	const savingRef = useRef( saving );
-	savingRef.current = saving;
-
-	useEffect(
-		() => () => {
-			if ( ! savingRef.current[ integrationId ] ) {
-				onDiscardChanges( integrationId );
-			}
-		},
-		[ integrationId, onDiscardChanges ]
-	);
+	const handleFieldChange = ( fieldKey, value ) => {
+		setDraft( prev => ( { ...prev, [ fieldKey ]: value } ) );
+	};
 
 	// Split settings into groups.
 	const { settingsFields, inboundField, outboundField } = useMemo( () => {
@@ -83,7 +82,8 @@ export const ConfigureView = ( { integrations, loading, pendingChanges, saving, 
 		} );
 	}, [ integration?.id, integration?.name, integration?.description, setHeaderData ] );
 
-	// Update only the header actions when save state changes.
+	// Update only the header actions when save state changes. The action reads
+	// the draft ref so it always submits the latest edit.
 	useEffect( () => {
 		if ( ! integration ) {
 			return;
@@ -93,7 +93,11 @@ export const ConfigureView = ( { integrations, loading, pendingChanges, saving, 
 				{
 					type: 'primary',
 					label: __( 'Save', 'newspack-plugin' ),
-					action: () => onSave( integrationId ),
+					action: () => {
+						onSave( integrationId, draftRef.current )
+							.then( () => setDraft( {} ) )
+							.catch( () => {} );
+					},
 					disabled: ! hasPending || integrationSaving,
 				},
 			],
@@ -129,8 +133,8 @@ export const ConfigureView = ( { integrations, loading, pendingChanges, saving, 
 	}
 
 	const getFieldValue = field => {
-		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
-			return pendingChanges[ integrationId ][ field.key ];
+		if ( field.key in draft ) {
+			return draft[ field.key ];
 		}
 		return field.value;
 	};
@@ -138,7 +142,7 @@ export const ConfigureView = ( { integrations, loading, pendingChanges, saving, 
 	const handleCheckboxListChange = ( fieldKey, currentValue, optionName, checked ) => {
 		const selected = Array.isArray( currentValue ) ? currentValue : [];
 		const newValue = checked ? [ ...selected, optionName ] : selected.filter( f => f !== optionName );
-		onFieldChange( integrationId, fieldKey, newValue );
+		handleFieldChange( fieldKey, newValue );
 	};
 
 	const fieldIsVisible = field => {
@@ -177,7 +181,7 @@ export const ConfigureView = ( { integrations, loading, pendingChanges, saving, 
 										key={ field.key }
 										field={ field }
 										value={ getFieldValue( field ) }
-										onChange={ val => onFieldChange( integrationId, field.key, val ) }
+										onChange={ val => handleFieldChange( field.key, val ) }
 									/>
 								) ) }
 							</Grid>

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -16,12 +16,23 @@ import { SettingsField } from './settings-field';
 
 import './configure-view.scss';
 
+// Coerce a value to boolean. Values can arrive from WP options as scalar
+// strings (`'1'`/`'0'`/`'true'`/`'false'`/`''`); note `Boolean( '0' )` is `true`
+// in JS, so the falsy string forms are matched explicitly.
+const toBool = value => ( typeof value === 'string' ? ! [ '', '0', 'false' ].includes( value.toLowerCase() ) : Boolean( value ) );
+
 // Compare a draft field value against its saved server value. Field values are
-// scalars (string/boolean) or arrays of strings (metadata/checkbox lists); the
-// array compare is order-sensitive, matching how the draft builds them.
+// scalars (string/boolean) or arrays of strings (metadata/checkbox lists). The
+// backend can round-trip these unfaithfully — metadata arrays come back in
+// canonical order (`array_intersect`), and booleans as `'1'`/`''` — so arrays
+// are compared as sets and booleans are coerced, else a saved field would stay
+// stuck "dirty".
 const valuesMatch = ( a, b ) => {
 	if ( Array.isArray( a ) && Array.isArray( b ) ) {
-		return a.length === b.length && a.every( ( value, index ) => value === b[ index ] );
+		return a.length === b.length && a.every( value => b.includes( value ) );
+	}
+	if ( typeof a === 'boolean' || typeof b === 'boolean' ) {
+		return toBool( a ) === toBool( b );
 	}
 	return a === b;
 };
@@ -191,14 +202,11 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 			return true;
 		}
 		const refValue = getFieldValue( ref );
-		// For boolean conditions, coerce both sides — values can arrive from WP options
-		// as scalar strings (`'1'`/`'0'`/`'true'`/`'false'`/`''`) after migration or from
-		// the REST layer, so strict equality would hide dependent fields until the parent
-		// is re-saved. Note `Boolean( '0' )` is `true` in JS, so the falsy string forms
-		// are matched explicitly rather than via a bare `Boolean()` cast.
+		// For boolean conditions, coerce both sides so a string-typed option value
+		// (`'1'`/`'0'`/`''`) still matches — strict equality would otherwise hide
+		// dependent fields until the parent is re-saved.
 		if ( typeof field.condition.equals === 'boolean' ) {
-			const normalized = typeof refValue === 'string' ? ! [ '', '0', 'false' ].includes( refValue.toLowerCase() ) : Boolean( refValue );
-			return normalized === field.condition.equals;
+			return toBool( refValue ) === field.condition.equals;
 		}
 		return refValue === field.condition.equals;
 	};

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -16,6 +16,16 @@ import { SettingsField } from './settings-field';
 
 import './configure-view.scss';
 
+// Compare a draft field value against its saved server value. Field values are
+// scalars (string/boolean) or arrays of strings (metadata/checkbox lists); the
+// array compare is order-sensitive, matching how the draft builds them.
+const valuesMatch = ( a, b ) => {
+	if ( Array.isArray( a ) && Array.isArray( b ) ) {
+		return a.length === b.length && a.every( ( value, index ) => value === b[ index ] );
+	}
+	return a === b;
+};
+
 // Remount the inner view when the integration id changes so the local draft is
 // per-integration. Switching integrations (same Route, new params) and leaving
 // the view both reset the draft structurally — no unmount cleanup effect needed.
@@ -68,6 +78,33 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 		return { settingsFields: settings, inboundField: inbound, outboundField: outbound };
 	}, [ integration?.settings ] );
 
+	// A successful save (or refetch) replaces integration.settings with the saved
+	// server values. Drop draft keys that now match the server value so the draft
+	// clears even when the initiating view has remounted, while genuine unsaved
+	// edits (typed during the in-flight window, or a still-failing field) survive.
+	useEffect( () => {
+		if ( ! integration?.settings ) {
+			return;
+		}
+		setDraft( prev => {
+			const keys = Object.keys( prev );
+			if ( keys.length === 0 ) {
+				return prev;
+			}
+			let changed = false;
+			const next = {};
+			for ( const key of keys ) {
+				const field = integration.settings.find( f => f.key === key );
+				if ( field && valuesMatch( field.value, prev[ key ] ) ) {
+					changed = true;
+					continue;
+				}
+				next[ key ] = prev[ key ];
+			}
+			return changed ? next : prev;
+		} );
+	}, [ integration?.settings ] );
+
 	// Set the static header data (name/title/description) only when the
 	// integration identity changes. Avoids per-keystroke churn from
 	// hasPending/saving updates feeding through SET_HEADER_DATA.
@@ -94,9 +131,9 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 					type: 'primary',
 					label: __( 'Save', 'newspack-plugin' ),
 					action: () => {
-						onSave( integrationId, draftRef.current )
-							.then( () => setDraft( {} ) )
-							.catch( () => {} );
+						// The draft clears via the reconcile effect once the parent
+						// reflects the saved values; on failure the draft is retained.
+						onSave( integrationId, draftRef.current ).catch( () => {} );
 					},
 					disabled: ! hasPending || integrationSaving,
 				},

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -21,12 +21,11 @@ import './configure-view.scss';
 // in JS, so the falsy string forms are matched explicitly.
 const toBool = value => ( typeof value === 'string' ? ! [ '', '0', 'false' ].includes( value.toLowerCase() ) : Boolean( value ) );
 
-// Compare a draft field value against its saved server value. Field values are
-// scalars (string/boolean) or arrays of strings (metadata/checkbox lists). The
-// backend can round-trip these unfaithfully — metadata arrays come back in
-// canonical order (`array_intersect`), and booleans as `'1'`/`''` — so arrays
-// are compared as sets and booleans are coerced, else a saved field would stay
-// stuck "dirty".
+// Compare two field values for equivalence. Field values are scalars
+// (string/boolean) or arrays of strings (metadata/checkbox lists). The backend
+// can round-trip these unfaithfully — metadata arrays come back in canonical
+// order (`array_intersect`), and booleans as `'1'`/`''` — so arrays are compared
+// as sets and booleans are coerced, else a saved field would stay stuck "dirty".
 const valuesMatch = ( a, b ) => {
 	if ( Array.isArray( a ) && Array.isArray( b ) ) {
 		return a.length === b.length && a.every( value => b.includes( value ) );
@@ -58,7 +57,21 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	const draftRef = useRef( draft );
 	draftRef.current = draft;
 
-	const hasPending = Object.keys( draft ).length > 0;
+	// Diff draft values against the saved values, not mere key presence, so
+	// editing a field back to its original value disarms the guard.
+	const hasPending = useMemo( () => {
+		const keys = Object.keys( draft );
+		if ( keys.length === 0 ) {
+			return false;
+		}
+		if ( ! integration?.settings ) {
+			return true;
+		}
+		return keys.some( key => {
+			const field = integration.settings.find( f => f.key === key );
+			return ! field || ! valuesMatch( field.value, draft[ key ] );
+		} );
+	}, [ draft, integration?.settings ] );
 	const integrationSaving = saving[ integrationId ];
 
 	const { confirmDialog: navBlockDialog } = useUnsavedChangesDialog( {
@@ -89,24 +102,24 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 		return { settingsFields: settings, inboundField: inbound, outboundField: outbound };
 	}, [ integration?.settings ] );
 
-	// A successful save (or refetch) replaces integration.settings with the saved
-	// server values. Drop draft keys that now match the server value so the draft
-	// clears even when the initiating view has remounted, while genuine unsaved
-	// edits (typed during the in-flight window, or a still-failing field) survive.
+	// The parent clears the submitted change from its retry buffer on save
+	// success (a failed save keeps it): drop the submitted keys not re-edited
+	// since. Matching the submitted value, not the server's, survives backend
+	// normalization (`'' → 'NP_'`, `'5' → 5`) that value-equality would misread.
+	const lastInFlightRef = useRef( inFlightChanges?.[ integrationId ] );
 	useEffect( () => {
-		if ( ! integration?.settings ) {
+		const submitted = lastInFlightRef.current;
+		const current = inFlightChanges?.[ integrationId ];
+		lastInFlightRef.current = current;
+		if ( ! submitted || current ) {
 			return;
 		}
 		setDraft( prev => {
 			const keys = Object.keys( prev );
-			if ( keys.length === 0 ) {
-				return prev;
-			}
 			let changed = false;
 			const next = {};
 			for ( const key of keys ) {
-				const field = integration.settings.find( f => f.key === key );
-				if ( field && valuesMatch( field.value, prev[ key ] ) ) {
+				if ( key in submitted && valuesMatch( submitted[ key ], prev[ key ] ) ) {
 					changed = true;
 					continue;
 				}
@@ -114,7 +127,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 			}
 			return changed ? next : prev;
 		} );
-	}, [ integration?.settings ] );
+	}, [ inFlightChanges, integrationId ] );
 
 	// Set the static header data (name/title/description) only when the
 	// integration identity changes. Avoids per-keystroke churn from

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -41,7 +41,7 @@ const valuesMatch = ( a, b ) => {
 // the view both reset the draft structurally — no unmount cleanup effect needed.
 export const ConfigureView = props => <ConfigureViewInner key={ props.match?.params?.integrationId } { ...props } />;
 
-const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, onSave, match } ) => {
+const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, onSave, onDiscardChanges, match } ) => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	const integrationId = match?.params?.integrationId;
@@ -57,8 +57,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	const draftRef = useRef( draft );
 	draftRef.current = draft;
 
-	// Diff draft values against the saved values, not mere key presence, so
-	// editing a field back to its original value disarms the guard.
+	// Diff against saved values, not key presence, so a revert disarms the guard.
 	const hasPending = useMemo( () => {
 		const keys = Object.keys( draft );
 		if ( keys.length === 0 ) {
@@ -102,10 +101,9 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 		return { settingsFields: settings, inboundField: inbound, outboundField: outbound };
 	}, [ integration?.settings ] );
 
-	// The parent clears the submitted change from its retry buffer on save
-	// success (a failed save keeps it): drop the submitted keys not re-edited
-	// since. Matching the submitted value, not the server's, survives backend
-	// normalization (`'' → 'NP_'`, `'5' → 5`) that value-equality would misread.
+	// The parent clears the retry buffer on save success; drop submitted keys not
+	// re-edited since. Matching the submitted value (not the server's) survives
+	// backend normalization (`'' → 'NP_'`, `'5' → 5`) that equality would misread.
 	const lastInFlightRef = useRef( inFlightChanges?.[ integrationId ] );
 	useEffect( () => {
 		const submitted = lastInFlightRef.current;
@@ -128,6 +126,14 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 			return changed ? next : prev;
 		} );
 	}, [ inFlightChanges, integrationId ] );
+
+	// Clear the retry buffer once a reverted draft is clean, else it re-seeds the
+	// stale failed edit on the next visit.
+	useEffect( () => {
+		if ( ! hasPending && ! integrationSaving && inFlightChanges?.[ integrationId ] ) {
+			onDiscardChanges?.( integrationId );
+		}
+	}, [ hasPending, integrationSaving, inFlightChanges, integrationId, onDiscardChanges ] );
 
 	// Set the static header data (name/title/description) only when the
 	// integration identity changes. Avoids per-keystroke churn from

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.scss
@@ -1,23 +1,7 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
-
 .newspack-configure-view {
 	// Align section headers to the top of the grid row.
 	.newspack-grid .newspack-section-header {
 		margin-top: 0;
 		margin-bottom: 0;
-	}
-
-	// Accordion overrides: top/bottom borders only, no box border.
-	.newspack-accordion {
-		border: none;
-		border-top: 1px solid wp-colors.$gray-300;
-
-		&:first-child {
-			border-top: none;
-		}
-
-		&:last-child {
-			border-bottom: none;
-		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -230,6 +230,36 @@ describe( 'ConfigureView save wiring', () => {
 		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
+
+	// Metadata lists round-trip in canonical (not click) order, so the reconcile
+	// must set-compare them or a saved field would stay stuck dirty.
+	it( 'reconciles a metadata array even when the server reorders it', () => {
+		const withOutbound = value => ( {
+			esp: { ...INTEGRATION, settings: [ { key: 'outgoing_metadata_fields', type: 'metadata', label: 'Outbound', value } ] },
+		} );
+		const { rerender } = renderConfigureView( {
+			integrations: withOutbound( [] ),
+			inFlightChanges: { esp: { outgoing_metadata_fields: [ 'B', 'A' ] } },
+		} );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+		rerender( buildConfigureView( { integrations: withOutbound( [ 'A', 'B' ] ) } ) );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	// A boolean checkbox draft round-trips from WP options as the string '1', so
+	// the reconcile must coerce or the field would stay stuck dirty.
+	it( 'reconciles a boolean checkbox against a string-typed server value', () => {
+		const withCheckbox = value => ( {
+			esp: { ...INTEGRATION, settings: [ { key: 'sync_delete', type: 'checkbox', label: 'Sync delete', value } ] },
+		} );
+		const { rerender } = renderConfigureView( {
+			integrations: withCheckbox( false ),
+			inFlightChanges: { esp: { sync_delete: true } },
+		} );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+		rerender( buildConfigureView( { integrations: withCheckbox( '1' ) } ) );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
 } );
 
 describe( 'ConfigureView per-id remount', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -20,6 +20,7 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Accordion: ( { children } ) => children,
+	AccordionPanel: ( { children } ) => children,
 	Divider: () => null,
 	Grid: ( { children } ) => children,
 	SectionHeader: () => null,

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -14,10 +14,7 @@ const mockSetHeaderData = jest.fn();
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { setHeaderData: mockSetHeaderData } ),
 } ) );
-// Mocking @wordpress/data above breaks @wordpress/components' real barrel
-// (its autocomplete submodule eagerly requires @wordpress/rich-text, which
-// calls combineReducers() at module load). Stub CheckboxControl directly —
-// the fixtures below have no inbound/outbound fields, so it never renders.
+// Stub the components barrel: with @wordpress/data mocked, the real barrel eagerly loads @wordpress/rich-text, whose module-load combineReducers() call throws.
 jest.mock( '@wordpress/components', () => ( {
 	CheckboxControl: () => null,
 } ) );
@@ -172,6 +169,21 @@ describe( 'ConfigureView save wiring', () => {
 		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abc123' } );
 		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+	} );
+
+	// Guards the draftRef: the header Save action is only re-registered when
+	// hasPending transitions, so a second edit made while already dirty does not
+	// re-run that effect. Reading draftRef.current (not a captured draft) is what
+	// makes Save submit the latest edit.
+	it( 'saves the latest draft after multiple edits', async () => {
+		const onSave = jest.fn( () => Promise.resolve() );
+		renderConfigureView( { onSave } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc' } } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abcd' } } );
+		await act( async () => {
+			getLatestSaveAction()();
+		} );
+		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abcd' } );
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -147,15 +147,21 @@ describe( 'ConfigureView save wiring', () => {
 		useUnsavedChangesDialog.mockReturnValue( { confirmDialog: null, requestConfirm: jest.fn() } );
 	} );
 
-	it( 'saves the current draft and clears it on success', async () => {
+	// Server value for the field once a save of `value` has landed.
+	const savedIntegrations = value => ( {
+		esp: { ...INTEGRATION, settings: [ { key: 'mailchimp_audience_id', type: 'text', label: 'Audience ID', value } ] },
+	} );
+
+	it( 'reconciles the draft once the parent reflects the saved value', async () => {
 		const onSave = jest.fn( () => Promise.resolve() );
-		renderConfigureView( { onSave } );
+		const { rerender } = renderConfigureView( { onSave } );
 		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
 		await act( async () => {
 			getLatestSaveAction()();
 		} );
 		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abc123' } );
-		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( '' );
+		rerender( buildConfigureView( { integrations: savedIntegrations( 'abc123' ), onSave } ) );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 
@@ -184,6 +190,45 @@ describe( 'ConfigureView save wiring', () => {
 			getLatestSaveAction()();
 		} );
 		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abcd' } );
+	} );
+
+	// Fields stay editable during an in-flight save; a successful save must clear
+	// only the submitted values, not edits typed while the request was pending.
+	it( 'preserves edits typed while a save is in flight', async () => {
+		let resolveSave;
+		const onSave = jest.fn(
+			() =>
+				new Promise( resolve => {
+					resolveSave = resolve;
+				} )
+		);
+		const { rerender } = renderConfigureView( { onSave } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
+		act( () => {
+			getLatestSaveAction()();
+		} );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123-more' } } );
+		await act( async () => {
+			resolveSave();
+		} );
+		// Parent reflects only the submitted 'abc123'; the later edit must survive.
+		rerender( buildConfigureView( { integrations: savedIntegrations( 'abc123' ), onSave } ) );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123-more' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+	} );
+
+	// After a save completes the mounted view must clear its draft even if the
+	// instance that clicked Save has since remounted (the seeded instance owns no
+	// success closure) — otherwise it shows a phantom "unsaved changes" state.
+	it( 'clears a re-seeded draft once the server reflects the save', () => {
+		const { rerender } = renderConfigureView( {
+			inFlightChanges: { esp: { mailchimp_audience_id: 'abc123' } },
+			saving: { esp: true },
+		} );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
+		rerender( buildConfigureView( { integrations: savedIntegrations( 'abc123' ), inFlightChanges: {}, saving: {} } ) );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -66,6 +66,7 @@ const buildConfigureView = ( {
 	inFlightChanges = {},
 	saving = {},
 	onSave = jest.fn( () => Promise.resolve() ),
+	onDiscardChanges = jest.fn(),
 	integrationId = 'esp',
 } = {} ) => (
 	<ConfigureView
@@ -74,6 +75,7 @@ const buildConfigureView = ( {
 		inFlightChanges={ inFlightChanges }
 		saving={ saving }
 		onSave={ onSave }
+		onDiscardChanges={ onDiscardChanges }
 		match={ { params: { integrationId } } }
 	/>
 );
@@ -118,6 +120,20 @@ describe( 'ConfigureView unsaved-changes guard', () => {
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
 		fireEvent.change( input, { target: { value: '' } } );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	// Reverting a seeded failed-save edit must clear the parent's retry buffer.
+	it( 'discards the retry buffer when a seeded draft is reverted to its saved value', () => {
+		const onDiscardChanges = jest.fn();
+		const seeded = {
+			esp: { ...INTEGRATION, settings: [ { key: 'mailchimp_audience_id', type: 'text', label: 'Audience ID', value: 'saved' } ] },
+		};
+		render(
+			buildConfigureView( { integrations: seeded, inFlightChanges: { esp: { mailchimp_audience_id: 'failed-edit' } }, onDiscardChanges } )
+		);
+		expect( onDiscardChanges ).not.toHaveBeenCalled();
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'saved' } } );
+		expect( onDiscardChanges ).toHaveBeenCalledWith( 'esp' );
 	} );
 
 	// The "integration not found" branch renders no dialog, so the guard must

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -1,20 +1,33 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import { ConfigureView } from './configure-view';
 import { useUnsavedChangesDialog } from '../../../../../packages/components/src';
-import registerWizardStore from '../../../../../packages/components/src/wizard/store';
 
+const mockSetHeaderData = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setHeaderData: mockSetHeaderData } ),
+} ) );
+// Mocking @wordpress/data above breaks @wordpress/components' real barrel
+// (its autocomplete submodule eagerly requires @wordpress/rich-text, which
+// calls combineReducers() at module load). Stub CheckboxControl directly —
+// the fixtures below have no inbound/outbound fields, so it never renders.
+jest.mock( '@wordpress/components', () => ( {
+	CheckboxControl: () => null,
+} ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Accordion: ( { children } ) => children,
 	Divider: () => null,
 	Grid: ( { children } ) => children,
 	SectionHeader: () => null,
+	// Minimal controlled input so tests can drive the local draft by typing.
+	TextControl: ( { label, value, onChange } ) => <input aria-label={ label } value={ value || '' } onChange={ e => onChange( e.target.value ) } />,
 	useUnsavedChangesDialog: jest.fn( () => ( { confirmDialog: null, requestConfirm: jest.fn() } ) ),
 } ) );
 jest.mock(
@@ -23,76 +36,78 @@ jest.mock(
 		( { children } ) =>
 			children
 );
-
-// Mocking the components barrel above bypasses the Wizard module's module-load
-// side effect that registers the `newspack/wizards` @wordpress/data store, so
-// ConfigureView's useDispatch( WIZARD_STORE_NAMESPACE ) needs it registered here.
-registerWizardStore();
+jest.mock( '../../../../../packages/components/src/wizard/store', () => ( {
+	WIZARD_STORE_NAMESPACE: 'newspack/wizards',
+} ) );
 
 const INTEGRATION = {
 	id: 'esp',
 	name: 'Newsletter ESP',
 	description: 'Syncs reader data with your ESP.',
-	settings: [],
+	settings: [ { key: 'mailchimp_audience_id', type: 'text', label: 'Audience ID', value: '' } ],
 };
 
 const OTHER_INTEGRATION = {
 	id: 'other',
 	name: 'Other ESP',
 	description: 'Syncs reader data with another ESP.',
-	settings: [],
+	settings: [ { key: 'other_id', type: 'text', label: 'Other ID', value: '' } ],
 };
 
-// `saving` accepts either the raw { [integrationId]: boolean } map, or (for the
-// single-integration tests below) a bare boolean shorthand that gets wrapped as
-// { esp: saving }.
 const buildConfigureView = ( {
 	integrations = { esp: INTEGRATION },
-	pendingChanges = {},
-	saving = false,
-	onDiscardChanges = jest.fn(),
+	inFlightChanges = {},
+	saving = {},
+	onSave = jest.fn( () => Promise.resolve() ),
 	integrationId = 'esp',
 } = {} ) => (
 	<ConfigureView
 		integrations={ integrations }
 		loading={ false }
-		pendingChanges={ pendingChanges }
-		saving={ typeof saving === 'object' ? saving : { esp: saving } }
-		onFieldChange={ jest.fn() }
-		onDiscardChanges={ onDiscardChanges }
-		onSave={ jest.fn() }
+		inFlightChanges={ inFlightChanges }
+		saving={ saving }
+		onSave={ onSave }
 		match={ { params: { integrationId } } }
 	/>
 );
 
 const renderConfigureView = props => render( buildConfigureView( props ) );
 
+// The Save button lives in the wizard header, registered via setHeaderData.
+// Pull the latest registered Save action closure so tests can invoke it.
+const getLatestSaveAction = () => {
+	const calls = mockSetHeaderData.mock.calls.filter( ( [ data ] ) => data.actions );
+	return calls[ calls.length - 1 ][ 0 ].actions[ 0 ].action;
+};
+
 describe( 'ConfigureView unsaved-changes guard', () => {
 	beforeEach( () => {
+		mockSetHeaderData.mockClear();
 		useUnsavedChangesDialog.mockClear();
 		useUnsavedChangesDialog.mockReturnValue( { confirmDialog: null, requestConfirm: jest.fn() } );
 	} );
 
-	it( 'does not arm the guard when there are no pending changes and no save in flight', () => {
-		renderConfigureView( { pendingChanges: {}, saving: false } );
+	it( 'does not arm the guard with no draft and no save in flight', () => {
+		renderConfigureView();
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 
-	it( 'arms the guard while there are pending changes and no save in flight', () => {
-		renderConfigureView( { pendingChanges: { esp: { mailchimp_audience_id: 'abc123' } }, saving: false } );
+	it( 'arms the guard once the user edits a field', () => {
+		renderConfigureView();
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
 	} );
 
-	it( 'does not arm the guard while a save is in flight, even with pending changes', () => {
-		renderConfigureView( { pendingChanges: { esp: { mailchimp_audience_id: 'abc123' } }, saving: true } );
+	it( 'does not arm the guard while a save is in flight, even with a draft', () => {
+		renderConfigureView( { saving: { esp: true } } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 
-	// Pins Finding 2: the "integration not found" branch renders no dialog, so the
-	// guard must never arm there even if pendingChanges still has a stale entry
-	// (e.g. from an integration that disappeared from the payload on refetch).
+	// The "integration not found" branch renders no dialog, so the guard must
+	// never arm there even if the retry buffer still has a stale entry.
 	it( 'does not arm the guard when the integration is missing from the payload', () => {
-		renderConfigureView( { integrations: {}, pendingChanges: { esp: { mailchimp_audience_id: 'abc123' } }, saving: false } );
+		renderConfigureView( { integrations: {}, inFlightChanges: { esp: { mailchimp_audience_id: 'abc123' } } } );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 
@@ -101,57 +116,83 @@ describe( 'ConfigureView unsaved-changes guard', () => {
 			confirmDialog: <div data-testid="guard-dialog" />,
 			requestConfirm: jest.fn(),
 		} );
-		renderConfigureView( { pendingChanges: { esp: { mailchimp_audience_id: 'abc123' } }, saving: false } );
+		renderConfigureView( { inFlightChanges: { esp: { mailchimp_audience_id: 'abc123' } } } );
 		expect( screen.getByTestId( 'guard-dialog' ) ).toBeInTheDocument();
 	} );
+} );
 
-	// Pins Finding 1 at the ConfigureView level: unmounting must call the discard
-	// callback for the integration currently in view. The corresponding
-	// index.test.js coverage confirms the parent's real state actually clears.
-	it( 'calls onDiscardChanges for the current integration on unmount', () => {
-		const onDiscardChanges = jest.fn();
-		const { unmount } = renderConfigureView( {
-			pendingChanges: { esp: { mailchimp_audience_id: 'abc123' } },
-			saving: false,
-			onDiscardChanges,
-		} );
-		expect( onDiscardChanges ).not.toHaveBeenCalled();
-		unmount();
-		expect( onDiscardChanges ).toHaveBeenCalledWith( 'esp' );
+describe( 'ConfigureView draft seeding', () => {
+	beforeEach( () => {
+		mockSetHeaderData.mockClear();
+		useUnsavedChangesDialog.mockClear();
+		useUnsavedChangesDialog.mockReturnValue( { confirmDialog: null, requestConfirm: jest.fn() } );
 	} );
 
-	// A save in flight owns the pending changes: handleSave clears them itself on
-	// success, and on failure they are the user's only copy. Unmounting mid-save
-	// (e.g. the user navigates away while `when` is disarmed) must not discard them.
-	it( 'does not call onDiscardChanges on unmount while a save is in flight', () => {
-		const onDiscardChanges = jest.fn();
-		const { unmount } = renderConfigureView( {
-			pendingChanges: { esp: { mailchimp_audience_id: 'abc123' } },
-			saving: true,
-			onDiscardChanges,
-		} );
-		unmount();
-		expect( onDiscardChanges ).not.toHaveBeenCalled();
+	// Returning to an integration whose last save failed re-shows the edit with
+	// the guard armed, so the user can retry.
+	it( 'seeds the draft from the retry buffer', () => {
+		renderConfigureView( { inFlightChanges: { esp: { mailchimp_audience_id: 'abc123' } } } );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
 	} );
 
-	// Navigating between integrations (e.g. #/settings/esp -> #/settings/other)
-	// reuses the same ConfigureView instance instead of unmounting it, since both
-	// routes match the same <Route path="/settings/:integrationId">. The cleanup
-	// from the 'esp' render must still see 'esp' was saving, not whatever
-	// integration is current by the time the cleanup runs.
-	it( 'does not call onDiscardChanges when the integration id changes mid-save', () => {
-		const onDiscardChanges = jest.fn();
+	it( 'starts with a clean draft when the retry buffer is empty', () => {
+		renderConfigureView();
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( '' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+} );
+
+describe( 'ConfigureView save wiring', () => {
+	beforeEach( () => {
+		mockSetHeaderData.mockClear();
+		useUnsavedChangesDialog.mockClear();
+		useUnsavedChangesDialog.mockReturnValue( { confirmDialog: null, requestConfirm: jest.fn() } );
+	} );
+
+	it( 'saves the current draft and clears it on success', async () => {
+		const onSave = jest.fn( () => Promise.resolve() );
+		renderConfigureView( { onSave } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
+		await act( async () => {
+			getLatestSaveAction()();
+		} );
+		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abc123' } );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( '' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	it( 'keeps the draft when the save fails', async () => {
+		const onSave = jest.fn( () => Promise.reject( new Error( 'nope' ) ) );
+		renderConfigureView( { onSave } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
+		await act( async () => {
+			getLatestSaveAction()();
+		} );
+		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abc123' } );
+		expect( screen.getByLabelText( 'Audience ID' ).value ).toBe( 'abc123' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+	} );
+} );
+
+describe( 'ConfigureView per-id remount', () => {
+	beforeEach( () => {
+		mockSetHeaderData.mockClear();
+		useUnsavedChangesDialog.mockClear();
+		useUnsavedChangesDialog.mockReturnValue( { confirmDialog: null, requestConfirm: jest.fn() } );
+	} );
+
+	// Both #/settings/esp and #/settings/other match one Route, so React reuses
+	// the instance across an id change. Keying the inner view by id remounts it,
+	// resetting the draft — esp's edit must not bleed into other.
+	it( 'resets the draft when the integration id changes', () => {
 		const integrations = { esp: INTEGRATION, other: OTHER_INTEGRATION };
-		const pendingChanges = { esp: { mailchimp_audience_id: 'abc123' } };
-		const saving = { esp: true };
-		const { rerender } = renderConfigureView( {
-			integrations,
-			integrationId: 'esp',
-			pendingChanges,
-			saving,
-			onDiscardChanges,
-		} );
-		rerender( buildConfigureView( { integrations, integrationId: 'other', pendingChanges, saving, onDiscardChanges } ) );
-		expect( onDiscardChanges ).not.toHaveBeenCalled();
+		const { rerender } = renderConfigureView( { integrations, integrationId: 'esp' } );
+		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+
+		rerender( buildConfigureView( { integrations, integrationId: 'other' } ) );
+		expect( screen.getByLabelText( 'Other ID' ).value ).toBe( '' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -15,17 +15,26 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { setHeaderData: mockSetHeaderData } ),
 } ) );
 // Stub the components barrel: with @wordpress/data mocked, the real barrel eagerly loads @wordpress/rich-text, whose module-load combineReducers() call throws.
+// Cover everything SettingsField imports so a future select/oauth/textarea fixture renders a stub, not `undefined`.
 jest.mock( '@wordpress/components', () => ( {
 	CheckboxControl: () => null,
+	ExternalLink: ( { children } ) => children,
+	TextareaControl: ( { label, value, onChange } ) => (
+		<textarea aria-label={ label } value={ value || '' } onChange={ e => onChange( e.target.value ) } />
+	),
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Accordion: ( { children } ) => children,
 	AccordionPanel: ( { children } ) => children,
+	Button: ( { children } ) => children,
 	Divider: () => null,
 	Grid: ( { children } ) => children,
 	SectionHeader: () => null,
+	SelectControl: ( { label, value, onChange } ) => (
+		<input aria-label={ label } value={ value || '' } onChange={ e => onChange( e.target.value ) } />
+	),
 	// Minimal controlled input so tests can drive the local draft by typing.
-	TextControl: ( { label, value, onChange } ) => <input aria-label={ label } value={ value || '' } onChange={ e => onChange( e.target.value ) } />,
+	TextControl: ( { label, value, onChange } ) => <input aria-label={ label } value={ value ?? '' } onChange={ e => onChange( e.target.value ) } />,
 	useUnsavedChangesDialog: jest.fn( () => ( { confirmDialog: null, requestConfirm: jest.fn() } ) ),
 } ) );
 jest.mock(
@@ -99,6 +108,15 @@ describe( 'ConfigureView unsaved-changes guard', () => {
 	it( 'does not arm the guard while a save is in flight, even with a draft', () => {
 		renderConfigureView( { saving: { esp: true } } );
 		fireEvent.change( screen.getByLabelText( 'Audience ID' ), { target: { value: 'abc123' } } );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	it( 'disarms the guard when a field is edited back to its saved value', () => {
+		renderConfigureView();
+		const input = screen.getByLabelText( 'Audience ID' );
+		fireEvent.change( input, { target: { value: 'abc123' } } );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+		fireEvent.change( input, { target: { value: '' } } );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 
@@ -259,6 +277,39 @@ describe( 'ConfigureView save wiring', () => {
 		} );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
 		rerender( buildConfigureView( { integrations: withCheckbox( '1' ) } ) );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	// Cleared prefix submits '' but the backend forces 'NP_', so the saved value
+	// never equals the submitted one — value-equality would leave it stuck dirty.
+	it( 'reconciles a field the server normalizes away from the submitted value', () => {
+		const withPrefix = value => ( {
+			esp: { ...INTEGRATION, settings: [ { key: 'metadata_prefix', type: 'text', label: 'Prefix', value } ] },
+		} );
+		const { rerender } = renderConfigureView( {
+			integrations: withPrefix( 'OLD_' ),
+			inFlightChanges: { esp: { metadata_prefix: '' } },
+		} );
+		expect( screen.getByLabelText( 'Prefix' ).value ).toBe( '' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+		rerender( buildConfigureView( { integrations: withPrefix( 'NP_' ) } ) );
+		expect( screen.getByLabelText( 'Prefix' ).value ).toBe( 'NP_' );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	// The control emits '5' but the sanitizer stores 5, so the saved value never
+	// strict-equals the submitted one.
+	it( 'reconciles a number field the server coerces to a numeric type', () => {
+		const withNumber = value => ( {
+			esp: { ...INTEGRATION, settings: [ { key: 'batch_size', type: 'number', label: 'Batch size', value } ] },
+		} );
+		const { rerender } = renderConfigureView( {
+			integrations: withNumber( 1 ),
+			inFlightChanges: { esp: { batch_size: '5' } },
+		} );
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+		rerender( buildConfigureView( { integrations: withNumber( 5 ) } ) );
+		expect( screen.getByLabelText( 'Batch size' ).value ).toBe( '5' );
 		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -152,23 +152,49 @@ const AudienceIntegrations = ( props, ref ) => {
 				path: `${ API_PATH }/${ integrationId }`,
 				method: 'POST',
 				data: { settings },
-			} ).then( () =>
-				apiFetch( {
+			} ).then( () => {
+				// Drop only the just-saved keys from the retry buffer, so an unrelated
+				// pending edit survives but a stale one can't later overwrite the server.
+				setInFlightChanges( prev => {
+					const buffered = prev[ integrationId ];
+					if ( ! buffered ) {
+						return prev;
+					}
+					const remaining = { ...buffered };
+					Object.keys( settings ).forEach( key => delete remaining[ key ] );
+					const next = { ...prev };
+					if ( Object.keys( remaining ).length ) {
+						next[ integrationId ] = remaining;
+					} else {
+						delete next[ integrationId ];
+					}
+					return next;
+				} );
+				return apiFetch( {
 					path: `${ API_PATH }/${ integrationId }/enabled`,
 					method: 'POST',
 					data: { enabled: true },
 				} ).then( data => {
-					// Swap in the integration only once both steps succeed, so an enable
-					// failure leaves the modal's filled fields in place for a retry. The
-					// retry buffer is untouched: this flow saves only the modal's missing
-					// fields and must not discard an unrelated pending ConfigureView edit.
+					// Swap in state only once both steps succeed, so an enable failure
+					// keeps the modal's filled fields for a retry.
 					setIntegrations( data );
 					addEnabledNotice( integrationId, true, data );
 					return data;
-				} )
-			),
+				} );
+			} ),
 		[ addEnabledNotice ]
 	);
+
+	const handleDiscardChanges = useCallback( integrationId => {
+		setInFlightChanges( prev => {
+			if ( ! prev[ integrationId ] ) {
+				return prev;
+			}
+			const next = { ...prev };
+			delete next[ integrationId ];
+			return next;
+		} );
+	}, [] );
 
 	const handleActivatePlugin = useCallback(
 		pluginSlugs => {
@@ -230,6 +256,7 @@ const AudienceIntegrations = ( props, ref ) => {
 		activating,
 		loading,
 		onSave: handleSave,
+		onDiscardChanges: handleDiscardChanges,
 		onToggleEnabled: handleToggleEnabled,
 		onActivatePlugin: handleActivatePlugin,
 		onSetupAndEnable: handleSetupAndEnable,

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -27,7 +27,7 @@ const INTEGRATIONS_BREADCRUMBS = [
 
 const AudienceIntegrations = ( props, ref ) => {
 	const [ integrations, setIntegrations ] = useState( {} );
-	const [ pendingChanges, setPendingChanges ] = useState( {} );
+	const [ inFlightChanges, setInFlightChanges ] = useState( {} );
 	const [ saving, setSaving ] = useState( {} );
 	const [ toggling, setToggling ] = useState( {} );
 	const [ activating, setActivating ] = useState( {} );
@@ -59,7 +59,7 @@ const AudienceIntegrations = ( props, ref ) => {
 		return apiFetch( { path: API_PATH } )
 			.then( data => {
 				setIntegrations( data );
-				setPendingChanges( {} );
+				setInFlightChanges( {} );
 			} )
 			.finally( () => {
 				if ( showLoading ) {
@@ -72,63 +72,40 @@ const AudienceIntegrations = ( props, ref ) => {
 		fetchSettings();
 	}, [ fetchSettings ] );
 
-	const handleFieldChange = useCallback( ( integrationId, fieldKey, value ) => {
-		setPendingChanges( prev => ( {
-			...prev,
-			[ integrationId ]: {
-				...( prev[ integrationId ] || {} ),
-				[ fieldKey ]: value,
-			},
-		} ) );
-	}, [] );
-
-	const handleDiscardChanges = useCallback( integrationId => {
-		setPendingChanges( prev => {
-			if ( ! prev[ integrationId ] ) {
-				return prev;
-			}
-			const next = { ...prev };
-			delete next[ integrationId ];
-			return next;
-		} );
-	}, [] );
-
 	const handleSave = useCallback(
-		integrationId => {
-			setPendingChanges( currentPendingChanges => {
-				const changes = currentPendingChanges[ integrationId ];
-				if ( ! changes || Object.keys( changes ).length === 0 ) {
-					return currentPendingChanges;
-				}
-				setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
-				apiFetch( {
-					path: `${ API_PATH }/${ integrationId }`,
-					method: 'POST',
-					data: { settings: changes },
-				} )
-					.then( data => {
-						setIntegrations( data );
-						setPendingChanges( prev => {
-							const next = { ...prev };
-							delete next[ integrationId ];
-							return next;
-						} );
-					} )
-					.catch( () => {
-						// Leave pendingChanges untouched; the server never received the
-						// edit, so it's the user's only copy. apiFetch already logs the
-						// underlying error to the console and the user can retry.
-						addNotice( {
-							id: `integration-saved-${ integrationId }`,
-							type: 'error',
-							message: __( 'Something went wrong. Please try again.', 'newspack-plugin' ),
-						} );
-					} )
-					.finally( () => {
-						setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
+		( integrationId, changes ) => {
+			if ( ! changes || Object.keys( changes ).length === 0 ) {
+				return Promise.resolve();
+			}
+			setInFlightChanges( prev => ( { ...prev, [ integrationId ]: changes } ) );
+			setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
+			return apiFetch( {
+				path: `${ API_PATH }/${ integrationId }`,
+				method: 'POST',
+				data: { settings: changes },
+			} )
+				.then( data => {
+					setIntegrations( data );
+					setInFlightChanges( prev => {
+						const next = { ...prev };
+						delete next[ integrationId ];
+						return next;
 					} );
-				return currentPendingChanges;
-			} );
+				} )
+				.catch( error => {
+					// Retain inFlightChanges[ integrationId ] as the recovery copy —
+					// the server never received the edit. apiFetch already logged the
+					// error. Rethrow so ConfigureView keeps its local draft.
+					addNotice( {
+						id: `integration-saved-${ integrationId }`,
+						type: 'error',
+						message: __( 'Something went wrong. Please try again.', 'newspack-plugin' ),
+					} );
+					throw error;
+				} )
+				.finally( () => {
+					setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
+				} );
 		},
 		[ addNotice ]
 	);
@@ -186,7 +163,7 @@ const AudienceIntegrations = ( props, ref ) => {
 						return data;
 					} )
 					.finally( () => {
-						setPendingChanges( prev => {
+						setInFlightChanges( prev => {
 							const next = { ...prev };
 							delete next[ integrationId ];
 							return next;
@@ -250,13 +227,11 @@ const AudienceIntegrations = ( props, ref ) => {
 
 	const sharedProps = {
 		integrations,
-		pendingChanges,
+		inFlightChanges,
 		saving,
 		toggling,
 		activating,
 		loading,
-		onFieldChange: handleFieldChange,
-		onDiscardChanges: handleDiscardChanges,
 		onSave: handleSave,
 		onToggleEnabled: handleToggleEnabled,
 		onActivatePlugin: handleActivatePlugin,

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -33,7 +33,7 @@ const AudienceIntegrations = ( props, ref ) => {
 	const [ activating, setActivating ] = useState( {} );
 	const [ loading, setLoading ] = useState( true );
 
-	const { addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, removeNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	const addEnabledNotice = useCallback(
 		( integrationId, enabled, data ) => {
@@ -79,6 +79,9 @@ const AudienceIntegrations = ( props, ref ) => {
 			}
 			setInFlightChanges( prev => ( { ...prev, [ integrationId ]: changes } ) );
 			setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
+			// Drop the previous attempt's snackbar so a retry doesn't stack a second
+			// notice under the same id.
+			removeNotice( `integration-saved-${ integrationId }` );
 			return apiFetch( {
 				path: `${ API_PATH }/${ integrationId }`,
 				method: 'POST',
@@ -90,6 +93,11 @@ const AudienceIntegrations = ( props, ref ) => {
 						const next = { ...prev };
 						delete next[ integrationId ];
 						return next;
+					} );
+					addNotice( {
+						id: `integration-saved-${ integrationId }`,
+						type: 'success',
+						message: __( 'Settings saved.', 'newspack-plugin' ),
 					} );
 				} )
 				.catch( error => {
@@ -107,7 +115,7 @@ const AudienceIntegrations = ( props, ref ) => {
 					setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
 				} );
 		},
-		[ addNotice ]
+		[ addNotice, removeNotice ]
 	);
 
 	const handleToggleEnabled = useCallback(

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -152,31 +152,20 @@ const AudienceIntegrations = ( props, ref ) => {
 				path: `${ API_PATH }/${ integrationId }`,
 				method: 'POST',
 				data: { settings },
-			} ).then( savedData =>
+			} ).then( () =>
 				apiFetch( {
 					path: `${ API_PATH }/${ integrationId }/enabled`,
 					method: 'POST',
 					data: { enabled: true },
+				} ).then( data => {
+					// Swap in the integration only once both steps succeed, so an enable
+					// failure leaves the modal's filled fields in place for a retry. The
+					// retry buffer is untouched: this flow saves only the modal's missing
+					// fields and must not discard an unrelated pending ConfigureView edit.
+					setIntegrations( data );
+					addEnabledNotice( integrationId, true, data );
+					return data;
 				} )
-					// The settings save succeeded even if enabling failed — reflect
-					// the saved values so the UI doesn't offer the modal again for
-					// settings that are already stored.
-					.catch( error => {
-						setIntegrations( savedData );
-						throw error;
-					} )
-					.then( data => {
-						setIntegrations( data );
-						addEnabledNotice( integrationId, true, data );
-						return data;
-					} )
-					.finally( () => {
-						setInFlightChanges( prev => {
-							const next = { ...prev };
-							delete next[ integrationId ];
-							return next;
-						} );
-					} )
 			),
 		[ addEnabledNotice ]
 	);

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -14,12 +14,13 @@ import apiFetch from '@wordpress/api-fetch';
 import AudienceIntegrations from './index';
 
 const mockAddNotice = jest.fn();
+const mockRemoveNotice = jest.fn();
 const captured = {};
 const loadingStates = [];
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( { addNotice: mockAddNotice } ),
+	useDispatch: () => ( { addNotice: mockAddNotice, removeNotice: mockRemoveNotice } ),
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Wizard: ( { sections } ) => {
@@ -54,6 +55,7 @@ const flushPromises = () => new Promise( resolve => setTimeout( resolve, 0 ) );
 describe( 'AudienceIntegrations notices', () => {
 	beforeEach( async () => {
 		mockAddNotice.mockClear();
+		mockRemoveNotice.mockClear();
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( SETTINGS_MAP );
 		render( <AudienceIntegrations /> );
@@ -101,6 +103,31 @@ describe( 'AudienceIntegrations notices', () => {
 				message: 'Something went wrong. Please try again.',
 			} )
 		);
+	} );
+
+	it( 'announces a success snackbar when the save succeeds', async () => {
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+			await flushPromises();
+		} );
+		await waitFor( () =>
+			expect( mockAddNotice ).toHaveBeenCalledWith( {
+				id: 'integration-saved-esp',
+				type: 'success',
+				message: 'Settings saved.',
+			} )
+		);
+	} );
+
+	// Success and error share a notice id, and the wizard keys snackbars by id, so
+	// each save has to clear the previous attempt's notice before adding its own.
+	it( 'clears the previous save snackbar before each save', async () => {
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+			await flushPromises();
+		} );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( 'integration-saved-esp' );
+		expect( mockRemoveNotice.mock.invocationCallOrder[ 0 ] ).toBeLessThan( mockAddNotice.mock.invocationCallOrder[ 0 ] );
 	} );
 
 	it( 'announces an error snackbar when the save request fails', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -104,14 +104,9 @@ describe( 'AudienceIntegrations notices', () => {
 	} );
 
 	it( 'announces an error snackbar when the save request fails', async () => {
-		act( () => {
-			captured.props.onFieldChange( 'esp', 'mailchimp_audience_id', 'abc123' );
-		} );
-		await waitFor( () => expect( captured.props.pendingChanges.esp ).toEqual( { mailchimp_audience_id: 'abc123' } ) );
-
 		apiFetch.mockRejectedValue( new Error( 'nope' ) );
 		await act( async () => {
-			captured.props.onSave( 'esp' );
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } ).catch( () => {} );
 			await flushPromises();
 		} );
 		await waitFor( () =>
@@ -222,7 +217,7 @@ describe( 'AudienceIntegrations notices', () => {
 	} );
 } );
 
-describe( 'AudienceIntegrations pending changes', () => {
+describe( 'AudienceIntegrations retry buffer', () => {
 	beforeEach( async () => {
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( SETTINGS_MAP );
@@ -230,44 +225,41 @@ describe( 'AudienceIntegrations pending changes', () => {
 		await waitFor( () => expect( captured.props.loading ).toBe( false ) );
 	} );
 
-	// Pins Finding 1: onDiscardChanges must clear the real pendingChanges state
-	// in the parent, not just be a callback that gets invoked. A no-op
-	// handleDiscardChanges would fail this assertion even though it would pass
-	// a test that only checks the callback was called.
-	it( "clears an integration's pending changes when onDiscardChanges is called", async () => {
-		act( () => {
-			captured.props.onFieldChange( 'esp', 'mailchimp_audience_id', 'abc123' );
-		} );
-		await waitFor( () => expect( captured.props.pendingChanges.esp ).toEqual( { mailchimp_audience_id: 'abc123' } ) );
-
-		act( () => {
-			captured.props.onDiscardChanges( 'esp' );
-		} );
-		await waitFor( () => expect( captured.props.pendingChanges.esp ).toBeUndefined() );
-	} );
-
-	it( 'is a no-op when there is nothing pending for the integration', async () => {
-		const pendingChangesBefore = captured.props.pendingChanges;
-		act( () => {
-			captured.props.onDiscardChanges( 'esp' );
-		} );
-		expect( captured.props.pendingChanges ).toBe( pendingChangesBefore );
-	} );
-
-	// Pins a data-safety property: on a failed save, the server never received
-	// the edit, so pendingChanges is the user's only copy of it. A future
-	// refactor must not start clearing it on failure.
-	it( 'preserves pendingChanges when the save request fails', async () => {
-		act( () => {
-			captured.props.onFieldChange( 'esp', 'mailchimp_audience_id', 'abc123' );
-		} );
-		await waitFor( () => expect( captured.props.pendingChanges.esp ).toEqual( { mailchimp_audience_id: 'abc123' } ) );
-
-		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+	it( 'clears the retry buffer when the save succeeds', async () => {
 		await act( async () => {
-			captured.props.onSave( 'esp' );
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
 			await flushPromises();
 		} );
-		expect( captured.props.pendingChanges.esp ).toEqual( { mailchimp_audience_id: 'abc123' } );
+		expect( captured.props.inFlightChanges.esp ).toBeUndefined();
+	} );
+
+	// The server never received a failed edit, so the buffer is the user's only
+	// copy. A future change must not start clearing it on failure.
+	it( 'retains the retry buffer when the save fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } ).catch( () => {} );
+			await flushPromises();
+		} );
+		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'abc123' } );
+	} );
+
+	it( 'marks the integration saving while the request is in flight', async () => {
+		let resolveSave;
+		apiFetch.mockImplementation(
+			() =>
+				new Promise( resolve => {
+					resolveSave = resolve;
+				} )
+		);
+		act( () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+		} );
+		await waitFor( () => expect( captured.props.saving.esp ).toBe( true ) );
+		await act( async () => {
+			resolveSave( SETTINGS_MAP );
+			await flushPromises();
+		} );
+		expect( captured.props.saving.esp ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -303,6 +303,37 @@ describe( 'AudienceIntegrations retry buffer', () => {
 		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'from-configure' } );
 	} );
 
+	// A key saved via setup-and-enable is dropped from the buffer; others stay.
+	it( 'drops only the overlapping keys from the retry buffer on setup-and-enable', async () => {
+		apiFetch.mockReset();
+		apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'A', other_field: 'keep' } ).catch( () => {} );
+			await flushPromises();
+		} );
+		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'A', other_field: 'keep' } );
+
+		apiFetch.mockResolvedValue( SETTINGS_MAP );
+		await act( async () => {
+			await captured.props.onSetupAndEnable( 'esp', { mailchimp_audience_id: 'B' } );
+		} );
+		expect( captured.props.inFlightChanges.esp ).toEqual( { other_field: 'keep' } );
+	} );
+
+	it( 'clears the retry buffer when a ConfigureView discards its changes', async () => {
+		apiFetch.mockReset();
+		apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'A' } ).catch( () => {} );
+			await flushPromises();
+		} );
+		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'A' } );
+		act( () => {
+			captured.props.onDiscardChanges( 'esp' );
+		} );
+		expect( captured.props.inFlightChanges.esp ).toBeUndefined();
+	} );
+
 	it( 'marks the integration saving while the request is in flight', async () => {
 		let resolveSave;
 		apiFetch.mockImplementation(

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -164,6 +164,20 @@ describe( 'AudienceIntegrations notices', () => {
 		expect( mockAddNotice ).not.toHaveBeenCalled();
 	} );
 
+	// On a settings-ok/enable-fail partial, keep the pre-save integration so the
+	// modal keeps its fields for a retry instead of collapsing to a bare error.
+	it( 'does not swap integration state when only the enable step fails', async () => {
+		const savedData = {
+			esp: { id: 'esp', name: 'Newsletter ESP', enabled: false, settings: [ { key: 'mailchimp_audience_id', value: 'abc123' } ] },
+		};
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValueOnce( savedData ).mockRejectedValueOnce( new Error( 'nope' ) );
+		await act( async () => {
+			await expect( captured.props.onSetupAndEnable( 'esp', { mailchimp_audience_id: 'abc123' } ) ).rejects.toThrow( 'nope' );
+		} );
+		expect( captured.props.integrations.esp.settings ).toEqual( [] );
+	} );
+
 	it( 'keeps the activating state for a minimum window even when activation is instant', async () => {
 		jest.useFakeTimers();
 		try {
@@ -269,6 +283,24 @@ describe( 'AudienceIntegrations retry buffer', () => {
 			await flushPromises();
 		} );
 		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'abc123' } );
+	} );
+
+	// Setup-and-enable saves only the modal's fields, so it must not discard an
+	// unrelated failed ConfigureView edit still in the retry buffer.
+	it( 'preserves a prior failed-save retry buffer across a setup-and-enable', async () => {
+		apiFetch.mockReset();
+		apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'from-configure' } ).catch( () => {} );
+			await flushPromises();
+		} );
+		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'from-configure' } );
+
+		apiFetch.mockResolvedValue( SETTINGS_MAP );
+		await act( async () => {
+			await captured.props.onSetupAndEnable( 'esp', { other_field: 'x' } );
+		} );
+		expect( captured.props.inFlightChanges.esp ).toEqual( { mailchimp_audience_id: 'from-configure' } );
 	} );
 
 	it( 'marks the integration saving while the request is in flight', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
@@ -68,7 +68,7 @@ export const SettingsSection = ( {
 				) }
 				{ ! loading && integrationIds.length > 0 && (
 					<>
-						<Grid columns={ 2 } gutter={ 16 }>
+						<Grid columns={ 2 }>
 							{ integrationIds.map( id => {
 								const integration = integrations[ id ];
 								const {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Separates the Configure form's live draft from the save retry buffer in the Audience → Integrations wizard, and fixes the unsaved-changes edge cases that separation surfaces.

- The Configure form's unsaved edits now belong to the view and reset when you leave or switch integrations. The retry buffer — the copy that survives a failed save — stays in the request layer, so a failed edit is never lost: returning to the integration re-shows it with Save enabled to retry.
- A field the backend normalizes on save no longer stays stuck "unsaved" after a successful save (clearing the Metadata prefix stores `NP_`; a number field's text coerces to a number), and no longer fires a redundant save on the next click.
- Editing a field back to its saved value now clears the unsaved-changes state instead of leaving it dirty.
- When enabling an integration fails after its settings already saved, the enable dialog keeps the fields you filled in for an in-place retry, and an unrelated pending Configure edit is preserved.

Follows #258 (now merged), which added the unsaved-changes guard this refactor rebuilds on. Carries #641 (components more-menu fix) and #657 (integrations settings polish); both land together when this merges.

### How to test the changes in this Pull Request:

1. Go to **Audience → Integrations** and open an ESP integration's Configure view. Change a field and Save — confirm the success notice, that Save disables afterward, and that leaving the view prompts no unsaved-changes dialog.
2. Clear the **Metadata field prefix** and Save. Confirm the field reconciles to `NP_`, Save disables, and clicking Save again does **not** fire another request.
3. Edit a field, then edit it back to its original value. Confirm Save disables and leaving the view prompts no unsaved-changes dialog.
4. Simulate a failed save (e.g. go offline) and Save. Confirm an error notice, the value is retained, and Save stays enabled. Leave the view in-app and return — confirm the edit is re-shown with Save enabled. Go back online and Save — confirm success and that the retry state clears.
5. From the Integrations grid, **Enable** an integration that needs required fields. Fill the dialog fields and trigger an enable failure (e.g. offline). Confirm the dialog keeps your filled fields (does not collapse to a bare error) so you can retry.
6. With a pending failed Configure edit on one field, use the grid Enable dialog to save a **different** required field. Return to Configure and confirm your pending edit is still there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
