### PR TITLE
fix: robustness tweaks in data events, user admin, and dev scripts

### DIFF
--- a/bin/jn-cp.sh
+++ b/bin/jn-cp.sh
@@ -85,7 +85,7 @@ for opt in "${!opts[@]}"
 do
     if [[ ${opts["$opt"]} == "(x)" ]]
     then
-        process_plugin $opt $password
+        process_plugin "$opt" "$password"
     fi
 done
 

--- a/bin/jn-functions.sh
+++ b/bin/jn-functions.sh
@@ -10,6 +10,28 @@ DOMAIN="$2"
 #dest_folder="/srv/users/$USER/apps/$USER/public"
 dest_folder="/srv/htdocs/wp-content/plugins"
 
+# Jurassic Ninja hands out throwaway sites on recycled random subdomains, so the same
+# host name legitimately presents a different key each time it is reused. Strict host
+# key checking would fail on every reuse, hence StrictHostKeyChecking=no. The trade-off
+# is accepted because these are disposable test sites; do not reuse this for a durable
+# host, where an unverified key means a MITM can read whatever is uploaded.
+SSH_OPTS=(-o StrictHostKeyChecking=no)
+
+# Pass the password through the environment rather than argv. sshpass -p overwrites its
+# own command line at startup, but only after exec, leaving a brief window where ps can
+# read the plaintext; -e never puts it on the command line at all.
+jn_scp() {
+    local password="$1"
+    shift
+    SSHPASS="$password" sshpass -e scp "${SSH_OPTS[@]}" "$@"
+}
+
+jn_ssh() {
+    local password="$1"
+    shift
+    SSHPASS="$password" sshpass -e ssh "${SSH_OPTS[@]}" "$@"
+}
+
 process_plugin() {
 
     local plugin=$1
@@ -18,46 +40,46 @@ process_plugin() {
     do
         if [[ $i == $plugin ]]
         then
-            process_newspack_plugin $plugin $2
+            process_newspack_plugin "$plugin" "$2"
             return
         fi
     done
 
-    process_custom_plugin $plugin $2
+    process_custom_plugin "$plugin" "$2"
 }
 
 process_newspack_plugin() {
-    local plugin=$1
-    local password=$2
+    local plugin="$1"
+    local password="$2"
 
     source /var/scripts/resolve-project-path.sh
-    cd "$(resolve_project_path "$1")"
+    cd "$(resolve_project_path "$plugin")"
     echo "Creating package for $plugin"
     npm run --silent release:archive > /dev/null
     echo Uploading...
-    sshpass -p $password scp -o StrictHostKeyChecking=no "release/$plugin.zip" $USER@$DOMAIN:$dest_folder/
-    sshpass -p $password ssh -o StrictHostKeyChecking=no $USER@$DOMAIN "cd $dest_folder; wp plugin install $plugin.zip --force --activate"
+    jn_scp "$password" "release/$plugin.zip" "$USER@$DOMAIN:$dest_folder/"
+    jn_ssh "$password" "$USER@$DOMAIN" "cd $dest_folder; wp plugin install $plugin.zip --force --activate"
 }
 
 process_custom_plugin() {
-    local plugin=$1
-    local password=$2
+    local plugin="$1"
+    local password="$2"
 
     cd /var/www/html/wp-content/plugins/
     echo "Creating package for $plugin"
-    zip -r $plugin.zip $plugin/ > /dev/null
+    zip -r "$plugin.zip" "$plugin/" > /dev/null
     echo Uploading...
-    sshpass -p $password scp -o StrictHostKeyChecking=no "$plugin.zip" $USER@$DOMAIN:$dest_folder/
-    sshpass -p $password ssh -o StrictHostKeyChecking=no $USER@$DOMAIN "cd $dest_folder; wp plugin install $plugin.zip --force --activate"
-    rm $plugin.zip
+    jn_scp "$password" "$plugin.zip" "$USER@$DOMAIN:$dest_folder/"
+    jn_ssh "$password" "$USER@$DOMAIN" "cd $dest_folder; wp plugin install $plugin.zip --force --activate"
+    rm "$plugin.zip"
 }
 
 copy_secrets() {
-    local password=$1
+    local password="$1"
     if [ -f /var/scripts/secrets.json ]; then
-        sshpass -p $password scp -o StrictHostKeyChecking=no /var/scripts/secrets.json $USER@$DOMAIN:/tmp/
-        sshpass -p $password scp -o StrictHostKeyChecking=no /var/scripts/copy-secrets.php $USER@$DOMAIN:/tmp/
-        sshpass -p $password ssh -o StrictHostKeyChecking=no $USER@$DOMAIN "cd $dest_folder; wp eval-file /tmp/copy-secrets.php; rm /tmp/secrets.json; rm /tmp/copy-secrets.php"
+        jn_scp "$password" /var/scripts/secrets.json "$USER@$DOMAIN:/tmp/"
+        jn_scp "$password" /var/scripts/copy-secrets.php "$USER@$DOMAIN:/tmp/"
+        jn_ssh "$password" "$USER@$DOMAIN" "cd $dest_folder; wp eval-file /tmp/copy-secrets.php; rm /tmp/secrets.json; rm /tmp/copy-secrets.php"
     else
         echo "No secrets.json file found."
     fi

--- a/bin/jn-init.sh
+++ b/bin/jn-init.sh
@@ -7,13 +7,13 @@ read -s password
 echo
 
 echo "Uploading Newspack plugin"
-process_plugin newspack-plugin $password
+process_plugin newspack-plugin "$password"
 
 echo "Uploading Woocommerce premium extensions"
-process_plugin woocommerce-name-your-price $password
-process_plugin woocommerce-subscriptions $password
+process_plugin woocommerce-name-your-price "$password"
+process_plugin woocommerce-subscriptions "$password"
 
-sshpass -p $password ssh -o StrictHostKeyChecking=no $USER@$DOMAIN "cd $dest_folder; wp plugin install woocommerce; wp plugin activate newspack-plugin woocommerce; wp newspack setup"
+jn_ssh "$password" "$USER@$DOMAIN" "cd $dest_folder; wp plugin install woocommerce; wp plugin activate newspack-plugin woocommerce; wp newspack setup"
 
 echo "Copying secrets"
-copy_secrets $password
+copy_secrets "$password"

--- a/plugins/newspack-plugin/includes/data-events/class-data-events.php
+++ b/plugins/newspack-plugin/includes/data-events/class-data-events.php
@@ -687,7 +687,6 @@ final class Data_Events {
 		$url = \add_query_arg(
 			[
 				'action' => self::ACTION,
-				'nonce'  => self::get_nonce(),
 			],
 			\admin_url( 'admin-ajax.php' )
 		);
@@ -697,7 +696,14 @@ final class Data_Events {
 			[
 				'timeout'   => 0.01,
 				'blocking'  => false,
-				'body'      => [ 'dispatches' => self::$queued_dispatches ],
+				// The nonce travels in the body, not the query string: it is the only
+				// credential authenticating the (nopriv) receiving endpoint, and a query
+				// string is recorded verbatim in the web server access log on every
+				// dispatch. maybe_handle() reads it from $_REQUEST, which covers both.
+				'body'      => [
+					'nonce'      => self::get_nonce(),
+					'dispatches' => self::$queued_dispatches,
+				],
 				'cookies'   => $_COOKIE, // phpcs:ignore
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			]

--- a/plugins/newspack-plugin/includes/data-events/class-data-events.php
+++ b/plugins/newspack-plugin/includes/data-events/class-data-events.php
@@ -258,9 +258,17 @@ final class Data_Events {
 	 * @return bool Whether the nonce is valid.
 	 */
 	public static function verify_nonce( $nonce ) {
+		// Fail closed on anything that is not a usable nonce. The stored nonce is created
+		// lazily on the first dispatch, so before then it reads as an empty string -- a
+		// loose comparison would let an empty nonce authenticate against it and hand the
+		// dispatch endpoint to anyone.
+		if ( ! is_string( $nonce ) || '' === $nonce ) {
+			return false;
+		}
+
 		// Check against current nonce.
 		$current_nonce = \get_option( self::NONCE_OPTION, '' );
-		if ( $current_nonce === $nonce ) {
+		if ( is_string( $current_nonce ) && '' !== $current_nonce && \hash_equals( $current_nonce, $nonce ) ) {
 			return true;
 		}
 
@@ -268,7 +276,12 @@ final class Data_Events {
 		$previous_nonce = \get_option( self::PREVIOUS_NONCE_OPTION, '' );
 		$previous_expiration = \get_option( self::PREVIOUS_NONCE_EXPIRATION_OPTION, 0 );
 
-		if ( $previous_nonce === $nonce && time() <= $previous_expiration ) {
+		if (
+			is_string( $previous_nonce )
+			&& '' !== $previous_nonce
+			&& time() <= $previous_expiration
+			&& \hash_equals( $previous_nonce, $nonce )
+		) {
 			return true;
 		}
 

--- a/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php
+++ b/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php
@@ -136,9 +136,13 @@ class Nicename_Change_UI {
 			);
 		}
 
-		// The nonce only proves the request came from the user-edit screen, not that the
-		// caller may edit this particular user -- authorize the target before touching it.
-		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+		// The nonce only proves the request came from the user-edit screen. Require the same
+		// primitive that gates the availability check this handler may delegate to on a slug
+		// collision (so an authorized caller never gets 403'd mid-flow), and object-level
+		// authorization for the target so it can't be used to edit an arbitrary user. The
+		// primitive check also closes the self-edit gap where map_meta_cap grants
+		// `edit_user` on one's own ID to any logged-in user.
+		if ( ! current_user_can( 'edit_users' ) || ! current_user_can( 'edit_user', $user_id ) ) {
 			wp_send_json(
 				[
 					'success' => false,

--- a/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php
+++ b/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php
@@ -83,6 +83,18 @@ class Nicename_Change_UI {
 
 		check_ajax_referer( 'newspack_change_nicename_nonce', 'nonce' );
 
+		// The response enumerates existing users and guest authors, so it is gated on the
+		// same capability that gates the UI this endpoint serves (the user-edit screen).
+		if ( ! current_user_can( 'edit_users' ) ) {
+			wp_send_json(
+				[
+					'success' => false,
+					'message' => esc_html__( 'You are not allowed to do that.', 'newspack-plugin' ),
+				],
+				403
+			);
+		}
+
 		$new_nicename = isset( $_POST['new_nicename'] ) ? sanitize_title( wp_unslash( $_POST['new_nicename'] ) ) : '';
 
 		$existing = Nicename_Change::get_existing_nicenames( $new_nicename );
@@ -113,14 +125,6 @@ class Nicename_Change_UI {
 
 		check_ajax_referer( 'newspack_change_nicename_nonce', 'nonce' );
 
-		$new_nicename = isset( $_POST['new_nicename'] ) ? sanitize_title( wp_unslash( $_POST['new_nicename'] ) ) : '';
-
-		$existing = Nicename_Change::get_existing_nicenames( $new_nicename );
-
-		if ( ! empty( $existing ) ) {
-			return self::change_nicename_check_ajax();
-		}
-
 		$user_id = isset( $_POST['user_id'] ) ? (int) $_POST['user_id'] : 0;
 
 		if ( ! $user_id ) {
@@ -130,6 +134,26 @@ class Nicename_Change_UI {
 					'message' => esc_html__( 'User not found.', 'newspack-plugin' ),
 				]
 			);
+		}
+
+		// The nonce only proves the request came from the user-edit screen, not that the
+		// caller may edit this particular user -- authorize the target before touching it.
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			wp_send_json(
+				[
+					'success' => false,
+					'message' => esc_html__( 'You are not allowed to edit this user.', 'newspack-plugin' ),
+				],
+				403
+			);
+		}
+
+		$new_nicename = isset( $_POST['new_nicename'] ) ? sanitize_title( wp_unslash( $_POST['new_nicename'] ) ) : '';
+
+		$existing = Nicename_Change::get_existing_nicenames( $new_nicename );
+
+		if ( ! empty( $existing ) ) {
+			return self::change_nicename_check_ajax();
 		}
 
 		// Update the nicename.

--- a/plugins/newspack-plugin/tests/unit-tests/data-events.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events.php
@@ -404,12 +404,13 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		$action_name = 'test_nonce_action';
 		Data_Events::register_action( $action_name );
 
-		// Hook into the dispatched action to capture the URL.
-		$captured_url = '';
+		// Hook into the dispatched action to capture the request body. The nonce is sent
+		// in the body rather than the query string, which the access log would record.
+		$captured_body = [];
 		add_filter(
 			'pre_http_request',
-			function( $preempt, $args, $url ) use ( &$captured_url ) {
-				$captured_url = $url;
+			function( $preempt, $args, $url ) use ( &$captured_body ) {
+				$captured_body = $args['body'];
 				return true; // Short-circuit the request.
 			},
 			10,
@@ -420,9 +421,9 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		Data_Events::dispatch( $action_name, [ 'test' => 'data' ] );
 		Data_Events::execute_queued_dispatches();
 
-		// Verify the URL contains our custom nonce.
+		// Verify the body carries our custom nonce.
 		$nonce = Data_Events::get_nonce();
-		$this->assertStringContainsString( 'nonce=' . $nonce, $captured_url );
+		$this->assertSame( $nonce, $captured_body['nonce'] );
 	}
 
 	/**
@@ -510,12 +511,12 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		update_option( Data_Events::NONCE_EXPIRATION_OPTION, time() - 1 );
 		$new_nonce = Data_Events::get_nonce();
 
-		// Hook into the dispatched action to capture the URL.
-		$captured_url = '';
+		// Hook into the dispatched action to capture the request body.
+		$captured_body = [];
 		add_filter(
 			'pre_http_request',
-			function( $preempt, $args, $url ) use ( &$captured_url ) {
-				$captured_url = $url;
+			function( $preempt, $args, $url ) use ( &$captured_body ) {
+				$captured_body = $args['body'];
 				return true; // Short-circuit the request.
 			},
 			10,
@@ -526,8 +527,8 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		Data_Events::dispatch( $action_name, [ 'test' => 'data' ] );
 		Data_Events::execute_queued_dispatches();
 
-		// Verify the URL contains the new nonce.
-		$this->assertStringContainsString( 'nonce=' . $new_nonce, $captured_url );
+		// Verify the body carries the new nonce.
+		$this->assertSame( $new_nonce, $captured_body['nonce'] );
 
 		// Manually verify a request with the old nonce would be accepted.
 		$_REQUEST['nonce'] = $initial_nonce;

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/dispatch-nonce-transport.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/dispatch-nonce-transport.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests how the loopback dispatch transports its nonce.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events;
+
+/**
+ * The nonce is the only thing authenticating wp_ajax_nopriv_newspack_data_event, whose
+ * handlers write reader data for a caller-supplied user_id. Sending it as a query
+ * parameter puts it verbatim into the web server access log on every dispatch -- and
+ * this loopback is the default path (Action Scheduler dispatch is opt-in). Keep it in
+ * the request body, which is not logged.
+ *
+ * @group data-events
+ * @group dispatch-nonce
+ */
+class Test_Dispatch_Nonce_Transport extends WP_UnitTestCase {
+
+	/**
+	 * The URL the dispatch was sent to.
+	 *
+	 * @var string
+	 */
+	private $captured_url;
+
+	/**
+	 * The wp_remote_post args of the dispatch.
+	 *
+	 * @var array
+	 */
+	private $captured_args;
+
+	/**
+	 * Set up. Short-circuit the loopback HTTP request and capture what it would send.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->captured_url  = null;
+		$this->captured_args = null;
+
+		add_filter( 'pre_http_request', [ $this, 'capture_request' ], 10, 3 );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'capture_request' ], 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Intercept the dispatch request instead of letting it hit the network.
+	 *
+	 * @param false|array|WP_Error $response The preempted response.
+	 * @param array                $args     The request args.
+	 * @param string               $url      The request URL.
+	 *
+	 * @return array A canned response.
+	 */
+	public function capture_request( $response, $args, $url ) {
+		$this->captured_url  = $url;
+		$this->captured_args = $args;
+		return [
+			'headers'  => [],
+			'body'     => '',
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+	}
+
+	/**
+	 * Queue a dispatch and flush it through the loopback path.
+	 */
+	private function dispatch_one_event() {
+		Data_Events::register_action( 'test_nonce_transport_action' );
+		Data_Events::dispatch( 'test_nonce_transport_action', [ 'user_id' => 1 ] );
+		Data_Events::execute_queued_dispatches();
+	}
+
+	/**
+	 * The nonce must not travel in the URL, where the access log records it.
+	 */
+	public function test_nonce_is_not_sent_in_the_query_string() {
+		$this->dispatch_one_event();
+
+		$this->assertNotNull( $this->captured_url, 'The dispatch did not use the loopback path.' );
+
+		$query = wp_parse_url( $this->captured_url, PHP_URL_QUERY );
+		parse_str( (string) $query, $query_args );
+
+		$this->assertArrayNotHasKey(
+			'nonce',
+			$query_args,
+			'The dispatch nonce is in the request URL, so it lands in the access log.'
+		);
+	}
+
+	/**
+	 * The receiving handler reads $_REQUEST['nonce'], so the body must still carry a
+	 * valid nonce or every dispatch would be rejected.
+	 */
+	public function test_nonce_is_sent_in_the_body_and_is_valid() {
+		$this->dispatch_one_event();
+
+		$this->assertArrayHasKey(
+			'nonce',
+			$this->captured_args['body'],
+			'The dispatch body carries no nonce; the handler would reject it.'
+		);
+		$this->assertTrue(
+			Data_Events::verify_nonce( $this->captured_args['body']['nonce'] ),
+			'The nonce sent in the body does not verify.'
+		);
+	}
+
+	/**
+	 * The dispatch payload itself must survive the move.
+	 */
+	public function test_dispatches_are_still_sent() {
+		$this->dispatch_one_event();
+
+		$this->assertArrayHasKey( 'dispatches', $this->captured_args['body'] );
+		$this->assertSame(
+			'test_nonce_transport_action',
+			$this->captured_args['body']['dispatches'][0]['action_name'],
+			'The queued dispatch was not sent.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/nonce-verification.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/nonce-verification.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Tests nonce verification for the data events dispatch endpoint.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events;
+
+/**
+ * Nonce verification guards wp_ajax_nopriv_newspack_data_event, whose handlers write
+ * reader data for a caller-supplied user_id. The nonce is the only credential on that
+ * endpoint, so it has to fail closed when there is no stored nonce to compare against --
+ * otherwise a site that has not yet dispatched an event (the option is created lazily on
+ * first dispatch) accepts an empty nonce from anyone.
+ *
+ * @group data-events
+ * @group nonce-verification
+ */
+class Test_Data_Events_Nonce_Verification extends WP_UnitTestCase {
+
+	/**
+	 * Set up. Start from a site that has never dispatched an event.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Data_Events::NONCE_OPTION );
+		delete_option( Data_Events::NONCE_EXPIRATION_OPTION );
+		delete_option( Data_Events::PREVIOUS_NONCE_OPTION );
+		delete_option( Data_Events::PREVIOUS_NONCE_EXPIRATION_OPTION );
+	}
+
+	/**
+	 * An empty nonce must not authenticate against an unset stored nonce.
+	 */
+	public function test_empty_nonce_is_rejected_when_no_nonce_is_stored() {
+		$this->assertFalse(
+			Data_Events::verify_nonce( '' ),
+			'An empty nonce authenticated against an unset stored nonce -- anyone can dispatch.'
+		);
+	}
+
+	/**
+	 * The same, via the stored option explicitly set to an empty string.
+	 */
+	public function test_empty_nonce_is_rejected_when_stored_nonce_is_empty() {
+		update_option( Data_Events::NONCE_OPTION, '' );
+
+		$this->assertFalse(
+			Data_Events::verify_nonce( '' ),
+			'An empty nonce authenticated against an empty stored nonce.'
+		);
+	}
+
+	/**
+	 * An empty nonce must not slip through the grace-period branch either.
+	 */
+	public function test_empty_nonce_is_rejected_during_grace_period() {
+		update_option( Data_Events::NONCE_OPTION, 'a-real-nonce' );
+		update_option( Data_Events::PREVIOUS_NONCE_OPTION, '' );
+		update_option( Data_Events::PREVIOUS_NONCE_EXPIRATION_OPTION, time() + 3600 );
+
+		$this->assertFalse(
+			Data_Events::verify_nonce( '' ),
+			'An empty nonce authenticated via the previous-nonce grace period.'
+		);
+	}
+
+	/**
+	 * A non-string nonce must be rejected rather than raising a TypeError.
+	 */
+	public function test_non_string_nonce_is_rejected() {
+		update_option( Data_Events::NONCE_OPTION, 'a-real-nonce' );
+
+		$this->assertFalse( Data_Events::verify_nonce( null ), 'A null nonce was not rejected.' );
+		$this->assertFalse( Data_Events::verify_nonce( [] ), 'An array nonce was not rejected.' );
+	}
+
+	/**
+	 * The legitimate path must keep working: the current nonce verifies.
+	 */
+	public function test_current_nonce_verifies() {
+		$nonce = Data_Events::get_nonce();
+
+		$this->assertTrue( Data_Events::verify_nonce( $nonce ), 'The current nonce should verify.' );
+	}
+
+	/**
+	 * A wrong nonce is rejected.
+	 */
+	public function test_wrong_nonce_is_rejected() {
+		Data_Events::get_nonce();
+
+		$this->assertFalse( Data_Events::verify_nonce( 'not-the-nonce' ), 'A wrong nonce should be rejected.' );
+	}
+
+	/**
+	 * The previous nonce must still verify inside the grace period, so events dispatched
+	 * just before a rotation are not dropped.
+	 */
+	public function test_previous_nonce_verifies_during_grace_period() {
+		$initial_nonce = Data_Events::get_nonce();
+
+		// Force a rotation; the initial nonce becomes the previous one.
+		update_option( Data_Events::NONCE_EXPIRATION_OPTION, time() - 1 );
+		$new_nonce = Data_Events::get_nonce();
+
+		$this->assertNotSame( $initial_nonce, $new_nonce, 'The nonce should have rotated.' );
+		$this->assertTrue(
+			Data_Events::verify_nonce( $initial_nonce ),
+			'The previous nonce should still verify during the grace period.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/nicename-change-ui.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/nicename-change-ui.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests the authorization of the nicename-change AJAX handlers.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Nicename_Change_UI;
+
+/**
+ * The handlers take a caller-supplied `user_id` and pass it to wp_update_user(), so a
+ * nonce alone is not enough: it proves the request came from a page, not that the caller
+ * may edit that particular user. These tests pin the object-scoped capability check.
+ *
+ * Note on reachability: the nonce is only printed on user-edit.php (via edit_user_profile),
+ * which requires `edit_users` -- administrators only. So these tests hand the caller a nonce
+ * it could not obtain in production. That is deliberate: the capability check is the layer
+ * under test, and it must hold on its own rather than leaning on the nonce's scarcity.
+ *
+ * @group nicename-change
+ */
+class Test_Nicename_Change_UI extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * A user the attacker is not allowed to edit.
+	 *
+	 * @var int
+	 */
+	private $victim_user_id;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->victim_user_id = self::factory()->user->create(
+			[
+				'role'          => 'administrator',
+				'user_nicename' => 'original-slug',
+			]
+		);
+	}
+
+	/**
+	 * Tear down. The parent resets $_POST/$_GET but not $_REQUEST, which is where
+	 * check_ajax_referer() reads the nonce from -- clear it so it cannot leak into
+	 * another test.
+	 */
+	public function tear_down() {
+		unset( $_REQUEST['nonce'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Invoke the handler with a valid nonce, swallowing the wp_send_json() exit.
+	 *
+	 * @param int    $actor_user_id  The user making the request.
+	 * @param int    $target_user_id The user_id sent in the payload.
+	 * @param string $new_nicename   The requested nicename.
+	 */
+	private function post_nicename_change( $actor_user_id, $target_user_id, $new_nicename ) {
+		wp_set_current_user( $actor_user_id );
+
+		$_POST['user_id']      = $target_user_id;
+		$_POST['new_nicename'] = $new_nicename;
+		// check_ajax_referer() reads the nonce from $_REQUEST, which PHPUnit does not
+		// populate from $_POST -- set it there or the handler dies before doing any work.
+		$_REQUEST['nonce'] = wp_create_nonce( 'newspack_change_nicename_nonce' );
+
+		// The handler echoes JSON and terminates; buffer it so the response body does not
+		// leak into the test output, and swallow the die exception. The assertions below
+		// care about the side effect on the target user, not the response body.
+		// WP_Ajax_UnitTestCase's die handler closes a buffer on its way out, so unwind to
+		// the level we started at rather than assuming a matching ob_end_clean().
+		$initial_ob_level = ob_get_level();
+		ob_start();
+		try {
+			Nicename_Change_UI::change_nicename_ajax();
+		} catch ( WPAjaxDieContinueException | WPAjaxDieStopException ) {
+			return;
+		} finally {
+			while ( ob_get_level() > $initial_ob_level ) {
+				ob_end_clean();
+			}
+		}
+	}
+
+	/**
+	 * Get a user's nicename straight from the DB, bypassing any cached user object.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return string The nicename.
+	 */
+	private function get_nicename( $user_id ) {
+		clean_user_cache( $user_id );
+		return get_userdata( $user_id )->user_nicename;
+	}
+
+	/**
+	 * A subscriber must not be able to rewrite an administrator's archive slug.
+	 */
+	public function test_subscriber_cannot_change_another_users_nicename() {
+		$subscriber_user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$this->post_nicename_change( $subscriber_user_id, $this->victim_user_id, 'hijacked-slug' );
+
+		$this->assertSame(
+			'original-slug',
+			$this->get_nicename( $this->victim_user_id ),
+			'A subscriber changed an administrator nicename -- the handler is missing its capability check.'
+		);
+	}
+
+	/**
+	 * An editor has `edit_posts` but not `edit_users`, so it must also be rejected.
+	 */
+	public function test_editor_cannot_change_another_users_nicename() {
+		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+
+		$this->post_nicename_change( $editor_user_id, $this->victim_user_id, 'hijacked-by-editor' );
+
+		$this->assertSame(
+			'original-slug',
+			$this->get_nicename( $this->victim_user_id ),
+			'An editor changed another user nicename -- the handler is missing its capability check.'
+		);
+	}
+
+	/**
+	 * The legitimate path must keep working: an administrator may still change the slug.
+	 */
+	public function test_administrator_can_still_change_nicename() {
+		$admin_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+
+		$this->post_nicename_change( $admin_user_id, $this->victim_user_id, 'admin-set-slug' );
+
+		$this->assertSame(
+			'admin-set-slug',
+			$this->get_nicename( $this->victim_user_id ),
+			'An administrator should be able to change a user nicename.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A handful of small, self-contained robustness improvements spotted while reading through existing code. No new features and no changes to public APIs. Each commit stands alone and can be dropped independently if preferred.

**Data Events** (`includes/data-events/`)

- Send the dispatch nonce in the request body rather than as a query parameter. The receiving handler reads it from `$_REQUEST`, so this needs no change on the handler side and the dispatch behaves identically. It keeps the value out of web server access logs, which record query strings verbatim.
- Make `verify_nonce()` fail closed. The stored nonce is created lazily on the first dispatch, so before then it reads back as an empty string and a loose comparison would treat an empty input as a match. It now rejects empty/non-string input, ignores an empty stored value, and compares with `hash_equals()`. The current-nonce and previous-nonce grace period paths are unchanged in behaviour otherwise.

**Nicename change UI** (`includes/plugins/co-authors-plus/`, behind `NEWSPACK_CHANGE_NICENAME_UI`, off by default)

- The change handler takes a `user_id` from the request and passes it to `wp_update_user()`. It now confirms the caller may edit that specific user (`current_user_can( 'edit_user', $user_id )`) instead of relying on the nonce alone, and the availability-check endpoint (which enumerates existing users and guest authors) is gated on `edit_users`. In practice the UI is only reachable by administrators, so this is a defence-in-depth check rather than a behaviour change for any current user.

**Jurassic Ninja dev scripts** (`bin/jn-*`, local tooling only, not shipped)

- Quote variable expansions. A password containing a space previously mangled the command line.
- Pass the ssh password through the environment (`sshpass -e`) rather than argv.
- Document why `StrictHostKeyChecking=no` is used here (recycled throwaway subdomains legitimately present new host keys).

### How to test the changes in this Pull Request:

1. Run the test suites — new coverage accompanies each change:
   - `cd plugins/newspack-plugin && n test-php --group data-events`
   - `n test-php --group nonce-verification`
   - `n test-php --group dispatch-nonce`
   - `n test-php --group nicename-change`
   - Full plugin suite also passes: `n test-php`
2. On a local env, trigger any data event, e.g. `wp eval 'Newspack\Data_Events::dispatch( "donation_new", [ "user_id" => 1 ] );'`, and confirm it is still handled as before (the registered handler runs). The corresponding `admin-ajax.php?action=newspack_data_event` line in the access log no longer carries a nonce parameter.
3. With `NEWSPACK_CHANGE_NICENAME_UI` defined, open a user in wp-admin, change the archive slug as an administrator, and confirm it still updates.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?