### PR TITLE
feat(audience): polish integrations settings UI

### DIFF
--- a/packages/components/DEVELOPMENT.md
+++ b/packages/components/DEVELOPMENT.md
@@ -100,7 +100,7 @@ When building a screen, use the **spacing scale** (8px unit: 16, 24, 32, 48, 64)
 - **`Notice`** – Use for outcome feedback (success/error/warning) or short contextual messages. Vertical margin is 32px so notices don’t collide with cards; keep one primary message per area when possible.
 - **`Waiting`** – Loading state indicator.
 - **`ProgressBar`** – Progress indicator.
-- **`Accordion`** – Collapsible content sections.
+- **`Accordion`** / **`AccordionPanel`** – Container for one or more collapsible panels.
 - **`StepsList`** / **`StepsListItem`** – Step-by-step list components.
 - **`StyleCard`** – Style preview card.
 

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -36,7 +36,7 @@ const Accordion = ( { children, className, hideSingleTitle = false, spacing = 6 
 			{ panels.map( ( panel, index ) => (
 				<Fragment key={ panel.key }>
 					{ panel }
-					{ index < panels.length - 1 && <Divider variant="tertiary" marginBottom={ 0 } marginTop={ 0 } /> }
+					{ index < panels.length - 1 && <Divider variant="secondary" marginBottom={ 0 } marginTop={ 0 } /> }
 				</Fragment>
 			) ) }
 		</VStack>

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { __experimentalVStack as VStack, PanelBody } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Children, Fragment, cloneElement } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -12,22 +12,34 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Divider from '../divider';
 import './style.scss';
 
-const Accordion = ( { children, title, defaultOpen = false } ) => {
-	const [ isOpen, setIsOpen ] = useState( defaultOpen );
+export const AccordionPanel = ( { children, className, title, defaultOpen = false } ) => (
+	<PanelBody className={ className } title={ title } initialOpen={ defaultOpen }>
+		{ children }
+	</PanelBody>
+);
+
+const Accordion = ( { children, className, hideSingleTitle = false, spacing = 6 } ) => {
+	const panels = Children.toArray( children );
+	// With nothing to collapse against, a lone panel can render open and untitled.
+	if ( hideSingleTitle && panels.length === 1 ) {
+		return (
+			<div className={ classNames( 'newspack-accordion', className ) }>
+				{ cloneElement( panels[ 0 ], { defaultOpen: true, title: undefined } ) }
+			</div>
+		);
+	}
 	return (
-		<details
-			className={ classNames( 'newspack-accordion', { 'newspack-accordion--is-open': isOpen } ) }
-			open={ isOpen }
-			onToggle={ e => setIsOpen( e.currentTarget.open ) }
-		>
-			<summary>
-				{ title }
-				<Icon className="newspack-accordion__icon" icon={ chevronRight } size={ 24 } />
-			</summary>
-			<div className="newspack-accordion__content">{ children }</div>
-		</details>
+		<VStack className={ classNames( 'newspack-accordion', className ) } spacing={ spacing }>
+			{ panels.map( ( panel, index ) => (
+				<Fragment key={ panel.key }>
+					{ panel }
+					{ index < panels.length - 1 && <Divider variant="tertiary" marginBottom={ 0 } marginTop={ 0 } /> }
+				</Fragment>
+			) ) }
+		</VStack>
 	);
 };
 

--- a/packages/components/src/accordion/index.test.js
+++ b/packages/components/src/accordion/index.test.js
@@ -35,9 +35,9 @@ describe( 'Accordion dividers', () => {
 		expect( container.querySelector( '.newspack-accordion' ).lastElementChild ).not.toHaveClass( 'newspack-divider' );
 	} );
 
-	it( 'renders tertiary dividers', () => {
+	it( 'renders secondary dividers', () => {
 		const { container } = renderPanels( 2 );
-		expect( dividers( container )[ 0 ] ).toHaveClass( 'newspack-divider--variant-tertiary' );
+		expect( dividers( container )[ 0 ] ).toHaveClass( 'newspack-divider--variant-secondary' );
 	} );
 } );
 

--- a/packages/components/src/accordion/index.test.js
+++ b/packages/components/src/accordion/index.test.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Accordion, { AccordionPanel } from './index';
+
+const renderPanels = ( count, props = {} ) =>
+	render(
+		<Accordion { ...props }>
+			{ Array.from( { length: count }, ( _, i ) => (
+				<AccordionPanel key={ i } title={ `Panel ${ i }` }>
+					content
+				</AccordionPanel>
+			) ) }
+		</Accordion>
+	);
+
+const dividers = container => container.querySelectorAll( '.newspack-divider' );
+
+describe( 'Accordion dividers', () => {
+	it( 'renders no divider for a single panel', () => {
+		const { container } = renderPanels( 1 );
+		expect( container.querySelectorAll( '.components-panel__body' ) ).toHaveLength( 1 );
+		expect( dividers( container ) ).toHaveLength( 0 );
+	} );
+
+	it( 'renders a divider between panels but not after the last', () => {
+		const { container } = renderPanels( 3 );
+		expect( container.querySelectorAll( '.components-panel__body' ) ).toHaveLength( 3 );
+		expect( dividers( container ) ).toHaveLength( 2 );
+		expect( container.querySelector( '.newspack-accordion' ).lastElementChild ).not.toHaveClass( 'newspack-divider' );
+	} );
+
+	it( 'renders tertiary dividers', () => {
+		const { container } = renderPanels( 2 );
+		expect( dividers( container )[ 0 ] ).toHaveClass( 'newspack-divider--variant-tertiary' );
+	} );
+} );
+
+describe( 'Accordion hideSingleTitle', () => {
+	it( 'keeps the title on a lone panel by default', () => {
+		renderPanels( 1 );
+		expect( screen.getByRole( 'button', { name: 'Panel 0' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'drops the title and opens a lone panel when set', () => {
+		const { container } = renderPanels( 1, { hideSingleTitle: true } );
+		expect( screen.queryByRole( 'button', { name: 'Panel 0' } ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.components-panel__body' ) ).toHaveClass( 'is-opened' );
+		expect( screen.getByText( 'content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves titles alone when there is more than one panel', () => {
+		renderPanels( 2, { hideSingleTitle: true } );
+		expect( screen.getByRole( 'button', { name: 'Panel 0' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Panel 1' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/accordion/style.scss
+++ b/packages/components/src/accordion/style.scss
@@ -1,31 +1,35 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
+// Sit flush with the surrounding column: core insets panels horizontally, which
+// would misalign them against the section they belong to.
 .newspack-accordion {
-	border: 1px solid wp-colors.$gray-300;
+	.components-panel__body {
+		border: 0;
 
-	&__icon {
-		transition: transform 200ms ease-out;
-		transform: rotate(90deg);
-	}
-
-	&--is-open {
-		.newspack-accordion {
-			&__icon {
-				transform: rotate(-90deg);
-			}
+		> .components-panel__body-title:hover {
+			background: none;
 		}
 	}
-	summary {
-		padding: 16px 32px;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		cursor: pointer;
-		font-size: 14px;
-		font-weight: bold;
+
+	.components-panel__body.is-opened {
+		padding: 0;
+
+		> .components-panel__body-title {
+			margin: 0 0 wp-vars.$grid-unit-30;
+		}
 	}
 
-	&__content {
-		padding: 16px 32px;
+	.components-panel__body-toggle.components-button {
+		@include wp-mixins.heading-large();
+		padding: 0;
+
+		.components-panel__arrow {
+			right: 0;
+		}
+
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+		}
 	}
 }

--- a/packages/components/src/divider/style.scss
+++ b/packages/components/src/divider/style.scss
@@ -34,7 +34,7 @@
 	// Variant
 
 	&--variant-default {
-		background-color: wp-colors.$gray-300;
+		background-color: var( --wpds-color-stroke-surface-neutral, #{wp-colors.$gray-300} );
 	}
 
 	&--variant-primary {

--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -61,6 +61,11 @@
 		grid-row-gap: 16px;
 	}
 
+	// Row Gap 24
+	&__row-gap-24 {
+		grid-row-gap: 24px;
+	}
+
 	// Row Gap 32
 	&__row-gap-32 {
 		grid-row-gap: 32px;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,4 +1,4 @@
-export { default as Accordion } from './accordion';
+export { default as Accordion, AccordionPanel } from './accordion';
 export { default as ActionCard } from './action-card';
 export { default as AutocompleteTokenField } from './autocomplete-tokenfield';
 export { default as AutocompleteWithSuggestions } from './autocomplete-with-suggestions';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -35,12 +35,9 @@
 // Checkboxes
 .newspack-checkbox-control {
 	margin-top: 0 !important;
-	.components-checkbox-control__label {
-		font-weight: 600;
-	}
 
 	.components-base-control__help {
-		margin-left: 32px;
+		margin-left: calc(var(--checkbox-input-size) + var(--checkbox-input-margin));
 		margin-top: 0;
 	}
 }

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -46,7 +46,7 @@
 	}
 
 	&__main {
-		overflow-x: hidden;
+		overflow: hidden;
 		padding-bottom: 1px; /* Prevents borders from being cut off */
 	}
 

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -220,9 +220,9 @@ h1 {
 		margin-top: 8px;
 
 		// Match the width of a single card in the 2-column CardFeature grid
-		// (grid has 16px gutter; falls back to 1 column below 744px viewport).
+		// (grid has 32px gutter; falls back to 1 column below 744px viewport).
 		@media screen and ( min-width: 744px ) {
-			max-width: calc((100% - 16px) / 2);
+			max-width: calc((100% - 32px) / 2);
 		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -273,7 +273,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 									const currentValue = getFieldValue( outboundField );
 									const selected = Array.isArray( currentValue ) ? currentValue : [];
 									return (
-										<AccordionPanel key={ group.section } title={ group.section } defaultOpen={ index === 0 }>
+										<AccordionPanel key={ `${ index }-${ group.section }` } title={ group.section } defaultOpen={ index === 0 }>
 											<Grid columns={ 1 } rowGap={ 8 } noMargin>
 												{ group.fields.map( fieldName => (
 													<CheckboxControl

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -9,7 +9,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Accordion, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
+import { Accordion, AccordionPanel, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../wizards-tab';
 import { SettingsField } from './settings-field';
@@ -214,91 +214,87 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	return (
 		<>
 			{ navBlockDialog }
-			<WizardsTab isFetching={ loading }>
-				<div className="newspack-configure-view">
-					{ /* Section 1: Settings */ }
-					{ settingsFields.length > 0 && (
-						<Grid columns={ 2 } gutter={ 32 }>
-							<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
-							<Grid columns={ 1 } rowGap={ 16 }>
-								{ settingsFields.filter( fieldIsVisible ).map( field => (
-									<SettingsField
-										key={ field.key }
-										field={ field }
-										value={ getFieldValue( field ) }
-										onChange={ val => handleFieldChange( field.key, val ) }
-									/>
-								) ) }
+			<div className={ `newspack-configure-view${ loading ? ' is-fetching' : '' }` }>
+				{ /* Section 1: Settings */ }
+				{ settingsFields.length > 0 && (
+					<Grid columns={ 2 } gutter={ 32 }>
+						<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
+						<Grid columns={ 1 } gutter={ 24 }>
+							{ settingsFields.filter( fieldIsVisible ).map( field => (
+								<SettingsField
+									key={ field.key }
+									field={ field }
+									value={ getFieldValue( field ) }
+									onChange={ val => handleFieldChange( field.key, val ) }
+								/>
+							) ) }
+						</Grid>
+					</Grid>
+				) }
+
+				{ /* Section 2: Inbound */ }
+				{ inboundField && (
+					<>
+						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
+						<Grid columns={ 2 } gutter={ 32 } noMargin>
+							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
+							<Grid columns={ 1 } rowGap={ 8 } noMargin>
+								{ ( inboundField.options || [] ).map( option => {
+									// Framework injects options as { value, label } objects
+									// (see class-integration.php:get_settings_config()), but accepts bare strings
+									// for backward compatibility.
+									const optionValue = typeof option === 'string' ? option : option.value;
+									const optionLabel = typeof option === 'string' ? option : option.label || option.value;
+									const currentValue = getFieldValue( inboundField );
+									const selected = Array.isArray( currentValue ) ? currentValue : [];
+									return (
+										<CheckboxControl
+											className="newspack-checkbox-control"
+											key={ optionValue }
+											label={ optionLabel }
+											checked={ selected.includes( optionValue ) }
+											onChange={ checked => handleCheckboxListChange( inboundField.key, currentValue, optionValue, checked ) }
+										/>
+									);
+								} ) }
 							</Grid>
 						</Grid>
-					) }
+					</>
+				) }
 
-					{ /* Section 2: Inbound */ }
-					{ inboundField && (
-						<>
-							<Divider alignment="full-width" variant="tertiary" marginTop={ 32 } marginBottom={ 32 } />
-							<Grid columns={ 2 } gutter={ 32 } noMargin>
-								<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
-								<Grid columns={ 1 } rowGap={ 8 } noMargin>
-									{ ( inboundField.options || [] ).map( option => {
-										// Framework injects options as { value, label } objects
-										// (see class-integration.php:get_settings_config()), but accepts bare strings
-										// for backward compatibility.
-										const optionValue = typeof option === 'string' ? option : option.value;
-										const optionLabel = typeof option === 'string' ? option : option.label || option.value;
-										const currentValue = getFieldValue( inboundField );
-										const selected = Array.isArray( currentValue ) ? currentValue : [];
-										return (
-											<CheckboxControl
-												className="newspack-checkbox-control"
-												key={ optionValue }
-												label={ optionLabel }
-												checked={ selected.includes( optionValue ) }
-												onChange={ checked =>
-													handleCheckboxListChange( inboundField.key, currentValue, optionValue, checked )
-												}
-											/>
-										);
-									} ) }
-								</Grid>
-							</Grid>
-						</>
-					) }
-
-					{ /* Section 3: Outbound */ }
-					{ outboundField && (
-						<>
-							<Divider alignment="full-width" variant="tertiary" marginTop={ 32 } marginBottom={ 32 } />
-							<Grid columns={ 2 } gutter={ 32 } noMargin>
-								<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
-								<div>
-									{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
-										const currentValue = getFieldValue( outboundField );
-										const selected = Array.isArray( currentValue ) ? currentValue : [];
-										return (
-											<Accordion key={ group.section } title={ group.section } defaultOpen={ index === 0 }>
-												<Grid columns={ 1 } rowGap={ 8 } noMargin>
-													{ group.fields.map( fieldName => (
-														<CheckboxControl
-															className="newspack-checkbox-control"
-															key={ fieldName }
-															label={ fieldName }
-															checked={ selected.includes( fieldName ) }
-															onChange={ checked =>
-																handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
-															}
-														/>
-													) ) }
-												</Grid>
-											</Accordion>
-										);
-									} ) }
-								</div>
-							</Grid>
-						</>
-					) }
-				</div>
-			</WizardsTab>
+				{ /* Section 3: Outbound */ }
+				{ outboundField && (
+					<>
+						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
+						<Grid columns={ 2 } gutter={ 32 } noMargin>
+							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
+							<Accordion hideSingleTitle>
+								{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
+									const currentValue = getFieldValue( outboundField );
+									const selected = Array.isArray( currentValue ) ? currentValue : [];
+									return (
+										<AccordionPanel key={ group.section } title={ group.section } defaultOpen={ index === 0 }>
+											<Grid columns={ 1 } rowGap={ 8 } noMargin>
+												{ group.fields.map( fieldName => (
+													<CheckboxControl
+														className="newspack-checkbox-control"
+														key={ fieldName }
+														label={ fieldName }
+														checked={ selected.includes( fieldName ) }
+														onChange={ checked =>
+															handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
+														}
+													/>
+												) ) }
+											</Grid>
+										</AccordionPanel>
+									);
+								} ) }
+							</Accordion>
+						</Grid>
+					</>
+				) }
+			</div>
 		</>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -214,7 +214,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	return (
 		<>
 			{ navBlockDialog }
-			<div className={ `newspack-configure-view${ loading ? ' is-fetching' : '' }` }>
+			<div className="newspack-configure-view">
 				{ /* Section 1: Settings */ }
 				{ settingsFields.length > 0 && (
 					<Grid columns={ 2 } gutter={ 32 }>

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.scss
@@ -1,23 +1,7 @@
-@use "~@wordpress/base-styles/colors" as wp-colors;
-
 .newspack-configure-view {
 	// Align section headers to the top of the grid row.
 	.newspack-grid .newspack-section-header {
 		margin-top: 0;
 		margin-bottom: 0;
-	}
-
-	// Accordion overrides: top/bottom borders only, no box border.
-	.newspack-accordion {
-		border: none;
-		border-top: 1px solid wp-colors.$gray-300;
-
-		&:first-child {
-			border-top: none;
-		}
-
-		&:last-child {
-			border-bottom: none;
-		}
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -20,6 +20,7 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Accordion: ( { children } ) => children,
+	AccordionPanel: ( { children } ) => children,
 	Divider: () => null,
 	Grid: ( { children } ) => children,
 	SectionHeader: () => null,

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.js
@@ -33,7 +33,7 @@ const AudienceIntegrations = ( props, ref ) => {
 	const [ activating, setActivating ] = useState( {} );
 	const [ loading, setLoading ] = useState( true );
 
-	const { addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, removeNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	const addEnabledNotice = useCallback(
 		( integrationId, enabled, data ) => {
@@ -79,6 +79,9 @@ const AudienceIntegrations = ( props, ref ) => {
 			}
 			setInFlightChanges( prev => ( { ...prev, [ integrationId ]: changes } ) );
 			setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
+			// Drop the previous attempt's snackbar so a retry doesn't stack a second
+			// notice under the same id.
+			removeNotice( `integration-saved-${ integrationId }` );
 			return apiFetch( {
 				path: `${ API_PATH }/${ integrationId }`,
 				method: 'POST',
@@ -90,6 +93,11 @@ const AudienceIntegrations = ( props, ref ) => {
 						const next = { ...prev };
 						delete next[ integrationId ];
 						return next;
+					} );
+					addNotice( {
+						id: `integration-saved-${ integrationId }`,
+						type: 'success',
+						message: __( 'Settings saved.', 'newspack-plugin' ),
 					} );
 				} )
 				.catch( error => {
@@ -107,7 +115,7 @@ const AudienceIntegrations = ( props, ref ) => {
 					setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
 				} );
 		},
-		[ addNotice ]
+		[ addNotice, removeNotice ]
 	);
 
 	const handleToggleEnabled = useCallback(

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -14,12 +14,13 @@ import apiFetch from '@wordpress/api-fetch';
 import AudienceIntegrations from './index';
 
 const mockAddNotice = jest.fn();
+const mockRemoveNotice = jest.fn();
 const captured = {};
 const loadingStates = [];
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( { addNotice: mockAddNotice } ),
+	useDispatch: () => ( { addNotice: mockAddNotice, removeNotice: mockRemoveNotice } ),
 } ) );
 jest.mock( '../../../../../packages/components/src', () => ( {
 	Wizard: ( { sections } ) => {
@@ -54,6 +55,7 @@ const flushPromises = () => new Promise( resolve => setTimeout( resolve, 0 ) );
 describe( 'AudienceIntegrations notices', () => {
 	beforeEach( async () => {
 		mockAddNotice.mockClear();
+		mockRemoveNotice.mockClear();
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( SETTINGS_MAP );
 		render( <AudienceIntegrations /> );
@@ -101,6 +103,30 @@ describe( 'AudienceIntegrations notices', () => {
 				message: 'Something went wrong. Please try again.',
 			} )
 		);
+	} );
+
+	it( 'announces a success snackbar when the save succeeds', async () => {
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+			await flushPromises();
+		} );
+		await waitFor( () =>
+			expect( mockAddNotice ).toHaveBeenCalledWith( {
+				id: 'integration-saved-esp',
+				type: 'success',
+				message: 'Settings saved.',
+			} )
+		);
+	} );
+
+	// Success and error share a notice id, and the wizard keys snackbars by id, so
+	// each save has to clear the previous attempt's notice before adding its own.
+	it( 'clears the previous save snackbar before each save', async () => {
+		await act( async () => {
+			captured.props.onSave( 'esp', { mailchimp_audience_id: 'abc123' } );
+			await flushPromises();
+		} );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( 'integration-saved-esp' );
 	} );
 
 	it( 'announces an error snackbar when the save request fails', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/index.test.js
@@ -127,6 +127,7 @@ describe( 'AudienceIntegrations notices', () => {
 			await flushPromises();
 		} );
 		expect( mockRemoveNotice ).toHaveBeenCalledWith( 'integration-saved-esp' );
+		expect( mockRemoveNotice.mock.invocationCallOrder[ 0 ] ).toBeLessThan( mockAddNotice.mock.invocationCallOrder[ 0 ] );
 	} );
 
 	it( 'announces an error snackbar when the save request fails', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-section.js
@@ -59,7 +59,7 @@ export const SettingsSection = ( { integrations, loading, activating = {}, onTog
 				) }
 				{ ! loading && integrationIds.length > 0 && (
 					<>
-						<Grid columns={ 2 } gutter={ 16 }>
+						<Grid columns={ 2 }>
 							{ integrationIds.map( id => {
 								const integration = integrations[ id ];
 								const {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Design polish pass on the Audience → Integrations screens.

**Integrations list**

* Integration cards sit on the standard 32px gutter instead of a tighter 16px one.

**Integration settings**

* Section dividers get more breathing room (64px above and below).
* The settings column no longer sits inside a redundant wrapper, so it lines up with the rest of the screen.
* Saving an integration now confirms with a "Settings saved." snackbar. A failed save already told you something went wrong; a successful one said nothing at all.

**Accordion (`packages/components`)**

* Rebuilt on top of core's `PanelBody` rather than a hand-rolled `<details>` element. The previous version shipped a boxed look that its only consumer immediately overrode, so the two fought each other.
* An accordion is now a container of one or more panels — `Accordion` + `AccordionPanel` — mirroring core's `Panel`/`PanelBody`. Panels are separated by a tertiary divider, never trailing after the last one.
* New opt-in `hideSingleTitle` prop: where a group would render as a single panel, it renders open and untitled instead of as a pointless one-item disclosure. Opt-in rather than automatic, so a single titled collapsible is still expressible.

**Shared styles**

* Checkbox labels are no longer bold, and their help text is indented from the checkbox's own size/margin variables rather than a hardcoded value that no longer matched.
* `.newspack-wizard__main` clips on both axes.

Note: the multi-panel accordion only appears on sites running metadata schema 1.0 (`NEWSPACK_SYNC_METADATA_VERSION_1`). On the default (legacy) schema every field lands in one catch-all group, which is why `hideSingleTitle` exists.

Stacked on #641 — merge after #258 → #632 → #641.

Closes DSGNEWS-199.

### How to test the changes in this Pull Request:

1. Go to **Audience → Integrations**. The integration cards should sit on a 32px gutter.
2. Open **Newsletter ESP** → **Configure**. Check the dividers between Settings / Inbound / Outbound have 64px above and below, and that the settings column aligns with the page (no nested wrapper).
3. Confirm checkbox labels in Inbound/Outbound are regular weight, not bold.
4. Under **Outbound**, on a default site you should see the field list directly, with no redundant "Additional" toggle above it.
5. Change a setting (e.g. **Metadata field prefix**) and hit **Save**. A "Settings saved." snackbar should appear bottom-centre, and the value should persist on reload.
6. Break the save (e.g. go offline or block the REST request) and hit **Save** again. You should get the error snackbar, not a success one. Restore the connection and save again — the error snackbar should be replaced by the success one, not stacked alongside it.
7. To exercise the multi-panel accordion, add `define( 'NEWSPACK_SYNC_METADATA_VERSION_1', true );` to `wp-config.php` and reload. Outbound should now show Identity / Registration / Engagement as collapsible panels, separated by light dividers, with 24px between them and no divider after the last panel. The first panel is open; titles are kept because there is more than one.
8. Keyboard-tab to a panel toggle: the focus ring should show. Click one with the mouse: no focus ring, but it should still expand/collapse.
9. Check other wizard screens (Settings, Dashboard, Audience → Configuration) still scroll and render normally — `.newspack-wizard__main` and the checkbox styles are shared.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Test runs: lint:js clean (0 errors, 28 pre-existing warnings); newspack-plugin 42 suites / 390 tests; newspack-components 13 suites / 91 tests. -->
