### PR TITLE
feat(network): product network ID assignment + verification CLI (NPPD-2057)

### DIFF
--- a/plugins/newspack-network/includes/class-initializer.php
+++ b/plugins/newspack-network/includes/class-initializer.php
@@ -58,6 +58,7 @@ class Initializer {
 		Data_Backfill::init();
 		Membership_Dedupe::init();
 		CLI\Integrity_Check::init();
+		CLI\Product_Network_Ids::init();
 
 		Woocommerce\Events::init();
 		Woocommerce\Product_Admin::init();

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -719,8 +719,15 @@ class Product_Network_Ids {
 			WP_CLI::error( 'Verification found issues ( see above ). Not ready to flip.' );
 		}
 
+		if ( $is_json ) {
+			// JSON mode prints exactly one line, the report above, on both the passing and the failing
+			// path ( WP_CLI::error writes to stderr ), so an aggregator can json_decode stdout as-is.
+			// The verdict is carried by the exit code and by the report's own 'ready_to_flip'.
+			return;
+		}
+
 		WP_CLI::success( sprintf( 'All checked products carry a Network ID and are linked on %s.', $expectation['label'] ) );
-		if ( ! $is_json && ! $expectation['require_all'] && 1 === $expectation['minimum'] ) {
+		if ( ! $expectation['require_all'] && 1 === $expectation['minimum'] ) {
 			// Being linked *somewhere* is not the guarantee operators read into a green run: access is only
 			// granted from the site a reader's own subscription lives on.
 			WP_CLI::line( 'Note: this only proves each product is linked somewhere, not that every site a reader may subscribe on carries the ID. Re-run with --expect-sites=all ( on the Hub ) or --expect-sites=<count> to gate on real coverage.' );
@@ -745,6 +752,13 @@ class Product_Network_Ids {
 				'minimum'     => 1,
 				'label'       => 'at least 1 other site',
 			];
+		}
+
+		// A bare --expect-sites ( or --no-expect-sites ) arrives from WP-CLI as a boolean. (string) true
+		// is '1', which would pass the integer guard below and silently resolve to the 1-site floor: a
+		// green run for an operator who meant --expect-sites=all and fumbled the syntax.
+		if ( is_bool( $raw ) ) {
+			WP_CLI::error( '--expect-sites needs a value: pass "all" or a positive integer ( e.g. --expect-sites=all or --expect-sites=3 ). Omit the flag entirely for the default of 1 other site.' );
 		}
 
 		if ( 'all' === $raw ) {
@@ -966,9 +980,16 @@ class Product_Network_Ids {
 	 */
 	private static function get_products_to_check( $product_ids = null ) {
 		if ( null !== $product_ids ) {
+			$product_ids = array_map( 'intval', $product_ids );
+
+			// Prime up front, as on the default set below: get_network_id() reads the post and its meta,
+			// which would otherwise be a DB round trip per product on exactly the input a scripted flip
+			// gate passes.
+			self::prime_post_caches( $product_ids );
+
 			$products = [];
 			foreach ( $product_ids as $product_id ) {
-				$products[ (int) $product_id ] = Product_Admin::get_network_id( $product_id );
+				$products[ $product_id ] = Product_Admin::get_network_id( $product_id );
 			}
 			return $products;
 		}

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -236,6 +236,9 @@ class Product_Network_Ids {
 		$to_write = 0;
 		foreach ( $assignments as $product_id => $network_id ) {
 			$product_id = (int) $product_id;
+			// Sanitize at the write path so the meta is consistent whatever the source ( plan meta or --map ),
+			// matching the product metabox's sanitize_text_field(). Done before the preview so dry-run matches apply.
+			$network_id = sanitize_text_field( (string) $network_id );
 
 			$post_type = get_post_type( $product_id );
 			if ( 'product' !== $post_type ) {
@@ -473,7 +476,11 @@ class Product_Network_Ids {
 
 		$assignments = [];
 		foreach ( $decoded as $product_id => $network_id ) {
-			$network_id = trim( (string) $network_id );
+			if ( ! is_scalar( $network_id ) ) {
+				WP_CLI::warning( sprintf( 'Skipping product #%d in --map: Network ID must be a string.', (int) $product_id ) );
+				continue;
+			}
+			$network_id = sanitize_text_field( (string) $network_id );
 			if ( '' === $network_id ) {
 				WP_CLI::warning( sprintf( 'Skipping product #%d in --map: empty Network ID.', (int) $product_id ) );
 				continue;

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -34,11 +34,41 @@ class Product_Network_Ids {
 	const PLAN_PRODUCT_IDS_META_KEY = '_product_ids';
 
 	/**
-	 * Initialize this class and register the WP-CLI commands.
+	 * How many product writes to make before flushing the Data Events dispatch queue.
+	 *
+	 * Data_Events::dispatch() only queues; the queue is drained on shutdown. Flushing periodically
+	 * keeps the queued payloads from accumulating in memory for the whole run and means a run that
+	 * dies mid-way has already propagated everything up to the last flush.
+	 *
+	 * @var int
+	 */
+	const DISPATCH_FLUSH_INTERVAL = 100;
+
+	/**
+	 * How many posts to prime the meta cache for at a time.
+	 *
+	 * Priming loads every meta row of every listed post, so it is chunked to bound peak memory on
+	 * stores with many products.
+	 *
+	 * @var int
+	 */
+	const META_CACHE_CHUNK_SIZE = 500;
+
+	/**
+	 * Initialize this class and register hooks.
 	 *
 	 * @return void
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_commands' ] );
+	}
+
+	/**
+	 * Register the WP-CLI commands.
+	 *
+	 * @return void
+	 */
+	public static function register_commands() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			// These are migration tooling, so they take the migration flow's --apply flag ( dry-run by default )
 			// rather than this plugin's older data-* commands' --live flag.
@@ -56,17 +86,31 @@ class Product_Network_Ids {
 	 * two plans with different Network IDs is ambiguous: it is withheld from the assignments and
 	 * reported as a conflict rather than guessed.
 	 *
+	 * Plan Network IDs are sanitized here, before the emptiness check, so a whitespace-only ( or
+	 * markup-only ) plan value is treated as "no Network ID" rather than surviving as an assignment
+	 * that later sanitizes down to '' and blanks a product.
+	 *
 	 * @param array $plans Array of [ 'network_id' => string, 'product_ids' => int[] ].
 	 * @return array {
 	 *     @type array $assignments Map of product ID => Network ID.
 	 *     @type array $conflicts   Map of product ID => list of the distinct Network IDs claiming it.
+	 *     @type array $stats       Per-plan diagnostics: total, without_network_id, without_products.
 	 * }
 	 */
 	public static function derive_assignments_from_plans( array $plans ) {
-		$claims = []; // Product ID => list of distinct Network IDs claiming it.
+		$claims             = []; // Product ID => list of distinct Network IDs claiming it.
+		$without_network_id = 0;
+		$without_products   = 0;
+
 		foreach ( $plans as $plan ) {
-			$network_id  = (string) ( $plan['network_id'] ?? '' );
+			$network_id  = sanitize_text_field( (string) ( $plan['network_id'] ?? '' ) );
 			$product_ids = $plan['product_ids'] ?? [];
+			if ( '' === $network_id ) {
+				$without_network_id++;
+			}
+			if ( empty( $product_ids ) ) {
+				$without_products++;
+			}
 			if ( '' === $network_id || empty( $product_ids ) ) {
 				continue;
 			}
@@ -94,6 +138,11 @@ class Product_Network_Ids {
 		return [
 			'assignments' => $assignments,
 			'conflicts'   => $conflicts,
+			'stats'       => [
+				'total'              => count( $plans ),
+				'without_network_id' => $without_network_id,
+				'without_products'   => $without_products,
+			],
 		];
 	}
 
@@ -170,6 +219,10 @@ class Product_Network_Ids {
 	 * written to every product the plan links ). Pass --map to assign an explicit operator mapping
 	 * instead. Runs in dry-run mode unless --apply is given.
 	 *
+	 * Exits non-zero when anything could not be assigned ( a plan carrying no Network ID, a product
+	 * claimed by two plans with different IDs, a product already carrying a different ID without
+	 * --overwrite ), so a scripted migration cannot record a green step for a partial run.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--map=<map>]
@@ -180,6 +233,10 @@ class Product_Network_Ids {
 	 * : Overwrite a product's existing Network ID when it differs from the derived/mapped value.
 	 * By default, existing differing values are left untouched and reported.
 	 *
+	 * [--repropagate]
+	 * : Also emit a product_updated event for products that already carry the target Network ID.
+	 * Use this to re-sync an already-tagged but desynced product, which otherwise fires no event.
+	 *
 	 * [--apply]
 	 * : Write the changes. Without this flag the command only reports what it would do.
 	 *
@@ -188,6 +245,7 @@ class Product_Network_Ids {
 	 *     wp newspack-network assign-product-network-ids
 	 *     wp newspack-network assign-product-network-ids --apply
 	 *     wp newspack-network assign-product-network-ids --map='{"123":"premium","456":"premium"}' --apply
+	 *     wp newspack-network assign-product-network-ids --apply --repropagate
 	 *
 	 * @param array $args       Positional arguments ( unused ).
 	 * @param array $assoc_args Associative arguments.
@@ -196,8 +254,10 @@ class Product_Network_Ids {
 	public static function assign( $args, $assoc_args ) {
 		self::require_network_site();
 
-		$apply     = isset( $assoc_args['apply'] );
-		$overwrite = isset( $assoc_args['overwrite'] );
+		$apply       = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'apply', false );
+		$overwrite   = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'overwrite', false );
+		$repropagate = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'repropagate', false );
+		$map         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'map', null );
 
 		// Writing the meta only propagates across the network through the newspack_network_product_updated
 		// listener, which registers only when Newspack\Data_Events is loaded and emits only when wc_get_product
@@ -215,18 +275,48 @@ class Product_Network_Ids {
 
 		if ( ! $can_propagate ) {
 			WP_CLI::warning(
-				'Cross-site propagation is unavailable here ( newspack_network_product_updated needs Newspack\\Data_Events and WooCommerce active ). Network IDs will be written to this site only; propagate them afterwards with "wp newspack-network data-backfill newspack_network_product_updated --live".'
+				'Cross-site propagation is unavailable here ( newspack_network_product_updated needs Newspack\\Data_Events and WooCommerce active ). Network IDs will be written to this site only; once both are active, re-run this command with --apply --repropagate to emit the events.'
 			);
 			WP_CLI::line( '' );
 		}
 
-		if ( isset( $assoc_args['map'] ) ) {
-			$assignments = self::parse_map( $assoc_args['map'] );
+		// Everything this command cannot resolve. Reported per item below and rolled into a non-zero
+		// exit at the end so "assign, then verify" cannot record a green step on a partial run.
+		$unresolved  = 0;
+		$plans_found = 0;
+
+		if ( null !== $map ) {
+			$assignments = self::parse_map( $map );
 			WP_CLI::line( sprintf( 'Using explicit operator mapping ( %d product(s) ).', count( $assignments ) ) );
 		} else {
-			$derived     = self::derive_assignments_from_plans( self::get_plans() );
+			$plans       = self::get_plans();
+			$plans_found = count( $plans );
+			$derived     = self::derive_assignments_from_plans( $plans );
 			$assignments = $derived['assignments'];
+			$stats       = $derived['stats'];
+
+			WP_CLI::line(
+				sprintf(
+					'Found %d membership plan(s): %d carry no Network ID, %d link no products.',
+					$stats['total'],
+					$stats['without_network_id'],
+					$stats['without_products']
+				)
+			);
 			WP_CLI::line( sprintf( 'Derived %d assignment(s) from membership plans.', count( $assignments ) ) );
+
+			// A plan nobody ever tagged is the NPPD-2057 field condition, and this is the only place in
+			// the system positioned to see it -- so it is reported, not silently skipped.
+			if ( $stats['without_network_id'] > 0 ) {
+				WP_CLI::warning(
+					sprintf(
+						'%d membership plan(s) carry no Network ID, so their products cannot be derived. Set the plan Network ID on every site ( the same value on matching plans ), or assign the products via --map.',
+						$stats['without_network_id']
+					)
+				);
+				$unresolved += $stats['without_network_id'];
+			}
+
 			foreach ( $derived['conflicts'] as $product_id => $network_ids ) {
 				WP_CLI::warning(
 					sprintf(
@@ -235,37 +325,82 @@ class Product_Network_Ids {
 						implode( ', ', $network_ids )
 					)
 				);
+				$unresolved++;
 			}
 		}
 		WP_CLI::line( '' );
 
+		// One query for the whole working set: the loop below reads the post type and the Network ID
+		// meta of every assignment, which would otherwise be two DB round trips per product.
+		self::prime_post_caches( array_keys( $assignments ) );
+
+		// A plan may link variation IDs; the Network ID lives on the parent product ( that is where
+		// Product_Admin::get_network_id resolves it from ), so fold them in rather than skipping them.
+		$folded      = self::fold_variations_into_parents( $assignments );
+		$assignments = $folded['assignments'];
+		foreach ( $folded['conflicts'] as $product_id => $network_ids ) {
+			WP_CLI::warning(
+				sprintf(
+					'Product #%d is claimed with different Network IDs ( %s ) once its variations are resolved to it - skipped. Resolve manually or via --map.',
+					$product_id,
+					implode( ', ', $network_ids )
+				)
+			);
+			$unresolved++;
+		}
+
 		if ( empty( $assignments ) ) {
 			WP_CLI::warning( 'No assignments to make.' );
+			if ( $plans_found > 0 || null !== $map || $unresolved > 0 ) {
+				// Plans ( or a map ) exist but nothing could be derived from them: a no-op here reads as
+				// "already migrated" if it exits 0, so fail instead.
+				WP_CLI::error( 'Nothing could be assigned. Cross-site paid access will grant nothing here.' );
+			}
 			return;
 		}
 
-		$skipped  = 0;
-		$already  = 0;
-		$to_write = 0;
+		$skipped      = 0;
+		$already      = 0;
+		$to_write     = 0;
+		$inapplicable = 0;
+		$dispatched   = 0;
 		foreach ( $assignments as $product_id => $network_id ) {
 			$product_id = (int) $product_id;
 			// Sanitize at the write path so the meta is consistent whatever the source ( plan meta or --map ),
 			// matching the product metabox's sanitize_text_field(). Done before the preview so dry-run matches apply.
 			$network_id = sanitize_text_field( (string) $network_id );
 
-			$post_type = get_post_type( $product_id );
-			if ( 'product' !== $post_type ) {
-				// The Network ID lives on the parent product; variations resolve to it via Product_Admin::get_network_id.
-				$reason = 'product_variation' === $post_type ? 'a product variation ( set the Network ID on its parent product )' : 'not a product';
-				WP_CLI::warning( sprintf( 'Skipping #%d: %s.', $product_id, $reason ) );
+			// Never write a blank Network ID: it is indistinguishable from "untagged", and with --overwrite
+			// it would replace a correct value and propagate the blank to every site.
+			if ( '' === $network_id ) {
+				WP_CLI::warning( sprintf( 'Skipping #%d: the Network ID is empty - refusing to write a blank value.', $product_id ) );
 				$skipped++;
 				continue;
 			}
 
+			if ( 'product' !== get_post_type( $product_id ) ) {
+				WP_CLI::warning( sprintf( 'Skipping #%d: not a product.', $product_id ) );
+				$skipped++;
+				continue;
+			}
+
+			// Access only ever grants from a reader's synced subscriptions, and the product metabox only
+			// writes for these types, so tagging anything else would just bloat every site's synced map.
+			if ( ! self::is_taggable_product( $product_id ) ) {
+				WP_CLI::line( sprintf( '  #%d is not a subscription product; a Network ID would grant nothing - left alone.', $product_id ) );
+				$inapplicable++;
+				continue;
+			}
+
 			$current = (string) get_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, true );
-			if ( $current === (string) $network_id ) {
+			if ( $current === $network_id ) {
 				WP_CLI::line( sprintf( '  #%d already set to "%s".', $product_id, $network_id ) );
 				$already++;
+				if ( $apply && $repropagate ) {
+					do_action( 'newspack_network_save_product', $product_id );
+					$dispatched++;
+					self::maybe_flush_dispatch_queue( $dispatched );
+				}
 				continue;
 			}
 			if ( '' !== $current && ! $overwrite ) {
@@ -283,22 +418,63 @@ class Product_Network_Ids {
 				update_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, $network_id );
 				// Fire the same action the product metabox fires, so the existing emitter propagates the change.
 				do_action( 'newspack_network_save_product', $product_id );
+				$dispatched++;
+				self::maybe_flush_dispatch_queue( $dispatched );
 			}
+		}
+		$unresolved += $skipped;
+
+		if ( $dispatched > 0 ) {
+			self::flush_dispatch_queue();
 		}
 
 		WP_CLI::line( '' );
 		if ( $apply ) {
-			WP_CLI::success( sprintf( 'Wrote %d product Network ID(s), skipped %d, %d already set.', $to_write, $skipped, $already ) );
+			WP_CLI::line(
+				sprintf(
+					'Wrote %d product Network ID(s), skipped %d, %d already set, %d not applicable.',
+					$to_write,
+					$skipped,
+					$already,
+					$inapplicable
+				)
+			);
 			if ( ! $can_propagate ) {
-				WP_CLI::warning( 'These writes were NOT propagated ( see the warning above ). Once Data Events and WooCommerce are active, replay propagation with:' );
-			} else {
-				// A product already carrying the target Network ID fires no event, so this command cannot
-				// re-propagate an already-tagged-but-desynced product. Point operators at the backfill for that.
-				WP_CLI::line( 'Products already carrying the target Network ID fire no event; if propagation may have been missed ( including for already-set products ), replay it with:' );
+				WP_CLI::warning( 'These writes were NOT propagated ( see the warning above ). Once Data Events and WooCommerce are active, re-run with --apply --repropagate to emit the events.' );
+			} elseif ( ! $repropagate ) {
+				// A product already carrying the target Network ID fires no event, so a plain run cannot
+				// re-sync an already-tagged-but-desynced product.
+				WP_CLI::line( 'Products already carrying the target Network ID fired no event. To re-emit for every assigned product, re-run with --apply --repropagate.' );
+				WP_CLI::line( 'Note: "data-backfill newspack_network_product_updated --live" is not a reliable replay for this - on a Hub it dedupes against the event log on the product\'s post_modified_gmt timestamp, which writing this meta does not change.' );
 			}
-			WP_CLI::line( '  wp newspack-network data-backfill newspack_network_product_updated --live' );
 		} else {
-			WP_CLI::success( sprintf( 'Dry run: %d product Network ID(s) would be written, %d skipped, %d already set. Re-run with --apply.', $to_write, $skipped, $already ) );
+			WP_CLI::line(
+				sprintf(
+					'Dry run: %d product Network ID(s) would be written, %d skipped, %d already set, %d not applicable.',
+					$to_write,
+					$skipped,
+					$already,
+					$inapplicable
+				)
+			);
+		}
+		WP_CLI::line( '' );
+
+		if ( $unresolved > 0 ) {
+			// Exit non-zero so a scripted migration cannot treat a partial assignment as done: everything
+			// withheld here is a product ( or plan ) that will grant nothing across the network.
+			WP_CLI::error(
+				sprintf(
+					'%d item(s) could not be assigned ( see the warnings above ). Resolve them ( e.g. via --map ) and re-run; verify-product-network-ids will fail until they are.',
+					$unresolved
+				)
+			);
+		}
+
+		if ( $apply ) {
+			WP_CLI::success( 'Every derived product Network ID is assigned.' );
+		} else {
+			WP_CLI::success( 'Dry run complete: every derived product Network ID can be assigned. Re-run with --apply.' );
 		}
 		WP_CLI::line( '' );
 	}
@@ -312,6 +488,11 @@ class Product_Network_Ids {
 	 * or not tagged at all, so the cross-site grant resolves to nothing ). Run it on every site: each
 	 * site's linkage check confirms the other sites' products are present in its synced map.
 	 *
+	 * The default product set is every product the site's membership plans link, plus every product that
+	 * already carries a Network ID -- not just the tagged ones. Checking only tagged products would hide
+	 * exactly what assign-product-network-ids withholds ( conflicts, skipped products ), so a network
+	 * that assign could not finish would still verify green.
+	 *
 	 * Limitation: the synced products option is append-only ( there is no product-deleted listener ), so a
 	 * stale entry for a since-removed product or site can still report as "linked" -- the same class of
 	 * caveat as relying on the site's URL staying byte-identical as the map key.
@@ -319,9 +500,9 @@ class Product_Network_Ids {
 	 * ## OPTIONS
 	 *
 	 * [--products=<ids>]
-	 * : Comma-separated product IDs to check ( e.g. a gate's products ). Defaults to every local product
-	 * that carries a Network ID. To gate a flip, pass the gate's product IDs: the bare form only looks at
-	 * already-tagged products, so a site with zero tagged products ( the NPPD-2057 failure ) passes it.
+	 * : Comma-separated product IDs to check ( e.g. a gate's products ). Defaults to every product linked
+	 * by a membership plan plus every product that already carries a Network ID. Pass a gate's product IDs
+	 * to check exactly what the gate depends on.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -341,10 +522,16 @@ class Product_Network_Ids {
 			$network_products = [];
 		}
 
-		$explicit_products = isset( $assoc_args['products'] );
-		$local_products    = self::get_products_to_check(
-			$explicit_products ? wp_parse_id_list( $assoc_args['products'] ) : null
-		);
+		$product_ids = null;
+		if ( isset( $assoc_args['products'] ) ) {
+			$product_ids = wp_parse_id_list( $assoc_args['products'] );
+			if ( empty( $product_ids ) ) {
+				// An unset shell variable ( --products="$GATE_PRODUCTS" ) must never read as "nothing to
+				// check, all good": this is the path a scripted flip gate runs.
+				WP_CLI::error( '--products was passed but no product IDs could be parsed from it. Pass a comma-separated list of product IDs, or omit --products to check every plan-linked and tagged product.' );
+			}
+		}
+		$local_products = self::get_products_to_check( $product_ids );
 
 		WP_CLI::line( '' );
 		WP_CLI::line( sprintf( 'Verifying product Network IDs for %s.', $current_site ) );
@@ -353,15 +540,13 @@ class Product_Network_Ids {
 		WP_CLI::line( '' );
 
 		if ( empty( $local_products ) ) {
-			WP_CLI::warning( 'No products carry a Network ID on this site. Cross-site paid access will grant nothing here. Run assign-product-network-ids first.' );
-			return;
+			WP_CLI::error( 'No products to check: no membership plan links a subscription product and no product carries a Network ID. Cross-site paid access will grant nothing here. Run assign-product-network-ids first, or pass --products with the gate\'s products.' );
 		}
 
 		$findings = self::verify_products( $local_products, $network_products, $current_site );
 		$untagged = 0;
 		$unlinked = 0;
 		foreach ( $findings as $product_id => $finding ) {
-			// An untagged product ( only reachable when passed explicitly via --products ) is the NPPD-2057 failure itself.
 			if ( '' === $finding['network_id'] ) {
 				WP_CLI::warning( sprintf( '#%d: no Network ID set ( cross-site access grants nothing ). Run assign-product-network-ids.', $product_id ) );
 				$untagged++;
@@ -383,8 +568,8 @@ class Product_Network_Ids {
 		WP_CLI::line( '' );
 		WP_CLI::line( sprintf( 'Checked %d product(s): %d untagged, %d unlinked.', count( $findings ), $untagged, $unlinked ) );
 		if ( $unlinked > 0 ) {
-			WP_CLI::line( 'For unlinked products, make sure every site has run assign-product-network-ids and its product_updated events have propagated:' );
-			WP_CLI::line( '  wp newspack-network data-backfill newspack_network_product_updated --live' );
+			WP_CLI::line( 'For unlinked products, make sure every site has run assign-product-network-ids, then re-emit the events from those sites with:' );
+			WP_CLI::line( '  wp newspack-network assign-product-network-ids --apply --repropagate' );
 		}
 		if ( $untagged > 0 || $unlinked > 0 ) {
 			// Exit non-zero so callers can gate a flip on this check.
@@ -424,6 +609,8 @@ class Product_Network_Ids {
 			]
 		);
 
+		self::prime_post_caches( $plan_posts );
+
 		$plans = [];
 		foreach ( $plan_posts as $plan_id ) {
 			$product_ids = get_post_meta( $plan_id, self::PLAN_PRODUCT_IDS_META_KEY, true );
@@ -436,13 +623,106 @@ class Product_Network_Ids {
 	}
 
 	/**
+	 * Every product ID linked by a membership plan, whatever the plan's Network ID.
+	 *
+	 * @return int[]
+	 */
+	private static function get_plan_linked_product_ids() {
+		$product_ids = [];
+		foreach ( self::get_plans() as $plan ) {
+			foreach ( $plan['product_ids'] as $product_id ) {
+				$product_ids[] = (int) $product_id;
+			}
+		}
+		return array_values( array_unique( $product_ids ) );
+	}
+
+	/**
+	 * Resolve a variation ID to its parent product ID, leaving anything else untouched.
+	 *
+	 * The Network ID lives on the parent product; Product_Admin::get_network_id() performs the same
+	 * resolution when reading. Uses the post parent rather than wc_get_product() so it also works with
+	 * WooCommerce deactivated mid-migration.
+	 *
+	 * @param int $product_id The product or variation ID.
+	 * @return int
+	 */
+	private static function resolve_to_parent_product_id( $product_id ) {
+		$product_id = (int) $product_id;
+		if ( 'product_variation' !== get_post_type( $product_id ) ) {
+			return $product_id;
+		}
+		$parent_id = (int) wp_get_post_parent_id( $product_id );
+		return $parent_id ? $parent_id : $product_id;
+	}
+
+	/**
+	 * Fold variation IDs in an assignment map into their parent products.
+	 *
+	 * A parent that ends up claimed with two different Network IDs is ambiguous and is withheld as a
+	 * conflict, exactly like a product claimed by two plans.
+	 *
+	 * @param array $assignments Map of product ID => Network ID.
+	 * @return array {
+	 *     @type array $assignments Map of parent product ID => Network ID.
+	 *     @type array $conflicts   Map of parent product ID => the distinct Network IDs claiming it.
+	 * }
+	 */
+	private static function fold_variations_into_parents( array $assignments ) {
+		$claims = [];
+		foreach ( $assignments as $product_id => $network_id ) {
+			$target_id = self::resolve_to_parent_product_id( $product_id );
+			if ( ! isset( $claims[ $target_id ] ) ) {
+				$claims[ $target_id ] = [];
+			}
+			if ( ! in_array( $network_id, $claims[ $target_id ], true ) ) {
+				$claims[ $target_id ][] = $network_id;
+			}
+		}
+
+		$folded    = [];
+		$conflicts = [];
+		foreach ( $claims as $product_id => $network_ids ) {
+			if ( 1 === count( $network_ids ) ) {
+				$folded[ $product_id ] = $network_ids[0];
+			} else {
+				$conflicts[ $product_id ] = $network_ids;
+			}
+		}
+
+		return [
+			'assignments' => $folded,
+			'conflicts'   => $conflicts,
+		];
+	}
+
+	/**
+	 * Whether a Network ID on this product could ever grant cross-site access.
+	 *
+	 * Access resolves grants from a reader's synced subscriptions, and the product metabox only writes
+	 * the meta for subscription products, so tagging any other type would only bloat every site's synced
+	 * product map. With WooCommerce deactivated the type is unknowable, so nothing is filtered out.
+	 *
+	 * @param int $product_id The product ID.
+	 * @return bool
+	 */
+	private static function is_taggable_product( $product_id ) {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return true;
+		}
+		$product = wc_get_product( $product_id );
+		return $product && $product->is_type( [ 'subscription', 'variable-subscription' ] );
+	}
+
+	/**
 	 * Read the products to verify as a product ID => Network ID map.
 	 *
-	 * With an explicit list ( e.g. a gate's products ) every ID is returned, including untagged ones
-	 * ( Network ID '' ) so verify can flag them as the failure they are. With null, only products that
-	 * already carry a Network ID are returned.
+	 * With an explicit list ( e.g. a gate's products ) every ID is returned as passed, including untagged
+	 * ones ( Network ID '' ) so verify can flag them as the failure they are. With null, the set is every
+	 * plan-linked subscription product plus every product that already carries a Network ID -- so products
+	 * that assign-product-network-ids could not resolve are checked rather than defined away.
 	 *
-	 * @param array|null $product_ids Explicit product IDs to look up; null reads every tagged product.
+	 * @param array|null $product_ids Explicit product IDs to look up; null builds the default set.
 	 * @return array
 	 */
 	private static function get_products_to_check( $product_ids = null ) {
@@ -470,16 +750,72 @@ class Product_Network_Ids {
 			]
 		);
 
-		// Prime the postmeta cache in a single query so the get_network_id() reads below hit the cache
-		// instead of one get_post_meta() DB round-trip per product ( fields => 'ids' skips WP's own priming ).
-		update_meta_cache( 'post', $tagged_ids );
+		$candidate_ids = array_values( array_unique( array_merge( array_map( 'intval', $tagged_ids ), self::get_plan_linked_product_ids() ) ) );
 
-		// The meta_query already excludes empty/absent Network IDs, so every ID here is tagged.
-		$tagged = [];
-		foreach ( $tagged_ids as $product_id ) {
-			$tagged[ (int) $product_id ] = Product_Admin::get_network_id( $product_id );
+		// Prime the post and postmeta caches so the reads below hit the cache instead of one DB round
+		// trip per product ( fields => 'ids' skips WP's own priming ).
+		self::prime_post_caches( $candidate_ids );
+
+		$products = [];
+		foreach ( $candidate_ids as $candidate_id ) {
+			// A plan can link a variation, or a product that has since been deleted.
+			$product_id = self::resolve_to_parent_product_id( $candidate_id );
+			if ( 'product' !== get_post_type( $product_id ) ) {
+				continue;
+			}
+			// A plan-linked product that could never grant cross-site access is not a flip blocker.
+			if ( ! self::is_taggable_product( $product_id ) ) {
+				continue;
+			}
+			$products[ $product_id ] = Product_Admin::get_network_id( $product_id );
 		}
-		return $tagged;
+		return $products;
+	}
+
+	/**
+	 * Prime the post and postmeta caches for a set of post IDs, in chunks.
+	 *
+	 * Priming pulls every meta row of every listed post, so the chunking bounds peak memory on stores
+	 * with thousands of products.
+	 *
+	 * @param array $post_ids The post IDs.
+	 * @return void
+	 */
+	private static function prime_post_caches( array $post_ids ) {
+		$post_ids = array_map( 'intval', $post_ids );
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+		foreach ( array_chunk( $post_ids, self::META_CACHE_CHUNK_SIZE ) as $chunk ) {
+			_prime_post_caches( $chunk, false, true );
+		}
+	}
+
+	/**
+	 * Flush the Data Events dispatch queue every DISPATCH_FLUSH_INTERVAL dispatches.
+	 *
+	 * @param int $dispatched How many events have been dispatched so far.
+	 * @return void
+	 */
+	private static function maybe_flush_dispatch_queue( $dispatched ) {
+		if ( 0 === $dispatched % self::DISPATCH_FLUSH_INTERVAL ) {
+			self::flush_dispatch_queue();
+		}
+	}
+
+	/**
+	 * Send the events queued so far by Data Events.
+	 *
+	 * Data_Events::dispatch() only appends to an in-memory queue drained on shutdown, so a long
+	 * migration would hold every payload in memory and propagate nothing at all if the process were
+	 * killed before shutdown -- exactly the "wrote but didn't sync" state this command exists to avoid.
+	 *
+	 * @return void
+	 */
+	private static function flush_dispatch_queue() {
+		if ( method_exists( 'Newspack\Data_Events', 'execute_queued_dispatches' ) ) {
+			\Newspack\Data_Events::execute_queued_dispatches();
+		}
 	}
 
 	/**
@@ -496,18 +832,31 @@ class Product_Network_Ids {
 		}
 		$decoded = json_decode( (string) $map, true );
 		if ( ! is_array( $decoded ) ) {
-			WP_CLI::error( 'Invalid --map: expected a JSON object of { product_id: network_id } or a path to such a file.' );
+			WP_CLI::error( 'Invalid --map: expected a JSON object of { "product_id": "network_id" } or a path to such a file.' );
+		}
+		if ( empty( $decoded ) ) {
+			WP_CLI::error( 'Invalid --map: the mapping is empty.' );
+		}
+		// A JSON list is an array too, and its 0..n-1 keys would silently become product IDs.
+		if ( array_keys( $decoded ) === range( 0, count( $decoded ) - 1 ) ) {
+			WP_CLI::error( 'Invalid --map: expected a JSON object keyed by product ID, got a JSON list.' );
 		}
 
 		$assignments = [];
 		foreach ( $decoded as $product_id => $network_id ) {
+			// JSON object keys arrive as PHP int keys only when they are canonical integers; anything else
+			// ( "abc", "12abc" ) would cast to a real, unrelated product ID.
+			if ( ! preg_match( '/^[1-9][0-9]*$/', (string) $product_id ) ) {
+				WP_CLI::warning( sprintf( 'Skipping --map entry "%s": keys must be positive integer product IDs.', $product_id ) );
+				continue;
+			}
 			if ( ! is_scalar( $network_id ) ) {
-				WP_CLI::warning( sprintf( 'Skipping product #%d in --map: Network ID must be a string.', (int) $product_id ) );
+				WP_CLI::warning( sprintf( 'Skipping product #%s in --map: Network ID must be a string.', $product_id ) );
 				continue;
 			}
 			$network_id = sanitize_text_field( (string) $network_id );
 			if ( '' === $network_id ) {
-				WP_CLI::warning( sprintf( 'Skipping product #%d in --map: empty Network ID.', (int) $product_id ) );
+				WP_CLI::warning( sprintf( 'Skipping product #%s in --map: empty Network ID.', $product_id ) );
 				continue;
 			}
 			$assignments[ (int) $product_id ] = $network_id;

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -199,6 +199,12 @@ class Product_Network_Ids {
 		$apply     = isset( $assoc_args['apply'] );
 		$overwrite = isset( $assoc_args['overwrite'] );
 
+		// Writing the meta only propagates across the network through the newspack_network_product_updated
+		// listener, which registers only when Newspack\Data_Events is loaded and emits only when wc_get_product
+		// is available. With either missing the meta is written locally and nothing syncs -- surface that up
+		// front so "Wrote N" is never mistaken for "propagated", which is the NPPD-2057 flip failure.
+		$can_propagate = class_exists( 'Newspack\Data_Events' ) && function_exists( 'wc_get_product' );
+
 		WP_CLI::line( '' );
 		if ( $apply ) {
 			WP_CLI::line( '⚡️ Running live: product Network IDs will be written.' );
@@ -206,6 +212,13 @@ class Product_Network_Ids {
 			WP_CLI::line( 'Running in dry-run mode. Use --apply to write changes.' );
 		}
 		WP_CLI::line( '' );
+
+		if ( ! $can_propagate ) {
+			WP_CLI::warning(
+				'Cross-site propagation is unavailable here ( newspack_network_product_updated needs Newspack\\Data_Events and WooCommerce active ). Network IDs will be written to this site only; propagate them afterwards with "wp newspack-network data-backfill newspack_network_product_updated --live".'
+			);
+			WP_CLI::line( '' );
+		}
 
 		if ( isset( $assoc_args['map'] ) ) {
 			$assignments = self::parse_map( $assoc_args['map'] );
@@ -276,7 +289,13 @@ class Product_Network_Ids {
 		WP_CLI::line( '' );
 		if ( $apply ) {
 			WP_CLI::success( sprintf( 'Wrote %d product Network ID(s), skipped %d, %d already set.', $to_write, $skipped, $already ) );
-			WP_CLI::line( 'If propagation did not complete ( e.g. the Data Events listener was unavailable ), replay it with:' );
+			if ( ! $can_propagate ) {
+				WP_CLI::warning( 'These writes were NOT propagated ( see the warning above ). Once Data Events and WooCommerce are active, replay propagation with:' );
+			} else {
+				// A product already carrying the target Network ID fires no event, so this command cannot
+				// re-propagate an already-tagged-but-desynced product. Point operators at the backfill for that.
+				WP_CLI::line( 'Products already carrying the target Network ID fire no event; if propagation may have been missed ( including for already-set products ), replay it with:' );
+			}
 			WP_CLI::line( '  wp newspack-network data-backfill newspack_network_product_updated --live' );
 		} else {
 			WP_CLI::success( sprintf( 'Dry run: %d product Network ID(s) would be written, %d skipped, %d already set. Re-run with --apply.', $to_write, $skipped, $already ) );
@@ -451,6 +470,10 @@ class Product_Network_Ids {
 			]
 		);
 
+		// Prime the postmeta cache in a single query so the get_network_id() reads below hit the cache
+		// instead of one get_post_meta() DB round-trip per product ( fields => 'ids' skips WP's own priming ).
+		update_meta_cache( 'post', $tagged_ids );
+
 		// The meta_query already excludes empty/absent Network IDs, so every ID here is tagged.
 		$tagged = [];
 		foreach ( $tagged_ids as $product_id ) {
@@ -466,7 +489,9 @@ class Product_Network_Ids {
 	 * @return array
 	 */
 	private static function parse_map( $map ) {
-		if ( is_string( $map ) && is_readable( $map ) ) {
+		// Only treat the argument as a path when it's short enough to be one: passing a long inline-JSON
+		// map straight to is_readable() can trip an E_WARNING ( "File name too long" ) on some platforms.
+		if ( is_string( $map ) && strlen( $map ) < PHP_MAXPATHLEN && is_readable( $map ) ) {
 			$map = file_get_contents( $map ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		}
 		$decoded = json_decode( (string) $map, true );

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -1,0 +1,485 @@
+<?php
+/**
+ * WP-CLI tooling to assign and verify product Network IDs across a Newspack Network.
+ *
+ * Access Control's cross-site paid access only grants something when the gate's products
+ * carry a product Network ID ( the _newspack_network_product_id postmeta read by
+ * \Newspack_Network\Content_Gate\Access ). The only writer in the product UI is a manual
+ * per-product metabox, so networks migrated from Woo Memberships routinely end up with
+ * healthy membership/subscription sync but zero tagged products, which silently strips
+ * network-synced members on flip. This command derives those IDs from the membership plans
+ * ( or an explicit operator mapping ) and verifies the synced product map before a flip.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\CLI;
+
+use Newspack_Network\Site_Role;
+use Newspack_Network\Woocommerce\Product_Admin;
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use Newspack_Network\Incoming_Events\Product_Updated;
+use WP_CLI;
+
+/**
+ * Product Network ID assignment and verification commands.
+ */
+class Product_Network_Ids {
+
+	/**
+	 * The membership plan postmeta holding the plan's linked product IDs ( set by WooCommerce Memberships ).
+	 *
+	 * @var string
+	 */
+	const PLAN_PRODUCT_IDS_META_KEY = '_product_ids';
+
+	/**
+	 * Initialize this class and register the WP-CLI commands.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			// These are migration tooling, so they take the migration flow's --apply flag ( dry-run by default )
+			// rather than this plugin's older data-* commands' --live flag.
+			WP_CLI::add_command( 'newspack-network assign-product-network-ids', [ __CLASS__, 'assign' ] );
+			WP_CLI::add_command( 'newspack-network verify-product-network-ids', [ __CLASS__, 'verify' ] );
+		}
+	}
+
+	/**
+	 * Derive product => Network ID assignments from membership plans.
+	 *
+	 * Each plan carries a shared Network ID ( the same on the matching plan of every network site )
+	 * and a list of linked product IDs. Every one of a plan's products should carry the plan's
+	 * Network ID so that linked products across sites resolve to the same value. A product listed by
+	 * two plans with different Network IDs is ambiguous: it is withheld from the assignments and
+	 * reported as a conflict rather than guessed.
+	 *
+	 * @param array $plans Array of [ 'network_id' => string, 'product_ids' => int[] ].
+	 * @return array {
+	 *     @type array $assignments Map of product ID => Network ID.
+	 *     @type array $conflicts   Map of product ID => list of the distinct Network IDs claiming it.
+	 * }
+	 */
+	public static function derive_assignments_from_plans( array $plans ) {
+		$claims = []; // Product ID => list of distinct Network IDs claiming it.
+		foreach ( $plans as $plan ) {
+			$network_id  = (string) ( $plan['network_id'] ?? '' );
+			$product_ids = $plan['product_ids'] ?? [];
+			if ( '' === $network_id || empty( $product_ids ) ) {
+				continue;
+			}
+			foreach ( $product_ids as $product_id ) {
+				$product_id = (int) $product_id;
+				if ( ! isset( $claims[ $product_id ] ) ) {
+					$claims[ $product_id ] = [];
+				}
+				if ( ! in_array( $network_id, $claims[ $product_id ], true ) ) {
+					$claims[ $product_id ][] = $network_id;
+				}
+			}
+		}
+
+		$assignments = [];
+		$conflicts   = [];
+		foreach ( $claims as $product_id => $network_ids ) {
+			if ( 1 === count( $network_ids ) ) {
+				$assignments[ $product_id ] = $network_ids[0];
+			} else {
+				$conflicts[ $product_id ] = $network_ids;
+			}
+		}
+
+		return [
+			'assignments' => $assignments,
+			'conflicts'   => $conflicts,
+		];
+	}
+
+	/**
+	 * Index the synced network-products option into a per-Network-ID site-presence map.
+	 *
+	 * @param array $network_products The Product_Updated option value: [ site => [ product_id => [ 'network_id' => ... ] ] ].
+	 * @return array [ network_id => [ site => true ] ] -- which sites carry each Network ID. Untagged entries are ignored.
+	 */
+	public static function index_network_products_by_network_id( array $network_products ) {
+		$index = [];
+		foreach ( $network_products as $site => $products ) {
+			if ( ! is_array( $products ) ) {
+				continue;
+			}
+			foreach ( $products as $product ) {
+				if ( ! is_array( $product ) ) {
+					continue;
+				}
+				$network_id = (string) ( $product['network_id'] ?? '' );
+				if ( '' === $network_id ) {
+					continue;
+				}
+				$index[ $network_id ][ $site ] = true;
+			}
+		}
+		return $index;
+	}
+
+	/**
+	 * Verify local product tagging against the synced network-products map.
+	 *
+	 * A site can only see its own database plus the synced map option, so this checks, per product:
+	 * whether it carries a Network ID at all, and whether any *other* site in the map carries the same
+	 * Network ID ( without which cross-site access grants nothing ). The current site is excluded from
+	 * the linkage count so a product is never counted as "linked to itself": a Hub self-includes its own
+	 * products under its own URL key ( Product_Updated::always_process_in_hub ), so without this exclusion
+	 * a Hub-only Network ID would read as linked and produce a false "ready to flip". ( A Node has no such
+	 * self-entry -- it never receives its own events back -- so the exclusion is simply a no-op there. )
+	 *
+	 * @param array  $local_products   Map of product ID => Network ID, from local postmeta ( '' for untagged ).
+	 * @param array  $network_products The Product_Updated option value.
+	 * @param string $current_site     This site's URL ( the key it uses in the map ).
+	 * @return array Map of product ID => [ 'network_id' => string, 'linked_sites' => string[] ].
+	 */
+	public static function verify_products( array $local_products, array $network_products, $current_site ) {
+		$index    = self::index_network_products_by_network_id( $network_products );
+		$findings = [];
+
+		foreach ( $local_products as $product_id => $network_id ) {
+			$product_id = (int) $product_id;
+
+			// Other sites in the map that carry the same Network ID ( excluding this site's own entry -- see the docblock ).
+			$linked_sites = [];
+			foreach ( array_keys( $index[ $network_id ] ?? [] ) as $site ) {
+				if ( $site !== $current_site ) {
+					$linked_sites[] = $site;
+				}
+			}
+
+			$findings[ $product_id ] = [
+				'network_id'   => (string) $network_id,
+				'linked_sites' => $linked_sites,
+			];
+		}
+
+		return $findings;
+	}
+
+	/**
+	 * Assign product Network IDs across the network's products.
+	 *
+	 * By default IDs are derived from the site's membership plans ( each plan's shared Network ID is
+	 * written to every product the plan links ). Pass --map to assign an explicit operator mapping
+	 * instead. Runs in dry-run mode unless --apply is given.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--map=<map>]
+	 * : Assign an explicit mapping instead of deriving from membership plans. Either an inline JSON
+	 * object of { "<product_id>": "<network_id>" } or a path to a file containing that JSON.
+	 *
+	 * [--overwrite]
+	 * : Overwrite a product's existing Network ID when it differs from the derived/mapped value.
+	 * By default, existing differing values are left untouched and reported.
+	 *
+	 * [--apply]
+	 * : Write the changes. Without this flag the command only reports what it would do.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack-network assign-product-network-ids
+	 *     wp newspack-network assign-product-network-ids --apply
+	 *     wp newspack-network assign-product-network-ids --map='{"123":"premium","456":"premium"}' --apply
+	 *
+	 * @param array $args       Positional arguments ( unused ).
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public static function assign( $args, $assoc_args ) {
+		self::require_network_site();
+
+		$apply     = isset( $assoc_args['apply'] );
+		$overwrite = isset( $assoc_args['overwrite'] );
+
+		WP_CLI::line( '' );
+		if ( $apply ) {
+			WP_CLI::line( '⚡️ Running live: product Network IDs will be written.' );
+		} else {
+			WP_CLI::line( 'Running in dry-run mode. Use --apply to write changes.' );
+		}
+		WP_CLI::line( '' );
+
+		if ( isset( $assoc_args['map'] ) ) {
+			$assignments = self::parse_map( $assoc_args['map'] );
+			WP_CLI::line( sprintf( 'Using explicit operator mapping ( %d product(s) ).', count( $assignments ) ) );
+		} else {
+			$derived     = self::derive_assignments_from_plans( self::get_plans() );
+			$assignments = $derived['assignments'];
+			WP_CLI::line( sprintf( 'Derived %d assignment(s) from membership plans.', count( $assignments ) ) );
+			foreach ( $derived['conflicts'] as $product_id => $network_ids ) {
+				WP_CLI::warning(
+					sprintf(
+						'Product #%d is linked by plans with different Network IDs ( %s ) - skipped. Resolve manually or via --map.',
+						$product_id,
+						implode( ', ', $network_ids )
+					)
+				);
+			}
+		}
+		WP_CLI::line( '' );
+
+		if ( empty( $assignments ) ) {
+			WP_CLI::warning( 'No assignments to make.' );
+			return;
+		}
+
+		$skipped  = 0;
+		$already  = 0;
+		$to_write = 0;
+		foreach ( $assignments as $product_id => $network_id ) {
+			$product_id = (int) $product_id;
+
+			$post_type = get_post_type( $product_id );
+			if ( 'product' !== $post_type ) {
+				// The Network ID lives on the parent product; variations resolve to it via Product_Admin::get_network_id.
+				$reason = 'product_variation' === $post_type ? 'a product variation ( set the Network ID on its parent product )' : 'not a product';
+				WP_CLI::warning( sprintf( 'Skipping #%d: %s.', $product_id, $reason ) );
+				$skipped++;
+				continue;
+			}
+
+			$current = (string) get_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, true );
+			if ( $current === (string) $network_id ) {
+				WP_CLI::line( sprintf( '  #%d already set to "%s".', $product_id, $network_id ) );
+				$already++;
+				continue;
+			}
+			if ( '' !== $current && ! $overwrite ) {
+				WP_CLI::warning(
+					sprintf( 'Skipping #%d: already set to "%s" ( would become "%s" ). Use --overwrite to change.', $product_id, $current, $network_id )
+				);
+				$skipped++;
+				continue;
+			}
+
+			WP_CLI::line( sprintf( '  #%d "%s" => "%s"', $product_id, $current, $network_id ) );
+			$to_write++;
+
+			if ( $apply ) {
+				update_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, $network_id );
+				// Fire the same action the product metabox fires, so the existing emitter propagates the change.
+				do_action( 'newspack_network_save_product', $product_id );
+			}
+		}
+
+		WP_CLI::line( '' );
+		if ( $apply ) {
+			WP_CLI::success( sprintf( 'Wrote %d product Network ID(s), skipped %d, %d already set.', $to_write, $skipped, $already ) );
+			WP_CLI::line( 'If propagation did not complete ( e.g. the Data Events listener was unavailable ), replay it with:' );
+			WP_CLI::line( '  wp newspack-network data-backfill newspack_network_product_updated --live' );
+		} else {
+			WP_CLI::success( sprintf( 'Dry run: %d product Network ID(s) would be written, %d skipped, %d already set. Re-run with --apply.', $to_write, $skipped, $already ) );
+		}
+		WP_CLI::line( '' );
+	}
+
+	/**
+	 * Verify that this site's products resolve to a Network ID and are linked across the network.
+	 *
+	 * Runs per-site: it can only read this site's database and the synced network-products map option.
+	 * It reports, for each checked product, whether it carries a Network ID and whether any other site
+	 * shares that ID ( the NPPD-2057 failure is a product tagged with a Network ID no other site carries,
+	 * or not tagged at all, so the cross-site grant resolves to nothing ). Run it on every site: each
+	 * site's linkage check confirms the other sites' products are present in its synced map.
+	 *
+	 * Limitation: the synced products option is append-only ( there is no product-deleted listener ), so a
+	 * stale entry for a since-removed product or site can still report as "linked" -- the same class of
+	 * caveat as relying on the site's URL staying byte-identical as the map key.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--products=<ids>]
+	 * : Comma-separated product IDs to check ( e.g. a gate's products ). Defaults to every local product
+	 * that carries a Network ID. To gate a flip, pass the gate's product IDs: the bare form only looks at
+	 * already-tagged products, so a site with zero tagged products ( the NPPD-2057 failure ) passes it.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack-network verify-product-network-ids
+	 *     wp newspack-network verify-product-network-ids --products=123,456
+	 *
+	 * @param array $args       Positional arguments ( unused ).
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public static function verify( $args, $assoc_args ) {
+		self::require_network_site();
+
+		$current_site     = get_bloginfo( 'url' );
+		$network_products = get_option( Product_Updated::OPTION_NAME, [] );
+		if ( ! is_array( $network_products ) ) {
+			$network_products = [];
+		}
+
+		$explicit_products = isset( $assoc_args['products'] );
+		$local_products    = self::get_products_to_check(
+			$explicit_products ? wp_parse_id_list( $assoc_args['products'] ) : null
+		);
+
+		WP_CLI::line( '' );
+		WP_CLI::line( sprintf( 'Verifying product Network IDs for %s.', $current_site ) );
+		WP_CLI::line( 'Checked: whether this site\'s products carry a Network ID, and whether other sites in the synced map share it.' );
+		WP_CLI::line( 'Not checked from here: other sites\' databases ( only their synced map entries are visible ). Run this on every site.' );
+		WP_CLI::line( '' );
+
+		if ( empty( $local_products ) ) {
+			WP_CLI::warning( 'No products carry a Network ID on this site. Cross-site paid access will grant nothing here. Run assign-product-network-ids first.' );
+			return;
+		}
+
+		$findings = self::verify_products( $local_products, $network_products, $current_site );
+		$untagged = 0;
+		$unlinked = 0;
+		foreach ( $findings as $product_id => $finding ) {
+			// An untagged product ( only reachable when passed explicitly via --products ) is the NPPD-2057 failure itself.
+			if ( '' === $finding['network_id'] ) {
+				WP_CLI::warning( sprintf( '#%d: no Network ID set ( cross-site access grants nothing ). Run assign-product-network-ids.', $product_id ) );
+				$untagged++;
+				continue;
+			}
+
+			if ( empty( $finding['linked_sites'] ) ) {
+				WP_CLI::warning(
+					sprintf( '#%d "%s": no other site carries this Network ID ( cross-site access grants nothing ).', $product_id, $finding['network_id'] )
+				);
+				$unlinked++;
+			} else {
+				WP_CLI::line(
+					sprintf( '  ✓ #%d "%s" linked on: %s', $product_id, $finding['network_id'], implode( ', ', $finding['linked_sites'] ) )
+				);
+			}
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( sprintf( 'Checked %d product(s): %d untagged, %d unlinked.', count( $findings ), $untagged, $unlinked ) );
+		if ( $unlinked > 0 ) {
+			WP_CLI::line( 'For unlinked products, make sure every site has run assign-product-network-ids and its product_updated events have propagated:' );
+			WP_CLI::line( '  wp newspack-network data-backfill newspack_network_product_updated --live' );
+		}
+		if ( $untagged > 0 || $unlinked > 0 ) {
+			// Exit non-zero so callers can gate a flip on this check.
+			WP_CLI::error( 'Verification found issues ( see above ). Not ready to flip.' );
+		}
+		// A green run proves each product is linked to at least one other visible site, not the full mesh:
+		// this site cannot see whether every other site received its products. Run on every site for full coverage.
+		WP_CLI::success( 'All checked products carry a Network ID and are linked to at least one other site ( see the listed sites above ).' );
+	}
+
+	/**
+	 * Ensure the command runs on a Hub or Node site, erroring out otherwise.
+	 *
+	 * @return void
+	 */
+	private static function require_network_site() {
+		if ( ! Site_Role::is_hub() && ! Site_Role::is_node() ) {
+			WP_CLI::error( 'This command can only be run on a Hub or Node site.' );
+		}
+	}
+
+	/**
+	 * Read the site's membership plans as [ 'network_id' => string, 'product_ids' => int[] ] rows.
+	 *
+	 * Uses raw postmeta ( not the WooCommerce Memberships plan object ) so it keeps working after the
+	 * plugin is deactivated during a migration.
+	 *
+	 * @return array
+	 */
+	private static function get_plans() {
+		$plan_posts = get_posts(
+			[
+				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			]
+		);
+
+		$plans = [];
+		foreach ( $plan_posts as $plan_id ) {
+			$product_ids = get_post_meta( $plan_id, self::PLAN_PRODUCT_IDS_META_KEY, true );
+			$plans[]     = [
+				'network_id'  => (string) get_post_meta( $plan_id, Memberships_Admin::NETWORK_ID_META_KEY, true ),
+				'product_ids' => is_array( $product_ids ) ? $product_ids : [],
+			];
+		}
+		return $plans;
+	}
+
+	/**
+	 * Read the products to verify as a product ID => Network ID map.
+	 *
+	 * With an explicit list ( e.g. a gate's products ) every ID is returned, including untagged ones
+	 * ( Network ID '' ) so verify can flag them as the failure they are. With null, only products that
+	 * already carry a Network ID are returned.
+	 *
+	 * @param array|null $product_ids Explicit product IDs to look up; null reads every tagged product.
+	 * @return array
+	 */
+	private static function get_products_to_check( $product_ids = null ) {
+		if ( null !== $product_ids ) {
+			$products = [];
+			foreach ( $product_ids as $product_id ) {
+				$products[ (int) $product_id ] = Product_Admin::get_network_id( $product_id );
+			}
+			return $products;
+		}
+
+		$tagged_ids = get_posts(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => Product_Admin::NETWORK_ID_META_KEY,
+						'compare' => '!=',
+						'value'   => '',
+					],
+				],
+			]
+		);
+
+		// The meta_query already excludes empty/absent Network IDs, so every ID here is tagged.
+		$tagged = [];
+		foreach ( $tagged_ids as $product_id ) {
+			$tagged[ (int) $product_id ] = Product_Admin::get_network_id( $product_id );
+		}
+		return $tagged;
+	}
+
+	/**
+	 * Parse the --map value ( inline JSON or a path to a JSON file ) into a product ID => Network ID map.
+	 *
+	 * @param string $map The raw --map argument.
+	 * @return array
+	 */
+	private static function parse_map( $map ) {
+		if ( is_string( $map ) && is_readable( $map ) ) {
+			$map = file_get_contents( $map ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		}
+		$decoded = json_decode( (string) $map, true );
+		if ( ! is_array( $decoded ) ) {
+			WP_CLI::error( 'Invalid --map: expected a JSON object of { product_id: network_id } or a path to such a file.' );
+		}
+
+		$assignments = [];
+		foreach ( $decoded as $product_id => $network_id ) {
+			$network_id = trim( (string) $network_id );
+			if ( '' === $network_id ) {
+				WP_CLI::warning( sprintf( 'Skipping product #%d in --map: empty Network ID.', (int) $product_id ) );
+				continue;
+			}
+			$assignments[ (int) $product_id ] = $network_id;
+		}
+		return $assignments;
+	}
+}

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -16,6 +16,7 @@
 namespace Newspack_Network\CLI;
 
 use Newspack_Network\Site_Role;
+use Newspack_Network\Hub\Nodes as Hub_Nodes;
 use Newspack_Network\Woocommerce\Product_Admin;
 use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
 use Newspack_Network\Incoming_Events\Product_Updated;
@@ -183,12 +184,19 @@ class Product_Network_Ids {
 	 * a Hub-only Network ID would read as linked and produce a false "ready to flip". ( A Node has no such
 	 * self-entry -- it never receives its own events back -- so the exclusion is simply a no-op there. )
 	 *
+	 * Being linked to *some* other site is a weaker guarantee than access needs: a reader is only
+	 * granted access from the specific site their subscription lives on, so a product linked hub<->node1
+	 * grants nothing to a node2 subscriber. Pass $expected_sites ( the network's known sites ) to also
+	 * get, per product, which of them are missing the Network ID -- that is what an operator has to act
+	 * on, and what --expect-sites gates the exit code on.
+	 *
 	 * @param array  $local_products   Map of product ID => Network ID, from local postmeta ( '' for untagged ).
 	 * @param array  $network_products The Product_Updated option value.
 	 * @param string $current_site     This site's URL ( the key it uses in the map ).
-	 * @return array Map of product ID => [ 'network_id' => string, 'linked_sites' => string[] ].
+	 * @param array  $expected_sites   Site URLs the network is known to contain, excluding this one. Empty when unknown.
+	 * @return array Map of product ID => [ 'network_id' => string, 'linked_sites' => string[], 'missing_sites' => string[] ].
 	 */
-	public static function verify_products( array $local_products, array $network_products, $current_site ) {
+	public static function verify_products( array $local_products, array $network_products, $current_site, array $expected_sites = [] ) {
 		$index    = self::index_network_products_by_network_id( $network_products );
 		$findings = [];
 
@@ -198,18 +206,70 @@ class Product_Network_Ids {
 			// Other sites in the map that carry the same Network ID ( excluding this site's own entry -- see the docblock ).
 			$linked_sites = [];
 			foreach ( array_keys( $index[ $network_id ] ?? [] ) as $site ) {
-				if ( $site !== $current_site ) {
+				if ( self::normalize_site_url( $site ) !== self::normalize_site_url( $current_site ) ) {
 					$linked_sites[] = $site;
 				}
 			}
 
+			// Known network sites whose products never arrived carrying this ID. Compared on the
+			// normalized URL: the map is keyed by each site's own get_bloginfo( 'url' ), while the
+			// expected list comes from the Nodes CPT, so the two can differ by a trailing slash.
+			$linked_lookup = [];
+			foreach ( $linked_sites as $site ) {
+				$linked_lookup[ self::normalize_site_url( $site ) ] = true;
+			}
+			$missing_sites = [];
+			if ( '' !== (string) $network_id ) {
+				foreach ( $expected_sites as $expected_site ) {
+					if ( ! isset( $linked_lookup[ self::normalize_site_url( $expected_site ) ] ) ) {
+						$missing_sites[] = $expected_site;
+					}
+				}
+			}
+
 			$findings[ $product_id ] = [
-				'network_id'   => (string) $network_id,
-				'linked_sites' => $linked_sites,
+				'network_id'    => (string) $network_id,
+				'linked_sites'  => $linked_sites,
+				'missing_sites' => $missing_sites,
 			];
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * Normalize a site URL for comparison between the synced map's keys and the Nodes CPT's URLs.
+	 *
+	 * @param string $url The site URL.
+	 * @return string
+	 */
+	private static function normalize_site_url( $url ) {
+		return untrailingslashit( strtolower( trim( (string) $url ) ) );
+	}
+
+	/**
+	 * The other sites this network is known to contain.
+	 *
+	 * Only a Hub knows the network's membership ( the Nodes CPT ); a Node can see nothing but its own
+	 * synced map, which is why --expect-sites also takes a plain count.
+	 *
+	 * @return string[] Node URLs, or an empty array when the membership is not knowable here.
+	 */
+	private static function get_known_network_sites() {
+		if ( ! Site_Role::is_hub() ) {
+			return [];
+		}
+		$urls = [];
+		foreach ( Hub_Nodes::get_all_nodes() as $node ) {
+			$url = untrailingslashit( (string) $node->get_url() );
+			if ( '' !== $url ) {
+				$urls[ self::normalize_site_url( $url ) ] = $url;
+			}
+		}
+		// Sorted so the reported ( and JSON ) site list is stable across runs rather than following the
+		// Nodes CPT's post order, which makes two sites' reports diffable.
+		ksort( $urls );
+		return array_values( $urls );
 	}
 
 	/**
@@ -286,7 +346,12 @@ class Product_Network_Ids {
 		$plans_found = 0;
 
 		if ( null !== $map ) {
-			$assignments = self::parse_map( $map );
+			$parsed      = self::parse_map( $map );
+			$assignments = $parsed['assignments'];
+			// An entry the operator wrote but this command could not use is a product they believe is
+			// covered and which grants nothing -- it has to reach the non-zero exit like any other
+			// withheld item, not just scroll past as a warning.
+			$unresolved += $parsed['skipped'];
 			WP_CLI::line( sprintf( 'Using explicit operator mapping ( %d product(s) ).', count( $assignments ) ) );
 		} else {
 			$plans       = self::get_plans();
@@ -493,6 +558,11 @@ class Product_Network_Ids {
 	 * exactly what assign-product-network-ids withholds ( conflicts, skipped products ), so a network
 	 * that assign could not finish would still verify green.
 	 *
+	 * By default a product passes once *any* other site carries its Network ID, which is weaker than what
+	 * access needs: a reader is only granted from the specific site their subscription lives on, so a
+	 * product linked Hub<->node1 grants nothing to a node2 subscriber. Pass --expect-sites to gate the
+	 * exit code on real coverage -- "all" ( on a Hub, every registered Node ) or an explicit count.
+	 *
 	 * Limitation: the synced products option is append-only ( there is no product-deleted listener ), so a
 	 * stale entry for a since-removed product or site can still report as "linked" -- the same class of
 	 * caveat as relying on the site's URL staying byte-identical as the map key.
@@ -504,10 +574,28 @@ class Product_Network_Ids {
 	 * by a membership plan plus every product that already carries a Network ID. Pass a gate's product IDs
 	 * to check exactly what the gate depends on.
 	 *
+	 * [--expect-sites=<count|all>]
+	 * : How many *other* sites each product must be linked on to pass. "all" requires every Node registered
+	 * on this Hub ( unavailable on a Node, which cannot read the network's membership -- pass a count there ).
+	 * Defaults to 1, which only proves the product is linked somewhere.
+	 *
+	 * [--format=<format>]
+	 * : Output format. "json" prints a single machine-readable report ( per-product findings plus the summary
+	 * and the pass/fail verdict ) instead of the human-readable log, for aggregating this per-site gate
+	 * across a network. The exit code is the same either way.
+	 * ---
+	 * default: human
+	 * options:
+	 *   - human
+	 *   - json
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp newspack-network verify-product-network-ids
 	 *     wp newspack-network verify-product-network-ids --products=123,456
+	 *     wp newspack-network verify-product-network-ids --expect-sites=all
+	 *     wp newspack-network verify-product-network-ids --expect-sites=3 --format=json
 	 *
 	 * @param array $args       Positional arguments ( unused ).
 	 * @param array $assoc_args Associative arguments.
@@ -522,6 +610,15 @@ class Product_Network_Ids {
 			$network_products = [];
 		}
 
+		$format = (string) \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'human' );
+		if ( ! in_array( $format, [ 'human', 'json' ], true ) ) {
+			WP_CLI::error( sprintf( 'Invalid --format "%s": expected "human" or "json".', $format ) );
+		}
+		$is_json = 'json' === $format;
+
+		$known_sites = self::get_known_network_sites();
+		$expectation = self::parse_expected_sites( \WP_CLI\Utils\get_flag_value( $assoc_args, 'expect-sites', null ), $known_sites );
+
 		$product_ids = null;
 		if ( isset( $assoc_args['products'] ) ) {
 			$product_ids = wp_parse_id_list( $assoc_args['products'] );
@@ -533,51 +630,193 @@ class Product_Network_Ids {
 		}
 		$local_products = self::get_products_to_check( $product_ids );
 
-		WP_CLI::line( '' );
-		WP_CLI::line( sprintf( 'Verifying product Network IDs for %s.', $current_site ) );
-		WP_CLI::line( 'Checked: whether this site\'s products carry a Network ID, and whether other sites in the synced map share it.' );
-		WP_CLI::line( 'Not checked from here: other sites\' databases ( only their synced map entries are visible ). Run this on every site.' );
-		WP_CLI::line( '' );
+		if ( ! $is_json ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( sprintf( 'Verifying product Network IDs for %s.', $current_site ) );
+			WP_CLI::line( 'Checked: whether this site\'s products carry a Network ID, and whether other sites in the synced map share it.' );
+			WP_CLI::line( 'Not checked from here: other sites\' databases ( only their synced map entries are visible ). Run this on every site.' );
+			if ( ! empty( $known_sites ) ) {
+				WP_CLI::line( sprintf( 'Network sites registered on this Hub: %s.', implode( ', ', $known_sites ) ) );
+			}
+			WP_CLI::line( sprintf( 'Passing requires each product to be linked on %s.', $expectation['label'] ) );
+			WP_CLI::line( '' );
+		}
 
 		if ( empty( $local_products ) ) {
 			WP_CLI::error( 'No products to check: no membership plan links a subscription product and no product carries a Network ID. Cross-site paid access will grant nothing here. Run assign-product-network-ids first, or pass --products with the gate\'s products.' );
 		}
 
-		$findings = self::verify_products( $local_products, $network_products, $current_site );
+		$findings = self::verify_products( $local_products, $network_products, $current_site, $known_sites );
 		$untagged = 0;
 		$unlinked = 0;
+		$report   = [];
 		foreach ( $findings as $product_id => $finding ) {
+			$linked_sites  = $finding['linked_sites'];
+			$missing_sites = $finding['missing_sites'];
+
 			if ( '' === $finding['network_id'] ) {
-				WP_CLI::warning( sprintf( '#%d: no Network ID set ( cross-site access grants nothing ). Run assign-product-network-ids.', $product_id ) );
 				$untagged++;
+				$report[] = self::build_verify_report_row( $product_id, $finding, 'untagged' );
+				if ( ! $is_json ) {
+					WP_CLI::warning( sprintf( '#%d: no Network ID set ( cross-site access grants nothing ). Run assign-product-network-ids.', $product_id ) );
+				}
 				continue;
 			}
 
-			if ( empty( $finding['linked_sites'] ) ) {
-				WP_CLI::warning(
-					sprintf( '#%d "%s": no other site carries this Network ID ( cross-site access grants nothing ).', $product_id, $finding['network_id'] )
-				);
+			$passes = $expectation['require_all'] ? empty( $missing_sites ) : count( $linked_sites ) >= $expectation['minimum'];
+			if ( ! $passes ) {
 				$unlinked++;
-			} else {
+				$report[] = self::build_verify_report_row( $product_id, $finding, 'unlinked' );
+				if ( ! $is_json ) {
+					WP_CLI::warning( self::describe_unlinked_product( $product_id, $finding, $expectation ) );
+				}
+				continue;
+			}
+
+			$report[] = self::build_verify_report_row( $product_id, $finding, 'ok' );
+			if ( ! $is_json ) {
 				WP_CLI::line(
-					sprintf( '  ✓ #%d "%s" linked on: %s', $product_id, $finding['network_id'], implode( ', ', $finding['linked_sites'] ) )
+					sprintf( '  ✓ #%d "%s" linked on: %s', $product_id, $finding['network_id'], implode( ', ', $linked_sites ) )
 				);
+				// A pass under the default expectation still leaves known sites uncovered; those are what an
+				// operator has to act on, so name them even though they did not fail the run.
+				if ( ! empty( $missing_sites ) ) {
+					WP_CLI::line(
+						sprintf( '    not carried by: %s ( readers subscribing there are granted nothing ).', implode( ', ', $missing_sites ) )
+					);
+				}
 			}
 		}
 
-		WP_CLI::line( '' );
-		WP_CLI::line( sprintf( 'Checked %d product(s): %d untagged, %d unlinked.', count( $findings ), $untagged, $unlinked ) );
-		if ( $unlinked > 0 ) {
-			WP_CLI::line( 'For unlinked products, make sure every site has run assign-product-network-ids, then re-emit the events from those sites with:' );
-			WP_CLI::line( '  wp newspack-network assign-product-network-ids --apply --repropagate' );
+		$has_issues = $untagged > 0 || $unlinked > 0;
+
+		if ( $is_json ) {
+			WP_CLI::line(
+				(string) wp_json_encode(
+					[
+						'site'          => $current_site,
+						'expect_sites'  => $expectation['require_all'] ? 'all' : $expectation['minimum'],
+						'known_sites'   => $known_sites,
+						'checked'       => count( $findings ),
+						'untagged'      => $untagged,
+						'unlinked'      => $unlinked,
+						'ready_to_flip' => ! $has_issues,
+						'products'      => $report,
+					]
+				)
+			);
+		} else {
+			WP_CLI::line( '' );
+			WP_CLI::line( sprintf( 'Checked %d product(s): %d untagged, %d unlinked.', count( $findings ), $untagged, $unlinked ) );
+			if ( $unlinked > 0 ) {
+				WP_CLI::line( 'For unlinked products, make sure every site has run assign-product-network-ids, then re-emit the events from those sites with:' );
+				WP_CLI::line( '  wp newspack-network assign-product-network-ids --apply --repropagate' );
+			}
 		}
-		if ( $untagged > 0 || $unlinked > 0 ) {
+
+		if ( $has_issues ) {
 			// Exit non-zero so callers can gate a flip on this check.
 			WP_CLI::error( 'Verification found issues ( see above ). Not ready to flip.' );
 		}
-		// A green run proves each product is linked to at least one other visible site, not the full mesh:
-		// this site cannot see whether every other site received its products. Run on every site for full coverage.
-		WP_CLI::success( 'All checked products carry a Network ID and are linked to at least one other site ( see the listed sites above ).' );
+
+		WP_CLI::success( sprintf( 'All checked products carry a Network ID and are linked on %s.', $expectation['label'] ) );
+		if ( ! $is_json && ! $expectation['require_all'] && 1 === $expectation['minimum'] ) {
+			// Being linked *somewhere* is not the guarantee operators read into a green run: access is only
+			// granted from the site a reader's own subscription lives on.
+			WP_CLI::line( 'Note: this only proves each product is linked somewhere, not that every site a reader may subscribe on carries the ID. Re-run with --expect-sites=all ( on the Hub ) or --expect-sites=<count> to gate on real coverage.' );
+		}
+	}
+
+	/**
+	 * Resolve --expect-sites into the coverage each product must have to pass.
+	 *
+	 * @param mixed $raw         The raw flag value: null, "all", or a positive integer.
+	 * @param array $known_sites The network's other known sites ( empty when not knowable here ).
+	 * @return array {
+	 *     @type bool   $require_all Whether every known site must carry the Network ID.
+	 *     @type int    $minimum     The minimum number of other linked sites, when not requiring all.
+	 *     @type string $label       Human description of the requirement.
+	 * }
+	 */
+	private static function parse_expected_sites( $raw, array $known_sites ) {
+		if ( null === $raw ) {
+			return [
+				'require_all' => false,
+				'minimum'     => 1,
+				'label'       => 'at least 1 other site',
+			];
+		}
+
+		if ( 'all' === $raw ) {
+			if ( empty( $known_sites ) ) {
+				// A Node cannot read the network's membership, so "all" there would silently mean "any".
+				WP_CLI::error( '--expect-sites=all needs the network\'s registered Nodes, which are only readable on a Hub with Nodes registered. Run it on the Hub, or pass an explicit count ( e.g. --expect-sites=3 ).' );
+			}
+			return [
+				'require_all' => true,
+				'minimum'     => count( $known_sites ),
+				'label'       => sprintf( 'every registered network site ( %s )', implode( ', ', $known_sites ) ),
+			];
+		}
+
+		if ( ! preg_match( '/^[1-9][0-9]*$/', (string) $raw ) ) {
+			WP_CLI::error( 'Invalid --expect-sites: pass "all" or a positive integer ( how many other sites each product must be linked on ).' );
+		}
+
+		return [
+			'require_all' => false,
+			'minimum'     => (int) $raw,
+			'label'       => sprintf( 'at least %d other site(s)', (int) $raw ),
+		];
+	}
+
+	/**
+	 * Build one product's row of the machine-readable verify report.
+	 *
+	 * @param int    $product_id The product ID.
+	 * @param array  $finding    The verify_products() finding.
+	 * @param string $status     One of 'ok', 'untagged', 'unlinked'.
+	 * @return array
+	 */
+	private static function build_verify_report_row( $product_id, array $finding, $status ) {
+		return [
+			'id'            => (int) $product_id,
+			'network_id'    => $finding['network_id'],
+			'status'        => $status,
+			'linked_sites'  => array_values( $finding['linked_sites'] ),
+			'missing_sites' => array_values( $finding['missing_sites'] ),
+		];
+	}
+
+	/**
+	 * The warning for a product that did not meet the coverage requirement.
+	 *
+	 * @param int   $product_id  The product ID.
+	 * @param array $finding     The verify_products() finding.
+	 * @param array $expectation The parse_expected_sites() result.
+	 * @return string
+	 */
+	private static function describe_unlinked_product( $product_id, array $finding, array $expectation ) {
+		if ( empty( $finding['linked_sites'] ) ) {
+			return sprintf( '#%d "%s": no other site carries this Network ID ( cross-site access grants nothing ).', $product_id, $finding['network_id'] );
+		}
+		if ( $expectation['require_all'] ) {
+			return sprintf(
+				'#%d "%s": not carried by %s ( readers subscribing there are granted nothing ). Linked on: %s.',
+				$product_id,
+				$finding['network_id'],
+				implode( ', ', $finding['missing_sites'] ),
+				implode( ', ', $finding['linked_sites'] )
+			);
+		}
+		return sprintf(
+			'#%d "%s": linked on %d other site(s), fewer than the %d required. Linked on: %s.',
+			$product_id,
+			$finding['network_id'],
+			count( $finding['linked_sites'] ),
+			$expectation['minimum'],
+			implode( ', ', $finding['linked_sites'] )
+		);
 	}
 
 	/**
@@ -821,8 +1060,15 @@ class Product_Network_Ids {
 	/**
 	 * Parse the --map value ( inline JSON or a path to a JSON file ) into a product ID => Network ID map.
 	 *
+	 * Entries that cannot be used are reported and counted rather than dropped: the operator wrote them
+	 * because they believe those products are covered, so they have to reach the caller's non-zero exit
+	 * like any other withheld item.
+	 *
 	 * @param string $map The raw --map argument.
-	 * @return array
+	 * @return array {
+	 *     @type array $assignments Map of product ID => Network ID.
+	 *     @type int   $skipped     How many entries could not be used.
+	 * }
 	 */
 	private static function parse_map( $map ) {
 		// Only treat the argument as a path when it's short enough to be one: passing a long inline-JSON
@@ -843,24 +1089,31 @@ class Product_Network_Ids {
 		}
 
 		$assignments = [];
+		$skipped     = 0;
 		foreach ( $decoded as $product_id => $network_id ) {
 			// JSON object keys arrive as PHP int keys only when they are canonical integers; anything else
 			// ( "abc", "12abc" ) would cast to a real, unrelated product ID.
 			if ( ! preg_match( '/^[1-9][0-9]*$/', (string) $product_id ) ) {
 				WP_CLI::warning( sprintf( 'Skipping --map entry "%s": keys must be positive integer product IDs.', $product_id ) );
+				$skipped++;
 				continue;
 			}
 			if ( ! is_scalar( $network_id ) ) {
 				WP_CLI::warning( sprintf( 'Skipping product #%s in --map: Network ID must be a string.', $product_id ) );
+				$skipped++;
 				continue;
 			}
 			$network_id = sanitize_text_field( (string) $network_id );
 			if ( '' === $network_id ) {
 				WP_CLI::warning( sprintf( 'Skipping product #%s in --map: empty Network ID.', $product_id ) );
+				$skipped++;
 				continue;
 			}
 			$assignments[ (int) $product_id ] = $network_id;
 		}
-		return $assignments;
+		return [
+			'assignments' => $assignments,
+			'skipped'     => $skipped,
+		];
 	}
 }

--- a/plugins/newspack-network/tests/bootstrap.php
+++ b/plugins/newspack-network/tests/bootstrap.php
@@ -32,5 +32,10 @@ tests_add_filter( 'muplugins_loaded', 'newspack_network_hub_manually_load_plugin
 
 require_once __DIR__ . '/../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 
+// Lets tests call the WP-CLI command classes directly.
+require_once __DIR__ . '/class-wp-cli-halt.php';
+require_once __DIR__ . '/class-wp-cli.php';
+require_once __DIR__ . '/wp-cli-utils.php';
+
 // Start up the WP testing environment.
 require "{$newspack_network_hub_test_dir}/includes/bootstrap.php";

--- a/plugins/newspack-network/tests/class-wp-cli-halt.php
+++ b/plugins/newspack-network/tests/class-wp-cli-halt.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Stand-in for WP_CLI::error()'s process halt, so tests can assert a command exits non-zero.
+ *
+ * @package Newspack_Network
+ */
+
+if ( ! class_exists( 'WP_CLI_Halt' ) ) {
+	/**
+	 * Thrown by the test WP_CLI shim in place of WP-CLI's fatal exit.
+	 */
+	class WP_CLI_Halt extends \Exception {}
+}

--- a/plugins/newspack-network/tests/class-wp-cli.php
+++ b/plugins/newspack-network/tests/class-wp-cli.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Minimal WP_CLI shim for the test suite.
+ *
+ * The CLI command classes talk to WP_CLI for all of their output and for their exit codes, so
+ * without a stand-in they cannot be called from PHPUnit at all -- which is what kept assign() and
+ * verify() untested. This captures output in memory and turns WP_CLI::error() ( which halts the
+ * process with a non-zero exit code ) into a WP_CLI_Halt exception tests can assert on.
+ *
+ * The WP_CLI constant is deliberately NOT defined: the plugin registers its commands only when it
+ * is, and add_command() has no stand-in here.
+ *
+ * @package Newspack_Network
+ */
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	/**
+	 * Captures what a command would print.
+	 */
+	class WP_CLI {
+
+		/**
+		 * Everything printed since the last reset().
+		 *
+		 * @var string[]
+		 */
+		public static $output = [];
+
+		/**
+		 * Discard captured output.
+		 *
+		 * @return void
+		 */
+		public static function reset() {
+			self::$output = [];
+		}
+
+		/**
+		 * All captured output as a single string.
+		 *
+		 * @return string
+		 */
+		public static function get_output() {
+			return implode( "\n", self::$output );
+		}
+
+		/**
+		 * Capture a line.
+		 *
+		 * @param string $message The message.
+		 * @return void
+		 */
+		public static function line( $message = '' ) {
+			self::$output[] = (string) $message;
+		}
+
+		/**
+		 * Capture a log line.
+		 *
+		 * @param string $message The message.
+		 * @return void
+		 */
+		public static function log( $message = '' ) {
+			self::$output[] = (string) $message;
+		}
+
+		/**
+		 * Capture a warning.
+		 *
+		 * @param string $message The message.
+		 * @return void
+		 */
+		public static function warning( $message ) {
+			self::$output[] = 'Warning: ' . $message;
+		}
+
+		/**
+		 * Capture a success message.
+		 *
+		 * @param string $message The message.
+		 * @return void
+		 */
+		public static function success( $message ) {
+			self::$output[] = 'Success: ' . $message;
+		}
+
+		/**
+		 * Capture an error and halt, as WP_CLI does with a non-zero exit code.
+		 *
+		 * @param string $message The message.
+		 * @return void
+		 * @throws \WP_CLI_Halt Always.
+		 */
+		public static function error( $message ) {
+			self::$output[] = 'Error: ' . $message;
+			throw new \WP_CLI_Halt( esc_html( $message ) );
+		}
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli-commands.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli-commands.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Class TestProductNetworkIdsCLICommands
+ *
+ * End-to-end coverage of the assign/verify commands against real posts, postmeta and options,
+ * driven through the WP_CLI shim in tests/class-wp-cli.php. These pin the behaviour a migration
+ * runbook depends on: never writing a blank Network ID, never exiting 0 on a partial assignment,
+ * and never greening a flip gate on a product that grants nothing.
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\CLI\Product_Network_Ids;
+use Newspack_Network\Site_Role;
+use Newspack_Network\Woocommerce\Product_Admin;
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use Newspack_Network\Incoming_Events\Product_Updated;
+
+/**
+ * Test the assign and verify commands.
+ */
+class TestProductNetworkIdsCLICommands extends WP_UnitTestCase {
+
+	/**
+	 * Set the site up as a Hub and register the post types WooCommerce would ( it is not active here ).
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		update_option( Site_Role::OPTION_NAME, Site_Role::HUB_ROLE );
+		register_post_type( 'product', [ 'public' => true ] );
+		register_post_type( 'product_variation', [ 'public' => true ] );
+		register_post_type( Memberships_Admin::MEMBERSHIP_PLANS_CPT, [ 'public' => true ] );
+
+		WP_CLI::reset();
+	}
+
+	/**
+	 * Create a product, optionally already carrying a Network ID.
+	 *
+	 * @param string $network_id The Network ID to tag it with, or '' to leave it untagged.
+	 * @return int The product ID.
+	 */
+	private function create_product( $network_id = '' ) {
+		$product_id = self::factory()->post->create( [ 'post_type' => 'product' ] );
+		if ( '' !== $network_id ) {
+			update_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, $network_id );
+		}
+		return $product_id;
+	}
+
+	/**
+	 * Create a membership plan linking the given products.
+	 *
+	 * @param string $network_id  The plan's Network ID meta value.
+	 * @param array  $product_ids The linked product IDs.
+	 * @return int The plan ID.
+	 */
+	private function create_plan( $network_id, array $product_ids ) {
+		$plan_id = self::factory()->post->create( [ 'post_type' => Memberships_Admin::MEMBERSHIP_PLANS_CPT ] );
+		update_post_meta( $plan_id, Memberships_Admin::NETWORK_ID_META_KEY, $network_id );
+		update_post_meta( $plan_id, '_product_ids', $product_ids );
+		return $plan_id;
+	}
+
+	/**
+	 * The Network ID currently stored on a product.
+	 *
+	 * @param int $product_id The product ID.
+	 * @return string
+	 */
+	private function get_network_id( $product_id ) {
+		return (string) get_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, true );
+	}
+
+	/**
+	 * A plan whose Network ID is whitespace-only must never blank a correctly tagged product.
+	 *
+	 * The value survives a naive emptiness check but sanitizes to '', so before sanitization moved
+	 * ahead of that check --overwrite wrote the blank over a correct value and propagated it.
+	 */
+	public function test_assign_never_writes_a_blank_network_id_over_a_correct_one() {
+		$product_id = $this->create_product( 'golden-net' );
+		$this->create_plan( '   ', [ $product_id ] );
+
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::assign(
+				[],
+				[
+					'apply'     => true,
+					'overwrite' => true,
+				]
+			);
+		} finally {
+			$this->assertSame( 'golden-net', $this->get_network_id( $product_id ) );
+			$this->assertStringContainsString( 'carry no Network ID', WP_CLI::get_output() );
+		}
+	}
+
+	/**
+	 * The happy path: a plan's Network ID lands on every product it links, and the command exits 0.
+	 */
+	public function test_assign_writes_the_plans_network_id_to_its_products() {
+		$first_product_id  = $this->create_product();
+		$second_product_id = $this->create_product();
+		$this->create_plan( 'premium', [ $first_product_id, $second_product_id ] );
+
+		Product_Network_Ids::assign( [], [ 'apply' => true ] );
+
+		$this->assertSame( 'premium', $this->get_network_id( $first_product_id ) );
+		$this->assertSame( 'premium', $this->get_network_id( $second_product_id ) );
+		$this->assertStringContainsString( 'Success:', WP_CLI::get_output() );
+	}
+
+	/**
+	 * A plan linking a variation tags the parent product, where the Network ID is read from.
+	 */
+	public function test_assign_folds_a_linked_variation_into_its_parent_product() {
+		$parent_id    = $this->create_product();
+		$variation_id = self::factory()->post->create(
+			[
+				'post_type'   => 'product_variation',
+				'post_parent' => $parent_id,
+			]
+		);
+		$this->create_plan( 'premium', [ $variation_id ] );
+
+		Product_Network_Ids::assign( [], [ 'apply' => true ] );
+
+		$this->assertSame( 'premium', $this->get_network_id( $parent_id ) );
+		$this->assertSame( '', $this->get_network_id( $variation_id ) );
+	}
+
+	/**
+	 * A product claimed by two plans with different Network IDs is withheld -- and the command exits
+	 * non-zero, so a scripted migration cannot record a green step for a partial assignment.
+	 */
+	public function test_assign_withholds_a_conflicted_product_and_exits_non_zero() {
+		$conflicted_product_id  = $this->create_product();
+		$unambiguous_product_id = $this->create_product();
+		$this->create_plan( 'premium', [ $conflicted_product_id, $unambiguous_product_id ] );
+		$this->create_plan( 'basic', [ $conflicted_product_id ] );
+
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::assign( [], [ 'apply' => true ] );
+		} finally {
+			$this->assertSame( '', $this->get_network_id( $conflicted_product_id ) );
+			$this->assertSame( 'premium', $this->get_network_id( $unambiguous_product_id ) );
+		}
+	}
+
+	/**
+	 * --products with a value that parses to no IDs ( an unset shell variable in a runbook ) must fail
+	 * rather than report "nothing to check" and exit 0 -- this is the path a flip gate runs.
+	 */
+	public function test_verify_errors_when_the_products_flag_parses_to_nothing() {
+		$this->create_product( 'premium' );
+
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::verify( [], [ 'products' => '' ] );
+		} finally {
+			$this->assertStringContainsString( '--products was passed', WP_CLI::get_output() );
+		}
+	}
+
+	/**
+	 * Bare verify checks plan-linked products, not just already-tagged ones: otherwise everything
+	 * assign withholds is excluded from the check by construction and the gate greens a network
+	 * where a gate product grants nothing.
+	 */
+	public function test_verify_checks_plan_linked_products_that_assign_could_not_resolve() {
+		$conflicted_product_id = $this->create_product();
+		$this->create_plan( 'premium', [ $conflicted_product_id ] );
+		$this->create_plan( 'basic', [ $conflicted_product_id ] );
+
+		// A healthy, linked product, so the run would otherwise be green.
+		$tagged_product_id = $this->create_product( 'gold' );
+		update_option(
+			Product_Updated::OPTION_NAME,
+			[
+				'https://other-site.test' => [
+					9001 => [
+						'id'         => 9001,
+						'network_id' => 'gold',
+					],
+				],
+			]
+		);
+
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::verify( [], [] );
+		} finally {
+			$output = WP_CLI::get_output();
+			$this->assertStringContainsString( sprintf( '#%d: no Network ID set', $conflicted_product_id ), $output );
+			$this->assertStringContainsString( sprintf( '✓ #%d "gold"', $tagged_product_id ), $output );
+			$this->assertStringContainsString( 'Not ready to flip', $output );
+		}
+	}
+
+	/**
+	 * A green verify run: every checked product carries a Network ID another site also carries.
+	 */
+	public function test_verify_passes_when_a_product_is_linked_on_another_site() {
+		$product_id = $this->create_product( 'gold' );
+		$this->create_plan( 'gold', [ $product_id ] );
+		update_option(
+			Product_Updated::OPTION_NAME,
+			[
+				// The current site's own entry never counts as a link, so another site must carry it.
+				get_bloginfo( 'url' )     => [
+					$product_id => [
+						'id'         => $product_id,
+						'network_id' => 'gold',
+					],
+				],
+				'https://other-site.test' => [
+					9001 => [
+						'id'         => 9001,
+						'network_id' => 'gold',
+					],
+				],
+			]
+		);
+
+		Product_Network_Ids::verify( [], [] );
+
+		$this->assertStringContainsString( 'Success:', WP_CLI::get_output() );
+	}
+
+	/**
+	 * --map must be a JSON object keyed by product ID: a JSON list's 0..n-1 keys would otherwise be
+	 * taken for product IDs.
+	 */
+	public function test_assign_rejects_a_json_list_map() {
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::assign( [], [ 'map' => '["premium","basic"]' ] );
+		} finally {
+			$this->assertStringContainsString( 'got a JSON list', WP_CLI::get_output() );
+		}
+	}
+
+	/**
+	 * A non-integer --map key is reported and skipped rather than cast to an unrelated product ID
+	 * ( "12abc" would otherwise write to product 12 ).
+	 */
+	public function test_assign_skips_map_entries_with_non_integer_keys() {
+		$product_id = $this->create_product();
+
+		Product_Network_Ids::assign(
+			[],
+			[
+				'map'   => wp_json_encode(
+					[
+						'12abc'              => 'premium',
+						(string) $product_id => 'premium',
+					]
+				),
+				'apply' => true,
+			]
+		);
+
+		$this->assertSame( 'premium', $this->get_network_id( $product_id ) );
+		$this->assertSame( '', (string) get_post_meta( 12, Product_Admin::NETWORK_ID_META_KEY, true ) );
+		$this->assertStringContainsString( 'Skipping --map entry "12abc"', WP_CLI::get_output() );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli-commands.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli-commands.php
@@ -15,6 +15,7 @@ use Newspack_Network\Site_Role;
 use Newspack_Network\Woocommerce\Product_Admin;
 use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
 use Newspack_Network\Incoming_Events\Product_Updated;
+use Newspack_Network\Hub\Nodes as Hub_Nodes;
 
 /**
  * Test the assign and verify commands.
@@ -31,6 +32,7 @@ class TestProductNetworkIdsCLICommands extends WP_UnitTestCase {
 		register_post_type( 'product', [ 'public' => true ] );
 		register_post_type( 'product_variation', [ 'public' => true ] );
 		register_post_type( Memberships_Admin::MEMBERSHIP_PLANS_CPT, [ 'public' => true ] );
+		register_post_type( Hub_Nodes::POST_TYPE_SLUG, [ 'public' => false ] );
 
 		WP_CLI::reset();
 	}
@@ -232,6 +234,121 @@ class TestProductNetworkIdsCLICommands extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Register a Node on this Hub, so the network's membership is knowable.
+	 *
+	 * @param string $url The node's site URL.
+	 * @return int The node post ID.
+	 */
+	private function create_node( $url ) {
+		$node_id = self::factory()->post->create( [ 'post_type' => Hub_Nodes::POST_TYPE_SLUG ] );
+		update_post_meta( $node_id, 'node-url', untrailingslashit( $url ) );
+		return $node_id;
+	}
+
+	/**
+	 * A product linked to only one Node of several passes the default check but fails --expect-sites=all:
+	 * access is granted from the site the reader's own subscription lives on, so a product missing from
+	 * node2 grants a node2 subscriber nothing, however green the default run looks.
+	 */
+	public function test_verify_expect_sites_all_fails_on_a_node_missing_the_network_id() {
+		$product_id = $this->create_product( 'gold' );
+		$this->create_plan( 'gold', [ $product_id ] );
+		$this->create_node( 'https://node-one.test' );
+		$this->create_node( 'https://node-two.test' );
+		update_option(
+			Product_Updated::OPTION_NAME,
+			[
+				'https://node-one.test' => [
+					9001 => [
+						'id'         => 9001,
+						'network_id' => 'gold',
+					],
+				],
+			]
+		);
+
+		// Linked to one other site, so the default expectation passes -- while naming the gap.
+		Product_Network_Ids::verify( [], [] );
+		$this->assertStringContainsString( 'Success:', WP_CLI::get_output() );
+		$this->assertStringContainsString( 'not carried by: https://node-two.test', WP_CLI::get_output() );
+
+		WP_CLI::reset();
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::verify( [], [ 'expect-sites' => 'all' ] );
+		} finally {
+			$output = WP_CLI::get_output();
+			$this->assertStringContainsString( 'not carried by https://node-two.test', $output );
+			$this->assertStringContainsString( 'Not ready to flip', $output );
+		}
+	}
+
+	/**
+	 * --expect-sites=all is refused where the network's membership cannot be read, rather than silently
+	 * degrading to "any one site" -- a Node has no Nodes list, and that is the site a flip gate runs on.
+	 */
+	public function test_verify_expect_sites_all_errors_without_a_known_network_membership() {
+		$this->create_product( 'gold' );
+
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::verify( [], [ 'expect-sites' => 'all' ] );
+		} finally {
+			$this->assertStringContainsString( 'only readable on a Hub', WP_CLI::get_output() );
+		}
+	}
+
+	/**
+	 * --format=json emits one machine-readable report ( including the per-product missing sites ) so the
+	 * per-site gate can be aggregated across the network instead of scraped from prose.
+	 */
+	public function test_verify_json_format_reports_missing_sites() {
+		$product_id = $this->create_product( 'gold' );
+		$this->create_plan( 'gold', [ $product_id ] );
+		$this->create_node( 'https://node-one.test' );
+		$this->create_node( 'https://node-two.test' );
+		update_option(
+			Product_Updated::OPTION_NAME,
+			[
+				'https://node-one.test' => [
+					9001 => [
+						'id'         => 9001,
+						'network_id' => 'gold',
+					],
+				],
+			]
+		);
+
+		Product_Network_Ids::verify( [], [ 'format' => 'json' ] );
+
+		$json_lines = array_values(
+			array_filter(
+				WP_CLI::$output,
+				function ( $line ) {
+					return str_starts_with( $line, '{' );
+				}
+			)
+		);
+		$this->assertCount( 1, $json_lines, 'Only the report itself should be printed in JSON mode.' );
+
+		$report = json_decode( $json_lines[0], true );
+		$this->assertTrue( $report['ready_to_flip'] );
+		$this->assertSame( [ 'https://node-one.test', 'https://node-two.test' ], $report['known_sites'] );
+		$this->assertSame(
+			[
+				[
+					'id'            => $product_id,
+					'network_id'    => 'gold',
+					'status'        => 'ok',
+					'linked_sites'  => [ 'https://node-one.test' ],
+					'missing_sites' => [ 'https://node-two.test' ],
+				],
+			],
+			$report['products']
+		);
+	}
+
+	/**
 	 * --map must be a JSON object keyed by product ID: a JSON list's 0..n-1 keys would otherwise be
 	 * taken for product IDs.
 	 */
@@ -246,26 +363,32 @@ class TestProductNetworkIdsCLICommands extends WP_UnitTestCase {
 
 	/**
 	 * A non-integer --map key is reported and skipped rather than cast to an unrelated product ID
-	 * ( "12abc" would otherwise write to product 12 ).
+	 * ( "12abc" would otherwise write to product 12 ) -- and the skip counts as unresolved, so the
+	 * operator's other entries landing does not green a run that left a product they listed untagged.
 	 */
 	public function test_assign_skips_map_entries_with_non_integer_keys() {
 		$product_id = $this->create_product();
 
-		Product_Network_Ids::assign(
-			[],
-			[
-				'map'   => wp_json_encode(
-					[
-						'12abc'              => 'premium',
-						(string) $product_id => 'premium',
-					]
-				),
-				'apply' => true,
-			]
-		);
-
-		$this->assertSame( 'premium', $this->get_network_id( $product_id ) );
-		$this->assertSame( '', (string) get_post_meta( 12, Product_Admin::NETWORK_ID_META_KEY, true ) );
-		$this->assertStringContainsString( 'Skipping --map entry "12abc"', WP_CLI::get_output() );
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::assign(
+				[],
+				[
+					'map'   => wp_json_encode(
+						[
+							'12abc'              => 'premium',
+							(string) $product_id => 'premium',
+						]
+					),
+					'apply' => true,
+				]
+			);
+		} finally {
+			$output = WP_CLI::get_output();
+			$this->assertSame( 'premium', $this->get_network_id( $product_id ) );
+			$this->assertSame( '', (string) get_post_meta( 12, Product_Admin::NETWORK_ID_META_KEY, true ) );
+			$this->assertStringContainsString( 'Skipping --map entry "12abc"', $output );
+			$this->assertStringContainsString( '1 item(s) could not be assigned', $output );
+		}
 	}
 }

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli-commands.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli-commands.php
@@ -321,17 +321,12 @@ class TestProductNetworkIdsCLICommands extends WP_UnitTestCase {
 
 		Product_Network_Ids::verify( [], [ 'format' => 'json' ] );
 
-		$json_lines = array_values(
-			array_filter(
-				WP_CLI::$output,
-				function ( $line ) {
-					return str_starts_with( $line, '{' );
-				}
-			)
-		);
-		$this->assertCount( 1, $json_lines, 'Only the report itself should be printed in JSON mode.' );
+		// Everything printed, not just the lines that look like JSON: an aggregator runs json_decode over
+		// the whole of stdout, so a trailing "Success:" line on the green path would break it on exactly
+		// the sites that are healthy.
+		$this->assertCount( 1, WP_CLI::$output, 'Only the report itself should be printed in JSON mode.' );
 
-		$report = json_decode( $json_lines[0], true );
+		$report = json_decode( WP_CLI::$output[0], true );
 		$this->assertTrue( $report['ready_to_flip'] );
 		$this->assertSame( [ 'https://node-one.test', 'https://node-two.test' ], $report['known_sites'] );
 		$this->assertSame(
@@ -346,6 +341,38 @@ class TestProductNetworkIdsCLICommands extends WP_UnitTestCase {
 			],
 			$report['products']
 		);
+	}
+
+	/**
+	 * A bare --expect-sites ( no =value ) is refused. WP-CLI passes it as boolean true, which stringifies
+	 * to '1' and would otherwise resolve to the 1-site floor -- greening a flip for an operator who meant
+	 * --expect-sites=all and fumbled the syntax, on the very check meant to catch that gap.
+	 */
+	public function test_verify_errors_on_a_valueless_expect_sites_flag() {
+		$product_id = $this->create_product( 'gold' );
+		$this->create_plan( 'gold', [ $product_id ] );
+		$this->create_node( 'https://node-one.test' );
+		update_option(
+			Product_Updated::OPTION_NAME,
+			[
+				'https://node-one.test' => [
+					9001 => [
+						'id'         => 9001,
+						'network_id' => 'gold',
+					],
+				],
+			]
+		);
+
+		// Linked on one other site, so the 1-site floor this would silently fall back to passes.
+		$this->expectException( WP_CLI_Halt::class );
+		try {
+			Product_Network_Ids::verify( [], [ 'expect-sites' => true ] );
+		} finally {
+			$output = WP_CLI::get_output();
+			$this->assertStringContainsString( '--expect-sites needs a value', $output );
+			$this->assertStringNotContainsString( 'Success:', $output );
+		}
 	}
 
 	/**

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Class TestProductNetworkIdsCLI
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\CLI\Product_Network_Ids;
+
+/**
+ * Test the pure derivation and verification logic of the Product_Network_Ids CLI class.
+ */
+class TestProductNetworkIdsCLI extends WP_UnitTestCase {
+
+	/**
+	 * Two plans with disjoint products each yield their plan's Network ID, with no conflicts.
+	 */
+	public function test_derive_assignments_disjoint_plans() {
+		$plans = [
+			[
+				'network_id'  => 'premium',
+				'product_ids' => [ 10, 11 ],
+			],
+			[
+				'network_id'  => 'basic',
+				'product_ids' => [ 20 ],
+			],
+		];
+
+		$derived = Product_Network_Ids::derive_assignments_from_plans( $plans );
+
+		$this->assertSame(
+			[
+				10 => 'premium',
+				11 => 'premium',
+				20 => 'basic',
+			],
+			$derived['assignments']
+		);
+		$this->assertEmpty( $derived['conflicts'] );
+	}
+
+	/**
+	 * Plans with no Network ID or no products contribute nothing.
+	 */
+	public function test_derive_assignments_skips_empty_plans() {
+		$plans = [
+			[
+				'network_id'  => '',
+				'product_ids' => [ 10 ],
+			],
+			[
+				'network_id'  => 'premium',
+				'product_ids' => [],
+			],
+			[
+				'network_id'  => 'premium',
+				'product_ids' => [ 30 ],
+			],
+		];
+
+		$derived = Product_Network_Ids::derive_assignments_from_plans( $plans );
+
+		$this->assertSame( [ 30 => 'premium' ], $derived['assignments'] );
+		$this->assertEmpty( $derived['conflicts'] );
+	}
+
+	/**
+	 * A product listed by two plans with the same Network ID is not a conflict.
+	 */
+	public function test_derive_assignments_same_network_id_is_not_a_conflict() {
+		$plans = [
+			[
+				'network_id'  => 'premium',
+				'product_ids' => [ 10 ],
+			],
+			[
+				'network_id'  => 'premium',
+				'product_ids' => [ 10 ],
+			],
+		];
+
+		$derived = Product_Network_Ids::derive_assignments_from_plans( $plans );
+
+		$this->assertSame( [ 10 => 'premium' ], $derived['assignments'] );
+		$this->assertEmpty( $derived['conflicts'] );
+	}
+
+	/**
+	 * A product listed by two plans with different Network IDs is a conflict and is not assigned.
+	 */
+	public function test_derive_assignments_conflicting_network_ids() {
+		$plans = [
+			[
+				'network_id'  => 'premium',
+				'product_ids' => [ 10, 11 ],
+			],
+			[
+				'network_id'  => 'basic',
+				'product_ids' => [ 11 ],
+			],
+		];
+
+		$derived = Product_Network_Ids::derive_assignments_from_plans( $plans );
+
+		// Product 10 is unambiguous and still assigned; 11 is a conflict and withheld.
+		$this->assertSame( [ 10 => 'premium' ], $derived['assignments'] );
+		$this->assertArrayHasKey( 11, $derived['conflicts'] );
+		$this->assertContains( 'premium', $derived['conflicts'][11] );
+		$this->assertContains( 'basic', $derived['conflicts'][11] );
+	}
+
+	/**
+	 * The synced product map is indexed by Network ID, listing the sites that carry each ID.
+	 */
+	public function test_index_network_products_by_network_id() {
+		$network_products = [
+			'http://site1' => [
+				100 => [
+					'id'         => 100,
+					'network_id' => 'premium',
+				],
+				101 => [
+					'id'         => 101,
+					'network_id' => 'basic',
+				],
+				102 => [
+					'id'         => 102,
+					'network_id' => '', // Untagged, ignored.
+				],
+			],
+			'http://site2' => [
+				200 => [
+					'id'         => 200,
+					'network_id' => 'premium',
+				],
+			],
+		];
+
+		$index = Product_Network_Ids::index_network_products_by_network_id( $network_products );
+
+		// The index is a per-Network-ID site-presence map: which sites carry each ID.
+		$this->assertSame( [ 'http://site1', 'http://site2' ], array_keys( $index['premium'] ) );
+		$this->assertTrue( $index['premium']['http://site1'] );
+		$this->assertTrue( $index['premium']['http://site2'] );
+		$this->assertSame( [ 'http://site1' ], array_keys( $index['basic'] ) );
+		$this->assertArrayNotHasKey( '', $index );
+	}
+
+	/**
+	 * Verification reports cross-site linkage per product and flags the NPPD-2057 field failures:
+	 * a product tagged with a Network ID no other site carries, or a product not tagged at all.
+	 * The current site is excluded from the linkage count so a product is not counted as linked to
+	 * itself: site1 self-includes product 100 ( 'premium' ) in the map, yet 100's linked_sites is
+	 * [ site2 ] only -- proving the self-entry is dropped, not that it is absent.
+	 */
+	public function test_verify_products() {
+		$current_site = 'http://site1';
+
+		$local_products = [
+			100 => 'premium', // Linked on site2 -> healthy.
+			101 => 'basic',   // No other site carries it -> unlinked.
+			103 => 'gold',    // No other site carries it -> unlinked.
+			104 => '',        // Untagged (explicit --products path) -> nothing resolves.
+		];
+
+		$network_products = [
+			'http://site1' => [
+				100 => [
+					'id'         => 100,
+					'network_id' => 'premium',
+				],
+				101 => [
+					'id'         => 101,
+					'network_id' => 'basic',
+				],
+			],
+			'http://site2' => [
+				200 => [
+					'id'         => 200,
+					'network_id' => 'premium',
+				],
+			],
+		];
+
+		$findings = Product_Network_Ids::verify_products( $local_products, $network_products, $current_site );
+
+		// Product 100: linked to site2. The current site's own entry is ignored (never counts as a link).
+		$this->assertSame( [ 'http://site2' ], $findings[100]['linked_sites'] );
+
+		// Product 101: no other site shares 'basic'.
+		$this->assertEmpty( $findings[101]['linked_sites'] );
+
+		// Product 103: no other site shares 'gold'.
+		$this->assertEmpty( $findings[103]['linked_sites'] );
+
+		// Product 104: untagged - resolves to nothing.
+		$this->assertSame( '', $findings[104]['network_id'] );
+		$this->assertEmpty( $findings[104]['linked_sites'] );
+	}
+
+	/**
+	 * --map parsing coerces JSON string keys to integer product IDs and trims Network ID values.
+	 *
+	 * ( The empty-value branch calls WP_CLI::warning, which is unavailable under PHPUnit, so it is
+	 * exercised via the CLI end-to-end rather than here. )
+	 */
+	public function test_parse_map() {
+		$parse_map_method = new ReflectionMethod( Product_Network_Ids::class, 'parse_map' );
+		$parse_map_method->setAccessible( true );
+
+		$parsed = $parse_map_method->invoke( null, '{"5":"premium","6":" basic "}' );
+
+		// JSON object keys arrive as strings; they must become integer product IDs.
+		$this->assertSame( [ 5, 6 ], array_keys( $parsed ) );
+		$this->assertSame( 'premium', $parsed[5] );
+		// Values are trimmed.
+		$this->assertSame( 'basic', $parsed[6] );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
@@ -209,13 +209,16 @@ class TestProductNetworkIdsCLI extends WP_UnitTestCase {
 		$parse_map_method = new ReflectionMethod( Product_Network_Ids::class, 'parse_map' );
 		$parse_map_method->setAccessible( true );
 
-		$parsed = $parse_map_method->invoke( null, '{"5":"premium","6":" basic "}' );
+		$parsed = $parse_map_method->invoke( null, '{"5":"premium","6":" basic ","7":"  "}' );
 
 		// JSON object keys arrive as strings; they must become integer product IDs.
-		$this->assertSame( [ 5, 6 ], array_keys( $parsed ) );
-		$this->assertSame( 'premium', $parsed[5] );
+		$this->assertSame( [ 5, 6 ], array_keys( $parsed['assignments'] ) );
+		$this->assertSame( 'premium', $parsed['assignments'][5] );
 		// Values are sanitized ( sanitize_text_field trims surrounding whitespace ).
-		$this->assertSame( 'basic', $parsed[6] );
+		$this->assertSame( 'basic', $parsed['assignments'][6] );
+		// #7 sanitizes to '', so it is withheld -- and counted, so assign() can fail the run rather than
+		// letting an entry the operator listed vanish into a warning.
+		$this->assertSame( 1, $parsed['skipped'] );
 	}
 
 	/**
@@ -237,7 +240,7 @@ class TestProductNetworkIdsCLI extends WP_UnitTestCase {
 
 		$parsed = $parse_map_method->invoke( null, $long_map );
 
-		$this->assertSame( count( $pairs ), count( $parsed ) );
-		$this->assertSame( 'premium', reset( $parsed ) );
+		$this->assertSame( count( $pairs ), count( $parsed['assignments'] ) );
+		$this->assertSame( 'premium', reset( $parsed['assignments'] ) );
 	}
 }

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
@@ -200,10 +200,10 @@ class TestProductNetworkIdsCLI extends WP_UnitTestCase {
 	}
 
 	/**
-	 * --map parsing coerces JSON string keys to integer product IDs and trims Network ID values.
+	 * --map parsing coerces JSON string keys to integer product IDs and sanitizes Network ID values.
 	 *
-	 * ( The empty-value branch calls WP_CLI::warning, which is unavailable under PHPUnit, so it is
-	 * exercised via the CLI end-to-end rather than here. )
+	 * ( The empty-value and non-scalar branches call WP_CLI::warning, which is unavailable under PHPUnit,
+	 * so they are exercised via the CLI end-to-end rather than here. )
 	 */
 	public function test_parse_map() {
 		$parse_map_method = new ReflectionMethod( Product_Network_Ids::class, 'parse_map' );
@@ -214,7 +214,7 @@ class TestProductNetworkIdsCLI extends WP_UnitTestCase {
 		// JSON object keys arrive as strings; they must become integer product IDs.
 		$this->assertSame( [ 5, 6 ], array_keys( $parsed ) );
 		$this->assertSame( 'premium', $parsed[5] );
-		// Values are trimmed.
+		// Values are sanitized ( sanitize_text_field trims surrounding whitespace ).
 		$this->assertSame( 'basic', $parsed[6] );
 	}
 }

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
@@ -217,4 +217,27 @@ class TestProductNetworkIdsCLI extends WP_UnitTestCase {
 		// Values are sanitized ( sanitize_text_field trims surrounding whitespace ).
 		$this->assertSame( 'basic', $parsed[6] );
 	}
+
+	/**
+	 * An inline-JSON map longer than PHP_MAXPATHLEN still parses: the path-detection guard skips
+	 * is_readable() for over-length strings, so no "File name too long" E_WARNING is raised.
+	 */
+	public function test_parse_map_long_inline_json_is_not_treated_as_a_path() {
+		$parse_map_method = new ReflectionMethod( Product_Network_Ids::class, 'parse_map' );
+		$parse_map_method->setAccessible( true );
+
+		// Build a JSON object whose serialized length comfortably exceeds PHP_MAXPATHLEN: each
+		// entry serializes to more than one character, so PHP_MAXPATHLEN entries guarantees it.
+		$pairs = [];
+		foreach ( range( 1, PHP_MAXPATHLEN ) as $product_id ) {
+			$pairs[ (string) $product_id ] = 'premium';
+		}
+		$long_map = wp_json_encode( $pairs );
+		$this->assertGreaterThan( PHP_MAXPATHLEN, strlen( $long_map ) );
+
+		$parsed = $parse_map_method->invoke( null, $long_map );
+
+		$this->assertSame( count( $pairs ), count( $parsed ) );
+		$this->assertSame( 'premium', reset( $parsed ) );
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
+++ b/plugins/newspack-network/tests/unit-tests/test-product-network-ids-cli.php
@@ -202,8 +202,8 @@ class TestProductNetworkIdsCLI extends WP_UnitTestCase {
 	/**
 	 * --map parsing coerces JSON string keys to integer product IDs and sanitizes Network ID values.
 	 *
-	 * ( The empty-value and non-scalar branches call WP_CLI::warning, which is unavailable under PHPUnit,
-	 * so they are exercised via the CLI end-to-end rather than here. )
+	 * ( The rejected-input branches are covered in TestProductNetworkIdsCLICommands, which drives the
+	 * commands through the WP_CLI shim. )
 	 */
 	public function test_parse_map() {
 		$parse_map_method = new ReflectionMethod( Product_Network_Ids::class, 'parse_map' );

--- a/plugins/newspack-network/tests/wp-cli-utils.php
+++ b/plugins/newspack-network/tests/wp-cli-utils.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Stand-in for the WP-CLI helpers the command classes call, for the test suite.
+ *
+ * @package Newspack_Network
+ */
+
+namespace WP_CLI\Utils;
+
+if ( ! function_exists( 'WP_CLI\Utils\get_flag_value' ) ) {
+	/**
+	 * Read an associative argument, falling back to a default when it was not passed.
+	 *
+	 * @param array  $assoc_args    The associative arguments.
+	 * @param string $flag          The flag name.
+	 * @param mixed  $default_value Value to return when the flag is absent.
+	 * @return mixed
+	 */
+	function get_flag_value( $assoc_args, $flag, $default_value = null ) {
+		return isset( $assoc_args[ $flag ] ) ? $assoc_args[ $flag ] : $default_value;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds migration tooling for the Access Control rollout on a Newspack Network (hub + nodes).

**Why.** Access Control's cross-site paid access only grants something when a gate's products carry a product Network ID (the `_newspack_network_product_id` postmeta that `Content_Gate\Access` reads). The only writer today is a manual per-product metabox, so a network migrated from Woo Memberships routinely ends up with healthy membership/subscription sync but **zero tagged products** — and flipping a node in that state silently strips its network-synced members, because nothing links its gate products to the matching products on other sites. This PR makes tagging assignable in bulk and verifiable before a flip.

**What.** Two WP-CLI commands in the `newspack-network` namespace:

- `wp newspack-network assign-product-network-ids` — assigns product Network IDs across the network's products. By default it **derives** them from the shared plan-level `_newspack_network_id` (writing each membership plan's Network ID onto every product the plan links, read from the plan's `_product_ids`); alternatively `--map` takes an explicit operator mapping (inline JSON `{"<product_id>":"<network_id>"}` or a path to a JSON file). Dry-run by default; `--apply` writes. When a product is claimed by two plans with **different** Network IDs the assignment is **withheld** and reported as a conflict rather than guessed. Existing differing values are protected unless `--overwrite`, and a Network ID that sanitizes to empty is never written whatever the flags — with `--overwrite` a whitespace-only plan value would otherwise blank a correct ID and propagate the blank network-wide. Everything the command **could not** resolve (an untagged plan, a conflict, a skipped product, an unusable `--map` entry) rolls into a **non-zero exit**, so a scripted migration cannot record a green step for a partial run. On write it fires the existing `newspack_network_save_product` action — the same one the product metabox fires — so the shipped emitter/propagation path runs; `--repropagate` re-emits for products that already carry the target ID (which otherwise fire no event), which is the way to re-sync a tagged-but-desynced product.
- `wp newspack-network verify-product-network-ids` — a per-site pre-flip gate. It reports, per product, whether it carries a Network ID and which **other sites** in the synced products map share that ID (without which the cross-site grant resolves to nothing). The default product set is every product a membership plan links **plus** every already-tagged product, so the products `assign` withheld are checked rather than defined away; `--products` narrows it to a gate's products. `--expect-sites=<count|all>` raises the bar from "linked somewhere" to real coverage (`all` = every Node registered on this Hub), since a reader is only granted from the site their own subscription lives on. `--format=json` emits one machine-readable report for aggregating the per-site gate across a network. It **exits non-zero** on any issue so a flip can be gated on it.

**Hub self-inclusion subtlety.** `verify` excludes the current site from the linkage count. This is load-bearing on the **Hub**: a Hub self-includes its own products under its own URL key in the synced map (via `always_process_in_hub`), so without the exclusion a Hub-only Network ID would count as "linked to itself" and produce a false "ready to flip". On a **Node** there is no self-entry (a node never receives its own events back — the Hub excludes the requesting node when serving pulls), so the exclusion is simply a no-op there. Checking only cross-site linkage is what makes the command correct on both roles.

**Documented limitations** (in the command docblocks):

- A default `verify` run only proves each product is linked to *some* other visible site. Full coverage needs `--expect-sites=all`, which is only available on a Hub (a Node cannot read the network's membership — pass a count there).
- The synced products option is **append-only** (there is no product-deleted listener), so a stale entry for a since-removed product or site can still report as "linked".
- Linkage matching relies on the site's URL staying stable as the map key (compared case- and trailing-slash-insensitively, but still the usual URL-key caveat).

This is a **hard prerequisite step for Access Control migration on networked sites**; runbook integration follows separately.

Closes NPPD-2057.

### How to test the changes in this Pull Request:

1. On a Newspack Network (hub + nodes) with membership plans carrying `_newspack_network_id` and linked products, run `wp newspack-network assign-product-network-ids` (dry-run) and confirm it reports the plan-derived product => Network ID assignments, withholds any conflicting product, and protects already-tagged products; then `--apply` and confirm the meta is written and the save-product event fires.
2. Run `wp newspack-network verify-product-network-ids` and confirm a plan-linked but untagged product is flagged and the command exits non-zero; then `--products=<gate product IDs>` for the gate-specific check, and `--expect-sites=all` on the Hub to confirm a product missing from one Node fails even though it is linked on another.
3. Unit suite: from `plugins/newspack-network`, `n test-php --filter TestProductNetworkIds` — green. PHPCS clean on the changed files.

E2E-verified locally in an isolated env: dry-run/apply/`--overwrite`/`--map` paths; conflict withholding; the save-product propagation action firing on `--apply`; verify exit codes (0 green / non-zero on untagged or unlinked); and specifically that a product self-included in the map under the current site's own URL (with no other site sharing the ID) is correctly flagged **unlinked**, proving the Hub self-exclusion is load-bearing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
