### PR TITLE
ci: stack-aware branch pruning + stacked-PR retargeting

### DIFF
--- a/.github/workflows/prune-merged-branches.yml
+++ b/.github/workflows/prune-merged-branches.yml
@@ -1,0 +1,92 @@
+name: Prune merged branches
+
+# Stack-aware replacement for the "Automatically delete head branches" repo
+# setting (which is to be turned OFF once this workflow is live – see the PR
+# that introduced it for the rollout order).
+#
+# Why not just use the setting: deleting a head branch at the instant of merge
+# races GitHub's own PR-retargeting. When a branch is deleted, two independent
+# server-side jobs fire against PRs that use it as their base: a legacy job
+# that closes them, and the 2020 retargeting job that repoints them at the
+# merged PR's base. They are not mutually exclusive – a stacked ("daisychained")
+# PR can be retargeted AND closed in the same second (see e.g. #626, closed
+# collaterally by the merge of #608 with a live 16-file diff:
+# base_ref_deleted + automatic_base_change_succeeded + closed, all at
+# 2026-07-18T21:38:28Z). Refs:
+# https://github.blog/changelog/2020-05-19-pull-request-retargeting/
+# https://github.com/orgs/community/discussions/176698
+#
+# This workflow enforces the invariant that makes the race structurally
+# impossible: a branch is only ever deleted when NO open PR has it as a base.
+# Branches that fail the check are kept and logged, and retried on the next
+# run – by then the retarget-stacked-prs workflow (or a human) will normally
+# have repointed the dependents. The grace period is cosmetic by comparison;
+# the dependents check is what carries the safety.
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: prune-merged-branches
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Delete merged branches with no open dependents
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      GRACE_DAYS: 3
+    steps:
+      - name: Prune
+        run: |
+          cutoff=$(date -u -d "$GRACE_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+          default_branch=$(gh api "repos/$REPO" --jq .default_branch)
+          # Long-lived integration branches are never candidates, protected or not.
+          keep_regex='^(main|alpha|release|trunk|master)$'
+
+          branches=$(gh api "repos/$REPO/branches" --paginate --jq '.[] | select(.protected | not) | .name')
+
+          for branch in $branches; do
+            [ "$branch" = "$default_branch" ] && continue
+            [[ "$branch" =~ $keep_regex ]] && continue
+
+            # An open PR from this branch means active work.
+            open_head=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq length)
+            if [ "$open_head" -gt 0 ]; then
+              continue
+            fi
+
+            # The load-bearing check: never delete a branch that any open PR
+            # still targets. Deleting it would hand those PRs to GitHub's
+            # deletion-time handlers, and with them the close race this
+            # workflow exists to avoid.
+            dependents=$(gh pr list --repo "$REPO" --base "$branch" --state open --json number --jq '[.[].number | tostring] | join(", #")')
+            if [ -n "$dependents" ]; then
+              echo "::notice::Keeping $branch – it is the base of open PR(s) #$dependents. Retarget them first (retarget-stacked-prs normally does this on merge)."
+              continue
+            fi
+
+            # Only branches whose PR actually merged are pruned; a branch with
+            # no merged PR is in-progress or abandoned work, not ours to judge.
+            merged_at=$(gh pr list --repo "$REPO" --head "$branch" --state merged --json mergedAt --jq 'map(.mergedAt) | max // empty')
+            if [ -z "$merged_at" ]; then
+              continue
+            fi
+            if [[ "$merged_at" > "$cutoff" ]]; then
+              echo "Keeping $branch – merged $merged_at, inside the $GRACE_DAYS-day grace period."
+              continue
+            fi
+
+            echo "Deleting $branch (merged $merged_at, no open PRs from or onto it)."
+            if ! gh api -X DELETE "repos/$REPO/git/refs/heads/$branch"; then
+              echo "::warning::Could not delete $branch."
+            fi
+          done

