### PR TITLE
chore: TypeScript migration wrap-up (phase 6)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,67 @@
+# JS→TypeScript migration: mechanical rename + type-annotation commits.
+# These commits rename .js/.jsx to .ts/.tsx and add type annotations without
+# changing runtime behavior. Use `git blame --ignore-revs-file .git-blame-ignore-revs`
+# (or configure `git config blame.ignoreRevsFile .git-blame-ignore-revs`) to skip
+# past them and attribute lines to their last real logic change instead.
+
+# Phase 0-2: infra, gates, packages/icons+components, newspack-plugin.
+# chore(scripts): revive typescript-check as the canonical type gate
+3037610393688e3142c42a0a235cdca327aaff52
+# ci: run typescript:check per changed package in the js job
+9e84149de04bc162c7b98a3e84b26b2276ece435
+# chore: make webpack entry resolution extension-agnostic
+9c913eef1afc2fda6b29c9c6074b8d6cc354971f
+# chore: add per-unit tsconfig and typescript:check gates
+a700563c373eefea000a88b9727beada30661acf
+# chore(components): fix strict type errors surfaced by the type gate
+d18b76b0d08fbfaa1291bab85c58c25121b1ae76
+# chore(sync): hold legacy sync when incoming JS regresses TS migration
+ea8bbb2d2b000df255806959d5bc8c2fe2ddcf73
+# chore(blocks): make TypeScript strict-clean and enable type gate
+8823cd48351fdd1058f844188404ee68e3394eb4
+# chore(components): generic DataViews wrapper and color-picker JSDoc
+f177fec93c4aa6283f14df622d8cc918b54d49ad
+# chore(newspack-plugin): make TS strict-clean and enable type gate
+fb03a1d610c3179c1c56b818bf7a8d34688fca70
+# chore(scripts): run TypeScript test files in jest
+ff62f6b8e3502fd783496169cace04738a75054e
+# chore(icons): migrate newspack-icons to TypeScript
+3fe7b6d7bd73c44c689b5bb1ca775c07ab63b726
+# chore(components): migrate newspack-components to TypeScript
+5469da32695dc392c19b434733cfd0db7f186878
+# chore(newspack-plugin): adapt call sites to typed components
+5702a9eb39e172cac59ac8890c8bb7770ee04a8b
+# chore(components): extend shared RAS contract and widen prop types
+ae2f5a05fa54dacfef1a50037cfa6b694ba11ac5
+# chore(newspack-plugin): migrate src to TypeScript and lock the unit
+af89cd162f5533fcd751a34e324e3ec192c344d3
+
+# Phase 3: blocks + newsletters.
+# chore(blocks): migrate src to TypeScript and lock the unit
+448b2f50f79afdd875770e5e18be93fc907ce922
+# chore(newsletters): migrate src to TypeScript and lock the unit
+4c2864f6a867853394da2f781a8804981615efb8
+
+# Phase 4: small plugins.
+# chore(republication-tracker-tool): migrate src to TypeScript and lock the unit
+fa715bcf402785106b3815072f8c2c7dcb43ae2f
+# chore(sponsors): migrate src to TypeScript and lock the unit
+a0bd4260dcee8ec9166b1032d7dc1d78342f978d
+# chore(network): migrate src to TypeScript and lock the unit
+3227347c0d7e6762aa459a192e1c615095ff2081
+# chore(multibranded-site): migrate src to TypeScript and lock the unit
+0d020cafbb12b4298086a08dd457700018bfb1d2
+# chore(ads): migrate src to TypeScript and lock the unit
+e142523ac7496a8e729626c4b6739ba7316c78c9
+# chore(listings): migrate src to TypeScript and lock the unit
+ce326781e05f52af3574aa26252455a7e94f2bb9
+# chore(popups): migrate src to TypeScript and lock the unit
+cebe8949cf455b173c85945d539c73a61e1f4f16
+# chore(story-budget): migrate src to TypeScript and lock the unit
+90e944b7a14961c0be010e1537bdf774956d2250
+
+# Phase 5: themes.
+# chore(block-theme): migrate src to TypeScript and lock the unit
+360b2a9418493551df62bc7202809775e4b6d670
+# chore(theme): migrate js/src to TypeScript and lock the unit
+eddd52aa667149867f8025515d925592c5c8e867

