### PR TITLE
fix(components): keep the more menu on enabled unsupported cards

### DIFF
--- a/packages/components/DEVELOPMENT.md
+++ b/packages/components/DEVELOPMENT.md
@@ -100,7 +100,7 @@ When building a screen, use the **spacing scale** (8px unit: 16, 24, 32, 48, 64)
 - **`Notice`** – Use for outcome feedback (success/error/warning) or short contextual messages. Vertical margin is 32px so notices don’t collide with cards; keep one primary message per area when possible.
 - **`Waiting`** – Loading state indicator.
 - **`ProgressBar`** – Progress indicator.
-- **`Accordion`** – Collapsible content sections.
+- **`Accordion`** / **`AccordionPanel`** – Container for one or more collapsible panels.
 - **`StepsList`** / **`StepsListItem`** – Step-by-step list components.
 - **`StyleCard`** – Style preview card.
 

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { __experimentalVStack as VStack, PanelBody } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Children, Fragment, cloneElement } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -12,22 +12,34 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Divider from '../divider';
 import './style.scss';
 
-const Accordion = ( { children, title, defaultOpen = false } ) => {
-	const [ isOpen, setIsOpen ] = useState( defaultOpen );
+export const AccordionPanel = ( { children, className, title, defaultOpen = false } ) => (
+	<PanelBody className={ className } title={ title } initialOpen={ defaultOpen }>
+		{ children }
+	</PanelBody>
+);
+
+const Accordion = ( { children, className, hideSingleTitle = false, spacing = 6 } ) => {
+	const panels = Children.toArray( children );
+	// With nothing to collapse against, a lone panel can render open and untitled.
+	if ( hideSingleTitle && panels.length === 1 ) {
+		return (
+			<div className={ classNames( 'newspack-accordion', className ) }>
+				{ cloneElement( panels[ 0 ], { defaultOpen: true, title: undefined } ) }
+			</div>
+		);
+	}
 	return (
-		<details
-			className={ classNames( 'newspack-accordion', { 'newspack-accordion--is-open': isOpen } ) }
-			open={ isOpen }
-			onToggle={ e => setIsOpen( e.currentTarget.open ) }
-		>
-			<summary>
-				{ title }
-				<Icon className="newspack-accordion__icon" icon={ chevronRight } size={ 24 } />
-			</summary>
-			<div className="newspack-accordion__content">{ children }</div>
-		</details>
+		<VStack className={ classNames( 'newspack-accordion', className ) } spacing={ spacing }>
+			{ panels.map( ( panel, index ) => (
+				<Fragment key={ panel.key }>
+					{ panel }
+					{ index < panels.length - 1 && <Divider variant="secondary" marginBottom={ 0 } marginTop={ 0 } /> }
+				</Fragment>
+			) ) }
+		</VStack>
 	);
 };
 

--- a/packages/components/src/accordion/index.test.js
+++ b/packages/components/src/accordion/index.test.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Accordion, { AccordionPanel } from './index';
+
+const renderPanels = ( count, props = {} ) =>
+	render(
+		<Accordion { ...props }>
+			{ Array.from( { length: count }, ( _, i ) => (
+				<AccordionPanel key={ i } title={ `Panel ${ i }` }>
+					content
+				</AccordionPanel>
+			) ) }
+		</Accordion>
+	);
+
+const dividers = container => container.querySelectorAll( '.newspack-divider' );
+
+describe( 'Accordion dividers', () => {
+	it( 'renders no divider for a single panel', () => {
+		const { container } = renderPanels( 1 );
+		expect( container.querySelectorAll( '.components-panel__body' ) ).toHaveLength( 1 );
+		expect( dividers( container ) ).toHaveLength( 0 );
+	} );
+
+	it( 'renders a divider between panels but not after the last', () => {
+		const { container } = renderPanels( 3 );
+		expect( container.querySelectorAll( '.components-panel__body' ) ).toHaveLength( 3 );
+		expect( dividers( container ) ).toHaveLength( 2 );
+		expect( container.querySelector( '.newspack-accordion' ).lastElementChild ).not.toHaveClass( 'newspack-divider' );
+	} );
+
+	it( 'renders secondary dividers', () => {
+		const { container } = renderPanels( 2 );
+		expect( dividers( container )[ 0 ] ).toHaveClass( 'newspack-divider--variant-secondary' );
+	} );
+} );
+
+describe( 'Accordion hideSingleTitle', () => {
+	it( 'keeps the title on a lone panel by default', () => {
+		renderPanels( 1 );
+		expect( screen.getByRole( 'button', { name: 'Panel 0' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'drops the title and opens a lone panel when set', () => {
+		const { container } = renderPanels( 1, { hideSingleTitle: true } );
+		expect( screen.queryByRole( 'button', { name: 'Panel 0' } ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-panel__body' ) ).toHaveClass( 'is-opened' );
+		expect( screen.getByText( 'content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves titles alone when there is more than one panel', () => {
+		renderPanels( 2, { hideSingleTitle: true } );
+		expect( screen.getByRole( 'button', { name: 'Panel 0' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Panel 1' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/accordion/style.scss
+++ b/packages/components/src/accordion/style.scss
@@ -1,31 +1,35 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
+// Sit flush with the surrounding column: core insets panels horizontally, which
+// would misalign them against the section they belong to.
 .newspack-accordion {
-	border: 1px solid wp-colors.$gray-300;
+	.components-panel__body {
+		border: 0;
 
-	&__icon {
-		transition: transform 200ms ease-out;
-		transform: rotate(90deg);
-	}
-
-	&--is-open {
-		.newspack-accordion {
-			&__icon {
-				transform: rotate(-90deg);
-			}
+		> .components-panel__body-title:hover {
+			background: none;
 		}
 	}
-	summary {
-		padding: 16px 32px;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		cursor: pointer;
-		font-size: 14px;
-		font-weight: bold;
+
+	.components-panel__body.is-opened {
+		padding: 0;
+
+		> .components-panel__body-title {
+			margin: 0 0 wp-vars.$grid-unit-30;
+		}
 	}
 
-	&__content {
-		padding: 16px 32px;
+	.components-panel__body-toggle.components-button {
+		@include wp-mixins.heading-large();
+		padding: 0;
+
+		.components-panel__arrow {
+			right: 0;
+		}
+
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+		}
 	}
 }

--- a/packages/components/src/card-feature/README.md
+++ b/packages/components/src/card-feature/README.md
@@ -11,7 +11,7 @@ A card component for presenting a named feature or setting with a predictable, s
 
 | State | Condition | Button | Dropdown | Badge |
 |---|---|---|---|---|
-| **Unmet requirements** | `requirements` is set | "Enable" — disabled (clickable if `requirementsActionable`) | Hidden | Error badge with `requirements` text |
+| **Unmet requirements** | `requirements` is set | "Enable" — disabled (clickable if `requirementsActionable`) | Shown if `enabled` and `requirementsActionable` (and `moreControls` provided); otherwise hidden | Error badge with `requirements` text |
 | **Disabled** | `!enabled`, no requirements | "Enable" | Hidden | None |
 | **Enabled** | `enabled`, no requirements | "Configure" | Shown if `moreControls` provided | Success badge ("Enabled") |
 
@@ -155,12 +155,12 @@ import { __ } from '@wordpress/i18n';
 | `icon` | `CardFeatureIcon` | — | Icon displayed on the right. See `CardFeatureIcon` below. |
 | `enabled` | `boolean` | `false` | Whether the feature is currently enabled |
 | `requirements` | `string` | — | When set, enters the unmet-requirements state; value is used as the error badge text |
-| `requirementsActionable` | `boolean` | `false` | When `requirements` is set, keep the primary button clickable so it can remediate the unmet requirement |
+| `requirementsActionable` | `boolean` | `false` | When `requirements` is set, keep the primary button clickable so it can remediate the unmet requirement, and keep the "More" dropdown visible on an enabled card (degraded but still operable) |
 | `enableLabel` | `string` | `"Enable"` | Primary button label when not enabled |
 | `configureLabel` | `string` | `"Configure"` | Primary button label when enabled |
 | `onEnable` | `() => void` | — | Called when the primary button is clicked and the feature is not enabled |
 | `onConfigure` | `() => void` | — | Called when the primary button is clicked and the feature is enabled |
-| `moreControls` | `MoreControl[]` | — | Items for the "More" dropdown, shown only when enabled |
+| `moreControls` | `MoreControl[]` | — | Items for the "More" dropdown. Shown when `enabled` and either there are no `requirements` or `requirementsActionable` is set |
 | `badgeText` | `string` | `"Enabled"` | Badge text shown when enabled |
 | `badgeLevel` | `BadgeLevel` | `"success"` | Badge level shown when enabled |
 | `className` | `string` | — | Additional class name applied to the card element |

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -58,7 +58,9 @@ type CardFeatureProps = {
 	requirements?: string;
 	/**
 	 * When `requirements` is set, keep the primary button clickable so the
-	 * user can remediate the unmet requirement from this card.
+	 * user can remediate the unmet requirement from this card, and keep the
+	 * "More" dropdown available — the feature is degraded but still operable
+	 * (e.g. can be disabled), unlike a hard-locked requirement.
 	 */
 	requirementsActionable?: boolean;
 	/** Primary button label when not enabled. Default: "Enable". */
@@ -71,7 +73,7 @@ type CardFeatureProps = {
 	onEnable?: () => void;
 	/** Called when the primary button is clicked and the feature is enabled. */
 	onConfigure?: () => void;
-	/** Controls rendered inside the "More" dropdown, shown only when enabled. */
+	/** Controls rendered inside the "More" dropdown, shown when enabled — including the unmet-requirements state when `requirementsActionable`. */
 	moreControls?: MoreControl[];
 	/** Badge text shown when enabled. Default: "Enabled". */
 	badgeText?: string;
@@ -118,6 +120,7 @@ const CardFeature = ( {
 
 	const isConfigureState = enabled && ! requirements;
 	const buttonLabel = isConfigureState ? configureLabel ?? __( 'Configure', 'newspack-plugin' ) : enableLabel ?? __( 'Enable', 'newspack-plugin' );
+	const showMoreControls = enabled && !! moreControls?.length && ( ! requirements || requirementsActionable );
 
 	const handleButtonClick = () => {
 		if ( isConfigureState ) {
@@ -174,7 +177,7 @@ const CardFeature = ( {
 								>
 									{ buttonLabel }
 								</Button>
-								{ isConfigureState && !! moreControls?.length && (
+								{ showMoreControls && (
 									<DropdownMenu
 										icon={ moreVertical }
 										label={ __( 'More', 'newspack-plugin' ) }

--- a/packages/components/src/divider/style.scss
+++ b/packages/components/src/divider/style.scss
@@ -34,7 +34,7 @@
 	// Variant
 
 	&--variant-default {
-		background-color: wp-colors.$gray-300;
+		background-color: var( --wpds-color-stroke-surface-neutral, #{wp-colors.$gray-300} );
 	}
 
 	&--variant-primary {

--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -61,6 +61,11 @@
 		grid-row-gap: 16px;
 	}
 
+	// Row Gap 24
+	&__row-gap-24 {
+		grid-row-gap: 24px;
+	}
+
 	// Row Gap 32
 	&__row-gap-32 {
 		grid-row-gap: 32px;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,4 +1,4 @@
-export { default as Accordion } from './accordion';
+export { default as Accordion, AccordionPanel } from './accordion';
 export { default as ActionCard } from './action-card';
 export { default as AutocompleteTokenField } from './autocomplete-tokenfield';
 export { default as AutocompleteWithSuggestions } from './autocomplete-with-suggestions';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -35,12 +35,9 @@
 // Checkboxes
 .newspack-checkbox-control {
 	margin-top: 0 !important;
-	.components-checkbox-control__label {
-		font-weight: 600;
-	}
 
 	.components-base-control__help {
-		margin-left: 32px;
+		margin-left: calc(var(--checkbox-input-size) + var(--checkbox-input-margin));
 		margin-top: 0;
 	}
 }

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -46,7 +46,7 @@
 	}
 
 	&__main {
-		overflow-x: hidden;
+		overflow: hidden;
 		padding-bottom: 1px; /* Prevents borders from being cut off */
 	}
 

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -220,9 +220,9 @@ h1 {
 		margin-top: 8px;
 
 		// Match the width of a single card in the 2-column CardFeature grid
-		// (grid has 16px gutter; falls back to 1 column below 744px viewport).
+		// (grid has 32px gutter; falls back to 1 column below 744px viewport).
 		@media screen and ( min-width: 744px ) {
-			max-width: calc((100% - 16px) / 2);
+			max-width: calc((100% - 32px) / 2);
 		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/card-feature-more-menu.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/card-feature-more-menu.test.js
@@ -41,6 +41,11 @@ describe( 'CardFeature More menu gating', () => {
 		expect( moreMenu() ).not.toBeInTheDocument();
 	} );
 
+	it( 'hides the More menu when not enabled even with an actionable requirement', () => {
+		renderCard( { enabled: false, requirements: 'Requires an API-based ESP', requirementsActionable: true } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+
 	it( 'hides the More menu when there are no controls', () => {
 		renderCard( { enabled: true, moreControls: [] } );
 		expect( moreMenu() ).not.toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/card-feature-more-menu.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/card-feature-more-menu.test.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { CardFeature } from '../../../../../packages/components/src';
+
+// packages/components has no test runner and is outside the `--filter newspack`
+// suite, so CardFeature's More-menu gating is exercised here against the real
+// component. Do NOT mock @wordpress/data — mocking it breaks the real
+// @wordpress/components barrel (its @wordpress/rich-text dependency runs
+// combineReducers() at module load).
+
+const defaultControls = [ { title: 'Disable', onClick: jest.fn() } ];
+
+const renderCard = props => render( <CardFeature title="Newsletter ESP" moreControls={ defaultControls } { ...props } /> );
+
+const moreMenu = () => screen.queryByRole( 'button', { name: 'More' } );
+
+describe( 'CardFeature More menu gating', () => {
+	it( 'shows the More menu when enabled with no requirements', () => {
+		renderCard( { enabled: true } );
+		expect( moreMenu() ).toBeInTheDocument();
+	} );
+
+	it( 'shows the More menu when enabled with an actionable requirement', () => {
+		renderCard( { enabled: true, requirements: 'Requires an API-based ESP', requirementsActionable: true } );
+		expect( moreMenu() ).toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when the requirement is not actionable (locked)', () => {
+		renderCard( { enabled: true, requirements: 'Managed by site configuration', requirementsActionable: false } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when not enabled', () => {
+		renderCard( { enabled: false } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the More menu when there are no controls', () => {
+		renderCard( { enabled: true, moreControls: [] } );
+		expect( moreMenu() ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -9,7 +9,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Accordion, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
+import { Accordion, AccordionPanel, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../wizards-tab';
 import { SettingsField } from './settings-field';
@@ -214,91 +214,87 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	return (
 		<>
 			{ navBlockDialog }
-			<WizardsTab isFetching={ loading }>
-				<div className="newspack-configure-view">
-					{ /* Section 1: Settings */ }
-					{ settingsFields.length > 0 && (
-						<Grid columns={ 2 } gutter={ 32 }>
-							<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
-							<Grid columns={ 1 } rowGap={ 16 }>
-								{ settingsFields.filter( fieldIsVisible ).map( field => (
-									<SettingsField
-										key={ field.key }
-										field={ field }
-										value={ getFieldValue( field ) }
-										onChange={ val => handleFieldChange( field.key, val ) }
-									/>
-								) ) }
+			<div className="newspack-configure-view">
+				{ /* Section 1: Settings */ }
+				{ settingsFields.length > 0 && (
+					<Grid columns={ 2 } gutter={ 32 }>
+						<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
+						<Grid columns={ 1 } gutter={ 24 }>
+							{ settingsFields.filter( fieldIsVisible ).map( field => (
+								<SettingsField
+									key={ field.key }
+									field={ field }
+									value={ getFieldValue( field ) }
+									onChange={ val => handleFieldChange( field.key, val ) }
+								/>
+							) ) }
+						</Grid>
+					</Grid>
+				) }
+
+				{ /* Section 2: Inbound */ }
+				{ inboundField && (
+					<>
+						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
+						<Grid columns={ 2 } gutter={ 32 } noMargin>
+							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
+							<Grid columns={ 1 } rowGap={ 8 } noMargin>
+								{ ( inboundField.options || [] ).map( option => {
+									// Framework injects options as { value, label } objects
+									// (see class-integration.php:get_settings_config()), but accepts bare strings
+									// for backward compatibility.
+									const optionValue = typeof option === 'string' ? option : option.value;
+									const optionLabel = typeof option === 'string' ? option : option.label || option.value;
+									const currentValue = getFieldValue( inboundField );
+									const selected = Array.isArray( currentValue ) ? currentValue : [];
+									return (
+										<CheckboxControl
+											className="newspack-checkbox-control"
+											key={ optionValue }
+											label={ optionLabel }
+											checked={ selected.includes( optionValue ) }
+											onChange={ checked => handleCheckboxListChange( inboundField.key, currentValue, optionValue, checked ) }
+										/>
+									);
+								} ) }
 							</Grid>
 						</Grid>
-					) }
+					</>
+				) }
 
-					{ /* Section 2: Inbound */ }
-					{ inboundField && (
-						<>
-							<Divider alignment="full-width" variant="tertiary" marginTop={ 32 } marginBottom={ 32 } />
-							<Grid columns={ 2 } gutter={ 32 } noMargin>
-								<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
-								<Grid columns={ 1 } rowGap={ 8 } noMargin>
-									{ ( inboundField.options || [] ).map( option => {
-										// Framework injects options as { value, label } objects
-										// (see class-integration.php:get_settings_config()), but accepts bare strings
-										// for backward compatibility.
-										const optionValue = typeof option === 'string' ? option : option.value;
-										const optionLabel = typeof option === 'string' ? option : option.label || option.value;
-										const currentValue = getFieldValue( inboundField );
-										const selected = Array.isArray( currentValue ) ? currentValue : [];
-										return (
-											<CheckboxControl
-												className="newspack-checkbox-control"
-												key={ optionValue }
-												label={ optionLabel }
-												checked={ selected.includes( optionValue ) }
-												onChange={ checked =>
-													handleCheckboxListChange( inboundField.key, currentValue, optionValue, checked )
-												}
-											/>
-										);
-									} ) }
-								</Grid>
-							</Grid>
-						</>
-					) }
-
-					{ /* Section 3: Outbound */ }
-					{ outboundField && (
-						<>
-							<Divider alignment="full-width" variant="tertiary" marginTop={ 32 } marginBottom={ 32 } />
-							<Grid columns={ 2 } gutter={ 32 } noMargin>
-								<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
-								<div>
-									{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
-										const currentValue = getFieldValue( outboundField );
-										const selected = Array.isArray( currentValue ) ? currentValue : [];
-										return (
-											<Accordion key={ group.section } title={ group.section } defaultOpen={ index === 0 }>
-												<Grid columns={ 1 } rowGap={ 8 } noMargin>
-													{ group.fields.map( fieldName => (
-														<CheckboxControl
-															className="newspack-checkbox-control"
-															key={ fieldName }
-															label={ fieldName }
-															checked={ selected.includes( fieldName ) }
-															onChange={ checked =>
-																handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
-															}
-														/>
-													) ) }
-												</Grid>
-											</Accordion>
-										);
-									} ) }
-								</div>
-							</Grid>
-						</>
-					) }
-				</div>
-			</WizardsTab>
+				{ /* Section 3: Outbound */ }
+				{ outboundField && (
+					<>
+						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
+						<Grid columns={ 2 } gutter={ 32 } noMargin>
+							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
+							<Accordion hideSingleTitle>
+								{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
+									const currentValue = getFieldValue( outboundField );
+									const selected = Array.isArray( currentValue ) ? currentValue : [];
+									return (
+										<AccordionPanel key={ `${ index }-${ group.section }` } title={ group.section } defaultOpen={ index === 0 }>
+											<Grid columns={ 1 } rowGap={ 8 } noMargin>
+												{ group.fields.map( fieldName => (
+													<CheckboxControl
+														className="newspack-checkbox-control"
+														key={ fieldName }
+														label={ fieldName }
+														checked={ selected.includes( fieldName ) }
+														onChange={ checked =>
+															handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
+														}
+													/>
+												) ) }
+											</Grid>
+										</AccordionPanel>
+									);
+								} ) }
+							</Accordion>
+						</Grid>
+					</>
+				) }
+			</div>
 		</>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.scss
@@ -1,23 +1,7 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
-
 .newspack-configure-view {
 	// Align section headers to the top of the grid row.
 	.newspack-grid .newspack-section-header {
 		margin-top: 0;
 		margin-bottom: 0;
-	}
-
-	// Accordion overrides: top/bottom borders only, no box border.
-	.newspack-accordion {
-		border: none;
-		border-top: 1px solid wp-colors.$gray-300;
-
-		&:first-child {
-			border-top: none;
-		}
-
-		&:last-child {
-			border-bottom: none;
-		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -20,6 +20,7 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Accordion: ( { children } ) => children,
+	AccordionPanel: ( { children } ) => children,
 	Divider: () => null,
 	Grid: ( { children } ) => children,
 	SectionHeader: () => null,

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -33,7 +33,7 @@ const AudienceIntegrations = ( props, ref ) => {
 	const [ activating, setActivating ] = useState( {} );
 	const [ loading, setLoading ] = useState( true );
 
-	const { addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, removeNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	const addEnabledNotice = useCallback(
 		( integrationId, enabled, data ) => {
@@ -79,6 +79,9 @@ const AudienceIntegrations = ( props, ref ) => {
 			}
 			setInFlightChanges( prev => ( { ...prev, [ integrationId ]: changes } ) );
 			setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
+			// Drop the previous attempt's snackbar so a retry doesn't stack a second
+			// notice under the same id.
+			removeNotice( `integration-saved-${ integrationId }` );
 			return apiFetch( {
 				path: `${ API_PATH }/${ integrationId }`,
 				method: 'POST',
@@ -90,6 +93,11 @@ const AudienceIntegrations = ( props, ref ) => {
 						const next = { ...prev };
 						delete next[ integrationId ];
 						return next;
+					} );
+					addNotice( {
+						id: `integration-saved-${ integrationId }`,
+						type: 'success',
+						message: __( 'Settings saved.', 'newspack-plugin' ),
 					} );
 				} )
 				.catch( error => {
@@ -107,7 +115,7 @@ const AudienceIntegrations = ( props, ref ) => {
 					setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
 				} );
 		},
-		[ addNotice ]
+		[ addNotice, removeNotice ]
 	);
 
 	const handleToggleEnabled = useCallback(

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -14,12 +14,13 @@ import apiFetch from '@wordpress/api-fetch';
 import AudienceIntegrations from './index';
 
 const mockAddNotice = jest.fn();
+const mockRemoveNotice = jest.fn();
 const captured = {};
 const loadingStates = [];
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( { addNotice: mockAddNotice } ),
+	useDispatch: () => ( { addNotice: mockAddNotice, removeNotice: mockRemoveNotice } ),
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Wizard: ( { sections } ) => {
@@ -54,6 +55,7 @@ const flushPromises = () => new Promise( resolve => setTimeout( resolve, 0 ) );
 describe( 'AudienceIntegrations notices', () => {
 	beforeEach( async () => {
 		mockAddNotice.mockClear();
+		mockRemoveNotice.mockClear();
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( SETTINGS_MAP );
 		render( <AudienceIntegrations /> );
@@ -101,6 +103,31 @@ describe( 'AudienceIntegrations notices', () => {
 				message: 'Something went wrong. Please try again.',
 			} )
 		);
+	} );
+
+	it( 'announces a success snackbar when the save succeeds', async () => {
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+			await flushPromises();
+		} );
+		await waitFor( () =>
+			expect( mockAddNotice ).toHaveBeenCalledWith( {
+				id: 'integration-saved-esp',
+				type: 'success',
+				message: 'Settings saved.',
+			} )
+		);
+	} );
+
+	// Success and error share a notice id, and the wizard keys snackbars by id, so
+	// each save has to clear the previous attempt's notice before adding its own.
+	it( 'clears the previous save snackbar before each save', async () => {
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+			await flushPromises();
+		} );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( 'integration-saved-esp' );
+		expect( mockRemoveNotice.mock.invocationCallOrder[ 0 ] ).toBeLessThan( mockAddNotice.mock.invocationCallOrder[ 0 ] );
 	} );
 
 	it( 'announces an error snackbar when the save request fails', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
@@ -59,7 +59,7 @@ export const SettingsSection = ( { integrations, loading, activating = {}, onTog
 				) }
 				{ ! loading && integrationIds.length > 0 && (
 					<>
-						<Grid columns={ 2 } gutter={ 16 }>
+						<Grid columns={ 2 }>
 							{ integrationIds.map( id => {
 								const integration = integrations[ id ];
 								const {


### PR DESCRIPTION
Stacked on #632 (base `pr-a/split-pending-changes`).

## Problem

Enable ESP on Mailchimp, then switch the provider to Manual. The card correctly shows the red "Requires an API-based ESP" badge and a "Change provider" button, but its More menu vanishes, so there is no Disable and no Logs for an integration that is enabled and still operable.

Cause: in `card-feature/index.tsx` the More dropdown is gated on `isConfigureState` (`enabled && !requirements`), so any `requirements` string hides the menu.

## Why not just gate on `enabled`

The enabled+requirements state means opposite things across consumers:

- **ESP integrations** (unsupported provider): degraded but operable, sets `requirementsActionable` -> More menu should show.
- **experimental-tools** (`constant_active`, managed by a wp-config constant): locked, does not set `requirementsActionable` -> More ("Disable") must stay hidden.
- **content-gates** ("Requires metering"): prerequisite missing, no `requirementsActionable` -> unchanged.

A blanket `enabled` gate would expose a broken "Disable" on a constant-locked tool.

## Fix

Gate the dropdown on operability, reusing the existing `requirementsActionable` signal:

```js
const showMoreControls = enabled && !! moreControls?.length && ( ! requirements || requirementsActionable );
```

`isConfigureState` stays as-is for the primary button's label, variant, and click handler. Exactly one behavior row changes (enabled + requirements + actionable: hidden -> shown); every other card renders its More menu identically. No consumer files change.

Known edge: an enabled ESP that is unsupported with no remediation target (`requirementsActionable` false, e.g. empty `setup_url`) keeps the menu hidden. Rare, and the deliberate cost of tying the gate to the remediable signal.

## Testing

`packages/components` has no test runner and is not in the `--filter newspack` suite, so the test lives in `newspack-plugin` and renders the real `CardFeature`. It asserts the "More" toggle across the 5-row matrix; the enabled+actionable-requirement row is the discriminator (fails against the old gating), and the enabled+non-actionable row pins the locked case so a future "gate on `enabled`" regression is caught. Suite: 41 suites / 374 tests green.

Note: interactive browser QA (ESP card, experimental-tools locked) is pending a manual pass; the component behavior is covered by the real-component unit test above.