--- a/.github/workflows/retarget-stacked-prs.yml
+++ b/.github/workflows/retarget-stacked-prs.yml
@@ -73,9 +73,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          children=$(gh pr list --repo "$REPO" --base "$PARENT_HEAD" --state open --json number,headRefName --jq '.[] | "\(.number):\(.headRefName)"')
+          # Ref names cannot contain ":", so it is a safe field separator.
+          children=$(gh pr list --repo "$REPO" --base "$PARENT_HEAD" --state open --json number,headRefName,isCrossRepository --jq '.[] | "\(.number):\(.isCrossRepository):\(.headRefName)"')
 
-          while IFS=: read -r number branch; do
+          while IFS=: read -r number cross branch; do
             [ -z "$number" ] && continue
             echo "Retargeting #$number ($branch) from $PARENT_HEAD to $PARENT_BASE."
             if ! gh api -X PATCH "repos/$REPO/pulls/$number" -f base="$PARENT_BASE" > /dev/null; then
@@ -83,7 +84,20 @@ jobs:
               continue
             fi
 
-            git fetch origin "$branch" "$PARENT_BASE"
+            # A fork-headed child can be retargeted but not pushed to – its
+            # branch lives in the fork, not here. Leave the merge to the author.
+            if [ "$cross" = "true" ]; then
+              gh pr comment "$number" --repo "$REPO" --body "Base branch \`$PARENT_HEAD\` was merged into \`$PARENT_BASE\` (#$PARENT_NUMBER), so this PR was retargeted to \`$PARENT_BASE\`. The branch lives in a fork, so the automatic merge of \`$PARENT_BASE\` was skipped – please merge \`$PARENT_BASE\` into \`$branch\` yourself. Until then the diff will include changes already merged via #$PARENT_NUMBER."
+              continue
+            fi
+
+            # The branch can vanish or move between listing and fetch; a failed
+            # fetch must not kill the loop for the remaining children.
+            if ! git fetch origin "$branch" "$PARENT_BASE"; then
+              gh pr comment "$number" --repo "$REPO" --body "Base branch \`$PARENT_HEAD\` was merged into \`$PARENT_BASE\` (#$PARENT_NUMBER), so this PR was retargeted to \`$PARENT_BASE\`. The automatic merge of \`$PARENT_BASE\` into \`$branch\` was skipped (the branch could not be fetched) – please merge \`$PARENT_BASE\` in manually."
+              echo "::warning::Could not fetch $branch – automatic merge skipped for #$number."
+              continue
+            fi
             git checkout -B "$branch" "origin/$branch"
             if git merge --no-edit "origin/$PARENT_BASE"; then
               if git push origin "$branch"; then