--- a/plugins/newspack-plugin/src/content-gate/editor/block-visibility.test.ts
+++ b/plugins/newspack-plugin/src/content-gate/editor/block-visibility.test.ts
@@ -3,24 +3,34 @@
  */
 
 /**
+ * Shape of a single block attribute schema entry, as registered via the
+ * `blocks.registerBlockType` filter (mirrors `@wordpress/blocks` attribute definitions).
+ */
+type RegisteredAttributeSchema = {
+	type: string;
+	default?: unknown;
+	items?: { type: string };
+};
+
+/**
  * Capture callbacks registered via addFilter, keyed by namespace.
  */
-const registeredFilters: Record< string, ( settings: any, name: string ) => any > = {};
+const registeredFilters: Record< string, ( settings: BlockSettings, name: string ) => BlockSettings > = {};
 
 jest.mock( '@wordpress/hooks', () => ( {
-	addFilter: jest.fn( ( _hook: string, namespace: string, callback: ( settings: any, name: string ) => any ) => {
+	addFilter: jest.fn( ( _hook: string, namespace: string, callback: ( settings: BlockSettings, name: string ) => BlockSettings ) => {
 		registeredFilters[ namespace ] = callback;
 	} ),
 } ) );
 
 jest.mock( '@wordpress/compose', () => ( {
-	createHigherOrderComponent: jest.fn( ( fn: any ) => fn ),
+	createHigherOrderComponent: jest.fn( ( fn: unknown ) => fn ),
 } ) );
 jest.mock( '@wordpress/block-editor', () => ( { InspectorControls: () => null } ) );
 jest.mock( '@wordpress/components', () => ( {} ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( s: string ) => s } ) );
 jest.mock( '@wordpress/element', () => ( {
-	useState: jest.fn( ( v: any ) => [ v, jest.fn() ] ),
+	useState: jest.fn( ( v: unknown ) => [ v, jest.fn() ] ),
 	useEffect: jest.fn(),
 } ) );
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
@@ -32,41 +42,43 @@ const attributeFilter = registeredFilters[ 'newspack-plugin/block-visibility/att
 
 describe( 'block-visibility attribute registration', () => {
 	it( 'adds attributes to core/group', () => {
-		const result = attributeFilter( { attributes: {} }, 'core/group' );
+		const result = attributeFilter( { attributes: {}, name: 'core/group' }, 'core/group' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlVisibility' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlRules' );
 	} );
 
 	it( 'adds attributes to core/stack', () => {
-		const result = attributeFilter( { attributes: {} }, 'core/stack' );
+		const result = attributeFilter( { attributes: {}, name: 'core/stack' }, 'core/stack' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlVisibility' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlRules' );
 	} );
 
 	it( 'adds attributes to core/row', () => {
-		const result = attributeFilter( { attributes: {} }, 'core/row' );
+		const result = attributeFilter( { attributes: {}, name: 'core/row' }, 'core/row' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlVisibility' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlRules' );
 	} );
 
 	it( 'does not modify non-target blocks', () => {
-		const settings = { attributes: { align: { type: 'string' } } };
+		const settings = { attributes: { align: { type: 'string' } }, name: 'core/paragraph' };
 		const result = attributeFilter( settings, 'core/paragraph' );
 		expect( result ).toBe( settings );
 	} );
 
 	it( 'newspackAccessControlVisibility defaults to visible', () => {
-		const result = attributeFilter( { attributes: {} }, 'core/group' );
-		expect( result.attributes.newspackAccessControlVisibility.default ).toBe( 'visible' );
+		const result = attributeFilter( { attributes: {}, name: 'core/group' }, 'core/group' );
+		const attributes = result.attributes as Record< string, RegisteredAttributeSchema >;
+		expect( attributes.newspackAccessControlVisibility.default ).toBe( 'visible' );
 	} );
 
 	it( 'newspackAccessControlRules defaults to empty object', () => {
-		const result = attributeFilter( { attributes: {} }, 'core/group' );
-		expect( result.attributes.newspackAccessControlRules.default ).toEqual( {} );
+		const result = attributeFilter( { attributes: {}, name: 'core/group' }, 'core/group' );
+		const attributes = result.attributes as Record< string, RegisteredAttributeSchema >;
+		expect( attributes.newspackAccessControlRules.default ).toEqual( {} );
 	} );
 
 	it( 'preserves existing attributes on target blocks', () => {
-		const result = attributeFilter( { attributes: { align: { type: 'string' } } }, 'core/group' );
+		const result = attributeFilter( { attributes: { align: { type: 'string' } }, name: 'core/group' }, 'core/group' );
 		expect( result.attributes ).toHaveProperty( 'align' );
 		expect( result.attributes ).toHaveProperty( 'newspackAccessControlVisibility' );
 	} );

--- a/plugins/newspack-plugin/src/wizards/audience/components/billing-fields/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/billing-fields/index.tsx
@@ -11,6 +11,7 @@ import { CheckboxControl } from '@wordpress/components';
 import { Button, Grid } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import type { WizardsStoreSelectors } from '../../../../../packages/components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
 
 const BillingFields = () => {
@@ -20,13 +21,16 @@ const BillingFields = () => {
 		billing_fields: string[];
 	} >( 'newspack-audience/billing-fields' );
 	const { updateWizardSettings, saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
-	const isQuietLoading = useSelect( ( select: any ) => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false, [] );
+	const isQuietLoading = useSelect(
+		( select: ( store: string ) => WizardsStoreSelectors ) => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false,
+		[]
+	);
 
 	if ( ! wizardData ) {
 		return null;
 	}
 
-	const changeHandler = ( value: any ) =>
+	const changeHandler = ( value: string[] ) =>
 		updateWizardSettings( {
 			slug: 'newspack-audience/billing-fields',
 			path: [ 'billing_fields' ],

--- a/plugins/newspack-plugin/src/wizards/audience/components/checkout-configuration/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/checkout-configuration/index.tsx
@@ -11,6 +11,7 @@ import { ToggleControl, TextareaControl } from '@wordpress/components';
 import { Button, Grid } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import type { WizardsStoreSelectors } from '../../../../../packages/components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
 
 const DATA_STORE_KEY = 'newspack-audience/checkout-configuration';
@@ -23,9 +24,12 @@ function CheckoutConfiguration() {
 		woocommerce_checkout_privacy_policy_text: string;
 	} >( DATA_STORE_KEY );
 	const { updateWizardSettings, saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
-	const isQuietLoading = useSelect( ( select: any ) => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false, [] );
+	const isQuietLoading = useSelect(
+		( select: ( store: string ) => WizardsStoreSelectors ) => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false,
+		[]
+	);
 
-	const onChange = ( value: any, key: string ) =>
+	const onChange = ( value: string | boolean, key: string ) =>
 		updateWizardSettings( {
 			slug: DATA_STORE_KEY,
 			path: [ key ],

--- a/plugins/newspack-plugin/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/subscription-settings/index.tsx
@@ -11,6 +11,7 @@ import { ToggleControl, TextareaControl, TextControl } from '@wordpress/componen
 import { Button, Grid } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import type { WizardsStoreSelectors } from '../../../../../packages/components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
 
 const DATA_STORE_KEY = 'newspack-audience/subscription-settings';
@@ -24,11 +25,14 @@ function SubscriptionSettings() {
 		woocommerce_terms_confirmation_url: string;
 	} >( DATA_STORE_KEY );
 	const { updateWizardSettings, saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
-	const isQuietLoading = useSelect( ( select: any ) => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false, [] );
+	const isQuietLoading = useSelect(
+		( select: ( store: string ) => WizardsStoreSelectors ) => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false,
+		[]
+	);
 
 	// Toggle between the Subscription confirmation and Terms & Conditions confirmation.
 	// Only one can be enabled at a time.
-	const onChange = ( value: any, key: string ) => {
+	const onChange = ( value: string | boolean, key: string ) => {
 		// If enabling Subscription confirmation, disable terms confirmation.
 		if ( key === 'woocommerce_enable_subscription_confirmation' && value ) {
 			updateWizardSettings( {

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.tsx
@@ -20,14 +20,15 @@ interface DynamicRuleConfig< T > {
 	mapItem: ( item: T ) => RuleOption;
 }
 
-function dynamicRule< T >( config: DynamicRuleConfig< T > ): DynamicRuleConfig< T > {
-	return config;
+// Type-erase T to unknown so differently-shaped rule configs can share one heterogeneous record.
+function dynamicRule< T >( config: DynamicRuleConfig< T > ): DynamicRuleConfig< unknown > {
+	return config as DynamicRuleConfig< unknown >;
 }
 
 /**
  * Rules whose options should be fetched dynamically via the REST API.
  */
-const DYNAMIC_OPTION_RULES: Record< string, DynamicRuleConfig< any > > = {
+const DYNAMIC_OPTION_RULES: Record< string, DynamicRuleConfig< unknown > > = {
 	institution: dynamicRule< Institution >( {
 		path: '/wp/v2/np_institution?per_page=100&context=edit',
 		mapItem: item => ( { value: item.id, label: item.title.raw } ),

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
@@ -166,7 +166,7 @@ export default function Institutions() {
 				id: 'copy-url',
 				label: __( 'Copy access page URL', 'newspack-plugin' ),
 				callback: ( items: Institution[] ) => {
-					const baseUrl = ( window as any ).newspackAudience?.institutional_access_url;
+					const baseUrl = window.newspackAudience?.institutional_access_url;
 					const url = baseUrl ? `${ baseUrl }/${ items[ 0 ].slug }/` : '';
 					if ( url ) {
 						navigator.clipboard.writeText( url ).then(

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.tsx
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Get edit gate layout URL.
  */
 export function getEditGateLayoutUrl( gateId: number, gateMode: string ) {
-	const audienceGates = ( window as any ).newspackAudienceContentGates;
+	const audienceGates = window.newspackAudienceContentGates;
 
 	if ( ! audienceGates || typeof audienceGates.edit_gate_layout_url !== 'string' || ! audienceGates.edit_gate_layout_url ) {
 		// Fallback to avoid runtime errors if the global config is not available.

--- a/plugins/newspack-plugin/src/wizards/audience/views/donations/configuration/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/donations/configuration/index.tsx
@@ -49,7 +49,7 @@ export const DonationAmounts = () => {
 
 	const { amounts, currencySymbol, tiered, disabledFrequencies, minimumDonation, trashed } = wizardData.donation_data;
 
-	const changeHandler = ( path: ( string | number )[] ) => ( value: any ) =>
+	const changeHandler = ( path: ( string | number )[] ) => ( value: string | boolean ) =>
 		updateWizardSettings( {
 			slug: AUDIENCE_DONATIONS_WIZARD_SLUG,
 			path: [ 'donation_data', ...path ],

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
@@ -13,7 +13,7 @@ import { Button, Card, SelectControl, Wizard, withWizard, Notice } from '../../.
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 
-function AudienceSubscriptions( props: Record< string, any >, ref: React.ForwardedRef< HTMLDivElement > ) {
+function AudienceSubscriptions( props: object, ref: React.ForwardedRef< HTMLDivElement > ) {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ primaryProduct, setPrimaryProduct ] = useState( window.newspackAudienceSubscriptions.primary_product );
 

--- a/plugins/newspack-plugin/src/wizards/errors/class-wizard-error.ts
+++ b/plugins/newspack-plugin/src/wizards/errors/class-wizard-error.ts
@@ -5,7 +5,7 @@ class WizardError extends Error {
 	errorCode: string;
 	details: string;
 
-	constructor( message: string, errorCode: string, details: any = '' ) {
+	constructor( message: string, errorCode: string, details: string = '' ) {
 		super( message );
 		this.name = 'WizardError';
 		this.errorCode = errorCode;

--- a/plugins/newspack-plugin/src/wizards/hooks/use-wizard-api-fetch.ts
+++ b/plugins/newspack-plugin/src/wizards/hooks/use-wizard-api-fetch.ts
@@ -27,9 +27,13 @@ function removeQueryArgs( str: string ) {
 }
 
 /**
- * Holds in-progress promises for each fetch request.
+ * Holds in-progress promises for each fetch request. Shared across every
+ * `useWizardApiFetch` call site, each of which may use a different `T`, so
+ * the resolved value type can't be known here — callers cast back to their
+ * own `T` when reading. `Partial` keeps entries honestly optional, since this
+ * is a sparse cache and most keys are never set.
  */
-let promiseCache: Record< string, any > = {};
+let promiseCache: Partial< Record< string, Promise< unknown > > > = {};
 
 /**
  * Parses the API error response into a WizardApiError object.
@@ -67,10 +71,13 @@ const parseApiError = ( error: WpFetchError | string ): WizardApiError | null =>
  * @return             Object with an `on` method to trigger callbacks.
  */
 const onCallbacks = < T >( callbacks: ApiFetchCallbacks< T > ) => ( {
-	on( cb: keyof ApiFetchCallbacks< T >, d: any = null ) {
+	on( cb: keyof ApiFetchCallbacks< T >, d: T | WizardApiError | null = null ) {
 		const callback = callbacks?.[ cb ];
 		if ( callback && typeof callback === 'function' ) {
-			callback( d );
+			// Cast: `cb` picks which callback (and thus which parameter shape) runs at
+			// runtime, so the exact match between `d` and that callback's declared
+			// parameter can't be verified statically.
+			( callback as ( arg: T | WizardApiError | null ) => void )( d );
 		}
 	},
 } );
@@ -124,7 +131,7 @@ export function useWizardApiFetch( slug: string ) {
 		 * @param value                The value to set for the property.
 		 * @param cacheKeyPathOverride The path to update in the wizard data.
 		 */
-		return ( prop: string | string[], value: any, cacheKeyPathOverride = cacheKeyPath ) => {
+		return ( prop: string | string[], value: unknown, cacheKeyPathOverride = cacheKeyPath ) => {
 			// Remove query parameters from the cacheKeyPath
 
 			const normalizedPath = cacheKeyPathOverride ? removeQueryArgs( cacheKeyPathOverride ) : cacheKeyPathOverride;
@@ -146,7 +153,9 @@ export function useWizardApiFetch( slug: string ) {
 	 * @return               The result of the API fetch request.
 	 */
 	const apiFetch = useCallback(
-		async < T = any >( opts: ApiFetchOptions, callbacks?: ApiFetchCallbacks< T > ) => {
+		// Defaults to `{}` (not `unknown`) to match the `WizardApiFetch<T = {}>` contract
+		// that downstream call sites type this function against when no `T` is given.
+		async < T = object >( opts: ApiFetchOptions, callbacks?: ApiFetchCallbacks< T > ) => {
 			const { on } = onCallbacks< T >( callbacks ?? {} );
 			const updateSettings = updateWizardData( opts.path );
 			const { path, method = 'GET' } = opts;
@@ -204,15 +213,18 @@ export function useWizardApiFetch( slug: string ) {
 			}
 
 			// If the promise is already in progress, return it before making a new request.
+			// Cast: this cache entry may have been written by a call site using a
+			// different `T`, so its resolved value type can't be verified here.
 			if ( promiseCache[ cacheKeyPath ] ) {
 				setIsFetching( true );
-				return promiseCache[ cacheKeyPath ].then( thenCallback ).catch( catchCallback ).finally( finallyCallback );
+				return ( promiseCache[ cacheKeyPath ] as Promise< T > ).then( thenCallback ).catch( catchCallback ).finally( finallyCallback );
 			}
 
 			// Cache exists and is not empty, return it.
 			if ( isCached && ( cachedError || cachedMethod ) ) {
 				setError( cachedError );
-				on( 'onSuccess', cachedMethod );
+				// Cast: the wizard store's `WizardData` shape doesn't carry this call's `T`.
+				on( 'onSuccess', cachedMethod as T );
 				return cachedMethod;
 			}
 
@@ -235,7 +247,8 @@ export function useWizardApiFetch( slug: string ) {
 			// so a `.catch()` at the call site attached to the resolved async
 			// wrapper instead of the real request and never saw the rejection
 			// `catchCallback` re-throws.
-			return promiseCache[ cacheKeyPath ];
+			// Cast: we just stored this call's own `Promise<T>` under `cacheKeyPath` above.
+			return promiseCache[ cacheKeyPath ] as Promise< T >;
 		},
 		[ wizardApiFetch, wizardData, updateWizardSettings, isFetching, slug ]
 	);
@@ -250,7 +263,7 @@ export function useWizardApiFetch( slug: string ) {
 				get( method: ApiMethods = 'GET' ) {
 					return wizardData[ cacheKey ][ method ];
 				},
-				set( value: any, method: ApiMethods = 'GET' ) {
+				set( value: unknown, method: ApiMethods = 'GET' ) {
 					updateWizardSettings( {
 						slug,
 						path: [ cacheKey, method ],

--- a/plugins/newspack-plugin/src/wizards/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/index.tsx
@@ -24,7 +24,18 @@ import '../shared/js/public-path';
 const pageParam = new URLSearchParams( window.location.search ).get( 'page' ) ?? '';
 const rootElement = document.getElementById( pageParam );
 
-const components: Record< string, any > = {
+type WizardEntryPoint = {
+	label: string;
+	// `React.ElementType` (not `ComponentType`): a few wrapped views declare their
+	// own props as `WithWizardInjectedProps` — the shape `withWizard` injects at
+	// runtime — which makes `withWizard`'s generic `P` resolve to that type and
+	// its class component require it as an external prop too. That's a
+	// pre-existing gap in `withWizard`'s typing (not fixed here); `ElementType`
+	// is the loosest non-`any` React type that still accommodates it.
+	component: React.ElementType;
+};
+
+const components: Record< string, WizardEntryPoint > = {
 	/**
 	 * `page` param with `newspack-*`.
 	 */

--- a/plugins/newspack-plugin/src/wizards/newspack/components/site-statuses/site-status-modal.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/components/site-statuses/site-status-modal.tsx
@@ -16,7 +16,7 @@ const SiteActionModal = ( { onRequestClose, plugins, onSuccess }: SiteActionModa
 		<Modal title={ __( 'Add missing dependencies', 'newspack-plugin' ) } onRequestClose={ () => onRequestClose( false ) }>
 			<PluginInstaller
 				plugins={ plugins }
-				onStatus={ ( { complete, pluginInfo }: { complete: boolean; pluginInfo: Record< string, any > } ) => {
+				onStatus={ ( { complete, pluginInfo } ) => {
 					if ( complete ) {
 						onSuccess( pluginInfo );
 						onRequestClose( false );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -22,6 +22,9 @@ import { TAB_PATH } from './constants';
 
 const { Route, Switch, useHistory, useRouteMatch, useLocation } = Router;
 
+// The `/wp/v2/media/<id>` REST response; only the fields this view reads are declared.
+type MediaAttachment = Record< string, unknown > & { source_url?: string };
+
 export default function AdditionalBrands() {
 	const { wizardApiFetch, isFetching, cache, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/additional-brands' );
 
@@ -129,7 +132,7 @@ export default function AdditionalBrands() {
 		if ( ! attachmentId ) {
 			return;
 		}
-		wizardApiFetch(
+		wizardApiFetch< MediaAttachment >(
 			{
 				path: `/wp/v2/media/${ attachmentId }`,
 			},
@@ -144,10 +147,13 @@ export default function AdditionalBrands() {
 												..._brand,
 												meta: {
 													..._brand.meta,
+													// The full media REST payload is stored as-is; it satisfies the
+													// `Attachment` shape at runtime but TS can't verify that from
+													// a partially-declared response type.
 													_logo: {
 														...attachment,
 														url: attachment.source_url,
-													},
+													} as Brand[ 'meta' ][ '_logo' ],
 												},
 										  }
 										: _brand

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -29,7 +29,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 	// Function to fetch fresh data
 	const fetchFreshData = () => {
 		setLocalIsFetching( true );
-		wizardApiFetch(
+		wizardApiFetch< PageData >(
 			{
 				path: `/newspack/v1/wizard/newspack-settings/accessibility-statement`,
 				method: 'GET',
@@ -60,7 +60,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 
 	const createPage = () => {
 		setLocalIsFetching( true );
-		wizardApiFetch(
+		wizardApiFetch< PageData >(
 			{
 				path: '/newspack/v1/wizard/newspack-settings/accessibility-statement',
 				method: 'POST',

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/recaptcha.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/recaptcha.tsx
@@ -30,16 +30,24 @@ const settingsDefault: RecaptchaData = {
 
 type RecaptchaDependsOn = Partial< Record< keyof RecaptchaData, string > >;
 
-const fieldValidationMap = new Map<
-	keyof Omit< RecaptchaData, 'use_captcha' >,
-	{
-		callback: ( value: any, version?: RecaptchaVersions ) => string;
-		dependsOn?: RecaptchaDependsOn;
-	}
->( [
+type FieldValidation = {
+	callback: ( value: string | RecaptchaData[ 'credentials' ], version?: RecaptchaVersions ) => string;
+	dependsOn?: RecaptchaDependsOn;
+};
+
+// Type-erases each field's specific `value` type to `FieldValidation`'s shared union, so
+// per-field configs (each precisely typed against its own field) can share one Map value type.
+function fieldValidation< T extends string | RecaptchaData[ 'credentials' ] >( config: {
+	callback: ( value: T, version?: RecaptchaVersions ) => string;
+	dependsOn?: RecaptchaDependsOn;
+} ): FieldValidation {
+	return config as FieldValidation;
+}
+
+const fieldValidationMap = new Map< keyof Omit< RecaptchaData, 'use_captcha' >, FieldValidation >( [
 	[
 		'credentials',
-		{
+		fieldValidation( {
 			dependsOn: { version: 'v3' },
 			callback: ( credentials: RecaptchaData[ 'credentials' ], version = 'v3' ) => {
 				if ( ! credentials[ version ].site_key ) {
@@ -50,13 +58,13 @@ const fieldValidationMap = new Map<
 				}
 				return '';
 			},
-		},
+		} ),
 	],
 	[
 		'threshold',
-		{
+		fieldValidation( {
 			dependsOn: { version: 'v3' },
-			callback: value => {
+			callback: ( value: string ) => {
 				const threshold = parseFloat( value || '0' );
 				if ( threshold < 0.1 ) {
 					return ERROR_MESSAGES.RECAPTCHA.THRESHOLD_INVALID_MIN;
@@ -66,7 +74,7 @@ const fieldValidationMap = new Map<
 				}
 				return '';
 			},
-		},
+		} ),
 	],
 ] );
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/sections.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/sections.tsx
@@ -5,6 +5,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { lazy } from '@wordpress/element';
+import type { WizardSection } from '../../../../../packages/components/src/wizard';
 
 // NPPD-1538: forward stale bookmarks of `?page=newspack-settings#/emails`
 // to the new Audience > Configuration > Emails home. This is an
@@ -93,7 +94,7 @@ if ( 'experimental-tools' in settingsTabs ) {
 
 const settingsSectionKeys = Object.keys( settingsTabs ) as SectionKeys[];
 
-export default settingsSectionKeys.reduce( ( acc: any[], sectionPath ) => {
+export default settingsSectionKeys.reduce( ( acc: WizardSection[], sectionPath ) => {
 	acc.push( {
 		label: settingsTabs[ sectionPath ].label,
 		exact: '/' === ( settingsTabs[ sectionPath ].path ?? '' ),

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
@@ -78,7 +78,7 @@ function Seo() {
 	useEffect( get, [] );
 
 	function get() {
-		wizardApiFetch(
+		wizardApiFetch< SeoData >(
 			{
 				path: PATH,
 			},
@@ -94,7 +94,7 @@ function Seo() {
 		if ( ! isVerificationCodesValid || ! isAccountsValid ) {
 			return;
 		}
-		wizardApiFetch(
+		wizardApiFetch< SeoData >(
 			{
 				path: PATH,
 				method: 'POST',

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/theme-and-brand/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/theme-and-brand/index.tsx
@@ -43,7 +43,7 @@ const ThemeBrand = ( { isPartOfSetup = false } ) => {
 	}
 
 	const finishSetup = () => {
-		wizardApiFetch(
+		wizardApiFetch< ThemeData >(
 			{
 				data,
 				path: '/newspack/v1/wizard/newspack-setup-wizard/complete',
@@ -61,7 +61,7 @@ const ThemeBrand = ( { isPartOfSetup = false } ) => {
 
 	async function save() {
 		return new Promise( resolve =>
-			wizardApiFetch(
+			wizardApiFetch< ThemeData >(
 				{
 					data,
 					path: '/newspack/v1/wizard/newspack-setup-wizard/theme',
@@ -79,7 +79,7 @@ const ThemeBrand = ( { isPartOfSetup = false } ) => {
 	}
 
 	useEffect( () => {
-		wizardApiFetch(
+		wizardApiFetch< ThemeData >(
 			{
 				path: '/newspack/v1/wizard/newspack-setup-wizard/theme',
 			},

--- a/plugins/newspack-plugin/src/wizards/types/window.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/window.d.ts
@@ -40,6 +40,9 @@ declare global {
 			};
 			// Products purchasable via gifting / countdown CTAs.
 			available_products?: PurchasableProductOption[];
+			// Front-end URL of the institutional (IP-range) access endpoint, localized
+			// by the Content Gates wizard for the "Copy access page URL" action.
+			institutional_access_url?: string;
 			// Optional: consumers guard with `?.`/fallbacks because the
 			// payload can be absent (plugin filter strips it, non-Audience
 			// mount, HMR reseed) — keep the type honest about that.

--- a/plugins/newspack-plugin/src/wizards/wizards-toggle-header-card.tsx
+++ b/plugins/newspack-plugin/src/wizards/wizards-toggle-header-card.tsx
@@ -80,7 +80,7 @@ function validationErrorHandler( { setError }: { setError: ( value: WizardErrorT
  * @param props.onToggle           Callback for the toggle
  * @param props.onChecked          Callback for the checked state
  */
-const WizardsToggleHeaderCard = < T extends Record< string, any > >( {
+const WizardsToggleHeaderCard = < T extends { active: boolean } >( {
 	title,
 	description,
 	namespace,
@@ -122,7 +122,10 @@ const WizardsToggleHeaderCard = < T extends Record< string, any > >( {
 						}
 					}
 					if ( typeof validate.callback === 'string' ) {
-						if ( ! fieldValidations[ validate.callback ]( settingsUpdates[ field ] ) ) {
+						// Cast: `fieldValidationMap` lets any `keyof T` pair with the 'isIntegerId'/'isId'
+						// string validators, which require a string value — a pre-existing contract
+						// the type system can't verify (not fixed here; callers must self-police it).
+						if ( ! fieldValidations[ validate.callback ]( settingsUpdates[ field ] as string ) ) {
 							return;
 						}
 					} else if ( typeof validate.callback === 'function' ) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Final PR in the TypeScript migration stack.

- Tightens the remaining `no-explicit-any` lint warnings in `newspack-plugin` — the handful of `any`s left at opaque third-party boundaries during the sweep, now narrowed.
- Adds `.git-blame-ignore-revs` listing the migration commits, so `git blame` skips the renames and keeps pointing at the real authors.

Type-stripping is behavior-neutral: the Babel build removes types with no runtime effect, so these sweeps are typing work rather than logic changes. Any behavior-affecting change is called out explicitly above.

### How to test the changes in this Pull Request:

1. `pnpm install` at the workspace root.
2. `pnpm --filter <unit> run typescript:check` — the strict gate passes for every unit touched here.
3. `pnpm --filter <unit> run lint:js` and `pnpm --filter <unit> run build` — both green.
4. `pnpm --filter <unit> run test` for units carrying JS tests.
5. Compare the built `dist/` file list against the base branch — unchanged.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

### Stack

Part of the [NPPM-2977](https://linear.app/a8c/issue/NPPM-2977/monorepo-jstypescript-migration) JS→TypeScript migration — a chain of stacked PRs, each targeting the previous phase's branch:

| Phase | PR | Scope |
|---|---|---|
| phase0 | #526 | Infra: type gate, tsconfigs, webpack ext-agnostic entry resolution |
| phase0.5 | #649 | Make the existing TS strict-clean, turn the gate on |
| phase1 | #650 | `packages/icons` + `packages/components` |
| phase2 | #651 | `newspack-plugin` |
| phase3 | #652 | `newspack-blocks` + `newspack-newsletters` |
| phase4 | #653 | Remaining plugins |
| phase5 | #654 | Both themes |
| phase6 | #655 | Wrap-up: tighten remaining `any`, blame-ignore revs |

Each PR will be retargeted as the chain lands. **Do not merge out of order.**

