### PR TITLE
test(e2e): align content-gate save helper with release channel

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -31,6 +31,16 @@ The suite provisions the site from scratch each phase rather than restoring a DB
 dump. This keeps it drift-free: the site is always rebuilt against the currently
 installed plugin code, so a plugin/core update can't leave a stale fixture behind.
 
+> **Specs run against the *installed* plugin version, not the version they were
+> merged with.** The nightly targets a site pinned to the **stable release**
+> channel, but specs land on `main`, which tracks `alpha`. So a spec that drives
+> UI only present in `alpha` (a feature not yet shipped to stable) will fail every
+> night until that feature reaches the release channel – even though it passes
+> locally against `main`. When adding coverage for recently-merged UI, either
+> feature-detect the new element and fall back to the older flow (see
+> `saveGateAsActive` in `tests/utils-content-gates.ts`), or gate the spec so it
+> skips when the feature is absent. Don't assume the newest UI is present.
+
 - **`site-setup.sh`** (this repo) is the from-scratch Newspack bootstrap (DB reset +
   fresh install + posts/users/WooCommerce+donations/memberships/subscriptions/
   campaigns/menus). It's a generic dev provisioner, parameterised by `--url`,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,6 +26,13 @@ site `https://e2e.newspackstaging.com`. The build definition lives in TeamCity
 settings, not in this repo; its steps are: install dependencies, write a `.env`,
 then run `npm run test:setup` (the setup projects provision the site over SSH).
 
+That staging site is pinned to the **stable release** channel, and provisioning
+rebuilds against the plugin version installed there – not the version the specs
+were merged with. A spec that drives UI which only exists in `alpha`/`main` will
+therefore fail nightly until that feature ships to stable, so new specs must
+feature-detect such UI rather than assume it is present. See `AGENTS.md` →
+"Site setup model" for details.
+
 [Credentials for the Atomic site used for the e2e testing.](https://mc.a8c.com/secret-store/?secret_id=12168)
 
 The build is parameterised by these variables (set in TeamCity, not committed):

--- a/e2e/tests/utils-content-gates.ts
+++ b/e2e/tests/utils-content-gates.ts
@@ -93,15 +93,26 @@ const clickHeaderSave = async (page: Page) => {
   }
 };
 
-// Save the gate being edited and set it live via the save panel ("Are you
-// ready to save?"). New gates default to Inactive in the panel, so explicitly
-// pick Active.
+// Save the gate being edited and leave it live (Active). Two plugin flows
+// exist and the target site may run either, so detect which one Save triggers:
+//   - Pre-save checks on: Save opens a confirmation panel ("Are you ready to
+//     save?") where the status is chosen. New gates default to Inactive there,
+//     so pick Active explicitly.
+//   - Pre-save checks off / older plugin: Save persists immediately and new
+//     gates default to Active, so there is no panel to drive.
+// Either way the wizard routes back to the gate list once the gate is saved.
 export const saveGateAsActive = async (page: Page) => {
   await clickHeaderSave(page);
   const saveDialog = page.getByRole("dialog");
-  await expect(saveDialog.getByText("Are you ready to save?")).toBeVisible();
-  await saveDialog.getByRole("radio", { name: "Active", exact: true }).check();
-  await saveDialog.getByRole("button", { name: "Save", exact: true }).click();
+  const saveConfirmation = saveDialog.getByText("Are you ready to save?");
+  const hasSavePanel = await saveConfirmation
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  if (hasSavePanel) {
+    await saveDialog.getByRole("radio", { name: "Active", exact: true }).check();
+    await saveDialog.getByRole("button", { name: "Save", exact: true }).click();
+  }
   await page.waitForURL(/#\/content-gates/);
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The nightly E2E run (build [18571507](https://teamcity.a8c.com/buildConfiguration/Newspack_E2eTests/18571507)) went red with 2 new failures right after the Access Control specs merged. Both timed out at `saveGateAsActive` waiting for the pre-save panel (`"Are you ready to save?"`).

Root cause is **version skew**, not a product regression: the pre-save checklist panel (`#408`) only exists on `alpha`/`main`, but the nightly runs against a site pinned to the **stable release** channel, where clicking Save persists the gate immediately (new gates default to Active) with no panel. The helper assumed the panel unconditionally.

This makes `saveGateAsActive` **feature-detect** the panel: drive it when present, otherwise fall back to the immediate-save flow. Both flows route back to `#/content-gates`, so the helper passes against the current release channel now and stays correct when the panel ships to stable.

Also documents the release-channel pinning in `e2e/README.md` and `e2e/AGENTS.md` so future specs feature-detect newer UI instead of assuming it's present.

### How to test the changes in this Pull Request:

1. Point the suite at a site running a plugin version **without** the pre-save panel (stable release, e.g. the local `e2e-release` env on `newspack-plugin` 6.43.7).
2. Run `USE_SETUP=true npx playwright test --project="Vanilla in Desktop Chrome" content-gating.spec.ts premium-newsletters.spec.ts`.
3. Both specs pass (they timed out at `saveGateAsActive` before this change).

Verified locally against the `e2e-release` env (release channel, no panel): **3 passed** (setup + both specs).

### Other information:

Infra-only change to the E2E suite (out of the release pipeline); no publisher-facing behavior.