--- a/.github/workflows/retarget-stacked-prs.yml
+++ b/.github/workflows/retarget-stacked-prs.yml
@@ -1,0 +1,100 @@
+name: Retarget stacked PRs
+
+# When a PR merges, any open PR that targets its head branch (a stacked /
+# daisychained PR) is repointed at the merged PR's base, and that base is then
+# merged into the child branch so the child's diff stops showing the parent's
+# already-squashed changes.
+#
+# This deliberately takes over from GitHub's own deletion-time retargeting,
+# which is bundled with a race that can close the child PR outright: on branch
+# deletion, a legacy close-dependents job and the 2020 retargeting job both
+# fire, and a child can be retargeted AND closed in the same second (see #626,
+# closed collaterally by the merge of #608 despite a successful retarget and a
+# live 16-file diff). With this workflow doing the retargeting at merge time
+# and prune-merged-branches only deleting branches nothing targets, GitHub's
+# racy path never runs. That also makes this workflow load-bearing: if it is
+# disabled, stacked PRs strand on their merged base branch silently instead of
+# GitHub catching them. Refs:
+# https://github.blog/changelog/2020-05-19-pull-request-retargeting/
+# https://github.com/orgs/community/discussions/176698
+#
+# Merge-the-base-in rather than rebase, on purpose: it advances the merge-base
+# (de-polluting the PR diff) with no force-push, so review comment anchors and
+# commit SHAs survive, conflicts are resolved once rather than per commit, and
+# the squash-merge strategy keeps the merge commit out of main's history
+# anyway. The merge is best-effort – on conflict the child keeps its retarget
+# and gets a comment asking for a manual merge.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize runs: near-simultaneous parent merges get queued, not raced.
+concurrency:
+  group: retarget-stacked-prs
+  cancel-in-progress: false
+
+jobs:
+  retarget:
+    name: Retarget PRs stacked on the merged branch
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      REPO: ${{ github.repository }}
+      PARENT_NUMBER: ${{ github.event.pull_request.number }}
+      PARENT_HEAD: ${{ github.event.pull_request.head.ref }}
+      PARENT_BASE: ${{ github.event.pull_request.base.ref }}
+    steps:
+      - name: Find stacked PRs
+        id: children
+        run: |
+          count=$(gh pr list --repo "$REPO" --base "$PARENT_HEAD" --state open --json number --jq length)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "$count open PR(s) are based on $PARENT_HEAD."
+
+      # GH_TOKEN is a PAT, not GITHUB_TOKEN, on purpose: a merge commit pushed
+      # with GITHUB_TOKEN would not trigger ci.yml, leaving the child PR's
+      # checks pending forever on its new head.
+      - name: Checkout
+        if: steps.children.outputs.count != '0'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Retarget and integrate
+        if: steps.children.outputs.count != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          children=$(gh pr list --repo "$REPO" --base "$PARENT_HEAD" --state open --json number,headRefName --jq '.[] | "\(.number):\(.headRefName)"')
+
+          while IFS=: read -r number branch; do
+            [ -z "$number" ] && continue
+            echo "Retargeting #$number ($branch) from $PARENT_HEAD to $PARENT_BASE."
+            if ! gh api -X PATCH "repos/$REPO/pulls/$number" -f base="$PARENT_BASE" > /dev/null; then
+              echo "::warning::Could not retarget #$number – skipping it."
+              continue
+            fi
+
+            git fetch origin "$branch" "$PARENT_BASE"
+            git checkout -B "$branch" "origin/$branch"
+            if git merge --no-edit "origin/$PARENT_BASE"; then
+              if git push origin "$branch"; then
+                gh pr comment "$number" --repo "$REPO" --body "Base branch \`$PARENT_HEAD\` was merged into \`$PARENT_BASE\` (#$PARENT_NUMBER), so this PR was retargeted to \`$PARENT_BASE\`, and \`$PARENT_BASE\` was merged into \`$branch\` so the diff only shows this PR's own changes. No history was rewritten – a plain \`git pull\` brings your local branch up to date."
+              else
+                gh pr comment "$number" --repo "$REPO" --body "Base branch \`$PARENT_HEAD\` was merged into \`$PARENT_BASE\` (#$PARENT_NUMBER), so this PR was retargeted to \`$PARENT_BASE\`. The automatic merge of \`$PARENT_BASE\` into \`$branch\` could not be pushed (the branch moved in the meantime) – please merge \`$PARENT_BASE\` in manually."
+                echo "::warning::Push to $branch rejected – the branch moved during the run."
+              fi
+            else
+              git merge --abort
+              gh pr comment "$number" --repo "$REPO" --body "Base branch \`$PARENT_HEAD\` was merged into \`$PARENT_BASE\` (#$PARENT_NUMBER), so this PR was retargeted to \`$PARENT_BASE\`. Merging \`$PARENT_BASE\` into \`$branch\` hit conflicts, so it was left untouched – please merge \`$PARENT_BASE\` in (or rebase) manually. Until then the diff will include changes already merged via #$PARENT_NUMBER."
+              echo "::warning::Merge of $PARENT_BASE into $branch conflicted – left for the author."
+            fi
+          done <<< "$children"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two workflows that together replace the repo's **"Automatically delete head branches"** setting with a stack-aware equivalent, so that merging a PR can never collaterally close a PR stacked on top of it.

**The problem being fixed.** When a branch is deleted, two independent GitHub server-side behaviors fire against open PRs that use it as their *base*:

1. a legacy job that **closes** them ("If the branch is associated with at least one open pull request, deleting the branch will close the pull requests" – [docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository)), and
2. the [May 2020 retargeting job](https://github.blog/changelog/2020-05-19-pull-request-retargeting/) that was built to replace it, which repoints them at the merged PR's base and keeps them open.

These are not mutually exclusive: the close job is enqueued against a snapshot of "PRs based on the deleted branch" taken at deletion time, so it can fire even after the retarget has already succeeded. With auto-delete on, deletion is fused to the merge instant, maximizing exposure. It is a live, recurring issue ([community discussion](https://github.com/orgs/community/discussions/176698)).

**Concrete example, this repo:** merging #608 (2026-07-18 21:38:26 UTC) auto-deleted its head branch, which was the base of the stacked #626. One second later #626's timeline shows all three events at once – `base_ref_deleted`, `automatic_base_change_succeeded` (base repointed to `main`), and `closed` – despite #626 carrying a live 16-file diff. The retarget worked *and* the close job killed the PR anyway.

**The fix** enforces one invariant: *a branch is only ever deleted when no open PR has it as a base* – at which point GitHub's racy deletion-time handlers have nothing to act on.

- **`retarget-stacked-prs.yml`** (on PR merge): repoints every open PR based on the merged head branch at the merged PR's base, then merges that base into the child branch. Merge rather than rebase, deliberately: it advances the merge-base so the child's diff stops showing the parent's already-squashed changes, with no force-push (review anchors and SHAs survive, `git pull` just works), and the squash-merge strategy keeps the merge commit out of `main` anyway. The merge is best-effort: on conflict the child keeps its retarget and gets a comment asking for a manual merge. Pushes with the `GH_TOKEN` PAT so CI runs on the new head (same reasoning as `dependabot-branch-auto-update.yml`).
- **`prune-merged-branches.yml`** (daily cron + manual dispatch): deletes branches whose PR merged more than 3 days ago, skipping (and logging) any branch that is still the base of an open PR, plus protected/long-lived branches and branches with no merged PR. The dependents check is the safety mechanism; the grace period is a courtesy.

**Trade-off to be aware of:** once the setting is off, GitHub's own deletion-time retargeting never runs (by design – it's the path bundled with the race). That makes `retarget-stacked-prs.yml` load-bearing: if it is disabled, stacked PRs strand on their merged base branch silently. Both workflow headers document this.

### Rollout order (matters):

1. Merge this PR. Both workflows are safe with auto-delete still on: retarget just finds no children left to fix, prune finds no branches old enough that aren't already gone.
2. Watch one stacked merge (or dispatch `prune-merged-branches` manually and read its log).
3. A repo admin turns **off** Settings → General → "Automatically delete head branches". From then on the workflows own branch cleanup.

(Reverse order is the only wrong one: setting off with the workflows not yet live leaves merged branches accumulating and stacked children stranded.)

### How to test the changes in this Pull Request:

1. Dispatch `prune-merged-branches` manually (Actions → Prune merged branches → Run workflow) while auto-delete is still on: expect a clean run that deletes nothing and logs any kept branches with reasons.
2. Create a throwaway stack: branch `test/stack-parent` off `main` with a trivial commit + PR; branch `test/stack-child` off it with another commit + PR targeting `test/stack-parent`.
3. Merge the parent PR. Expect the `Retarget stacked PRs` run to: repoint the child PR to `main`, push a merge commit to `test/stack-child`, comment on the child PR, and trigger CI on the new head. The child PR must remain **open** with a diff showing only its own commit.
4. For the conflict path: make the child's commit touch the same lines as a commit added to the parent after branching; on parent merge, expect the child to be retargeted but not pushed to, with the "hit conflicts" comment.
5. After the setting flip (step 3 of rollout), confirm the next scheduled prune deletes the parent branch once the child PR is closed/merged and 3 days have passed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?